### PR TITLE
[WIP][Kubernetes] Enable `sky stop` on K8s via allow_unmanaged_cluster_destructive_stop

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2373,6 +2373,37 @@ def _query_cluster_status_via_cloud_api(
     return node_status_dict
 
 
+def _kubernetes_pod_loss_reason(
+    handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',) -> Optional[str]:
+    """Best-effort reason why a Kubernetes cluster's pods disappeared.
+
+    Returns a human-readable reason derived from the pods'/nodes' Kubernetes
+    events (e.g. an eviction or node-loss message), or None if no specific
+    cause can be recovered -- common once the pod object is fully gone, e.g. a
+    container OOMKill, whose signal is lost with the pod. As a side effect, the
+    underlying query records the pods'/nodes' Kubernetes events as cluster
+    events, surfacing them on the dashboard's cluster events page.
+    """
+    try:
+        ray_config = global_user_state.get_cluster_yaml_dict(
+            handle.cluster_yaml)
+        node_status_dict = provision_lib.query_instances(
+            repr(handle.launched_resources.cloud),
+            handle.cluster_name,
+            handle.cluster_name_on_cloud,
+            ray_config['provider'],
+            non_terminated_only=False)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to query pod-loss reason for '
+                     f'{handle.cluster_name!r}: {e}')
+        return None
+    reasons = sorted(
+        {reason for _, reason in node_status_dict.values() if reason})
+    if not reasons:
+        return None
+    return '; '.join(reasons)
+
+
 def _query_cluster_info_via_cloud_api(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle'
 ) -> provision_common.ClusterInfo:
@@ -3116,6 +3147,56 @@ def _update_cluster_status(
             cluster_name,
             include_user_info=include_user_info,
             summary_response=summary_response)
+
+    # Kubernetes clusters delete their pods on stop, so a cloud query returns
+    # no nodes. Unlike VM clouds -- which still report a STOPPED instance --
+    # an empty result is ambiguous between "stopped" and "terminated". When
+    # destructive stops are enabled for the cluster
+    # (`kubernetes.allow_unmanaged_cluster_destructive_stop`), treat a pod-less
+    # cluster as STOPPED rather than tearing it down, so the retained
+    # PersistentVolumes survive and the cluster can be restarted with
+    # `sky start`. This covers
+    # both clusters we explicitly stopped and clusters whose pods vanished
+    # unexpectedly (e.g. OOM with restartPolicy=Never, eviction, node loss).
+    # The entire behavior is gated behind the feature flag.
+    if to_terminate and isinstance(launched_resources.cloud, clouds.Kubernetes):
+        allow_unmanaged_cluster_destructive_stop = (
+            skypilot_config.get_effective_region_config(
+                cloud='kubernetes',
+                region=handle.launched_resources.region,
+                keys=('allow_unmanaged_cluster_destructive_stop',),
+                default_value=False))
+        if allow_unmanaged_cluster_destructive_stop:
+            if record['status'] != status_lib.ClusterStatus.STOPPED:
+                # Pods vanished while the cluster was running. Record the
+                # transition for visibility (surfaced on the dashboard's
+                # cluster events page) and stop the cluster instead of
+                # terminating it. Include the detected cause when available
+                # (e.g. an eviction/node-loss reason); a container OOMKill
+                # often leaves no recoverable signal once the pod is gone.
+                pod_loss_reason = _kubernetes_pod_loss_reason(handle)
+                cause = (pod_loss_reason
+                         if pod_loss_reason else 'e.g. OOM, eviction, or '
+                         'node loss')
+                global_user_state.add_cluster_event(
+                    cluster_name,
+                    status_lib.ClusterStatus.STOPPED,
+                    f'Kubernetes pods are no longer present ({cause}). '
+                    'Stopping the cluster instead of terminating it; '
+                    'persistent volumes are retained so it can be restarted '
+                    'with `sky start`.',
+                    global_user_state.ClusterEventType.STATUS_CHANGE,
+                    nop_if_duplicate=True)
+                backend = backends.CloudVmRayBackend()
+                backend.post_teardown_cleanup(handle,
+                                              terminate=False,
+                                              purge=False)
+            # Already STOPPED: leave the record (and its retained PVCs /
+            # generated YAML) intact.
+            return global_user_state.get_cluster_from_name(
+                cluster_name,
+                include_user_info=include_user_info,
+                summary_response=summary_response)
 
     verb = 'terminated' if to_terminate else 'stopped'
     backend = backends.CloudVmRayBackend()

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -261,10 +261,26 @@ class Kubernetes(clouds.Cloud):
         else:
             contexts = [context]
         unsupported_features[clouds.CloudImplementationFeatures.STOP] = (
-            'Stopping clusters is not supported on Kubernetes.')
+            'Stopping clusters is not supported on Kubernetes. To enable it, '
+            'set `kubernetes.allow_unmanaged_cluster_destructive_stop: true` '
+            'in your SkyPilot '
+            'config. Note: stopping deletes the pod, so any state not on a '
+            'persistent volume is lost.')
         unsupported_features[clouds.CloudImplementationFeatures.AUTOSTOP] = (
             'Auto-stop is not supported on Kubernetes.')
         for context in contexts:
