### PR TITLE
[Helm] Make API server RollingUpdate maxSurge/maxUnavailable configurable

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   {{- if and .Values.storage.enabled (ne .Values.storage.accessMode "ReadWriteMany") }}
   {{- fail "Local storage with ReadWriteOnce access mode is not supported when using RollingUpdate strategy. Either use Recreate upgrade strategy, set storage.enabled to false, or use ReadWriteMany access mode with a compatible storage class (e.g., NFS-backed storage like Google Filestore)." }}
   {{- end }}
-  {{- $rollingUpdate := .Values.apiService.rollingUpdate | default dict }}
+  {{- $rollingUpdate := .Values.apiService.rollingUpdate | default (dict) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -14,11 +14,14 @@ spec:
   {{- if and .Values.storage.enabled (ne .Values.storage.accessMode "ReadWriteMany") }}
   {{- fail "Local storage with ReadWriteOnce access mode is not supported when using RollingUpdate strategy. Either use Recreate upgrade strategy, set storage.enabled to false, or use ReadWriteMany access mode with a compatible storage class (e.g., NFS-backed storage like Google Filestore)." }}
   {{- end }}
+  {{- $rollingUpdate := .Values.apiService.rollingUpdate | default dict }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      {{- /* dig (not `default`) so an explicit 0 is honored — Go templates treat
+             0 as empty, which would silently fall back to the default. */}}
+      maxSurge: {{ dig "maxSurge" 1 $rollingUpdate }}
+      maxUnavailable: {{ dig "maxUnavailable" 0 $rollingUpdate }}
   {{- else }}
   strategy:
     type: Recreate

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -191,6 +191,50 @@ tests:
               fieldRef:
                 fieldPath: metadata.uid
 
+  - it: should honor configurable maxSurge/maxUnavailable including explicit 0
+    set:
+      apiService.upgradeStrategy: RollingUpdate
+      apiService.dbConnectionSecretName: test-db-secret
+      storage.enabled: false
+      apiService.rollingUpdate.maxSurge: 0
+      apiService.rollingUpdate.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  - it: should support percentage strings for maxSurge/maxUnavailable
+    set:
+      apiService.upgradeStrategy: RollingUpdate
+      apiService.dbConnectionSecretName: test-db-secret
+      storage.enabled: false
+      apiService.rollingUpdate.maxSurge: 25%
+      apiService.rollingUpdate.maxUnavailable: 50%
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 25%
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 50%
+
+  - it: should fall back to defaults when rollingUpdate is null
+    set:
+      apiService.upgradeStrategy: RollingUpdate
+      apiService.dbConnectionSecretName: test-db-secret
+      storage.enabled: false
+      apiService.rollingUpdate: null
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
   - it: should fail RollingUpdate strategy without external database
     set:
       apiService.upgradeStrategy: RollingUpdate

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -192,6 +192,26 @@
                 "resources": {
                     "type": "object"
                 },
+                "rollingUpdate": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "maxSurge": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "maxUnavailable": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        }
+                    }
+                },
                 "serveServerLog": {
                     "type": "boolean"
                 },
@@ -236,26 +256,6 @@
                 },
                 "upgradeStrategy": {
                     "type": "string"
-                },
-                "rollingUpdate": {
-                    "type": [
-                        "object",
-                        "null"
-                    ],
-                    "properties": {
-                        "maxSurge": {
-                            "type": [
-                                "integer",
-                                "string"
-                            ]
-                        },
-                        "maxUnavailable": {
-                            "type": [
-                                "integer",
-                                "string"
-                            ]
-                        }
-                    }
                 }
             }
         },

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -236,6 +236,26 @@
                 },
                 "upgradeStrategy": {
                     "type": "string"
+                },
+                "rollingUpdate": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "maxSurge": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "maxUnavailable": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        }
+                    }
                 }
             }
         },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -40,6 +40,16 @@ apiService:
   # If storage.enabled=false with RollingUpdate, file mounts and logs will be lost on pod restart; consider configuring
   # 'jobs.bucket' in the SkyPilot config to persist file mounts to cloud storage.
   upgradeStrategy: Recreate
+  # Rolling update tuning, only applied when upgradeStrategy is RollingUpdate.
+  # Defaults reproduce the previous hard-coded behavior: surge a new pod before
+  # removing an old one (zero-downtime). For deployments whose api-server pod
+  # requests most or all of a node's allocatable resources, a surge replica
+  # cannot be scheduled and the rollout stalls; set maxSurge: 0 and
+  # maxUnavailable: 1 to roll in place without surging. Values may be integers
+  # or percentage strings (e.g. "25%").
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
   # Deprecated: use other auth methods instead.
   # Refer to https://docs.skypilot.co/en/latest/reference/auth.html for more details.
   # Enable basic auth and user management in the API server

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -47,8 +47,11 @@ apiService:
   # cannot be scheduled and the rollout stalls; set maxSurge: 0 and
   # maxUnavailable: 1 to roll in place without surging. Values may be integers
   # or percentage strings (e.g. "25%").
+  # @schema type: [object, null]
   rollingUpdate:
+    # @schema type: [integer, string]
     maxSurge: 1
+    # @schema type: [integer, string]
     maxUnavailable: 0
   # Deprecated: use other auth methods instead.
   # Refer to https://docs.skypilot.co/en/latest/reference/auth.html for more details.


### PR DESCRIPTION
## Summary

The api-server `Deployment` hardcodes `maxSurge: 1` / `maxUnavailable: 0` for the `RollingUpdate` upgrade strategy. When the api-server pod requests most or all of a node's allocatable resources, the surge replica has nowhere to schedule, so the rolling update stalls indefinitely (the new pod stays `Pending`).

This exposes the values under `apiService.rollingUpdate`:

```yaml
apiService:
  upgradeStrategy: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1   # roll in place, no surge
```

- Defaults stay `maxSurge: 1` / `maxUnavailable: 0`, so existing deployments are **unchanged** (backward compatible).
- Uses `dig` rather than `default` so an explicit `0` is honored — Go templates treat `0` as empty, which would otherwise silently fall back to the default.
- Only applies when `upgradeStrategy: RollingUpdate`; the `Recreate` path is untouched.
- `values.schema.json` updated to match.

## Test

- `helm template` with `upgradeStrategy=RollingUpdate` and no override → `maxSurge: 1`, `maxUnavailable: 0` (unchanged from before).
- `helm template` with `apiService.rollingUpdate.maxSurge=0` / `maxUnavailable=1` → renders `0` / `1` (explicit `0` honored).
- `helm template` with default (`Recreate`) → unchanged, no `rollingUpdate` block.
- `helm lint` passes.