### PR TITLE
[Storage] HF: forward extra hf-mount flags via config.mount.hf_mount_args

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -522,6 +522,12 @@ Storage YAML reference
             - read_only: bool; default: false
                 Whether the mount is read-only. When enabled, writes to the
                 mount path will be rejected by the filesystem.
+            - hf_mount_args: list of str (Hugging Face stores only)
+                Extra ``hf-mount`` flags forwarded verbatim to the mount
+                daemon. Each element is one shell token, e.g.
+                ``['--cache-dir', '/mnt/nvme/hf-cache', '--cache-size',
+                '200000000000', '--advanced-writes']``. Ignored by other
+                stores. See the hf-mount README for the full flag list.
           - mount_cached: dict of rclone parameters for MOUNT_CACHED mode.
             Any parameters set here override the defaults from the workload type.
             Available parameters:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6422,12 +6422,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 read_only = bool(storage_obj.mount_config and
                                  storage_obj.mount_config.read_only)
                 if isinstance(store, storage_lib.HuggingFaceStore):
-                    hf_mount_args = (storage_obj.mount_config.hf_mount_args
-                                     if storage_obj.mount_config else None)
-                    mount_cmd = store.mount_command(
-                        dst,
-                        read_only=read_only,
-                        hf_mount_args=hf_mount_args)
+                    # getattr guards against MountConfig instances serialized
+                    # before hf_mount_args existed (and against a None config).
+                    hf_mount_args = getattr(storage_obj.mount_config,
+                                            'hf_mount_args', None)
+                    mount_cmd = store.mount_command(dst,
+                                                    read_only=read_only,
+                                                    hf_mount_args=hf_mount_args)
                 else:
                     mount_cmd = store.mount_command(dst, read_only=read_only)
                 action_message = 'Mounting'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6421,7 +6421,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             if storage_obj.mode == storage_lib.StorageMode.MOUNT:
                 read_only = bool(storage_obj.mount_config and
                                  storage_obj.mount_config.read_only)
-                mount_cmd = store.mount_command(dst, read_only=read_only)
+                if isinstance(store, storage_lib.HuggingFaceStore):
+                    hf_mount_args = (storage_obj.mount_config.hf_mount_args
+                                     if storage_obj.mount_config else None)
+                    mount_cmd = store.mount_command(
+                        dst,
+                        read_only=read_only,
+                        hf_mount_args=hf_mount_args)
+                else:
+                    mount_cmd = store.mount_command(dst, read_only=read_only)
                 action_message = 'Mounting'
             else:
                 assert storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -5,7 +5,7 @@ import random
 import shlex
 import textwrap
 import typing
-from typing import Optional
+from typing import List, Optional
 
 from sky import exceptions
 from sky import skypilot_config
