### PR TITLE
[Helm] History dashboard: cap GPU allocation at per-node capacity (fix >100%)

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -602,5 +602,5 @@
   "timezone": "",
   "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
-  "version": 6
+  "version": 5
 }

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - clamp_min((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - (max by (cluster, node)(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})), 0)) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -602,5 +602,5 @@
   "timezone": "",
   "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
-  "version": 5
+  "version": 6
 }

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -363,7 +363,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - clamp_min((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - (max by (cluster, node)(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})), 0)) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "GPU Allocation",
           "range": true,
@@ -387,7 +387,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg_over_time((sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100)[$__range:$__interval] @ end())",
+          "expr": "avg_over_time((sum((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - clamp_min((sum by (cluster, node) (max by (cluster, namespace, pod, container, node)(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"}))) - (max by (cluster, node)(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})), 0)) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100)[$__range:$__interval] @ end())",
           "instant": false,
           "legendFormat": "Avg GPU Allocation",
           "range": true,
@@ -602,5 +602,5 @@
   "timezone": "",
   "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
## Problem

The **"Allocation & Utilization Over Time"** panel in the SkyPilot History (compute-overview) dashboard can report GPU allocation **above 100%** (observed values up to ~178%). Allocation as a fraction of GPU capacity should always be in `[0%, 100%]`.

The panel computed:

```
sum(requests) / sum(allocatable) * 100
```

This overshoots in two independent situations:

1. **Per-node double-count** — a single node can momentarily carry GPU requests beyond its own capacity, e.g. when a terminating pod and its replacement are both counted on the same node.
2. **Node-set mismatch** — when a node drops out of `kube_node_status_allocatable`, its pods' requests still inflate the numerator while the denominator shrinks, so the ratio exceeds 100%.

## Fix

Cap each node's counted requests at that node's allocatable before summing:

```
sum( min(requests_per_node, allocatable_per_node) ) / sum(allocatable) * 100
```

expressed in PromQL as `req - clamp_min(req - alloc, 0)` matched per `(cluster, node)`. Because the per-node `min` join only retains nodes present in **both** the request and allocatable sets, the numerator and denominator are evaluated over the same node set and each node contributes at most its capacity — so the result is bounded to `[0, 100]` **by construction**.

The "Avg GPU Allocation" reference line reuses the same expression, so it stays consistent with the corrected series and is likewise bounded.

## Verification

Validated against live data over a 7-day range at 10-minute resolution:

| | min | max | points outside [0,100] |
|---|---|---|---|
| previous query | 0.39% | **178%** | many |
| this PR (per-node cap) | 0.39% | **100.00%** | **0** |

## Notes

- Dashboard-only change (`charts/skypilot/manifests/compute-overview-dashboard.json`); ships via the Grafana ConfigMap, no image rebuild required, and applies retroactively since the panel recomputes from raw metrics at query time.
- Utilization series are unaffected.
