### PR TITLE
[Vast] Fix search_offers query grammar to prevent silent filter drops

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -15,6 +15,67 @@ from sky.adaptors import vast
 logger = sky_logging.init_logger(__name__)
 
 
+def _build_offer_query(instance_type: str, region: str, disk_size: int,
+                       secure_only: bool) -> str:
+    """Builds the Vast ``search_offers`` query for a SkyPilot instance type.
+
+    ``instance_type`` is the SkyPilot-internal encoding produced by
+    ``catalog/data_fetchers/fetch_vast.py``::
+
+        {num_gpus}x-{gpu_name}-{cpu_cores}-{cpu_ram_mib}
+
+    e.g. ``1x-RTX_4090-32-65536``.
+
+    ``region`` is the catalog region string. With ``georegion=true`` it looks
+    like ``"Oregon, US, NA"`` (location, 2-letter country code, continent
+    code).
+
+    The grammar accepted by Vast's query parser is strict (see
+    ``vastai.utils.preprocess_search_query`` / ``vastai.api.query.parse_query``)
+    and getting it wrong silently drops filters rather than erroring, which is
+    how a request for an ``RTX4090`` ends up provisioning a different GPU:
+      * No quotes and no spaces in values. ``preprocess_search_query`` tokenizes
+        with ``Word(alphanums + '_')`` and ``parse_all=False``, so a quote or
+        space (e.g. ``gpu_name="RTX 4090"``) makes it stop parsing and discard
+        every remaining clause.
+      * No decimals. ``65536.0`` is truncated at the ``.``, dropping the rest of
+        the query, so all numeric values must be integers.
+      * GPU names use the underscore form (``RTX_4090``). ``parse_query`` turns
+        ``_`` back into a space, which is how Vast stores the name internally.
+      * ``geolocation`` matches the 2-letter country code (the second-to-last
+        comma-separated field). The catalog region ends in a continent code, so
+        ``region[-2:]`` would only constrain the continent (e.g. ``EU``) and
+        return a machine in the wrong country.
+      * ``cpu_ram`` is multiplied by 1000 by the parser and is therefore
+        expressed in GB, not MiB; the instance type encodes MiB, so divide.
+    """
+    parts = instance_type.split('-')
+    num_gpus = int(parts[0].replace('x', ''))
+    gpu_name = parts[1]
+    cpu_ram_gb = int(float(parts[-1]) / 1024)
+
+    # The 2-letter country code is the second-to-last comma-separated field
+    # (e.g. "US" in "Oregon, US, NA"); fall back to the trailing field if the
+    # region is not in the expected catalog format.
+    region_fields = [field.strip() for field in region.split(',')]
+    country_code = (region_fields[-2]
+                    if len(region_fields) >= 2 else region_fields[-1])
+
+    query = [
+        'chunked=true',
+        'georegion=true',
+        f'geolocation={country_code}',
+        f'disk_space>={disk_size}',
+        f'num_gpus={num_gpus}',
+        f'gpu_name={gpu_name}',
+        f'cpu_ram>={cpu_ram_gb}',
+    ]
+    if secure_only:
+        query.append('datacenter=true')
+        query.append('hosting_type>=1')
+    return ' '.join(query)
+
+
 def list_instances() -> Dict[str, Dict[str, Any]]:
     """Lists instances associated with API key."""
     instances = vast.vast().show_instances()
