### PR TITLE
[Core] Add optional total timeout to CommandRunner rsync

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -543,7 +543,13 @@ class CommandRunner:
             if deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
+                    # The deadline is exhausted before this attempt could run.
+                    # Set the outputs to reflect the timeout so the post-loop
+                    # error handling has defined (and accurate) values.
                     timed_out = True
+                    returncode = 255
+                    stdout = ''
+                    stderr = f'rsync timed out after {timeout} seconds.'
                     break
                 # run_with_log expects an int; clamp to >=1 so we never pass 0,
                 # which would disable the timeout.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -577,8 +577,14 @@ class CommandRunner:
             sleep_time = backoff.current_backoff()
             if deadline is not None:
                 # Do not let the backoff wait push us past the deadline.
-                sleep_time = min(sleep_time,
-                                 max(0.0, deadline - time.monotonic()))
+                new_remaining = deadline - time.monotonic()
+                if new_remaining <= 0 or sleep_time >= new_remaining:
+                    # The deadline will be exhausted by the time this backoff wait completed; early exit.
+                    timed_out = True
+                    returncode = 255
+                    stdout = ''
+                    stderr = f'rsync timed out after {timeout} seconds.'
+                    break
             time.sleep(sleep_time)
 
         direction = 'up' if up else 'down'

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -455,7 +455,8 @@ class CommandRunner:
             stream_logs: bool = True,
             max_retry: int = 1,
             prefix_command: Optional[str] = None,
-            get_remote_home_dir: Callable[[], str] = lambda: '~') -> None:
+            get_remote_home_dir: Callable[[], str] = lambda: '~',
+            timeout: Optional[int] = None) -> None:
         """Builds the rsync command."""
         # Build command.
         rsync_command = []
@@ -530,20 +531,55 @@ class CommandRunner:
 
         backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
         assert max_retry > 0, f'max_retry {max_retry} must be positive.'
+        # `timeout`, when set, bounds the total wall-clock time of the rsync
+        # including all retries and backoff waits, rather than each individual
+        # attempt. This guarantees the call returns within `timeout` seconds
+        # even if a connection hangs, which matters for callers that rsync
+        # across many clusters (e.g. the debug dump).
+        deadline = (time.monotonic() + timeout) if timeout is not None else None
+        timed_out = False
         while max_retry >= 0:
-            returncode, stdout, stderr = log_lib.run_with_log(
-                command,
-                log_path=log_path,
-                stream_logs=stream_logs,
-                shell=True,
-                require_outputs=True)
+            attempt_timeout: Optional[int] = None
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                # run_with_log expects an int; clamp to >=1 so we never pass 0,
+                # which would disable the timeout.
+                attempt_timeout = max(1, int(remaining))
+            try:
+                returncode, stdout, stderr = log_lib.run_with_log(
+                    command,
+                    log_path=log_path,
+                    stream_logs=stream_logs,
+                    shell=True,
+                    require_outputs=True,
+                    timeout=attempt_timeout)
+            except subprocess.TimeoutExpired:
+                # run_with_log already terminated the rsync process tree. The
+                # attempt consumed the remaining budget, so the overall
+                # deadline is exhausted; stop instead of retrying.
+                timed_out = True
+                returncode = 255
+                stdout = ''
+                stderr = f'rsync timed out after {timeout} seconds.'
+                break
             if returncode == 0:
                 break
             max_retry -= 1
-            time.sleep(backoff.current_backoff())
+            sleep_time = backoff.current_backoff()
+            if deadline is not None:
+                # Do not let the backoff wait push us past the deadline.
+                sleep_time = min(sleep_time,
+                                 max(0.0, deadline - time.monotonic()))
+            time.sleep(sleep_time)
 
         direction = 'up' if up else 'down'