@@ -391,7 +391,8 @@ def get_hf_mount_cmd(hf_id: str,
                      read_only: bool = False,
                      token_file: Optional[str] = None,
                      mode: str = 'bucket',
-                     revision: Optional[str] = None) -> str:
+                     revision: Optional[str] = None,
+                     extra_args: Optional[List[str]] = None) -> str:
     """Returns a command to mount an HF Bucket/repo via ``hf-mount``.
 
     Uses the FUSE backend (``--fuse``). hf-mount defaults to NFS, but the
@@ -414,6 +415,12 @@ def get_hf_mount_cmd(hf_id: str,
         mode: One of ``'bucket'`` (read-write) or ``'repo'`` (read-only).
         revision: Optional git revision for repo mounts (e.g. ``'main'`` or
             a tag/commit). Ignored for buckets.
+        extra_args: Extra ``hf-mount`` flags forwarded verbatim to the backend
+            daemon (e.g. ``['--cache-dir', '/mnt/nvme/hf-cache', '--cache-size',
+            '200000000000']``). Each element is one shell token and is quoted
+            individually. They are injected as backend-passthrough options
+            (alongside ``--token-file`` / ``--read-only``), before the
+            ``bucket``/``repo`` subcommand.
     """
     if mode not in ('bucket', 'repo'):
         raise ValueError(
@@ -436,6 +443,10 @@ def get_hf_mount_cmd(hf_id: str,
     if read_only and mode == 'bucket':
         # ``hf-mount`` repos are always read-only, no flag needed.
         backend_flags += ' --read-only'
+    if extra_args:
+        # Forwarded verbatim to the backend daemon. Quote each token so paths
+        # with spaces or shell metacharacters survive.
+        backend_flags += ''.join(f' {shlex.quote(a)}' for a in extra_args)
     extra = ''
     if mode == 'repo' and revision:
         extra = f' --revision {shlex.quote(revision)}'

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -519,6 +519,10 @@ class MountConfig:
     """
     # Mount as read-only.
     read_only: Optional[bool] = None
+    # Extra CLI flags forwarded verbatim to ``hf-mount`` (Hugging Face stores
+    # only; ignored by every other store). Each element is one shell token,
+    # e.g. ``['--cache-dir', '/mnt/nvme/hf-cache', '--advanced-writes']``.
+    hf_mount_args: Optional[List[str]] = None
 
     def to_yaml_config(self) -> Dict[str, Any]:
         """Serialize non-None fields to a dict for YAML round-tripping."""
@@ -5932,12 +5936,19 @@ class HuggingFaceStore(AbstractStore):
             return None
         return [f'{self._bucket_sub_path.rstrip("/")}/*']
 
-    def mount_command(self, mount_path: str, read_only: bool = False) -> str:
+    def mount_command(self,
+                      mount_path: str,
+                      read_only: bool = False,
+                      hf_mount_args: Optional[List[str]] = None) -> str:
         """Returns a command to mount the HF bucket/repo at ``mount_path``.
 
         Uses the ``hf-mount`` NFS backend. The token file is expected to be
         available on the remote host (it is synced via
         ``huggingface.get_credential_file_mounts``).
+
+        ``hf_mount_args`` are extra ``hf-mount`` flags (from
+        ``config.mount.hf_mount_args``) forwarded verbatim to the daemon,
+        e.g. ``--cache-dir`` / ``--cache-size`` / ``--advanced-writes``.
         """
         install_cmd = mounting_utils.get_hf_mount_install_cmd()
         mount_cmd = mounting_utils.get_hf_mount_cmd(
@@ -5946,7 +5957,8 @@ class HuggingFaceStore(AbstractStore):
             _bucket_sub_path=self._bucket_sub_path,
             read_only=read_only,
             mode='repo' if self.is_repo else 'bucket',
-            revision=self._revision)
+            revision=self._revision,
+            extra_args=hf_mount_args)
         version_check_cmd = mounting_utils.get_hf_mount_version_check_cmd()
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -812,6 +812,15 @@ def get_storage_schema():
                             'read_only': {
                                 'type': 'boolean',
                             },
+                            # Hugging Face stores only: extra ``hf-mount``
+                            # flags forwarded verbatim to the daemon. Each
+                            # element is one shell token.
+                            'hf_mount_args': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
+                            },
                         },
                     },
                 },

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -804,6 +804,14 @@ class TestMountConfig:
         restored = storage_lib.MountConfig.from_yaml_config(yaml_dict)
         assert restored.read_only is False
 
+    def test_round_trip_yaml_hf_mount_args(self):
+        args = ['--cache-dir', '/mnt/nvme/hf', '--advanced-writes']
+        config = storage_lib.MountConfig(hf_mount_args=args)
+        yaml_dict = config.to_yaml_config()
+        assert yaml_dict == {'hf_mount_args': args}
+        restored = storage_lib.MountConfig.from_yaml_config(yaml_dict)
+        assert restored.hf_mount_args == args
+
 
 class TestStorageFromYamlWithMountConfig:
     """Tests for Storage.from_yaml_config with mount config."""

--- a/tests/unit_tests/test_sky/storage/test_huggingface.py
+++ b/tests/unit_tests/test_sky/storage/test_huggingface.py
@@ -419,6 +419,26 @@ class TestHfMountCommands:
         with pytest.raises(ValueError, match='hf-mount mode'):
             mounting_utils.get_hf_mount_cmd('x/y', '/mnt', mode='invalid')
 
+    def test_mount_cmd_extra_args(self):
+        cmd = mounting_utils.get_hf_mount_cmd(
+            'user/bucket',
+            '/mnt/data',
+            extra_args=['--cache-dir', '/mnt/nvme/hf', '--advanced-writes'])
+        assert '--cache-dir /mnt/nvme/hf' in cmd
+        assert '--advanced-writes' in cmd
+        # Extra args are backend-passthrough options and must come before the
+        # ``bucket``/``repo`` subcommand, like ``--token-file``/``--read-only``.
+        assert cmd.find('--advanced-writes') < cmd.find('bucket user/bucket')
+
+    def test_mount_cmd_extra_args_quoted(self):
+        # Tokens with spaces/metacharacters are quoted individually so they
+        # survive the shell.
+        cmd = mounting_utils.get_hf_mount_cmd(
+            'user/bucket',
+            '/mnt/data',
+            extra_args=['--cache-dir', '/mnt/my cache'])
+        assert "'/mnt/my cache'" in cmd
+
 
 class TestStorageIntegration:
     """Tests for public Storage/Task integration paths."""


### PR DESCRIPTION
## Summary

The Hugging Face MOUNT integration builds the `hf-mount` command with a fixed set of flags (`--fuse`, `--token-file`, `--read-only`, `--revision`), so users currently cannot tune `hf-mount`'s own knobs. This is limiting for ML workloads on shared nodes, where the relevant settings are exactly the ones we can't reach today:

- `--cache-dir` (point all mounts on a node at one shared NVMe cache so a model is fetched once, not per researcher),
- `--cache-size` (bound the on-disk cache to avoid `No space left on device`),
- `--advanced-writes` + `--max-staging-size` + `--flush-*` (async checkpoint flushing with a bounded staging GC).

This PR adds an `hf_mount_args` list to the MOUNT config, forwarded verbatim to the daemon.

```yaml
file_mounts:
  /checkpoints:
    source: hf://buckets/my-org/run-42
    store: hf
    mode: MOUNT
    config:
      mount:
        hf_mount_args:
          - --cache-dir
          - /mnt/nvme-pool/hf-cache
          - --cache-size
          - "200000000000"
          - --advanced-writes
          - --max-staging-size
          - "50000000000"
```

### Changes

- `MountConfig` gains `hf_mount_args: Optional[List[str]]` (round-trips through YAML via the existing generic serialization).
- `get_hf_mount_cmd` accepts `extra_args`, quoted per-token and injected as backend-passthrough options (before the `bucket`/`repo` subcommand, alongside `--token-file`/`--read-only`).
- The MOUNT mount path threads `mount_config.hf_mount_args` to the HF store; other stores are untouched.
- Schema (`config.mount.hf_mount_args`), storage reference docs, and unit tests.

Args are HF-specific and ignored by every other store. The full flag list lives in the [hf-mount README](https://github.com/huggingface/hf-mount).

## Tested

- `pytest tests/unit_tests/test_sky/storage/test_huggingface.py -k "mount_cmd"` (8 passed), including new cases for arg placement (before the subcommand) and per-token shell quoting.
- `pytest tests/test_storage.py -k "MountConfig"` (13 passed), including `hf_mount_args` YAML round-trip.
- Manually verified the rendered command:
  `hf-mount start --fuse $TOKEN_FILE_ARG --advanced-writes --max-staging-size 50000000000 --cache-dir /mnt/nvme-pool/hf-cache bucket my-org/run-42 /checkpoints`