### PR TITLE
Set request to PENDING before retry backoff wait

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -91,9 +91,8 @@ multiprocessing.set_start_method('spawn', force=True)
 # server process become overloaded.
 _REQUEST_THREADS_LIMIT = 128
 
-# Max length of the retry reason embedded in a request's status message during
-# a retry backoff. The reason comes from the (potentially long) exception
-# message, so we truncate it to keep the status line readable.
+# Max length of the retry reason in a request's backoff status message; the
+# reason comes from the exception message, so truncate to keep it readable.
 _RETRY_STATUS_MSG_REASON_MAX_LEN = 200
 
 _REQUEST_THREAD_EXECUTOR_LOCK = threading.Lock()
@@ -287,26 +286,16 @@ class RequestWorker:
                 queue = _get_queue(self.schedule_type)
                 queue.put(request_element)
         except exceptions.ExecutionRetryableError as e:
-            # Reset the request status to PENDING *before* the backoff wait,
-            # not after. During the wait the request is no longer executing --
-            # it is parked waiting to be rescheduled -- so PENDING is its
-            # accurate state. Marking it PENDING up front also lets any
-            # request-recovery mechanism re-enqueue it if this server is
-            # interrupted mid-wait; if it stayed RUNNING, such a request would
-            # look like a crashed in-flight task and be failed instead of
-            # retried. The request is not put back on the queue until after the
-            # wait below, so no worker picks it up early.
-            # Assume retryable since the error is ExecutionRetryableError.
+            # Set PENDING before the wait, not after: during the backoff the
+            # request is parked waiting to be rescheduled, so PENDING is its
+            # accurate state and lets a request-recovery mechanism re-enqueue
+            # it if the server is interrupted mid-wait. It is not put back on
+            # the queue until after the wait, so no worker picks it up early.
             request_id, _, _ = request_element
-            # Guard against a negative wait: time.sleep() would raise
-            # ValueError and crash this monitor thread, leaving the request
-            # parked in PENDING without ever being re-enqueued below.
+            # Clamp to avoid ValueError from time.sleep() on a negative wait.
             retry_wait_seconds = max(0, e.retry_wait_seconds)
