### PR TITLE
[Dashboard] Hide managed-job-backing clusters in history view

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -396,11 +396,11 @@ def endpoints(cluster: str,
 
 
 @usage_lib.entrypoint
-def cost_report(
-        days: Optional[int] = None,
-        dashboard_summary_response: bool = False,
-        cluster_hashes: Optional[List[str]] = None,
-        cluster_names: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+def cost_report(days: Optional[int] = None,
+                dashboard_summary_response: bool = False,
+                cluster_hashes: Optional[List[str]] = None,
+                cluster_names: Optional[List[str]] = None,
+                exclude_managed_clusters: bool = False) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -449,6 +449,10 @@ def cost_report(
             provided, rows matching either are returned (logical OR). Note
             that a single cluster name may map to multiple history records
             when the name is reused across launches.
+        exclude_managed_clusters: If True, exclude clusters launched by a
+            controller (managed jobs and services). Used by the dashboard so
+            that clusters backing managed jobs do not show up in the cluster
+            history view.
 
     Returns:
         A list of dicts, with each dict containing the cost information of a
@@ -464,7 +468,8 @@ def cost_report(
         days=days,
         abbreviate_response=abbreviate_response,
         cluster_hashes=cluster_hashes,
-        cluster_names=cluster_names)
+        cluster_names=cluster_names,
+        exclude_managed_clusters=exclude_managed_clusters)
     logger.debug(
         f'{len(cluster_reports)} clusters found from history with {days} days.')
 

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -170,6 +170,11 @@ export async function getClusterHistory(
     const requestBody = {
       days: days,
       dashboard_summary_response: true,
+      // Hide clusters that back managed jobs/services from the history view.
+      // These controller-launched clusters are already excluded from the
+      // active cluster list (sky.core.status), so excluding them here keeps
+      // the "Show history" view consistent.
+      exclude_managed_clusters: true,
     };
 
     // If a specific cluster hash is provided, include it in the request

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2422,8 +2422,9 @@ def get_clusters_from_history(
         if exclude_managed_clusters:
             # Treat NULL (rows predating the is_managed column) as not managed.
             query = query.filter(
-                sqlalchemy.or_(cluster_history_table.c.is_managed.is_(None),
-                               cluster_history_table.c.is_managed == 0))
+                sqlalchemy.or_(
+                    cluster_history_table.c.is_managed.is_(None),
+                    cluster_history_table.c.is_managed == int(False)))
         rows = query.all()
 
     usage_intervals_dict = {}

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -219,6 +219,13 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('zone', sqlalchemy.Text, server_default=None),
     # Node names for dashboard display (comma-separated)
     sqlalchemy.Column('node_names', sqlalchemy.Text, server_default=None),
+    # Whether the cluster was launched by a controller (managed job or
+    # service). Mirrors the `is_managed` column on the clusters table so that
+    # history queries (e.g. the dashboard's cost report) can filter out
+    # controller-backed clusters even after they are terminated, since at that
+    # point the clusters table row is gone and the join can no longer supply
+    # the flag.
+    sqlalchemy.Column('is_managed', sqlalchemy.Integer, server_default='0'),
 )
 
 
@@ -929,6 +936,7 @@ def add_or_update_cluster(cluster_name: str,
             region=region,
             zone=zone,
             node_names=node_names,
+            is_managed=int(is_managed),
             **creation_info,
         )
         do_update_stmt = insert_stmnt.on_conflict_do_update(
@@ -951,6 +959,7 @@ def add_or_update_cluster(cluster_name: str,
                 cluster_history_table.c.region: region,
                 cluster_history_table.c.zone: zone,
                 cluster_history_table.c.node_names: node_names,
+                cluster_history_table.c.is_managed: int(is_managed),
                 **creation_info,
             })
         session.execute(do_update_stmt)
@@ -2322,7 +2331,8 @@ def get_clusters_from_history(
         days: Optional[int] = None,
         abbreviate_response: bool = False,
         cluster_hashes: Optional[List[str]] = None,
-        cluster_names: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        cluster_names: Optional[List[str]] = None,
+        exclude_managed_clusters: bool = False) -> List[Dict[str, Any]]:
     """Get cluster reports from history.
 
     Args:
@@ -2337,6 +2347,9 @@ def get_clusters_from_history(
               specified, rows matching either are returned (logical OR).
               Note that a single cluster name can map to multiple history
               records when a name is reused across launches.
+        exclude_managed_clusters: If True, exclude clusters launched by a
+              controller (managed jobs and services). Rows recorded before the
+              is_managed column existed are treated as not managed.
 
     Returns:
         List of cluster records with history information.
@@ -2406,6 +2419,11 @@ def get_clusters_from_history(
                 cluster_history_table.c.name.in_(cluster_names))
         if identifier_filters:
             query = query.filter(sqlalchemy.or_(*identifier_filters))
+        if exclude_managed_clusters:
+            # Treat NULL (rows predating the is_managed column) as not managed.
+            query = query.filter(
+                sqlalchemy.or_(cluster_history_table.c.is_managed.is_(None),
+                               cluster_history_table.c.is_managed == 0))
         rows = query.all()
 
     usage_intervals_dict = {}

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -959,7 +959,12 @@ def add_or_update_cluster(cluster_name: str,
                 cluster_history_table.c.region: region,
                 cluster_history_table.c.zone: zone,
                 cluster_history_table.c.node_names: node_names,
-                cluster_history_table.c.is_managed: int(is_managed),
+                # Intentionally do not update is_managed here (mirrors the
+                # clusters table above, which only sets it on insert).
+                # add_or_update_cluster is called multiple times during a
+                # managed-job launch and is_managed defaults to False on
+                # subsequent calls; overwriting it would reset the flag to 0
+                # and leak managed-job clusters into the history view.
                 **creation_info,
             })
         session.execute(do_update_stmt)

--- a/sky/schemas/db/global_user_state/020_add_is_managed_to_cluster_history.py
+++ b/sky/schemas/db/global_user_state/020_add_is_managed_to_cluster_history.py
@@ -1,0 +1,40 @@
+"""Add is_managed column to cluster_history table.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-06-18
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '020'
+down_revision: Union[str, Sequence[str], None] = '019'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add is_managed column to mirror the clusters table.
+
+    This lets history queries (e.g. the dashboard cost report) filter out
+    clusters launched by a controller (managed jobs and services) even after
+    they are terminated, when the clusters table row is gone.
+    """
+    from alembic import op  # pylint: disable=import-outside-toplevel
+
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('cluster_history',
+                                             'is_managed',
+                                             sa.Integer(),
+                                             server_default='0')
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -983,6 +983,10 @@ class CostReportBody(RequestBody):
     # Only return fields that are needed for the dashboard
     # summary page
     dashboard_summary_response: bool = False
+    # Exclude clusters launched by a controller (managed jobs and services).
+    # Used by the dashboard so that clusters backing managed jobs do not show
+    # up in the cluster history view.
+    exclude_managed_clusters: bool = False
 
 
 class CreateDebugDumpBody(RequestBody):

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '019'  # add preferred_workspace column to users
+GLOBAL_USER_STATE_VERSION = '020'  # add is_managed column to cluster_history
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_sky/test_cost_report.py
+++ b/tests/unit_tests/test_sky/test_cost_report.py
@@ -21,10 +21,12 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report()
 
             # Should call with default 30 days
-            mock_get_history.assert_called_once_with(days=30,
-                                                     abbreviate_response=False,
-                                                     cluster_hashes=None,
-                                                     cluster_names=None)
+            mock_get_history.assert_called_once_with(
+                days=30,
+                abbreviate_response=False,
+                cluster_hashes=None,
+                cluster_names=None,
+                exclude_managed_clusters=False)
             self.assertEqual(result, [])
 
     def test_cost_report_custom_days(self):
@@ -36,10 +38,12 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=7)
 
             # Should call with custom 7 days
-            mock_get_history.assert_called_once_with(days=7,
-                                                     abbreviate_response=False,
-                                                     cluster_hashes=None,
-                                                     cluster_names=None)
+            mock_get_history.assert_called_once_with(
+                days=7,
+                abbreviate_response=False,
+                cluster_hashes=None,
+                cluster_names=None,
+                exclude_managed_clusters=False)
             self.assertEqual(result, [])
 
     def test_cost_report_none_days(self):
@@ -51,10 +55,12 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=None)
 
             # Should call with default 30 days when None is passed
-            mock_get_history.assert_called_once_with(days=30,
-                                                     abbreviate_response=False,
-                                                     cluster_hashes=None,
-                                                     cluster_names=None)
+            mock_get_history.assert_called_once_with(
+                days=30,
+                abbreviate_response=False,
+                cluster_hashes=None,
+                cluster_names=None,
+                exclude_managed_clusters=False)
             self.assertEqual(result, [])
 
     def test_cost_report_with_cluster_names_filter(self):
@@ -65,7 +71,8 @@ class TestCostReportCore(unittest.TestCase):
             mock_get_history.return_value = []
 
             core.cost_report(dashboard_summary_response=True,
-                             cluster_names=['my-cluster'])
+                             cluster_names=['my-cluster'],
+                             exclude_managed_clusters=False)
 
             # When filtering by name, abbreviate_response must be False so
             # the dashboard receives full records (yaml/command fields).
@@ -73,7 +80,8 @@ class TestCostReportCore(unittest.TestCase):
                 days=30,
                 abbreviate_response=False,
                 cluster_hashes=None,
-                cluster_names=['my-cluster'])
+                cluster_names=['my-cluster'],
+                exclude_managed_clusters=False)
 
     def test_cost_report_with_both_hash_and_name_filters(self):
         """Test cost_report forwards both filters when both are given."""
@@ -83,13 +91,15 @@ class TestCostReportCore(unittest.TestCase):
 
             core.cost_report(dashboard_summary_response=True,
                              cluster_hashes=['abc'],
-                             cluster_names=['my-cluster'])
+                             cluster_names=['my-cluster'],
+                             exclude_managed_clusters=False)
 
             mock_get_history.assert_called_once_with(
                 days=30,
                 abbreviate_response=False,
                 cluster_hashes=['abc'],
-                cluster_names=['my-cluster'])
+                cluster_names=['my-cluster'],
+                exclude_managed_clusters=False)
 
     def test_cost_report_with_pickle_errors(self):
         """Test cost_report handles pickle errors gracefully when loading historical data."""
@@ -105,10 +115,12 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=30)
 
             self.assertEqual(result, [])
-            mock_get_history.assert_called_once_with(days=30,
-                                                     abbreviate_response=False,
-                                                     cluster_hashes=None,
-                                                     cluster_names=None)
+            mock_get_history.assert_called_once_with(
+                days=30,
+                abbreviate_response=False,
+                cluster_hashes=None,
+                cluster_names=None,
+                exclude_managed_clusters=False)
 
 
 class TestCostReportStatusUtils(unittest.TestCase):

--- a/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
@@ -1,0 +1,89 @@
+"""Tests that cluster history can filter out controller-backed clusters.
+
+Clusters that back managed jobs/services are recorded with is_managed=1.
+`sky.core.status` already hides them from the active cluster list, but the
+cluster history (which powers the dashboard's "Show history" / cost report
+view) reads the cluster_history table. That table now carries its own
+is_managed column so these clusters stay hidden even after they are
+terminated and their clusters-table row is gone (the history join is a LEFT
+OUTER JOIN, so the flag can no longer be sourced from the clusters table at
+that point).
+"""
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+class _MinimalHandle:
+    """Just enough for global_user_state.add_or_update_cluster to pickle."""
+    launched_resources = None
+
+
+def _add_cluster(name: str, is_managed: bool) -> None:
+    global_user_state.add_or_update_cluster(
+        cluster_name=name,
+        cluster_handle=_MinimalHandle(),
+        requested_resources=set(),
+        ready=True,
+        is_managed=is_managed,
+    )
+
+
+def _history_names(exclude_managed_clusters: bool):
+    return {
+        r['name'] for r in global_user_state.get_clusters_from_history(
+            exclude_managed_clusters=exclude_managed_clusters)
+    }
+
+
+def test_history_includes_managed_by_default(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('regular', is_managed=False)
+    _add_cluster('my-job-1', is_managed=True)
+
+    # Default behavior is unchanged: both clusters are reported.
+    assert _history_names(exclude_managed_clusters=False) == {
+        'regular', 'my-job-1'
+    }
+
+
+def test_history_excludes_managed_when_requested(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('regular', is_managed=False)
+    _add_cluster('my-job-1', is_managed=True)
+
+    assert _history_names(exclude_managed_clusters=True) == {'regular'}
+
+
+def test_history_excludes_managed_after_termination(tmp_path, monkeypatch):
+    """The bug scenario: a terminated managed-job cluster must stay hidden.
+
+    Once the cluster is terminated its clusters-table row is deleted, so the
+    is_managed flag can only come from the cluster_history table.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('regular', is_managed=False)
+    _add_cluster('my-job-1', is_managed=True)
+
+    global_user_state.remove_cluster('regular', terminate=True)
+    global_user_state.remove_cluster('my-job-1', terminate=True)
+
+    # Both are now history-only (no clusters-table row).
+    assert _history_names(exclude_managed_clusters=False) == {
+        'regular', 'my-job-1'
+    }
+    assert _history_names(exclude_managed_clusters=True) == {'regular'}

--- a/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
@@ -69,6 +69,21 @@ def test_history_excludes_managed_when_requested(tmp_path, monkeypatch):
     assert _history_names(exclude_managed_clusters=True) == {'regular'}
 
 
+def test_history_managed_flag_not_reset_on_update(tmp_path, monkeypatch):
+    """add_or_update_cluster is called multiple times during a managed-job
+    launch, and is_managed defaults to False on the later calls. The flag
+    recorded on the first call must not be overwritten, otherwise the managed
+    cluster would leak back into the history view.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('my-job-1', is_managed=True)
+    # Subsequent update with the default is_managed=False must not clear it.
+    _add_cluster('my-job-1', is_managed=False)
+
+    assert _history_names(exclude_managed_clusters=True) == set()
+    assert _history_names(exclude_managed_clusters=False) == {'my-job-1'}
+
+
 def test_history_excludes_managed_after_termination(tmp_path, monkeypatch):
     """The bug scenario: a terminated managed-job cluster must stay hidden.
 


### PR DESCRIPTION
## Summary

When **Show history** is toggled on the dashboard's clusters page, clusters that back managed jobs/services were appearing in the list (most visible in consolidation mode). This PR hides them so the history view stays consistent with the active cluster list.

**Root cause:** `sky.core.status()` (the active cluster list) already filters out controller-launched clusters via the `is_managed` column on the `clusters` table. But the history view is powered by `sky.core.cost_report()`, which reads the `cluster_history` table — and that table had no `is_managed` column. The history → `clusters` join is a `LEFT OUTER JOIN`, so once a managed-job cluster is terminated (its `clusters` row deleted) the flag could not be recovered there either. There was no way to filter these out of history.

**Fix:** carry `is_managed` onto the history table so it survives termination, then filter on it for the dashboard.

- Add an `is_managed` column to `cluster_history` (migration `020`) and populate it from `add_or_update_cluster` (reusing the `is_managed` arg already passed in).
- Add `exclude_managed_clusters` to `get_clusters_from_history()` / `cost_report()` / `CostReportBody` (defaults to `False`, so `sky cost-report` (CLI) and the SDK are unchanged).
- The dashboard's `getClusterHistory` now requests `exclude_managed_clusters: true`.

**Scope / compatibility:**
- Behavior change is limited to the dashboard. CLI/SDK are untouched (param defaults to `False`). The dashboard JS ships with its own server version, so there is no version-skew concern.
- Known limitation (documented in code): history rows written *before* this migration default to `is_managed=0` and cannot be backfilled, so pre-existing terminated managed clusters won't be retroactively hidden — but all new ones will be.

## Test plan

- New `tests/unit_tests/test_sky/test_global_user_state_history_managed.py` — DB-level tests covering: include-by-default, exclude-when-requested, and the key bug scenario (a managed cluster stays hidden **after termination**).
- Updated `tests/unit_tests/test_sky/test_cost_report.py` assertions for the forwarded kwarg.
- Migration verified to apply to a fresh DB (lands at revision `020` with the column present).
- `format.sh` clean (yapf/isort/mypy/pylint 10.00/10, ESLint clean); related unit tests pass.

Manual verification: with consolidation mode on, launch a managed job, let its backing cluster terminate, then open the dashboard clusters page and toggle **Show history** — the `<task>-<job_id>` cluster should no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
