### PR TITLE
[Server] Don't wipe in-use file-mounts blobs on API server startup

### DIFF
--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import shutil
 import time
-from typing import List, Tuple
+from typing import List, Optional, Set, Tuple
 
 import anyio
 import filelock
@@ -17,6 +17,31 @@ from sky.server.blob import blob_storage as bs
 from sky.server.requests import executor
 
 logger = sky_logging.init_logger(__name__)
+
+
+def _remove_dir_contents_except(root: pathlib.Path,
+                                keep: Set[pathlib.Path]) -> None:
+    """Remove everything under ``root`` except the paths in ``keep``.
+
+    ``root`` itself is never removed. Directories that contain a kept path
+    are recursed into (and so survive); any directory or file that does not
+    lead to a kept path is removed wholesale.
+    """
+    root = root.resolve()
+    if root in keep:
+        return
+    has_kept_descendant = any(root in path.parents for path in keep)
+    if not has_kept_descendant:
+        if root.is_dir() and not root.is_symlink():
+            shutil.rmtree(root, ignore_errors=True)
+        else:
+            try:
+                root.unlink()
+            except OSError:
+                pass
+        return
+    for child in root.iterdir():
+        _remove_dir_contents_except(child, keep)
 
 
 class LocalFilesystemBlobStorage(bs.BlobStorage):
@@ -112,8 +137,56 @@ class LocalFilesystemBlobStorage(bs.BlobStorage):
         return users
 
     def reset_on_startup(self) -> None:
-        """Called on server startup to clean up ephemeral client state."""
-        logger.debug('clearing local API server client directory at '
-                     f'{server_common.API_SERVER_CLIENT_DIR.expanduser()}')
-        shutil.rmtree(server_common.API_SERVER_CLIENT_DIR.expanduser(),
-                      ignore_errors=True)
+        """Reclaim ephemeral client state on server startup.
+
+        Historically this wiped the entire client directory. That is unsafe:
+        a file-mounts blob referenced by a non-terminal managed job must
+        survive a server restart, because the jobs controller re-resolves the
+        blob to stage file mounts when it recovers the job. Wiping it breaks
+        recovery with a ``Blob not found`` error.
+
+        Instead, preserve blobs that are still referenced -- reusing the same
+        ref-count as the periodic GC (``cleanup_unreferenced_file_mounts``):
+        the union of blobs referenced by active requests and by non-terminal
+        managed jobs -- and remove everything else (unreferenced blobs, stale
+        uploads, and per-user log/download staging).
+        """
+        client_dir = server_common.API_SERVER_CLIENT_DIR.expanduser().resolve()
+        logger.debug(
+            f'resetting local API server client directory at {client_dir}')
+        if not client_dir.exists():
+            return
+
+        # Imported here rather than at module scope to avoid an import cycle
+        # during server bootstrap; reset_on_startup runs once at startup, so
+        # the import cost is irrelevant.
+        # pylint: disable=import-outside-toplevel
+        from sky.jobs import state as managed_job_state
+        from sky.server.requests import requests as requests_lib
+        active_blob_ids: Optional[Set[str]]
+        try:
+            active_blob_ids = (
+                requests_lib.get_active_file_mounts_blob_ids() |
+                managed_job_state.get_active_file_mounts_blob_ids())
+        except Exception as e:  # pylint: disable=broad-except
+            # If we cannot determine which blobs are still referenced, preserve
+            # all of them: a leaked blob is reclaimed later by the periodic GC,
+            # but a wrongly-deleted blob breaks managed-job recovery.
+            logger.warning(
+                'Failed to query active file-mount blobs on startup; '
+                f'preserving all blobs. Error: {e}')
+            active_blob_ids = None
+
+        preserved: Set[pathlib.Path] = set()
+        for user_id in self.list_users():
+            for blob_id, _ in self.list_blob_ids(user_id):
+                if active_blob_ids is None or blob_id in active_blob_ids:
+                    preserved.add(
+                        self.get_target_dir(user_id, blob_id).resolve())
+
+        if not preserved:
+            # Nothing to preserve: keep the cheap blanket wipe.
+            shutil.rmtree(client_dir, ignore_errors=True)
+            return
+
+        _remove_dir_contents_except(client_dir, preserved)

