### PR TITLE
[API] remove deprecated orjson response in fastapi routes

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -33,7 +33,6 @@ import zlib
 import aiofiles
 import anyio
 import fastapi
-from fastapi import responses as fastapi_responses
 from fastapi.middleware import cors
 import jwt as pyjwt
 import starlette.background
@@ -2277,7 +2276,7 @@ async def get_expanded_request_id(request_id: str) -> str:
 
 
 # === API server related APIs ===
-@app.get('/api/get', response_class=fastapi_responses.ORJSONResponse)
+@app.get('/api/get')
 async def api_get(request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
     # Validate request_id prefix matches a single request.
@@ -2609,7 +2608,7 @@ async def api_status(
         return encoded_request_tasks
 
 
-@app.get('/dashboard_config', response_class=fastapi_responses.ORJSONResponse)
+@app.get('/dashboard_config')
 async def dashboard_config() -> Dict[str, Any]:
     """Returns admin-configured dashboard settings consumed by the UI.
 
@@ -2631,7 +2630,7 @@ async def dashboard_config() -> Dict[str, Any]:
     return {'external_links': sanitized}
 
 
-@app.get('/api/plugins', response_class=fastapi_responses.ORJSONResponse)
+@app.get('/api/plugins')
 async def list_plugins() -> Dict[str, List[Dict[str, Any]]]:
     """Return metadata about loaded backend plugins."""
     plugin_infos = []

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -789,3 +789,87 @@ async def test_serve_dashboard_client_route_falls_back_to_index(tmp_path):
         response = await server.serve_dashboard(request, full_path='clusters')
 
     assert response.status_code == 200
+
+
+def _api_get_dummy_entrypoint():
+    """Module-level entrypoint so Request.encode() can pickle it."""
+    pass
+
+
+def test_api_get_endpoint_serializes_request_payload(monkeypatch):
+    """/api/get returns a JSON-serialized RequestPayload over the wire.
+
+    Guards the response serialization path: after removing the deprecated
+    ORJSONResponse response_class, FastAPI must natively serialize the
+    returned Pydantic RequestPayload model into valid JSON.
+    """
+    from fastapi.testclient import TestClient
+
+    from sky.server.requests import payloads
+    from sky.server.requests import requests as requests_lib
+
+    created_at = 1234567890.0
+    request = requests_lib.Request(
+        request_id='test-req-123',
+        name='test-request',
+        entrypoint=_api_get_dummy_entrypoint,
+        request_body=payloads.RequestBody(),
+        status=requests_lib.RequestStatus.SUCCEEDED,
+        created_at=created_at,
+        user_id='user-123',
+    )
+
+    async def fake_expand(request_id):
+        return request_id
+
+    async def fake_status(request_id, include_msg=False):
+        return requests_lib.StatusWithMsg(
+            status=requests_lib.RequestStatus.SUCCEEDED)
+
+    async def fake_get_request(request_id):
+        return request
+
+    monkeypatch.setattr(server, 'get_expanded_request_id', fake_expand)
+    monkeypatch.setattr(requests_lib, 'get_request_status_async', fake_status)
+    monkeypatch.setattr(requests_lib, 'get_request_async', fake_get_request)
+
+    client = TestClient(server.app)
+    response = client.get('/api/get', params={'request_id': 'test-req-123'})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data['request_id'] == 'test-req-123'
+    assert data['name'] == 'test-request'
+    assert data['status'] == 'SUCCEEDED'
+    assert data['created_at'] == created_at
+    assert data['user_id'] == 'user-123'
+
+
+def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
+    """/dashboard_config returns JSON-serialized dashboard settings.
+
+    Guards the response serialization path after removing the deprecated
+    ORJSONResponse response_class: FastAPI must natively serialize the
+    returned dict into valid JSON.
+    """
+    from fastapi.testclient import TestClient
+
+    from sky import skypilot_config
+
+    monkeypatch.setattr(
+        skypilot_config, 'get_nested', lambda keys, default: [{
+            'label': 'Grafana',
+            'regex': 'https://grafana.example.com/.*'
+        }])
+
+    client = TestClient(server.app)
+    response = client.get('/dashboard_config')
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        'external_links': [{
+            'label': 'Grafana',
+            'regex': 'https://grafana.example.com/.*'
+        }]
+    }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Remove usage of deprecated fastapi orjson response in backend routes.

`FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class`


Added sanity serialization api unit tests for /get and /dashboard (plugin already has) + validated dashboard page loads with no errors.


<!-- Describe the tests ran -->

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
