### PR TITLE
[k8s] generate_kubeconfig.sh: mirror current-context CA, not SA secret CA

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -211,7 +211,9 @@ Following tabs describe how to configure credentials for different clouds on the
               --set kubernetesCredentials.useKubeconfig=true \
               --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
 
-        .. tip::
+        .. admonition:: Convert an exec-based kubeconfig to a service account kubeconfig
+            :class: tip
+            :name: generate-service-account-kubeconfig
 
             If you are using a kubeconfig file that contains `exec-based authentication <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration>`_ (e.g., GKE's default ``gke-gcloud-auth-plugin``, Nebius Managed Kubernetes, OCI, etc.), you will need to generate a kubeconfig with static authentication instead.
             You can use the ``generate_kubeconfig.sh`` script to do this.

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -299,22 +299,55 @@ sleep 2
 # Note: service account token is stored base64-encoded in the secret but must
 # be plaintext in kubeconfig.
 SA_TOKEN=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['token']}" | base64 ${BASE64_DECODE_FLAG})
-CA_CERT=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['ca\.crt']}")
 
 # Extract cluster IP from the current context
 CURRENT_CONTEXT=$(kubectl config current-context)
 CURRENT_CLUSTER=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"${CURRENT_CONTEXT}\"})].context.cluster}")
 CURRENT_CLUSTER_ADDR=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"${CURRENT_CLUSTER}\"})].cluster.server}")
 
+# Mirror the TLS trust config from the user's current kubeconfig context rather
+# than the Service Account secret's ca.crt. The SA secret's ca.crt is the
+# *internal* cluster CA: it only verifies the API server's own serving cert.
+# When the external endpoint terminates TLS at a CDN/proxy that presents a
+# different (often publicly-trusted) certificate -- e.g. clusters fronted by
+# Cloudflare -- that internal CA does not match what the endpoint serves, so
+# embedding it makes every request fail with
+# "x509: certificate signed by unknown authority". kubectl already reaches
+# ${CURRENT_CLUSTER_ADDR} successfully using the current context's TLS config,
+# and the generated kubeconfig reuses the same server URL, so reusing the same
+# TLS config is guaranteed to verify. "--raw" keeps kubectl from redacting
+# certificate-authority-data; "--flatten" inlines any certificate-authority
+# file reference into certificate-authority-data (resolving relative paths
+# against the kubeconfig's directory), so the generated kubeconfig is
+# self-contained even when the source pins its CA via a file path.
+SRC_CA_DATA=$(kubectl config view --raw --flatten -o jsonpath="{.clusters[?(@.name == \"${CURRENT_CLUSTER}\")].cluster.certificate-authority-data}")
+SRC_INSECURE=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name == \"${CURRENT_CLUSTER}\")].cluster.insecure-skip-tls-verify}")
+
+# Build the cluster TLS line to embed, including its trailing newline so the
+# heredoc emits no blank line when there is nothing to pin. An empty value
+# means no CA pinning in the source context, so the generated kubeconfig
+# relies on the system CA store (the correct trust anchor for CDN-fronted,
+# publicly-signed endpoints).
+if [ -n "${SRC_CA_DATA}" ]; then
+  CLUSTER_TLS=$'    certificate-authority-data: '"${SRC_CA_DATA}"$'\n'
+  TLS_MODE="mirrored certificate-authority-data from context '${CURRENT_CONTEXT}'"
+elif [ "${SRC_INSECURE}" = "true" ]; then
+  CLUSTER_TLS=$'    insecure-skip-tls-verify: true\n'
+  TLS_MODE="mirrored insecure-skip-tls-verify from context '${CURRENT_CONTEXT}'"
+else
+  CLUSTER_TLS=""
+  TLS_MODE="no CA pinning in source context; using system CA store"
+fi
+
 echo ""
 echo "[3/3] Generating kubeconfig file..."
+echo "      TLS: ${TLS_MODE}"
 
 cat > kubeconfig <<EOF
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: ${CA_CERT}
-    server: ${CURRENT_CLUSTER_ADDR}
+${CLUSTER_TLS}    server: ${CURRENT_CLUSTER_ADDR}
   name: ${CURRENT_CLUSTER}
 contexts:
 - context:


### PR DESCRIPTION
## Summary

`generate_kubeconfig.sh` unconditionally wrote the ServiceAccount secret's `ca.crt` — the cluster's **internal** CA — into the generated kubeconfig's `certificate-authority-data`. That CA only verifies the API server's own serving certificate.

For clusters whose **external** endpoint terminates TLS at a CDN/proxy presenting a *different* (often publicly-trusted) certificate — e.g. CoreWeave clusters fronted by Cloudflare — the internal CA does not match what the endpoint serves, so every request through the generated kubeconfig fails with:

```
x509: certificate signed by unknown authority
```

This is wrong even on EKS/GKE; it only "happened to" work there because the SA secret's `ca.crt` coincided with the CA that signs the external endpoint's cert.

### Fix

Mirror the TLS trust config from the user's **current kubeconfig context** instead of the SA secret. The current context already reaches the same `server:` URL successfully via `kubectl`, and the generated kubeconfig reuses that same URL, so reusing its TLS config is guaranteed to verify. Specifically:

- inline `certificate-authority-data` → copied verbatim
- `certificate-authority` file path → base64-inlined so the generated kubeconfig stays self-contained (it is typically shipped to a remote API server pod)
- `insecure-skip-tls-verify: true` → preserved
- nothing pinned → omit CA and rely on the system CA store (correct for CDN-fronted, publicly-signed endpoints)

The generation step also prints which TLS mode was used.

## Tested

- **EKS/GKE** (source context has `certificate-authority-data`): generated kubeconfig keeps it; `kubectl get nodes` works exactly as before.
- **CDN-fronted endpoint with a publicly-trusted cert and no CA in the source** (CoreWeave behind Cloudflare): generated kubeconfig now omits the CA → system CA verifies → `kubectl get pods/nodes` succeeds (previously failed with `x509: certificate signed by unknown authority`). Verified end-to-end against a live CoreWeave cluster.
- **Source references a CA file path**: base64-inlined as `certificate-authority-data`.
- Generated YAML validated as well-formed for all branches (CA-data / insecure / system-CA), including no stray blank line when no CA is emitted.