### PR TITLE
Fix Ray helper crash on externally-managed Python (PEP 668)

### DIFF
--- a/sky_templates/ray/start_cluster
+++ b/sky_templates/ray/start_cluster
@@ -68,7 +68,15 @@ fi
 # See: https://github.com/ray-project/ray/issues/56747
 # TODO(kevin): Remove this once the issue is fixed in a future click release
 RAY_INSTALL_SPEC="ray[default]${VERSION_SPEC} click<8.3.0"
-uv pip install ${RAY_INSTALL_SPEC} || uv pip install --system ${RAY_INSTALL_SPEC}
+# On bring-your-own images without a virtualenv, the first `uv pip install`
+# fails and we fall back to `--system`. If the system Python is externally
+# managed (PEP 668, e.g. Ubuntu 24.04+), uv refuses to modify it unless
+# UV_BREAK_SYSTEM_PACKAGES is set, which would otherwise crash the cluster
+# startup even when the required Ray version is already present in the image.
+# Setting it lets the `--system` fallback succeed (Ray stays at the image
+# version when already installed).
+uv pip install ${RAY_INSTALL_SPEC} || \
+    UV_BREAK_SYSTEM_PACKAGES=true uv pip install --system ${RAY_INSTALL_SPEC}
 
 # Verify Ray is working
 if ! run_ray --version > /dev/null; then

--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -182,6 +182,86 @@ def test_ray_basic(generic_cloud: str) -> None:
         smoke_tests_utils.run_one_test(test)
 
 
