### PR TITLE
[Test] chaos_proxy: rewrite Host header so it works behind a reverse proxy

### DIFF
--- a/tests/chaos/chaos_proxy.py
+++ b/tests/chaos/chaos_proxy.py
@@ -1,12 +1,144 @@
 """TCP proxy that brings chaos."""
 import argparse
 import asyncio
+from typing import Optional
 from urllib import parse
 
 from sky.server import common
 
 # Global connection counter
 connection_counter = 0
+
+
+def _host_header_value(target_host: str, target_port: Optional[int]) -> bytes:
+    if target_port in (None, 80):
+        return target_host.encode()
+    return f'{target_host}:{target_port}'.encode()
+
+
+def _rewrite_host_header(header_block: bytes, host_value: bytes) -> bytes:
+    """Point the request's Host header at the upstream.
+
+    The client connects to the proxy's loopback address, so it sends
+    `Host: 127.0.0.1:<port>`. A Host-routing reverse proxy in front of the
+    upstream (e.g. an nginx virtual host) would not recognize that authority
+    and serve a 404, so rewrite it to the upstream's host before forwarding.
+    """
+    lines = header_block.split(b'\r\n')
+    for i, line in enumerate(lines):
+        if line.lower().startswith(b'host:'):
+            lines[i] = b'Host: ' + host_value
+            break
+    return b'\r\n'.join(lines)
+
+
+def _content_length(header_block: bytes) -> Optional[int]:
+    for line in header_block.split(b'\r\n'):
+        if line.lower().startswith(b'content-length:'):
+            try:
+                return int(line.split(b':', 1)[1].strip())
+            except ValueError:
+                return None
+    return None
+
+
+def _is_chunked(header_block: bytes) -> bool:
+    for line in header_block.split(b'\r\n'):
+        if (line.lower().startswith(b'transfer-encoding:') and
+                b'chunked' in line.lower()):
+            return True
+    return False
+
+
+async def _read_until(reader, buffer: bytes, delimiter: bytes):
+    """Read until `delimiter` appears in the buffer.
+
+    Returns (consumed, remaining) where `consumed` includes the delimiter, or
+    (None, buffer) on EOF before the delimiter is seen.
+    """
+    while delimiter not in buffer:
+        data = await reader.read(4096)
+        if not data:
+            return None, buffer
+        buffer += data
+    idx = buffer.find(delimiter) + len(delimiter)
+    return buffer[:idx], buffer[idx:]
+
+
+async def _forward_exact(reader, writer, buffer: bytes, n: int) -> bytes:
+    """Forward exactly `n` bytes, draining `buffer` first. Returns leftover."""
+    remaining = n
+    if buffer:
+        chunk = buffer[:remaining]
+        writer.write(chunk)
+        await writer.drain()
+        buffer = buffer[len(chunk):]
+        remaining -= len(chunk)
+    while remaining > 0:
+        data = await reader.read(min(4096, remaining))
+        if not data:
+            break
+        writer.write(data)
+        await writer.drain()
+        remaining -= len(data)
+    return buffer
+
+
+async def _forward_raw(reader, writer, buffer: bytes = b''):
+    """Forward bytes verbatim until EOF."""
+    if buffer:
+        writer.write(buffer)
+        await writer.drain()
+    while True:
+        data = await reader.read(4096)
+        if not data:
+            break
+        writer.write(data)
+        await writer.drain()
+
+
+async def forward_with_host_rewrite(reader, writer, host_value: bytes):
+    """Forward an HTTP/1.1 client->server stream, rewriting Host per request.
+
+    Bodies are framed via Content-Length. A chunked body is not reframed; the
+    rest of the connection is forwarded verbatim after its (already rewritten)
+    request line. Anything that isn't an HTTP/1.x request (e.g. an HTTP/2
+    connection preface) is also forwarded verbatim, since it can't be reframed.
+    """
+    try:
+        buffer = b''
+        while True:
+            header_block, buffer = await _read_until(reader, buffer,
+                                                     b'\r\n\r\n')
+            if header_block is None:
+                if buffer:
+                    writer.write(buffer)
+                    await writer.drain()
+                break
+            request_line = header_block.split(b'\r\n', 1)[0]
+            if not (request_line.endswith(b' HTTP/1.1') or
+                    request_line.endswith(b' HTTP/1.0')):
+                # Not HTTP/1.x; the CRLF framing this parser relies on does not
+                # apply, so forward the rest of the connection verbatim.
+                writer.write(header_block)
+                await writer.drain()
+                await _forward_raw(reader, writer, buffer)
+                break
+            writer.write(_rewrite_host_header(header_block, host_value))
+            await writer.drain()
+            if _is_chunked(header_block):
+                await _forward_raw(reader, writer, buffer)
+                break
+            content_length = _content_length(header_block)
+            if content_length:
+                buffer = await _forward_exact(reader, writer, buffer,
+                                              content_length)
+    except asyncio.CancelledError:
+        pass
+    except Exception as e:
+        print(f'client->server error: {e}')
+    finally:
+        writer.close()
 
 
 async def handle_client(local_reader, local_writer, target_host, target_port,
@@ -40,8 +172,9 @@ async def handle_client(local_reader, local_writer, target_host, target_port,
         finally:
             writer.close()
 
+    host_value = _host_header_value(target_host, target_port)
     task1 = asyncio.create_task(
-        forward(local_reader, remote_writer, 'client->server'))
+        forward_with_host_rewrite(local_reader, remote_writer, host_value))
     task2 = asyncio.create_task(
         forward(remote_reader, local_writer, 'server->client'))
 


### PR DESCRIPTION
## Summary

`tests/chaos/chaos_proxy.py` raw-forwards TCP bytes between the client and the upstream API server. Because the client connects to the proxy on `127.0.0.1:<port>`, every forwarded HTTP request keeps `Host: 127.0.0.1:<port>`.

When the API server sits behind a Host-routing reverse proxy (e.g. an nginx virtual host), that authority isn't recognized and the request gets a `404`, which `sky` surfaces as `ApiServerConnectionError`. A `404` is not retried, so `test_cli_auto_retry` fails immediately on such a server even though the server is healthy.

## Changes

- Make the client→server direction HTTP/1.1-aware: parse each request's header block and rewrite the `Host` header to the upstream host before forwarding (port omitted for `:80`, matching what a direct client sends).
- Frame request bodies via `Content-Length`; a chunked body is forwarded verbatim after its (already rewritten) request line. Keep-alive and the existing chaos disconnect/cancellation behavior are preserved.
- The server→client direction stays a raw byte forward, so log streaming is unchanged.

## Test plan

- `curl /api/health` through the proxy against a server behind an nginx reverse proxy: `404` → `200` after the change.
- `pytest tests/smoke_tests/test_cli.py::test_cli_auto_retry --kubernetes`: fails on the first `sky launch` before the change; passes after, completing the streaming launch, a managed job, and `sky jobs logs` streaming across multiple proxy disconnects.