### PR TITLE
[Debug Dump] Collect skylet log from live clusters in debug dump

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pathlib
 import platform
+import posixpath
 import shutil
 import time
 import traceback
@@ -795,12 +796,15 @@ def _collect_cluster_skylet_log(
     # exposes the location as skypilot_runtime_dir; every other runner keeps
     # it under $HOME. Resolve against that dir so the source path is correct
     # regardless of provider.
+    # posixpath (not os.path): this is a remote *nix path, built server-side
+    # but resolved on the cluster, so it must use forward slashes regardless
+    # of the server's OS.
     runtime_dir = getattr(runner, 'skypilot_runtime_dir', None)
     if runtime_dir:
-        remote_path = os.path.join(runtime_dir,
-                                   skylet_constants.SKYLET_LOG_FILE)
+        remote_path = posixpath.join(runtime_dir,
+                                     skylet_constants.SKYLET_LOG_FILE)
     else:
-        remote_path = os.path.join('~', skylet_constants.SKYLET_LOG_FILE)
+        remote_path = posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
     target = os.path.join(cluster_dir, 'skylet.log')
     try:
         runner.rsync(source=remote_path,

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -764,6 +764,13 @@ def _dump_request_id_info(
 # rather than hang the dump waiting to connect.
 _SKYLET_LOG_RESOLVE_CONNECT_TIMEOUT = 10
 
+# Total wall-clock timeout for the skylet-log rsync. Reachability is already
+# gated by the resolve step above (connect_timeout), so this is a backstop
+# for a connected-but-stalled transfer (flaky network, oversized rotated
+# log): generous enough not to trip on a healthy node + small log, tight
+# enough that one bad node can't hang the whole dump.
+_SKYLET_LOG_RSYNC_TIMEOUT = 60
+
 
 def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
     """Resolve the absolute skylet log path on the head node.
@@ -873,7 +880,8 @@ def _collect_cluster_skylet_log(
         runner.rsync(source=remote_path,
                      target=target,
                      up=False,
-                     stream_logs=False)
+                     stream_logs=False,
+                     timeout=_SKYLET_LOG_RSYNC_TIMEOUT)
         logger.debug(f'Collected skylet log for cluster {cluster_name!r}')
     except exceptions.CommandError as e:
         if e.returncode == exceptions.RSYNC_FILE_NOT_FOUND_CODE:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -758,6 +758,48 @@ def _dump_request_id_info(
     logger.debug('Exiting _dump_request_id_info')
 
 
+def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
+    """Resolve the absolute skylet log path on the head node.
+
+    Skylet writes its log to ``$SKY_RUNTIME_DIR/.sky/skylet.log``, where
+    SKY_RUNTIME_DIR defaults to ``$HOME`` (see runtime_utils.get_runtime_dir_path,
+    used by skylet/attempt_skylet.py to place the log). The runtime dir can be
+    relocated off ``$HOME`` -- Slurm moves it off the NFS home, and devspaces
+    override it via the pod env -- and not every command runner exposes that
+    location as a Python attribute. Rather than special-casing each provider, we
+    resolve the path on the remote node using the same env var, in the same
+    ``source_bashrc`` environment that instance_setup uses to start skylet (see
+    start_skylet_on_head_node), so it is correct for every runner.
+
+    Falls back to ``~/.sky/skylet.log`` if the resolution command fails; rsync
+    then handles a missing file best-effort. posixpath (not os.path) is used for
+    the fallback because this is a remote *nix path resolved on the cluster.
+    """
+    default_path = posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
+    # Mirror the shell form of the runtime dir (constants.SKY_RUNTIME_DIR) so
+    # the remote shell expands the same env var skylet read.
+    cmd = (f'echo "${{{skylet_constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}:-$HOME}}/'
+           f'{skylet_constants.SKYLET_LOG_FILE}"')
+    try:
+        returncode, stdout, _ = runner.run(cmd,
+                                           require_outputs=True,
+                                           stream_logs=False,
+                                           source_bashrc=True)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to resolve skylet log path on cluster '
+                     f'{cluster_name!r}, falling back to {default_path!r}: {e}')
+        return default_path
+    # sourcing bashrc can emit banner/warning lines before our echo; the path is
+    # the last non-empty line.
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if returncode != 0 or not lines:
+        logger.debug(f'Could not resolve skylet log path on cluster '
+                     f'{cluster_name!r} (rc={returncode}), falling back to '
+                     f'{default_path!r}')
+        return default_path
+    return lines[-1]
+
+
 def _collect_cluster_skylet_log(
         cluster_name: str,
         cluster_dir: str,
@@ -766,11 +808,12 @@ def _collect_cluster_skylet_log(
     """Rsync the head node's skylet log into the cluster dump dir.
 
     Skylet runs only on the head node (see
-    instance_setup.start_skylet_on_head_node), writing ~/.sky/skylet.log, so
-    we pull it off the first command runner (runners[0] is always the head;
-    ClusterInfo.ip_tuples() guarantees head-first ordering). Best-effort: a
-    missing log or any failure is recorded in ``errors`` and never aborts the
-    dump.
+    instance_setup.start_skylet_on_head_node), so we pull it off the first
+    command runner (runners[0] is always the head; ClusterInfo.ip_tuples()
+    guarantees head-first ordering). The log path is resolved on the remote node
+    (see _resolve_remote_skylet_log_path) to honor a relocated SKY_RUNTIME_DIR.
+    Best-effort: a missing log or any failure is recorded in ``errors`` and
+    never aborts the dump.
     """
     try:
         runners = handle.get_command_runners()
@@ -792,19 +835,7 @@ def _collect_cluster_skylet_log(
         return
 
     runner = runners[0]  # Head node; skylet runs only there.
-    # Slurm relocates the SkyPilot runtime off the (often NFS) home dir and
-    # exposes the location as skypilot_runtime_dir; every other runner keeps
-    # it under $HOME. Resolve against that dir so the source path is correct
-    # regardless of provider.
-    # posixpath (not os.path): this is a remote *nix path, built server-side
-    # but resolved on the cluster, so it must use forward slashes regardless
-    # of the server's OS.
-    runtime_dir = getattr(runner, 'skypilot_runtime_dir', None)
-    if runtime_dir:
-        remote_path = posixpath.join(runtime_dir,
-                                     skylet_constants.SKYLET_LOG_FILE)
-    else:
-        remote_path = posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
+    remote_path = _resolve_remote_skylet_log_path(runner, cluster_name)
     target = os.path.join(cluster_dir, 'skylet.log')
     try:
         runner.rsync(source=remote_path,
@@ -935,13 +966,16 @@ def _dump_cluster_info(cluster_names: Set[str],
                     'traceback': _full_traceback()
                 })
 
-        # Pull the skylet log from the head node for live clusters. Skylet
-        # only runs on UP clusters, and a stopped/terminated cluster has no
-        # reachable node, so we skip anything that isn't UP.
+        # Pull the skylet log from the head node. We attempt this for both UP
+        # and INIT clusters: an INIT cluster may be degraded (failed setup,
+        # partial provisioning) but still have a reachable node with a skylet
+        # log, which is exactly when the log is most useful. The only status we
+        # skip is STOPPED, which has no reachable node. A not-yet-provisioned
+        # cluster simply fails the rsync, which is handled best-effort.
         status = cluster_record.get('status') if cluster_record else None
         handle = cluster_record.get('handle') if cluster_record else None
 
-        if status == status_lib.ClusterStatus.UP and handle is not None:
+        if status != status_lib.ClusterStatus.STOPPED and handle is not None:
             _collect_cluster_skylet_log(cluster_name, cluster_dir, handle,
                                         errors)
         else:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -758,6 +758,13 @@ def _dump_request_id_info(
     logger.debug('Exiting _dump_request_id_info')
 
 
+# Short connection timeout for the skylet-log-path resolution command. The
+# debug dump may run against many clusters, some of which are still
+# provisioning or otherwise unreachable; we want such a node to fail fast
+# rather than hang the dump waiting to connect.
+_SKYLET_LOG_RESOLVE_CONNECT_TIMEOUT = 10
+
+
 def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
     """Resolve the absolute skylet log path on the head node.
 
@@ -771,9 +778,11 @@ def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
     ``source_bashrc`` environment that instance_setup uses to start skylet (see
     start_skylet_on_head_node), so it is correct for every runner.
 
-    Falls back to ``~/.sky/skylet.log`` if the resolution command fails; rsync
-    then handles a missing file best-effort. posixpath (not os.path) is used for
-    the fallback because this is a remote *nix path resolved on the cluster.
+    Bounded by a short connect timeout so an unreachable node (e.g. a cluster
+    still provisioning) fails fast instead of hanging the dump. Falls back to
+    ``~/.sky/skylet.log`` if the resolution command fails; rsync then handles a
+    missing file best-effort. posixpath (not os.path) is used for the fallback
+    because this is a remote *nix path resolved on the cluster.
     """
     default_path = posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
     # Mirror the shell form of the runtime dir (constants.SKY_RUNTIME_DIR) so
@@ -781,10 +790,12 @@ def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
     cmd = (f'echo "${{{skylet_constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}:-$HOME}}/'
            f'{skylet_constants.SKYLET_LOG_FILE}"')
     try:
-        returncode, stdout, _ = runner.run(cmd,
-                                           require_outputs=True,
-                                           stream_logs=False,
-                                           source_bashrc=True)
+        returncode, stdout, _ = runner.run(
+            cmd,
+            require_outputs=True,
+            stream_logs=False,
+            source_bashrc=True,
+            connect_timeout=_SKYLET_LOG_RESOLVE_CONNECT_TIMEOUT)
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Failed to resolve skylet log path on cluster '
                      f'{cluster_name!r}, falling back to {default_path!r}: {e}')

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -769,8 +769,9 @@ def _resolve_remote_skylet_log_path(runner: Any, cluster_name: str) -> str:
     """Resolve the absolute skylet log path on the head node.
 
     Skylet writes its log to ``$SKY_RUNTIME_DIR/.sky/skylet.log``, where
-    SKY_RUNTIME_DIR defaults to ``$HOME`` (see runtime_utils.get_runtime_dir_path,
-    used by skylet/attempt_skylet.py to place the log). The runtime dir can be
+    SKY_RUNTIME_DIR defaults to ``$HOME`` (see
+    runtime_utils.get_runtime_dir_path, used by skylet/attempt_skylet.py to
+    place the log). The runtime dir can be
     relocated off ``$HOME`` -- Slurm moves it off the NFS home, and devspaces
     override it via the pod env -- and not every command runner exposes that
     location as a Python attribute. Rather than special-casing each provider, we

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -31,6 +31,7 @@ from sky.utils import common
 from sky.utils import controller_utils
 from sky.utils import debug_dump_helpers
 from sky.utils import message_utils
+from sky.utils import status_lib
 from sky.utils import subprocess_utils
 from sky.utils import tempstore
 from sky.utils import ux_utils
@@ -756,6 +757,82 @@ def _dump_request_id_info(
     logger.debug('Exiting _dump_request_id_info')
 
 
+def _collect_cluster_skylet_log(
+        cluster_name: str,
+        cluster_dir: str,
+        handle: Any,
+        errors: Optional[List[Dict[str, str]]] = None) -> None:
+    """Rsync the head node's skylet log into the cluster dump dir.
+
+    Skylet runs only on the head node (see
+    instance_setup.start_skylet_on_head_node), writing ~/.sky/skylet.log, so
+    we pull it off the first command runner (runners[0] is always the head;
+    ClusterInfo.ip_tuples() guarantees head-first ordering). Best-effort: a
+    missing log or any failure is recorded in ``errors`` and never aborts the
+    dump.
+    """
+    try:
+        runners = handle.get_command_runners()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to get command runners for cluster '
+                       f'{cluster_name}: {e}')
+        if errors is not None:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{cluster_name}/skylet_log',
+                'error': str(e),
+                'traceback': _full_traceback()
+            })
+        return
+
+    if not runners:
+        logger.debug(f'No command runners for cluster {cluster_name!r}; '
+                     f'skipping skylet log')
+        return
+
+    runner = runners[0]  # Head node; skylet runs only there.
+    # Slurm relocates the SkyPilot runtime off the (often NFS) home dir and
+    # exposes the location as skypilot_runtime_dir; every other runner keeps
+    # it under $HOME. Resolve against that dir so the source path is correct
+    # regardless of provider.
+    runtime_dir = getattr(runner, 'skypilot_runtime_dir', None)
+    if runtime_dir:
+        remote_path = os.path.join(runtime_dir,
+                                   skylet_constants.SKYLET_LOG_FILE)
+    else:
+        remote_path = os.path.join('~', skylet_constants.SKYLET_LOG_FILE)
+    target = os.path.join(cluster_dir, 'skylet.log')
+    try:
+        runner.rsync(source=remote_path,
+                     target=target,
+                     up=False,
+                     stream_logs=False)
+        logger.debug(f'Collected skylet log for cluster {cluster_name!r}')
+    except exceptions.CommandError as e:
+        if e.returncode == exceptions.RSYNC_FILE_NOT_FOUND_CODE:
+            logger.debug(f'No skylet log found on cluster {cluster_name!r}')
+        else:
+            logger.warning(f'Failed to rsync skylet log for cluster '
+                           f'{cluster_name}: {e}')
+            if errors is not None:
+                errors.append({
+                    'component': 'clusters',
+                    'resource': f'{cluster_name}/skylet_log',
+                    'error': str(e),
+                    'traceback': _full_traceback()
+                })
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to collect skylet log for cluster '
+                       f'{cluster_name}: {e}')
+        if errors is not None:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{cluster_name}/skylet_log',
+                'error': str(e),
+                'traceback': _full_traceback()
+            })
+
+
 def _dump_cluster_info(cluster_names: Set[str],
                        dump_dir: str,
                        errors: Optional[List[Dict[str, str]]] = None) -> None:
