### PR TITLE
[Helm] History dashboard: add average reference lines to allocation/utilization chart

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -256,6 +256,80 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg GPU Allocation"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    0,
+                    10
+                  ],
+                  "fill": "dot"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg GPU Utilization"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    0,
+                    10
+                  ],
+                  "fill": "dot"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
           }
         ]
       },
@@ -306,6 +380,30 @@
           "legendFormat": "GPU Utilization",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time((sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100)[$__range:$__interval] @ end())",
+          "instant": false,
+          "legendFormat": "Avg GPU Allocation",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time((avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"}))[$__range:$__interval] @ end())",
+          "instant": false,
+          "legendFormat": "Avg GPU Utilization",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Allocation & Utilization Over Time",
@@ -504,5 +602,5 @@
   "timezone": "",
   "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
-  "version": 1
+  "version": 4
 }


### PR DESCRIPTION
## What

Add two dashed average-reference lines to the **"Allocation & Utilization Over Time"** panel of the SkyPilot History (compute-overview) Grafana dashboard:

- **Avg GPU Allocation** — average GPU allocation over the selected time range (amber, dotted)
- **Avg GPU Utilization** — average GPU utilization over the selected time range (green, dotted)

The lines update dynamically as the time-range picker changes, giving operators a quick visual reference for typical usage without mentally averaging the chart.

## How

Each average reuses the existing series expression wrapped in:

```
avg_over_time((<series expr>)[$__range:$__interval] @ end())
```

The `@ end()` modifier pins the lookback window to `[to - $__range, to]` — i.e. exactly the visible range — so the value is constant across the panel (a true flat line) and matches the per-series Mean already shown in the legend. Reusing the existing expressions verbatim (including the allocation numerator's `node!=""` guard) keeps the reference line consistent with the plotted series rather than re-deriving a separate aggregation.

Styling:
- Average lines reuse each series' color (allocation amber, utilization green), rendered dotted with no area fill.
- The average series are hidden from the legend (they're self-evident reference lines), so the legend keeps showing the two base series with a single Mean value each — no duplicated Mean entries.

## Notes

- Dashboard-only change (`charts/skypilot/manifests/compute-overview-dashboard.json`); ships via the Grafana dashboard ConfigMap, no image rebuild required.
- PromQL validated against a live Prometheus 3.4.1: both new queries parse and return a flat constant equal to the corresponding series mean.
