### PR TITLE
[Examples] Job Groups: disaggregated RL training (GRPO) with NCCL weight sync

### DIFF
--- a/examples/job-group-sdk/README.md
+++ b/examples/job-group-sdk/README.md
@@ -14,6 +14,10 @@ This example shows how to create and launch [Job Groups](https://docs.skypilot.c
 | `job_group_sdk.py` | Builds and launches a server-client Job Group in Python |
 | `job_group_primary_aux_sdk.py` | Demonstrates primary/auxiliary task lifecycle |
 | `job_group.yaml` | Equivalent YAML for reference |
+| `job_group_nccl.yaml` | Optional: disaggregated RL training (GRPO) — trainer/actor/reward as separate tasks, NCCL weight sync (needs GPUs) |
+| `trainer.py` | RL driver: owns prompts, runs GRPO updates, pushes weights to the actor over NCCL |
+| `rollout_server.py` | Actor: GPU inference server; generates completions, receives weights over NCCL |
+| `reward_server.py` | Reward: CPU verifier that scores completions |
 
 ## Usage
 
@@ -42,6 +46,68 @@ This example shows how to designate a primary task (trainer) and an auxiliary ta
 ```bash
 python examples/job-group-sdk/job_group_primary_aux_sdk.py
 ```
+
+### Disaggregated RL training with NCCL weight sync (optional)
+
+`job_group_nccl.yaml` runs a small but real reinforcement-learning loop —
+**GRPO** (Group Relative Policy Optimization, the algorithm behind DeepSeek-R1
+and modern RL-for-LLM stacks) — split into three **different** components, each
+its own Job Group task (not one program replicated across nodes). This mirrors
+how production RL stacks disaggregate generation, reward, and training so each
+scales and fails independently:
+
+| Task | Role |
+|------|------|
+| `trainer` (GPU) | Owns the prompt distribution, drives the loop, holds the trainable policy + optimizer, pushes weights to the actor |
+| `actor` (GPU) | Inference server: generates completion groups on request; receives weight updates |
+| `reward` (CPU) | Verifier: scores completions (no GPU, standard library only) |
+
+Two communication planes, each on the channel that fits it:
+
+- **Data plane** (prompts → completions → rewards): plain HTTP over Job Group
+  service discovery — the trainer calls `actor-0.${SKYPILOT_JOBGROUP_NAME}` and
+  `reward-0.${SKYPILOT_JOBGROUP_NAME}`.
+- **Weight sync** (trainer → actor): a `torch.distributed` (NCCL) broadcast over
+  a 2-rank process group (trainer = rank 0 + rendezvous host at
+  `trainer-0.${SKYPILOT_JOBGROUP_NAME}`, actor = rank 1). Pushing fresh weights
+  to inference workers over a collective — rather than via disk — is exactly how
+  stacks like SGLang/vLLM + a training engine keep rollouts on-policy. This is
+  the collective that `network_tier: best` accelerates.
+
+```bash
+sky jobs launch examples/job-group-sdk/job_group_nccl.yaml
+```
+
+Each step: the trainer samples prompts → asks the actor to generate a group of
+completions per prompt → asks the reward server to score them → standardizes
+rewards within each group (GRPO advantages) → runs a policy-gradient update on
+its local policy → **broadcasts the new weights to the actor over NCCL** so the
+next rollouts are on-policy. The trainer logs the mean reward, which climbs as
+the policy learns:
+
+```console
+(trainer, ...) [trainer] components up; model=Qwen/Qwen2.5-0.5B-Instruct group=8 prompts/step=4 steps=40
+(actor, ...)   [actor] NCCL joined as rank 1; serving generate on :8000
+(reward, ...)  [reward] serving on :8001
+(trainer, ...) [step   1/40] mean_reward=0.214 loss=-0.0031
+(trainer, ...) [step  20/40] mean_reward=0.638 loss=-0.0204
+(trainer, ...) [step  40/40] mean_reward=0.961 loss=-0.0117
+(trainer, ...) [done] training complete
+```
+
+The example is self-contained — only `torch` + `transformers` on the GPU tasks,
+and the standard library on the CPU reward task; no external inference server,
+dataset, or RL framework.
+
+`primary_tasks: [trainer]` makes the run finish when training completes; the
+long-running `actor` and `reward` servers are then terminated after a short
+grace period. The GPU tasks set `network_tier: best`, so the NCCL weight-sync
+collective uses the cluster's high-performance fabric (RDMA / InfiniBand / EFA)
+when available — auto-detected per task, a no-op (TCP fallback) otherwise. No
+group-level network setting is required.
+
+Requires a Kubernetes cluster with NVIDIA GPUs. Scale the actor or trainer with
+more GPUs, or add more actor/reward replicas as separate tasks.
 
 ## Example output
 

--- a/examples/job-group-sdk/job_group_nccl.yaml
+++ b/examples/job-group-sdk/job_group_nccl.yaml
@@ -1,0 +1,81 @@
+# Job Group: disaggregated RL training with cross-task NCCL weight sync.
+#
+# A small but *real* reinforcement-learning loop (GRPO -- the algorithm behind
+# DeepSeek-R1 and modern RL-for-LLM stacks) split into three *different*
+# components, each its own Job Group task -- not one program replicated across
+# nodes. This mirrors how production RL stacks disaggregate generation, reward,
+# and training so each scales and fails independently:
+#
+#   - trainer (GPU): owns the prompt distribution, drives the loop, holds the
+#     trainable policy + optimizer, and pushes updated weights to the actor.
+#   - actor   (GPU): inference server; generates completion groups on request
+#     and receives weight updates from the trainer.
+#   - reward  (CPU): verifier; scores completions. No GPU, no ML libraries.
+#
+# Two communication planes, each on the channel that fits it:
+#   - Data plane (prompts -> completions -> rewards): plain HTTP over Job Group
+#     service discovery (`actor-0.${SKYPILOT_JOBGROUP_NAME}`, `reward-0...`).
+#   - Weight sync (trainer -> actor): a torch.distributed (NCCL) broadcast over
+#     a 2-rank process group (trainer = rank 0 + rendezvous host, actor =
+#     rank 1). The trainer is reachable at `trainer-0.${SKYPILOT_JOBGROUP_NAME}`.
+#
+# The GPU tasks set `network_tier: best`, so the NCCL weight-sync collective
+# uses the cluster's high-performance fabric (RDMA/InfiniBand/EFA) when
+# available -- auto-detected per task, a no-op (TCP) otherwise. No group-level
+# network setting is needed.
+#
+# `primary_tasks: [trainer]` makes the run finish when training completes; the
+# long-running actor and reward servers are then terminated after a short grace
+# period.
+#
+# Requires a Kubernetes cluster with NVIDIA GPUs (Job Group service discovery
+# requires Kubernetes).
+#
+# Usage:
+#   sky jobs launch examples/job-group-sdk/job_group_nccl.yaml
+
+---
+name: disagg-rl
+execution: parallel
+primary_tasks: [trainer]
+termination_delay: 30s
+
+---
+name: trainer
+resources:
+  accelerators: A100:1
+  infra: kubernetes
+  # NCCL weight-sync collective uses the high-performance fabric when present.
+  network_tier: best
+file_mounts:
+  /tmp/trainer.py: ./examples/job-group-sdk/trainer.py
+envs:
+  STEPS: "40"
+setup: |
+  pip install torch transformers
+run: |
+  python /tmp/trainer.py
+
+---
+name: actor
+resources:
+  accelerators: A100:1
+  infra: kubernetes
+  # NCCL weight-sync collective uses the high-performance fabric when present.
+  network_tier: best
+file_mounts:
+  /tmp/rollout_server.py: ./examples/job-group-sdk/rollout_server.py
+setup: |
+  pip install torch transformers
+run: |
+  python /tmp/rollout_server.py
+
+---
+name: reward
+resources:
+  cpus: 2
+  infra: kubernetes
+file_mounts:
+  /tmp/reward_server.py: ./examples/job-group-sdk/reward_server.py
+run: |
+  python /tmp/reward_server.py

--- a/examples/job-group-sdk/reward_server.py
+++ b/examples/job-group-sdk/reward_server.py
@@ -1,0 +1,69 @@
+"""Reward (verifier) component of the disaggregated RL Job Group.
+
+A standalone CPU service that scores completions. It runs as its own Job Group
+task -- it needs no GPU and no ML libraries, only the standard library -- which
+is the point of disaggregation: the verifier scales and fails independently of
+the GPU actor and trainer.
+
+Protocol (HTTP/JSON):
+  POST /score  {"items": [{"text": str, "a": int, "b": int}, ...]}
+               -> {"rewards": [float, ...]}
+  POST /ping   {} -> {"ok": true}
+
+The reward is verifiable: a small bonus for emitting a well-formed
+'#### <int>' answer, plus a larger bonus when that integer equals a + b.
+"""
+
+import json
+import os
+import re
+from http.server import BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer
+
+PORT = int(os.environ.get("REWARD_PORT", "8001"))
+_ANSWER = re.compile(r"####\s*(-?\d+)")
+
+
+def score(text, a, b):
+    match = _ANSWER.search(text)
+    if match is None:
+        return 0.0
+    reward = 0.1  # well-formed answer
+    if int(match.group(1)) == a + b:
+        reward += 1.0  # and correct
+    return reward
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    def _send(self, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        if self.path == "/ping":
+            self._send({"ok": True})
+        elif self.path == "/score":
+            rewards = [score(it["text"], it["a"], it["b"])
+                       for it in payload["items"]]
+            self._send({"rewards": rewards})
+        else:
+            self.send_error(404)
+
+    def log_message(self, *args):  # quiet the default access log
+        pass
+
+
+def main():
+    print(f"[reward] serving on :{PORT}", flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/job-group-sdk/rollout_server.py
+++ b/examples/job-group-sdk/rollout_server.py
@@ -1,0 +1,132 @@
+"""Actor (rollout) component of the disaggregated RL Job Group.
+
+A standalone GPU inference server that generates completion groups on request,
+and -- crucially -- receives updated policy weights from the trainer **over
+NCCL**. This mirrors how production RL stacks (e.g. SGLang/vLLM + a training
+engine) disaggregate generation from training and push fresh weights to the
+inference workers via a collective rather than through disk.
+
+This task is rank 1 of a 2-rank torch.distributed (NCCL) process group; the
+trainer is rank 0 and the rendezvous master. The group is used only for
+trainer -> actor weight broadcast.
+
+Protocol (HTTP/JSON), served concurrently with the NCCL group:
+  POST /generate {"prompt": str, "n": int, "max_new_tokens": int,
+                  "temperature": float}
+                 -> {"prompt_ids": [int],
+                     "completions": [{"ids": [int], "text": str}, ...]}
+  POST /sync     {} -> {"ok": true}   # enter NCCL receive; load broadcast weights
+  POST /ping     {} -> {"ok": true}
+
+A lock serializes generation and weight-sync so the model is never read while
+its parameters are being overwritten.
+"""
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer
+
+import torch
+import torch.distributed as dist
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+MODEL = os.environ.get("MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+PORT = int(os.environ.get("ACTOR_PORT", "8000"))
+JOBGROUP = os.environ["SKYPILOT_JOBGROUP_NAME"]
+MASTER_ADDR = f"trainer-0.{JOBGROUP}"
+MASTER_PORT = os.environ.get("NCCL_RENDEZVOUS_PORT", "29500")
+
+_model = None
+_tokenizer = None
+_device = None
+_lock = threading.Lock()
+
+
+def _generate(prompt, n, max_new_tokens, temperature):
+    torch.cuda.set_device(0)  # CUDA current device is per-thread
+    enc = _tokenizer(prompt, return_tensors="pt").to(_device)
+    prompt_len = enc.input_ids.shape[1]
+    with _lock, torch.no_grad():
+        seqs = _model.generate(
+            **enc,
+            do_sample=True,
+            temperature=temperature,
+            top_p=1.0,
+            num_return_sequences=n,
+            max_new_tokens=max_new_tokens,
+            pad_token_id=_tokenizer.pad_token_id,
+        )
+    completions = []
+    for row in seqs:
+        comp_ids = row[prompt_len:].tolist()
+        text = _tokenizer.decode(comp_ids, skip_special_tokens=True)
+        completions.append({"ids": comp_ids, "text": text})
+    return {"prompt_ids": enc.input_ids[0].tolist(), "completions": completions}
+
+
+def _receive_weights():
+    """Match the trainer's per-parameter broadcast and overwrite the policy."""
+    torch.cuda.set_device(0)  # CUDA current device is per-thread
+    with _lock:
+        for param in _model.parameters():
+            dist.broadcast(param.data, src=0)
+    torch.cuda.synchronize()
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    def _send(self, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        if self.path == "/ping":
+            self._send({"ok": True})
+        elif self.path == "/generate":
+            self._send(_generate(payload["prompt"],
+                                 int(payload.get("n", 8)),
+                                 int(payload.get("max_new_tokens", 32)),
+                                 float(payload.get("temperature", 1.0))))
+        elif self.path == "/sync":
+            _receive_weights()
+            self._send({"ok": True})
+        else:
+            self.send_error(404)
+
+    def log_message(self, *args):
+        pass
+
+
+def main():
+    global _model, _tokenizer, _device
+    # Join the trainer's NCCL group as rank 1 (weight-sync channel).
+    torch.cuda.set_device(0)
+    _device = torch.device("cuda", 0)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://{MASTER_ADDR}:{MASTER_PORT}",
+        world_size=2,
+        rank=1,
+    )
+    _tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    if _tokenizer.pad_token_id is None:
+        _tokenizer.pad_token = _tokenizer.eos_token
+    _model = AutoModelForCausalLM.from_pretrained(MODEL, torch_dtype=torch.bfloat16)
+    _model.to(_device)
+    _model.eval()
+    print(f"[actor] NCCL joined as rank 1; serving generate on :{PORT}",
+          flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/job-group-sdk/trainer.py
+++ b/examples/job-group-sdk/trainer.py
@@ -1,0 +1,198 @@
+"""Trainer component of the disaggregated RL Job Group.
+
+This is the driver of a small but *real* RL loop -- GRPO (Group Relative Policy
+Optimization, the algorithm behind DeepSeek-R1 and modern RL-for-LLM stacks).
+Unlike data-parallel training where the same program runs on every node, here
+each Job Group task is a *different* component:
+
+  - trainer        (this file): owns the prompt distribution, drives the loop,
+                    holds the trainable policy + optimizer, and pushes updated
+                    weights to the actor over NCCL.
+  - actor          (rollout_server.py): GPU inference server that generates
+                    completions and receives weight updates over NCCL.
+  - reward         (reward_server.py): CPU verifier that scores completions.
+
+Two communication planes, each on the channel that fits it:
+  - Data plane (prompts -> completions -> rewards): plain HTTP over Job Group
+    service discovery (`actor-0.${SKYPILOT_JOBGROUP_NAME}`, `reward-0...`).
+  - Weight sync (trainer -> actor): a torch.distributed (NCCL) broadcast. The
+    trainer is rank 0 / rendezvous master, the actor is rank 1. This collective
+    is what `network_tier: best` accelerates.
+
+Each step: sample prompts -> ask the actor to generate a group of completions
+per prompt -> ask the reward server to score them -> standardize rewards within
+each group (GRPO advantages) -> policy-gradient update on the local policy ->
+broadcast the new weights to the actor so its next rollouts are on-policy.
+
+Env knobs (all optional): MODEL, STEPS, GROUP_SIZE, PROMPTS_PER_STEP,
+MAX_NEW_TOKENS, MAX_INT, LR.
+"""
+
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+MODEL = os.environ.get("MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+STEPS = int(os.environ.get("STEPS", "40"))
+GROUP_SIZE = int(os.environ.get("GROUP_SIZE", "8"))
+PROMPTS_PER_STEP = int(os.environ.get("PROMPTS_PER_STEP", "4"))
+MAX_NEW_TOKENS = int(os.environ.get("MAX_NEW_TOKENS", "32"))
+MAX_INT = int(os.environ.get("MAX_INT", "9"))
+LR = float(os.environ.get("LR", "1e-5"))
+
+JOBGROUP = os.environ["SKYPILOT_JOBGROUP_NAME"]
+ACTOR = f"http://actor-0.{JOBGROUP}:{os.environ.get('ACTOR_PORT', '8000')}"
+REWARD = f"http://reward-0.{JOBGROUP}:{os.environ.get('REWARD_PORT', '8001')}"
+MASTER_PORT = os.environ.get("NCCL_RENDEZVOUS_PORT", "29500")
+
+
+def post_json(url, payload, retries=120, backoff=2.0, timeout=600):
+    data = json.dumps(payload).encode()
+    last = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(
+                url, data=data, method="POST",
+                headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode())
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last = exc
+            time.sleep(backoff)  # service may still be starting up
+    raise RuntimeError(f"POST {url} failed after {retries} attempts: {last}")
+
+
+def build_prompt(tokenizer, a, b):
+    messages = [{
+        "role": "user",
+        "content": (f"What is {a} + {b}? Think briefly, then give the final "
+                    f"integer answer on its own line after '####'."),
+    }]
+    return tokenizer.apply_chat_template(messages,
+                                         tokenize=False,
+                                         add_generation_prompt=True)
+
+
+def sync_weights_to_actor(model):
+    """Broadcast every parameter to the actor (rank 1) over NCCL.
+
+    The actor's /sync handler enters a matching receive loop. We fire the HTTP
+    trigger from a background thread and broadcast from this thread so the two
+    ranks rendezvous instead of deadlocking on each other.
+    """
+    kicker = threading.Thread(target=post_json, args=(f"{ACTOR}/sync", {}))
+    kicker.start()
+    for param in model.parameters():
+        dist.broadcast(param.data, src=0)
+    torch.cuda.synchronize()
+    kicker.join()
+
+
+def main():
+    torch.manual_seed(0)
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+
+    # Rank 0 / rendezvous master of the trainer<->actor NCCL group.
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://0.0.0.0:{MASTER_PORT}",
+        world_size=2,
+        rank=0,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    pad_id = tokenizer.pad_token_id
+    model = AutoModelForCausalLM.from_pretrained(MODEL, torch_dtype=torch.bfloat16)
+    model.to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=LR)
+
+    post_json(f"{REWARD}/ping", {})
+    print(f"[trainer] components up; model={MODEL} group={GROUP_SIZE} "
+          f"prompts/step={PROMPTS_PER_STEP} steps={STEPS}", flush=True)
+
+    for step in range(STEPS):
+        groups = []  # (sequences[list[list[int]]], prompt_len, advantages)
+        step_reward = 0.0
+        num_completions = 0
+
+        for _ in range(PROMPTS_PER_STEP):
+            a = int(torch.randint(0, MAX_INT + 1, (1,)).item())
+            b = int(torch.randint(0, MAX_INT + 1, (1,)).item())
+            prompt = build_prompt(tokenizer, a, b)
+
+            # Rollout: actor generates the completion group (different component).
+            gen = post_json(f"{ACTOR}/generate", {
+                "prompt": prompt, "n": GROUP_SIZE,
+                "max_new_tokens": MAX_NEW_TOKENS, "temperature": 1.0})
+            prompt_ids = gen["prompt_ids"]
+            comps = gen["completions"]
+
+            # Reward: verifier scores the completions (different component).
+            scored = post_json(f"{REWARD}/score", {
+                "items": [{"text": c["text"], "a": a, "b": b} for c in comps]})
+            rewards = torch.tensor(scored["rewards"], device=device,
+                                   dtype=torch.float32)
+            step_reward += float(rewards.sum().item())
+            num_completions += rewards.numel()
+
+            advantages = (rewards - rewards.mean()) / (rewards.std() + 1e-4)
+            seqs = [prompt_ids + c["ids"] for c in comps]
+            groups.append((seqs, len(prompt_ids), advantages))
+
+        # Policy update: recompute completion log-probs on the local policy
+        # (on-policy: the actor generated with the same weights), one forward +
+        # one backward.
+        max_len = max(len(s) for seqs, _, _ in groups for s in seqs)
+        rows, adv_rows, prompt_lens = [], [], []
+        for seqs, prompt_len, advantages in groups:
+            for s in seqs:
+                rows.append(s + [pad_id] * (max_len - len(s)))
+            adv_rows.append(advantages)
+            prompt_lens.extend([prompt_len] * len(seqs))
+        batch = torch.tensor(rows, device=device)             # [N, max_len]
+        adv = torch.cat(adv_rows, dim=0)                      # [N]
+        plens = torch.tensor(prompt_lens, device=device)      # [N]
+
+        attn = (batch != pad_id).long()
+        logits = model(input_ids=batch, attention_mask=attn).logits[:, :-1, :]
+        labels = batch[:, 1:]
+        logp = F.log_softmax(logits.float(), dim=-1).gather(
+            -1, labels.unsqueeze(-1)).squeeze(-1)             # [N, max_len-1]
+
+        pos = torch.arange(batch.shape[1] - 1, device=device).unsqueeze(0)
+        comp_mask = (pos >= (plens.unsqueeze(1) - 1)).float()
+        comp_mask = comp_mask * (labels != pad_id).float()
+        seq_logp = (logp * comp_mask).sum(dim=-1)             # [N]
+
+        loss = -(adv * seq_logp).mean()
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+
+        # Push fresh weights to the actor over NCCL so its next rollouts are
+        # on-policy.
+        sync_weights_to_actor(model)
+
+        mean_reward = step_reward / num_completions
+        print(f"[step {step + 1:>3}/{STEPS}] mean_reward={mean_reward:.3f} "
+              f"loss={loss.item():+.4f}", flush=True)
+
+    print("[done] training complete", flush=True)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an optional Job Group example that runs a small but **real**
reinforcement-learning loop (**GRPO** — the algorithm behind DeepSeek-R1 and
modern RL-for-LLM stacks) split into three **different** components, each its own
Job Group task — not one program replicated across nodes. This mirrors how
production RL stacks disaggregate generation, reward, and training so each scales
and fails independently:

| Task | Role |
|------|------|
| `trainer` (GPU) | Owns the prompt distribution, drives the loop, holds the trainable policy + optimizer, pushes weights to the actor |
| `actor` (GPU) | Inference server: generates completion groups on request; receives weight updates |
| `reward` (CPU) | Verifier: scores completions (no GPU, standard library only) |

Two communication planes, each on the channel that fits it:

- **Data plane** (prompts → completions → rewards): plain HTTP over Job Group
  service discovery (`actor-0.${SKYPILOT_JOBGROUP_NAME}`, `reward-0...`).
- **Weight sync** (trainer → actor): a `torch.distributed` (NCCL) broadcast over
  a 2-rank process group (trainer = rank 0 + rendezvous host, actor = rank 1).
  Pushing fresh weights to inference workers over a collective rather than via
  disk is exactly how stacks like SGLang/vLLM + a training engine keep rollouts
  on-policy. This is the collective `network_tier: best` accelerates.

`primary_tasks: [trainer]` makes the run finish when training completes; the
long-running `actor` and `reward` servers are then terminated after a grace
period. The GPU tasks set `network_tier: best` so the NCCL collective uses the
cluster's high-performance fabric (RDMA / InfiniBand / EFA) when available —
auto-detected per task, a no-op (TCP fallback) otherwise.

## What's included

- `examples/job-group-sdk/trainer.py` — RL driver: owns prompts, calls the actor
  and reward server over HTTP, computes GRPO advantages + a policy-gradient
  update on the local policy, and broadcasts updated weights to the actor over
  NCCL each step (one forward/backward per step).
- `examples/job-group-sdk/rollout_server.py` — actor: GPU inference server
  (`/generate`) that also joins the NCCL group as rank 1 and overwrites its
  weights on `/sync` via a matching broadcast.
- `examples/job-group-sdk/reward_server.py` — CPU verifier (`/score`), standard
  library only.
- `examples/job-group-sdk/job_group_nccl.yaml` — the three heterogeneous tasks
  wired together with service discovery, `network_tier: best` on the GPU tasks,
  and `primary_tasks`/`termination_delay` for teardown.
- README section documenting the architecture and expected output (mean reward
  climbing as the policy learns).

Self-contained: only `torch` + `transformers` on the GPU tasks, standard library
on the reward task. No external inference server, dataset, or RL framework.

## Test plan

- `python -m py_compile` on all three component scripts ✅
- YAML validated (4 docs; `primary_tasks: [trainer]`, `network_tier: best` on
  trainer + actor) ✅
- Completion-token masking logic unit-verified ✅
- Run on a Kubernetes GPU cluster: `sky jobs launch examples/job-group-sdk/job_group_nccl.yaml`