+            # Allow `sky stop` if the destructive-stop flag is enabled for the
+            # context. The pod is deleted on stop; only PersistentVolume-backed
+            # state survives and is reattached on restart.
+            allow_unmanaged_cluster_destructive_stop = (
+                skypilot_config.get_effective_region_config(
+                    cloud=cls._REPR.lower(),
+                    region=context,
+                    keys=('allow_unmanaged_cluster_destructive_stop',),
+                    default_value=False))
+            if allow_unmanaged_cluster_destructive_stop:
+                unsupported_features.pop(
+                    clouds.CloudImplementationFeatures.STOP, None)
             # Allow spot instances if supported by the cluster
             try:
                 # Run spot label check and network type detection concurrently

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1718,7 +1718,49 @@ def stop_instances(
     provider_config: Optional[Dict[str, Any]] = None,
     worker_only: bool = False,
 ) -> None:
-    raise NotImplementedError()
+    """Stop a Kubernetes cluster by deleting its pods and services.
+
+    Unlike `terminate_instances`, this retains the cluster's
+    PersistentVolumeClaim(s): only the pods (and their services) are deleted,
+    so any state on a persistent volume survives and is reattached when the
+    cluster is restarted with `sky start`.
+
+    Note: a pod's ephemeral (non-PV) filesystem is lost on stop. Enabled only
+    when `kubernetes.allow_unmanaged_cluster_destructive_stop` is set in the
+    SkyPilot config
+    (gated in `Kubernetes._unsupported_features_for_resources`).
+    """
+    assert provider_config is not None, cluster_name_on_cloud
+    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    context = kubernetes_utils.get_context_from_config(provider_config)
+
+    # High-availability clusters are backed by a Deployment that would
+    # immediately recreate any deleted pod, so stopping is not meaningful here.
+    if is_high_availability_cluster_by_kubectl(cluster_name_on_cloud, context,
+                                               namespace):
+        raise NotImplementedError(
+            'Stopping high-availability Kubernetes clusters is not supported.')
+
+    pods = kubernetes_utils.filter_pods(namespace, context,
+                                        ray_tag_filter(cluster_name_on_cloud),
+                                        None)
+
+    def _stop_pod_thread(pod_info):
+        pod_name, pod = pod_info
+        if _is_head(pod) and worker_only:
+            return
+        # `_terminate_node` deletes the pod and its services but never deletes
+        # PersistentVolumeClaims, which is exactly the stop semantics we want.
+        logger.debug(f'stop_instances: deleting pod {pod_name}')
+        _terminate_node(namespace, context, pod_name, _is_head(pod))
+
+    subprocess_utils.run_in_parallel(_stop_pod_thread, list(pods.items()),
+                                     _NUM_THREADS)
+
+    if not worker_only:
+        # Fallback service cleanup by label selector, in case pods were
+        # already gone. PVCs are intentionally left intact.
+        _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
 def _delete_services(name_prefix: str,
@@ -2869,6 +2911,16 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
             _record_failure_reason('pod was evicted by taint manager', 2)
         elif event.startswith('DeletingNode '):
             _record_failure_reason(event[len('DeletingNode '):], 3)
+        elif event.startswith('Evicted '):
+            # Pod evicted under node resource pressure (e.g. memory). Unlike a
+            # container cgroup OOMKill, this Event survives the pod, so it is
+            # recoverable here. Keep the full message (it names the resource).
+            _record_failure_reason(event, 4)
+        elif event.startswith(('SystemOOM ', 'OOMKilling ')):
+            # Node-level (kernel) OOM killer fired. Emitted as a Node event
+            # that outlives the pod, so it is recoverable even after the pod
+            # is gone -- the most decisive cause when present.
+            _record_failure_reason(event, 5)
     return failure_reason
 
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1582,6 +1582,12 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             type.value for type in kubernetes_enums.KubernetesAutoscalerType
         ],
     },
