### PR TITLE
[Dashboard] Update infra page to show storage-only clouds when no others exist

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2017,7 +2017,6 @@ export function GPUs() {
   const [perNodeSlurmGPUs, setPerNodeSlurmGPUs] = useState([]);
   const [cloudInfraData, setCloudInfraData] = useState([]);
   const [totalClouds, setTotalClouds] = useState(0);
-  const [enabledClouds, setEnabledClouds] = useState(0);
   // Separate cluster/job counts for Cloud panel (for progressive loading)
   const [cloudClusterCounts, setCloudClusterCounts] = useState({});
   const [cloudJobCounts, setCloudJobCounts] = useState({});
@@ -2126,7 +2125,6 @@ export function GPUs() {
         setClusterDataLoading(false);
         setCloudInfraData([]);
         setTotalClouds(0);
-        setEnabledClouds(0);
         setCloudClusterCounts({});
         setCloudJobCounts({});
         setCloudDataLoaded(true);
@@ -2398,13 +2396,11 @@ export function GPUs() {
       if (cloudData) {
         setCloudInfraData(cloudData.clouds || []);
         setTotalClouds(cloudData.totalClouds || 0);
-        setEnabledClouds(cloudData.enabledClouds || 0);
         setCloudDataLoaded(true);
       } else if (cloudData === null) {
         // Data was explicitly null (not just missing)
         setCloudInfraData([]);
         setTotalClouds(0);
-        setEnabledClouds(0);
         setCloudDataLoaded(true);
       }
       // Clear loading state as soon as Cloud list is ready
@@ -2413,7 +2409,6 @@ export function GPUs() {
       console.error('Error in fetchCloudData:', error);
       setCloudInfraData([]);
       setTotalClouds(0);
-      setEnabledClouds(0);
       setCloudDataLoaded(true);
       setCloudLoading(false);
     }
@@ -2851,12 +2846,18 @@ export function GPUs() {
   // Check if all infrastructure is disabled
   const allInfrastructureDisabled = (() => {
     // Ensure all data has been loaded
-    if (!cloudDataLoaded || !kubeDataLoaded || kubeLoading || cloudLoading) {
+    if (
+      !cloudDataLoaded ||
+      !kubeDataLoaded ||
+      kubeLoading ||
+      cloudLoading ||
+      pluginInfraLoading
+    ) {
       return false; // Still loading, don't show hint
     }
 
     // Check all infrastructure types
-    const noCloud = enabledClouds === 0;
+    const noCloud = filteredEnabledCloudsCount === 0;
     const noSSH = sshContexts.length === 0;
     const noKubernetes = kubeContexts.length === 0;
     const noSlurm = slurmClusters.length === 0;
@@ -3276,8 +3277,9 @@ export function GPUs() {
       });
 
       // Add Cloud section (always show)
-      // Cloud section is active if there are any enabled clouds
-      const cloudHasActivity = enabledClouds > 0;
+      // Cloud section is active if there are any enabled clouds or
+      // storage-only cloud rows.
+      const cloudHasActivity = filteredEnabledCloudsCount > 0;
       sections.push({
         name: 'Cloud',
         render: renderCloudInfrastructure,

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2849,8 +2849,10 @@ export function GPUs() {
     if (
       !cloudDataLoaded ||
       !kubeDataLoaded ||
+      !slurmDataLoaded ||
       kubeLoading ||
       cloudLoading ||
+      slurmLoading ||
       pluginInfraLoading
     ) {
       return false; // Still loading, don't show hint


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Use filteredEnabledCloudsCount (include extra storage-only clouds) instead of enabledClouds for infra page view.

Also add missing slurm guard for ux flicker (extra - caught in gemini review)


<!-- Describe the tests ran -->

With nothing connected -> page still shows up empty
With storage only connection -> page shows with connection up top


<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


Note on testing:

Frontend-only dashboard change (sky/dashboard/src/components/infra.jsx).
- Verified manually via the local dev stack (see Tested section).
- Smoke / individual / backward-compat suites are N/A: they exercise the
  Python/CLI/cluster-launch paths, not the Next.js dashboard render logic,
  and this change has no API or protocol impact.

Tested (run the relevant ones):



- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