+# ---------- Test ray helper on externally-managed (PEP 668) Python ----------
+# Regression test for the Ray helper (~/sky_templates/ray/start_cluster)
+# crashing on bring-your-own images that use an externally-managed system
+# Python (PEP 668, e.g. Ubuntu 24.04+) with no virtualenv. There, the first
+# `uv pip install` fails (no venv) and the `--system` fallback used to fail
+# too because uv refuses to modify an externally-managed Python -- crashing
+# cluster startup even when the correct Ray was already installed. The fix
+# sets UV_BREAK_SYSTEM_PACKAGES on the `--system` fallback.
+#
+# We reproduce the failure deterministically (without needing a special
+# image) by shimming `uv` so that a non-system install fails and a `--system`
+# install only succeeds when UV_BREAK_SYSTEM_PACKAGES=true. This test FAILS
+# before the fix (the `--system` fallback exits non-zero, `set -e` aborts
+# start_cluster, the job ends as FAILED) and PASSES after it.
+@pytest.mark.no_hyperbolic  # Custom run command not relevant for this provider
+def test_ray_externally_managed_python(generic_cloud: str) -> None:
+    name = smoke_tests_utils.get_cluster_name()
+
+    yaml_content = """\
+resources:
+  cpus: 2+
+
+num_nodes: 1
+
+run: |
+  set -e
+  # Shim `uv` to emulate a BYO image with an externally-managed (PEP 668)
+  # system Python and no virtualenv:
+  #   - a non-system `uv pip install` fails (no virtualenv), and
+  #   - a `--system` install only succeeds when UV_BREAK_SYSTEM_PACKAGES=true.
+  FAKE_BIN=$(mktemp -d)
+  cat > "$FAKE_BIN/uv" <<'FAKE_UV_EOF'
+  #!/bin/bash
+  arg_str="$*"
+  if [[ "$arg_str" == "pip install"* ]]; then
+    if [[ "$arg_str" == *--system* ]]; then
+      if [[ "$UV_BREAK_SYSTEM_PACKAGES" == "true" ]]; then
+        echo "FAKE_UV_SYSTEM_INSTALL_OK"
+        exit 0
+      fi
+      echo "error: externally-managed-environment (PEP 668)" >&2
+      exit 2
+    fi
+    echo "error: no virtual environment found" >&2
+    exit 1
+  fi
+  exit 0
+  FAKE_UV_EOF
+  chmod +x "$FAKE_BIN/uv"
+  export PATH="$FAKE_BIN:$PATH"
+  echo "Using uv at: $(which uv)"
+  ~/sky_templates/ray/start_cluster
+  ~/sky_templates/ray/stop_cluster
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml',
+                                     delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        yaml_file_path = f.name
+
+    test = smoke_tests_utils.Test(
+        'ray_externally_managed_python',
+        [
+            f'sky launch -y -c {name} --infra {generic_cloud} {yaml_file_path}',
+            f'sky logs {name} 1 --status',
+            # FAKE_UV_SYSTEM_INSTALL_OK only appears when the `--system`
+            # fallback runs AND succeeds, which only happens once the helper
+            # sets UV_BREAK_SYSTEM_PACKAGES (i.e. after the fix).
+            f'outputs=$(sky logs {name} 1); echo "$outputs" && '
+            f'echo "$outputs" | grep "FAKE_UV_SYSTEM_INSTALL_OK" && '
+            f'echo "$outputs" | grep "Head node started successfully" && '
+            f'echo "$outputs" | grep "SUCCEEDED"',
+        ],
+        f'sky down -y {name}; rm {yaml_file_path}',
+        timeout=10 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Test NeMo RL ----------
 @pytest.mark.no_scp  # SCP does not support num_nodes > 1 yet
 @pytest.mark.no_hyperbolic  # Hyperbolic not support num_nodes > 1 yet

--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -184,55 +184,42 @@ def test_ray_basic(generic_cloud: str) -> None:
 
 # ---------- Test ray helper on externally-managed (PEP 668) Python ----------
 # Regression test for the Ray helper (~/sky_templates/ray/start_cluster)
-# crashing on bring-your-own images that use an externally-managed system
-# Python (PEP 668, e.g. Ubuntu 24.04+) with no virtualenv. There, the first
-# `uv pip install` fails (no venv) and the `--system` fallback used to fail
-# too because uv refuses to modify an externally-managed Python -- crashing
-# cluster startup even when the correct Ray was already installed. The fix
-# sets UV_BREAK_SYSTEM_PACKAGES on the `--system` fallback.
+# crashing on bring-your-own images whose system Python is externally managed
+# (PEP 668). We use a real public RL training image (slimerl/slime) which has
+# exactly the properties that trigger the original failure:
+#   - based on Ubuntu 24.04, so the system Python is externally managed
+#     (PEP 668) and uv refuses to modify it by default;
+#   - Ray is already installed into that system Python (no virtualenv).
+# In this environment the helper's first `uv pip install` fails (no venv) and
+# the `--system` fallback used to fail too, crashing cluster startup even
+# though the required Ray was already present. The fix sets
+# UV_BREAK_SYSTEM_PACKAGES on the `--system` fallback so it succeeds.
 #
-# We reproduce the failure deterministically (without needing a special
-# image) by shimming `uv` so that a non-system install fails and a `--system`
-# install only succeeds when UV_BREAK_SYSTEM_PACKAGES=true. This test FAILS
-# before the fix (the `--system` fallback exits non-zero, `set -e` aborts
-# start_cluster, the job ends as FAILED) and PASSES after it.
-@pytest.mark.no_hyperbolic  # Custom run command not relevant for this provider
+# This test FAILS before the fix (the `--system` fallback exits non-zero,
+# `set -e` aborts start_cluster, the job ends as FAILED) and PASSES after it.
+#
+# Note: this is a large CUDA image, hence resource_heavy and a generous
+# timeout. No GPU is requested -- the bug is purely in the install step.
+@pytest.mark.no_vast  # Custom docker image_id not supported
+@pytest.mark.no_fluidstack  # Custom docker image_id not supported
+@pytest.mark.no_hyperbolic  # Custom docker image_id not supported
+@pytest.mark.no_seeweb  # Custom docker image_id not supported
+@pytest.mark.resource_heavy
 def test_ray_externally_managed_python(generic_cloud: str) -> None:
     name = smoke_tests_utils.get_cluster_name()
 
     yaml_content = """\
 resources:
-  cpus: 2+
+  cpus: 4+
+  # A real RL training image based on Ubuntu 24.04 (externally-managed,
+  # PEP 668 system Python) with Ray preinstalled and no virtualenv -- the
+  # conditions that trigger the original failure.
+  image_id: docker:slimerl/slime:latest
 
 num_nodes: 1
 
 run: |
   set -e
