### PR TITLE
[API] Prevent service account role privilege escalation

### DIFF
--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -333,6 +333,29 @@ def get_supported_roles() -> List[str]:
     return [role_name.value for role_name in RoleName]
 
 
+# Role privilege ordering for grant checks (viewer < user < admin).
+_ROLE_RANK: Dict[str, int] = {
+    RoleName.VIEWER.value: 0,
+    RoleName.USER.value: 1,
+    RoleName.ADMIN.value: 2,
+}
+
+
+def get_role_rank(role: str) -> int:
+    """Return the privilege rank of a role, or -1 if unknown."""
+    return _ROLE_RANK.get(role, -1)
+
+
+def caller_can_grant_role(caller_roles: List[str], granted_role: str) -> bool:
+    """Return whether caller_roles may assign granted_role to another user."""
+    if granted_role not in get_supported_roles():
+        return False
+    if not caller_roles:
+        return False
+    caller_rank = max(get_role_rank(role) for role in caller_roles)
+    return get_role_rank(granted_role) <= caller_rank
+
+
 def get_default_role() -> str:
     return skypilot_config.get_nested(('rbac', 'default_role'),
                                       default_value=RoleName.ADMIN.value)

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -348,12 +348,13 @@ def get_role_rank(role: str) -> int:
 
 def caller_can_grant_role(caller_roles: List[str], granted_role: str) -> bool:
     """Return whether caller_roles may assign granted_role to another user."""
-    if granted_role not in get_supported_roles():
+    granted_rank = get_role_rank(granted_role)
+    if granted_rank == -1:
         return False
     if not caller_roles:
         return False
     caller_rank = max(get_role_rank(role) for role in caller_roles)
-    return get_role_rank(granted_role) <= caller_rank
+    return granted_rank <= caller_rank
 
 
 def get_default_role() -> str:

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -69,8 +69,7 @@ def get_user_type(user: models.User) -> str:
 
 def _assert_caller_can_grant_role(caller_id: str, role: str) -> None:
     """Ensure the caller may assign role to another identity."""
-    supported_roles = rbac.get_supported_roles()
-    if role not in supported_roles:
+    if rbac.get_role_rank(role) == -1:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Invalid role: {role}')
     caller_roles = permission.permission_service.get_user_roles(caller_id)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -67,6 +67,24 @@ def get_user_type(user: models.User) -> str:
     return models.UserType.LEGACY.value
 
 
+def _assert_caller_can_grant_role(caller_id: str, role: str) -> None:
+    """Ensure the caller may assign role to another identity."""
+    supported_roles = rbac.get_supported_roles()
+    if role not in supported_roles:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=f'Invalid role: {role}')
+    caller_roles = permission.permission_service.get_user_roles(caller_id)
+    if not caller_roles:
+        raise fastapi.HTTPException(status_code=403, detail='Invalid user')
+    if rbac.caller_can_grant_role(caller_roles, role):
+        return
+    if role == rbac.RoleName.ADMIN.value:
+        raise fastapi.HTTPException(
+            status_code=403, detail='Only admin can grant the admin role')
+    raise fastapi.HTTPException(
+        status_code=403, detail='Cannot grant a role higher than your own')
+
+
 # All handlers in user handler are sync to get fastAPI run it in a
 # ThreadPoolExecutor to avoid blocking the async event loop.
 # TODO(aylei): make these async once we have the global_user_state async
@@ -960,6 +978,8 @@ def update_service_account_role(
             detail='You can only update roles for your own service accounts. '
             'Only admins can update roles for service accounts owned by other '
             'users.')
+
+    _assert_caller_can_grant_role(auth_user.id, role_body.role)
 
     try:
         # Update service account role

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -146,3 +146,23 @@ class TestDefaultRoleConfig:
         with mock.patch('sky.skypilot_config.get_nested',
                         return_value='viewer'):
             assert rbac.get_default_role() == 'viewer'
+
+
+class TestCallerCanGrantRole:
+    """Privilege-escalation guard for service-account role grants."""
+
+    def test_admin_can_grant_admin(self):
+        assert rbac.caller_can_grant_role(['admin'], 'admin')
+
+    def test_user_cannot_grant_admin(self):
+        assert not rbac.caller_can_grant_role(['user'], 'admin')
+
+    def test_user_can_grant_user_or_viewer(self):
+        assert rbac.caller_can_grant_role(['user'], 'user')
+        assert rbac.caller_can_grant_role(['user'], 'viewer')
+
+    def test_viewer_cannot_grant_user(self):
+        assert not rbac.caller_can_grant_role(['viewer'], 'user')
+
+    def test_empty_caller_roles_cannot_grant(self):
+        assert not rbac.caller_can_grant_role([], 'user')

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -166,3 +166,6 @@ class TestCallerCanGrantRole:
 
     def test_empty_caller_roles_cannot_grant(self):
         assert not rbac.caller_can_grant_role([], 'user')