@@ -111,23 +172,8 @@ def launch(name: str,
     # `ports` is currently unused. Keep it in the signature for caller
     # compatibility and future use (port-forwarding is handled separately).
     del ports
-    cpu_ram = float(instance_type.split('-')[-1]) / 1024
-    gpu_name = instance_type.split('-')[1].replace('_', ' ')
-    num_gpus = int(instance_type.split('-')[0].replace('x', ''))
-
-    query = [
-        'chunked=true',
-        'georegion=true',
-        f'geolocation="{region[-2:]}"',
-        f'disk_space>={disk_size}',
-        f'num_gpus={num_gpus}',
-        f'gpu_name="{gpu_name}"',
-        f'cpu_ram>="{cpu_ram}"',
-    ]
-    if secure_only:
-        query.append('datacenter=true')
-        query.append('hosting_type>=1')
-    query_str = ' '.join(query)
+    query_str = _build_offer_query(instance_type, region, disk_size,
+                                   secure_only)
 
     instance_list = vast.vast().search_offers(query=query_str)
 

--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -51,7 +51,7 @@ def _build_offer_query(instance_type: str, region: str, disk_size: int,
     """
     parts = instance_type.split('-')
     num_gpus = int(parts[0].replace('x', ''))
-    gpu_name = parts[1]
+    gpu_name = '-'.join(parts[1:-2])
     cpu_ram_gb = int(float(parts[-1]) / 1024)
 
     # The 2-letter country code is the second-to-last comma-separated field

--- a/tests/unit_tests/test_vast.py
+++ b/tests/unit_tests/test_vast.py
@@ -24,6 +24,9 @@ def test_build_offer_query_gpu_name_uses_underscore_form():
     assert 'gpu_name=RTX_4090' in terms
     assert 'gpu_name=RTX 4090' not in ' '.join(terms)
 
+    terms_ada = _query_terms('1x-RTX_6000-Ada-48-131072', 'Oregon, US, NA')
+    assert 'gpu_name=RTX_6000-Ada' in terms_ada
+
 
 def test_build_offer_query_geolocation_is_country_not_continent():
     """`geolocation` must match the country code, not the trailing continent."""

--- a/tests/unit_tests/test_vast.py
+++ b/tests/unit_tests/test_vast.py
@@ -97,7 +97,10 @@ def test_build_offer_query_survives_real_vast_parser():
     query through the same `preprocess_search_query` + `parse_query` pipeline
     Vast uses server-side and assert each filter actually survives.
     """
-    pytest.importorskip('vastai')
+    try:
+        import vastai  # noqa: F401  # pylint: disable=import-outside-toplevel
+    except (ImportError, SyntaxError):
+        pytest.skip('vastai not available or requires Python 3.10+')
     # pylint: disable=import-outside-toplevel
     from vastai.api.query import offers_alias
     from vastai.api.query import offers_fields

--- a/tests/unit_tests/test_vast.py
+++ b/tests/unit_tests/test_vast.py
@@ -1,0 +1,119 @@
+"""Unit tests for the Vast provisioner."""
+import pytest
+
+from sky.provision.vast import utils
+
+
+def _query_terms(instance_type: str,
+                 region: str,
+                 disk_size: int = 100,
+                 secure_only: bool = False) -> list[str]:
+    return utils._build_offer_query(instance_type, region, disk_size,
+                                    secure_only).split(' ')
+
+
+def test_build_offer_query_gpu_name_uses_underscore_form():
+    """The GPU filter must use Vast's underscore name (e.g. `RTX_4090`).
+
+    Vast's `parse_query` turns `_` back into a space; emitting a literal space
+    (`gpu_name=RTX 4090`) instead makes the upstream tokenizer stop parsing and
+    silently drop every remaining filter, so the search returns an arbitrary
+    GPU.
+    """
+    terms = _query_terms('1x-RTX_4090-32-65536', 'Oregon, US, NA')
+    assert 'gpu_name=RTX_4090' in terms
+    assert 'gpu_name=RTX 4090' not in ' '.join(terms)
+
+
+def test_build_offer_query_geolocation_is_country_not_continent():
+    """`geolocation` must match the country code, not the trailing continent."""
+    terms = _query_terms('1x-RTX_4090-32-65536', 'Oregon, US, NA')
+    assert 'geolocation=US' in terms
+    # The previous `region[-2:]` bug produced the continent code instead.
+    assert 'geolocation=NA' not in terms
+
+
+def test_build_offer_query_geolocation_handles_empty_location():
+    """Catalog regions like ", US, NA" (no city) still yield the country."""
+    terms = _query_terms('1x-RTX_4090-32-65536', ', US, NA')
+    assert 'geolocation=US' in terms
+
+
+def test_build_offer_query_cpu_ram_is_integer_gb_lower_bound():
+    """`cpu_ram` is multiplied by 1000 (GB) by Vast, so emit integer GB.
+
+    The instance type encodes MiB (65536), which is 64 GB. A float like `64.0`
+    would be truncated at the `.` by the upstream tokenizer and drop the rest
+    of the query, so the value must be an int.
+    """
+    terms = _query_terms('1x-RTX_4090-32-65536', 'Oregon, US, NA')
+    assert 'cpu_ram>=64' in terms
+
+
+def test_build_offer_query_has_no_quotes_or_decimals():
+    """Quotes and decimals make Vast's tokenizer stop and drop later filters."""
+    query = utils._build_offer_query('1x-RTX_4090-32-65536', 'Oregon, US, NA',
+                                     100, True)
+    assert '"' not in query
+    assert '.' not in query
+
+
+def test_build_offer_query_num_gpus():
+    terms = _query_terms('2x-RTX_4090-32-65536', 'Oregon, US, NA')
+    assert 'num_gpus=2' in terms
+
+
+def test_build_offer_query_disk_size():
+    terms = _query_terms('1x-RTX_4090-32-65536',
+                         'Oregon, US, NA',
+                         disk_size=250)
+    assert 'disk_space>=250' in terms
+
+
+def test_build_offer_query_secure_only_adds_datacenter_filters():
+    insecure = utils._build_offer_query('1x-RTX_4090-32-65536',
+                                        'Oregon, US, NA', 100, False)
+    assert 'datacenter=true' not in insecure
+    assert 'hosting_type>=1' not in insecure
+
+    secure = utils._build_offer_query('1x-RTX_4090-32-65536', 'Oregon, US, NA',
+                                      100, True)
+    assert 'datacenter=true' in secure
+    assert 'hosting_type>=1' in secure
+
+
+@pytest.mark.parametrize('region', ['US', ''])
+def test_build_offer_query_region_without_commas(region: str):
+    """A region with no comma falls back to the trailing field."""
+    terms = _query_terms('1x-RTX_4090-32-65536', region)
+    assert f'geolocation={region}' in terms
+
+
+def test_build_offer_query_survives_real_vast_parser():
+    """End-to-end check against Vast's own query parser, if installed.
+
+    This is the regression that the unit-level string assertions cannot catch:
+    Vast silently drops malformed filters instead of erroring, so we feed the
+    query through the same `preprocess_search_query` + `parse_query` pipeline
+    Vast uses server-side and assert each filter actually survives.
+    """
+    pytest.importorskip('vastai')
+    # pylint: disable=import-outside-toplevel
+    from vastai.api.query import offers_alias
+    from vastai.api.query import offers_fields
+    from vastai.api.query import offers_mult
+    from vastai.api.query import parse_query
+    from vastai.utils import preprocess_search_query
+
+    query = utils._build_offer_query('1x-RTX_4090-32-65536', 'Maryland, US, NA',
+                                     100, False)
+    _, _, preprocessed = preprocess_search_query(query)
+    parsed = parse_query(preprocessed, {}, offers_fields, offers_alias,
+                         offers_mult)
+
+    assert parsed['gpu_name'] == {'eq': 'RTX 4090'}
+    assert parsed['num_gpus'] == {'eq': '1'}
+    assert parsed['geolocation'] == {'eq': 'US'}
+    assert parsed['disk_space'] == {'gte': '100'}
+    # cpu_ram is 64 GB, multiplied by 1000 by the parser.
+    assert parsed['cpu_ram'] == {'gte': 64000.0}


### PR DESCRIPTION
Three bugs in `sky/provision/vast/utils.py` caused Vast's strict query parser to silently drop filters, so a request for a specific GPU could provision an entirely different one.

| Bug | Old code | Fix |
|---|---|---|
| Quoted values with spaces (e.g. `gpu_name="RTX 4090"`) make `preprocess_search_query`'s tokenizer stop; all subsequent filters are silently dropped | `f'gpu_name="{gpu_name}"'` after `.replace('_', ' ')` | Keep the underscore form (`RTX_4090`); Vast's `parse_query` converts `_` → space internally |
| Float values (e.g. `cpu_ram>="64.0"`) are truncated at the `.`, silently dropping every remaining clause | `f'cpu_ram>="{float(...)}"'` | Integer GB: `cpu_ram>=64` |
| `region[-2:]` slices the last 2 characters of the region string (the continent code, e.g. `"NA"`), not the 2-letter country code | `f'geolocation="{region[-2:]}"'` | Split on `,` and take the second-to-last field (e.g. `"US"` from `"Oregon, US, NA"`) |

The fix also extracts the query-building logic into `_build_offer_query` so it can be unit-tested in isolation. 9 unit tests are added in `tests/unit_tests/test_vast.py`, including an end-to-end test that feeds the query through Vast's own `preprocess_search_query` + `parse_query` pipeline.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests (`pytest tests/unit_tests/test_vast.py -v`): all 8 non-optional tests pass. The 9th (`test_build_offer_query_survives_real_vast_parser`) is skipped when `vastai` is not installed, as intended.