-  # Shim `uv` to emulate a BYO image with an externally-managed (PEP 668)
-  # system Python and no virtualenv:
-  #   - a non-system `uv pip install` fails (no virtualenv), and
-  #   - a `--system` install only succeeds when UV_BREAK_SYSTEM_PACKAGES=true.
-  FAKE_BIN=$(mktemp -d)
-  cat > "$FAKE_BIN/uv" <<'FAKE_UV_EOF'
-  #!/bin/bash
-  arg_str="$*"
-  if [[ "$arg_str" == "pip install"* ]]; then
-    if [[ "$arg_str" == *--system* ]]; then
-      if [[ "$UV_BREAK_SYSTEM_PACKAGES" == "true" ]]; then
-        echo "FAKE_UV_SYSTEM_INSTALL_OK"
-        exit 0
-      fi
-      echo "error: externally-managed-environment (PEP 668)" >&2
-      exit 2
-    fi
-    echo "error: no virtual environment found" >&2
-    exit 1
-  fi
-  exit 0
-  FAKE_UV_EOF
-  chmod +x "$FAKE_BIN/uv"
-  export PATH="$FAKE_BIN:$PATH"
-  echo "Using uv at: $(which uv)"
   ~/sky_templates/ray/start_cluster
   ~/sky_templates/ray/stop_cluster
 """
@@ -248,16 +235,15 @@ run: |
         [
             f'sky launch -y -c {name} --infra {generic_cloud} {yaml_file_path}',
             f'sky logs {name} 1 --status',
-            # FAKE_UV_SYSTEM_INSTALL_OK only appears when the `--system`
-            # fallback runs AND succeeds, which only happens once the helper
-            # sets UV_BREAK_SYSTEM_PACKAGES (i.e. after the fix).
+            # Before the fix the `--system` fallback fails on this image's
+            # externally-managed Python and start_cluster aborts; these
+            # markers only appear once the helper succeeds (after the fix).
             f'outputs=$(sky logs {name} 1); echo "$outputs" && '
-            f'echo "$outputs" | grep "FAKE_UV_SYSTEM_INSTALL_OK" && '
             f'echo "$outputs" | grep "Head node started successfully" && '
             f'echo "$outputs" | grep "SUCCEEDED"',
         ],
         f'sky down -y {name}; rm {yaml_file_path}',
-        timeout=10 * 60,
+        timeout=40 * 60,
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -213,8 +213,9 @@ resources:
   cpus: 4+
   # A real RL training image based on Ubuntu 24.04 (externally-managed,
   # PEP 668 system Python) with Ray preinstalled and no virtualenv -- the
-  # conditions that trigger the original failure.
-  image_id: docker:slimerl/slime:latest
+  # conditions that trigger the original failure. Pinned to a stable release
+  # tag (not `latest`) for reproducibility.
+  image_id: docker:slimerl/slime:v0.3.0
 
 num_nodes: 1
 


### PR DESCRIPTION
## Description

Fixes a regression where the Ray helper (`~/sky_templates/ray/start_cluster`) crashes on bring-your-own images with externally-managed system Python (PEP 668), such as Ubuntu 24.04+.

### Root Cause

When Ray is already installed in the system Python (no virtualenv):
1. The first `uv pip install` fails because there's no virtualenv
2. The fallback `uv pip install --system` also fails on PEP 668 systems because `uv` refuses to modify externally-managed Python by default
3. This causes `set -e` to abort cluster startup, even though the required Ray version is already present

### Solution

Set `UV_BREAK_SYSTEM_PACKAGES=true` on the `--system` fallback command. This allows `uv` to modify the externally-managed system Python, letting the fallback succeed. When Ray is already installed, it remains at the image version.

### Changes

- **sky_templates/ray/start_cluster**: Modified the Ray installation fallback to set `UV_BREAK_SYSTEM_PACKAGES=true` when using `--system` flag
- **tests/smoke_tests/test_examples.py**: Added regression test `test_ray_externally_managed_python` that validates the fix using a real public RL training image (`slimerl/slime:v0.3.0`) which has the exact properties that trigger the original failure

## Tested

- [x] Added regression test: `test_ray_externally_managed_python` validates cluster startup succeeds on externally-managed Python environments
- [x] Test uses real public image with Ubuntu 24.04 (PEP 668) and pre-installed Ray
- [x] Test verifies both `start_cluster` and `stop_cluster` succeed and produce expected output markers

https://claude.ai/code/session_01N1SvkP9mWd1mpNCcAdBvwC