--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -26,22 +26,39 @@ def _remove_dir_contents_except(root: pathlib.Path,
     ``root`` itself is never removed. Directories that contain a kept path
     are recursed into (and so survive); any directory or file that does not
     lead to a kept path is removed wholesale.
+
+    Children are not path-resolved during traversal: a symlinked directory is
+    unlinked (the link removed) rather than followed and its target deleted.
     """
     root = root.resolve()
-    if root in keep:
-        return
-    has_kept_descendant = any(root in path.parents for path in keep)
-    if not has_kept_descendant:
-        if root.is_dir() and not root.is_symlink():
-            shutil.rmtree(root, ignore_errors=True)
-        else:
-            try:
-                root.unlink()
-            except OSError:
-                pass
-        return
-    for child in root.iterdir():
-        _remove_dir_contents_except(child, keep)
+    # Pre-compute the ancestors of every kept path for O(1) membership tests.
+    kept_ancestors = {ancestor for path in keep for ancestor in path.parents}
+
+    def _prune(path: pathlib.Path) -> None:
+        if path in keep:
+            return
+        if path not in kept_ancestors:
+            # Not on the path to any kept blob: remove it. Do not resolve()
+            # here -- a symlinked directory must be unlinked, not followed.
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+            return
+        try:
+            for child in path.iterdir():
+                _prune(child)
+        except OSError:
+            pass
+
+    try:
+        for child in root.iterdir():
+            _prune(child)
+    except OSError:
+        pass
 
 
 class LocalFilesystemBlobStorage(bs.BlobStorage):

--- a/tests/unit_tests/test_local_blob_storage.py
+++ b/tests/unit_tests/test_local_blob_storage.py
@@ -51,6 +51,29 @@ def test_reset_on_startup_preserves_active_blobs(tmp_path, monkeypatch):
     assert client_dir.exists()
 
 
+def test_reset_on_startup_does_not_follow_symlinks(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+    active = _make_blob(client_dir, 'user1', 'active')
+
+    # An external directory that a symlink under the client dir points to. It
+    # must not be touched: the symlink should be unlinked, not followed.
+    external = tmp_path / 'external'
+    external.mkdir()
+    (external / 'important').write_text('do-not-delete')
+    link = client_dir / 'user1' / 'link'
+    link.symlink_to(external)
+
+    _patch_active(monkeypatch, requests=set(), jobs={'active'})
+
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+
+    assert active.exists()
+    assert not link.exists()  # the symlink itself is removed
+    assert external.exists()  # ... but its target is untouched
+    assert (external / 'important').read_text() == 'do-not-delete'
+
+
 def test_reset_on_startup_honors_request_refs(tmp_path, monkeypatch):
     client_dir = tmp_path / 'clients'
     _patch_client_dir(monkeypatch, client_dir)

--- a/tests/unit_tests/test_local_blob_storage.py
+++ b/tests/unit_tests/test_local_blob_storage.py
@@ -1,0 +1,100 @@
+"""Tests for LocalFilesystemBlobStorage.reset_on_startup."""
+import pathlib
+
+from sky.server.blob import local_blob_storage
+
+
+def _make_blob(client_dir: pathlib.Path,
+               user: str,
+               blob_id: str,
+               content: str = 'data') -> pathlib.Path:
+    blob_dir = client_dir / user / 'file_mounts' / 'blobs' / blob_id
+    blob_dir.mkdir(parents=True)
+    (blob_dir / 'file').write_text(content)
+    return blob_dir
+
+
+def _patch_client_dir(monkeypatch, client_dir: pathlib.Path) -> None:
+    monkeypatch.setattr('sky.server.common.API_SERVER_CLIENT_DIR', client_dir)
+
+
+def _patch_active(monkeypatch, *, requests=None, jobs=None) -> None:
+    monkeypatch.setattr(
+        'sky.server.requests.requests.get_active_file_mounts_blob_ids',
+        lambda: set(requests or set()))
+    monkeypatch.setattr('sky.jobs.state.get_active_file_mounts_blob_ids',
+                        lambda: set(jobs or set()))
+
+
+def test_reset_on_startup_preserves_active_blobs(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+
+    active = _make_blob(client_dir, 'user1', 'active', content='keep')
+    stale = _make_blob(client_dir, 'user1', 'stale')
+    # A non-blob per-user staging dir that should be reclaimed.
+    logs = client_dir / 'user1' / 'sky_logs'
+    logs.mkdir(parents=True)
+    (logs / 'run.log').write_text('log')
+
+    # Referenced by a non-terminal managed job; requests table is empty (as it
+    # is at startup, after the request DB is reset).
+    _patch_active(monkeypatch, requests=set(), jobs={'active'})
+
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+
+    assert active.exists()
+    assert (active / 'file').read_text() == 'keep'
+    assert not stale.exists()
+    assert not logs.exists()
+    # The client dir itself is preserved.
+    assert client_dir.exists()
+
+
+def test_reset_on_startup_honors_request_refs(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+    req_blob = _make_blob(client_dir, 'user1', 'req')
+    _patch_active(monkeypatch, requests={'req'}, jobs=set())
+
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+
+    assert req_blob.exists()
+
+
+def test_reset_on_startup_wipes_when_none_active(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+    _make_blob(client_dir, 'user1', 'b1')
+    _patch_active(monkeypatch, requests=set(), jobs=set())
+
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+
+    assert not client_dir.exists()
+
+
+def test_reset_on_startup_preserves_all_on_query_error(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+    blob = _make_blob(client_dir, 'user1', 'b1')
+
+    def _boom():
+        raise RuntimeError('db down')
+
+    monkeypatch.setattr(
+        'sky.server.requests.requests.get_active_file_mounts_blob_ids', _boom)
+    monkeypatch.setattr('sky.jobs.state.get_active_file_mounts_blob_ids', _boom)
+
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+
+    # On query failure we err on the side of preserving blobs.
+    assert blob.exists()
+
+
+def test_reset_on_startup_noop_when_missing(tmp_path, monkeypatch):
+    client_dir = tmp_path / 'clients'
+    _patch_client_dir(monkeypatch, client_dir)
+    _patch_active(monkeypatch, requests=set(), jobs=set())
+    # Should not raise when the client dir does not exist.
+    local_blob_storage.LocalFilesystemBlobStorage().reset_on_startup()
+    assert not client_dir.exists()


### PR DESCRIPTION
## Problem

On startup the API server calls `reset_db_and_logs()`, which unconditionally `rmtree`s the entire client directory (`~/.sky/api_server/clients/`) via `LocalFilesystemBlobStorage.reset_on_startup()`. That directory holds the content-addressed **file-mounts blobs**.

A blob referenced by a **non-terminal managed job** must survive an API server restart: when the jobs controller recovers a job (e.g. after a restart, or HA failover landing the controller on a fresh host) it re-resolves the blob to stage the job's file mounts (`recovery_strategy.py` → `server.common.resolve_blob_dir`). If the restart wiped the blob, recovery fails with:

```
FileNotFoundError: Blob not found: ~/.sky/api_server/clients/<user>/file_mounts/blobs/<id>
```

The directory itself is persistent (it can live on a PVC), so the data survives the process restart — only the unconditional startup wipe removes it.

## How this regressed

The startup wipe predates file-mounts blobs — back when the client dir held only transient per-request upload state, wiping it on boot was harmless.

**#9444** is where it turned into a latent bug. That change made the jobs controller **re-resolve a blob on relaunch** to stage file mounts (the `resolve_blob_dir` call above), which makes a surviving blob a correctness requirement across an API server restart — and, in the same PR, taught the periodic GC (`cleanup_unreferenced_file_mounts`) to **ref-count blobs against non-terminal managed jobs** (`managed_job_state.get_active_file_mounts_blob_ids()`) so it never reclaims an in-use blob.

But that ref-count was added to **one** deletion path (the GC) and not **the other** (the startup reset). The GC correctly spares in-use blobs; `reset_on_startup` still deletes everything unconditionally. In steady state that's invisible — the GC keeps the blob alive and the controller re-resolves it fine. It only bites on an **API server restart**, where the startup wipe removes the blob out from under a referenced, in-flight job before the GC ref-count ever applies.

## Change

`reset_on_startup` now applies the **same ref-count the GC already uses** — `requests_lib.get_active_file_mounts_blob_ids() | managed_job_state.get_active_file_mounts_blob_ids()` — preserving referenced blob directories and removing everything else (unreferenced blobs, stale uploads, and per-user log/download staging). When nothing is referenced it keeps the cheap blanket wipe. If the reference query fails it errs on the side of preserving blobs (a leaked blob is later reclaimed by the GC; a wrongly-deleted one breaks recovery).

The request DB is reset earlier in the same `reset_db_and_logs` call, so in practice the request side of the union is empty at startup and managed jobs are what's preserved; the union is used anyway to stay identical to the GC and robust to ordering changes.

## Test plan

- New unit tests in `tests/unit_tests/test_local_blob_storage.py`:
  - referenced blob (by a non-terminal managed job) is preserved while an unreferenced blob and per-user `sky_logs/` staging are removed
  - a blob referenced by an active request is preserved
  - with nothing referenced, the whole client dir is wiped (unchanged behavior)
  - on a reference-query error, all blobs are preserved
  - no-op when the client dir doesn't exist
- `pytest tests/unit_tests/test_local_blob_storage.py` → 5 passed.
- `format.sh` clean (yapf/isort/mypy/pylint 10.00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)