+    # Allow `sky stop` on Kubernetes. This is "destructive": stopping deletes
+    # the pod, so any state not on a PersistentVolume is lost. Restart
+    # recreates the pod and reattaches the cluster's PVC(s).
+    'allow_unmanaged_cluster_destructive_stop': {
+        'type': 'boolean',
+    },
     'high_availability': {
         'type': 'object',
         'required': [],

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3262,3 +3262,106 @@ class TestConfigureRuntimeClass:
                                           nvidia_runtime_exists=True,
                                           needs_gpus_nvidia=False)
         assert pod_spec['spec']['runtimeClassName'] == 'sysbox-runc'
+
+
+def _make_event(reason, message):
+    """Build a fake Kubernetes event with a real timestamp."""
+    import datetime
+    event = mock.MagicMock()
+    event.reason = reason
+    event.message = message
+    event.metadata.creation_timestamp = datetime.datetime(2024, 1, 1, 0, 0, 0)
+    return event
+
+
+def test_stop_instances_deletes_pods_but_keeps_pvc(monkeypatch):
+    """`sky stop` on Kubernetes must delete pods/services but never PVCs."""
+    core_api_mock = mock.MagicMock()
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *a, **k: core_api_mock)
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils.get_namespace_from_config',
+        lambda *a, **k: 'default')
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils.get_context_from_config',
+        lambda *a, **k: 'test-context')
+    monkeypatch.setattr(instance, 'is_high_availability_cluster_by_kubectl',
+                        lambda *a, **k: False)
+    head_pod = mock.MagicMock()
+    head_pod.metadata.name = 'test-cluster-head'
+    monkeypatch.setattr('sky.provision.kubernetes.utils.filter_pods',
+                        lambda *a, **k: {'test-cluster-head': head_pod})
+    monkeypatch.setattr(instance, '_is_head', lambda pod: True)
+    monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                        lambda fn, items, n: [fn(i) for i in items])
+
+    instance.stop_instances('test-cluster-on-cloud',
+                            provider_config={'namespace': 'default'})
+
+    # Pods are deleted ...
+    assert core_api_mock.delete_namespaced_pod.called
+    # ... but the PersistentVolumeClaim is retained for restart.
+    assert not core_api_mock.delete_namespaced_persistent_volume_claim.called
+
+
+def test_stop_instances_high_availability_raises(monkeypatch):
+    """Stopping an HA (Deployment-backed) cluster is not supported."""
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils.get_namespace_from_config',
+        lambda *a, **k: 'default')
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils.get_context_from_config',
+        lambda *a, **k: 'test-context')
+    monkeypatch.setattr(instance, 'is_high_availability_cluster_by_kubectl',
+                        lambda *a, **k: True)
+    with pytest.raises(NotImplementedError):
+        instance.stop_instances('test-cluster-on-cloud',
+                                provider_config={'namespace': 'default'})
+
+
+def test_pod_missing_reason_classifies_evicted(monkeypatch):
+    """A pod `Evicted` event (survives the pod) is surfaced as the cause."""
+    from sky import global_user_state
+    evicted = _make_event('Evicted', 'The node was low on resource: memory.')
+    monkeypatch.setattr(instance, '_get_pod_events', lambda *a, **k: [evicted])
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *a, **k: mock.MagicMock())
+    monkeypatch.setattr(global_user_state, 'add_cluster_event',
+                        lambda *a, **k: None)
+    monkeypatch.setattr(
+        global_user_state, 'get_cluster_events', lambda *a, **k: [
+            '[kubernetes pod test-pod] Evicted The node was low on resource: '
+            'memory.'
+        ])
+
+    reason = instance._get_pod_missing_reason('ctx', 'ns', 'test-cluster',
+                                              'test-pod', True)
+    assert reason is not None
+    assert 'Evicted' in reason
+
+
+def test_pod_missing_reason_classifies_system_oom(monkeypatch):
+    """A node `SystemOOM` event (kernel OOM, survives the pod) is surfaced."""
+    from sky import global_user_state
+    scheduled = _make_event('Scheduled',
+                            'Successfully assigned ns/test-pod to node-1')
+    monkeypatch.setattr(instance, '_get_pod_events',
+                        lambda *a, **k: [scheduled])
+    system_oom = _make_event('SystemOOM',
+                             'System OOM encountered, victim process: python')
+    core_api_mock = mock.MagicMock()
+    core_api_mock.list_namespaced_event.return_value.items = [system_oom]
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *a, **k: core_api_mock)
+    monkeypatch.setattr(global_user_state, 'add_cluster_event',
+                        lambda *a, **k: None)
+    monkeypatch.setattr(
+        global_user_state, 'get_cluster_events', lambda *a, **k: [
+            '[kubernetes node node-1] SystemOOM System OOM encountered, '
+            'victim process: python'
+        ])
+
+    reason = instance._get_pod_missing_reason('ctx', 'ns', 'test-cluster',
+                                              'test-pod', True)
+    assert reason is not None
+    assert 'SystemOOM' in reason

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -163,3 +163,93 @@ class TestUpdateClusterStatusInitReason:
         msg = _capture_init_log_message(
             {'pod-0': (status_lib.ClusterStatus.UP, None)}, launched_nodes=2)
         assert 'one or more nodes terminated' in msg, msg