-            # Surface *why* we are retrying (e.g. 'Failed to provision ...'),
-            # not just the wait time, so a client attaching during the backoff
-            # sees the reason. The exception message can carry ANSI color and
-            # newlines; strip color and collapse whitespace since status_msg is
-            # a single-line field, then truncate to keep it readable.
+            # Surface why we are retrying, not just the wait time. status_msg
+            # is a single-line field, so strip color and collapse whitespace.
             reason = ' '.join(common_utils.remove_color(str(e)).split())
             if len(reason) > _RETRY_STATUS_MSG_REASON_MAX_LEN:
                 reason = reason[:_RETRY_STATUS_MSG_REASON_MAX_LEN].rstrip(
@@ -668,8 +657,7 @@ def _request_execution_wrapper(request_id: str,
             log_path = request_task.log_path
             request_task.pid = pid
             request_task.status = api_requests.RequestStatus.RUNNING
-            # Clear any status message left over from a prior retry backoff
-            # (e.g. 'Retrying in Ns') now that the request is running again.
+            # Clear any leftover retry-backoff message now that we are running.
             request_task.status_msg = None
             func = request_task.entrypoint
             request_body = request_task.request_body

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -293,12 +293,15 @@ class RequestWorker:
             # wait below, so no worker picks it up early.
             # Assume retryable since the error is ExecutionRetryableError.
             request_id, _, _ = request_element
+            # Guard against a negative wait: time.sleep() would raise
+            # ValueError and crash this monitor thread, leaving the request
+            # parked in PENDING without ever being re-enqueued below.
+            retry_wait_seconds = max(0, e.retry_wait_seconds)
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
                 request_task.status = api_requests.RequestStatus.PENDING
-                request_task.status_msg = (
-                    f'Retrying in {e.retry_wait_seconds}s')
-            time.sleep(e.retry_wait_seconds)
+                request_task.status_msg = (f'Retrying in {retry_wait_seconds}s')
+            time.sleep(retry_wait_seconds)
             # Reschedule the request.
             queue = _get_queue(self.schedule_type)
             queue.put(request_element)
@@ -648,6 +651,9 @@ def _request_execution_wrapper(request_id: str,
             log_path = request_task.log_path
             request_task.pid = pid
             request_task.status = api_requests.RequestStatus.RUNNING
+            # Clear any status message left over from a prior retry backoff
+            # (e.g. 'Retrying in Ns') now that the request is running again.
+            request_task.status_msg = None
             func = request_task.entrypoint
             request_body = request_task.request_body
             request_name = request_task.name

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -282,13 +282,23 @@ class RequestWorker:
                 queue = _get_queue(self.schedule_type)
                 queue.put(request_element)
         except exceptions.ExecutionRetryableError as e:
-            time.sleep(e.retry_wait_seconds)
-            # Reset the request status to PENDING so it can be picked up again.
+            # Reset the request status to PENDING *before* the backoff wait,
+            # not after. During the wait the request is no longer executing --
+            # it is parked waiting to be rescheduled -- so PENDING is its
+            # accurate state. Marking it PENDING up front also lets any
+            # request-recovery mechanism re-enqueue it if this server is
+            # interrupted mid-wait; if it stayed RUNNING, such a request would
+            # look like a crashed in-flight task and be failed instead of
+            # retried. The request is not put back on the queue until after the
+            # wait below, so no worker picks it up early.
             # Assume retryable since the error is ExecutionRetryableError.
             request_id, _, _ = request_element
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
                 request_task.status = api_requests.RequestStatus.PENDING
+                request_task.status_msg = (
+                    f'Retrying in {e.retry_wait_seconds}s')
+            time.sleep(e.retry_wait_seconds)
             # Reschedule the request.
             queue = _get_queue(self.schedule_type)
             queue.put(request_element)

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -91,6 +91,11 @@ multiprocessing.set_start_method('spawn', force=True)
 # server process become overloaded.
 _REQUEST_THREADS_LIMIT = 128
 
+# Max length of the retry reason embedded in a request's status message during
+# a retry backoff. The reason comes from the (potentially long) exception
+# message, so we truncate it to keep the status line readable.
+_RETRY_STATUS_MSG_REASON_MAX_LEN = 200
+
 _REQUEST_THREAD_EXECUTOR_LOCK = threading.Lock()
 # A dedicated thread pool executor for synced requests execution in coroutine to
 # avoid:
@@ -297,10 +302,22 @@ class RequestWorker:
             # ValueError and crash this monitor thread, leaving the request
             # parked in PENDING without ever being re-enqueued below.
             retry_wait_seconds = max(0, e.retry_wait_seconds)
+            # Surface *why* we are retrying (e.g. 'Failed to provision ...'),
+            # not just the wait time, so a client attaching during the backoff
+            # sees the reason. The exception message can carry ANSI color and
+            # newlines; strip color and collapse whitespace since status_msg is
+            # a single-line field, then truncate to keep it readable.
+            reason = ' '.join(common_utils.remove_color(str(e)).split())
+            if len(reason) > _RETRY_STATUS_MSG_REASON_MAX_LEN:
+                reason = reason[:_RETRY_STATUS_MSG_REASON_MAX_LEN].rstrip(
+                ) + '...'
+            retry_suffix = f'retrying in {retry_wait_seconds}s'
+            status_msg = (f'{reason} ({retry_suffix})'
+                          if reason else f'Retrying in {retry_wait_seconds}s')
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
                 request_task.status = api_requests.RequestStatus.PENDING
-                request_task.status_msg = (f'Retrying in {retry_wait_seconds}s')
+                request_task.status_msg = status_msg
             time.sleep(retry_wait_seconds)
             # Reschedule the request.
             queue = _get_queue(self.schedule_type)

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -581,12 +581,15 @@ async def test_request_worker_retry_execution_retryable_error(
     # PENDING (not RUNNING) and not yet re-enqueued before we wait.
     sleep_calls = []
     status_at_sleep = []
+    status_msg_at_sleep = []
     queue_len_at_sleep = []
 
     def mock_sleep(seconds):
         sleep_calls.append(seconds)
-        observed = requests_lib.get_request(request_id, fields=['status'])
+        observed = requests_lib.get_request(request_id,
+                                            fields=['status', 'status_msg'])
         status_at_sleep.append(observed.status if observed else None)
+        status_msg_at_sleep.append(observed.status_msg if observed else None)
         queue_len_at_sleep.append(len(queue_items))
 
     monkeypatch.setattr('time.sleep', mock_sleep)
@@ -649,6 +652,16 @@ async def test_request_worker_retry_execution_retryable_error(
         0
     ], ('Expected request to be re-enqueued only after the wait, but it was '
         f'already on the queue at sleep time: {queue_len_at_sleep}')
+
+    # The status message during the backoff should surface both the retry
+    # reason (from the exception message) and the wait time.
+    assert len(status_msg_at_sleep) == 1
+    msg = status_msg_at_sleep[0]
+    assert msg is not None
+    assert 'Failed to provision all possible launchable resources' in msg, (
+        f'Expected retry reason in status_msg, got: {msg!r}')
+    assert 'retrying in 30s' in msg, (
+        f'Expected wait time in status_msg, got: {msg!r}')
 
     # Verify the request status was reset to PENDING
     updated_request = requests_lib.get_request(request_id, fields=['status'])

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -575,11 +575,19 @@ async def test_request_worker_retry_execution_retryable_error(
 
     monkeypatch.setattr(executor, '_get_queue', mock_get_queue)
 
-    # Mock time.sleep to track calls (but still sleep for very short waits)
+    # Mock time.sleep to track calls (but still sleep for very short waits).
+    # Capture the request status and queue length observed *at the moment*
+    # the backoff sleep happens, to pin the ordering: the request must be
+    # PENDING (not RUNNING) and not yet re-enqueued before we wait.
     sleep_calls = []
+    status_at_sleep = []
+    queue_len_at_sleep = []
 
     def mock_sleep(seconds):
         sleep_calls.append(seconds)
+        observed = requests_lib.get_request(request_id, fields=['status'])
+        status_at_sleep.append(observed.status if observed else None)
+        queue_len_at_sleep.append(len(queue_items))
 
     monkeypatch.setattr('time.sleep', mock_sleep)
 
@@ -629,6 +637,18 @@ async def test_request_worker_retry_execution_retryable_error(
         30
     ], (f'Expected first time.sleep call to be 30 seconds, got {sleep_calls[0]}'
        )
+
+    # Verify the status was set to PENDING *before* the backoff wait, and that
+    # the request was not yet re-enqueued at that point. This guards the
+    # failover-safety ordering: a server interrupted mid-wait leaves the
+    # request in PENDING (recoverable) rather than a stuck RUNNING orphan.
+    assert status_at_sleep == [
+        requests_lib.RequestStatus.PENDING
+    ], (f'Expected status to be PENDING at sleep time, got {status_at_sleep}')
+    assert queue_len_at_sleep == [
+        0
+    ], ('Expected request to be re-enqueued only after the wait, but it was '
+        f'already on the queue at sleep time: {queue_len_at_sleep}')
 
     # Verify the request status was reset to PENDING
     updated_request = requests_lib.get_request(request_id, fields=['status'])


### PR DESCRIPTION
When a request raises ExecutionRetryableError, the worker reset the request to PENDING only *after* sleeping for `retry_wait_seconds`. During that wait the request stayed RUNNING even though it was no longer executing, just parked waiting to be rescheduled.

Set the status to PENDING (with a 'Retrying in Ns' status message) before the wait instead. This reflects the request's true state during the backoff and lets any request-recovery mechanism re-enqueue it if the server is interrupted mid-wait, rather than treating it as a crashed in-flight task. The request is not put back on the queue until after the wait, so no worker picks it up early.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ]  All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
