### PR TITLE
[metrics] Make GPU/endpoint metrics federation observable + readable timeouts

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -265,8 +265,7 @@ def record_federation_phase(context: str, route: str, phase: str,
             context=context, route=route, phase=phase).observe(seconds)
 
 
-def record_federation_payload(context: str, route: str,
-                              num_bytes: int) -> None:
+def record_federation_payload(context: str, route: str, num_bytes: int) -> None:
     """Records the decompressed federate payload size (non-blocking)."""
     if METRICS_ENABLED:
         SKY_APISERVER_FEDERATION_PAYLOAD_BYTES.labels(
@@ -641,9 +640,9 @@ GPU_METRICS_MATCH_PATTERNS = [
 ]
 
 
-async def get_metrics_for_context(
-        context: str,
-        stats: Optional[FederationStats] = None) -> str:
+async def get_metrics_for_context(context: str,
+                                  stats: Optional[FederationStats] = None
+                                 ) -> str:
     """Get GPU metrics for a single Kubernetes context.
     Args:
         context: Kubernetes context name
@@ -687,8 +686,7 @@ ENDPOINT_METRICS_MATCH_PATTERNS = [
 
 
 async def get_endpoint_metrics_for_context(
-        context: str,
-        stats: Optional[FederationStats] = None) -> str:
+        context: str, stats: Optional[FederationStats] = None) -> str:
     """Get Sky Endpoint serving-engine metrics for a single K8s context.
 
     Mirrors get_metrics_for_context() but federates the serving engines'

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -14,7 +14,6 @@ import prometheus_client as prom
 
 from sky import sky_logging
 from sky.skylet import constants
-from sky.utils import common_utils
 
 _SELECT_TIMEOUT = 1
 _SELECT_BUFFER_SIZE = 4096
@@ -214,6 +213,111 @@ SKY_MANAGED_JOBS_LIMIT_LAUNCHES_PER_WORKER = prom.Gauge(
     multiprocess_mode='liveall',
 )
 
+# --- Metrics federation (per remote Kubernetes context) ---
+# The /gpu-metrics and /endpoints-metrics endpoints federate each remote
+# compute context's Prometheus via a kubectl port-forward + /federate scrape.
+# These instruments make that path debuggable: latency split into the
+# port-forward setup vs the federate request (so a slow tunnel is
+# distinguishable from a large/slow scrape), the decompressed payload size,
+# and a per-context outcome counter so a cluster that is silently timing out
+# (and thus dropping out of the federated output) is alertable.
+#
+# `context` cardinality is bounded by the number of allowed compute clusters
+# (single digits in practice), so it is safe as a label. `route` separates the
+# two federation endpoints that share send_metrics_request_with_port_forward.
+SKY_APISERVER_FEDERATION_DURATION_SECONDS = prom.Histogram(
+    'sky_apiserver_metrics_federation_duration_seconds',
+    'Time to federate metrics from a remote Kubernetes context, by phase '
+    '(port_forward: kubectl port-forward setup; federate: the /federate HTTP '
+    'request including transfer + decompression)',
+    ['context', 'route', 'phase'],
+    buckets=_LATENCY_BUCKETS,
+)
+
+# Decompressed size of the /federate response body. Uses the byte buckets
+# (top finite bucket 256MiB) so 5K-GPU bodies (tens of MiB) are resolvable.
+SKY_APISERVER_FEDERATION_PAYLOAD_BYTES = prom.Histogram(
+    'sky_apiserver_metrics_federation_payload_bytes',
+    'Decompressed size of the federate response body per remote context',
+    ['context', 'route'],
+    buckets=_MEM_BUCKETS,
+)
+
+# End-to-end outcome per context+route: success | timeout | error. Alert on a
+# rising timeout rate per context to catch the silent-drop failure mode.
+SKY_APISERVER_FEDERATION_TOTAL = prom.Counter(
+    'sky_apiserver_metrics_federation_total',
+    'Count of metrics federation attempts per remote context and outcome',
+    ['context', 'route', 'outcome'],
+)
+
+
+def record_federation_phase(context: str, route: str, phase: str,
+                            seconds: float) -> None:
+    """Records the duration of one federation phase (non-blocking, best-effort).
+
+    Gated by METRICS_ENABLED to match time_it(); a no-op otherwise. Pure
+    in-memory observe() with no I/O or awaits, so it is safe to call from a
+    finally block on a cancelled/timed-out task without risking a hang.
+    """
+    if METRICS_ENABLED:
+        SKY_APISERVER_FEDERATION_DURATION_SECONDS.labels(
+            context=context, route=route, phase=phase).observe(seconds)
+
+
+def record_federation_payload(context: str, route: str,
+                              num_bytes: int) -> None:
+    """Records the decompressed federate payload size (non-blocking)."""
+    if METRICS_ENABLED:
+        SKY_APISERVER_FEDERATION_PAYLOAD_BYTES.labels(
+            context=context, route=route).observe(num_bytes)
+
+
+def record_federation_outcome(context: str, route: str, outcome: str) -> None:
+    """Increments the per-context federation outcome counter (non-blocking)."""
+    if METRICS_ENABLED:
+        SKY_APISERVER_FEDERATION_TOTAL.labels(context=context,
+                                              route=route,
+                                              outcome=outcome).inc()
+
+
+class FederationStats:
+    """Mutable per-context timing/size record for one federation attempt.
+
+    send_metrics_request_with_port_forward() fills this in phase-by-phase. The
+    caller (the /gpu-metrics or /endpoints-metrics gather loop) holds a
+    reference and reads it when logging the result — crucially, this still
+    works when the attempt is cancelled by asyncio.wait_for(): the fields
+    written before the timeout (e.g. a completed port-forward) are preserved,
+    so the timeout log can show exactly how far the attempt got.
+    """
+
+    def __init__(self) -> None:
+        self.port_forward_seconds: Optional[float] = None
+        self.federate_seconds: Optional[float] = None
+        self.body_bytes: Optional[int] = None
+        self.wire_bytes: Optional[int] = None
+        self.content_encoding: Optional[str] = None
+
+    def summary(self) -> str:
+        """A compact 'port_forward=..s, federate=..' breakdown for logs.
+
+        'incomplete' marks a phase that did not finish (the key signal on a
+        timeout: which phase blew the budget).
+        """
+        if self.port_forward_seconds is not None:
+            pf = f'{self.port_forward_seconds:.2f}s'
+        else:
+            pf = 'incomplete'
+        if self.federate_seconds is not None:
+            fed = (f'{self.federate_seconds:.2f}s, '
+                   f'body={self.body_bytes / _MB:.1f}MiB, '
+                   f'wire={self.wire_bytes / _MB:.2f}MiB, '
+                   f'enc={self.content_encoding}')
+        else:
+            fed = 'incomplete'
+        return f'port_forward={pf}, federate={fed}'
+
 
 @contextlib.contextmanager
 def time_it(name: str, group: str = 'default'):
@@ -392,7 +496,9 @@ async def send_metrics_request_with_port_forward(
         service_port: int,
         endpoint_path: str = '/federate',
         match_patterns: Optional[List[str]] = None,
-        timeout: float = 30.0) -> str:
+        timeout: float = 30.0,
+        route: str = 'gpu-metrics',
+        stats: Optional[FederationStats] = None) -> str:
     """Sends a metrics request to a Prometheus endpoint via port forwarding.
     Args:
         context: Kubernetes context name
@@ -404,21 +510,38 @@ async def send_metrics_request_with_port_forward(
         match_patterns: List of metric patterns to match (for federate
             endpoint)
         timeout: Request timeout in seconds
+        route: Federation route label for metrics/logs ('gpu-metrics' or
+            'endpoints-metrics'); does not affect the request itself.
+        stats: Optional FederationStats filled in phase-by-phase so the caller
+            can report the port-forward vs. federate breakdown even if this
+            call is cancelled by a timeout. A fresh one is used if not given.
     Returns:
         Response text containing the metrics
     Raises:
         RuntimeError: If port forward or HTTP request fails
     """