+
+
+def _run_update_status_pod_loss(record_status,
+                                flag_enabled,
+                                pod_loss_reason='SystemOOM victim: python'):
+    """Drive _update_cluster_status for a Kubernetes cluster whose pods are
+    gone (empty node_statuses). Returns (events, post_teardown_mock).
+
+    events is a list of (new_status, message) captured from add_cluster_event;
+    post_teardown_mock is the mocked CloudVmRayBackend.post_teardown_cleanup.
+    """
+    handle = _make_handle()
+    record = _make_record(handle, status=record_status)
+    events = []
+
+    def _capture_event(cluster_name, new_status, message, event_type, **kwargs):
+        events.append((new_status, message))
+
+    external_failure = mock.Mock()
+    external_failure.get.return_value = None
+
+    with mock.patch.object(backend_utils,
+                           '_query_cluster_status_via_cloud_api',
+                           return_value={}), \
+         mock.patch.object(backend_utils, 'ExternalFailureSource',
+                           external_failure), \
+         mock.patch.object(backend_utils.skypilot_config,
+                           'get_effective_region_config',
+                           return_value=flag_enabled), \
+         mock.patch.object(backend_utils, '_kubernetes_pod_loss_reason',
+                           return_value=pod_loss_reason), \
+         mock.patch.object(backend_utils.backends,
+                           'CloudVmRayBackend') as mock_backend_cls, \
+         mock.patch.object(backend_utils.global_user_state, 'add_cluster_event',
+                           side_effect=_capture_event), \
+         mock.patch.object(backend_utils.global_user_state,
+                           'add_or_update_cluster'), \
+         mock.patch.object(backend_utils.global_user_state,
+                           'get_cluster_from_name',
+                           return_value=record):
+        backend_utils._update_cluster_status('test-cluster',
+                                             record,
+                                             retry_if_missing=False)
+    return events, mock_backend_cls.return_value.post_teardown_cleanup
+
+
+class TestKubernetesDestructiveStop:
+    """`kubernetes.allow_unmanaged_cluster_destructive_stop` behavior when a
+    cluster's pods disappear (e.g. OOM / eviction / node loss)."""
+
+    def test_pod_loss_stops_cluster_when_flag_enabled(self):
+        # Flag on + pods gone => STOP (terminate=False), keep the record/PVC.
+        events, post_teardown = _run_update_status_pod_loss(
+            status_lib.ClusterStatus.UP, flag_enabled=True)
+        post_teardown.assert_called_once()
+        assert post_teardown.call_args.kwargs.get('terminate') is False
+        stopped_msgs = [
+            m for s, m in events if s == status_lib.ClusterStatus.STOPPED
+        ]
+        assert stopped_msgs, events
+        # The detected cause is surfaced in the event.
+        assert 'SystemOOM' in stopped_msgs[0]
+
+    def test_pod_loss_terminates_when_flag_disabled(self):
+        # Flag off => existing behavior: terminate (terminate=True).
+        _, post_teardown = _run_update_status_pod_loss(
+            status_lib.ClusterStatus.UP, flag_enabled=False)
+        post_teardown.assert_called_once()
+        assert post_teardown.call_args.kwargs.get('terminate') is True
+
+    def test_already_stopped_cluster_is_preserved(self):
+        # An already-STOPPED cluster with no pods stays STOPPED without
+        # re-running teardown.
+        _, post_teardown = _run_update_status_pod_loss(
+            status_lib.ClusterStatus.STOPPED, flag_enabled=True)
+        post_teardown.assert_not_called()
+
+    def test_generic_cause_when_no_reason_detected(self):
+        # Container cgroup OOMKill leaves no recoverable signal; fall back to
+        # the generic cause.
+        events, post_teardown = _run_update_status_pod_loss(
+            status_lib.ClusterStatus.UP,
+            flag_enabled=True,
+            pod_loss_reason=None)
+        post_teardown.assert_called_once()
+        stopped_msgs = [
+            m for s, m in events if s == status_lib.ClusterStatus.STOPPED
+        ]
+        assert stopped_msgs, events
+        assert 'OOM, eviction, or node loss' in stopped_msgs[0]