@@ -853,6 +930,19 @@ def _dump_cluster_info(cluster_names: Set[str],
                     'error': str(e),
                     'traceback': _full_traceback()
                 })
+
+        # Pull the skylet log from the head node for live clusters. Skylet
+        # only runs on UP clusters, and a stopped/terminated cluster has no
+        # reachable node, so we skip anything that isn't UP.
+        status = cluster_record.get('status') if cluster_record else None
+        handle = cluster_record.get('handle') if cluster_record else None
+
+        if status == status_lib.ClusterStatus.UP and handle is not None:
+            _collect_cluster_skylet_log(cluster_name, cluster_dir, handle,
+                                        errors)
+        else:
+            logger.debug(f'Skipping skylet log for cluster {cluster_name!r} '
+                         f'(status={status})')
 
     logger.debug('Exiting _dump_cluster_info')
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -815,7 +815,8 @@ def _collect_cluster_skylet_log(
         cluster_name: str,
         cluster_dir: str,
         handle: Any,
-        errors: Optional[List[Dict[str, str]]] = None) -> None:
+        errors: Optional[List[Dict[str, str]]] = None,
+        status: Optional['status_lib.ClusterStatus'] = None) -> None:
     """Rsync the head node's skylet log into the cluster dump dir.
 
     Skylet runs only on the head node (see
@@ -823,21 +824,40 @@ def _collect_cluster_skylet_log(
     command runner (runners[0] is always the head; ClusterInfo.ip_tuples()
     guarantees head-first ordering). The log path is resolved on the remote node
     (see _resolve_remote_skylet_log_path) to honor a relocated SKY_RUNTIME_DIR.
-    Best-effort: a missing log or any failure is recorded in ``errors`` and
-    never aborts the dump.
+
+    Best-effort: the dump is never aborted. For an INIT cluster, collection
+    failures are *expected* (the node may not be reachable or provisioned yet),
+    so they are logged at debug level rather than recorded as dump errors --
+    otherwise a fleet with some always-launching clusters would fill ``errors``
+    with benign connection-refused noise. For other statuses a failure is
+    genuinely worth surfacing, so it is recorded in ``errors``.
     """
