### PR TITLE
Support execution wait on external condition

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1326,6 +1326,10 @@ class RetryingVmProvisioner(object):
                         # No teardown happens for this error.
                         with ux_utils.print_exception_no_traceback():
                             raise
+                    except exceptions.ExecutionPausedError:
+                        # Pausing to wait on an external condition: keep the
+                        # resources for resume, do not tear down or fail over.
+                        raise
                     except config_lib.KubernetesError as e:
                         if e.insufficent_resources:
                             insufficient_resources = e.insufficent_resources

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -730,9 +730,8 @@ class ExecutionPausedError(ExecutionRetryableError):
     """Pause execution mid-attempt while keeping provisioned resources.
 
     Raised from inside an in-progress attempt waiting on an external condition
-    (e.g. admission or quota). Unlike a plain retryable error, the partially
-    provisioned resources are kept so the request can resume, so teardown
-    layers must re-raise this instead of cleaning up.
+    (e.g. admission or quota). The partially provisioned resources are kept so
+    the request can resume, so teardown layers must not clean up the resources.
 
     ``continue_condition`` optionally says how to wait for the resume signal
     (see ``continue_condition.py``); it must be picklable, as the error crosses

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -726,6 +726,34 @@ class ExecutionRetryableError(Exception):
         return (self.__class__, (str(self), self.hint, self.retry_wait_seconds))
 
 
+class ExecutionPausedError(ExecutionRetryableError):
+    """Pause execution mid-attempt while keeping provisioned resources.
+
+    Raised from inside an in-progress attempt waiting on an external condition
+    (e.g. admission or quota). Unlike a plain retryable error, the partially
+    provisioned resources are kept so the request can resume, so teardown
+    layers must re-raise this instead of cleaning up.
+
+    ``continue_condition`` optionally says how to wait for the resume signal
+    (see ``continue_condition.py``); it must be picklable, as the error crosses
+    the worker/scheduler process boundary. ``retry_wait_seconds`` is the
+    fallback wait when it is absent.
+    """
+
+    def __init__(self,
+                 message: str,
+                 hint: str,
+                 retry_wait_seconds: int,
+                 continue_condition: Optional[Any] = None) -> None:
+        super().__init__(message, hint, retry_wait_seconds)
+        self.continue_condition = continue_condition
+
+    def __reduce__(self):
+        # Make sure the exception is picklable
+        return (self.__class__, (str(self), self.hint, self.retry_wait_seconds,
+                                 self.continue_condition))
+
+
 class ExecutionPoolFullError(Exception):
     """Raised when the execution pool is full."""
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -182,6 +182,10 @@ def bulk_provision(
             # This error is a user error instead of a provisioning failure.
             # And there is no possibility to fix it by teardown.
             raise
+        except exceptions.ExecutionPausedError:
+            # Pausing to wait on an external condition: keep the resources for
+            # resume, do not tear down.
+            raise
         except Exception as exc:  # pylint: disable=broad-except
             zone_str = 'all zones'
             if zones:

--- a/sky/server/requests/continue_condition.py
+++ b/sky/server/requests/continue_condition.py
@@ -1,0 +1,31 @@
+"""Resume conditions for paused request execution.
+
+A request that pauses (``exceptions.ExecutionPausedError``) instead of holding
+an executor worker may attach a ``ContinueCondition`` saying how to wait for
+the resume signal. The scheduler calls ``wait()`` from the request's monitor
+thread, so the worker is freed meanwhile. Subclass to own the polling/backoff/
+fallback policy; instances are pickled onto the exception, so keep state
+picklable and define subclasses in a module importable by the scheduler.
+"""
+import time
+from typing import Callable
+
+
+class ContinueCondition:
+    """A resumable wait attached to ``ExecutionPausedError``.
+
+    Subclass and override ``wait()`` to customize how a paused request waits
+    before being rescheduled.
+    """
+
+    def wait(self, *, is_cancelled: Callable[[], bool],
+             fallback_wait_seconds: float) -> bool:
+        """Block until the paused request should resume.
+
+        Returns True to reschedule, False to drop it (e.g. cancelled while
+        paused, per ``is_cancelled``). ``fallback_wait_seconds`` is the default
+        wait when there is no better signal.
+        """
+        # Default: one fixed wait, then reschedule unless cancelled.
+        time.sleep(max(0, fallback_wait_seconds))
+        return not is_cancelled()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -176,6 +176,16 @@ def executor_initializer(proc_group: str):
                      daemon=True).start()
 
 
+def _request_is_gone_or_cancelled(request_id: str) -> bool:
+    """Cancellation check passed to ``ContinueCondition.wait()``.
+
+    A request cancelled (or gone) while paused must not be re-queued.
+    """
+    request = api_requests.get_request(request_id, fields=['status'])
+    return (request is None or
+            request.status == api_requests.RequestStatus.CANCELLED)
+
+
 class RequestWorker:
     """A worker that polls requests from the queue and runs them.
 
