### PR TITLE
[Dashboard] Infra page: await sky check before reading enabled clouds on manual refresh

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2082,19 +2082,26 @@ export function GPUs() {
       }
 
       try {
-        // Run sky check in parallel with data fetches (not blocking)
-        // Sky check refreshes cloud credentials but shouldn't delay data display
-        const skyCheckPromise = forceRefresh
-          ? runSkyCheck().catch((error) => {
-              console.error('Error during sky check refresh:', error);
-            })
-          : Promise.resolve();
+        // On a manual refresh (forceRefresh), run sky check and wait for it to
+        // finish *before* fetching the data. sky check (POST /check) is the only
+        // thing that refreshes the cached per-workspace enabled_clouds verdict,
+        // and the data fetches below read that cache. If the check runs
+        // concurrently with the fetches (as it used to), the fetches return the
+        // pre-check cache and the freshly-checked results only appear on the
+        // next poll/refresh, so a single Refresh click looks like it did nothing
+        // after a credential / allowed_contexts change. Awaiting the check first
+        // makes the manual refresh slower but correct. The periodic
+        // auto-refresh (!forceRefresh) never runs a check and just reads the cache.
+        if (forceRefresh) {
+          await runSkyCheck().catch((error) => {
+            console.error('Error during sky check refresh:', error);
+          });
+        }
 
-        // Fetch all data in parallel (including sky check)
+        // Fetch all data in parallel.
         // SSH Node Pools are fetched independently - they don't depend on Kubernetes data.
         // The SSH GPU info comes from getWorkspaceInfrastructure() which handles both K8s and SSH contexts.
         await Promise.all([
-          skyCheckPromise,
           fetchKubernetesData(forceRefresh, showLoadingIndicators),
           fetchSSHNodePools(forceRefresh),
           fetchCloudData(forceRefresh),


### PR DESCRIPTION
## Problem

Clicking **Refresh** on the Infra page is meant to re-detect infrastructure. It triggers `runSkyCheck()` (`POST /check`), which is the only thing that refreshes the cached per-workspace `enabled_clouds` verdict. The data fetches on the same refresh (`enabled_clouds` / Kubernetes contexts) **read** that cache.

The problem is that `runSkyCheck()` and the data fetches ran in the **same `Promise.all`**, i.e. concurrently:

```js
const skyCheckPromise = forceRefresh ? runSkyCheck().catch(...) : Promise.resolve();
await Promise.all([
  skyCheckPromise,
  fetchKubernetesData(forceRefresh, ...),   // reads cached enabled_clouds
  ...
]);
```

Since `/check` only updates the cache *after* it completes, the fetches return the **pre-check** cache, and the freshly-checked results only appear on the **next** poll/refresh. After a credential or `allowed_contexts` change, a single Refresh click looks like it did nothing — the user has to refresh again (or wait for the periodic poll) to see the updated infra. The race widens when checking remote contexts adds latency. (Only the manual Refresh sets `forceRefresh=true`; the periodic auto-refresh never runs a check.)

## Fix

On a manual refresh (`forceRefresh`), **await `runSkyCheck()` before** kicking off the data fetches, so the refresh reflects the check it just triggered. The periodic auto-refresh path is unchanged (it never ran a check and just reads the cache).

Trade-off: a manual refresh is now slower because it waits for the check to finish, but it is correct. The existing top-right fetch spinner already covers the check duration, so the in-flight state is still indicated.

## Test plan

Verified end-to-end against a real local API server (`sky api start`) and the built dashboard, driving the page with a real browser (Playwright) — nothing mocked. Kubernetes was enabled on the server; the cached `enabled_clouds` verdict was emptied to simulate the post-credential-change stale state, and a slow/unreachable context was added so `sky check` takes long enough to expose the ordering (mirrors the remote-context latency case).

Observed the network ordering of `POST /check` vs the `GET /enabled_clouds` reads on a single Refresh click:

- **Before:** the `enabled_clouds` reads are dispatched at the same instant as `/check`, before it completes (race) — and with a slow check, after a full refresh the Infra page still shows the stale/empty set (Kubernetes not shown).
- **After:** the `enabled_clouds` reads are dispatched only **after** `/check` completes, and a single Refresh surfaces the freshly-detected Kubernetes context.

Also confirmed `prettier` formatting passes on the changed file.

-Claude