### PR TITLE
[CI] Fail pipeline generation when test collection errors

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -236,6 +236,18 @@ def _extract_marked_tests(
     # Args are already in the format pytest expects (cloud names like --lambda)
     cmd = f'pytest {file_path} --collect-only {args}'
     output = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    # pytest exit codes: 0 = tests collected, 5 = no tests collected (expected
+    # here for files that match no tests under the given filter). Any other code
+    # is a real collection failure (e.g. 4 = usage error from an unrecognized
+    # CLI flag, 2/3 = collection/internal error). Without this check a failed
+    # collection silently yields zero tests, so the generated pipeline drops the
+    # file's tests and the build "passes" having run nothing.
+    if output.returncode not in (0, 5):
+        raise RuntimeError(
+            f'Test collection failed (exit {output.returncode}) for command:\n'
+            f'  {cmd}\n'
+            f'--- stdout ---\n{output.stdout}\n'
+            f'--- stderr ---\n{output.stderr}')
     matches = re.findall('Collected .+?\.py::(.+?) with marks: \[(.*?)\]',
                          output.stdout)
 


### PR DESCRIPTION
## What

`generate_pipeline.py` builds the dynamic smoke-test pipeline by running
`pytest --collect-only` for each test file and scraping its stdout for
collected tests. It does not check the subprocess exit code, so a failed
collection silently produces zero tests for that file.

Failure modes this hides:
- exit 4 (usage error, e.g. an unrecognized CLI flag passed through `ARGS`)
- exit 2/3 (collection / internal error, e.g. an import error in a test module)

In each case the scraped output has no `Collected ... with marks` lines, so the
file is dropped from the generated pipeline. If every file fails the same way the
generated pipeline is empty and the upload step still succeeds — the build passes
without running any tests.

## Change

After `pytest --collect-only`, fail loudly when the return code is anything other
than `0` (tests collected) or `5` (no tests collected — expected for files a `-k`
filter excludes). The raised error includes the failing command and its captured
stdout/stderr so the cause is visible in the build log.

## Test plan

- Ran `generate_pipeline.py` with an unrecognized flag in `ARGS`: before, it emitted
  an empty pipeline and exited 0; after, it exits non-zero with
  `RuntimeError: Test collection failed (exit 4) ...` and writes no pipeline file.
- Verified a normal run, and files returning exit 5 under a `-k` filter, still
  generate the pipeline unchanged.