### PR TITLE
[Slurm] Add slurm.use_whole_node with TaskPlugin auto-detect

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -671,6 +671,29 @@ class SlurmClient:
             return match.group(1)
         return None
 
+    def get_task_plugin(self) -> Optional[str]:
+        """Get the TaskPlugin from Slurm configuration.
+
+        Returns:
+            The raw TaskPlugin value (e.g., 'task/none',
+            'task/cgroup,task/affinity', or '(null)' which Slurm reports
+            when TaskPlugin=task/none), or None if it cannot be
+            determined.
+
+        Note: ``scontrol show config`` reports ``task/none`` as ``(null)``
+        in newer Slurm versions. Callers should treat both as equivalent
+        when deciding whether per-task CPU subdivision is enforced.
+        """
+        cmd = 'scontrol show config | grep -i "^TaskPlugin"'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            logger.warning(f'Failed to get TaskPlugin: {stderr}')
+            return None
+        match = re.search(r'TaskPlugin\s*=\s*(\S+)', stdout)
+        if match:
+            return match.group(1)
+        return None
+
     def get_select_type_parameters(self) -> Optional[str]:
         """Get SelectTypeParameters from Slurm configuration.
 

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -64,6 +64,61 @@ def _merge_slurm_options(
     return merged
 
 
+def _resolve_use_whole_node(
+    cluster: Optional[str],
+    partition: Optional[str],
+    cluster_config_overrides: Optional[Dict[str, Any]],
+) -> bool:
+    """Resolve ``slurm.use_whole_node`` across four config levels + auto-detect.
+
+    Precedence (highest first):
+      1. task-YAML ``cluster_config_overrides`` (``config.slurm.use_whole_node``)
+      2. partition-level
+      3. cluster-level
+      4. global
+      5. auto-detect from the cluster's ``TaskPlugin`` — if effectively
+         ``task/none`` (no per-task CPU subdivision enforcement), default
+         to ``True``; otherwise ``False``.
+
+    Returns ``False`` by default (the conservative choice for
+    cgroup-managed multi-tenant clusters).
+    """
+    # Highest precedence first: task-YAML cluster_config_overrides.
+    if cluster_config_overrides and cluster is not None:
+        task_value = config_utils.get_cloud_config_value_from_dict(
+            dict_config=cluster_config_overrides,
+            cloud='slurm',
+            region=cluster,
+            keys=('use_whole_node',))
+        if task_value is not None:
+            return bool(task_value)
+    for keys in [
+        ('slurm', 'cluster_configs', cluster, 'partition_configs', partition,
+         'use_whole_node') if cluster and partition else None,
+        ('slurm', 'cluster_configs', cluster,
+         'use_whole_node') if cluster else None,
+        ('slurm', 'use_whole_node'),
+    ]:
+        if keys is None:
+            continue
+        value = skypilot_config.get_nested(keys, default_value=None)
+        if value is not None:
+            return bool(value)
+    # Auto-detect: default to True only if TaskPlugin is effectively
+    # task/none (no per-task subdivision enforcement). Failure to detect
+    # is treated as "subdivide" (safer default for shared clusters).
+    if cluster is not None:
+        try:
+            task_plugin = slurm_utils.get_task_plugin(cluster)
+            if slurm_utils.is_task_plugin_effectively_none(task_plugin):
+                return True
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Could not auto-detect TaskPlugin for {cluster}: '
+                         f'{common_utils.format_exception(e)}; defaulting '
+                         'use_whole_node=False')
+    return False
+
+
 @registry.CLOUD_REGISTRY.register
 class Slurm(clouds.Cloud):
     """Slurm."""
@@ -603,6 +658,38 @@ class Slurm(clouds.Cloud):
             resources.cluster_config_overrides)
         srun_options = _merge_slurm_options('srun_options', cluster, partition,
                                             resources.cluster_config_overrides)
+        # Resolve use_whole_node (explicit config > auto-detect from
+        # TaskPlugin > False). When True, the provision sbatch omits
+        # --cpus-per-task and adds --exclusive (required for the HyperPod
+        # auto-resume SPANK plugin and similar single-tenant patterns).
+        # Also rewrite displayed cpus/memory to match the chosen node so
+        # the optimizer reflects what the task actually receives.
+        use_whole_node = _resolve_use_whole_node(
+            cluster, partition, resources.cluster_config_overrides)
+        if use_whole_node:
+            # Rewrite cpus/memory to match the smallest cluster node that
+            # satisfies the request, since with --exclusive the task gets
+            # the full node regardless of --cpus-per-task. This keeps the
+            # optimizer's display honest about what the user actually
+            # gets. Falls through to the original (requested) values if
+            # we can't enumerate nodes.
+            try:
+                nodes = slurm_utils.get_slurm_nodes_info(cluster)
+                matching = [
+                    n for n in nodes
+                    if (partition is None or
+                        partition in n.partition.rstrip('*').split(',')) and
+                    n.cpus >= cpus and n.memory_gb >= mem
+                ]
+                if matching:
+                    smallest = min(matching,
+                                   key=lambda n: (n.cpus, n.memory_gb))
+                    cpus = float(smallest.cpus)
+                    mem = float(smallest.memory_gb)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'use_whole_node: could not enumerate nodes on '
+                             f'{cluster!r} to rewrite displayed resources: '
+                             f'{common_utils.format_exception(e)}')
 
         deploy_vars = {
             'instance_type': resources.instance_type,
@@ -632,6 +719,7 @@ class Slurm(clouds.Cloud):
             'image_id': image_id,
             'sbatch_options': sbatch_options,
             'srun_options': srun_options,
+            'use_whole_node': use_whole_node,
         }
 
         return deploy_vars

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -594,6 +594,18 @@ def _create_virtual_instance(
                                                        partition_info,
                                                        partition)
 
+    # Resolved by clouds/slurm.py:_resolve_use_whole_node. When True,
+    # the provision sbatch omits --cpus-per-task and adds --exclusive,
+    # which is the combination required by the HyperPod auto-resume
+    # SPANK plugin and is the natural default on TaskPlugin=task/none
+    # clusters where per-task CPU subdivision isn't enforced anyway.
+    use_whole_node = bool(resources.get('use_whole_node', False))
+    if use_whole_node:
+        cpus_per_task_directive = '#SBATCH --exclusive'
+    else:
+        cpus_per_task_directive = (
+            f'#SBATCH --cpus-per-task={int(resources["cpus"])}')
+
     # Build the sbatch script
     gpu_directive = ''
     if accelerator_count > 0:
@@ -705,9 +717,11 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 #SBATCH --error={_sbatch_log_path(sbatch_log_base_dir, '%j')}
 #SBATCH --nodes={num_nodes}
 #SBATCH --wait-all-nodes=1
-# Let the job be terminated rather than requeued implicitly.
+# Let the job be terminated rather than requeued implicitly. Users
+# can opt back in via slurm.sbatch_options.requeue=true (the directive
+# is appended after --no-requeue and Slurm honors the last-set value).
 #SBATCH --no-requeue
-#SBATCH --cpus-per-task={int(resources["cpus"])}
+{cpus_per_task_directive}
 {mem_directive}{gpu_directive}{extra_sbatch_directives}
 
 # Cleanup function to remove cluster dirs on job termination.

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -38,6 +38,8 @@ _GRES_GPU_PATTERN = re.compile(r'\bgpu:(?:(?P<type>[^:(]+):)?(?P<count>\d+)',
 _SLURM_NODES_INFO_CACHE_TTL = 30 * 60
 # Proctrack type is highly unlikely to change.
 _SLURM_PROCTRACK_TYPE_CACHE_TTL = 24 * 60 * 60
+
+_SLURM_TASK_PLUGIN_CACHE_TTL = 24 * 60 * 60
 # Pyxis plugin availability is unlikely to change frequently.
 _SLURM_PYXIS_CHECK_CACHE_TTL = 24 * 60 * 60
 # FUSE availability is unlikely to change frequently.
@@ -175,6 +177,61 @@ def get_proctrack_type(cluster: str) -> Optional[str]:
                          f'{common_utils.format_exception(e)}')
 
     return proctrack_type
+
+
+def get_task_plugin(cluster: str) -> Optional[str]:
+    """Get the TaskPlugin setting from Slurm configuration.
+
+    Returns the raw value (e.g. ``task/none`` or
+    ``task/cgroup,task/affinity``) or ``None`` if it cannot be
+    determined. Cached per cluster — TaskPlugin only changes via
+    slurm.conf edits and slurmctld restart, so a long TTL is fine.
+    """
+    cache_key = f'slurm:task_plugin:{cluster}'
+    cached = kv_cache.get_cache_entry(cache_key)
+    if cached is not None:
+        logger.debug(f'Slurm TaskPlugin found in cache ({cache_key})')
+        return cached
+
+    ssh_config = get_slurm_ssh_config()
+    ssh_config_dict = ssh_config.lookup(cluster)
+    client = slurm.SlurmClient(
+        ssh_config_dict['hostname'],
+        int(ssh_config_dict.get('port', 22)),
+        ssh_config_dict['user'],
+        get_identity_file(ssh_config_dict),
+        ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
+        ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
+        identities_only=get_identities_only(ssh_config_dict),
+    )
+    task_plugin = client.get_task_plugin()
+
+    if task_plugin is not None:
+        try:
+            kv_cache.add_or_update_cache_entry(
+                cache_key, task_plugin,
+                time.time() + _SLURM_TASK_PLUGIN_CACHE_TTL)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to cache slurm task plugin for {cluster}: '
+                         f'{common_utils.format_exception(e)}')
+
+    return task_plugin
+
+
+def is_task_plugin_effectively_none(task_plugin: Optional[str]) -> bool:
+    """Return True iff the TaskPlugin value implies no per-task subdivision.
+
+    Slurm reports ``task/none`` as ``(null)`` in some versions of
+    ``scontrol show config``; both mean the same thing. Treat an
+    unknown / unreachable value as ``False`` (preserve subdivision
+    semantics by default — safer for shared clusters).
+    """
+    if task_plugin is None:
+        return False
+    value = task_plugin.strip().lower()
+    if value in ('(null)', 'none', 'task/none', ''):
+        return True
+    return False
 
 
 def _check_cluster_feature(

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -563,6 +563,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('vast', 'create_instance_kwargs'),
     ('slurm', 'sbatch_options'),
     ('slurm', 'srun_options'),
+    ('slurm', 'use_whole_node'),
     ('slurm', 'cpu_partition'),
     ('active_workspace',),
 ]

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -51,6 +51,9 @@ available_node_types:
 {% if sbatch_options is defined and sbatch_options %}
       sbatch_options: {{sbatch_options | tojson}}
 {% endif %}
+{% if use_whole_node is defined and use_whole_node %}
+      use_whole_node: true
+{% endif %}
 
       # TODO: more configs that is required by the provisioner to create new
       # instances on the FluffyCloud:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2073,6 +2073,9 @@ def get_config_schema():
                 'pricing': _PRICING_SCHEMA,
                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
                 'srun_options': _SRUN_OPTIONS_SCHEMA,
+                'use_whole_node': {
+                    'type': 'boolean',
+                },
                 'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                 'cpu_partition': {
                     'type': 'string',
@@ -2095,6 +2098,9 @@ def get_config_schema():
                             'pricing': _PRICING_SCHEMA,
                             'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
                             'srun_options': _SRUN_OPTIONS_SCHEMA,
+                            'use_whole_node': {
+                                'type': 'boolean',
+                            },
                             'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                             'cpu_partition': {
                                 'type': 'string',
@@ -2111,6 +2117,9 @@ def get_config_schema():
                                         'pricing': _PRICING_SCHEMA,
                                         'sbatch_options': _SBATCH_OPTIONS_SCHEMA,  # pylint: disable=line-too-long
                                         'srun_options': _SRUN_OPTIONS_SCHEMA,
+                                        'use_whole_node': {
+                                            'type': 'boolean',
+                                        },
                                     },
                                 },
                             },

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from typing import Optional
 from unittest.mock import patch
 import unittest.mock as mock
 
@@ -961,6 +962,193 @@ class TestSrunOptionsPrecedence:
         assert result == {}
 
 
+class TestUseWholeNodeResolution:
+    """Resolution of ``slurm.use_whole_node`` across the four config levels
+    plus auto-detect from TaskPlugin.
+    """
+
+    FAKE_SSH_CONFIG = {
+        'hostname': '10.0.0.1',
+        'port': '22',
+        'user': 'slurm',
+        'identityfile': ['/home/user/.ssh/id_rsa'],
+    }
+
+    def _resolve(self,
+                 tmp_path,
+                 skypilot_config_dict,
+                 cluster_config_overrides=None,
+                 task_plugin_value: Optional[str] = None):
+        """Drive ``make_deploy_resources_variables`` and read ``use_whole_node``
+        from the returned ``deploy_vars``. Optionally stubs the TaskPlugin
+        lookup to exercise the auto-detect path.
+        """
+        from sky import skypilot_config
+        from sky.utils import yaml_utils
+
+        config_path = tmp_path / 'config.yaml'
+        config_path.write_text(yaml_utils.dump_yaml_str(skypilot_config_dict))
+
+        saved_global = skypilot_config._GLOBAL_CONFIG_PATH
+        saved_project = skypilot_config._PROJECT_CONFIG_PATH
+        saved_ctx = skypilot_config._global_config_context
+        try:
+            skypilot_config._GLOBAL_CONFIG_PATH = str(config_path)
+            skypilot_config._PROJECT_CONFIG_PATH = str(tmp_path /
+                                                       'nonexistent.yaml')
+            skypilot_config._global_config_context = (
+                skypilot_config.ConfigContext())
+            skypilot_config.reload_config()
+
+            cloud = slurm_cloud.Slurm()
+            mock_resources = mock.MagicMock(unsafe=True)
+            mock_resources.zone = 'gpu'
+            mock_resources.instance_type = '4CPU--16GB'
+            mock_resources.assert_launchable.return_value = mock_resources
+            mock_resources.extract_docker_image.return_value = None
+            mock_resources.cluster_config_overrides = (cluster_config_overrides
+                                                       or {})
+
+            region = mock.MagicMock()
+            region.name = 'mycluster'
+            zone_mock = mock.MagicMock()
+            zone_mock.name = 'gpu'
+
+            mock_ssh_config = mock.MagicMock()
+            mock_ssh_config.lookup.return_value = self.FAKE_SSH_CONFIG
+
+            with patch(
+                    'sky.clouds.slurm.slurm_utils.get_slurm_ssh_config',
+                    return_value=mock_ssh_config), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.get_partitions',
+                    return_value=['gpu', 'cpu']), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.resolve_gres_gpu_type',
+                    side_effect=lambda cluster, t, count=1, partition=None: t), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.get_task_plugin',
+                    return_value=task_plugin_value), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.get_slurm_nodes_info',
+                    return_value=[]):
+                deploy_vars = cloud.make_deploy_resources_variables(
+                    resources=mock_resources,
+                    cluster_name=mock.MagicMock(),
+                    region=region,
+                    zones=[zone_mock],
+                    num_nodes=1,
+                )
+            return deploy_vars['use_whole_node']
+        finally:
+            skypilot_config._GLOBAL_CONFIG_PATH = saved_global
+            skypilot_config._PROJECT_CONFIG_PATH = saved_project
+            skypilot_config._global_config_context = saved_ctx
+
+    def test_default_is_false_when_no_config_and_taskplugin_subdivides(
+            self, tmp_path):
+        # Auto-detect: cgroup → subdivision → use_whole_node defaults to False.
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={},
+                               task_plugin_value='task/cgroup,task/affinity')
+        assert result is False
+
+    def test_default_true_when_taskplugin_is_none(self, tmp_path):
+        # Auto-detect: task/none → no subdivision → defaults to True.
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={},
+                               task_plugin_value='task/none')
+        assert result is True
+
+    def test_default_true_when_taskplugin_reports_null(self, tmp_path):
+        # scontrol reports 'task/none' as '(null)' on some Slurm versions.
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={},
+                               task_plugin_value='(null)')
+        assert result is True
+
+    def test_default_false_when_taskplugin_unknown(self, tmp_path):
+        # Unreachable cluster / detection fails → conservative default.
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={},
+                               task_plugin_value=None)
+        assert result is False
+
+    def test_global_true_overrides_autodetect_false(self, tmp_path):
+        # Explicit global=True wins over auto-detect=False.
+        result = self._resolve(
+            tmp_path,
+            skypilot_config_dict={'slurm': {
+                'use_whole_node': True
+            }},
+            task_plugin_value='task/cgroup,task/affinity')
+        assert result is True
+
+    def test_global_false_overrides_autodetect_true(self, tmp_path):
+        # Explicit global=False wins over auto-detect=True.
+        result = self._resolve(
+            tmp_path,
+            skypilot_config_dict={'slurm': {
+                'use_whole_node': False
+            }},
+            task_plugin_value='task/none')
+        assert result is False
+
+    def test_cluster_overrides_global(self, tmp_path):
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={
+                                   'slurm': {
+                                       'use_whole_node': False,
+                                       'cluster_configs': {
+                                           'mycluster': {
+                                               'use_whole_node': True,
+                                           },
+                                       },
+                                   },
+                               },
+                               task_plugin_value='task/cgroup,task/affinity')
+        assert result is True
+
+    def test_partition_overrides_cluster(self, tmp_path):
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={
+                                   'slurm': {
+                                       'cluster_configs': {
+                                           'mycluster': {
+                                               'use_whole_node': False,
+                                               'partition_configs': {
+                                                   'gpu': {
+                                                       'use_whole_node': True,
+                                                   },
+                                               },
+                                           },
+                                       },
+                                   },
+                               },
+                               task_plugin_value='task/cgroup,task/affinity')
+        assert result is True
+
+    def test_task_yaml_overrides_all(self, tmp_path):
+        result = self._resolve(tmp_path,
+                               skypilot_config_dict={
+                                   'slurm': {
+                                       'use_whole_node': False,
+                                       'cluster_configs': {
+                                           'mycluster': {
+                                               'use_whole_node': False,
+                                           },
+                                       },
+                                   },
+                               },
+                               cluster_config_overrides={
+                                   'slurm': {
+                                       'use_whole_node': True,
+                                   },
+                               },
+                               task_plugin_value='task/cgroup,task/affinity')
+        assert result is True
+
+
 class TestSlurmProvisionTimeout:
     """Test conditional provision timeout logic in make_deploy_resources_variables.
 
