### PR TITLE
[Server] Add WAITING request status for parked retries

### DIFF
--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 54  # managed jobs queue submission-time filter (--since/--after/--before)
+API_VERSION = 55  # WAITING request status
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):
@@ -72,6 +72,12 @@ MIN_PREFERRED_WORKSPACE_API_VERSION = 53
 # --since / --after / --before flags). Older servers silently ignore these
 # fields, so the client warns and shows all jobs.
 MIN_JOBS_SUBMITTED_AT_FILTER_API_VERSION = 54
+
+# Servers >= this version may report the WAITING request status (a request
+# parked off its worker while waiting for a retry/resume condition). Older
+# clients don't know the value and would crash parsing it, so the server
+# downgrades WAITING to RUNNING on the wire for clients below this version.
+MIN_WAITING_STATUS_API_VERSION = 55
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -318,11 +318,6 @@ class RequestWorker:
                 queue = _get_queue(self.schedule_type)
                 queue.put(request_element)
         except exceptions.ExecutionRetryableError as e:
-            # Set PENDING before the wait, not after: during the backoff the
-            # request is parked waiting to be rescheduled, so PENDING is its
-            # accurate state and lets a request-recovery mechanism re-enqueue
-            # it if the server is interrupted mid-wait. It is not put back on
-            # the queue until after the wait, so no worker picks it up early.
             request_id, _, _ = request_element
             # Clamp to avoid ValueError from time.sleep() on a negative wait.
             retry_wait_seconds = max(0, e.retry_wait_seconds)
@@ -341,9 +336,10 @@ class RequestWorker:
                             f'retrying in {retry_wait_seconds}s')
             status_msg = (f'{reason} ({retry_suffix})'
                           if reason else retry_suffix.capitalize())
+            # Set request to WAITING status for visibility
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
-                request_task.status = api_requests.RequestStatus.PENDING
+                request_task.status = api_requests.RequestStatus.WAITING
                 request_task.status_msg = status_msg
             try:
                 if condition is not None:

--- a/sky/server/requests/preconditions.py
+++ b/sky/server/requests/preconditions.py
@@ -173,10 +173,7 @@ class ClusterStartCompletePrecondition(Precondition):
         # in UP status.
         requests = await api_requests.get_request_tasks_async(
             req_filter=api_requests.RequestTaskFilter(
-                status=[
-                    api_requests.RequestStatus.PENDING,
-                    api_requests.RequestStatus.RUNNING
-                ],
+                status=api_requests.RequestStatus.active_statuses(),
                 include_request_names=['sky.launch', 'sky.start'],
                 cluster_names=[self.cluster_name],
                 # Only get the request ID to avoid fetching the whole request.

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -30,6 +30,7 @@ from sky.metrics import utils as metrics_lib
 from sky.server import common as server_common
 from sky.server import constants as server_constants
 from sky.server import daemons
+from sky.server import versions
 from sky.server.blob import blob_storage as bs
 from sky.server.requests import payloads
 from sky.server.requests import storage as request_storage
@@ -68,6 +69,7 @@ class RequestStatus(enum.Enum):
     """The status of a request."""
 
     PENDING = 'PENDING'
+    WAITING = 'WAITING'
     RUNNING = 'RUNNING'
     SUCCEEDED = 'SUCCEEDED'
     FAILED = 'FAILED'
@@ -85,14 +87,36 @@ class RequestStatus(enum.Enum):
     def finished_status(cls) -> List['RequestStatus']:
         return [cls.SUCCEEDED, cls.FAILED, cls.CANCELLED]
 
+    @classmethod
+    def active_statuses(cls) -> List['RequestStatus']:
+        """Statuses of requests that are not finished yet."""
+        return [cls.PENDING, cls.WAITING, cls.RUNNING]
+
 
 _STATUS_TO_COLOR = {
     RequestStatus.PENDING: colorama.Fore.BLUE,
+    RequestStatus.WAITING: colorama.Fore.YELLOW,
     RequestStatus.RUNNING: colorama.Fore.GREEN,
     RequestStatus.SUCCEEDED: colorama.Fore.GREEN,
     RequestStatus.FAILED: colorama.Fore.RED,
     RequestStatus.CANCELLED: colorama.Fore.WHITE,
 }
+
+
+def _status_value_for_client(status_value: str) -> str:
+    """Map WAITING to RUNNING for clients that predate the WAITING status.
+
+    Older clients parse the status string straight into the RequestStatus enum
+    and crash on an unknown value, so downgrade it to the closest status they
+    understand on the wire.
+    """
+    remote_api_version = versions.get_remote_api_version()
+    if (status_value == RequestStatus.WAITING.value and
+            remote_api_version is not None and remote_api_version <
+            server_constants.MIN_WAITING_STATUS_API_VERSION):
+        return RequestStatus.RUNNING.value
+    return status_value
+
 
 REQUEST_COLUMNS = [
     'request_id',
@@ -222,7 +246,7 @@ class Request:
             name=self.name,
             entrypoint=self.entrypoint.__name__,
             request_body=self.request_body.model_dump_json(),
-            status=self.status.value,
+            status=_status_value_for_client(self.status.value),
             return_value=orjson.dumps(None).decode('utf-8'),
             error=orjson.dumps(None).decode('utf-8'),
             pid=None,
@@ -250,7 +274,7 @@ class Request:
                 name=self.name,
                 entrypoint=encoders.pickle_and_encode(self.entrypoint),
                 request_body=encoders.pickle_and_encode(self.request_body),
-                status=self.status.value,
+                status=_status_value_for_client(self.status.value),
                 return_value=serializer(self.return_value),
                 error=orjson.dumps(self.error).decode('utf-8'),
                 pid=self.pid,
@@ -346,7 +370,7 @@ def encode_requests(requests: List[Request]) -> List[payloads.RequestPayload]:
             request_body=request.request_body.model_dump_json()
             if request.request_body is not None else
             orjson.dumps(None).decode('utf-8'),
-            status=request.status.value,
+            status=_status_value_for_client(request.status.value),
             return_value=orjson.dumps(None).decode('utf-8'),
             error=orjson.dumps(None).decode('utf-8'),
             pid=None,
@@ -564,7 +588,7 @@ def kill_cluster_requests(cluster_name: str, exclude_request_name: str):
     request_ids = [
         request_task.request_id
         for request_task in storage.query_requests(req_filter=RequestTaskFilter(
-            status=[RequestStatus.PENDING, RequestStatus.RUNNING],
+            status=RequestStatus.active_statuses(),
             exclude_request_names=[exclude_request_name],
             cluster_names=[cluster_name],
             fields=['request_id']))
@@ -1368,7 +1392,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             request_ids = [
                 r.request_id
                 for r in self.query_requests(req_filter=RequestTaskFilter(
-                    status=[RequestStatus.PENDING, RequestStatus.RUNNING],
+                    status=RequestStatus.active_statuses(),
                     exclude_request_names=['sky.api_cancel'],
                     user_id=user_id,
                     fields=['request_id']))
@@ -1497,12 +1521,13 @@ class SqliteRequestBackend(request_storage.RequestBackend):
         assert _DB is not None
         with _DB.conn:
             cursor = _DB.conn.cursor()
+            active_values = [s.value for s in RequestStatus.active_statuses()]
+            placeholders = ', '.join('?' * len(active_values))
             cursor.execute(
                 f'SELECT DISTINCT {COL_FILE_MOUNTS_BLOB_ID} '
                 f'FROM {REQUEST_TABLE} '
-                f'WHERE status IN (?, ?) '
-                f'AND {COL_FILE_MOUNTS_BLOB_ID} IS NOT NULL',
-                (RequestStatus.PENDING.value, RequestStatus.RUNNING.value))
+                f'WHERE status IN ({placeholders}) '
+                f'AND {COL_FILE_MOUNTS_BLOB_ID} IS NOT NULL', active_values)
             return {row[0] for row in cursor.fetchall()}
 
     def get_shutdown_active_requests(self) -> List[Tuple[str, str]]:

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -218,6 +218,10 @@ class Request:
 
     def to_row(self) -> Tuple[Any, ...]:
         payload = self.encode()
+        # encode() may downgrade WAITING -> RUNNING for clients on an older API
+        # version; that is a wire-only concern. to_row() feeds the database, so
+        # always persist the true status regardless of the request context.
+        payload.status = self.status.value
         row = []
         for k in REQUEST_COLUMNS:
             row.append(getattr(payload, k))
@@ -483,12 +487,12 @@ def create_table(cursor, conn):
     # Add an index on (status, name) to speed up queries
     # that filter on these columns.
     cursor.execute(f"""\
-        CREATE INDEX IF NOT EXISTS status_name_idx ON {REQUEST_TABLE} (status, name) WHERE status IN ('PENDING', 'RUNNING');
+        CREATE INDEX IF NOT EXISTS status_name_idx ON {REQUEST_TABLE} (status, name) WHERE status IN ('PENDING', 'WAITING', 'RUNNING');
     """)
     # Add an index on cluster_name to speed up queries
     # that filter on this column.
     cursor.execute(f"""\
-        CREATE INDEX IF NOT EXISTS cluster_name_idx ON {REQUEST_TABLE} ({COL_CLUSTER_NAME}) WHERE status IN ('PENDING', 'RUNNING');
+        CREATE INDEX IF NOT EXISTS cluster_name_idx ON {REQUEST_TABLE} ({COL_CLUSTER_NAME}) WHERE status IN ('PENDING', 'WAITING', 'RUNNING');
     """)
     # Add an index on created_at to speed up queries that sort on this column.
     cursor.execute(f"""\

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2580,10 +2580,7 @@ async def api_status(
     if request_ids is None:
         statuses = None
         if not all_status:
-            statuses = [
-                requests_lib.RequestStatus.PENDING,
-                requests_lib.RequestStatus.RUNNING,
-            ]
+            statuses = requests_lib.RequestStatus.active_statuses()
         request_tasks = await requests_lib.get_request_tasks_async(
             req_filter=requests_lib.RequestTaskFilter(
                 status=statuses,

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -642,13 +642,13 @@ async def test_request_worker_retry_execution_retryable_error(
     ], (f'Expected first time.sleep call to be 30 seconds, got {sleep_calls[0]}'
        )
 
-    # Verify the status was set to PENDING *before* the backoff wait, and that
+    # Verify the status was set to WAITING *before* the backoff wait, and that
     # the request was not yet re-enqueued at that point. This guards the
     # failover-safety ordering: a server interrupted mid-wait leaves the
-    # request in PENDING (recoverable) rather than a stuck RUNNING orphan.
+    # request in WAITING (recoverable) rather than a stuck RUNNING orphan.
     assert status_at_sleep == [
-        requests_lib.RequestStatus.PENDING
-    ], (f'Expected status to be PENDING at sleep time, got {status_at_sleep}')
+        requests_lib.RequestStatus.WAITING
+    ], (f'Expected status to be WAITING at sleep time, got {status_at_sleep}')
     assert queue_len_at_sleep == [
         0
     ], ('Expected request to be re-enqueued only after the wait, but it was '
@@ -664,11 +664,12 @@ async def test_request_worker_retry_execution_retryable_error(
     assert 'retrying in 30s' in msg, (
         f'Expected wait time in status_msg, got: {msg!r}')
 
-    # Verify the request status was reset to PENDING
+    # The request stays WAITING through the backoff and re-enqueue; a worker
+    # flips it to RUNNING only when it picks the request back up.
     updated_request = requests_lib.get_request(request_id, fields=['status'])
     assert updated_request is not None
-    assert updated_request.status == requests_lib.RequestStatus.PENDING, (
-        f'Expected request status to be PENDING, got {updated_request.status}')
+    assert updated_request.status == requests_lib.RequestStatus.WAITING, (
+        f'Expected request status to be WAITING, got {updated_request.status}')
 
     # Call process_request - it should pick up the request from the queue
     # and call submit_until_success
@@ -788,10 +789,10 @@ def test_pause_reschedules_when_wait_returns_true(pause_harness):
         'is_cancelled': False,
         'fallback_wait_seconds': 30
     }]
-    # During the pause the request is PENDING with a "waiting to resume" msg.
+    # During the pause the request is WAITING with a "waiting to resume" msg.
     updated = requests_lib.get_request(pause_harness.request_id,
                                        fields=['status', 'status_msg'])
-    assert updated.status == requests_lib.RequestStatus.PENDING
+    assert updated.status == requests_lib.RequestStatus.WAITING
     assert 'waiting to resume' in updated.status_msg
 
 
@@ -814,7 +815,7 @@ def test_pause_base_condition_does_fixed_fallback_wait(pause_harness):
     assert pause_harness.queue_items == [request_element]
     updated = requests_lib.get_request(pause_harness.request_id,
                                        fields=['status'])
-    assert updated.status == requests_lib.RequestStatus.PENDING
+    assert updated.status == requests_lib.RequestStatus.WAITING
 
 
 def test_pause_base_condition_dropped_if_cancelled_during_wait(

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1912,3 +1912,19 @@ def test_encode_downgrades_waiting_for_old_clients(remote_api_version,
         assert requests.encode_requests([request])[0].status == expected
         assert request.readable_encode().status == expected
         assert request.encode().status == expected
+
+
+def test_to_row_keeps_true_status_for_old_clients(remote_api_version):
+    """to_row() (the DB path) must never persist the wire-downgraded status.
+
+    encode() downgrades WAITING -> RUNNING for old clients; to_row() feeds the
+    database, so it must store the true WAITING status regardless of the
+    request context, or the WAITING state would be silently lost.
+    """
+    remote_api_version(server_constants.MIN_WAITING_STATUS_API_VERSION - 1)
+    request = _waiting_request()
+    status_idx = requests.REQUEST_COLUMNS.index('status')
+
+    # Same context: the wire encoding downgrades, the DB row does not.
+    assert request.encode().status == 'RUNNING'
+    assert request.to_row()[status_idx] == 'WAITING'

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1838,3 +1838,77 @@ async def test_get_requests_with_prefix(isolated_database, test_async):
         assert req.finished_at is None
         assert req.should_retry is False
         assert req.status_msg is None
+
+
+def test_waiting_status_ordering_and_color():
+    """WAITING sits between PENDING and RUNNING and has a color mapping."""
+    from sky.server.requests.requests import _STATUS_TO_COLOR
+
+    assert RequestStatus.PENDING < RequestStatus.WAITING
+    assert RequestStatus.WAITING < RequestStatus.RUNNING
+    # Not terminal: the `> RUNNING` finished-check must not catch WAITING.
+    assert not RequestStatus.WAITING > RequestStatus.RUNNING
+    # Every status must have a color, or colored_str() raises KeyError.
+    for status in RequestStatus:
+        assert status in _STATUS_TO_COLOR
+    RequestStatus.WAITING.colored_str()  # must not raise
+
+
+def test_active_statuses_includes_waiting():
+    """The active set used by listing/kill/blob-GC filters must include WAITING."""
+    active = RequestStatus.active_statuses()
+    assert RequestStatus.WAITING in active
+    assert RequestStatus.PENDING in active
+    assert RequestStatus.RUNNING in active
+    assert not set(active) & set(RequestStatus.finished_status())
+
+
+def _waiting_request():
+    return requests.Request(request_id='waiting-req',
+                            name='test-request',
+                            entrypoint=dummy,
+                            request_body=payloads.RequestBody(),
+                            status=RequestStatus.WAITING,
+                            created_at=time.time(),
+                            user_id='user-1')
+
+
+@pytest.fixture()
+def remote_api_version():
+    """Set/restore the per-request client API version contextvar."""
+    from sky.server import versions
+
+    tokens = []
+
+    def _set(value):
+        tokens.append(versions._remote_api_version.set(value))
+
+    yield _set
+    for token in reversed(tokens):
+        versions._remote_api_version.reset(token)
+
+
+@pytest.mark.parametrize('client_version,expected', [
+    (None, 'WAITING'),
+    (server_constants.MIN_WAITING_STATUS_API_VERSION - 1, 'RUNNING'),
+    (server_constants.MIN_WAITING_STATUS_API_VERSION, 'WAITING'),
+])
+def test_encode_downgrades_waiting_for_old_clients(remote_api_version,
+                                                   client_version, expected):
+    """The server downgrades WAITING -> RUNNING only for old clients.
+
+    Covers all three encode paths (encode_requests, readable_encode, encode)
+    that put status on the wire.
+    """
+    from sky import models
+
+    remote_api_version(client_version)
+    request = _waiting_request()
+    mock_user = models.User(id='user-1', name='User One')
+    with mock.patch('sky.global_user_state.get_all_users',
+                    return_value=[mock_user]), \
+            mock.patch('sky.global_user_state.get_user',
+                       return_value=mock_user):
+        assert requests.encode_requests([request])[0].status == expected
+        assert request.readable_encode().status == expected
+        assert request.encode().status == expected


### PR DESCRIPTION
A request that releases its executor worker during a retry/pause backoff was marked PENDING for the duration of the wait, making it indistinguishable from a request that has never been scheduled. Add a distinct WAITING status (ordered between PENDING and RUNNING so existing relative status comparisons are unaffected) and use it while a request is parked off its worker waiting for a retry/resume condition.

WAITING is included in the active-request filters (listing, kill, active file-mount blob GC, launch precondition) so a parked request stays visible, cancellable, and keeps its uploaded artifacts.

For backward compatibility the server downgrades WAITING to RUNNING on the wire for clients whose API version predates the new status, so older clients that parse the status string into an enum do not crash.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