@@ -294,24 +304,45 @@ class RequestWorker:
             request_id, _, _ = request_element
             # Clamp to avoid ValueError from time.sleep() on a negative wait.
             retry_wait_seconds = max(0, e.retry_wait_seconds)
+            # A pause (ExecutionPausedError) may carry a continue condition that
+            # owns how to wait for the resume signal; without one, fall back to
+            # a fixed backoff. Either way the wait runs in this monitor thread,
+            # not an executor worker.
+            condition = getattr(e, 'continue_condition', None)
             # Surface why we are retrying, not just the wait time. status_msg
             # is a single-line field, so strip color and collapse whitespace.
             reason = ' '.join(common_utils.remove_color(str(e)).split())
             if len(reason) > _RETRY_STATUS_MSG_REASON_MAX_LEN:
                 reason = reason[:_RETRY_STATUS_MSG_REASON_MAX_LEN].rstrip(
                 ) + '...'
-            retry_suffix = f'retrying in {retry_wait_seconds}s'
+            retry_suffix = ('waiting to resume' if condition is not None else
+                            f'retrying in {retry_wait_seconds}s')
             status_msg = (f'{reason} ({retry_suffix})'
-                          if reason else f'Retrying in {retry_wait_seconds}s')
+                          if reason else retry_suffix.capitalize())
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
                 request_task.status = api_requests.RequestStatus.PENDING
                 request_task.status_msg = status_msg
-            time.sleep(retry_wait_seconds)
-            # Reschedule the request.
-            queue = _get_queue(self.schedule_type)
-            queue.put(request_element)
-            logger.info(f'Rescheduled request {request_id} for retry')
+            try:
+                if condition is not None:
+                    should_reschedule = condition.wait(
+                        is_cancelled=lambda: _request_is_gone_or_cancelled(
+                            request_id),
+                        fallback_wait_seconds=retry_wait_seconds)
+                else:
+                    time.sleep(retry_wait_seconds)
+                    should_reschedule = True
+            except Exception as wait_err:  # pylint: disable=broad-except
+                logger.error(
+                    f'Continue-condition wait failed for {request_id}: '
+                    f'{common_utils.format_exception(wait_err)}')
+                time.sleep(retry_wait_seconds)
+                should_reschedule = True
+            if should_reschedule:
+                # Reschedule the request.
+                queue = _get_queue(self.schedule_type)
+                queue.put(request_element)
+                logger.info(f'Rescheduled request {request_id} for retry')
         finally:
             # Increment the free executor count when a request finishes
             if metrics_utils.METRICS_ENABLED:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -276,10 +276,32 @@ class RequestWorker:
                 f'{request_id if "request_id" in locals() else ""} '
                 f'{common_utils.format_exception(e, use_bracket=True)}')
 
