### PR TITLE
[Core] Add per-cluster time-in-state metric for stuck-in-state alerting

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1152,31 +1152,43 @@ def get_last_status_change_times(
     Returns a mapping from cluster_hash to the epoch-seconds at which that
     cluster most recently transitioned into ``ending_status``. Clusters
     with no matching STATUS_CHANGE row are omitted.
+
+    Chunks the ``cluster_hash IN (...)`` predicate by
+    ``_CLUSTER_IN_QUERY_CHUNK_SIZE`` to stay under SQLite's 999-parameter
+    cap (PostgreSQL has no such cap but the chunking is harmless there).
     """
     if not cluster_hashes:
         return {}
     engine = _db_manager.get_engine()
+    hashes_list = list(cluster_hashes)
+    result: Dict[str, int] = {}
     with orm.Session(engine) as session:
-        row_number = sqlalchemy.func.row_number().over(
-            partition_by=cluster_event_table.c.cluster_hash,
-            order_by=cluster_event_table.c.transitioned_at.desc()).label('rn')
+        for offset in range(0, len(hashes_list), _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = hashes_list[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            row_number = sqlalchemy.func.row_number().over(
+                partition_by=cluster_event_table.c.cluster_hash,
+                order_by=cluster_event_table.c.transitioned_at.desc()).label(
+                    'rn')
 
-        ranked = session.query(
-            cluster_event_table.c.cluster_hash,
-            cluster_event_table.c.transitioned_at,
-            row_number,
-        ).filter(
-            cluster_event_table.c.cluster_hash.in_(cluster_hashes),
-            cluster_event_table.c.type == ClusterEventType.STATUS_CHANGE.value,
-            cluster_event_table.c.ending_status == ending_status.value,
-        ).subquery()
+            ranked = session.query(
+                cluster_event_table.c.cluster_hash,
+                cluster_event_table.c.transitioned_at,
+                row_number,
+            ).filter(
+                cluster_event_table.c.cluster_hash.in_(batch),
+                cluster_event_table.c.type ==
+                ClusterEventType.STATUS_CHANGE.value,
+                cluster_event_table.c.ending_status == ending_status.value,
+            ).subquery()
 
-        rows = session.query(
-            ranked.c.cluster_hash,
-            ranked.c.transitioned_at,
-        ).filter(ranked.c.rn == 1).all()
+            rows = session.query(
+                ranked.c.cluster_hash,
+                ranked.c.transitioned_at,
+            ).filter(ranked.c.rn == 1).all()
 
-    return {row.cluster_hash: int(row.transitioned_at) for row in rows}
+            for row in rows:
+                result[row.cluster_hash] = int(row.transitioned_at)
+    return result
 
 
 def cleanup_cluster_events_with_retention(retention_hours: float,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1144,6 +1144,41 @@ def get_last_cluster_event_of_type_multiple(
     return {row.cluster_hash: row.reason for row in rows}
 
 
+def get_last_status_change_times(
+        cluster_hashes: Set[str],
+        ending_status: status_lib.ClusterStatus) -> Dict[str, int]:
+    """Latest STATUS_CHANGE.transitioned_at per cluster for an ending_status.
+
+    Returns a mapping from cluster_hash to the epoch-seconds at which that
+    cluster most recently transitioned into ``ending_status``. Clusters
+    with no matching STATUS_CHANGE row are omitted.
+    """
+    if not cluster_hashes:
+        return {}
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        row_number = sqlalchemy.func.row_number().over(
+            partition_by=cluster_event_table.c.cluster_hash,
+            order_by=cluster_event_table.c.transitioned_at.desc()).label('rn')
+
+        ranked = session.query(
+            cluster_event_table.c.cluster_hash,
+            cluster_event_table.c.transitioned_at,
+            row_number,
+        ).filter(
+            cluster_event_table.c.cluster_hash.in_(cluster_hashes),
+            cluster_event_table.c.type == ClusterEventType.STATUS_CHANGE.value,
+            cluster_event_table.c.ending_status == ending_status.value,
+        ).subquery()
+
+        rows = session.query(
+            ranked.c.cluster_hash,
+            ranked.c.transitioned_at,
+        ).filter(ranked.c.rn == 1).all()
+
+    return {row.cluster_hash: int(row.transitioned_at) for row in rows}
+
+
 def cleanup_cluster_events_with_retention(retention_hours: float,
                                           event_type: ClusterEventType) -> None:
     engine = _db_manager.get_engine()

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -358,11 +358,14 @@ class WorkspaceUsageCollector:
       * ``sky_clusters_gpus_in_flight{workspace,user,cloud,gpu_type,kind}``
         — GPU count by accelerator model across ``UP`` clusters,
         summed over ``launched_nodes``.
-      * ``sky_cluster_time_in_state_seconds{workspace,status,cloud,kind}``
-        — Max time-in-state across clusters in each transient status
-        bucket (INIT / AUTOSTOPPING). Operators alert on this to catch
-        clusters stuck mid-transition. Source of truth is the
-        ``cluster_events`` STATUS_CHANGE log.
+      * ``sky_cluster_time_in_state_seconds{workspace,status,cloud,kind,
+        cluster_name}`` — Seconds in current state, per cluster, for
+        transient statuses (INIT / AUTOSTOPPING). Operators alert on
+        this to catch clusters stuck mid-transition; ``cluster_name``
+        on the label set means the alert series identifies exactly
+        which cluster is stuck. Source of truth is the
+        ``cluster_events`` STATUS_CHANGE log so the timer is not reset
+        by refresh paths that re-write ``cluster.status_updated_at``.
 
     All gauges share one cache to keep the cost of a scrape bounded to
     a single ``get_clusters()`` call (the same query

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -343,6 +343,14 @@ _TIME_IN_STATE_STATUSES: Tuple[status_lib.ClusterStatus, ...] = (
     status_lib.ClusterStatus.AUTOSTOPPING,
 )
 
+# Hard upper bound on rows emitted by sky_cluster_time_in_state_seconds.
+# A tenant launching/failing many clusters in tight succession (bug, retry
+# storm, or just heavy churn) can produce many simultaneously-transient
+# cluster_name series; capping defends Prometheus's series budget.
+# Sorting by age first means the clusters most likely to be stuck (and
+# therefore most likely to be alertable) survive the cap.
+_TIME_IN_STATE_MAX_SERIES = 100
+
 
 class WorkspaceUsageCollector:
     """Per-workspace / per-user cluster usage metrics.
@@ -496,6 +504,17 @@ class WorkspaceUsageCollector:
                     continue
                 time_in_state[label_key] = max(0.0, float(now_seconds - ts))
 
+        if len(time_in_state) > _TIME_IN_STATE_MAX_SERIES:
+            logger.warning(
+                'sky_cluster_time_in_state_seconds: %d transient clusters '
+                'observed; capping to top %d by age. Oldest clusters '
+                'survive the cap so any alertable case is preserved.',
+                len(time_in_state), _TIME_IN_STATE_MAX_SERIES)
+            time_in_state = dict(
+                sorted(time_in_state.items(),
+                       key=lambda kv: kv[1],
+                       reverse=True)[:_TIME_IN_STATE_MAX_SERIES])
+
         return {
             'counts': counts,
             'gpus': gpus,
@@ -518,7 +537,9 @@ class WorkspaceUsageCollector:
             'Seconds in current state, per cluster, for transient statuses '
             '(INIT, AUTOSTOPPING). Source is the cluster_events '
             'STATUS_CHANGE log; only transient statuses emit, so steady '
-            'cardinality is bounded by # in-flight transitions.',
+            'cardinality is bounded by # in-flight transitions. Capped at '
+            'the top 100 oldest clusters per scrape to defend Prometheus '
+            'series budget against pathological churn.',
             labels=['workspace', 'status', 'cloud', 'kind', 'cluster_name'])
 
     def collect(self):
@@ -556,7 +577,9 @@ class WorkspaceUsageCollector:
             'Seconds in current state, per cluster, for transient statuses '
             '(INIT, AUTOSTOPPING). Source is the cluster_events '
             'STATUS_CHANGE log; only transient statuses emit, so steady '
-            'cardinality is bounded by # in-flight transitions.',
+            'cardinality is bounded by # in-flight transitions. Capped at '
+            'the top 100 oldest clusters per scrape to defend Prometheus '
+            'series budget against pathological churn.',
             labels=['workspace', 'status', 'cloud', 'kind', 'cluster_name'])
         for key, v in data['time_in_state'].items():
             workspace, status, cloud, kind, cluster_name = key

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -8,7 +8,7 @@ import os
 import re
 import threading
 import time
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import fastapi
 from prometheus_client import core as prom_core