+    if stats is None:
+        stats = FederationStats()
     port_forward_process = None
+    # monotonic() so durations are immune to wall-clock adjustments.
     try:
-        # Start port forward
+        # Start port forward.
+        pf_start = time.monotonic()
         port_forward_process, local_port = await asyncio.to_thread(
             start_svc_port_forward, context, namespace, service, service_port)
+        stats.port_forward_seconds = time.monotonic() - pf_start
+        record_federation_phase(context, route, 'port_forward',
+                                stats.port_forward_seconds)
 
         # Build endpoint URL
         endpoint = f'http://localhost:{local_port}{endpoint_path}'
 
-        # Make HTTP request
+        # Make HTTP request. httpx sends `Accept-Encoding: gzip, deflate` by
+        # default and transparently decompresses, so a Prometheus that
+        # compresses /federate (any version >= 2.0) is already gzipped on the
+        # wire; stats captures content-encoding + wire vs. decompressed size so
+        # this is observable rather than assumed.
+        federate_start = time.monotonic()
         async with httpx.AsyncClient(timeout=timeout) as client:
             if match_patterns:
                 # For federate endpoint, add match[] parameters
@@ -428,12 +551,24 @@ async def send_metrics_request_with_port_forward(
                 response = await client.get(endpoint)
 
             response.raise_for_status()
-            return response.text
+            text = response.text
+            # response.content is the decompressed body (already materialized
+            # for a non-streamed request, no await); num_bytes_downloaded is
+            # the raw on-wire (compressed) count.
+            stats.body_bytes = len(response.content)
+            stats.wire_bytes = response.num_bytes_downloaded
+            stats.content_encoding = response.headers.get(
+                'content-encoding', 'identity')
+            # Assign federate_seconds LAST so that (federate_seconds is not
+            # None) structurally implies the byte fields are set — summary()
+            # relies on this. The body is already materialized above, so
+            # measuring the duration here does not lose any transfer time.
+            stats.federate_seconds = time.monotonic() - federate_start
+            record_federation_phase(context, route, 'federate',
+                                    stats.federate_seconds)
+            record_federation_payload(context, route, stats.body_bytes)
+            return text
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.error(f'Failed to send metrics request with port forward: '
-                     f'{common_utils.format_exception(e)}')
-        raise
     finally:
         # Clean up port forward synchronously to guarantee cleanup
         # even if the task is cancelled by asyncio.wait_for().
@@ -501,10 +636,15 @@ GPU_METRICS_MATCH_PATTERNS = [
 ]
 
 
-async def get_metrics_for_context(context: str) -> str:
+async def get_metrics_for_context(
+        context: str,
+        stats: Optional[FederationStats] = None) -> str:
     """Get GPU metrics for a single Kubernetes context.
     Args:
         context: Kubernetes context name
+        stats: Optional FederationStats populated with the port-forward /
+            federate timing + payload size for this context (see the caller's
+            timeout logging).
     Returns:
         metrics_text: String containing the metrics
     Raises:
@@ -519,7 +659,9 @@ async def get_metrics_for_context(context: str) -> str:
         service='skypilot-prometheus-server',
         service_port=80,
         endpoint_path='/federate',
-        match_patterns=match_patterns)
+        match_patterns=match_patterns,
+        route='gpu-metrics',
+        stats=stats)
 
     # add cluster name as a label to each metric line
     metrics_text = await add_cluster_name_label(metrics_text, context)
@@ -539,7 +681,9 @@ ENDPOINT_METRICS_MATCH_PATTERNS = [
 ]
 
 
-async def get_endpoint_metrics_for_context(context: str) -> str:
+async def get_endpoint_metrics_for_context(
+        context: str,
+        stats: Optional[FederationStats] = None) -> str:
     """Get Sky Endpoint serving-engine metrics for a single K8s context.
 
     Mirrors get_metrics_for_context() but federates the serving engines'
@@ -549,6 +693,8 @@ async def get_endpoint_metrics_for_context(context: str) -> str:
 
     Args:
         context: Kubernetes context name
+        stats: Optional FederationStats populated with the port-forward /
+            federate timing + payload size for this context.
     Returns:
         metrics_text: String containing the metrics
     Raises:
@@ -562,7 +708,9 @@ async def get_endpoint_metrics_for_context(context: str) -> str:
         service='skypilot-prometheus-server',
         service_port=80,
         endpoint_path='/federate',
-        match_patterns=match_patterns)
+        match_patterns=match_patterns,
+        route='endpoints-metrics',
+        stats=stats)
 
     # add cluster name as a label to each metric line
     metrics_text = await add_cluster_name_label(metrics_text, context)

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -303,17 +303,22 @@ class FederationStats:
         """A compact 'port_forward=..s, federate=..' breakdown for logs.
 
         'incomplete' marks a phase that did not finish (the key signal on a
-        timeout: which phase blew the budget).
+        timeout: which phase blew the budget). This runs inside log calls, so
+        it must never raise: the byte fields are formatted defensively even
+        though federate_seconds is assigned last (so in practice they are
+        always set whenever federate_seconds is).
         """
         if self.port_forward_seconds is not None:
             pf = f'{self.port_forward_seconds:.2f}s'
         else:
             pf = 'incomplete'
         if self.federate_seconds is not None:
-            fed = (f'{self.federate_seconds:.2f}s, '
-                   f'body={self.body_bytes / _MB:.1f}MiB, '
-                   f'wire={self.wire_bytes / _MB:.2f}MiB, '
-                   f'enc={self.content_encoding}')
+            body = (f'{self.body_bytes / _MB:.1f}MiB'
+                    if self.body_bytes is not None else 'unknown')
+            wire = (f'{self.wire_bytes / _MB:.2f}MiB'
+                    if self.wire_bytes is not None else 'unknown')
+            fed = (f'{self.federate_seconds:.2f}s, body={body}, '
+                   f'wire={wire}, enc={self.content_encoding}')
         else:
             fed = 'incomplete'
         return f'port_forward={pf}, federate={fed}'

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -742,11 +742,10 @@ def _handle_federation_result(context: str, route: str, result: object,
         return
     if isinstance(result, Exception):
         metrics_utils.record_federation_outcome(context, route, 'error')
+        # format_exception already renders as '<ClassName>: <message>'.
         logger.error(
             f'Failed to get metrics for context {context} (route {route}): '
-            f'{type(result).__name__}: '
-            f'{common_utils.format_exception(result) or repr(result)} '
-            f'({stats.summary()})')
+            f'{common_utils.format_exception(result)} ({stats.summary()})')
         return
     if isinstance(result, BaseException):
         # Avoid changing behavior for non-Exception BaseExceptions like

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -27,6 +27,7 @@ from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.utils import annotations
 from sky.utils import common
