### PR TITLE
[Test] Make launch-output validation tolerant of interleaved stream warnings

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -871,8 +871,11 @@ VALIDATE_LAUNCH_OUTPUT = (
     # ├── To submit a job:            sky exec test yaml_file
     # ├── To stop the cluster:        sky stop test
     # └── To teardown the cluster:    sky down test
-    # Reset s to remove any line with FutureWarning
-    's=$(echo "$s" | grep -v "FutureWarning") && '
+    # Reset s to drop transient warning lines that can interleave with the
+    # structured launch output and break the one-line-adjacency greps below:
+    # Python FutureWarning lines, and any server-emitted notice banner that is
+    # streamed back to the client prefixed with the warning glyph (⚠).
+    's=$(echo "$s" | grep -v "FutureWarning" | grep -v "⚠") && '
     'echo "$s" && echo "==Validating launching==" && '
     'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
     'echo "$s" && echo "==Validating setup output==" && '


### PR DESCRIPTION
## Summary

`VALIDATE_LAUNCH_OUTPUT` (in `tests/smoke_tests/smoke_tests_utils.py`) validates `sky launch` progress output with:

```sh
echo "$s" | grep -A 1 "Job submitted, ID:" | grep "Waiting for task resources on "
```

This assumes `Waiting for task resources on` is on the line *immediately* after `Job submitted, ID:`. A warning/notice banner streamed back on the log stream (prefixed with the `⚠` glyph) can land between those two lines, shifting `Waiting for task resources on` out of the one-line `-A 1` context window and failing the check (the same fragility applies to the other `-A` adjacency greps in this validator).

## Change

Drop `⚠`-prefixed warning lines from the captured output alongside the existing `FutureWarning` filter, so the adjacency greps stay robust. The filter is a no-op when no such banner is present, so normal runs are unaffected.

## Test plan

Simulated the validator against launch output with and without an interleaved `⚠` warning line:
- Current validator: fails (exit 1) when the banner is present.
- With this change: passes when the banner is present, and still passes on normal output with no banner.