### PR TITLE
Fix Kubernetes volume default context selection

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3158,6 +3158,33 @@ def get_current_kube_config_context_name() -> Optional[str]:
         return None
 
 
+@annotations.lru_cache(scope='request')
+def get_default_volume_context() -> Optional[str]:
+    """Returns the default Kubernetes context for a volume with no --infra.
+
+    When a volume is created without an explicit context (e.g.
+    ``sky volumes apply`` without ``--infra``), we must pick a context to
+    create and register the PVC against. Defaulting to the kubeconfig's
+    current/first context is wrong when that context is not one of the
+    configured ``allowed_contexts``: the volume gets registered against a
+    context the optimizer will never schedule on, so any later launch that
+    mounts it fails its precheck with a "not enabled" error.
+
+    Prefer an enabled ``allowed_context`` so the volume lands on a context
+    that can actually be used. The current context is preferred when it is
+    itself allowed (preserving prior behavior); otherwise the first allowed
+    context is used. Falls back to the current kubeconfig context when no
+    allowed contexts can be determined.
+    """
+    current_context = get_current_kube_config_context_name()
+    allowed_contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
+    if not allowed_contexts:
+        return current_context
+    if current_context in allowed_contexts:
+        return current_context
+    return allowed_contexts[0]
+
+
 def is_incluster_config_available() -> bool:
     """Check if in-cluster auth is available.
 

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -34,7 +34,12 @@ def _is_rbac_permission_error(e: Exception) -> bool:
 def _get_context_namespace(config: models.VolumeConfig) -> Tuple[str, str]:
     """Gets the context and namespace of a volume."""
     if config.region is None:
-        context = kubernetes_utils.get_current_kube_config_context_name()
+        # No context was specified (e.g. `sky volumes apply` without --infra).
+        # Default to an enabled allowed_context rather than the arbitrary
+        # kubeconfig current/first context, otherwise the volume would be
+        # registered against a context the optimizer cannot schedule on and
+        # later launches that mount it would fail their prechecks.
+        context = kubernetes_utils.get_default_volume_context()
         config.region = context
     else:
         context = config.region

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -21,6 +21,7 @@ from sky import exceptions
 from sky import models
 from sky.catalog import kubernetes_catalog
 from sky.provision.kubernetes import utils
+from sky.utils import annotations
 
 
 # Test for exception on permanent errors like 401 (Unauthorized)
@@ -530,6 +531,43 @@ users:
             # Clean up temporary files
             os.unlink(f1.name)
             os.unlink(f2.name)
+
+
+def test_get_default_volume_context_prefers_allowed_context():
+    """Default context for a volume must be an enabled allowed_context.
+
+    Regression test: `sky volumes apply` without --infra used to default to
+    the kubeconfig current/first context even when it was not one of the
+    configured allowed_contexts, producing a volume the optimizer could never
+    schedule on.
+    """
+    # The helper is request-cached; clear between cases to exercise each one.
+    # Current context is NOT in allowed_contexts: fall back to an allowed one.
+    annotations.clear_request_level_cache()
+    with patch('sky.provision.kubernetes.utils.'
+               'get_current_kube_config_context_name',
+               return_value='context-a'), \
+         patch('sky.clouds.Kubernetes.existing_allowed_contexts',
+               return_value=['context-b']):
+        assert utils.get_default_volume_context() == 'context-b'
+
+    # Current context IS allowed: prefer it (preserves prior behavior).
+    annotations.clear_request_level_cache()
+    with patch('sky.provision.kubernetes.utils.'
+               'get_current_kube_config_context_name',
+               return_value='context-b'), \
+         patch('sky.clouds.Kubernetes.existing_allowed_contexts',
+               return_value=['context-a', 'context-b']):
+        assert utils.get_default_volume_context() == 'context-b'
+
+    # No allowed contexts available: fall back to the current context.
+    annotations.clear_request_level_cache()
+    with patch('sky.provision.kubernetes.utils.'
+               'get_current_kube_config_context_name',
+               return_value='context-a'), \
+         patch('sky.clouds.Kubernetes.existing_allowed_contexts',
+               return_value=[]):
+        assert utils.get_default_volume_context() == 'context-a'
 
 
 def test_detect_gpu_label_formatter_invalid_label_skip():

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -122,6 +122,41 @@ class TestGetContextNamespace:
         mock_get_namespace.assert_called_once_with('default-context')
 
     @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
+           'get_current_kube_config_context_name')
+    @patch('sky.clouds.Kubernetes.existing_allowed_contexts')
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
+           'get_kube_config_context_namespace')
+    def test_get_context_namespace_without_region_uses_allowed_context(
+            self, mock_get_namespace, mock_allowed_contexts, mock_get_context):
+        """Region defaults to an enabled allowed_context, not the current one.
+
+        Regression test for the bug where a volume created without --infra was
+        registered against the kubeconfig current/first context even when that
+        context was not an allowed_context, making it unschedulable.
+        """
+        mock_get_context.return_value = 'context-a'
+        mock_allowed_contexts.return_value = ['context-b']
+        mock_get_namespace.return_value = 'default-namespace'
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region=None,
+            zone=None,
+            name_on_cloud='test-vol-pvc',
+            size=None,
+            config={},
+        )
+        context, namespace = k8s_volume._get_context_namespace(config)
+
+        assert context == 'context-b'
+        assert config.region == 'context-b'
+        assert namespace == 'default-namespace'
+        mock_get_namespace.assert_called_once_with('context-b')
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
            'get_kube_config_context_namespace')
     def test_get_context_namespace_without_namespace(self, mock_get_namespace):
         """Test when namespace is not specified."""


### PR DESCRIPTION
## Description

Fixes a regression where `sky volumes apply` without `--infra` would default to the kubeconfig's current/first context even when that context was not in the configured `allowed_contexts`. This caused volumes to be registered against contexts the optimizer could never schedule on, resulting in failed prechecks when launching tasks that mount those volumes.

### Changes

1. **Added `get_default_volume_context()` function** in `sky/provision/kubernetes/utils.py`:
   - New request-cached helper that intelligently selects a default Kubernetes context for volumes
   - Prefers the current context if it's in `allowed_contexts` (preserves existing behavior)
   - Falls back to the first allowed context if the current one isn't allowed
   - Falls back to the current context only when no allowed contexts are available
   - Uses `@annotations.lru_cache(scope='request')` for caching within a request

2. **Updated `_get_context_namespace()` in `sky/provision/kubernetes/volume.py`**:
   - Changed from using `get_current_kube_config_context_name()` to `get_default_volume_context()`
   - Added explanatory comment about why we prefer allowed contexts

3. **Added comprehensive unit tests**:
   - `test_get_default_volume_context_prefers_allowed_context()` in `tests/unit_tests/kubernetes/test_kubernetes_utils.py` - Tests all three scenarios (current not allowed, current allowed, no allowed contexts)
   - `test_get_context_namespace_without_region_uses_allowed_context()` in `tests/unit_tests/test_sky/volumes/test_k8s_volume.py` - Tests the integration with volume config

### Testing

Added unit tests covering:
- Current context not in allowed_contexts → uses first allowed context
- Current context in allowed_contexts → uses current context (preserves behavior)
- No allowed contexts available → falls back to current context

All new tests pass and verify the regression is fixed.

https://claude.ai/code/session_01AnYMKL4Gzeygs5yrXPSGo6