+from sky.utils import common_utils
 from sky.utils import status_lib
 
 logger = sky_logging.init_logger(__name__)
@@ -715,6 +716,50 @@ async def gpu_metrics_debug() -> dict:
     }
 
 
+def _handle_federation_result(context: str, route: str, result: object,
+                              stats: metrics_utils.FederationStats,
+                              all_metrics: List[str]) -> None:
+    """Classifies one federation task result and records its outcome.
+
+    On success appends the metrics text; on failure logs a readable, per-
+    cluster message that names the context and includes the port-forward vs.
+    /federate timing breakdown (so a timeout shows which phase blew the
+    budget). Records the per-context outcome counter. Re-raises non-Exception
+    BaseExceptions (KeyboardInterrupt/SystemExit) to preserve prior behavior.
+
+    All work here is synchronous and non-blocking — no awaits, no I/O beyond
+    logging — so it cannot hang the gather loop.
+    """
+    # asyncio.TimeoutError is an Exception subclass, so check it first.
+    if isinstance(result, asyncio.TimeoutError):
+        metrics_utils.record_federation_outcome(context, route, 'timeout')
+        logger.error(
+            f'Failed to get metrics for context {context} (route {route}): '
+            f'timed out after {_PER_CONTEXT_TIMEOUT_SECONDS}s '
+            f'({stats.summary()}); kubectl port-forward + /federate exceeded '
+            f"the per-context budget; this cluster's series are omitted from "
+            f'this scrape')
+        return
+    if isinstance(result, Exception):
+        metrics_utils.record_federation_outcome(context, route, 'error')
+        logger.error(
+            f'Failed to get metrics for context {context} (route {route}): '
+            f'{type(result).__name__}: '
+            f'{common_utils.format_exception(result) or repr(result)} '
+            f'({stats.summary()})')
+        return
+    if isinstance(result, BaseException):
+        # Avoid changing behavior for non-Exception BaseExceptions like
+        # KeyboardInterrupt/SystemExit: re-raise them.
+        raise result
+    metrics_utils.record_federation_outcome(context, route, 'success')
+    logger.info(f'Federated metrics for context {context} (route {route}): '
+                f'{stats.summary()}')
+    # The three guards above leave only the success case: a metrics-text str.
+    assert isinstance(result, str)
+    all_metrics.append(result)
+
+
 @metrics_app.get('/gpu-metrics')
 async def gpu_metrics() -> fastapi.Response:
     """Gets the GPU metrics from multiple external k8s clusters"""
