### PR TITLE
Add GitOps read-only dashboard config mode

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -256,6 +256,9 @@ Below is the configuration syntax and some example values. See detailed explanat
   :ref:`rbac <config-yaml-rbac>`:
     :ref:`default_role <config-yaml-rbac-default-role>`: admin
 
+  :ref:`dashboard <config-yaml-dashboard>`:
+    :ref:`disable_config_editor <config-yaml-dashboard-disable-config-editor>`: false
+
   :ref:`db <config-yaml-db>`: postgresql://postgres@localhost/skypilot
 
   :ref:`logs <config-yaml-logs>`:
@@ -2730,6 +2733,34 @@ If not specified, the default role is ``admin``.
 .. TODO(aylei): Refine this after unified authentication.
 
 Note: RBAC is only functional when :ref:`OAuth <api-server-oauth>` is configured.
+
+.. _config-yaml-dashboard:
+
+``dashboard``
+~~~~~~~~~~~~~
+
+SkyPilot dashboard configuration (optional).
+
+.. _config-yaml-dashboard-disable-config-editor:
+
+``dashboard.disable_config_editor``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set to ``true`` to keep the dashboard available while disabling config edits
+from ``/dashboard/config``. This is useful for API server deployments where
+``~/.sky/config.yaml`` is managed outside the dashboard, for example with Helm,
+Terraform, Nix, or GitOps.
+
+When enabled, the dashboard renders the config editor read-only, and
+``POST /workspaces/config`` returns ``403 Forbidden`` without scheduling a
+config update.
+
+Example:
+
+.. code-block:: yaml
+
+  dashboard:
+    disable_config_editor: true
 
 .. _config-yaml-db:
 

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getConfig, updateConfig } from '@/data/connectors/workspaces';
@@ -25,7 +25,40 @@ export function Config() {
   const [error, setError] = useState(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
+  const [configEditorDisabled, setConfigEditorDisabled] = useState(false);
   const successTimeoutRef = useRef(null);
+
+  const loadDashboardConfig = useCallback(async () => {
+    const response = await apiClient.get('/dashboard_config');
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load dashboard settings: ${response.statusText}`
+      );
+    }
+    return await response.json();
+  }, []);
+
+  const loadConfig = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [config, dashboardConfig] = await Promise.all([
+        getConfig(),
+        loadDashboardConfig(),
+      ]);
+      setConfigEditorDisabled(Boolean(dashboardConfig?.disable_config_editor));
+      if (Object.keys(config).length === 0) {
+        setEditableConfig('');
+      } else {
+        setEditableConfig(yaml.dump(config, { indent: 2 }));
+      }
+    } catch (error) {
+      console.error('Error loading config:', error);
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadDashboardConfig]);
 
   useEffect(() => {
     loadConfig();
@@ -39,7 +72,7 @@ export function Config() {
     if (typeof window !== 'undefined') {
       checkGrafana();
     }
-  }, []);
+  }, [loadConfig]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -49,24 +82,6 @@ export function Config() {
       }
     };
   }, []);
-
-  const loadConfig = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const config = await getConfig();
-      if (Object.keys(config).length === 0) {
-        setEditableConfig('');
-      } else {
-        setEditableConfig(yaml.dump(config, { indent: 2 }));
-      }
-    } catch (error) {
-      console.error('Error loading config:', error);
-      setError(error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleSave = async () => {
     trackSettingsAction('save');
@@ -79,6 +94,14 @@ export function Config() {
     }
 
     try {
+      if (configEditorDisabled) {
+        setError(
+          new Error('Configuration editing is disabled for this deployment.')
+        );
+        setSaving(false);
+        return;
+      }
+
       // Check user role first
       const response = await apiClient.get(`/users/role`);
       if (!response.ok) {
@@ -292,20 +315,29 @@ export function Config() {
             </div>
           )}
 
+          {configEditorDisabled && (
+            <div className="bg-blue-50 border border-blue-200 rounded p-4 mb-6">
+              <p className="text-sm font-medium text-blue-900">
+                This deployment is GitOps-managed. Configuration changes are
+                disabled in the dashboard.
+              </p>
+            </div>
+          )}
+
           <div className="w-full">
             <YamlEditor
               value={editableConfig}
               onChange={(val) => setEditableConfig(val)}
               minHeight="384px"
               maxHeight="600px"
-              disabled={loading || saving}
+              disabled={loading || saving || configEditorDisabled}
             />
           </div>
 
           <div className="flex justify-end space-x-3 pt-3">
             <Button
               onClick={handleSave}
-              disabled={loading || saving}
+              disabled={loading || saving || configEditorDisabled}
               className="inline-flex items-center bg-sky-600 hover:bg-sky-700 text-white"
             >
               {saving ? (

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getConfig, updateConfig } from '@/data/connectors/workspaces';
+import { getDashboardConfig } from '@/data/connectors/dashboard_config';
 import { ErrorDisplay } from '@/components/elements/ErrorDisplay';
 import { CircularProgress } from '@mui/material';
 import { SaveIcon } from 'lucide-react';
@@ -28,23 +29,13 @@ export function Config() {
   const [configEditorDisabled, setConfigEditorDisabled] = useState(false);
   const successTimeoutRef = useRef(null);
 
-  const loadDashboardConfig = useCallback(async () => {
-    const response = await apiClient.get('/dashboard_config');
-    if (!response.ok) {
-      throw new Error(
-        `Failed to load dashboard settings: ${response.statusText}`
-      );
-    }
-    return await response.json();
-  }, []);
-
   const loadConfig = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const [config, dashboardConfig] = await Promise.all([
         getConfig(),
-        loadDashboardConfig(),
+        getDashboardConfig(),
       ]);
       setConfigEditorDisabled(Boolean(dashboardConfig?.disable_config_editor));
       if (Object.keys(config).length === 0) {
@@ -58,7 +49,7 @@ export function Config() {
     } finally {
       setLoading(false);
     }
-  }, [loadDashboardConfig]);
+  }, []);
 
   useEffect(() => {
     loadConfig();

--- a/sky/dashboard/src/data/connectors/dashboard_config.jsx
+++ b/sky/dashboard/src/data/connectors/dashboard_config.jsx
@@ -8,14 +8,17 @@ import { apiClient } from '@/data/connectors/client';
 let dashboardConfigCache = null;
 let dashboardConfigPromise = null;
 
-const EMPTY_CONFIG = { externalLinks: [] };
+const EMPTY_CONFIG = {
+  externalLinks: [],
+  disable_config_editor: false,
+};
 
 /**
  * Fetch the admin-configured dashboard settings from the server.
  *
- * Returns an object of the shape { externalLinks: [{ label, regex }] }. On
- * network or parse failure, returns an empty config rather than throwing so
- * the dashboard stays usable when the endpoint is unavailable.
+ * Returns dashboard settings normalized for the UI. On network or parse
+ * failure, returns an empty config rather than throwing so the dashboard stays
+ * usable when the endpoint is unavailable.
  */
 export const getDashboardConfig = async () => {
   if (dashboardConfigCache !== null) {
@@ -46,7 +49,10 @@ export const getDashboardConfig = async () => {
             entry.regex.length > 0
         )
         .map((entry) => ({ label: entry.label, regex: entry.regex }));
-      dashboardConfigCache = { externalLinks };
+      dashboardConfigCache = {
+        externalLinks,
+        disable_config_editor: Boolean(data?.disable_config_editor),
+      };
       return dashboardConfigCache;
     } catch (error) {
       console.debug('Dashboard config fetch failed:', error);

--- a/sky/dashboard/src/data/connectors/dashboard_config.test.jsx
+++ b/sky/dashboard/src/data/connectors/dashboard_config.test.jsx
@@ -1,0 +1,47 @@
+import {
+  getDashboardConfig,
+  resetDashboardConfigCache,
+} from '@/data/connectors/dashboard_config';
+import { apiClient } from '@/data/connectors/client';
+
+jest.mock('@/data/connectors/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('getDashboardConfig', () => {
+  beforeEach(() => {
+    resetDashboardConfigCache();
+    jest.clearAllMocks();
+  });
+
+  it('normalizes external links and read-only config flag', async () => {
+    apiClient.get.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        disable_config_editor: true,
+        external_links: [
+          { label: 'Run', regex: 'https://example.com/runs/.*' },
+          { label: '', regex: 'https://bad.example.com/.*' },
+        ],
+      }),
+    });
+
+    await expect(getDashboardConfig()).resolves.toEqual({
+      disable_config_editor: true,
+      externalLinks: [{ label: 'Run', regex: 'https://example.com/runs/.*' }],
+    });
+  });
+
+  it('falls back when dashboard config fetch fails', async () => {
+    apiClient.get.mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(getDashboardConfig()).resolves.toEqual({
+      disable_config_editor: false,
+      externalLinks: [],
+    });
+  });
+});

--- a/sky/dashboard/src/data/connectors/workspaces.jsx
+++ b/sky/dashboard/src/data/connectors/workspaces.jsx
@@ -727,8 +727,17 @@ export async function updateConfig(config) {
     });
 
     if (!scheduleResponse.ok) {
+      let errorDetail = scheduleResponse.statusText;
+      try {
+        const errorData = await scheduleResponse.json();
+        if (errorData && errorData.detail) {
+          errorDetail = errorData.detail;
+        }
+      } catch (e) {
+        /* Use statusText when the response body is not JSON. */
+      }
       throw new Error(
-        `Error scheduling updateConfig: ${scheduleResponse.statusText} (status ${scheduleResponse.status})`
+        `Error scheduling updateConfig: ${errorDetail} (status ${scheduleResponse.status})`
       );
     }
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2610,12 +2610,14 @@ async def api_status(
 async def dashboard_config() -> Dict[str, Any]:
     """Returns admin-configured dashboard settings consumed by the UI.
 
-    Currently exposes the optional `external_links` allowlist that the dashboard
-    matches against streamed logs to render labeled external links on cluster
-    and job detail pages.
+    Exposes the optional `external_links` allowlist that the dashboard matches
+    against streamed logs to render labeled external links, as well as
+    dashboard feature flags used by admin-managed deployments.
     """
     external_links = skypilot_config.get_nested(('dashboard', 'external_links'),
                                                 [])
+    disable_config_editor = skypilot_config.get_nested(
+        ('dashboard', 'disable_config_editor'), False)
     sanitized: List[Dict[str, str]] = []
     if isinstance(external_links, list):
         for entry in external_links:
@@ -2625,7 +2627,10 @@ async def dashboard_config() -> Dict[str, Any]:
             regex = entry.get('regex')
             if isinstance(label, str) and isinstance(regex, str):
                 sanitized.append({'label': label, 'regex': regex})
-    return {'external_links': sanitized}
+    return {
+        'disable_config_editor': bool(disable_config_editor),
+        'external_links': sanitized,
+    }
 
 
 @app.get('/api/plugins')

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2668,6 +2668,10 @@ def get_config_schema():
         'required': [],
         'additionalProperties': False,
         'properties': {
+            'disable_config_editor': {
+                'type': 'boolean',
+                'default': False,
+            },
             'external_links': {
                 'type': 'array',
                 'items': {

--- a/sky/workspaces/server.py
+++ b/sky/workspaces/server.py
@@ -2,6 +2,7 @@
 
 import fastapi
 
+from sky import skypilot_config
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import request_names
@@ -113,6 +114,14 @@ async def get_config(request: fastapi.Request) -> None:
 async def update_config(request: fastapi.Request,
                         update_config_body: payloads.UpdateConfigBody) -> None:
     """Updates the entire SkyPilot configuration."""
+    if skypilot_config.get_nested(('dashboard', 'disable_config_editor'),
+                                  False):
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail=('SkyPilot API server config editing is disabled '
+                    'for this deployment.'),
+        )
+
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.WORKSPACES_UPDATE_CONFIG,

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -856,11 +856,17 @@ def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
 
     from sky import skypilot_config
 
-    monkeypatch.setattr(
-        skypilot_config, 'get_nested', lambda keys, default: [{
-            'label': 'Grafana',
-            'regex': 'https://grafana.example.com/.*'
-        }])
+    def fake_get_nested(keys, default):
+        if keys == ('dashboard', 'external_links'):
+            return [{
+                'label': 'Grafana',
+                'regex': 'https://grafana.example.com/.*'
+            }]
+        if keys == ('dashboard', 'disable_config_editor'):
+            return True
+        return default
+
+    monkeypatch.setattr(skypilot_config, 'get_nested', fake_get_nested)
 
     client = TestClient(server.app)
     response = client.get('/dashboard_config')
@@ -868,6 +874,7 @@ def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
     assert response.status_code == 200
     data = response.json()
     assert data == {
+        'disable_config_editor': True,
         'external_links': [{
             'label': 'Grafana',
             'regex': 'https://grafana.example.com/.*'

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -1274,6 +1274,15 @@ class TestDashboardSchema(unittest.TestCase):
         config = {'dashboard': {}}
         jsonschema.validate(instance=config, schema=self._get_schema())
 
+    def test_accepts_disable_config_editor(self):
+        config = {'dashboard': {'disable_config_editor': True}}
+        jsonschema.validate(instance=config, schema=self._get_schema())
+
+    def test_rejects_non_boolean_disable_config_editor(self):
+        config = {'dashboard': {'disable_config_editor': 'true'}}
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=config, schema=self._get_schema())
+
     def test_rejects_missing_label(self):
         config = {
             'dashboard': {

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_server.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_server.py
@@ -1,0 +1,51 @@
+"""Unit tests for workspace REST handlers."""
+
+import types
+from unittest import mock
+
+import pytest
+
+from sky.server.requests import payloads
+from sky.workspaces import server as workspaces_server
+
+
+@pytest.mark.asyncio
+async def test_update_config_rejects_when_dashboard_config_editor_disabled(
+        monkeypatch):
+    monkeypatch.setattr(
+        workspaces_server.skypilot_config, 'get_nested',
+        lambda keys, default: True
+        if keys == ('dashboard', 'disable_config_editor') else default)
+    schedule_mock = mock.AsyncMock()
+    monkeypatch.setattr(workspaces_server.executor, 'schedule_request_async',
+                        schedule_mock)
+    request = types.SimpleNamespace(
+        state=types.SimpleNamespace(request_id='req-123', auth_user=None))
+    body = payloads.UpdateConfigBody(config={'workspaces': {'default': {}}})
+
+    with pytest.raises(workspaces_server.fastapi.HTTPException) as exc_info:
+        await workspaces_server.update_config(request, body)
+
+    assert exc_info.value.status_code == 403
+    assert 'config editing is disabled' in exc_info.value.detail
+    schedule_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_config_schedules_when_dashboard_config_editor_enabled(
+        monkeypatch):
+    monkeypatch.setattr(
+        workspaces_server.skypilot_config, 'get_nested',
+        lambda keys, default: False
+        if keys == ('dashboard', 'disable_config_editor') else default)
+    schedule_mock = mock.AsyncMock()
+    monkeypatch.setattr(workspaces_server.executor, 'schedule_request_async',
+                        schedule_mock)
+    request = types.SimpleNamespace(
+        state=types.SimpleNamespace(request_id='req-123', auth_user='user'))
+    body = payloads.UpdateConfigBody(config={'workspaces': {'default': {}}})
+
+    response = await workspaces_server.update_config(request, body)
+
+    assert response is None
+    schedule_mock.assert_awaited_once()


### PR DESCRIPTION
Fixes #9188.

## Summary
- add `dashboard.disable_config_editor` to config validation and docs
- expose the flag through `/dashboard_config` and reject dashboard config writes with 403 when enabled
- render the dashboard config editor read-only and surface server error details on failed config updates

## Tested
- `uvx --python 3.11 --from yapf==0.32.0 --with toml yapf --in-place sky/workspaces/server.py sky/server/server.py sky/utils/schemas.py tests/unit_tests/test_sky/workspaces/test_workspace_server.py tests/unit_tests/test_sky/server/test_server.py tests/unit_tests/test_sky/utils/test_schemas.py`
- `git diff --check`
- `python3 -m py_compile sky/workspaces/server.py sky/server/server.py sky/utils/schemas.py tests/unit_tests/test_sky/workspaces/test_workspace_server.py tests/unit_tests/test_sky/server/test_server.py tests/unit_tests/test_sky/utils/test_schemas.py`
- `uv run --python 3.11 --with-editable . --with-requirements requirements-dev.txt python -m pytest tests/unit_tests/test_sky/workspaces/test_workspace_server.py tests/unit_tests/test_sky/server/test_server.py::test_dashboard_config_endpoint_serializes_external_links tests/unit_tests/test_sky/utils/test_schemas.py::TestDashboardSchema -q`
- `git diff --check` after dashboard config fallback update
- GitHub Actions `dashboard` check passed on commit `3246bf739`