### PR TITLE
[Dashboard] Add owner + activity toggles to Clusters page

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -734,6 +734,21 @@ export function ClusterTable({
     return 10;
   };
 
+  // An explicit User filter from the dropdown overrides the My/All toggle, so
+  // in that case we fetch every user's clusters and let the filter match.
+  const hasExplicitUserFilter = (filters || []).some(
+    (f) => (f.property || '').toLowerCase() === 'user' && f.value
+  );
+
+  // Scope the fetch to the current user server-side ("My Clusters") instead of
+  // pulling everyone's clusters and filtering client-side. Falls back to all
+  // users when the caller is anonymous or an explicit User filter is active.
+  const allUsers = !(
+    userScope === 'mine' &&
+    currentUser &&
+    !hasExplicitUserFilter
+  );
+
   // Use the cluster data hook (supports plugin override for server-side pagination)
   const {
     data: hookData,
@@ -757,6 +772,8 @@ export function ClusterTable({
     filters,
     initialPage: getInitialPage(),
     initialLimit: getInitialLimit(),
+    allUsers,
+    currentUser,
   });
 
   // Sync page/limit to URL query params.
@@ -872,18 +889,10 @@ export function ClusterTable({
     };
 
     // For server-side pagination, server already handles filtering - just apply sorting
-    // For client-side pagination, we filter/sort the full data then paginate
-    let dataToProcess = isServerPagination ? hookData : allData;
-
-    const hasExplicitUserFilter = (filters || []).some(
-      (f) => (f.property || '').toLowerCase() === 'user' && f.value
-    );
-    if (userScope === 'mine' && currentUser && !hasExplicitUserFilter) {
-      dataToProcess = (dataToProcess || []).filter(
-        (item) =>
-          item.user_hash === currentUser.id || item.user === currentUser.name
-      );
-    }
+    // For client-side pagination, we filter/sort the full data then paginate.
+    // The current-user ("My Clusters") scope is applied server-side via the
+    // allUsers flag on useClusterData, so no client-side owner filter here.
+    const dataToProcess = isServerPagination ? hookData : allData;
 
     if (!isServerPagination) {
       const historicalCount = (allData || []).filter(
@@ -904,27 +913,44 @@ export function ClusterTable({
       : filterData(dataToProcess, filters);
 
     return sortData(filteredData, sortConfig.key, sortConfig.direction);
-  }, [
-    hookData,
-    allData,
-    sortConfig,
-    filters,
-    isServerPagination,
-    userScope,
-    currentUser,
-  ]);
+  }, [hookData, allData, sortConfig, filters, isServerPagination]);
 
-  // Number of clusters in the current view owned by *other* users, i.e. how
-  // many rows switching to "All Clusters" would actually reveal. Used to gate
-  // the empty-state CTA so we don't nudge to All when there's nothing to show.
-  const othersTotal = useMemo(() => {
-    if (!currentUser) return 0;
-    const source = isServerPagination ? hookData : allData;
-    return (source || []).filter(
-      (item) =>
-        item.user_hash !== currentUser.id && item.user !== currentUser.name
-    ).length;
-  }, [hookData, allData, isServerPagination, currentUser]);
+  // Number of clusters owned by *other* users, i.e. how many rows switching to
+  // "All Clusters" would actually reveal. Used to gate the empty-state CTA so
+  // we don't nudge to All when there's nothing to show. Because the table is
+  // now scoped to the current user server-side, the scoped data no longer
+  // contains other users' clusters; probe the shared all-users cache (already
+  // warm from the preloader, so this is typically a free read) only when the
+  // "My Clusters" view comes back empty.
+  const [othersTotal, setOthersTotal] = useState(0);
+  const scopedEmpty = isServerPagination
+    ? total === 0
+    : sortedData.length === 0;
+  useEffect(() => {
+    let cancelled = false;
+    const scopedToMine =
+      userScope === 'mine' && currentUser && !hasExplicitUserFilter;
+    if (!scopedToMine || hookLoading || !scopedEmpty) {
+      setOthersTotal(0);
+      return;
+    }
+    (async () => {
+      try {
+        const all = await dashboardCache.get(getClusters);
+        if (cancelled) return;
+        const others = (all || []).filter(
+          (item) =>
+            item.user_hash !== currentUser.id && item.user !== currentUser.name
+        ).length;
+        setOthersTotal(others);
+      } catch (e) {
+        if (!cancelled) setOthersTotal(0);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userScope, currentUser, hasExplicitUserFilter, hookLoading, scopedEmpty]);
 
   // Expose refresh to parent component
   React.useEffect(() => {
@@ -1355,9 +1381,7 @@ export function ClusterTable({
               ) : (
                 userScope === 'mine' &&
                 currentUser &&
-                !(filters || []).some(
-                  (f) => (f.property || '').toLowerCase() === 'user' && f.value
-                ) &&
+                !hasExplicitUserFilter &&
                 othersTotal > 0 ? (
                   <EmptyTableState
                     colSpan={totalColSpan}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -163,6 +163,22 @@ const formatDuration = (durationSeconds) => {
   return result.trim() || '0s';
 };
 
+// Clusters are shared infra: default to All Clusters and remember the user's last My/All choice in localStorage.
+const OWNER_SCOPE_MINE = 'mine';
+const OWNER_SCOPE_ALL = 'all';
+const OWNER_SCOPE_STORAGE_KEY = 'skypilot-dashboard-clusters-owner-scope';
+
+const isOwnerScope = (value) =>
+  value === OWNER_SCOPE_MINE || value === OWNER_SCOPE_ALL;
+
+const readStoredOwnerScope = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const stored = window.localStorage.getItem(OWNER_SCOPE_STORAGE_KEY);
+  return isOwnerScope(stored) ? stored : null;
+};
+
 export function Clusters() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -196,10 +212,16 @@ export function Clusters() {
   };
 
   const getInitialUserScope = () => {
-    if (typeof window !== 'undefined' && router.isReady) {
-      return router.query.owner === 'all' ? 'all' : 'mine';
+    const owner = router.query.owner;
+    if (
+      typeof window !== 'undefined' &&
+      router.isReady &&
+      isOwnerScope(owner)
+    ) {
+      return owner;
     }
-    return 'mine';
+    // Fall back to the user's last choice, then to All Clusters.
+    return readStoredOwnerScope() ?? OWNER_SCOPE_ALL;
   };
 
   const [showHistory, setShowHistory] = useState(getInitialShowHistory);
@@ -218,13 +240,13 @@ export function Clusters() {
         if (info && info.id && info.id !== 'local') {
           setCurrentUser({ id: info.id, name: info.name });
         } else {
-          setUserScope('all');
+          setUserScope(OWNER_SCOPE_ALL);
         }
       })
       .catch(() => {
         if (!cancelled) {
           setAuthResolved(true);
-          setUserScope('all');
+          setUserScope(OWNER_SCOPE_ALL);
         }
       });
     return () => {
@@ -271,9 +293,14 @@ export function Clusters() {
       }
 
       const isAnonymous = authResolved && !currentUser;
-      const forceAllScope = router.query.owner === 'all' || isAnonymous;
-      const expectedScope = forceAllScope ? 'all' : 'mine';
-      if (userScope !== expectedScope) {
+      const owner = router.query.owner;
+      let expectedScope = null;
+      if (isAnonymous) {
+        expectedScope = OWNER_SCOPE_ALL;
+      } else if (isOwnerScope(owner)) {
+        expectedScope = owner;
+      }
+      if (expectedScope !== null && userScope !== expectedScope) {
         setUserScope(expectedScope);
       }
     }
@@ -462,12 +489,11 @@ export function Clusters() {
 
   const selectScope = (scope) => {
     setUserScope(scope);
-    const query = { ...router.query };
-    if (scope === 'all') {
-      query.owner = 'all';
-    } else {
-      delete query.owner;
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(OWNER_SCOPE_STORAGE_KEY, scope);
     }
+    const query = { ...router.query };
+    query.owner = scope;
     router.replace(
       {
         pathname: router.pathname,
@@ -497,11 +523,11 @@ export function Clusters() {
         ? currentUser &&
           (String(explicitUserFilter.value) === currentUser.id ||
             String(explicitUserFilter.value) === currentUser.name)
-        : userScope === 'mine',
+        : userScope === OWNER_SCOPE_MINE,
     [explicitUserFilter, currentUser, userScope]
   );
 
-  const isEveryone = !explicitUserFilter && userScope === 'all';
+  const isEveryone = !explicitUserFilter && userScope === OWNER_SCOPE_ALL;
 
   const handleRefresh = () => {
     // Invalidate cache to ensure fresh data is fetched
@@ -537,68 +563,6 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        <div
-          role="tablist"
-          aria-label="Filter clusters by activity"
-          className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-        >
-          <button
-            role="tab"
-            aria-selected={!showHistory}
-            onClick={() => selectHistoryTab(false)}
-            className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-              !showHistory
-                ? 'bg-white text-gray-900 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
-            }`}
-          >
-            Active
-          </button>
-          <button
-            role="tab"
-            aria-selected={showHistory}
-            onClick={() => selectHistoryTab(true)}
-            className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-              showHistory
-                ? 'bg-white text-gray-900 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
-            }`}
-          >
-            All
-          </button>
-        </div>
-        {currentUser && (
-          <div
-            role="tablist"
-            aria-label="Filter clusters by owner"
-            className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-          >
-            <button
-              role="tab"
-              aria-selected={isMine}
-              onClick={() => selectScope('mine')}
-              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                isMine
-                  ? 'bg-white text-gray-900 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              My Clusters
-            </button>
-            <button
-              role="tab"
-              aria-selected={isEveryone}
-              onClick={() => selectScope('all')}
-              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                isEveryone
-                  ? 'bg-white text-gray-900 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              All Clusters
-            </button>
-          </div>
-        )}
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
@@ -609,29 +573,103 @@ export function Clusters() {
             filters={filters}
           />
         </div>
-        <div className="flex items-center gap-2 ml-auto">
-          <div className="flex items-center gap-2">
-            {showHistory && (
-              <Select
-                value={historyDays.toString()}
-                onValueChange={(value) => {
-                  const newDays = parseInt(value);
-                  setHistoryDays(newDays);
-                  updateHistoryDaysURL(newDays);
-                }}
-              >
-                <SelectTrigger className="w-24 h-8 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="1">1 day</SelectItem>
-                  <SelectItem value="5">5 days</SelectItem>
-                  <SelectItem value="10">10 days</SelectItem>
-                  <SelectItem value="30">30 days</SelectItem>
-                </SelectContent>
-              </Select>
-            )}
+      </div>
+
+      <Filters
+        filters={filters}
+        setFilters={setFilters}
+        updateURLParams={updateURLParams}
+      />
+
+      {/* Toggles live on their own row (mirrors the Managed Jobs layout) so
+          they read consistently across pages and stay clear of the search
+          box. Refresh/last-updated sit on the right of the same row. */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <div
+            role="tablist"
+            aria-label="Filter clusters by activity"
+            className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+          >
+            <button
+              role="tab"
+              aria-selected={!showHistory}
+              onClick={() => selectHistoryTab(false)}
+              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                !showHistory
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              Active
+            </button>
+            <button
+              role="tab"
+              aria-selected={showHistory}
+              onClick={() => selectHistoryTab(true)}
+              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                showHistory
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              All
+            </button>
           </div>
+          {currentUser && (
+            <div
+              role="tablist"
+              aria-label="Filter clusters by owner"
+              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+            >
+              <button
+                role="tab"
+                aria-selected={isMine}
+                onClick={() => selectScope(OWNER_SCOPE_MINE)}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  isMine
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                My Clusters
+              </button>
+              <button
+                role="tab"
+                aria-selected={isEveryone}
+                onClick={() => selectScope(OWNER_SCOPE_ALL)}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  isEveryone
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                All Clusters
+              </button>
+            </div>
+          )}
+          {showHistory && (
+            <Select
+              value={historyDays.toString()}
+              onValueChange={(value) => {
+                const newDays = parseInt(value);
+                setHistoryDays(newDays);
+                updateHistoryDaysURL(newDays);
+              }}
+            >
+              <SelectTrigger className="w-24 h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">1 day</SelectItem>
+                <SelectItem value="5">5 days</SelectItem>
+                <SelectItem value="10">10 days</SelectItem>
+                <SelectItem value="30">30 days</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-2">
           {loading && (
             <div className="flex items-center">
               <CircularProgress size={15} className="mt-0" />
@@ -652,12 +690,6 @@ export function Clusters() {
         </div>
       </div>
 
-      <Filters
-        filters={filters}
-        setFilters={setFilters}
-        updateURLParams={updateURLParams}
-      />
-
       <ClusterTable
         refreshInterval={REFRESH_INTERVAL}
         setLoading={setLoading}
@@ -665,7 +697,7 @@ export function Clusters() {
         filters={filters}
         userScope={userScope}
         currentUser={currentUser}
-        onViewAllClusters={() => selectScope('all')}
+        onViewAllClusters={() => selectScope(OWNER_SCOPE_ALL)}
         showHistory={showHistory}
         historyDays={historyDays}
         onOpenSSHModal={(cluster) => {
@@ -744,7 +776,7 @@ export function ClusterTable({
   // pulling everyone's clusters and filtering client-side. Falls back to all
   // users when the caller is anonymous or an explicit User filter is active.
   const allUsers = !(
-    userScope === 'mine' &&
+    userScope === OWNER_SCOPE_MINE &&
     currentUser &&
     !hasExplicitUserFilter
   );
@@ -929,7 +961,7 @@ export function ClusterTable({
   useEffect(() => {
     let cancelled = false;
     const scopedToMine =
-      userScope === 'mine' && currentUser && !hasExplicitUserFilter;
+      userScope === OWNER_SCOPE_MINE && currentUser && !hasExplicitUserFilter;
     if (!scopedToMine || hookLoading || !scopedEmpty) {
       setOthersTotal(0);
       return;
@@ -1379,7 +1411,7 @@ export function ClusterTable({
                   );
                 })
               ) : (
-                userScope === 'mine' &&
+                userScope === OWNER_SCOPE_MINE &&
                 currentUser &&
                 !hasExplicitUserFilter &&
                 othersTotal > 0 ? (

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -216,7 +216,7 @@ export function Clusters() {
         if (cancelled) return;
         setAuthResolved(true);
         if (info && info.id && info.id !== 'local') {
-          setCurrentUser({ id: info.id, name: info.name || info.id });
+          setCurrentUser({ id: info.id, name: info.name });
         } else {
           setUserScope('all');
         }
@@ -271,8 +271,8 @@ export function Clusters() {
       }
 
       const isAnonymous = authResolved && !currentUser;
-      const expectedScope =
-        router.query.owner === 'all' ? 'all' : isAnonymous ? 'all' : 'mine';
+      const forceAllScope = router.query.owner === 'all' || isAnonymous;
+      const expectedScope = forceAllScope ? 'all' : 'mine';
       if (userScope !== expectedScope) {
         setUserScope(expectedScope);
       }

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -195,8 +195,6 @@ export function Clusters() {
     return 1; // Default to 1 day
   };
 
-  // Initialize ownership scope from URL parameter immediately.
-  // Defaults to showing only the current user's clusters.
   const getInitialUserScope = () => {
     if (typeof window !== 'undefined' && router.isReady) {
       return router.query.owner === 'all' ? 'all' : 'mine';
@@ -208,17 +206,9 @@ export function Clusters() {
   const [historyDays, setHistoryDays] = useState(getInitialHistoryDays);
   const [userScope, setUserScope] = useState(getInitialUserScope);
   const [currentUser, setCurrentUser] = useState(null);
-  // Whether the current-user lookup has finished. Used to distinguish
-  // "auth not resolved yet" from "resolved and anonymous" so the URL sync
-  // below doesn't reset an anonymous user's scope back to 'mine'.
   const [authResolved, setAuthResolved] = useState(false);
   const isMobile = useMobile();
 
-  // Resolve the logged-in user for the "My clusters" scope. Mirrors the
-  // jobs page: the 'local' sentinel id means the caller is anonymous
-  // (no auth / basic-auth without per-user identity, e.g. no Okta/SSO).
-  // There's no meaningful "Mine" view in that case, so flip to All and
-  // hide the My/All toggle entirely.
   useEffect(() => {
     let cancelled = false;
     getCurrentUserInfo()
@@ -280,9 +270,6 @@ export function Clusters() {
         }
       }
 
-      // Sync ownership scope with URL if it has changed. An anonymous
-      // caller has no "Mine" view, so it stays on 'all' regardless of the
-      // (absent) owner param.
       const isAnonymous = authResolved && !currentUser;
       const expectedScope =
         router.query.owner === 'all' ? 'all' : isAnonymous ? 'all' : 'mine';
@@ -473,8 +460,6 @@ export function Clusters() {
     setFilters(filters);
   };
 
-  // Switch ownership scope (My clusters vs All clusters), keeping it in the
-  // URL so the view is shareable/bookmarkable.
   const selectScope = (scope) => {
     setUserScope(scope);
     const query = { ...router.query };
@@ -493,16 +478,11 @@ export function Clusters() {
     );
   };
 
-  // Activity toggle: Active shows live clusters only; All also includes
-  // terminated clusters from history (same data as the old "Show history"
-  // checkbox, presented like the jobs page).
   const selectHistoryTab = (showHistoryValue) => {
     setShowHistory(showHistoryValue);
     updateShowHistoryURL(showHistoryValue);
   };
 
-  // An explicit User filter from the filter dropdown overrides the
-  // ownership scope toggle; reflect that in the highlighted tab.
   const explicitUserFilter = useMemo(
     () =>
       (filters || []).find(
@@ -557,9 +537,6 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        {/* Activity toggle: Active shows live clusters only; All also
-            includes terminated clusters from history (same data as the
-            old "Show history" checkbox, presented like the jobs page). */}
         <div
           role="tablist"
           aria-label="Filter clusters by activity"
@@ -590,11 +567,6 @@ export function Clusters() {
             All
           </button>
         </div>
-        {/* Ownership scope toggle. Only shown when the caller has a real
-            identity (e.g. Okta/SSO); with basic auth or no auth there is
-            no per-user view, so the toggle is hidden (same as the jobs
-            page). An explicit User filter overrides the toggle, so the
-            highlighted tab reflects that. */}
         {currentUser && (
           <div
             role="tablist"
@@ -901,8 +873,6 @@ export function ClusterTable({
     // For client-side pagination, we filter/sort the full data then paginate
     let dataToProcess = isServerPagination ? hookData : allData;
 
-    // Ownership scope: default to showing only the current user's clusters.
-    // An explicit User filter from the filter dropdown overrides the scope.
     const hasExplicitUserFilter = (filters || []).some(
       (f) => (f.property || '').toLowerCase() === 'user' && f.value
     );

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -208,6 +208,10 @@ export function Clusters() {
   const [historyDays, setHistoryDays] = useState(getInitialHistoryDays);
   const [userScope, setUserScope] = useState(getInitialUserScope);
   const [currentUser, setCurrentUser] = useState(null);
+  // Whether the current-user lookup has finished. Used to distinguish
+  // "auth not resolved yet" from "resolved and anonymous" so the URL sync
+  // below doesn't reset an anonymous user's scope back to 'mine'.
+  const [authResolved, setAuthResolved] = useState(false);
   const isMobile = useMobile();
 
   // Resolve the logged-in user for the "My clusters" scope. Mirrors the
@@ -220,6 +224,7 @@ export function Clusters() {
     getCurrentUserInfo()
       .then((info) => {
         if (cancelled) return;
+        setAuthResolved(true);
         if (info && info.id && info.id !== 'local') {
           setCurrentUser({ id: info.id, name: info.name || info.id });
         } else {
@@ -227,7 +232,10 @@ export function Clusters() {
         }
       })
       .catch(() => {
-        if (!cancelled) setUserScope('all');
+        if (!cancelled) {
+          setAuthResolved(true);
+          setUserScope('all');
+        }
       });
     return () => {
       cancelled = true;
@@ -272,8 +280,12 @@ export function Clusters() {
         }
       }
 
-      // Sync ownership scope with URL if it has changed
-      const expectedScope = router.query.owner === 'all' ? 'all' : 'mine';
+      // Sync ownership scope with URL if it has changed. An anonymous
+      // caller has no "Mine" view, so it stays on 'all' regardless of the
+      // (absent) owner param.
+      const isAnonymous = authResolved && !currentUser;
+      const expectedScope =
+        router.query.owner === 'all' ? 'all' : isAnonymous ? 'all' : 'mine';
       if (userScope !== expectedScope) {
         setUserScope(expectedScope);
       }
@@ -284,6 +296,8 @@ export function Clusters() {
     router.query.history,
     router.query.historyDays,
     router.query.owner,
+    authResolved,
+    currentUser,
   ]);
 
   useEffect(() => {
@@ -479,6 +493,36 @@ export function Clusters() {
     );
   };
 
+  // Activity toggle: Active shows live clusters only; All also includes
+  // terminated clusters from history (same data as the old "Show history"
+  // checkbox, presented like the jobs page).
+  const selectHistoryTab = (showHistoryValue) => {
+    setShowHistory(showHistoryValue);
+    updateShowHistoryURL(showHistoryValue);
+  };
+
+  // An explicit User filter from the filter dropdown overrides the
+  // ownership scope toggle; reflect that in the highlighted tab.
+  const explicitUserFilter = useMemo(
+    () =>
+      (filters || []).find(
+        (f) => (f.property || '').toLowerCase() === 'user' && f.value
+      ),
+    [filters]
+  );
+
+  const isMine = useMemo(
+    () =>
+      explicitUserFilter
+        ? currentUser &&
+          (String(explicitUserFilter.value) === currentUser.id ||
+            String(explicitUserFilter.value) === currentUser.name)
+        : userScope === 'mine',
+    [explicitUserFilter, currentUser, userScope]
+  );
+
+  const isEveryone = !explicitUserFilter && userScope === 'all';
+
   const handleRefresh = () => {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getClusters);
@@ -513,96 +557,76 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        {(() => {
-          // Activity toggle: Active shows live clusters only; All also
-          // includes terminated clusters from history (same data as the
-          // old "Show history" checkbox, presented like the jobs page).
-          const selectHistoryTab = (showHistoryValue) => {
-            setShowHistory(showHistoryValue);
-            updateShowHistoryURL(showHistoryValue);
-          };
-          return (
-            <div
-              role="tablist"
-              aria-label="Filter clusters by activity"
-              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+        {/* Activity toggle: Active shows live clusters only; All also
+            includes terminated clusters from history (same data as the
+            old "Show history" checkbox, presented like the jobs page). */}
+        <div
+          role="tablist"
+          aria-label="Filter clusters by activity"
+          className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+        >
+          <button
+            role="tab"
+            aria-selected={!showHistory}
+            onClick={() => selectHistoryTab(false)}
+            className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+              !showHistory
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            Active
+          </button>
+          <button
+            role="tab"
+            aria-selected={showHistory}
+            onClick={() => selectHistoryTab(true)}
+            className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+              showHistory
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            All
+          </button>
+        </div>
+        {/* Ownership scope toggle. Only shown when the caller has a real
+            identity (e.g. Okta/SSO); with basic auth or no auth there is
+            no per-user view, so the toggle is hidden (same as the jobs
+            page). An explicit User filter overrides the toggle, so the
+            highlighted tab reflects that. */}
+        {currentUser && (
+          <div
+            role="tablist"
+            aria-label="Filter clusters by owner"
+            className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+          >
+            <button
+              role="tab"
+              aria-selected={isMine}
+              onClick={() => selectScope('mine')}
+              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                isMine
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
             >
-              <button
-                role="tab"
-                aria-selected={!showHistory}
-                onClick={() => selectHistoryTab(false)}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  !showHistory
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                Active
-              </button>
-              <button
-                role="tab"
-                aria-selected={showHistory}
-                onClick={() => selectHistoryTab(true)}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  showHistory
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                All
-              </button>
-            </div>
-          );
-        })()}
-        {(() => {
-          // Ownership scope toggle. Only shown when the caller has a real
-          // identity (e.g. Okta/SSO); with basic auth or no auth there is
-          // no per-user view, so the toggle is hidden (same as the jobs
-          // page). An explicit User filter overrides the toggle, so
-          // reflect that in the highlighted tab.
-          if (!currentUser) return null;
-          const explicitUserFilter = (filters || []).find(
-            (f) => (f.property || '').toLowerCase() === 'user' && f.value
-          );
-          const isMine = explicitUserFilter
-            ? currentUser &&
-              (String(explicitUserFilter.value) === currentUser.id ||
-                String(explicitUserFilter.value) === currentUser.name)
-            : userScope === 'mine';
-          const isEveryone = !explicitUserFilter && userScope === 'all';
-          return (
-            <div
-              role="tablist"
-              aria-label="Filter clusters by owner"
-              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+              My Clusters
+            </button>
+            <button
+              role="tab"
+              aria-selected={isEveryone}
+              onClick={() => selectScope('all')}
+              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                isEveryone
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
             >
-              <button
-                role="tab"
-                aria-selected={isMine}
-                onClick={() => selectScope('mine')}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  isMine
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                My Clusters
-              </button>
-              <button
-                role="tab"
-                aria-selected={isEveryone}
-                onClick={() => selectScope('all')}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  isEveryone
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                All Clusters
-              </button>
-            </div>
-          );
-        })()}
+              All Clusters
+            </button>
+          </div>
+        )}
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -298,10 +298,17 @@ export function Clusters() {
         if (userScope !== OWNER_SCOPE_ALL) {
           setUserScope(OWNER_SCOPE_ALL);
         }
-      } else if (isOwnerScope(owner) && userScope !== owner) {
-        // Go through selectScope so a deep-linked ?owner=... choice is also
-        // persisted to localStorage like a manual toggle.
-        selectScope(owner);
+      } else if (isOwnerScope(owner)) {
+        if (userScope !== owner) {
+          // Go through selectScope so a deep-linked ?owner=... choice is also
+          // persisted to localStorage like a manual toggle.
+          selectScope(owner);
+        } else if (readStoredOwnerScope() !== owner) {
+          // On a fresh load the initial state is already seeded from the URL,
+          // so the branch above never runs; still persist the deep-linked
+          // choice like a manual toggle.
+          window.localStorage.setItem(OWNER_SCOPE_STORAGE_KEY, owner);
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -914,10 +914,17 @@ export function ClusterTable({
     currentUser,
   ]);
 
-  const everyoneTotal = useMemo(() => {
+  // Number of clusters in the current view owned by *other* users, i.e. how
+  // many rows switching to "All Clusters" would actually reveal. Used to gate
+  // the empty-state CTA so we don't nudge to All when there's nothing to show.
+  const othersTotal = useMemo(() => {
+    if (!currentUser) return 0;
     const source = isServerPagination ? hookData : allData;
-    return (source || []).length;
-  }, [hookData, allData, isServerPagination]);
+    return (source || []).filter(
+      (item) =>
+        item.user_hash !== currentUser.id && item.user !== currentUser.name
+    ).length;
+  }, [hookData, allData, isServerPagination, currentUser]);
 
   // Expose refresh to parent component
   React.useEffect(() => {
@@ -1351,14 +1358,14 @@ export function ClusterTable({
                 !(filters || []).some(
                   (f) => (f.property || '').toLowerCase() === 'user' && f.value
                 ) &&
-                everyoneTotal > 0 ? (
+                othersTotal > 0 ? (
                   <EmptyTableState
                     colSpan={totalColSpan}
                     icon={<ServerIcon className="w-5 h-5" />}
                     title={`You don't have any${showHistory ? '' : ' active'} clusters${showHistory ? ' yet' : ''}`}
-                    description={`${everyoneTotal.toLocaleString()} cluster${
-                      everyoneTotal === 1 ? '' : 's'
-                    } in total — switch to All Clusters to see them.`}
+                    description={`${othersTotal.toLocaleString()} cluster${
+                      othersTotal === 1 ? '' : 's'
+                    } owned by other users — switch to All Clusters to see them.`}
                     action={
                       <Button
                         variant="outline"

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -68,6 +68,7 @@ import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { evaluateCondition } from '@/components/shared/FilterSystem';
+import { getCurrentUserInfo } from '@/data/connectors/client';
 import { trackClusterAction, trackFilterUsed } from '@/lib/analytics';
 
 // Helper function to format cost (copied from workspaces.jsx)
@@ -194,10 +195,44 @@ export function Clusters() {
     return 1; // Default to 1 day
   };
 
+  // Initialize ownership scope from URL parameter immediately.
+  // Defaults to showing only the current user's clusters.
+  const getInitialUserScope = () => {
+    if (typeof window !== 'undefined' && router.isReady) {
+      return router.query.owner === 'all' ? 'all' : 'mine';
+    }
+    return 'mine';
+  };
+
   const [showHistory, setShowHistory] = useState(getInitialShowHistory);
-  const [shouldAnimate, setShouldAnimate] = useState(true); // Track if toggle should animate
   const [historyDays, setHistoryDays] = useState(getInitialHistoryDays);
+  const [userScope, setUserScope] = useState(getInitialUserScope);
+  const [currentUser, setCurrentUser] = useState(null);
   const isMobile = useMobile();
+
+  // Resolve the logged-in user for the "My clusters" scope. Mirrors the
+  // jobs page: the 'local' sentinel id means the caller is anonymous
+  // (no auth / basic-auth without per-user identity, e.g. no Okta/SSO).
+  // There's no meaningful "Mine" view in that case, so flip to All and
+  // hide the My/All toggle entirely.
+  useEffect(() => {
+    let cancelled = false;
+    getCurrentUserInfo()
+      .then((info) => {
+        if (cancelled) return;
+        if (info && info.id && info.id !== 'local') {
+          setCurrentUser({ id: info.id, name: info.name || info.id });
+        } else {
+          setUserScope('all');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setUserScope('all');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const [filters, setFilters] = useState([]);
   const [optionValues, setOptionValues] = useState({
@@ -221,10 +256,7 @@ export function Clusters() {
       const expectedState = historyParam === 'true';
 
       if (showHistory !== expectedState) {
-        setShouldAnimate(false); // Disable animation for programmatic changes
         setShowHistory(expectedState);
-        // Re-enable animation after a short delay
-        setTimeout(() => setShouldAnimate(true), 50);
       }
 
       // Sync historyDays state with URL if it has changed
@@ -239,9 +271,20 @@ export function Clusters() {
           setHistoryDays(expectedDays);
         }
       }
+
+      // Sync ownership scope with URL if it has changed
+      const expectedScope = router.query.owner === 'all' ? 'all' : 'mine';
+      if (userScope !== expectedScope) {
+        setUserScope(expectedScope);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, router.query.history, router.query.historyDays]);
+  }, [
+    router.isReady,
+    router.query.history,
+    router.query.historyDays,
+    router.query.owner,
+  ]);
 
   useEffect(() => {
     const fetchFilterData = async () => {
@@ -416,6 +459,26 @@ export function Clusters() {
     setFilters(filters);
   };
 
+  // Switch ownership scope (My clusters vs All clusters), keeping it in the
+  // URL so the view is shareable/bookmarkable.
+  const selectScope = (scope) => {
+    setUserScope(scope);
+    const query = { ...router.query };
+    if (scope === 'all') {
+      query.owner = 'all';
+    } else {
+      delete query.owner;
+    }
+    router.replace(
+      {
+        pathname: router.pathname,
+        query,
+      },
+      undefined,
+      { shallow: true }
+    );
+  };
+
   const handleRefresh = () => {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getClusters);
@@ -450,6 +513,96 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
+        {(() => {
+          // Activity toggle: Active shows live clusters only; All also
+          // includes terminated clusters from history (same data as the
+          // old "Show history" checkbox, presented like the jobs page).
+          const selectHistoryTab = (showHistoryValue) => {
+            setShowHistory(showHistoryValue);
+            updateShowHistoryURL(showHistoryValue);
+          };
+          return (
+            <div
+              role="tablist"
+              aria-label="Filter clusters by activity"
+              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+            >
+              <button
+                role="tab"
+                aria-selected={!showHistory}
+                onClick={() => selectHistoryTab(false)}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  !showHistory
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                Active
+              </button>
+              <button
+                role="tab"
+                aria-selected={showHistory}
+                onClick={() => selectHistoryTab(true)}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  showHistory
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                All
+              </button>
+            </div>
+          );
+        })()}
+        {(() => {
+          // Ownership scope toggle. Only shown when the caller has a real
+          // identity (e.g. Okta/SSO); with basic auth or no auth there is
+          // no per-user view, so the toggle is hidden (same as the jobs
+          // page). An explicit User filter overrides the toggle, so
+          // reflect that in the highlighted tab.
+          if (!currentUser) return null;
+          const explicitUserFilter = (filters || []).find(
+            (f) => (f.property || '').toLowerCase() === 'user' && f.value
+          );
+          const isMine = explicitUserFilter
+            ? currentUser &&
+              (String(explicitUserFilter.value) === currentUser.id ||
+                String(explicitUserFilter.value) === currentUser.name)
+            : userScope === 'mine';
+          const isEveryone = !explicitUserFilter && userScope === 'all';
+          return (
+            <div
+              role="tablist"
+              aria-label="Filter clusters by owner"
+              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+            >
+              <button
+                role="tab"
+                aria-selected={isMine}
+                onClick={() => selectScope('mine')}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  isMine
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                My Clusters
+              </button>
+              <button
+                role="tab"
+                aria-selected={isEveryone}
+                onClick={() => selectScope('all')}
+                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                  isEveryone
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                All Clusters
+              </button>
+            </div>
+          );
+        })()}
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
@@ -462,33 +615,6 @@ export function Clusters() {
         </div>
         <div className="flex items-center gap-2 ml-auto">
           <div className="flex items-center gap-2">
-            <label
-              className="flex items-center cursor-pointer"
-              title="Toggle cluster history"
-            >
-              <input
-                type="checkbox"
-                checked={showHistory}
-                onChange={(e) => {
-                  const newValue = e.target.checked;
-                  setShowHistory(newValue);
-                  updateShowHistoryURL(newValue);
-                }}
-                className="sr-only"
-              />
-              <div
-                className={`relative inline-flex h-5 w-9 items-center rounded-full ${shouldAnimate ? 'transition-colors' : ''} ${
-                  showHistory ? 'bg-sky-600' : 'bg-gray-300'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3 w-3 transform rounded-full bg-white ${shouldAnimate ? 'transition-transform' : ''} ${
-                    showHistory ? 'translate-x-5' : 'translate-x-1'
-                  }`}
-                />
-              </div>
-              <span className="ml-2 text-sm text-gray-700">Show history</span>
-            </label>
             {showHistory && (
               <Select
                 value={historyDays.toString()}
@@ -541,6 +667,8 @@ export function Clusters() {
         setLoading={setLoading}
         refreshDataRef={refreshDataRef}
         filters={filters}
+        userScope={userScope}
+        currentUser={currentUser}
         showHistory={showHistory}
         historyDays={historyDays}
         onOpenSSHModal={(cluster) => {
@@ -576,6 +704,8 @@ export function ClusterTable({
   setLoading,
   refreshDataRef,
   filters,
+  userScope,
+  currentUser,
   showHistory,
   historyDays,
   onOpenSSHModal,
@@ -745,7 +875,19 @@ export function ClusterTable({
 
     // For server-side pagination, server already handles filtering - just apply sorting
     // For client-side pagination, we filter/sort the full data then paginate
-    const dataToProcess = isServerPagination ? hookData : allData;
+    let dataToProcess = isServerPagination ? hookData : allData;
+
+    // Ownership scope: default to showing only the current user's clusters.
+    // An explicit User filter from the filter dropdown overrides the scope.
+    const hasExplicitUserFilter = (filters || []).some(
+      (f) => (f.property || '').toLowerCase() === 'user' && f.value
+    );
+    if (userScope === 'mine' && currentUser && !hasExplicitUserFilter) {
+      dataToProcess = (dataToProcess || []).filter(
+        (item) =>
+          item.user_hash === currentUser.id || item.user === currentUser.name
+      );
+    }
 
     if (!isServerPagination) {
       const historicalCount = (allData || []).filter(
@@ -766,7 +908,15 @@ export function ClusterTable({
       : filterData(dataToProcess, filters);
 
     return sortData(filteredData, sortConfig.key, sortConfig.direction);
-  }, [hookData, allData, sortConfig, filters, isServerPagination]);
+  }, [
+    hookData,
+    allData,
+    sortConfig,
+    filters,
+    isServerPagination,
+    userScope,
+    currentUser,
+  ]);
 
   // Expose refresh to parent component
   React.useEffect(() => {

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -294,14 +294,14 @@ export function Clusters() {
 
       const isAnonymous = authResolved && !currentUser;
       const owner = router.query.owner;
-      let expectedScope = null;
       if (isAnonymous) {
-        expectedScope = OWNER_SCOPE_ALL;
-      } else if (isOwnerScope(owner)) {
-        expectedScope = owner;
-      }
-      if (expectedScope !== null && userScope !== expectedScope) {
-        setUserScope(expectedScope);
+        if (userScope !== OWNER_SCOPE_ALL) {
+          setUserScope(OWNER_SCOPE_ALL);
+        }
+      } else if (isOwnerScope(owner) && userScope !== owner) {
+        // Go through selectScope so a deep-linked ?owner=... choice is also
+        // persisted to localStorage like a manual toggle.
+        selectScope(owner);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -530,12 +530,14 @@ export function Clusters() {
   const isEveryone = !explicitUserFilter && userScope === OWNER_SCOPE_ALL;
 
   const handleRefresh = () => {
-    // Invalidate cache to ensure fresh data is fetched
-    dashboardCache.invalidate(getClusters);
+    // Invalidate cache to ensure fresh data is fetched. Use invalidateFunction
+    // so every cache key is dropped regardless of arguments (e.g. the
+    // current-user-scoped [{allUsers: false}] entry used by "My Clusters").
+    dashboardCache.invalidateFunction(getClusters);
     dashboardCache.invalidate(getWorkspaces);
     // Only invalidate cluster history if we're currently showing history
     if (showHistory) {
-      dashboardCache.invalidate(getClusterHistory);
+      dashboardCache.invalidateFunction(getClusterHistory);
     }
 
     // Reset preloading state so ClusterTable can fetch fresh data immediately
@@ -1410,43 +1412,41 @@ export function ClusterTable({
                     </TableRow>
                   );
                 })
-              ) : (
-                userScope === OWNER_SCOPE_MINE &&
+              ) : userScope === OWNER_SCOPE_MINE &&
                 currentUser &&
                 !hasExplicitUserFilter &&
                 othersTotal > 0 ? (
-                  <EmptyTableState
-                    colSpan={totalColSpan}
-                    icon={<ServerIcon className="w-5 h-5" />}
-                    title={`You don't have any${showHistory ? '' : ' active'} clusters${showHistory ? ' yet' : ''}`}
-                    description={`${othersTotal.toLocaleString()} cluster${
-                      othersTotal === 1 ? '' : 's'
-                    } owned by other users — switch to All Clusters to see them.`}
-                    action={
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={onViewAllClusters}
-                        className="text-sky-blue hover:text-sky-blue-bright"
-                      >
-                        View all clusters
-                      </Button>
-                    }
-                  />
-                ) : (
-                  <EmptyTableState
-                    colSpan={totalColSpan}
-                    icon={<ServerIcon className="w-5 h-5" />}
-                    title={
-                      showHistory ? 'No clusters found' : 'No active clusters'
-                    }
-                    description={
-                      showHistory
-                        ? 'No clusters in the selected time range'
-                        : 'Launch a cluster to run your workloads'
-                    }
-                  />
-                )
+                <EmptyTableState
+                  colSpan={totalColSpan}
+                  icon={<ServerIcon className="w-5 h-5" />}
+                  title={`You don't have any${showHistory ? '' : ' active'} clusters${showHistory ? ' yet' : ''}`}
+                  description={`${othersTotal.toLocaleString()} cluster${
+                    othersTotal === 1 ? '' : 's'
+                  } owned by other users — switch to All Clusters to see them.`}
+                  action={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={onViewAllClusters}
+                      className="text-sky-blue hover:text-sky-blue-bright"
+                    >
+                      View all clusters
+                    </Button>
+                  }
+                />
+              ) : (
+                <EmptyTableState
+                  colSpan={totalColSpan}
+                  icon={<ServerIcon className="w-5 h-5" />}
+                  title={
+                    showHistory ? 'No clusters found' : 'No active clusters'
+                  }
+                  description={
+                    showHistory
+                      ? 'No clusters in the selected time range'
+                      : 'Launch a cluster to run your workloads'
+                  }
+                />
               )}
             </TableBody>
           </Table>

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -665,6 +665,7 @@ export function Clusters() {
         filters={filters}
         userScope={userScope}
         currentUser={currentUser}
+        onViewAllClusters={() => selectScope('all')}
         showHistory={showHistory}
         historyDays={historyDays}
         onOpenSSHModal={(cluster) => {
@@ -702,6 +703,7 @@ export function ClusterTable({
   filters,
   userScope,
   currentUser,
+  onViewAllClusters,
   showHistory,
   historyDays,
   onOpenSSHModal,
@@ -911,6 +913,11 @@ export function ClusterTable({
     userScope,
     currentUser,
   ]);
+
+  const everyoneTotal = useMemo(() => {
+    const source = isServerPagination ? hookData : allData;
+    return (source || []).length;
+  }, [hookData, allData, isServerPagination]);
 
   // Expose refresh to parent component
   React.useEffect(() => {
@@ -1339,18 +1346,44 @@ export function ClusterTable({
                   );
                 })
               ) : (
-                <EmptyTableState
-                  colSpan={totalColSpan}
-                  icon={<ServerIcon className="w-5 h-5" />}
-                  title={
-                    showHistory ? 'No clusters found' : 'No active clusters'
-                  }
-                  description={
-                    showHistory
-                      ? 'No clusters in the selected time range'
-                      : 'Launch a cluster to run your workloads'
-                  }
-                />
+                userScope === 'mine' &&
+                currentUser &&
+                !(filters || []).some(
+                  (f) => (f.property || '').toLowerCase() === 'user' && f.value
+                ) &&
+                everyoneTotal > 0 ? (
+                  <EmptyTableState
+                    colSpan={totalColSpan}
+                    icon={<ServerIcon className="w-5 h-5" />}
+                    title={`You don't have any${showHistory ? '' : ' active'} clusters${showHistory ? ' yet' : ''}`}
+                    description={`${everyoneTotal.toLocaleString()} cluster${
+                      everyoneTotal === 1 ? '' : 's'
+                    } in total — switch to All Clusters to see them.`}
+                    action={
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={onViewAllClusters}
+                        className="text-sky-blue hover:text-sky-blue-bright"
+                      >
+                        View all clusters
+                      </Button>
+                    }
+                  />
+                ) : (
+                  <EmptyTableState
+                    colSpan={totalColSpan}
+                    icon={<ServerIcon className="w-5 h-5" />}
+                    title={
+                      showHistory ? 'No clusters found' : 'No active clusters'
+                    }
+                    description={
+                      showHistory
+                        ? 'No clusters in the selected time range'
+                        : 'Launch a cluster to run your workloads'
+                    }
+                  />
+                )
               )}
             </TableBody>
           </Table>

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -72,11 +72,14 @@ const clusterStatusMap = {
   null: 'TERMINATED',
 };
 
-export async function getClusters({ clusterNames = null } = {}) {
+export async function getClusters({
+  clusterNames = null,
+  allUsers = true,
+} = {}) {
   try {
     const clusters = await apiClient.fetch('/status', {
       cluster_names: clusterNames,
-      all_users: true,
+      all_users: allUsers,
       include_credentials: false,
       include_handle: false,
       summary_response: clusterNames == null,
@@ -543,6 +546,13 @@ export function useClusterDetails({ cluster, job = null }) {
  * @param {boolean} options.showHistory - Whether to include historical clusters
  * @param {number} options.historyDays - Number of days of history to fetch
  * @param {number} options.refreshInterval - Auto-refresh interval in ms
+ * @param {Object} options.sortConfig - {key, direction} sort configuration
+ * @param {Array} options.filters - Active filter definitions
+ * @param {boolean} options.allUsers - When false, ask the server to return
+ *   only the current user's clusters (scopes the fetch instead of filtering
+ *   client-side).
+ * @param {Object} options.currentUser - Logged-in user {id, name}, used to
+ *   scope the historical (cost_report) rows that the server doesn't filter.
  * @returns {Object} Cluster data with pagination state and actions
  */
 export function useClusterData(options = {}) {
@@ -552,6 +562,8 @@ export function useClusterData(options = {}) {
     refreshInterval = null,
     sortConfig = { key: null, direction: 'ascending' },
     filters = [],
+    allUsers = true,
+    currentUser = null,
   } = options;
 
   // Convert sortConfig to API format
@@ -581,15 +593,15 @@ export function useClusterData(options = {}) {
   const [isServerPagination, setIsServerPagination] = useState(false);
   const isInitialMount = useRef(true);
 
-  // Reset to page 1 when filters change, but skip on initial mount
-  // so the page number read from the URL isn't overwritten.
+  // Reset to page 1 when filters or ownership scope change, but skip on
+  // initial mount so the page number read from the URL isn't overwritten.
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
       return;
     }
     setPage(1);
-  }, [filtersKey]);
+  }, [filtersKey, allUsers]);
 
   /**
    * Fetch clusters using server-side pagination (plugin path)
@@ -607,6 +619,7 @@ export function useClusterData(options = {}) {
         sortBy,
         sortOrder,
         filters,
+        allUsers,
       },
     ]);
 
@@ -634,13 +647,23 @@ export function useClusterData(options = {}) {
         sortBy,
         sortOrder,
         filters,
+        allUsers,
       };
       dashboardCache
         .get(pluginFetch, [nextPageOptions], { ttl: 30000 })
         .then(() => console.log('[useClusterData] Prefetched page', page + 1))
         .catch((err) => console.warn('[useClusterData] Prefetch failed:', err));
     }
-  }, [page, limit, showHistory, historyDays, sortBy, sortOrder, filters]);
+  }, [
+    page,
+    limit,
+    showHistory,
+    historyDays,
+    sortBy,
+    sortOrder,
+    filters,
+    allUsers,
+  ]);
 
   /**
    * Fetch clusters using client-side pagination (default path)
@@ -648,9 +671,25 @@ export function useClusterData(options = {}) {
   const fetchClientSide = useCallback(async () => {
     console.log('[useClusterData] Using client-side pagination');
 
+    // Scope the active-cluster fetch server-side when we only want the current
+    // user's clusters. The all-users variant keeps the default (no-arg) cache
+    // key so it stays shared with the rest of the dashboard.
+    const fetchActiveClusters = () =>
+      allUsers
+        ? dashboardCache.get(getClusters)
+        : dashboardCache.get(getClusters, [{ allUsers: false }]);
+
+    // The cost_report (history) endpoint always returns every user's rows, so
+    // scope them here to match the server-scoped active clusters.
+    const belongsToCurrentUser = (c) =>
+      allUsers ||
+      !currentUser ||
+      c.user_hash === currentUser.id ||
+      c.user === currentUser.name;
+
     let allClusters;
     if (showHistory) {
-      const activeClusters = await dashboardCache.get(getClusters);
+      const activeClusters = await fetchActiveClusters();
       let historyClusters = [];
       try {
         historyClusters = await dashboardCache.get(getClusterHistory, [
@@ -669,12 +708,14 @@ export function useClusterData(options = {}) {
         ...historyClusters
           .filter(
             (c) =>
-              c.status === 'TERMINATED' && !activeHashes.has(c.cluster_hash)
+              c.status === 'TERMINATED' &&
+              !activeHashes.has(c.cluster_hash) &&
+              belongsToCurrentUser(c)
           )
           .map((c) => ({ ...c, isHistorical: true })),
       ];
     } else {
-      const activeClusters = await dashboardCache.get(getClusters);
+      const activeClusters = await fetchActiveClusters();
       allClusters = activeClusters.map((c) => ({
         ...c,
         isHistorical: false,
@@ -693,7 +734,7 @@ export function useClusterData(options = {}) {
     setHasNext(page < clientTotalPages);
     setHasPrev(page > 1);
     setIsServerPagination(false);
-  }, [showHistory, historyDays, page, limit]);
+  }, [showHistory, historyDays, page, limit, allUsers, currentUser]);
 
   /**
    * Main fetch function - chooses server or client path

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -664,11 +664,19 @@ export function useClusterData(options = {}) {
 
       // cost_report also returns active clusters, so only keep truly
       // terminated rows from history (status === TERMINATED); the live
-      // rows come from cluster_table above and carry fresher data.
+      // rows come from cluster_table above and carry fresher data. Drop
+      // any history row that's still present in the active set (matched by
+      // cluster_hash) to avoid duplicate rows.
+      const activeHashes = new Set(
+        activeClusters.map((c) => c.cluster_hash).filter(Boolean)
+      );
       allClusters = [
         ...activeClusters.map((c) => ({ ...c, isHistorical: false })),
         ...historyClusters
-          .filter((c) => c.status === 'TERMINATED')
+          .filter(
+            (c) =>
+              c.status === 'TERMINATED' && !activeHashes.has(c.cluster_hash)
+          )
           .map((c) => ({ ...c, isHistorical: true })),
       ];
     } else {

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -592,6 +592,10 @@ export function useClusterData(options = {}) {
   const [error, setError] = useState(null);
   const [isServerPagination, setIsServerPagination] = useState(false);
   const isInitialMount = useRef(true);
+  // Monotonic id used to drop stale responses: if the fetch options change
+  // (e.g. the ownership scope flips from all-users to current-user) while a
+  // request is in flight, the older response must not overwrite the newer one.
+  const fetchIdRef = useRef(0);
 
   // Reset to page 1 when filters or ownership scope change, but skip on
   // initial mount so the page number read from the URL isn't overwritten.
@@ -629,14 +633,6 @@ export function useClusterData(options = {}) {
     const resultHasPrev = result.hasPrev || result.has_prev || false;
     const resultData = result.items || result.data || [];
 
-    setData(resultData);
-    setFullData(resultData);
-    setTotal(resultTotal);
-    setTotalPages(resultTotalPages);
-    setHasNext(resultHasNext);
-    setHasPrev(resultHasPrev);
-    setIsServerPagination(true);
-
     // Prefetch next page in background if there is one
     if (resultHasNext) {
       const nextPageOptions = {
@@ -654,6 +650,16 @@ export function useClusterData(options = {}) {
         .then(() => console.log('[useClusterData] Prefetched page', page + 1))
         .catch((err) => console.warn('[useClusterData] Prefetch failed:', err));
     }
+
+    return {
+      data: resultData,
+      fullData: resultData,
+      total: resultTotal,
+      totalPages: resultTotalPages,
+      hasNext: resultHasNext,
+      hasPrev: resultHasPrev,
+      isServerPagination: true,
+    };
   }, [
     page,
     limit,
@@ -723,29 +729,44 @@ export function useClusterData(options = {}) {
     const startIndex = (page - 1) * limit;
     const paginatedData = allClusters.slice(startIndex, startIndex + limit);
 
-    setData(paginatedData);
-    setFullData(allClusters);
-    setTotal(clientTotal);
-    setTotalPages(clientTotalPages);
-    setHasNext(page < clientTotalPages);
-    setHasPrev(page > 1);
-    setIsServerPagination(false);
+    return {
+      data: paginatedData,
+      fullData: allClusters,
+      total: clientTotal,
+      totalPages: clientTotalPages,
+      hasNext: page < clientTotalPages,
+      hasPrev: page > 1,
+      isServerPagination: false,
+    };
   }, [showHistory, historyDays, page, limit, allUsers, currentUser]);
 
   /**
    * Main fetch function - chooses server or client path
    */
   const fetchData = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
     setLoading(true);
     setError(null);
 
     try {
-      if (isPaginationPluginAvailable()) {
-        await fetchServerSide();
-      } else {
-        await fetchClientSide();
+      const result = isPaginationPluginAvailable()
+        ? await fetchServerSide()
+        : await fetchClientSide();
+      // A newer fetch started while this one was in flight; drop the result.
+      if (fetchId !== fetchIdRef.current) {
+        return;
       }
+      setData(result.data);
+      setFullData(result.fullData);
+      setTotal(result.total);
+      setTotalPages(result.totalPages);
+      setHasNext(result.hasNext);
+      setHasPrev(result.hasPrev);
+      setIsServerPagination(result.isServerPagination);
     } catch (fetchError) {
+      if (fetchId !== fetchIdRef.current) {
+        return;
+      }
       console.error('[useClusterData] Error fetching clusters:', fetchError);
       setError(fetchError);
       setData([]);

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -650,6 +650,8 @@ export function useClusterData(options = {}) {
 
     let allClusters;
     if (showHistory) {
+      // "All" view: live clusters plus terminated ones from history.
+      const activeClusters = await dashboardCache.get(getClusters);
       let historyClusters = [];
       try {
         historyClusters = await dashboardCache.get(getClusterHistory, [
@@ -660,12 +662,15 @@ export function useClusterData(options = {}) {
         console.error('Error fetching cluster history:', historyError);
       }
 
-      // "Show history" surfaces only truly terminated clusters within the
-      // selected time window. cost_report also returns active clusters, so
-      // drop anything still present in cluster_table (status !== TERMINATED).
-      allClusters = historyClusters
-        .filter((c) => c.status === 'TERMINATED')
-        .map((c) => ({ ...c, isHistorical: true }));
+      // cost_report also returns active clusters, so only keep truly
+      // terminated rows from history (status === TERMINATED); the live
+      // rows come from cluster_table above and carry fresher data.
+      allClusters = [
+        ...activeClusters.map((c) => ({ ...c, isHistorical: false })),
+        ...historyClusters
+          .filter((c) => c.status === 'TERMINATED')
+          .map((c) => ({ ...c, isHistorical: true })),
+      ];
     } else {
       const activeClusters = await dashboardCache.get(getClusters);
       allClusters = activeClusters.map((c) => ({

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -650,7 +650,6 @@ export function useClusterData(options = {}) {
 
     let allClusters;
     if (showHistory) {
-      // "All" view: live clusters plus terminated ones from history.
       const activeClusters = await dashboardCache.get(getClusters);
       let historyClusters = [];
       try {
@@ -662,11 +661,6 @@ export function useClusterData(options = {}) {
         console.error('Error fetching cluster history:', historyError);
       }
 
-      // cost_report also returns active clusters, so only keep truly
-      // terminated rows from history (status === TERMINATED); the live
-      // rows come from cluster_table above and carry fresher data. Drop
-      // any history row that's still present in the active set (matched by
-      // cluster_hash) to avoid duplicate rows.
       const activeHashes = new Set(
         activeClusters.map((c) => c.cluster_hash).filter(Boolean)
       );

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -671,16 +671,11 @@ export function useClusterData(options = {}) {
   const fetchClientSide = useCallback(async () => {
     console.log('[useClusterData] Using client-side pagination');
 
-    // Scope the active-cluster fetch server-side when we only want the current
-    // user's clusters. The all-users variant keeps the default (no-arg) cache
-    // key so it stays shared with the rest of the dashboard.
     const fetchActiveClusters = () =>
       allUsers
         ? dashboardCache.get(getClusters)
         : dashboardCache.get(getClusters, [{ allUsers: false }]);
 
-    // The cost_report (history) endpoint always returns every user's rows, so
-    // scope them here to match the server-scoped active clusters.
     const belongsToCurrentUser = (c) =>
       allUsers ||
       !currentUser ||
@@ -705,6 +700,7 @@ export function useClusterData(options = {}) {
       );
       allClusters = [
         ...activeClusters.map((c) => ({ ...c, isHistorical: false })),
+        // cost_report returns every user's rows, so scope history client-side.
         ...historyClusters
           .filter(
             (c) =>

--- a/sky/dashboard/src/data/connectors/clusters.test.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.test.jsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 // Mock the shared dashboard cache so we can observe which cache key the hook
 // fetches under (all-users vs. current-user scope) without hitting the network.
@@ -138,5 +138,61 @@ describe('useClusterData ownership scoping (client path)', () => {
     const names = result.current.allData.map((c) => c.cluster).sort();
     expect(names).toEqual(['mine-active', 'mine-terminated']);
     expect(names).not.toContain('other-terminated');
+  });
+
+  it('drops a stale all-users response that resolves after a newer scoped fetch', async () => {
+    // Deep-linking ?owner=mine starts an all-users fetch (initial scope)
+    // followed by a scoped fetch once the URL is synced. If the all-users
+    // response lands last it must not overwrite the scoped data.
+    let resolveAllUsers;
+    dashboardCache.get.mockImplementation((fn, args) => {
+      if (args && args[0] && args[0].allUsers === false) {
+        return Promise.resolve([
+          {
+            cluster: 'mine-active',
+            user_hash: 'u-1',
+            user: 'alice',
+            status: 'RUNNING',
+          },
+        ]);
+      }
+      return new Promise((resolve) => {
+        resolveAllUsers = () =>
+          resolve([
+            {
+              cluster: 'other-active',
+              user_hash: 'u-2',
+              user: 'bob',
+              status: 'RUNNING',
+            },
+          ]);
+      });
+    });
+
+    // Stable identities: fresh objects every render would recreate the hook's
+    // fetch callbacks and trigger spurious refetches.
+    const currentUser = { id: 'u-1', name: 'alice' };
+    const filters = [];
+    const { result, rerender } = renderHook(
+      ({ allUsers }) => useClusterData({ allUsers, currentUser, filters }),
+      { initialProps: { allUsers: true } }
+    );
+
+    // Flip to the scoped fetch while the all-users request is still pending.
+    rerender({ allUsers: false });
+    await waitFor(() =>
+      expect(result.current.allData.map((c) => c.cluster)).toEqual([
+        'mine-active',
+      ])
+    );
+
+    // The stale all-users response resolves last; it must be discarded.
+    await act(async () => {
+      resolveAllUsers();
+    });
+    expect(result.current.allData.map((c) => c.cluster)).toEqual([
+      'mine-active',
+    ]);
+    expect(result.current.loading).toBe(false);
   });
 });

--- a/sky/dashboard/src/data/connectors/clusters.test.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.test.jsx
@@ -1,0 +1,142 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+// Mock the shared dashboard cache so we can observe which cache key the hook
+// fetches under (all-users vs. current-user scope) without hitting the network.
+jest.mock('@/lib/cache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    invalidate: jest.fn(),
+    invalidateFunction: jest.fn(),
+    setPreloader: jest.fn(),
+    getCached: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+// Stub the API client so getClusters can be exercised in isolation.
+jest.mock('@/data/connectors/client', () => ({
+  __esModule: true,
+  apiClient: { fetch: jest.fn() },
+}));
+
+// Plugin enhancements are a no-op passthrough for these tests.
+jest.mock('@/plugins/dataEnhancement', () => ({
+  __esModule: true,
+  applyEnhancements: jest.fn(async (data) => data),
+}));
+
+import dashboardCache from '@/lib/cache';
+import { apiClient } from '@/data/connectors/client';
+import {
+  getClusters,
+  getClusterHistory,
+  useClusterData,
+} from '@/data/connectors/clusters';
+
+describe('getClusters all_users scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiClient.fetch.mockResolvedValue([]);
+  });
+
+  it('requests all users by default', async () => {
+    await getClusters();
+
+    expect(apiClient.fetch).toHaveBeenCalledTimes(1);
+    const [, body] = apiClient.fetch.mock.calls[0];
+    expect(body.all_users).toBe(true);
+  });
+
+  it('scopes the request to the current user when allUsers is false', async () => {
+    await getClusters({ allUsers: false });
+
+    expect(apiClient.fetch).toHaveBeenCalledTimes(1);
+    const [, body] = apiClient.fetch.mock.calls[0];
+    expect(body.all_users).toBe(false);
+  });
+});
+
+describe('useClusterData ownership scoping (client path)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // No pagination plugin -> client-side path.
+    delete window.__skyPaginationFetch;
+    dashboardCache.get.mockResolvedValue([]);
+  });
+
+  it('fetches the shared all-users cache entry when allUsers is true', async () => {
+    renderHook(() => useClusterData({ allUsers: true }));
+
+    await waitFor(() => expect(dashboardCache.get).toHaveBeenCalled());
+    // All-users keeps the default (no-arg) cache key so it stays shared with
+    // the rest of the dashboard.
+    expect(dashboardCache.get).toHaveBeenCalledWith(getClusters);
+    expect(dashboardCache.get).not.toHaveBeenCalledWith(getClusters, [
+      { allUsers: false },
+    ]);
+  });
+
+  it('fetches the current-user-scoped cache entry when allUsers is false', async () => {
+    renderHook(() =>
+      useClusterData({
+        allUsers: false,
+        currentUser: { id: 'u-1', name: 'alice' },
+      })
+    );
+
+    await waitFor(() =>
+      expect(dashboardCache.get).toHaveBeenCalledWith(getClusters, [
+        { allUsers: false },
+      ])
+    );
+    expect(dashboardCache.get).not.toHaveBeenCalledWith(getClusters);
+  });
+
+  it("drops other users' terminated clusters from history when scoped to mine", async () => {
+    // The cost_report (history) endpoint always returns every user's rows, so
+    // the hook scopes them client-side to match the server-scoped active list.
+    dashboardCache.get.mockImplementation((fn) => {
+      if (fn === getClusterHistory) {
+        return Promise.resolve([
+          {
+            cluster: 'mine-terminated',
+            user_hash: 'u-1',
+            user: 'alice',
+            cluster_hash: 'h2',
+            status: 'TERMINATED',
+          },
+          {
+            cluster: 'other-terminated',
+            user_hash: 'u-2',
+            user: 'bob',
+            cluster_hash: 'h3',
+            status: 'TERMINATED',
+          },
+        ]);
+      }
+      return Promise.resolve([
+        {
+          cluster: 'mine-active',
+          user_hash: 'u-1',
+          user: 'alice',
+          cluster_hash: 'h1',
+          status: 'RUNNING',
+        },
+      ]);
+    });
+
+    const { result } = renderHook(() =>
+      useClusterData({
+        showHistory: true,
+        allUsers: false,
+        currentUser: { id: 'u-1', name: 'alice' },
+      })
+    );
+
+    await waitFor(() => expect(result.current.allData.length).toBe(2));
+    const names = result.current.allData.map((c) => c.cluster).sort();
+    expect(names).toEqual(['mine-active', 'mine-terminated']);
+    expect(names).not.toContain('other-terminated');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the **Show history** checkbox on the Clusters page with an **Active / All** activity toggle. `All` shows live clusters plus terminated ones from history (the history-days selector still applies in `All`).
- Add a **My Clusters / All Clusters** ownership toggle that defaults to the signed-in user's own clusters. It is only shown when the caller has a real identity (e.g. Okta/SSO); with basic auth or no auth there is no per-user view, so the toggle is hidden and the page falls back to `All` — mirroring the jobs page behavior.
- Add a jobs-page-style empty-state CTA: when **My Clusters** is empty but other users' clusters exist, show the total count and a **View all clusters** button that switches to the All Clusters scope, instead of a bare "No active clusters" message.
- Both toggles are reflected in the URL (`?owner=all`, `?history=true`) so the view is shareable/bookmarkable. An explicit `User` filter from the filter dropdown overrides the ownership scope.

## Test plan

- `npm --prefix sky/dashboard run lint` and `prettier --check` pass on the changed files.
- Manual, local API server (`sky api stop && sky api start`, rebuild dashboard):
  - With SSO/Okta identity: Clusters page defaults to **My Clusters**; toggling to **All Clusters** shows everyone's; switching **Active/All** includes terminated clusters; URL updates with `owner`/`history` and is restored on reload.
  - With basic/no auth (`local` user): ownership toggle is hidden; only **Active/All** is shown; defaults to all clusters.
  - With an identity but zero own clusters while others exist: **My Clusters** shows the "you have none, N in total — View all clusters" CTA; clicking it flips to All Clusters.
  - Applying a `User:` filter highlights the correct ownership tab and overrides the scope.

no SSO view

https://github.com/user-attachments/assets/24b665ff-18d5-4d8d-9dbc-1ecb1ed379c8

SSO view

https://github.com/user-attachments/assets/4cde7f28-a7e2-426d-a5dd-a7554001242d

