### PR TITLE
[Dashboard] Jobs: click a user to filter in place instead of navigating

### DIFF
--- a/sky/dashboard/src/components/elements/UserDisplay.jsx
+++ b/sky/dashboard/src/components/elements/UserDisplay.jsx
@@ -21,6 +21,9 @@ const ServiceAccountBadge = () => (
  * @param {string} [props.className] - Additional CSS classes for the container
  * @param {string} [props.linkClassName] - Additional CSS classes for the link
  * @param {boolean} [props.showBadge=true] - Whether to show the SA badge for service accounts
+ * @param {Function} [props.onUserClick] - When provided, clicking the user name
+ *   calls this with (username, userHash) instead of navigating to the users
+ *   page. Used to turn the user into an in-page filter rather than a link.
  */
 export const UserDisplay = ({
   username,
@@ -28,15 +31,32 @@ export const UserDisplay = ({
   className = 'flex items-center gap-1',
   linkClassName = 'text-gray-700 hover:text-blue-600 hover:underline',
   showBadge = true,
+  onUserClick = null,
 }) => {
   const isServiceAcc = isServiceAccount(userHash);
   const userUrl = getUserLink(userHash);
 
   return (
     <div className={className}>
-      <Link href={userUrl} className={linkClassName}>
-        {username}
-      </Link>
+      {onUserClick ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            // Stop the click from bubbling to row-level handlers (e.g. row
+            // expand) since this is an in-cell filter action.
+            e.stopPropagation();
+            onUserClick(username, userHash);
+          }}
+          className={linkClassName}
+          title={`Filter by ${username}`}
+        >
+          {username}
+        </button>
+      ) : (
+        <Link href={userUrl} className={linkClassName}>
+          {username}
+        </Link>
+      )}
       {showBadge && isServiceAcc && <ServiceAccountBadge />}
     </div>
   );
@@ -48,6 +68,7 @@ UserDisplay.propTypes = {
   className: PropTypes.string,
   linkClassName: PropTypes.string,
   showBadge: PropTypes.bool,
+  onUserClick: PropTypes.func,
 };
 
 export default UserDisplay;

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -364,6 +364,28 @@ export function ManagedJobs() {
     trackFilterUsed('job', { property, value });
   };
 
+  // Clicking a user in the table adds (or replaces) a "User" filter rather
+  // than navigating to the users page. Replace-not-stack is intentional:
+  // two AND'd user filters would yield zero results.
+  const handleUserFilterClick = React.useCallback(
+    (username) => {
+      if (!username) return;
+      setFilters((prevFilters) => {
+        const withoutUser = prevFilters.filter(
+          (f) => (f.property || '').toLowerCase() !== 'user'
+        );
+        const updatedFilters = [
+          ...withoutUser,
+          { property: 'User', operator: ':', value: username },
+        ];
+        sharedUpdateURLParams(router, updatedFilters);
+        return updatedFilters;
+      });
+      trackFilterUsed('job', { property: 'User', value: username });
+    },
+    [router]
+  );
+
   const updateFiltersByURLParams = React.useCallback(() => {
     const propertyMap = new Map();
     propertyMap.set('', '');
@@ -427,6 +449,7 @@ export function ManagedJobs() {
         setLoading={setLoading}
         refreshDataRef={jobsRefreshRef}
         filters={filters}
+        onUserFilter={handleUserFilterClick}
         onRefresh={handleRefresh}
         poolsData={poolsData}
         poolsLoading={poolsLoading}
@@ -475,6 +498,7 @@ export function ManagedJobsTable({
   setLoading,
   refreshDataRef,
   filters,
+  onUserFilter,
   onRefresh,
   poolsData,
   poolsLoading,
@@ -1532,7 +1556,11 @@ export function ManagedJobsTable({
         ),
         renderCell: (item) => (
           <TableCell>
-            <UserDisplay username={item.user} userHash={item.user_hash} />
+            <UserDisplay
+              username={item.user}
+              userHash={item.user_hash}
+              onUserClick={onUserFilter}
+            />
           </TableCell>
         ),
       },
@@ -1886,6 +1914,7 @@ export function ManagedJobsTable({
       expandedRowId,
       poolsLoading,
       poolsData,
+      onUserFilter,
     ]
   );
 


### PR DESCRIPTION
## Summary
- On the Managed Jobs page, clicking a user name navigated to `/users`, which incidentally surfaced other users' jobs. Apply an in-page User filter on click and stay on `/jobs`.
- The existing User filter is replaced rather than stacked (two AND'd user filters would yield zero results).
- `UserDisplay` gains an optional `onUserClick` prop; with no prop the existing `/users` link is preserved, so other call sites (Clusters page, cluster-detail jobs view) are unchanged.

## Test plan
- [x] Click a user on `/jobs` stays on `/jobs` (no navigation to `/users`)
- [x] User chip appears + URL updates to `?property=user&operator=:&value=<name>`
- [x] Clicking a different user replaces (single user chip enforced)
- [x] `npm run build` passes; `prettier --check` passes