@@ -728,34 +773,29 @@ async def gpu_metrics() -> fastapi.Response:
     annotations.clear_request_level_cache()
     contexts = core.get_all_contexts()
     all_metrics: List[str] = []
-    successful_contexts = 0
 
     remote_contexts = [
         context for context in contexts if context != 'in-cluster'
     ]
+    # One stats record per context, filled in by get_metrics_for_context even
+    # if the task is later cancelled by the wait_for timeout — so the timeout
+    # log can report how far the attempt got (port-forward vs. federate).
+    stats_list = [
+        metrics_utils.FederationStats() for _ in remote_contexts
+    ]
     tasks = [
         asyncio.create_task(
             asyncio.wait_for(
-                metrics_utils.get_metrics_for_context(context),
+                metrics_utils.get_metrics_for_context(context, stats=stats),
                 timeout=_PER_CONTEXT_TIMEOUT_SECONDS,
-            )) for context in remote_contexts
+            )) for context, stats in zip(remote_contexts, stats_list)
     ]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            logger.error(
-                f'Failed to get metrics for context {remote_contexts[i]}: '
-                f'{result}')
-        elif isinstance(result, BaseException):
-            # Avoid changing behavior for non-Exception BaseExceptions
-            # like KeyboardInterrupt/SystemExit: re-raise them.
-            raise result
-        else:
-            metrics_text = result
-            all_metrics.append(metrics_text)
-            successful_contexts += 1
+        _handle_federation_result(remote_contexts[i], 'gpu-metrics', result,
+                                  stats_list[i], all_metrics)
 
     combined_metrics = '\n\n'.join(all_metrics)
 
@@ -785,25 +825,23 @@ async def endpoint_metrics() -> fastapi.Response:
     remote_contexts = [
         context for context in contexts if context != 'in-cluster'
     ]
+    stats_list = [
+        metrics_utils.FederationStats() for _ in remote_contexts
+    ]
     tasks = [
         asyncio.create_task(
             asyncio.wait_for(
-                metrics_utils.get_endpoint_metrics_for_context(context),
+                metrics_utils.get_endpoint_metrics_for_context(context,
+                                                               stats=stats),
                 timeout=_PER_CONTEXT_TIMEOUT_SECONDS,
-            )) for context in remote_contexts
+            )) for context, stats in zip(remote_contexts, stats_list)
     ]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            logger.error(f'Failed to get endpoint metrics for context '
-                         f'{remote_contexts[i]}: {result}')
-        elif isinstance(result, BaseException):
-            raise result
-        else:
-            metrics_text = result
-            all_metrics.append(metrics_text)
+        _handle_federation_result(remote_contexts[i], 'endpoints-metrics',
+                                  result, stats_list[i], all_metrics)
 
     combined_metrics = '\n\n'.join(all_metrics)
 

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -779,9 +779,7 @@ async def gpu_metrics() -> fastapi.Response:
     # One stats record per context, filled in by get_metrics_for_context even
     # if the task is later cancelled by the wait_for timeout — so the timeout
     # log can report how far the attempt got (port-forward vs. federate).