+    def _mark_executor_free(self) -> None:
+        """Increment the free-executor gauge for this worker's schedule type.
+
+        Called the instant the worker process is released (i.e. the future
+        completes), so the gauge stays accurate even while a retry/pause wait
+        is still running in this monitor thread.
+        """
+        if not metrics_utils.METRICS_ENABLED:
+            return
+        if self.schedule_type == api_requests.ScheduleType.LONG:
+            metrics_utils.SKY_APISERVER_LONG_EXECUTORS.inc()
+        elif self.schedule_type == api_requests.ScheduleType.SHORT:
+            metrics_utils.SKY_APISERVER_SHORT_EXECUTORS.inc()
+
     def handle_task_result(self, fut: concurrent.futures.Future,
                            request_element: Tuple[str, bool, bool]) -> None:
         try:
-            fut.result()
+            try:
+                fut.result()
+            finally:
+                # The worker process is released the instant the future
+                # completes, before any retry/pause wait below. Account for it
+                # here so the free-executor gauge reflects the idle process
+                # during the wait, instead of staying decremented until the
+                # request finishes or reschedules.
+                self._mark_executor_free()
         except concurrent.futures.process.BrokenProcessPool as e:
             # Happens when the worker process dies unexpectedly, e.g. OOM
             # killed.
@@ -343,13 +365,6 @@ class RequestWorker:
                 queue = _get_queue(self.schedule_type)
                 queue.put(request_element)
                 logger.info(f'Rescheduled request {request_id} for retry')
-        finally:
-            # Increment the free executor count when a request finishes
-            if metrics_utils.METRICS_ENABLED:
-                if self.schedule_type == api_requests.ScheduleType.LONG:
-                    metrics_utils.SKY_APISERVER_LONG_EXECUTORS.inc()
-                elif self.schedule_type == api_requests.ScheduleType.SHORT:
-                    metrics_utils.SKY_APISERVER_SHORT_EXECUTORS.inc()
 
     def run(self) -> None:
         # Handle the SIGTERM signal to abort the executor process gracefully.

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -8,14 +8,123 @@ import pytest
 from sky import clouds
 from sky import exceptions as sky_exceptions
 from sky import resources
+from sky.adaptors import kubernetes
 from sky.backends import cloud_vm_ray_backend
+from sky.provision import common as provision_common
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import instance
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.instance import logger
+from sky.utils import subprocess_utils
 
 
 def _remove_colorama_escape_codes(error_output):
     return [re.sub(r'\x1b\[[0-9;]*m', '', line) for line in error_output]
