### PR TITLE
[Jobs] Don't treat terminal jobs without submitted_at as recent in the time-range filter

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1504,9 +1504,10 @@ def build_managed_jobs_with_filters_no_status_query(
 
     submitted_after / submitted_before are epoch seconds (matching the
     ``submitted_at`` column) and restrict the result to jobs submitted within
-    the inclusive window. A still-pending job (NULL ``submitted_at``) is
-    treated as submitted now, so it is kept or dropped by the window the same
-    way a job submitted at the current moment would be.
+    the inclusive window. A still-active job that hasn't been submitted yet
+    (NULL ``submitted_at``) is treated as submitted now, so it is kept or
+    dropped by the window like a job submitted at the current moment; a
+    terminal job that never got a ``submitted_at`` is excluded from the window.
     """
     # Join spot and job_info tables to get the job name for each task.
     # We use LEFT OUTER JOIN mainly for backward compatibility, as for an
@@ -1577,17 +1578,24 @@ def build_managed_jobs_with_filters_no_status_query(
         query = query.where(job_info_table.c.user_hash.in_(user_hashes))
     if submitted_after is not None or submitted_before is not None:
         # submitted_at is NULL until a job leaves PENDING (it is set at
-        # STARTING), so a pending job has no submission time yet. Treat it as
-        # submitted "now" so it is filtered consistently regardless of whether
-        # the bound is in the past or the future: e.g. a pending job is kept by
-        # --since (now >= a past lower bound) and by a future --before
-        # (now <= it), but dropped by a past --before (now > it).
-        submitted_at = sqlalchemy.func.coalesce(spot_table.c.submitted_at,
-                                                time.time())
+        # STARTING). For a still-active job that just means "not submitted
+        # yet", so treat it as submitted "now". A terminal job with no
+        # submitted_at never started (cancelled/failed before STARTING) and
+        # has no submission time, so leave it NULL to exclude it from the
+        # window rather than letting it masquerade as "now".
+        terminal_values = [
+            s.value for s in ManagedJobStatus.terminal_statuses()
+        ]
+        effective_submitted_at = sqlalchemy.case(
+            (spot_table.c.submitted_at.is_not(None), spot_table.c.submitted_at),
+            (sqlalchemy.or_(
+                spot_table.c.status.is_(None),
+                ~spot_table.c.status.in_(terminal_values)), time.time()),
+        )
         if submitted_after is not None:
-            query = query.where(submitted_at >= submitted_after)
+            query = query.where(effective_submitted_at >= submitted_after)
         if submitted_before is not None:
-            query = query.where(submitted_at <= submitted_before)
+            query = query.where(effective_submitted_at <= submitted_before)
     return query
 
 

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -937,6 +937,27 @@ def _seed_pending_job(_mock_managed_jobs_db_conn):
     return job_id
 
 
+@pytest.fixture
+def _seed_terminal_no_submit(_mock_managed_jobs_db_conn):
+    """Seed a job cancelled while PENDING: terminal, with a NULL submitted_at
+    (it never reached STARTING)."""
+    job_id = state.set_job_info_without_job_id(name='job-cancelled',
+                                               workspace='ws1',
+                                               entrypoint='ep',
+                                               pool=None,
+                                               pool_hash=None,
+                                               user_hash='user1')
+    state.set_pending(job_id,
+                      task_id=0,
+                      task_name='task0',
+                      resources_str='{}',
+                      metadata='{}')
+    state.scheduler_set_waiting([job_id], '/tmp/dag-c.yaml', '/tmp/user-c.yaml',
+                                '/tmp/env-c', None, 100)
+    state.set_pending_cancelled(job_id)
+    return job_id
+
+
 class TestSubmittedAtRangeFilter:
     """Time-range filter on submitted_at via get_managed_jobs_with_filters."""
 
@@ -1018,6 +1039,29 @@ class TestSubmittedAtRangeFilter:
     def test_pending_dropped_by_future_lower_bound(self, _seed_pending_job):
         jobs, total = state.get_managed_jobs_with_filters(
             submitted_after=_FAR_FUTURE)
+        assert jobs == []
+        assert total == 0
+
+    # A terminal job that never got a submitted_at (cancelled/failed before
+    # STARTING) has no submission time, so it is excluded from any window —
+    # it must not be treated as submitted "now" like a still-pending job.
+    def test_terminal_no_submit_present_without_filter(
+            self, _seed_terminal_no_submit):
+        jobs, total = state.get_managed_jobs_with_filters()
+        assert total == 1
+        assert jobs[0]['submitted_at'] is None
+        assert jobs[0]['status'].is_terminal()
+
+    def test_terminal_no_submit_excluded_from_lower_bound(
+            self, _seed_terminal_no_submit):
+        jobs, total = state.get_managed_jobs_with_filters(submitted_after=_T100)
+        assert jobs == []
+        assert total == 0
+
+    def test_terminal_no_submit_excluded_from_future_upper_bound(
+            self, _seed_terminal_no_submit):
+        jobs, total = state.get_managed_jobs_with_filters(
+            submitted_before=_FAR_FUTURE)
         assert jobs == []
         assert total == 0
 


### PR DESCRIPTION
## Summary

Follow-up to #9854. The managed-jobs submission-time filter
(`--since`/`--after`/`--before`) used `COALESCE(submitted_at, now())`, so a row
with a NULL `submitted_at` was treated as submitted **now**.

`submitted_at` is NULL until a job leaves PENDING (it's set at STARTING). For a
still-pending job, "treat as now" is correct — a just-submitted job should show
up in `--since`. But a **terminal** job that was cancelled/failed *before*
STARTING also has a NULL `submitted_at`, and those were wrongly matching recent
windows. For pipelines it was worse: one such task row matched, and job-level
inclusion (the filter matches at the task level, then all tasks of a matched
job are returned) pulled the whole — often month-old — job into the result.

Fix: treat a NULL `submitted_at` as "now" **only for non-terminal jobs**; leave
it NULL for terminal jobs so they're excluded from the window.

```python
effective_submitted_at = case(
    (submitted_at IS NOT NULL, submitted_at),
    (status is non-terminal,   now()),
    # terminal + NULL -> NULL -> excluded from the window
)
```

## Test plan

- New tests in `test_jobs_state.py::TestSubmittedAtRangeFilter`: a job cancelled
  while PENDING (terminal, NULL `submitted_at`) is excluded from both a past
  lower bound and a future upper bound, while the existing pending-job tests
  (non-terminal, NULL → now) still pass. `pytest -k SubmittedAtRange` → 16 passed.
- Reproduced manually before the fix: `sky jobs queue --since 1h` returned
  month-old CANCELLED/FAILED jobs that had a NULL `submitted_at`; after the fix
  only genuinely-recent jobs remain.
- `bash format.sh` clean (pylint 10.00 on `state.py`, mypy passes).
