### PR TITLE
[K8s] Detect container terminal state in Pending pods; fix api-login URL match

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -798,27 +798,37 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             init_reason: Optional[str] = None
             if container_statuses is not None:
                 for container_status in container_statuses:
-                    waiting = (container_status.state.waiting
-                               if container_status.state else None)
-                    if waiting is None:
+                    if not container_status.state:
                         continue
-                    if waiting.reason == 'PodInitializing':
-                        running_init = _check_init_containers(pod)
-                        if running_init is not None:
-                            name, idx, total = running_init
-                            init_reason = (f'init container {name!r} '
-                                           f'running ({idx}/{total})')
-                        else:
-                            init_reason = 'init container running'
-                    elif waiting.reason != 'ContainerCreating':
-                        msg = waiting.message if (
-                            waiting.message) else str(waiting)
-                        unmasked = _unmask_crashloopbackoff_reason(
-                            container_status)
-                        reason_text = (unmasked if unmasked is not None else
-                                       (waiting.reason or 'Unknown'))
+                    waiting = container_status.state.waiting
+                    if waiting is not None:
+                        if waiting.reason == 'PodInitializing':
+                            running_init = _check_init_containers(pod)
+                            if running_init is not None:
+                                name, idx, total = running_init
+                                init_reason = (f'init container {name!r} '
+                                               f'running ({idx}/{total})')
+                            else:
+                                init_reason = 'init container running'
+                        elif waiting.reason != 'ContainerCreating':
+                            msg = waiting.message if (
+                                waiting.message) else str(waiting)
+                            unmasked = _unmask_crashloopbackoff_reason(
+                                container_status)
+                            reason_text = (unmasked if unmasked is not None else
+                                           (waiting.reason or 'Unknown'))
+                            raise config_lib.KubernetesError(
+                                f'{reason_text}: {msg}')
+                    terminated = container_status.state.terminated
+                    if terminated is not None and terminated.exit_code != 0:
+                        reason_str = (terminated.reason if terminated.reason
+                                      else f'exit({terminated.exit_code})')
                         raise config_lib.KubernetesError(
-                            f'{reason_text}: {msg}')
+                            f'Container in pod {pod.metadata.name} '
+                            f'terminated with error while pod is still '
+                            f'pending: {reason_str}. Run '
+                            f'`sky logs --provision {cluster_name}` '
+                            'for more details.')
 
             # Init container reason wins over all event-based reasons,
             # since events can retain stale "Pulling image" entries long

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2807,7 +2807,7 @@ def test_remote_server_api_login():
             # Echo the config file content to see what was written
             f'echo "Config file content after sky api login:" && cat {config_path}',
             # Verify the config file is updated with the endpoint
-            f'grep -q "endpoint: {endpoint}" {config_path}',
+            f'grep -q "endpoint: {endpoint.rstrip("/")}" {config_path}',
             # Verify the api_server section exists
             f'grep -q "api_server:" {config_path}',
         ],


### PR DESCRIPTION
## Summary

- `_inspect_pod_status` now raises immediately when a container in a
  `Pending` pod has `state.terminated` with a non-zero exit code (e.g.
  `StartError`, `OOMKilled`). Previously the caller polled forever because
  only `state.waiting` was checked for Pending pods.
- `test_remote_server_api_login`: strip trailing slash from the endpoint
  URL before building the grep pattern — `sky api login` normalises the
  stored endpoint without a trailing slash, so the grep was silently
  failing when `get_api_server_url()` returned a URL with one.

## Test plan
- [ ] `pytest tests/smoke_tests/test_cluster_job.py::test_kubernetes_pod_failure_detection --kubernetes`
- [ ] `pytest tests/smoke_tests/test_cluster_job.py::test_remote_server_api_login --kubernetes --remote-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)