+
+
+def _make_provision_config(count):
+    """A minimal ProvisionConfig sufficient to drive _create_pods."""
+    return provision_common.ProvisionConfig(
+        provider_config={'timeout': 10},
+        authentication_config={},
+        docker_config={},
+        node_config={
+            'metadata': {
+                'labels': {}
+            },
+            'spec': {
+                'containers': [{}]
+            },
+        },
+        count=count,
+        tags={},
+        resume_stopped_nodes=False,
+        ports_to_open_on_launch=None,
+    )
+
+
+def _fake_pod(name):
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod.status.phase = 'Pending'
+    return pod
+
+
+def _patch_create_pods_k8s_boundary(monkeypatch, existing_pods, head_name):
+    """Stub the Kubernetes-touching calls _create_pods makes.
+
+    Leaves the to_start_count arithmetic and per-pod skip logic to run for
+    real, so the idempotency contract is what's actually exercised.
+    """
+
+    def fake_filter_pods(namespace, context, tags, phases):
+        # Only the Pending/Running query returns existing pods; the
+        # Terminating and Failed/Succeeded cleanup queries return nothing.
+        if 'Pending' in phases:
+            return dict(existing_pods)
+        return {}
+
+    monkeypatch.setattr(kubernetes_utils, 'get_namespace_from_config',
+                        lambda *a, **k: 'ns')
+    monkeypatch.setattr(kubernetes_utils, 'get_context_from_config',
+                        lambda *a, **k: 'ctx')
+    monkeypatch.setattr(kubernetes_utils, 'filter_pods', fake_filter_pods)
+    monkeypatch.setattr(instance, '_get_head_pod_name', lambda pods: head_name)
+    monkeypatch.setattr(kubernetes_utils, 'check_nvidia_runtime_class',
+                        lambda *a, **k: False)
+    monkeypatch.setattr(instance, '_wait_for_pods_to_schedule',
+                        lambda *a, **k: None)
+    monkeypatch.setattr(instance, '_wait_for_pods_to_run', lambda *a, **k: None)
+    monkeypatch.setattr(instance, 'is_high_availability_cluster_by_kubectl',
+                        lambda *a, **k: False)
+
+
+def test_create_pods_is_idempotent_when_all_pods_exist(monkeypatch):
+    """Relaunching with all pods already present must create nothing.
+
+    This pins the reattach-safety contract that lets a paused launch resume
+    onto the pods it already created: _create_pods computes to_start_count == 0
+    and issues no create_namespaced_pod calls, returning the existing head.
+    """
+    cluster_on_cloud = 'test-cluster-abc'
+    head_name = f'{cluster_on_cloud}-head'
+    existing = {
+        head_name: _fake_pod(head_name),
+        f'{cluster_on_cloud}-worker1': _fake_pod(f'{cluster_on_cloud}-worker1'),
+    }
+    _patch_create_pods_k8s_boundary(monkeypatch, existing, head_name)
+
+    core_api = mock.MagicMock()
+    monkeypatch.setattr(kubernetes, 'core_api', lambda *a, **k: core_api)
+
+    # run_in_parallel drives the per-index create thread; run it inline so the
+    # head/worker skip logic actually executes.
+    monkeypatch.setattr(subprocess_utils, 'run_in_parallel',
+                        lambda fn, items, *a, **k: [fn(i) for i in items])
+
+    config = _make_provision_config(count=2)
+    record = instance._create_pods('us', cluster_on_cloud, cluster_on_cloud,
+                                   config)
+
+    core_api.create_namespaced_pod.assert_not_called()
+    assert record.created_instance_ids == []
+    assert record.head_instance_id == head_name
+
+
+def test_create_pods_raises_on_more_pods_than_requested(monkeypatch):
+    """More running+pending pods than requested trips the leak guard."""
+    cluster_on_cloud = 'test-cluster-xyz'
+    head_name = f'{cluster_on_cloud}-head'
+    existing = {
+        head_name: _fake_pod(head_name),
+        f'{cluster_on_cloud}-worker1': _fake_pod(f'{cluster_on_cloud}-worker1'),
+        f'{cluster_on_cloud}-worker2': _fake_pod(f'{cluster_on_cloud}-worker2'),
+    }
+    _patch_create_pods_k8s_boundary(monkeypatch, existing, head_name)
+
+    config = _make_provision_config(count=2)
+    with pytest.raises(RuntimeError, match='resource leak'):
+        instance._create_pods('us', cluster_on_cloud, cluster_on_cloud, config)
 
 
 def test_out_of_cpus(monkeypatch):