+
+    def test_invalid_granted_role_returns_false(self):
+        assert not rbac.caller_can_grant_role(['admin'], 'superadmin')

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -1175,3 +1175,88 @@ class TestUserContextIsolation:
 
         assert captured['inside'] == 'u-alice'  # set inside the context
         assert after == before  # no leak after the handler returns
+
+
+class TestUpdateServiceAccountRole:
+    """Tests for POST /users/service-account-tokens/update-role."""
+
+    @mock.patch('sky.global_user_state.get_service_account_token')
+    @mock.patch('sky.users.permission.permission_service'
+                '.check_service_account_token_permission')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    def test_non_admin_cannot_grant_admin_to_own_service_account(
+            self, mock_update_role, mock_get_user_roles,
+            mock_check_sa_permission, mock_get_token, mock_request):
+        """Regression: users must not escalate via their own SA token."""
+        mock_request.state.auth_user = models.User(id='regular-user',
+                                                   name='Regular')
+        mock_get_token.return_value = {
+            'creator_user_hash': 'regular-user',
+            'service_account_user_id': 'sa-abc123',
+        }
+        mock_check_sa_permission.return_value = True
+        mock_get_user_roles.return_value = ['user']
+
+        role_body = payloads.ServiceAccountTokenUpdateRoleBody(
+            token_id='token-1', role='admin')
+
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            server.update_service_account_role(mock_request, role_body)
+
+        assert exc_info.value.status_code == 403
+        assert 'Only admin can grant the admin role' in str(
+            exc_info.value.detail)
+        mock_update_role.assert_not_called()
+
+    @mock.patch('sky.global_user_state.get_service_account_token')
+    @mock.patch('sky.users.permission.permission_service'
+                '.check_service_account_token_permission')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    def test_admin_can_grant_admin_to_service_account(self, mock_update_role,
+                                                      mock_get_user_roles,
+                                                      mock_check_sa_permission,
+                                                      mock_get_token,
+                                                      mock_request):
+        mock_request.state.auth_user = models.User(id='admin-user',
+                                                   name='Admin')
+        mock_get_token.return_value = {
+            'creator_user_hash': 'admin-user',
+            'service_account_user_id': 'sa-abc123',
+        }
+        mock_check_sa_permission.return_value = True
+        mock_get_user_roles.return_value = ['admin']
+
+        role_body = payloads.ServiceAccountTokenUpdateRoleBody(
+            token_id='token-1', role='admin')
+
+        result = server.update_service_account_role(mock_request, role_body)
+
+        assert result['new_role'] == 'admin'
+        mock_update_role.assert_called_once_with('sa-abc123', 'admin')
+
+    @mock.patch('sky.global_user_state.get_service_account_token')
+    @mock.patch('sky.users.permission.permission_service'
+                '.check_service_account_token_permission')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    def test_user_can_grant_user_to_own_service_account(
+            self, mock_update_role, mock_get_user_roles,
+            mock_check_sa_permission, mock_get_token, mock_request):
+        mock_request.state.auth_user = models.User(id='regular-user',
+                                                   name='Regular')
+        mock_get_token.return_value = {
+            'creator_user_hash': 'regular-user',
+            'service_account_user_id': 'sa-abc123',
+        }
+        mock_check_sa_permission.return_value = True
+        mock_get_user_roles.return_value = ['user']
+
+        role_body = payloads.ServiceAccountTokenUpdateRoleBody(
+            token_id='token-1', role='user')
+
+        result = server.update_service_account_role(mock_request, role_body)
+
+        assert result['new_role'] == 'user'
+        mock_update_role.assert_called_once_with('sa-abc123', 'user')


### PR DESCRIPTION
Closes #9846 


<!-- Describe the changes in this PR -->
## Summary

Fixes a privilege-escalation bug on multi-user SkyPilot API servers with RBAC and service accounts enabled.

A non-admin user could create their own service account and promote it to `admin` via `POST /users/service-account-tokens/update-role`, because the handler only verified token ownership—not whether the caller was allowed to grant that role. The human user update path (`POST /users/update`) already requires admin to change roles; the service-account path did not.

This PR adds a role grant check (`viewer < user < admin`) so callers cannot assign a role above their own privilege level.

## Changes

- Add `caller_can_grant_role()` and `get_role_rank()` in `sky/users/rbac.py`
- Enforce grant validation in `update_service_account_role()` via `_assert_caller_can_grant_role()`
- Add unit tests for grant logic and the service-account update endpoin


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - `pytest tests/unit_tests/test_sky/users/test_rbac.py::TestCallerCanGrantRole -v`
  - `pytest tests/unit_tests/test_sky/users/test_server.py::TestUpdateServiceAccountRole -v`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