### PR DESCRIPTION
> **🚧 WIP — DO NOT REVIEW.** Exploratory work-in-progress; the API/UX and naming may still change. Pushed for visibility/CI only.

## Summary

Enables `sky stop` / `sky start` for unmanaged **Kubernetes** clusters, gated behind a new config flag `kubernetes.allow_unmanaged_cluster_destructive_stop` (default off).

- **Gating**: when the flag is set, `CloudImplementationFeatures.STOP` is allowed for that K8s context; otherwise stop is rejected with a message pointing at the flag.
- **Destructive stop**: `stop_instances` deletes the pod and its services but **retains the cluster's PersistentVolumeClaim(s)**, so persistent-volume state survives and is reattached on `sky start`. The ephemeral (non-PV) filesystem is lost on stop, by design. HA (Deployment-backed) clusters are rejected.
- **Unexpected pod loss → STOPPED**: with the flag on, a cluster whose pods vanish (OOM / eviction / node loss) transitions to `STOPPED` (retaining PVCs) instead of being terminated, and records a cluster event describing the detected cause (`SystemOOM` / `Evicted` when recoverable, generic otherwise). Already-`STOPPED` clusters are not purged by the status-refresh daemon.

## Why

Lets users power-cycle K8s clusters with disk-style persistence (VM-like) while leaving snapshot/backup of the PV to the user's own infra. This is the minimal SkyPilot-side enablement.

## Test plan

Unit tests (added):
- `tests/unit_tests/kubernetes/test_provision.py`: `stop_instances` retains PVC; HA rejected; OOM/eviction event classification (`SystemOOM`, `Evicted`).
- `tests/unit_tests/test_backend_utils_init_reason.py::TestKubernetesDestructiveStop`: pod-loss → stop (terminate=False) with cause in event; flag-off → terminate; already-STOPPED preserved; generic-cause fallback.

```
pytest tests/unit_tests/kubernetes/test_provision.py \
       tests/unit_tests/test_backend_utils_init_reason.py
```

Manual e2e on a local `kind` cluster (local API server built from this branch):
- `sky launch` on K8s → `sky stop` ⇒ status `STOPPED`, pod + services deleted, cluster record retained. ✅
- `sky start` ⇒ back to `UP`, pod recreated. ✅
- `kubectl delete pod` (simulating OOM/eviction) + `sky status --refresh` ⇒ auto-transitions to `STOPPED` (not terminated) with a recorded event. ✅
- `sky status --refresh` on a STOPPED cluster ⇒ stays `STOPPED` (not purged). ✅
- PVC-backed cluster: wrote a marker file to a mounted `k8s-pvc`, `sky stop` (PVC stayed `Bound`), `sky start` ⇒ **marker file survived**. ✅

## Open items / TODO

- Naming + docs for the flag.
- Backward-compat review of the status-refresh change.
- Smoke test (`/smoke-test --kubernetes`) for the full launch→stop→start cycle.

Made with [Cursor](https://cursor.com)