@@ -27,6 +27,7 @@ from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.utils import annotations
 from sky.utils import common
+from sky.utils import status_lib
 
 logger = sky_logging.init_logger(__name__)
 
@@ -334,6 +335,15 @@ class ManagedJobsCollector:
         yield metric
 
 
+# Transient statuses we report time-in-state for. UP / STOPPED are steady
+# states by design (no upper bound on residence time, alerting on age is
+# meaningless). PENDING is display-only per status_lib.ClusterStatus.
+_TIME_IN_STATE_STATUSES: Tuple[status_lib.ClusterStatus, ...] = (
+    status_lib.ClusterStatus.INIT,
+    status_lib.ClusterStatus.AUTOSTOPPING,
+)
+
+
 class WorkspaceUsageCollector:
     """Per-workspace / per-user cluster usage metrics.
 
@@ -348,6 +358,11 @@ class WorkspaceUsageCollector:
       * ``sky_clusters_gpus_in_flight{workspace,user,cloud,gpu_type,kind}``
         — GPU count by accelerator model across ``UP`` clusters,
         summed over ``launched_nodes``.
+      * ``sky_cluster_time_in_state_seconds{workspace,status,cloud,kind}``
+        — Max time-in-state across clusters in each transient status
+        bucket (INIT / AUTOSTOPPING). Operators alert on this to catch
+        clusters stuck mid-transition. Source of truth is the
+        ``cluster_events`` STATUS_CHANGE log.
 
     All gauges share one cache to keep the cost of a scrape bounded to
     a single ``get_clusters()`` call (the same query
@@ -365,6 +380,7 @@ class WorkspaceUsageCollector:
         self._cached: dict = {
             'counts': {},
             'gpus': {},
+            'time_in_state': {},
         }
 
     @staticmethod
@@ -399,6 +415,15 @@ class WorkspaceUsageCollector:
         clusters = global_user_state.get_clusters(summary_response=True)
         counts: dict = {}
         gpus: dict = {}
+        # Per-transient-status: list of (label_key, cluster_hash). label_key
+        # is (workspace, status, cloud, kind, cluster_name) — the labels
+        # the metric ultimately emits. We resolve the entered-at timestamps
+        # in one batched DB call per status, then emit one gauge row per
+        # cluster (no aggregation at the collector — alerts/dashboards can
+        # max/sum however they want).
+        transient: Dict[str, List[Tuple[Tuple[str, str, str, str, str],
+                                        str]]] = {}
+        transient_statuses = {s.name for s in _TIME_IN_STATE_STATUSES}
 
         for cluster in clusters:
             workspace = _label_or_default(cluster.get('workspace'),
@@ -421,6 +446,16 @@ class WorkspaceUsageCollector:
             count_key = (workspace, user, status_name, cloud, kind)
             counts[count_key] = counts.get(count_key, 0) + 1
 
+            # ── time-in-state, transient statuses only ──
+            if status_name in transient_statuses:
+                cluster_hash = cluster.get('cluster_hash')
+                cluster_name = cluster.get('name')
+                if cluster_hash and cluster_name:
+                    label_key = (workspace, status_name, cloud, kind,
+                                 cluster_name)
+                    transient.setdefault(status_name, []).append(
+                        (label_key, cluster_hash))
+
             # ── GPUs, only for UP clusters ──
             if status_name != 'UP':
                 continue
@@ -434,9 +469,34 @@ class WorkspaceUsageCollector:
                 gpus[gpu_key] = (gpus.get(gpu_key, 0.0) +
                                  float(acc_count) * num_nodes)
 
+        # Resolve the entered-at timestamp per cluster. One DB call per
+        # transient status; total cost bounded by # of distinct transient
+        # statuses observed (≤ |_TIME_IN_STATE_STATUSES|).
+        now_seconds = int(time.time())
+        time_in_state: Dict[Tuple[str, str, str, str, str], float] = {}
+        for status_name, entries in transient.items():
+            try:
+                status_enum = status_lib.ClusterStatus[status_name]
+            except KeyError:
+                continue
+            hashes = {h for _, h in entries}
+            entered_at = global_user_state.get_last_status_change_times(
+                hashes, status_enum)
+            for label_key, cluster_hash in entries:
+                ts = entered_at.get(cluster_hash)
+                if ts is None:
+                    # Cluster has no recorded STATUS_CHANGE event for this
+                    # status — typically a launch in the sub-second window
+                    # before the event row is written, or a row written
+                    # before the cluster_events table existed. Either way
+                    # the residence is too short to alert on.
+                    continue
+                time_in_state[label_key] = max(0.0, float(now_seconds - ts))
+
         return {
             'counts': counts,
             'gpus': gpus,
+            'time_in_state': time_in_state,
         }
 
     def describe(self):
@@ -450,6 +510,13 @@ class WorkspaceUsageCollector:
             'GPU count across UP clusters, by workspace, user, cloud, '
             'gpu_type, kind',
             labels=['workspace', 'user', 'cloud', 'gpu_type', 'kind'])
+        yield prom_core.GaugeMetricFamily(
+            'sky_cluster_time_in_state_seconds',
+            'Seconds in current state, per cluster, for transient statuses '
+            '(INIT, AUTOSTOPPING). Source is the cluster_events '
+            'STATUS_CHANGE log; only transient statuses emit, so steady '
+            'cardinality is bounded by # in-flight transitions.',
+            labels=['workspace', 'status', 'cloud', 'kind', 'cluster_name'])
 
     def collect(self):
         now = time.time()
@@ -479,6 +546,18 @@ class WorkspaceUsageCollector:
             labels=['workspace', 'user', 'cloud', 'gpu_type', 'kind'])
         for (workspace, user, cloud, gpu_type, kind), v in data['gpus'].items():
             m.add_metric([workspace, user, cloud, gpu_type, kind], v)
+        yield m
+
+        m = prom_core.GaugeMetricFamily(
+            'sky_cluster_time_in_state_seconds',
+            'Seconds in current state, per cluster, for transient statuses '
+            '(INIT, AUTOSTOPPING). Source is the cluster_events '
+            'STATUS_CHANGE log; only transient statuses emit, so steady '
+            'cardinality is bounded by # in-flight transitions.',
+            labels=['workspace', 'status', 'cloud', 'kind', 'cluster_name'])
+        for key, v in data['time_in_state'].items():
+            workspace, status, cloud, kind, cluster_name = key
+            m.add_metric([workspace, status, cloud, kind, cluster_name], v)
         yield m
 
 


### PR DESCRIPTION
## Summary
- New Prometheus gauge `sky_cluster_time_in_state_seconds{workspace, status, cloud, kind, cluster_name}` — per-cluster seconds in current state. Emitted only for transient statuses (`INIT`, `AUTOSTOPPING`); `UP` / `STOPPED` clusters never emit, so steady cardinality is bounded by # of clusters currently in flight.
- New helper `global_user_state.get_last_status_change_times(cluster_hashes, ending_status)` — batched DB read that mirrors the existing `get_last_cluster_event_of_type_multiple` row-number / partition-by pattern.

## Why STATUS_CHANGE event, not status_updated_at

`cluster.status_updated_at` is rewritten on every `_add_or_update_cluster` call — including the periodic refresh path (`backend_utils._update_cluster_status_no_lock` → `add_or_update_cluster(ready=False)` when an existing INIT cluster is still INIT). A cluster stuck in INIT for 30 min would look freshly-entered after every refresh cycle, masking the stuck condition.

`cluster_events` STATUS_CHANGE rows are written only on actual transitions (the refresh path explicitly skips duplicate-INIT events). So `transitioned_at` is the canonical "entered this state at" timestamp.

## Per-cluster, not aggregated

Earlier draft aggregated to a single max per `(workspace, status, cloud, kind)` bucket to bound cardinality. Switched to per-cluster (added `cluster_name` label) because alerts firing on the aggregated value tell operators "something stuck somewhere" but not which cluster — requiring a manual DB lookup. With `cluster_name` on the alert series, runbook starts with the cluster identity directly.

Cardinality is fine in practice: only transient-status clusters emit, and a single tenant rarely has many concurrent transitions. UP / STOPPED clusters (the bulk of the fleet) contribute zero series.

## Test plan
- [ ] Launch a cluster on K8s, confirm `curl /metrics | grep sky_cluster_time_in_state_seconds` returns one row with `status=\"INIT\", kind=\"cluster\"` while provisioning.
- [ ] Let provisioning finish (status → UP); confirm the row disappears.
- [ ] Force a refresh of an INIT cluster (`sky status --refresh`); confirm the metric value continues to grow rather than resetting (validates the STATUS_CHANGE-vs-status_updated_at choice).
- [ ] \`sky autostop\` a cluster; confirm a row with `status=\"AUTOSTOPPING\"` appears.