### PR TITLE
[K8s] Detect container terminal state in Pending pods; fix api-login URL match

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -695,6 +695,17 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                             raise config_lib.KubernetesError(
                                 'Failed to create container while launching '
                                 f'the node. Error details: {msg}.')
+                    terminated = container_status.state.terminated
+                    if terminated is not None and terminated.exit_code != 0:
+                        reason_str = (terminated.reason
+                                      if terminated.reason else
+                                      f'exit({terminated.exit_code})')
+                        raise config_lib.KubernetesError(
+                            f'Container in pod {pod.metadata.name} '
+                            f'terminated with error while pod is still '
+                            f'pending: {reason_str}. Run '
+                            f'`sky logs --provision {cluster_name}` '
+                            'for more details.')
         return False, reason
 
     missing_pods_retry = 0

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2787,7 +2787,7 @@ def test_remote_server_api_login():
             # Echo the config file content to see what was written
             f'echo "Config file content after sky api login:" && cat {config_path}',
             # Verify the config file is updated with the endpoint
-            f'grep -q "endpoint: {endpoint}" {config_path}',
+            f'grep -q "endpoint: {endpoint.rstrip("/")}" {config_path}',
             # Verify the api_server section exists
             f'grep -q "api_server:" {config_path}',
         ],


### PR DESCRIPTION
## Summary

- `_inspect_pod_status` now raises immediately when a container in a
  `Pending` pod has `state.terminated` with a non-zero exit code (e.g.
  `StartError`, `OOMKilled`). Previously the caller polled forever because
  only `state.waiting` was checked for Pending pods — a container that
  terminated with an error while its pod was still in `Pending` phase
  slipped through undetected and the wait loop spun until provision timeout.
- `test_remote_server_api_login`: strip trailing slash from the endpoint
  URL before building the grep pattern — `sky api login` normalises the
  stored endpoint without a trailing slash, so the grep was silently
  failing when `get_api_server_url()` returned a URL with one.

## Test plan
- [ ] `pytest tests/smoke_tests/test_cluster_job.py::test_kubernetes_pod_failure_detection --kubernetes`
- [ ] `pytest tests/smoke_tests/test_cluster_job.py::test_remote_server_api_login --kubernetes --remote-server`