-    stats_list = [
-        metrics_utils.FederationStats() for _ in remote_contexts
-    ]
+    stats_list = [metrics_utils.FederationStats() for _ in remote_contexts]
     tasks = [
         asyncio.create_task(
             asyncio.wait_for(
@@ -824,9 +822,7 @@ async def endpoint_metrics() -> fastapi.Response:
     remote_contexts = [
         context for context in contexts if context != 'in-cluster'
     ]
-    stats_list = [
-        metrics_utils.FederationStats() for _ in remote_contexts
-    ]
+    stats_list = [metrics_utils.FederationStats() for _ in remote_contexts]
     tasks = [
         asyncio.create_task(
             asyncio.wait_for(

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -752,8 +752,10 @@ def _handle_federation_result(context: str, route: str, result: object,
         # KeyboardInterrupt/SystemExit: re-raise them.
         raise result
     metrics_utils.record_federation_outcome(context, route, 'success')
-    logger.info(f'Federated metrics for context {context} (route {route}): '
-                f'{stats.summary()}')
+    # debug: one line per context per scrape; the timeout/error paths above
+    # log at error level, and the Prometheus metrics capture this regardless.
+    logger.debug(f'Federated metrics for context {context} (route {route}): '
+                 f'{stats.summary()}')
     # The three guards above leave only the success case: a metrics-text str.
     assert isinstance(result, str)
     all_metrics.append(result)

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -737,7 +737,7 @@ def _handle_federation_result(context: str, route: str, result: object,
             f'Failed to get metrics for context {context} (route {route}): '
             f'timed out after {_PER_CONTEXT_TIMEOUT_SECONDS}s '
             f'({stats.summary()}); kubectl port-forward + /federate exceeded '
-            f"the per-context budget; this cluster's series are omitted from "
+            f'the per-context budget; series for this cluster are omitted from '
             f'this scrape')
         return
     if isinstance(result, Exception):

--- a/tests/unit_tests/test_metrics_federation.py
+++ b/tests/unit_tests/test_metrics_federation.py
@@ -4,9 +4,19 @@ serving-engine metrics.
 The serving dashboards (vLLM Serving, Autoscaling) read these series from the
 central Prometheus: vllm:* via /endpoints-metrics, and Deployment replica
 counts + the HPA target via the /gpu-metrics federation.
+
+Also covers the federation observability helpers: FederationStats.summary()
+(the timing/size breakdown surfaced in logs) and _handle_federation_result()
+(the per-context success/timeout/error classification).
 """
+import asyncio
+
+import pytest
+
 from sky.metrics import utils as metrics_utils
 from sky.server import metrics as server_metrics
+
+_MIB = 2**20
 
 
 def test_endpoint_metrics_carries_autoscaling_dashboard_series():
@@ -40,3 +50,94 @@ def test_endpoint_metrics_route_registered():
     assert '/endpoints-metrics' in paths
     assert '/gpu-metrics' in paths
     assert hasattr(metrics_utils, 'get_endpoint_metrics_for_context')
+
+
+# --- FederationStats.summary() ---
+
+
+def test_federation_stats_summary_empty():
+    # No phase finished (e.g. timed out establishing the port-forward).
+    stats = metrics_utils.FederationStats()
+    assert stats.summary() == 'port_forward=incomplete, federate=incomplete'
+
+
+def test_federation_stats_summary_port_forward_only():
+    # Port-forward done, federate cancelled mid-transfer (the timeout case).
+    stats = metrics_utils.FederationStats()
+    stats.port_forward_seconds = 0.31
+    assert stats.summary() == 'port_forward=0.31s, federate=incomplete'
+
+
+def test_federation_stats_summary_full():
+    stats = metrics_utils.FederationStats()
+    stats.port_forward_seconds = 0.29
+    stats.federate_seconds = 4.82
+    stats.body_bytes = int(64.4 * _MIB)
+    stats.wire_bytes = int(3.45 * _MIB)
+    stats.content_encoding = 'gzip'
+    out = stats.summary()
+    assert 'port_forward=0.29s' in out
+    assert 'federate=4.82s' in out
+    assert 'body=64.4MiB' in out
+    assert 'wire=3.45MiB' in out
+    assert 'enc=gzip' in out
+
+
+def test_federation_stats_summary_never_raises_on_missing_bytes():
+    # Defensive: summary() runs inside log calls and must never raise, even in
+    # the should-not-happen state where federate_seconds is set but the byte
+    # fields are not.
+    stats = metrics_utils.FederationStats()
+    stats.federate_seconds = 1.0
+    out = stats.summary()  # must not raise
+    assert 'body=unknown' in out
+    assert 'wire=unknown' in out
+
+
+# --- _handle_federation_result() classification ---
+
+
+def test_handle_result_success_appends():
+    out = []
+    server_metrics._handle_federation_result('ctx', 'gpu-metrics',
+                                             'metric_text',
+                                             metrics_utils.FederationStats(),
+                                             out)
+    assert out == ['metric_text']
+
+
+def test_handle_result_empty_body_appends():
+    # An empty federated body is valid and must still be appended.
+    out = []
+    server_metrics._handle_federation_result('ctx', 'gpu-metrics', '',
+                                             metrics_utils.FederationStats(),
+                                             out)
+    assert out == ['']
+
+
+def test_handle_result_timeout_not_appended():
+    out = []
+    server_metrics._handle_federation_result('ctx', 'gpu-metrics',
+                                             asyncio.TimeoutError(),
+                                             metrics_utils.FederationStats(),
+                                             out)
+    assert out == []
+
+
+def test_handle_result_error_not_appended():
+    out = []
+    server_metrics._handle_federation_result('ctx', 'gpu-metrics',
+                                             ValueError('boom'),
+                                             metrics_utils.FederationStats(),
+                                             out)
+    assert out == []
+
+
+def test_handle_result_base_exception_reraised():
+    # KeyboardInterrupt/SystemExit must propagate, not be swallowed.
+    out = []
+    with pytest.raises(KeyboardInterrupt):
+        server_metrics._handle_federation_result(
+            'ctx', 'gpu-metrics', KeyboardInterrupt(),
+            metrics_utils.FederationStats(), out)
+    assert out == []


### PR DESCRIPTION
## What

The `/gpu-metrics` and `/endpoints-metrics` endpoints federate each remote Kubernetes context's Prometheus via a `kubectl port-forward` + `/federate` scrape. This makes that path debuggable — **without changing what is federated**.

### Before
When a context timed out, the log said:
```
Failed to get metrics for context coreweave-gb300:
```
…nothing after the colon, because the per-context `asyncio.wait_for` raises `asyncio.TimeoutError` whose `str()` is `''`. There was also no visibility into where a slow scrape spends its time or how big the payload is.

### After
- **Readable, per-cluster failures** that name the context + route and, on timeout, show which phase blew the budget:
  ```
  Failed to get metrics for context coreweave-gb300 (route gpu-metrics): timed out
    after 30s (port_forward=0.31s, federate=incomplete); kubectl port-forward +
    /federate exceeded the per-context budget; this cluster's series are omitted
  ```
- **Per-attempt timing + size** on success (port-forward vs. federate phases, decompressed body, on-wire bytes, content-encoding) so gzip activity and transfer cost are observable rather than assumed:
  ```
  Federated metrics for context coreweave-gb300 (route gpu-metrics):
    port_forward=0.29s, federate=4.82s, body=64.4MiB, wire=3.45MiB, enc=gzip
  ```
- **Three Prometheus instruments** following the existing `sky_apiserver_*` pattern, gated by `METRICS_ENABLED`:
  - `sky_apiserver_metrics_federation_duration_seconds{context,route,phase}`
  - `sky_apiserver_metrics_federation_payload_bytes{context,route}`
  - `sky_apiserver_metrics_federation_total{context,route,outcome}`

  `context` cardinality is bounded by the number of allowed compute clusters.

## Why
At GPU scale a large context can exceed the per-context federation timeout and silently drop out of the federated output (e.g. the utilization panel goes empty). The old empty-string error gave no way to tell a timeout from any other failure, or to see whether the time went to port-forward setup vs. the `/federate` transfer. This adds that signal.

## Notes
- **No behavior change** to the federated `match[]` or the `cluster=` relabel.
- **No hang risk**: all added work is synchronous/non-blocking (`time.monotonic`, `logger`, `.observe`/`.inc`) and stays within the existing per-context `wait_for(_PER_CONTEXT_TIMEOUT_SECONDS)` bound; the port-forward keeps its own setup/terminate timeouts. A `FederationStats` carrier records phase timings as they complete, so the timeout log can report how far the attempt got even though the task was cancelled.
- The `asyncio.TimeoutError` branch is checked before the generic `Exception` branch (it is a subclass); non-`Exception` `BaseException`s (KeyboardInterrupt/SystemExit) are still re-raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UjVe5YeCks28pU9e2LBTQ

## Tested
- **Unit tests** (`tests/unit_tests/test_metrics_federation.py`, 13 passing):
  - `FederationStats.summary()` — empty / port-forward-only / full breakdown / never-raises when byte fields are missing.
  - `_handle_federation_result()` — success appends, empty body appends, `asyncio.TimeoutError` → not appended, generic `Exception` → not appended, `BaseException` (KeyboardInterrupt) re-raised.
- **Manual**: against a real compute-cluster Prometheus (v3.4.1), confirmed `/federate` returns `Content-Encoding: gzip` and httpx decompresses it, so the new log surfaces `enc=gzip` with `wire` ≈ 1/19 of `body`.
- `format.sh` tooling: `yapf 0.32.0`, `isort 5.12.0`, `pylint 2.14.5` + `pylint-quotes 0.2.3` all clean on the changed files.