+        timeout_hint = (f'rsync timed out after {timeout} seconds. '
+                        if timed_out else '')
         error_msg = (f'Failed to rsync {direction}: {source} -> {target}. '
+                     f'{timeout_hint}'
                      'Ensure that the network is stable, then retry.')
 
         subprocess_utils.handle_returncode(returncode,
@@ -652,6 +688,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -664,6 +701,10 @@ class CommandRunner:
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: The maximum number of retries for the rsync command.
               This value should be non-negative.
+            timeout: Optional total timeout in seconds for the rsync, including
+              all retries and backoff waits. If exceeded, the rsync is
+              terminated and treated as a failure. None means no timeout
+              (default).
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -679,6 +720,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Rsync files related to the job driver execution.
 
@@ -694,6 +736,8 @@ class CommandRunner:
             log_path: Redirect stdout/stderr to the log_path.
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: Maximum retry attempts.
+            timeout: Optional total timeout in seconds for the rsync, including
+              all retries and backoff waits. None means no timeout (default).
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -703,7 +747,8 @@ class CommandRunner:
                           up=up,
                           log_path=log_path,
                           stream_logs=stream_logs,
-                          max_retry=max_retry)
+                          max_retry=max_retry,
+                          timeout=timeout)
 
     def rsync_setup(
         self,
@@ -714,6 +759,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Rsync files for setting up the SkyPilot runtime on the cluster.
 
@@ -728,6 +774,8 @@ class CommandRunner:
             log_path: Redirect stdout/stderr to the log_path.
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: Maximum retry attempts.
+            timeout: Optional total timeout in seconds for the rsync, including
+              all retries and backoff waits. None means no timeout (default).
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -737,7 +785,8 @@ class CommandRunner:
                           up=up,
                           log_path=log_path,
                           stream_logs=stream_logs,
-                          max_retry=max_retry)
+                          max_retry=max_retry,
+                          timeout=timeout)
 
     @classmethod
     def make_runner_list(
@@ -1363,6 +1412,7 @@ class SSHCommandRunner(CommandRunner):
         stream_logs: bool = True,
         max_retry: int = 1,
         get_remote_home_dir: Callable[[], str] = lambda: '~',
+        timeout: Optional[int] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -1377,6 +1427,8 @@ class SSHCommandRunner(CommandRunner):
               This value should be non-negative.
             get_remote_home_dir: A callable that returns the remote home
               directory. Defaults to '~'.
+            timeout: Optional total timeout in seconds for the rsync, including
+              all retries and backoff waits. None means no timeout (default).
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -1404,7 +1456,8 @@ class SSHCommandRunner(CommandRunner):
                     log_path=log_path,
                     stream_logs=stream_logs,
                     max_retry=max_retry,
-                    get_remote_home_dir=get_remote_home_dir)
+                    get_remote_home_dir=get_remote_home_dir,
+                    timeout=timeout)
 
 
 class KubernetesCommandRunner(CommandRunner):
@@ -1690,6 +1743,7 @@ class KubernetesCommandRunner(CommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -1702,6 +1756,8 @@ class KubernetesCommandRunner(CommandRunner):
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: The maximum number of retries for the rsync command.
               This value should be non-negative.
+            timeout: Optional total timeout in seconds for the rsync, including
+              all retries and backoff waits. None means no timeout (default).
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -1734,7 +1790,8 @@ class KubernetesCommandRunner(CommandRunner):
             # rsync with `kubectl` as the rsh command will cause ~/xx parsed as
             # /~/xx, so we need to replace ~ with the remote home directory. We
             # only need to do this when ~ is at the beginning of the path.
-            get_remote_home_dir=self.get_remote_home_dir)
+            get_remote_home_dir=self.get_remote_home_dir,
+            timeout=timeout)
 
 
 class LocalProcessCommandRunner(CommandRunner):