--- a/tests/unit_tests/test_sky/provision/test_provisioner_pause.py
+++ b/tests/unit_tests/test_sky/provision/test_provisioner_pause.py
@@ -78,7 +78,7 @@ def test_bulk_provision_tears_down_on_ordinary_failure(patched_bulk_provision,
     """Negative control: an ordinary failure still tears down.
 
     Proves the test harness actually reaches the teardown branch, so the
-    pause test above is meaningful rather than vacuous.
+    pause test above is meaningful rather than superfluous.
     """
     monkeypatch.setattr(
         provisioner, '_bulk_provision',

--- a/tests/unit_tests/test_sky/provision/test_provisioner_pause.py
+++ b/tests/unit_tests/test_sky/provision/test_provisioner_pause.py
@@ -1,0 +1,90 @@
+"""bulk_provision must not tear down resources when execution pauses.
+
+A paused execution (ExecutionPausedError) is waiting on an external condition
+and wants its partially provisioned resources kept so it can resume. This pins
+that bulk_provision re-raises the pause without tearing down, while still
+tearing down on an ordinary provisioning failure.
+"""
+import contextlib
+from unittest import mock
+
+import pytest
+
+from sky import clouds
+from sky import exceptions
+from sky import global_user_state
+from sky.provision import provisioner
+from sky.utils import resources_utils
+
+_CLUSTER_YAML_DICT = {
+    'head_node_type': 'ray.head.default',
+    'provider': {},
+    'auth': {},
+    'docker': {},
+    'available_node_types': {
+        'ray.head.default': {
+            'node_config': {}
+        }
+    },
+}
+
+
+@pytest.fixture()
+def patched_bulk_provision(monkeypatch):
+    """Drive bulk_provision with its filesystem/state deps stubbed out.
+
+    Returns the teardown_cluster mock so tests can assert on it; the caller
+    sets _bulk_provision's side effect.
+    """
+    monkeypatch.setattr(global_user_state, 'get_cluster_yaml_dict',
+                        lambda *a, **k: dict(_CLUSTER_YAML_DICT))
+    monkeypatch.setattr(provisioner.provision_logging,
+                        'setup_provision_logging',
+                        lambda *a, **k: contextlib.nullcontext())
+    teardown_mock = mock.MagicMock()
+    monkeypatch.setattr(provisioner, 'teardown_cluster', teardown_mock)
+    return teardown_mock
+
+
+def _call_bulk_provision(tmp_path):
+    return provisioner.bulk_provision(cloud=clouds.Kubernetes(),
+                                      region=clouds.Region('us'),
+                                      zones=None,
+                                      cluster_name=resources_utils.ClusterName(
+                                          'c', 'c-on-cloud'),
+                                      num_nodes=1,
+                                      cluster_yaml='/fake/cluster.yaml',
+                                      prev_cluster_ever_up=False,
+                                      log_dir=str(tmp_path))
+
+
+def test_bulk_provision_does_not_teardown_on_pause(patched_bulk_provision,
+                                                   monkeypatch, tmp_path):
+    """A pause propagates without tearing down the kept resources."""
+    paused = exceptions.ExecutionPausedError('Waiting on admission.',
+                                             hint='resume later',
+                                             retry_wait_seconds=5)
+    monkeypatch.setattr(provisioner, '_bulk_provision',
+                        mock.MagicMock(side_effect=paused))
+
+    with pytest.raises(exceptions.ExecutionPausedError):
+        _call_bulk_provision(tmp_path)
+
+    patched_bulk_provision.assert_not_called()
+
+
+def test_bulk_provision_tears_down_on_ordinary_failure(patched_bulk_provision,
+                                                       monkeypatch, tmp_path):
+    """Negative control: an ordinary failure still tears down.
+
+    Proves the test harness actually reaches the teardown branch, so the
+    pause test above is meaningful rather than vacuous.
+    """
+    monkeypatch.setattr(
+        provisioner, '_bulk_provision',
+        mock.MagicMock(side_effect=RuntimeError('provisioning failed')))
+
+    with pytest.raises(RuntimeError, match='provisioning failed'):
+        _call_bulk_provision(tmp_path)
+
+    patched_bulk_provision.assert_called_once()

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -16,6 +16,7 @@ from sky import skypilot_config
 from sky.server import config as server_config
 from sky.server import constants as server_constants
 from sky.server import daemons as server_daemons
+from sky.server.requests import continue_condition as continue_condition_lib
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import process
@@ -677,6 +678,163 @@ async def test_request_worker_retry_execution_retryable_error(
     assert len(submit_calls) == 1, (
         f'Expected submit_until_success to be called once, got {len(submit_calls)} calls'
     )
+
+
+class _PauseHarness:
+    """Bundles the worker, queue, and request id for pause/watch tests."""
+
+    def __init__(self, worker, request_id, queue_items, sleep_calls):
+        self.worker = worker
+        self.request_id = request_id
+        self.queue_items = queue_items
+        self.sleep_calls = sleep_calls
+
+    def run(self, condition, retry_wait_seconds=30):
+        """Drive handle_task_result with an ExecutionPausedError."""
+        paused_error = exceptions.ExecutionPausedError(
+            'Waiting on external admission.',
+            hint='Will resume when admitted',
+            retry_wait_seconds=retry_wait_seconds,
+            continue_condition=condition)
+        fut = concurrent.futures.Future()
+        fut.set_exception(paused_error)
+        request_element = (self.request_id, False, True)
+        self.worker.handle_task_result(fut, request_element)
+        return request_element
+
+
+@pytest.fixture()
+def pause_harness(isolated_database, monkeypatch):
+    """A RequestWorker wired to an in-memory queue, watching time.sleep."""
+    request_id = 'test-pause-request'
+    request = requests_lib.Request(
+        request_id=request_id,
+        name='test-request',
+        entrypoint=_dummy_entrypoint_for_retry_test,
+        request_body=payloads.RequestBody(),
+        status=requests_lib.RequestStatus.RUNNING,
+        created_at=time.time(),
+        user_id='test-user',
+    )
+    asyncio.run(requests_lib.create_if_not_exists_async(request))
+
+    queue_items = []
+    backing = queue_lib.Queue()
+
+    class MockRequestQueue:
+
+        def get(self):
+            try:
+                return backing.get(block=False)
+            except queue_lib.Empty:
+                return None
+
+        def put(self, item):
+            queue_items.append(item)
+            backing.put(item)
+
+    request_queue = MockRequestQueue()
+    monkeypatch.setattr(executor, '_get_queue',
+                        lambda schedule_type: request_queue)
+
+    # Capture (and skip) the fixed fallback sleep so the tests run instantly.
+    sleep_calls = []
+
+    def mock_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr('time.sleep', mock_sleep)
+
+    worker = executor.RequestWorker(
+        schedule_type=requests_lib.ScheduleType.LONG,
+        config=server_config.WorkerConfig(garanteed_parallelism=1,
+                                          burstable_parallelism=0,
+                                          num_db_connections_per_worker=0))
+    return _PauseHarness(worker, request_id, queue_items, sleep_calls)
+
+
+class _RecordingCondition(continue_condition_lib.ContinueCondition):
+    """A ContinueCondition whose wait() returns a fixed verdict.
+
+    Records the OSS-provided wait() arguments so tests can assert the executor
+    drives the condition's interface correctly.
+    """
+
+    def __init__(self, verdict: bool):
+        self._verdict = verdict
+        self.calls = []
+
+    def wait(self, *, is_cancelled, fallback_wait_seconds) -> bool:
+        self.calls.append({
+            'is_cancelled': is_cancelled(),
+            'fallback_wait_seconds': fallback_wait_seconds,
+        })
+        return self._verdict
+
+
+def test_pause_reschedules_when_wait_returns_true(pause_harness):
+    """The executor calls condition.wait() and reschedules when it returns True.
+
+    The wait policy (poll interval, backoff, deadline, fallback) lives in the
+    condition; the executor just acts on the boolean verdict.
+    """
+    condition = _RecordingCondition(verdict=True)
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert pause_harness.queue_items == [request_element]
+    # wait() was given the fallback and a working cancellation check.
+    assert condition.calls == [{
+        'is_cancelled': False,
+        'fallback_wait_seconds': 30
+    }]
+    # During the pause the request is PENDING with a "waiting to resume" msg.
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status', 'status_msg'])
+    assert updated.status == requests_lib.RequestStatus.PENDING
+    assert 'waiting to resume' in updated.status_msg
+
+
+def test_pause_dropped_when_wait_returns_false(pause_harness):
+    """A condition.wait() returning False drops the request (no reschedule)."""
+    condition = _RecordingCondition(verdict=False)
+
+    pause_harness.run(condition)
+
+    assert pause_harness.queue_items == []
+
+
+def test_pause_base_condition_does_fixed_fallback_wait(pause_harness):
+    """The base ContinueCondition just waits the fallback, then reschedules."""
+    condition = continue_condition_lib.ContinueCondition()
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert pause_harness.sleep_calls == [30]
+    assert pause_harness.queue_items == [request_element]
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status'])
+    assert updated.status == requests_lib.RequestStatus.PENDING
+
+
+def test_pause_base_condition_dropped_if_cancelled_during_wait(
+        pause_harness, monkeypatch):
+    """The base condition drops the request if it is cancelled while waiting.
+
+    Also exercises the OSS-provided is_cancelled check, which the base wait()
+    consults after the fallback sleep.
+    """
+
+    def cancel_on_sleep(seconds):
+        pause_harness.sleep_calls.append(seconds)
+        with requests_lib.update_request(pause_harness.request_id) as r:
+            r.status = requests_lib.RequestStatus.CANCELLED
+
+    monkeypatch.setattr('time.sleep', cancel_on_sleep)
+
+    pause_harness.run(continue_condition_lib.ContinueCondition())
+
+    assert pause_harness.queue_items == []
 
 
 def test_resolve_blob_valid(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -837,6 +837,43 @@ def test_pause_base_condition_dropped_if_cancelled_during_wait(
     assert pause_harness.queue_items == []
 
 
+def test_pause_marks_executor_free_before_wait(pause_harness, monkeypatch):
+    """The freed worker process is accounted for before the pause wait runs.
+
+    The worker process is released the instant the future completes (it raised
+    ExecutionPausedError), so the free-executor gauge must be incremented
+    before the - potentially long-lived - pause wait, not after the request
+    reschedules. Otherwise the gauge under-reports idle executors for the whole
+    duration of the pause.
+
+    This snapshots the gauge's inc() count at the moment condition.wait() is
+    entered; on the old code (increment in a post-wait finally) it would be 0.
+    """
+    gauge = mock.Mock()
+    monkeypatch.setattr(executor.metrics_utils, 'METRICS_ENABLED', True)
+    monkeypatch.setattr(executor.metrics_utils, 'SKY_APISERVER_LONG_EXECUTORS',
+                        gauge)
+
+    inc_count_at_wait = []
+
+    class _GaugeWatchingCondition(continue_condition_lib.ContinueCondition):
+
+        def wait(self, *, is_cancelled, fallback_wait_seconds) -> bool:
+            del is_cancelled, fallback_wait_seconds
+            inc_count_at_wait.append(gauge.inc.call_count)
+            return True
+
+    request_element = pause_harness.run(_GaugeWatchingCondition(),
+                                        retry_wait_seconds=30)
+
+    # The slot was marked free (inc()'d) before the wait began ...
+    assert inc_count_at_wait == [1]
+    # ... and exactly once overall: no lingering post-wait finally double-counts.
+    assert gauge.inc.call_count == 1
+    # Sanity: the request still rescheduled as before.
+    assert pause_harness.queue_items == [request_element]
+
+
 def test_resolve_blob_valid(tmp_path, monkeypatch):
     """Test that resolve_blob_dir returns the shared extraction dir."""
     blob_id = 'a' * 64

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -756,7 +756,7 @@ def pause_harness(isolated_database, monkeypatch):
 class _RecordingCondition(continue_condition_lib.ContinueCondition):
     """A ContinueCondition whose wait() returns a fixed verdict.
 
-    Records the OSS-provided wait() arguments so tests can assert the executor
+    Records the wait() arguments so tests can assert the executor
     drives the condition's interface correctly.
     """
 
@@ -821,7 +821,7 @@ def test_pause_base_condition_dropped_if_cancelled_during_wait(
         pause_harness, monkeypatch):
     """The base condition drops the request if it is cancelled while waiting.
 
-    Also exercises the OSS-provided is_cancelled check, which the base wait()
+    Also exercises the is_cancelled check, which the base wait()
     consults after the fallback sleep.
     """
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

External resources may require the provision process to wait. Supporting the provision process to yield the process executor and wait to improve provision concurrency.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