-    try:
-        runners = handle.get_command_runners()
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to get command runners for cluster '
-                       f'{cluster_name}: {e}')
+    # INIT clusters are expected to sometimes be unreachable; don't treat a
+    # collection failure as a real dump error in that case.
+    expected_failure = (status == status_lib.ClusterStatus.INIT)
+
+    def _record_failure(message: str, exc: BaseException) -> None:
+        # str(exc) is empty for some exceptions (e.g. FetchClusterInfoError);
+        # fall back to the type name so the entry is never blank.
+        detail = str(exc) or type(exc).__name__
+        if expected_failure:
+            logger.debug(f'{message} (expected for {status} cluster '
+                         f'{cluster_name!r}): {detail}')
+            return
+        logger.warning(f'{message}: {detail}')
         if errors is not None:
             errors.append({
                 'component': 'clusters',
                 'resource': f'{cluster_name}/skylet_log',
-                'error': str(e),
+                'error': detail,
                 'traceback': _full_traceback()
             })
+
+    try:
+        runners = handle.get_command_runners()
+    except Exception as e:  # pylint: disable=broad-except
+        _record_failure(
+            f'Failed to get command runners for cluster {cluster_name}', e)
         return
 
     if not runners:
@@ -858,25 +878,11 @@ def _collect_cluster_skylet_log(
         if e.returncode == exceptions.RSYNC_FILE_NOT_FOUND_CODE:
             logger.debug(f'No skylet log found on cluster {cluster_name!r}')
         else:
-            logger.warning(f'Failed to rsync skylet log for cluster '
-                           f'{cluster_name}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'clusters',
-                    'resource': f'{cluster_name}/skylet_log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+            _record_failure(
+                f'Failed to rsync skylet log for cluster {cluster_name}', e)
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to collect skylet log for cluster '
-                       f'{cluster_name}: {e}')
-        if errors is not None:
-            errors.append({
-                'component': 'clusters',
-                'resource': f'{cluster_name}/skylet_log',
-                'error': str(e),
-                'traceback': _full_traceback()
-            })
+        _record_failure(
+            f'Failed to collect skylet log for cluster {cluster_name}', e)
 
 
 def _dump_cluster_info(cluster_names: Set[str],
@@ -988,7 +994,7 @@ def _dump_cluster_info(cluster_names: Set[str],
 
         if status != status_lib.ClusterStatus.STOPPED and handle is not None:
             _collect_cluster_skylet_log(cluster_name, cluster_dir, handle,
-                                        errors)
+                                        errors, status)
         else:
             logger.debug(f'Skipping skylet log for cluster {cluster_name!r} '
                          f'(status={status})')

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -10,10 +10,13 @@ import zipfile
 
 import pytest
 
+from sky import exceptions
 from sky.server import constants as server_constants
 from sky.server.requests import request_names
+from sky.skylet import constants as skylet_constants
 from sky.utils import debug_dump_helpers
 from sky.utils import debug_utils
+from sky.utils import status_lib
 
 
 def _make_context(
@@ -2433,3 +2436,157 @@ class TestDumpClusterInfo:
             data = json.load(f)
         assert len(data) == 1
         assert data[0]['request_id'] == 'req-a'
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.debug_dump_helpers'
+                '.get_cluster_events_data',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.global_user_state'
+                '.get_cluster_from_name')
+    def test_up_cluster_collects_skylet_log(self, mock_get_cluster, mock_events,
+                                            mock_requests, tmp_path):
+        """An UP cluster with a handle should rsync the skylet log."""
+        del mock_events, mock_requests  # unused but required by mock.patch
+        handle = mock.Mock()
+        runner = mock.Mock(skypilot_runtime_dir=None)
+        handle.get_command_runners.return_value = [runner]
+        mock_get_cluster.return_value = {
+            'name': 'live-cluster',
+            'cluster_hash': 'abc',
+            'status': status_lib.ClusterStatus.UP,
+            'handle': handle,
+        }
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_cluster_info({'live-cluster'}, str(tmp_path), errors)
+
+        # Pulled the skylet log off the head node (runners[0]) into the
+        # cluster dump dir.
+        runner.rsync.assert_called_once()
+        _, kwargs = runner.rsync.call_args
+        assert kwargs['source'] == os.path.join(
+            '~', skylet_constants.SKYLET_LOG_FILE)
+        assert kwargs['target'] == str(tmp_path / 'clusters' / 'live-cluster' /
+                                       'skylet.log')
+        assert kwargs['up'] is False
+        assert not errors
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.debug_dump_helpers'
+                '.get_cluster_events_data',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.global_user_state'
+                '.get_cluster_from_name')
+    def test_stopped_cluster_skips_skylet_log(self, mock_get_cluster,
+                                              mock_events, mock_requests,
+                                              tmp_path):
+        """A non-UP cluster should not attempt to reach the node."""
+        del mock_events, mock_requests  # unused but required by mock.patch
+        handle = mock.Mock()
+        mock_get_cluster.return_value = {
+            'name': 'stopped-cluster',
+            'cluster_hash': 'abc',
+            'status': status_lib.ClusterStatus.STOPPED,
+            'handle': handle,
+        }
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_cluster_info({'stopped-cluster'}, str(tmp_path),
+                                       errors)
+
+        handle.get_command_runners.assert_not_called()
+        assert not errors
+
+
+class TestCollectClusterSkyletLog:
+    """Tests for the _collect_cluster_skylet_log helper."""
+
+    def test_rsyncs_skylet_log_from_head(self, tmp_path):
+        """Pulls ~/.sky/skylet.log off the first (head) runner."""
+        runner = mock.Mock(skypilot_runtime_dir=None)
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner, mock.Mock()]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        # Only the head runner (index 0) is used.
+        runner.rsync.assert_called_once()
+        handle.get_command_runners.return_value[1].rsync.assert_not_called()
+        _, kwargs = runner.rsync.call_args
+        assert kwargs['source'] == os.path.join(
+            '~', skylet_constants.SKYLET_LOG_FILE)
+        assert kwargs['target'] == os.path.join(str(tmp_path), 'skylet.log')
+        assert not errors
+
+    def test_uses_relocated_runtime_dir(self, tmp_path):
+        """A runner exposing skypilot_runtime_dir (Slurm) resolves the source
+        against it instead of $HOME."""
+        runner = mock.Mock(skypilot_runtime_dir='/scratch/rt')
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        _, kwargs = runner.rsync.call_args
+        assert kwargs['source'] == os.path.join(
+            '/scratch/rt', skylet_constants.SKYLET_LOG_FILE)
+        assert not errors
+
+    def test_missing_log_is_not_an_error(self, tmp_path):
+        """A not-found rsync (code 23) is silently skipped, not recorded."""
+        runner = mock.Mock(skypilot_runtime_dir=None)
+        runner.rsync.side_effect = exceptions.CommandError(
+            exceptions.RSYNC_FILE_NOT_FOUND_CODE, 'rsync', 'not found', None)
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        assert not errors
+
+    def test_other_rsync_failure_is_recorded(self, tmp_path):
+        """A non-23 rsync failure is recorded in errors."""
+        runner = mock.Mock(skypilot_runtime_dir=None)
+        runner.rsync.side_effect = exceptions.CommandError(
+            255, 'rsync', 'connection refused', None)
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'clusters'
+        assert errors[0]['resource'] == 'c/skylet_log'
+
+    def test_empty_runners_is_noop(self, tmp_path):
+        """No runners (e.g. headless cluster) is a safe no-op."""
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = []
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        assert not errors
+
+    def test_get_command_runners_failure_is_recorded(self, tmp_path):
+        """A failure obtaining runners is recorded but does not raise."""
+        handle = mock.Mock()
+        handle.get_command_runners.side_effect = RuntimeError('unreachable')
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log('c', str(tmp_path), handle,
+                                                errors)
+
+        assert len(errors) == 1
+        assert errors[0]['resource'] == 'c/skylet_log'

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import os
+import posixpath
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set
@@ -2465,7 +2466,7 @@ class TestDumpClusterInfo:
         # cluster dump dir.
         runner.rsync.assert_called_once()
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == os.path.join(
+        assert kwargs['source'] == posixpath.join(
             '~', skylet_constants.SKYLET_LOG_FILE)
         assert kwargs['target'] == str(tmp_path / 'clusters' / 'live-cluster' /
                                        'skylet.log')
@@ -2517,7 +2518,7 @@ class TestCollectClusterSkyletLog:
         runner.rsync.assert_called_once()
         handle.get_command_runners.return_value[1].rsync.assert_not_called()
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == os.path.join(
+        assert kwargs['source'] == posixpath.join(
             '~', skylet_constants.SKYLET_LOG_FILE)
         assert kwargs['target'] == os.path.join(str(tmp_path), 'skylet.log')
         assert not errors
@@ -2534,7 +2535,7 @@ class TestCollectClusterSkyletLog:
                                                 errors)
 
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == os.path.join(
+        assert kwargs['source'] == posixpath.join(
             '/scratch/rt', skylet_constants.SKYLET_LOG_FILE)
         assert not errors
 

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2636,10 +2636,13 @@ class TestResolveRemoteSkyletLogPath:
         path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
 
         assert path == '/scratch/rt/.sky/skylet.log'
-        # Resolved with source_bashrc to match how skylet is started.
         _, kwargs = runner.run.call_args
+        # Resolved with source_bashrc to match how skylet is started.
         assert kwargs['source_bashrc'] is True
         assert kwargs['require_outputs'] is True
+        # Bounded by a connect timeout so an unreachable node fails fast.
+        assert kwargs['connect_timeout'] == (
+            debug_utils._SKYLET_LOG_RESOLVE_CONNECT_TIMEOUT)
 
     def test_takes_last_non_empty_line(self):
         """bashrc banner/warning lines before the echo are ignored."""

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2624,6 +2624,80 @@ class TestCollectClusterSkyletLog:
         assert len(errors) == 1
         assert errors[0]['resource'] == 'c/skylet_log'
 
+    def test_init_rsync_failure_is_demoted_not_recorded(self, tmp_path):
+        """For an INIT cluster, a (non-23) rsync failure is expected and is
+        debug-logged, not recorded as a dump error."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
+        runner.rsync.side_effect = exceptions.CommandError(
+            255, 'rsync', 'connection refused', None)
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log(
+            'c',
+            str(tmp_path),
+            handle,
+            errors,
+            status=status_lib.ClusterStatus.INIT)
+
+        assert not errors
+
+    def test_init_get_runners_failure_is_demoted_not_recorded(self, tmp_path):
+        """For an INIT cluster, an unreachable node (no runners yet) is
+        expected and not recorded."""
+        handle = mock.Mock()
+        handle.get_command_runners.side_effect = RuntimeError('not up yet')
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log(
+            'c',
+            str(tmp_path),
+            handle,
+            errors,
+            status=status_lib.ClusterStatus.INIT)
+
+        assert not errors
+
+    def test_up_rsync_failure_is_recorded(self, tmp_path):
+        """For an UP cluster, a (non-23) rsync failure is genuinely worth
+        surfacing and is recorded."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
+        runner.rsync.side_effect = exceptions.CommandError(
+            255, 'rsync', 'connection refused', None)
+        handle = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log(
+            'c',
+            str(tmp_path),
+            handle,
+            errors,
+            status=status_lib.ClusterStatus.UP)
+
+        assert len(errors) == 1
+        assert errors[0]['resource'] == 'c/skylet_log'
+
+    def test_empty_exception_message_falls_back_to_type_name(self, tmp_path):
+        """A recorded error never has a blank message: an exception whose
+        str() is empty falls back to the exception type name."""
+        handle = mock.Mock()
+        handle.get_command_runners.side_effect = RuntimeError('')
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._collect_cluster_skylet_log(
+            'c',
+            str(tmp_path),
+            handle,
+            errors,
+            status=status_lib.ClusterStatus.UP)
+
+        assert len(errors) == 1
+        assert errors[0]['error'] == 'RuntimeError'
+
 
 class TestResolveRemoteSkyletLogPath:
     """Tests for the _resolve_remote_skylet_log_path helper."""

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2450,7 +2450,9 @@ class TestDumpClusterInfo:
         """An UP cluster with a handle should rsync the skylet log."""
         del mock_events, mock_requests  # unused but required by mock.patch
         handle = mock.Mock()
-        runner = mock.Mock(skypilot_runtime_dir=None)
+        runner = mock.Mock()
+        # Head node resolves the skylet log path against $HOME.
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
         handle.get_command_runners.return_value = [runner]
         mock_get_cluster.return_value = {
             'name': 'live-cluster',
@@ -2463,11 +2465,10 @@ class TestDumpClusterInfo:
         debug_utils._dump_cluster_info({'live-cluster'}, str(tmp_path), errors)
 
         # Pulled the skylet log off the head node (runners[0]) into the
-        # cluster dump dir.
+        # cluster dump dir, using the remotely-resolved source path.
         runner.rsync.assert_called_once()
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == posixpath.join(
-            '~', skylet_constants.SKYLET_LOG_FILE)
+        assert kwargs['source'] == '/home/sky/.sky/skylet.log'
         assert kwargs['target'] == str(tmp_path / 'clusters' / 'live-cluster' /
                                        'skylet.log')
         assert kwargs['up'] is False
@@ -2483,7 +2484,7 @@ class TestDumpClusterInfo:
     def test_stopped_cluster_skips_skylet_log(self, mock_get_cluster,
                                               mock_events, mock_requests,
                                               tmp_path):
-        """A non-UP cluster should not attempt to reach the node."""
+        """A STOPPED cluster has no reachable node, so we don't attempt it."""
         del mock_events, mock_requests  # unused but required by mock.patch
         handle = mock.Mock()
         mock_get_cluster.return_value = {
@@ -2500,13 +2501,43 @@ class TestDumpClusterInfo:
         handle.get_command_runners.assert_not_called()
         assert not errors
 
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.debug_dump_helpers'
+                '.get_cluster_events_data',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.global_user_state'
+                '.get_cluster_from_name')
+    def test_init_cluster_collects_skylet_log(self, mock_get_cluster,
+                                              mock_events, mock_requests,
+                                              tmp_path):
+        """An INIT (possibly degraded) cluster is still attempted."""
+        del mock_events, mock_requests  # unused but required by mock.patch
+        handle = mock.Mock()
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
+        handle.get_command_runners.return_value = [runner]
+        mock_get_cluster.return_value = {
+            'name': 'init-cluster',
+            'cluster_hash': 'abc',
+            'status': status_lib.ClusterStatus.INIT,
+            'handle': handle,
+        }
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_cluster_info({'init-cluster'}, str(tmp_path), errors)
+
+        runner.rsync.assert_called_once()
+        assert not errors
+
 
 class TestCollectClusterSkyletLog:
     """Tests for the _collect_cluster_skylet_log helper."""
 
     def test_rsyncs_skylet_log_from_head(self, tmp_path):
-        """Pulls ~/.sky/skylet.log off the first (head) runner."""
-        runner = mock.Mock(skypilot_runtime_dir=None)
+        """Pulls the remotely-resolved skylet log off the first (head) runner."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
         handle = mock.Mock()
         handle.get_command_runners.return_value = [runner, mock.Mock()]
 
@@ -2518,15 +2549,15 @@ class TestCollectClusterSkyletLog:
         runner.rsync.assert_called_once()
         handle.get_command_runners.return_value[1].rsync.assert_not_called()
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == posixpath.join(
-            '~', skylet_constants.SKYLET_LOG_FILE)
+        assert kwargs['source'] == '/home/sky/.sky/skylet.log'
         assert kwargs['target'] == os.path.join(str(tmp_path), 'skylet.log')
         assert not errors
 
     def test_uses_relocated_runtime_dir(self, tmp_path):
-        """A runner exposing skypilot_runtime_dir (Slurm) resolves the source
-        against it instead of $HOME."""
-        runner = mock.Mock(skypilot_runtime_dir='/scratch/rt')
+        """A relocated SKY_RUNTIME_DIR (Slurm/devspaces) is honored because the
+        path is resolved on the remote node, not from a Python attribute."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/scratch/rt/.sky/skylet.log\n', '')
         handle = mock.Mock()
         handle.get_command_runners.return_value = [runner]
 
@@ -2535,13 +2566,13 @@ class TestCollectClusterSkyletLog:
                                                 errors)
 
         _, kwargs = runner.rsync.call_args
-        assert kwargs['source'] == posixpath.join(
-            '/scratch/rt', skylet_constants.SKYLET_LOG_FILE)
+        assert kwargs['source'] == '/scratch/rt/.sky/skylet.log'
         assert not errors
 
     def test_missing_log_is_not_an_error(self, tmp_path):
         """A not-found rsync (code 23) is silently skipped, not recorded."""
-        runner = mock.Mock(skypilot_runtime_dir=None)
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
         runner.rsync.side_effect = exceptions.CommandError(
             exceptions.RSYNC_FILE_NOT_FOUND_CODE, 'rsync', 'not found', None)
         handle = mock.Mock()
@@ -2555,7 +2586,8 @@ class TestCollectClusterSkyletLog:
 
     def test_other_rsync_failure_is_recorded(self, tmp_path):
         """A non-23 rsync failure is recorded in errors."""
-        runner = mock.Mock(skypilot_runtime_dir=None)
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
         runner.rsync.side_effect = exceptions.CommandError(
             255, 'rsync', 'connection refused', None)
         handle = mock.Mock()
@@ -2591,3 +2623,58 @@ class TestCollectClusterSkyletLog:
 
         assert len(errors) == 1
         assert errors[0]['resource'] == 'c/skylet_log'
+
+
+class TestResolveRemoteSkyletLogPath:
+    """Tests for the _resolve_remote_skylet_log_path helper."""
+
+    def test_returns_resolved_remote_path(self):
+        """Returns the path echoed by the remote shell."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/scratch/rt/.sky/skylet.log\n', '')
+
+        path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
+
+        assert path == '/scratch/rt/.sky/skylet.log'
+        # Resolved with source_bashrc to match how skylet is started.
+        _, kwargs = runner.run.call_args
+        assert kwargs['source_bashrc'] is True
+        assert kwargs['require_outputs'] is True
+
+    def test_takes_last_non_empty_line(self):
+        """bashrc banner/warning lines before the echo are ignored."""
+        runner = mock.Mock()
+        runner.run.return_value = (0,
+                                   'motd banner\n\n/home/sky/.sky/skylet.log\n',
+                                   '')
+
+        path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
+
+        assert path == '/home/sky/.sky/skylet.log'
+
+    def test_falls_back_on_nonzero_returncode(self):
+        """A failed resolution command falls back to ~/.sky/skylet.log."""
+        runner = mock.Mock()
+        runner.run.return_value = (1, '', 'boom')
+
+        path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
+
+        assert path == posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
+
+    def test_falls_back_on_empty_output(self):
+        """Empty stdout falls back to ~/.sky/skylet.log."""
+        runner = mock.Mock()
+        runner.run.return_value = (0, '   \n', '')
+
+        path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
+
+        assert path == posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
+
+    def test_falls_back_on_exception(self):
+        """A raising runner.run falls back instead of propagating."""
+        runner = mock.Mock()
+        runner.run.side_effect = RuntimeError('unreachable')
+
+        path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
+
+        assert path == posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2551,6 +2551,8 @@ class TestCollectClusterSkyletLog:
         _, kwargs = runner.rsync.call_args
         assert kwargs['source'] == '/home/sky/.sky/skylet.log'
         assert kwargs['target'] == os.path.join(str(tmp_path), 'skylet.log')
+        # Bounded by a total timeout so one stalled node can't hang the dump.
+        assert kwargs['timeout'] == debug_utils._SKYLET_LOG_RSYNC_TIMEOUT
         assert not errors
 
     def test_uses_relocated_runtime_dir(self, tmp_path):


### PR DESCRIPTION
## Summary

- When `sky debug-dump` includes a cluster that is **UP**, we now rsync the head node's skylet log (`~/.sky/skylet.log`) into `clusters/<name>/skylet.log` in the dump. Previously the cluster section only contained server-side DB state (cluster info, events, associated requests) and never pulled anything off the box.
- Skylet runs only on the head node (`instance_setup.start_skylet_on_head_node`), so a single rsync off `runners[0]` suffices. The remote path resolves against `skypilot_runtime_dir` when the runner exposes it (Slurm relocates the runtime off the NFS home dir) and falls back to `$HOME` otherwise.
- Non-UP clusters are skipped (no node to reach), and any failure is recorded in `errors.json` and never aborts the dump — mirroring the existing controller-rsync pattern in `_collect_controller_debug_data`.

## Test plan

- **Unit:** `pytest tests/unit_tests/test_sky/utils/test_debug_utils.py` (126 passed). New coverage for the `_collect_cluster_skylet_log` helper (head-only rsync, relocated runtime dir, missing-log-is-not-an-error, other-failure-recorded, empty-runners no-op, runner-fetch-failure) and the UP/STOPPED branches of `_dump_cluster_info`.
- **Manual (AWS):**
  - Live cluster → `clusters/<name>/skylet.log` present in the dump zip.
  - `sky stop`ed cluster → skylet collection skipped: no `skylet.log`, empty `errors.json`, and `debug_dump.log` shows `Skipping skylet log ... (status=ClusterStatus.STOPPED)`.

## Known follow-ups

- Only the SSH transport (AWS) was exercised manually; the Kubernetes `KubernetesCommandRunner.rsync` path for a single-file pull hasn't been validated end-to-end yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)