@@ -1819,6 +1876,7 @@ class LocalProcessCommandRunner(CommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Use rsync to sync the source to the target."""
         self._rsync(source,
@@ -1828,7 +1886,8 @@ class LocalProcessCommandRunner(CommandRunner):
                     rsh_option=None,
                     log_path=log_path,
                     stream_logs=stream_logs,
-                    max_retry=max_retry)
+                    max_retry=max_retry,
+                    timeout=timeout)
 
 
 class SlurmCommandRunner(SSHCommandRunner):
@@ -1903,6 +1962,7 @@ class SlurmCommandRunner(SSHCommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         """Rsyncs files via srun, either to host or into container.
 
@@ -1915,6 +1975,8 @@ class SlurmCommandRunner(SSHCommandRunner):
             log_path: Path for rsync logs.
             stream_logs: Whether to stream logs.
             max_retry: Maximum retry attempts.
+            timeout: Optional total timeout in seconds for the rsync, including
+                all retries and backoff waits. None means no timeout (default).
         """
         ssh_command = ' '.join(
             self.ssh_base_command(ssh_mode=SshMode.NON_INTERACTIVE,
@@ -1952,7 +2014,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                         log_path=log_path,
                         stream_logs=stream_logs,
                         max_retry=max_retry,
-                        get_remote_home_dir=lambda: remote_home_dir)
+                        get_remote_home_dir=lambda: remote_home_dir,
+                        timeout=timeout)
         finally:
             try:
                 os.unlink(rsh_script_path)
@@ -2010,6 +2073,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         # Default: run in container if container_args set, otherwise on host
         in_container = self.container_args is not None
@@ -2019,7 +2083,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=in_container,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             timeout=timeout)
 
     @timeline.event
     @context_utils.cancellation_guard
@@ -2062,6 +2127,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         # Host only: driver runs on host and uses srun internally.
         self._rsync_via_srun(source=source,
@@ -2070,7 +2136,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=False,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             timeout=timeout)
 
     def rsync_setup(
         self,
@@ -2081,6 +2148,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        timeout: Optional[int] = None,
     ) -> None:
         # Both host and container: ensure environment is consistent.
         self._rsync_via_srun(source=source,
@@ -2089,7 +2157,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=False,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             timeout=timeout)
         if self.container_args is not None:
             self._rsync_via_srun(source=source,
                                  target=target,
@@ -2097,4 +2166,5 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                                  in_container=True,
                                  log_path=log_path,
                                  stream_logs=stream_logs,
-                                 max_retry=max_retry)
+                                 max_retry=max_retry,
+                                 timeout=timeout)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -579,7 +579,8 @@ class CommandRunner:
                 # Do not let the backoff wait push us past the deadline.
                 new_remaining = deadline - time.monotonic()
                 if new_remaining <= 0 or sleep_time >= new_remaining:
-                    # The deadline will be exhausted by the time this backoff wait completed; early exit.
+                    # The deadline will be exhausted by the time
+                    # this backoff wait completed; early exit.
                     timed_out = True
                     returncode = 255
                     stdout = ''

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 import os
 import select
 import socket
+import subprocess
 import tempfile
 import threading
 import time
@@ -12,6 +13,7 @@ from unittest import mock
 import paramiko
 import pytest
 
+from sky import exceptions
 from sky.utils import auth_utils
 from sky.utils import command_runner
 from sky.utils import common_utils
@@ -803,3 +805,138 @@ def test_kubernetes_runner_run_does_not_enrich_on_success() -> None:
 
     assert (returncode, stdout, stderr) == (0, 'ok', '')
     mock_diagnose.assert_not_called()
+
+
+class TestRsyncTimeout:
+    """Tests for the optional total timeout on CommandRunner.rsync."""
+
+    def test_timeout_passed_to_run_with_log_as_remaining_budget(self) -> None:
+        """The first attempt receives (nearly) the whole timeout budget."""
+        captured = {}
+
+        def fake_run_with_log(command, *args, **kwargs):
+            captured['timeout'] = kwargs.get('timeout')
+            return 0, '', ''
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log):
+            runner = command_runner.LocalProcessCommandRunner()
+            runner.rsync('/tmp/src',
+                         '/tmp/dst',
+                         up=True,
+                         stream_logs=False,
+                         timeout=100)
+
+        # The per-attempt timeout is the remaining budget, so the first attempt
+        # should get close to the full 100s (minus negligible elapsed time).
+        assert isinstance(captured['timeout'], int)
+        assert 90 <= captured['timeout'] <= 100
+
+    def test_no_timeout_passes_none_to_run_with_log(self) -> None:
+        """Without a timeout, run_with_log is called with timeout=None."""
+        captured = {}
+
+        def fake_run_with_log(command, *args, **kwargs):
+            captured['timeout'] = kwargs.get('timeout', 'MISSING')
+            return 0, '', ''
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log):
+            runner = command_runner.LocalProcessCommandRunner()
+            runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
+
+        assert captured['timeout'] is None
+
+    def test_timeout_expiry_raises_command_error_without_retry(self) -> None:
+        """A timeout exhausts the budget: raise immediately, do not retry."""
+        calls = []
+
+        def fake_run_with_log(command, *args, **kwargs):
+            calls.append(kwargs.get('timeout'))
+            raise subprocess.TimeoutExpired(command, kwargs.get('timeout'))
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log), \
+             mock.patch.object(command_runner.time, 'sleep') as mock_sleep:
+            runner = command_runner.LocalProcessCommandRunner()
+            with pytest.raises(exceptions.CommandError) as exc_info:
+                runner.rsync('/tmp/src',
+                             '/tmp/dst',
+                             up=True,
+                             stream_logs=False,
+                             max_retry=3,
+                             timeout=30)
+
+        assert 'timed out' in str(exc_info.value).lower()
+        # The single attempt consumed the whole budget; no retries.
+        assert len(calls) == 1
+        mock_sleep.assert_not_called()
+
+    def test_failures_retry_while_budget_remains(self) -> None:
+        """Plain failures retry up to max_retry while budget remains."""
+        calls = []
+
+        def fake_run_with_log(command, *args, **kwargs):
+            calls.append(kwargs.get('timeout'))
+            return 1, '', 'boom'
+
+        # Mock sleep so no wall-clock is consumed by the backoff; with a large
+        # timeout the deadline never trips and all retries run.
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log), \
+             mock.patch.object(command_runner.time, 'sleep'):
+            runner = command_runner.LocalProcessCommandRunner()
+            with pytest.raises(exceptions.CommandError):
+                runner.rsync('/tmp/src',
+                             '/tmp/dst',
+                             up=True,
+                             stream_logs=False,
+                             max_retry=2,
+                             timeout=600)
+
+        # max_retry=2 -> 3 attempts total.
+        assert len(calls) == 3
+        # Each attempt got a positive remaining budget.
+        assert all(t is not None and t > 0 for t in calls)
+
+    def test_deadline_stops_retries_even_with_budget_for_max_retry(
+            self) -> None:
+        """The deadline caps total time even if max_retry is not exhausted."""
+        calls = []
+
+        def fake_run_with_log(command, *args, **kwargs):
+            calls.append(kwargs.get('timeout'))
+            return 1, '', 'boom'
+
+        # A monotonic clock that advances 10s on every read, so the 15s budget
+        # is exhausted after the first attempt despite max_retry=5.
+        clock = [1000.0]
+
+        def fake_monotonic():
+            value = clock[0]
+            clock[0] += 10.0
+            return value
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log), \
+             mock.patch.object(command_runner.time, 'sleep'), \
+             mock.patch.object(command_runner.time,
+                               'monotonic',
+                               side_effect=fake_monotonic):
+            runner = command_runner.LocalProcessCommandRunner()
+            with pytest.raises(exceptions.CommandError) as exc_info:
+                runner.rsync('/tmp/src',
+                             '/tmp/dst',
+                             up=True,
+                             stream_logs=False,
+                             max_retry=5,
+                             timeout=15)
+
+        assert 'timed out' in str(exc_info.value).lower()
+        # Deadline tripped before max_retry was exhausted.
+        assert len(calls) == 1

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -903,6 +903,35 @@ class TestRsyncTimeout:
         # Each attempt got a positive remaining budget.
         assert all(t is not None and t > 0 for t in calls)
 
+    def test_deadline_exhausted_before_first_attempt_raises_cleanly(
+            self) -> None:
+        """A non-positive timeout trips the deadline before any attempt runs.
+
+        This must raise a clean CommandError rather than UnboundLocalError
+        from referencing undefined returncode/stdout/stderr after the loop.
+        """
+        calls = []
+
+        def fake_run_with_log(command, *args, **kwargs):
+            calls.append(kwargs.get('timeout'))
+            return 0, '', ''
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log), \
+             mock.patch.object(command_runner.time, 'sleep'):
+            runner = command_runner.LocalProcessCommandRunner()
+            with pytest.raises(exceptions.CommandError) as exc_info:
+                runner.rsync('/tmp/src',
+                             '/tmp/dst',
+                             up=True,
+                             stream_logs=False,
+                             timeout=0)
+
+        assert 'timed out' in str(exc_info.value).lower()
+        # No rsync attempt should have run.
+        assert calls == []
+
     def test_deadline_stops_retries_even_with_budget_for_max_retry(
             self) -> None:
         """The deadline caps total time even if max_retry is not exhausted."""


### PR DESCRIPTION
## Summary

- Adds an optional `timeout` parameter to the `rsync` API on `CommandRunner` and all subclasses (`SSHCommandRunner`, `KubernetesCommandRunner`, `LocalProcessCommandRunner`, `SlurmCommandRunner`), plus `rsync_driver`/`rsync_setup`.
- The timeout is handled centrally in `_rsync` (the single chokepoint all rsync paths funnel through) and bounds the **total wall-clock time** of the rsync — including all retries and backoff waits — rather than each individual attempt. This guarantees the call returns within `timeout` seconds even if a connection hangs.
- A timeout is converted into a clean retryable failure / `CommandError` via the existing `handle_returncode` path, instead of surfacing a raw `TimeoutExpired` traceback. The `timeout=None` path (default) is behaviorally unchanged.

### Motivation

This came out of review feedback on #9894 (collecting skylet logs in the debug dump): rsyncing a log down from a hung/degraded cluster could hang or significantly delay collection, and the problem compounds for users with hundreds of clusters. Making `timeout` a native, total-deadline part of the rsync API gives callers a hard bound. It's intended to be reusable beyond the debug dump.

The subprocess-level timeout machinery already exists in `log_lib.run_with_log` (it kills the process tree and raises `TimeoutExpired`); this change just threads a `timeout` through the rsync API to it, with a total-deadline semantics on top of the existing retry loop.

## Test plan

- Added `TestRsyncTimeout` unit tests in `tests/unit_tests/test_sky/utils/test_command_runner.py`:
  - timeout is passed to `run_with_log` as the remaining budget
  - `timeout=None` passes `None` (unchanged behavior)
  - a timeout raises `CommandError` ("timed out") and does not retry
  - plain failures still retry up to `max_retry` while budget remains
  - the deadline caps retries even when `max_retry` is not exhausted
- `pytest tests/unit_tests/test_sky/utils/test_command_runner.py` — 42 passed.
- `format.sh` clean (yapf/isort/mypy: no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)