@@ -1311,6 +1499,56 @@ class TestCreateVirtualInstance:
         written_script = self._run_and_capture_script(
             'test-cluster-no-container', config)
         assert_sbatch_matches_snapshot('basic', written_script)
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    def test_use_whole_node_swaps_cpus_per_task_for_exclusive(
+            self, mock_ssh_runner, mock_slurm_client, mock_get_partition_info,
+            mock_get_proctrack_type, mock_wait_for_job_nodes):
+        """When use_whole_node is true, the provision script must drop
+        ``--cpus-per-task`` and emit ``--exclusive`` instead. This is the
+        directive combination required for the HyperPod auto-resume SPANK
+        plugin and for any cluster running ``TaskPlugin=task/none``."""
+        from sky.provision import common
+
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'gpu')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'testuser',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'gpu',
+                'provision_timeout': 300,
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': 4,
+                'memory': 16,
+                'use_whole_node': True,
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        written_script = self._run_and_capture_script('test-cluster-whole-node',
+                                                      config)
+        # The hardcoded line for cpus-per-task must be gone.
+        assert '#SBATCH --cpus-per-task=' not in written_script
+        # And replaced by --exclusive.
+        assert '#SBATCH --exclusive' in written_script
 
     @pytest.mark.parametrize('memory_gb,expected_mem_mb', [
         (0.5, 512),

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -4,7 +4,9 @@
 #SBATCH --error=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --nodes=1
 #SBATCH --wait-all-nodes=1
-# Let the job be terminated rather than requeued implicitly.
+# Let the job be terminated rather than requeued implicitly. Users
+# can opt back in via slurm.sbatch_options.requeue=true (the directive
+# is appended after --no-requeue and Slurm honors the last-set value).
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task=2
 #SBATCH --mem=8192M

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -4,7 +4,9 @@
 #SBATCH --error=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --nodes=1
 #SBATCH --wait-all-nodes=1
-# Let the job be terminated rather than requeued implicitly.
+# Let the job be terminated rather than requeued implicitly. Users
+# can opt back in via slurm.sbatch_options.requeue=true (the directive
+# is appended after --no-requeue and Slurm honors the last-set value).
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task=4
 #SBATCH --mem=16384M

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -20,6 +20,34 @@ class TestFormatSlurmDuration:
         assert result == expected
 
 
+class TestIsTaskPluginEffectivelyNone:
+    """Test is_task_plugin_effectively_none() classification."""
+
+    @pytest.mark.parametrize(
+        'task_plugin,expected',
+        [
+            # Effectively "no subdivision" — all map to True.
+            ('task/none', True),
+            ('TASK/NONE', True),  # case-insensitive
+            ('(null)', True),  # scontrol's representation on some versions
+            ('none', True),
+            ('', True),  # explicitly empty
+            # Anything that enforces per-task pinning — False.
+            ('task/cgroup', False),
+            ('task/affinity', False),
+            ('task/cgroup,task/affinity', False),
+            ('task/affinity,task/cgroup', False),
+        ],
+    )
+    def test_classification(self, task_plugin, expected):
+        assert utils.is_task_plugin_effectively_none(task_plugin) is expected
+
+    def test_none_input_is_false(self):
+        # Unreachable cluster / detection failure should NOT default to
+        # "no subdivision" — that would be unsafe on shared clusters.
+        assert utils.is_task_plugin_effectively_none(None) is False
+
+
 class TestValidateSbatchTime:
     """Test validate_sbatch_time()."""
 

--- a/tests/unit_tests/test_sky/provision/slurm/test_srun_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_srun_config.py
@@ -19,8 +19,8 @@ class TestBuildCustomSrunArgs:
         assert _build_custom_srun_args({}) == ''
 
     def test_string_value(self):
-        assert _build_custom_srun_args({'cpu-bind': 'cores'}) == (
-            "--cpu-bind=cores")
+        assert _build_custom_srun_args({'cpu-bind': 'cores'
+                                       }) == ("--cpu-bind=cores")
 
     def test_numeric_value(self):
         assert _build_custom_srun_args({'auto-resume': 1}) == '--auto-resume=1'
@@ -90,12 +90,7 @@ class TestSrunConfigSchema:
         jsonschema.validate(instance=config, schema=schema)
 
     def test_valid_cloud_level(self):
-        self._validate(
-            {'slurm': {
-                'srun_options': {
-                    'auto-resume': 1,
-                }
-            }})
+        self._validate({'slurm': {'srun_options': {'auto-resume': 1,}}})
 
     def test_valid_cluster_level(self):
         self._validate({


### PR DESCRIPTION
**Stacked on top of #9760.** Targets the `slurm-srun-options` branch — review/merge after #9760 lands and this will rebase cleanly onto master.

## Summary

- New `slurm.use_whole_node` config (4 levels: global / cluster / partition / task-YAML, mirrors `sbatch_options` / `srun_options` precedence).
- When `true`, the provision sbatch swaps `#SBATCH --cpus-per-task=N` for `#SBATCH --exclusive` — the combination required for AWS HyperPod's auto-resume SPANK plugin and the natural default on any cluster running `TaskPlugin=task/none`.
- Auto-detect from `scontrol show config | grep TaskPlugin` when the config is not set explicitly: `task/none` → True; anything that enforces per-task CPU subdivision → False. Conservative fallback (detection failure → False) preserves current behavior on shared cgroup-managed clusters.
- Optimizer-displayed cpus/memory are rewritten to match the smallest satisfying node when `use_whole_node` is True, so users see what they actually get, not just what they declared as a minimum.

## Why two PRs

The full HyperPod auto-resume recipe spans two coherent slices:

| Mechanism | Where |
|---|---|
| `srun_options.auto-resume=1` plumbing | PR #9760 |
| `SLURM_JOB_ID` preservation past env-strip | PR #9760 |
| `sbatch_options.requeue: true` to override `--no-requeue` | already works via last-wins (no code change) |
| `use_whole_node` → drop `--cpus-per-task`, add `--exclusive` | **this PR** |

Splitting keeps each PR reviewable in isolation.

## Validated end-to-end

Against an AWS HyperPod L4 cluster (today, captured in conversation log):

- Without `use_whole_node`: SPANK plugin self-disables — *"Resuming jobs is not supported when the parameter --cpus-per-task is used. Requeue will be used instead."* (just emits stderr advisory, autoresume.log silent, no recovery action.)
- With `use_whole_node` (matching the `--exclusive` + no `--cpus-per-task` recipe): plugin's `process_task_init` engages cleanly. Inject Xid 74 via syslog → plugin issues UpdateJobStatus(STEP_FAILED) + health check request → cluster agent verifies UNHEALTHY → plugin issues Action:Replace with `source: \"AutoResume\"` → node transitions DRAINING → FAILING → slurmctld requeues → EC2 replaced (~14 min) → job re-allocates with `Restarts=1`. Health check on the replacement returns HEALTHY → plugin correctly stops further requeues.

## Example

\`\`\`yaml
# task.yaml
resources:
  cloud: slurm
  cpus: 8+
  accelerators: L4:1

config:
  slurm:
    use_whole_node: true       # added by this PR
    sbatch_options:
      requeue: true            # overrides SkyPilot's --no-requeue
    srun_options:
      auto-resume: 1           # added by PR #9760
\`\`\`

On a HyperPod cluster with default lifecycle config (`TaskPlugin=task/cgroup,task/affinity`), the user can explicitly opt in to `use_whole_node: true` per task. On a cluster admin-configured for `task/none`, the default auto-detects to `true` so users don't need to set it.

## UX note (documented in the docstring)

When `use_whole_node: true`, the user-declared `resources.cpus / resources.memory` become **minimums for instance selection**. The optimizer displays the chosen node's full resources because that's what the task actually has access to under `--exclusive` without per-task subdivision. Without this rewrite, the displayed resources would silently understate access.

## Test plan

- **294 unit tests** pass across `tests/unit_tests/test_sky/clouds/test_slurm.py`, `tests/unit_tests/test_sky/provision/slurm/`, and `tests/unit_tests/test_sky/backends/test_task_codegen.py`.
- `TestUseWholeNodeResolution` (8 cases): 4-level precedence + auto-detect from TaskPlugin.
- `TestIsTaskPluginEffectivelyNone` (10 cases): `task/none` / `(null)` / `task/cgroup` / `task/cgroup,task/affinity` / unknown classifications.
- `TestCreateVirtualInstance::test_use_whole_node_swaps_cpus_per_task_for_exclusive`: provision script flips directives correctly.
- Snapshot tests `basic.sh` + `containers.sh` updated for the expanded comment above `#SBATCH --no-requeue`.

Recommend `/smoke-test` to exercise Slurm-relevant paths before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)