### PR TITLE
[Dashboard] Allow text selection/copy in read-only YAML viewer

### DIFF
--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -10,28 +10,13 @@ import { getNonce } from '@/utils/csp';
 import { yamlHighlightStyle } from './yaml-editor';
 
 const editorTheme = EditorView.theme({
-  '&': {
-    height: '100%',
-    backgroundColor: '#f9fafb',
-  },
-  '.cm-scroller': {
-    minHeight: '100%',
-    overflow: 'auto',
-    backgroundColor: '#f9fafb',
-  },
-  '.cm-content': {
-    minHeight: '100%',
-    backgroundColor: '#f9fafb',
-    padding: '8px 0',
-  },
   '.cm-gutters': {
-    backgroundColor: '#f3f4f6',
-    borderRight: '1px solid #e5e7eb',
-    color: '#9ca3af',
-    minHeight: '100%',
+    backgroundColor: '#ffffff',
+    border: 'none',
+    color: '#6e7781',
   },
   '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 12px 0 8px',
+    padding: '0 16px 0 8px',
     minWidth: '2.5em',
   },
   '&.cm-focused': {

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -67,7 +67,7 @@ export function YamlCodeBlock({
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),
         ]}
-        editable={!readOnly}
+        readOnly={readOnly}
         height={fixed ? '100%' : undefined}
         maxHeight={fixed ? undefined : maxHeight}
         basicSetup={{

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -11,9 +11,12 @@ import { yamlHighlightStyle, yamlGutterTheme } from './yaml-editor';
 
 // In read-only mode, suppress CodeMirror's drawn caret so the viewer
 // doesn't look editable when focused. Selection backgrounds still render
-// (they're drawn by a separate layer).
+// (they're drawn by a separate layer). `!important` is required because
+// CodeMirror's base theme has a more-specific
+// `&.cm-focused > .cm-scroller > .cm-cursorLayer .cm-cursor { display: block }`
+// rule that re-enables the cursor on focus.
 const hideCaretTheme = EditorView.theme({
-  '.cm-cursor, .cm-cursor-primary': { display: 'none' },
+  '.cm-cursor, .cm-cursor-primary': { display: 'none !important' },
 });
 
 export function YamlCodeBlock({

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -7,7 +7,11 @@ import { Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { syntaxHighlighting } from '@codemirror/language';
 import { getNonce } from '@/utils/csp';
-import { yamlHighlightStyle, yamlGutterTheme } from './yaml-editor';
+import {
+  yamlHighlightStyle,
+  yamlGutterTheme,
+  yamlTextCursorTheme,
+} from './yaml-editor';
 
 // In read-only mode, suppress CodeMirror's drawn caret so the viewer
 // doesn't look editable when focused. Selection backgrounds still render
@@ -44,7 +48,7 @@ export function YamlCodeBlock({
         extensions={[
           yaml(),
           yamlGutterTheme,
-          ...(readOnly ? [hideCaretTheme] : []),
+          ...(readOnly ? [hideCaretTheme] : [yamlTextCursorTheme]),
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),
         ]}

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -7,11 +7,7 @@ import { Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { syntaxHighlighting } from '@codemirror/language';
 import { getNonce } from '@/utils/csp';
-import {
-  yamlHighlightStyle,
-  yamlGutterTheme,
-  selectionGutterHighlighter,
-} from './yaml-editor';
+import { yamlHighlightStyle, yamlGutterTheme } from './yaml-editor';
 
 export function YamlCodeBlock({
   value,
@@ -38,7 +34,6 @@ export function YamlCodeBlock({
         extensions={[
           yaml(),
           yamlGutterTheme,
-          selectionGutterHighlighter,
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),
         ]}

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -47,7 +47,7 @@ export function YamlCodeBlock({
         maxHeight={fixed ? undefined : maxHeight}
         basicSetup={{
           lineNumbers: true,
-          foldGutter: true,
+          foldGutter: false,
           highlightActiveLineGutter: false,
           highlightActiveLine: false,
           indentOnInput: true,

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -9,6 +9,13 @@ import { syntaxHighlighting } from '@codemirror/language';
 import { getNonce } from '@/utils/csp';
 import { yamlHighlightStyle, yamlGutterTheme } from './yaml-editor';
 
+// In read-only mode, suppress CodeMirror's drawn caret so the viewer
+// doesn't look editable when focused. Selection backgrounds still render
+// (they're drawn by a separate layer).
+const hideCaretTheme = EditorView.theme({
+  '.cm-cursor, .cm-cursor-primary': { display: 'none' },
+});
+
 export function YamlCodeBlock({
   value,
   onChange,
@@ -34,6 +41,7 @@ export function YamlCodeBlock({
         extensions={[
           yaml(),
           yamlGutterTheme,
+          ...(readOnly ? [hideCaretTheme] : []),
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),
         ]}

--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -7,22 +7,11 @@ import { Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { syntaxHighlighting } from '@codemirror/language';
 import { getNonce } from '@/utils/csp';
-import { yamlHighlightStyle } from './yaml-editor';
-
-const editorTheme = EditorView.theme({
-  '.cm-gutters': {
-    backgroundColor: '#ffffff',
-    border: 'none',
-    color: '#6e7781',
-  },
-  '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 16px 0 8px',
-    minWidth: '2.5em',
-  },
-  '&.cm-focused': {
-    outline: 'none',
-  },
-});
+import {
+  yamlHighlightStyle,
+  yamlGutterTheme,
+  selectionGutterHighlighter,
+} from './yaml-editor';
 
 export function YamlCodeBlock({
   value,
@@ -48,7 +37,8 @@ export function YamlCodeBlock({
         onChange={onChange}
         extensions={[
           yaml(),
-          editorTheme,
+          yamlGutterTheme,
+          selectionGutterHighlighter,
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),
         ]}

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import CodeMirror from '@uiw/react-codemirror';
-import { EditorView } from '@codemirror/view';
-import { Prec } from '@codemirror/state';
+import { EditorView, GutterMarker, gutterLineClass } from '@codemirror/view';
+import { Prec, RangeSet } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
@@ -21,15 +21,48 @@ export const yamlHighlightStyle = HighlightStyle.define([
   { tag: t.punctuation, color: '#6b7280' },
 ]);
 
-const gutterTheme = EditorView.theme({
+class SelectedLineGutterMarker extends GutterMarker {}
+SelectedLineGutterMarker.prototype.elementClass = 'cm-selectedLineGutter';
+const selectedLineGutterMarker = new SelectedLineGutterMarker();
+
+export const selectionGutterHighlighter = gutterLineClass.compute(
+  ['selection'],
+  (state) => {
+    const marks = [];
+    let lastMarked = -1;
+    for (const range of state.selection.ranges) {
+      if (range.empty) continue;
+      const fromLine = state.doc.lineAt(range.from).number;
+      let toLine = state.doc.lineAt(range.to).number;
+      // Selection that ends at the very start of a line doesn't actually
+      // cover that line's content — exclude it.
+      if (toLine > fromLine && state.doc.line(toLine).from === range.to) {
+        toLine -= 1;
+      }
+      for (let n = Math.max(fromLine, lastMarked + 1); n <= toLine; n++) {
+        marks.push(selectedLineGutterMarker.range(state.doc.line(n).from));
+        lastMarked = n;
+      }
+    }
+    return RangeSet.of(marks);
+  }
+);
+
+export const yamlGutterTheme = EditorView.theme({
   '.cm-gutters': {
-    backgroundColor: '#f9fafb',
-    borderRight: '1px solid #e5e7eb',
-    color: '#9ca3af',
+    backgroundColor: '#ffffff',
+    border: 'none',
+    color: '#8c959f',
   },
   '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 12px 0 8px',
-    minWidth: '2.5em',
+    padding: '0 16px 0 16px',
+    minWidth: '3em',
+  },
+  '.cm-selectedLineGutter': {
+    backgroundColor: '#d7d4f0',
+  },
+  '&.cm-focused': {
+    outline: 'none',
   },
 });
 
@@ -48,7 +81,7 @@ export function YamlEditor({
 }) {
   return (
     <div
-      className={`rounded-md border border-gray-300 overflow-hidden flex flex-col ${className || ''}`}
+      className={`rounded-md border border-gray-200 overflow-hidden flex flex-col ${className || ''}`}
       style={{
         width: '100%',
         maxWidth: '100%',
@@ -63,7 +96,8 @@ export function YamlEditor({
         onChange={onChange}
         extensions={[
           yaml(),
-          gutterTheme,
+          yamlGutterTheme,
+          selectionGutterHighlighter,
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           // Pass CSP nonce so CodeMirror's injected <style> tags are allowed.
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import CodeMirror from '@uiw/react-codemirror';
-import { EditorView, GutterMarker, gutterLineClass } from '@codemirror/view';
-import { Prec, RangeSet } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
@@ -21,33 +21,6 @@ export const yamlHighlightStyle = HighlightStyle.define([
   { tag: t.punctuation, color: '#6b7280' },
 ]);
 
-class SelectedLineGutterMarker extends GutterMarker {}
-SelectedLineGutterMarker.prototype.elementClass = 'cm-selectedLineGutter';
-const selectedLineGutterMarker = new SelectedLineGutterMarker();
-
-export const selectionGutterHighlighter = gutterLineClass.compute(
-  ['selection'],
-  (state) => {
-    const marks = [];
-    let lastMarked = -1;
-    for (const range of state.selection.ranges) {
-      if (range.empty) continue;
-      const fromLine = state.doc.lineAt(range.from).number;
-      let toLine = state.doc.lineAt(range.to).number;
-      // Selection that ends at the very start of a line doesn't actually
-      // cover that line's content — exclude it.
-      if (toLine > fromLine && state.doc.line(toLine).from === range.to) {
-        toLine -= 1;
-      }
-      for (let n = Math.max(fromLine, lastMarked + 1); n <= toLine; n++) {
-        marks.push(selectedLineGutterMarker.range(state.doc.line(n).from));
-        lastMarked = n;
-      }
-    }
-    return RangeSet.of(marks);
-  }
-);
-
 export const yamlGutterTheme = EditorView.theme({
   '.cm-gutters': {
     backgroundColor: '#ffffff',
@@ -57,9 +30,6 @@ export const yamlGutterTheme = EditorView.theme({
   '.cm-lineNumbers .cm-gutterElement': {
     padding: '0 16px 0 16px',
     minWidth: '3em',
-  },
-  '.cm-selectedLineGutter': {
-    backgroundColor: '#d7d4f0',
   },
   '&.cm-focused': {
     outline: 'none',
@@ -97,7 +67,6 @@ export function YamlEditor({
         extensions={[
           yaml(),
           yamlGutterTheme,
-          selectionGutterHighlighter,
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           // Pass CSP nonce so CodeMirror's injected <style> tags are allowed.
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -21,6 +21,15 @@ export const yamlHighlightStyle = HighlightStyle.define([
   { tag: t.punctuation, color: '#6b7280' },
 ]);
 
+// I-beam over the entire editor box (gutter + content + empty area)
+// so the whole surface reads as a single text region. CodeMirror's
+// default only puts the I-beam on `.cm-content` (the contenteditable
+// text), leaving the gutter on the default arrow — fine for IDEs,
+// but in a small embedded YAML viewer the box feels split otherwise.
+export const yamlTextCursorTheme = EditorView.theme({
+  '&': { cursor: 'text' },
+});
+
 export const yamlGutterTheme = EditorView.theme({
   '.cm-gutters': {
     backgroundColor: '#ffffff',
@@ -72,6 +81,7 @@ export function YamlEditor({
         extensions={[
           yaml(),
           yamlGutterTheme,
+          yamlTextCursorTheme,
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           // Pass CSP nonce so CodeMirror's injected <style> tags are allowed.
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -27,9 +27,14 @@ export const yamlGutterTheme = EditorView.theme({
     border: 'none',
     color: '#8c959f',
   },
+  // Fixed-width line-number column so the gutter doesn't jitter when the
+  // line count crosses 1 → 2 → 3 digits. Right-aligned within a 4em box
+  // (fits 3-digit numbers at 13px font without growing).
   '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 16px 0 16px',
-    minWidth: '3em',
+    padding: '0 16px 0 8px',
+    minWidth: '4em',
+    boxSizing: 'border-box',
+    textAlign: 'right',
   },
   '&.cm-focused': {
     outline: 'none',

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -108,7 +108,7 @@ export function YamlEditor({
         maxHeight={height ? undefined : maxHeight}
         basicSetup={{
           lineNumbers: true,
-          foldGutter: true,
+          foldGutter: false,
           highlightActiveLineGutter: false,
           highlightActiveLine: false,
           indentOnInput: true,

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1638,7 +1638,7 @@ function JobDetailsContent({
                 </div>
 
                 {isYamlExpanded && (
-                  <div className="bg-gray-50 border border-gray-200 rounded-md p-3 max-h-96 overflow-y-auto">
+                  <div>
                     {(() => {
                       const yamlDocs = formatJobYaml(jobData.dag_yaml);
                       // Build JobGroup header with name and execution


### PR DESCRIPTION
## Summary

Follow-up polish on the read-only YAML viewer wired in by #9881, plus a
consistency pass on the editable YAML editor so both surfaces look and
behave the same.

- **Selection + copy works in the viewer.** Previously `editable={false}`
  set `contenteditable="false"` on `.cm-content`, which disables
  CodeMirror's selection model — users couldn't highlight YAML to copy
  it. Switched to `readOnly={readOnly}` (`EditorState.readOnly.of(true)`),
  which keeps the editor selectable/focusable but still blocks edits.
- **Theme simplified.** Dropped the gray `#f9fafb` backgrounds on
  `.cm-editor`, `.cm-scroller`, and `.cm-content`, plus the
  `height: 100%` / `minHeight: 100%` overrides. The background overrides
  were painting over CodeMirror's selection-layer rectangles inside
  `.cm-content`, making mouse-drag selections invisible even when they
  were registering. With them gone, the default selection color is
  visible against the white background.
- **Shared theme.** Lifted the gutter theme and the existing
  `yamlHighlightStyle` into named exports on `yaml-editor.jsx`.
  `YamlCodeBlock` now imports them instead of duplicating the theme code.
  Both components now render with the same:
  - white gutter, no vertical separator, GitHub-style line-number color
    (`#8c959f`);
  - outer wrapper border color (`gray-200`).
- **Fold gutter disabled.** The fold-arrow chevrons next to line
  numbers had a small click target that was awkward to hit, and they
  add visual noise for a YAML surface of this size. Set
  `foldGutter: false` in both components' `basicSetup`.
- **Double border around managed-job YAML viewer.** The managed-job
  detail page wrapped `<YamlCodeBlock>` in a div that already had its
  own `border border-gray-200 rounded-md`, producing two concentric
  rounded borders separated by 12px padding. Dropped the outer
  wrapper's styling; the inner `<YamlCodeBlock>` is the single visible
  frame.
- **Selected-line gutter highlight removed.** Dropped the
  `gutterLineClass` decoration that tinted the line-number cell for any
  line touched by the current selection. GitHub / VSCode / JetBrains
  don't visually link gutter rows to the selection, and at this surface
  size it read as visual noise rather than a useful affordance.
- **Caret hidden in the read-only viewer.** Clicking into a read-only
  `YamlCodeBlock` parked a blinking text caret in the editor, making it
  feel editable. Added a `hideCaretTheme` that hides `.cm-cursor` only
  when `readOnly` is true (with `!important` to beat CodeMirror's base
  rule that re-shows the cursor on focus). Selection backgrounds still
  render — they live in a separate layer (`.cm-selectionLayer`) — so
  click-drag + Cmd+C are unaffected. The editable `YamlEditor` is
  untouched.
- **Line-number gutter width locked.** The gutter was sized with
  `min-width: 3em` plus symmetric padding, so a 1-digit number occupied
  less width than a 2-digit one and the gutter visibly grew as the doc
  passed 9 lines. Bumped `min-width` to `4em` (fits 3-digit numbers at
  13px) and added `text-align: right` + `box-sizing: border-box` so 1 /
  9 / 99 / 999 all render in the same column.
- **I-beam over the whole editor box in edit mode.** CodeMirror's
  default only puts the text cursor on `.cm-content`, leaving the gutter
  and any empty area below the last line on the default arrow — fine
  for a full IDE, but in a small embedded YAML editor the box feels
  inert outside the actual lines. Added a `yamlTextCursorTheme`
  (`& { cursor: text }`) and apply it in edit mode only (`YamlEditor`
  always, `YamlCodeBlock` when `readOnly` is false). Read-only viewers
  keep CodeMirror's standard cursor — the box isn't meant to invite
  typing.

## Files

- `sky/dashboard/src/components/ui/yaml-code-block.jsx` — `readOnly`
  prop, theme simplification, shared imports from `yaml-editor.jsx`,
  `foldGutter: false`, `hideCaretTheme` gated on `readOnly`,
  `yamlTextCursorTheme` applied in edit mode only.
- `sky/dashboard/src/components/ui/yaml-editor.jsx` — new exports
  (`yamlGutterTheme`, `yamlTextCursorTheme`), white gutter, wrapper
  border `gray-300` → `gray-200`, `foldGutter: false`, line-number
  gutter `min-width: 4em` with right-aligned tabular layout.
- `sky/dashboard/src/pages/jobs/[job].js` — drop the outer
  `bg-gray-50 border border-gray-200 rounded-md p-3 max-h-96 overflow-y-auto`
  wrapper around the managed-job YAML viewer.

## Test plan

- [x] Cluster/job/pool/volume/recipe detail pages → expand the SkyPilot
  YAML viewer:
  - [x] Click-and-drag inside the YAML highlights a visible range.
  - [x] Cmd/Ctrl+C → paste elsewhere → only code text, no line numbers.
  - [x] Typing/paste inside the viewer is still blocked (read-only
    behavior preserved).
  - [x] No blinking caret appears when the viewer is focused.
  - [x] Cursor is CodeMirror standard (I-beam over text, default over
    gutter).
- [x] Settings → Config page (uses `YamlEditor`): same gutter style and
  editing still works; I-beam cursor extends to the gutter and to the
  empty area below the last line.
- [x] No fold-arrow chevrons next to line numbers on either surface.
- [x] No tinted gutter rows when selecting text — the line-number cells
  stay neutral.
- [x] Type a document that crosses the 9 → 10 line boundary; the gutter
  column doesn't shift width. Same at 99 → 100.
- [x] Managed-job detail page: the YAML viewer shows a single frame, no
  outer box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)