### PR TITLE
[CLI][Dashboard] Warn on unicode dashes in CLI + SA token page improvements

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -946,6 +946,39 @@ def _get_recipe_yaml(entrypoint: str) -> Optional[str]:
     return None
 
 
+_UNICODE_DASH_MAP = {
+    '–': '--',  # en dash
+    '—': '--',  # em dash
+    '‒': '-',  # figure dash
+    '‐': '-',  # hyphen
+    '‑': '-',  # non-breaking hyphen
+    '−': '-',  # minus sign
+    '－': '-',  # fullwidth hyphen-minus
+}
+
+
+def _warn_if_unicode_dashes(entrypoint: str) -> None:
+    """Warn user if entrypoint contains unicode dash characters.
+
+    This happens when commands are copy-pasted from rich-text sources
+    (docs, Notion, iOS keyboard) which replace ASCII dashes with
+    typographic variants like em dash or en dash.
+    """
+    found = {ch for ch in entrypoint if ch in _UNICODE_DASH_MAP}
+    if not found:
+        return
+    replacements = ', '.join(
+        f'U+{ord(ch):04X} {repr(ch)} -> {repr(_UNICODE_DASH_MAP[ch])}'
+        for ch in sorted(found))
+    click.secho(
+        f'Warning: The entrypoint contains Unicode dash character(s) '
+        f'({replacements}) that look like regular dashes but are not. '
+        f'This often happens when copying commands from rich-text '
+        f'sources (docs, Notion, iOS). Please retype the dashes manually.',
+        fg='yellow',
+        err=True)
+
+
 # TODO(zhwu): All CLI command handlers should be wrapped with
 # @annotations.client_api so that is_on_api_server is False during
 # YAML parsing and schema validation. For now, we wrap this common
@@ -991,6 +1024,8 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
         raise click.UsageError('Cannot specify both --git-url and --workdir')
 
     entrypoint = ' '.join(entrypoint)
+
+    _warn_if_unicode_dashes(entrypoint)
 
     # Check if entrypoint is a recipe reference (recipes:<name>)
     recipe_yaml = _get_recipe_yaml(entrypoint)

--- a/sky/dashboard/package-lock.json
+++ b/sky/dashboard/package-lock.json
@@ -4796,9 +4796,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4807,9 +4807,9 @@
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -5116,13 +5116,13 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -7160,9 +7160,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -8832,14 +8832,14 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.19.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.1.tgz",
-      "integrity": "sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "motion-dom": "^12.19.0",
-        "motion-utils": "^12.19.0",
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -11737,19 +11737,19 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.19.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
-      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "motion-utils": "^12.19.0"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.19.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
-      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT",
       "peer": true
     },
@@ -13701,9 +13701,9 @@
       }
     },
     "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13711,9 +13711,9 @@
       }
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT",
       "peer": true
     },

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { formatDistance } from 'date-fns';
 import React, {
   useState,
   useEffect,
@@ -35,7 +36,6 @@ import { sortData } from '@/data/utils';
 import {
   CustomTooltip,
   TimestampWithTooltip,
-  formatFullTimestamp,
   CustomTooltip as Tooltip,
   LastUpdatedTimestamp,
 } from '@/components/utils';
@@ -3329,12 +3329,9 @@ function ServiceAccountTokensView({
                       {!token.expires_at ? (
                         'Never'
                       ) : new Date(token.expires_at * 1000) < new Date() ? (
-                        <CustomTooltip
-                          content={`Expired on ${formatFullTimestamp(new Date(token.expires_at * 1000))}`}
-                          className="text-sm text-muted-foreground"
-                        >
-                          <span className="text-red-600 border-b border-dotted border-red-400 cursor-help">Expired</span>
-                        </CustomTooltip>
+                        <span className="text-red-600">
+                          Expired {formatDistance(new Date(token.expires_at * 1000), new Date(), { addSuffix: true })}
+                        </span>
                       ) : (
                         <TimestampWithTooltip
                           date={new Date(token.expires_at * 1000)}

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -3329,14 +3329,9 @@ function ServiceAccountTokensView({
                       {!token.expires_at ? (
                         'Never'
                       ) : new Date(token.expires_at * 1000) < new Date() ? (
-                        <CustomTooltip
-                          content={new Date(token.expires_at * 1000).toLocaleString()}
-                          className="text-sm text-muted-foreground"
-                        >
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-50 text-red-700 border-b border-dotted border-red-300 cursor-help">
-                            Expired {formatDistance(new Date(token.expires_at * 1000), new Date(), { addSuffix: true })}
-                          </span>
-                        </CustomTooltip>
+                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                          Expired {formatDistance(new Date(token.expires_at * 1000), new Date(), { addSuffix: true })}
+                        </span>
                       ) : (
                         <TimestampWithTooltip
                           date={new Date(token.expires_at * 1000)}

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -3329,9 +3329,14 @@ function ServiceAccountTokensView({
                       {!token.expires_at ? (
                         'Never'
                       ) : new Date(token.expires_at * 1000) < new Date() ? (
-                        <span className="text-red-600">
-                          Expired {formatDistance(new Date(token.expires_at * 1000), new Date(), { addSuffix: true })}
-                        </span>
+                        <CustomTooltip
+                          content={new Date(token.expires_at * 1000).toLocaleString()}
+                          className="text-sm text-muted-foreground"
+                        >
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-50 text-red-700 border-b border-dotted border-red-300 cursor-help">
+                            Expired {formatDistance(new Date(token.expires_at * 1000), new Date(), { addSuffix: true })}
+                          </span>
+                        </CustomTooltip>
                       ) : (
                         <TimestampWithTooltip
                           date={new Date(token.expires_at * 1000)}

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -35,6 +35,7 @@ import { sortData } from '@/data/utils';
 import {
   CustomTooltip,
   TimestampWithTooltip,
+  formatFullTimestamp,
   CustomTooltip as Tooltip,
   LastUpdatedTimestamp,
 } from '@/components/utils';
@@ -3170,6 +3171,11 @@ function ServiceAccountTokensView({
                   <TableRow key={token.token_id}>
                     <TableCell className="truncate" title={token.token_name}>
                       {token.token_name}
+                      {token.last_four && (
+                        <span className="ml-2 text-xs text-gray-400 font-mono">
+                          ····{token.last_four}
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell className="truncate">
                       <div className="flex items-center">
@@ -3323,7 +3329,12 @@ function ServiceAccountTokensView({
                       {!token.expires_at ? (
                         'Never'
                       ) : new Date(token.expires_at * 1000) < new Date() ? (
-                        <span className="text-red-600">Expired</span>
+                        <CustomTooltip
+                          content={`Expired on ${formatFullTimestamp(new Date(token.expires_at * 1000))}`}
+                          className="text-sm text-muted-foreground"
+                        >
+                          <span className="text-red-600 border-b border-dotted border-red-400 cursor-help">Expired</span>
+                        </CustomTooltip>
                       ) : (
                         <TimestampWithTooltip
                           date={new Date(token.expires_at * 1000)}

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -289,6 +289,8 @@ service_account_token_table = sqlalchemy.Table(
                       sqlalchemy.Text),  # Who created this token
     sqlalchemy.Column('service_account_user_id',
                       sqlalchemy.Text),  # Service account's own user ID
+    sqlalchemy.Column('last_four', sqlalchemy.Text,
+                      server_default=None),  # Last 4 chars of token
 )
 
 cluster_yaml_table = sqlalchemy.Table(
@@ -3076,7 +3078,8 @@ def add_service_account_token(token_id: str,
                               token_hash: str,
                               creator_user_hash: str,
                               service_account_user_id: str,
-                              expires_at: Optional[int] = None) -> None:
+                              expires_at: Optional[int] = None,
+                              last_four: Optional[str] = None) -> None:
     """Add a service account token to the database."""
     engine = _db_manager.get_engine()
     created_at = int(time.time())
@@ -3097,7 +3100,8 @@ def add_service_account_token(token_id: str,
             created_at=created_at,
             expires_at=expires_at,
             creator_user_hash=creator_user_hash,
-            service_account_user_id=service_account_user_id)
+            service_account_user_id=service_account_user_id,
+            last_four=last_four)
         session.execute(insert_stmnt)
         session.commit()
 
@@ -3120,6 +3124,7 @@ def get_service_account_token(token_id: str) -> Optional[Dict[str, Any]]:
         'expires_at': row.expires_at,
         'creator_user_hash': row.creator_user_hash,
         'service_account_user_id': row.service_account_user_id,
+        'last_four': getattr(row, 'last_four', None),
     }
 
 
@@ -3148,6 +3153,7 @@ def get_service_account_token_by_hash(
         'expires_at': row.expires_at,
         'creator_user_hash': row.creator_user_hash,
         'service_account_user_id': row.service_account_user_id,
+        'last_four': getattr(row, 'last_four', None),
     }
 
 
@@ -3167,6 +3173,7 @@ def get_user_service_account_tokens(user_hash: str) -> List[Dict[str, Any]]:
         'expires_at': row.expires_at,
         'creator_user_hash': row.creator_user_hash,
         'service_account_user_id': row.service_account_user_id,
+        'last_four': getattr(row, 'last_four', None),
     } for row in rows]
 
 
@@ -3202,13 +3209,15 @@ def delete_service_account_token(token_id: str) -> bool:
 @metrics_lib.time_me
 def rotate_service_account_token(token_id: str,
                                  new_token_hash: str,
-                                 new_expires_at: Optional[int] = None) -> None:
+                                 new_expires_at: Optional[int] = None,
+                                 new_last_four: Optional[str] = None) -> None:
     """Rotate a service account token by updating its hash and expiration.
 
     Args:
         token_id: The token ID to rotate.
         new_token_hash: The new hashed token value.
         new_expires_at: New expiration timestamp, or None for no expiration.
+        new_last_four: Last 4 characters of the new token.
     """
     engine = _db_manager.get_engine()
     current_time = int(time.time())
@@ -3222,6 +3231,7 @@ def rotate_service_account_token(token_id: str,
             service_account_token_table.c.last_used_at: None,  # Reset last used
             # Update creation time
             service_account_token_table.c.created_at: current_time,
+            service_account_token_table.c.last_four: new_last_four,
         })
         session.commit()
 
@@ -3388,6 +3398,7 @@ def get_expired_service_account_tokens_by_name_prefix(
         'expires_at': row.expires_at,
         'creator_user_hash': row.creator_user_hash,
         'service_account_user_id': row.service_account_user_id,
+        'last_four': getattr(row, 'last_four', None),
     } for row in rows]
 
 
@@ -3406,6 +3417,7 @@ def get_all_service_account_tokens() -> List[Dict[str, Any]]:
         'expires_at': row.expires_at,
         'creator_user_hash': row.creator_user_hash,
         'service_account_user_id': row.service_account_user_id,
+        'last_four': getattr(row, 'last_four', None),
     } for row in rows]
 
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -653,7 +653,8 @@ def _create_job_api_token(creator_user_id: str, job_name: Optional[str],
         token_hash=token_data['token_hash'],
         creator_user_hash=creator_user_id,
         service_account_user_id=creator_user_id,
-        expires_at=token_data['expires_at'])
+        expires_at=token_data['expires_at'],
+        last_four=token_data['last_four'])
 
     return token_data['token'], token_data['token_id']
 

--- a/sky/schemas/db/global_user_state/021_add_token_last_four.py
+++ b/sky/schemas/db/global_user_state/021_add_token_last_four.py
@@ -1,0 +1,33 @@
+"""Add last_four column to service_account_tokens table.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-06-19
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '021'
+down_revision: Union[str, Sequence[str], None] = '020'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add last_four column to store the last 4 characters of the token."""
+    from alembic import op  # pylint: disable=import-outside-toplevel
+
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('service_account_tokens',
+                                             'last_four', sa.Text())
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -741,6 +741,7 @@ def get_service_account_tokens(
             'expires_at': token['expires_at'],
             'creator_user_hash': token['creator_user_hash'],
             'service_account_user_id': token['service_account_user_id'],
+            'last_four': token.get('last_four'),
         }
 
         # Add creator display name
@@ -839,7 +840,8 @@ def create_service_account_token(
             token_hash=token_data['token_hash'],
             creator_user_hash=auth_user.id,
             service_account_user_id=service_account_user_id,
-            expires_at=token_data['expires_at'])
+            expires_at=token_data['expires_at'],
+            last_four=token_data['last_four'])
 
         # Return the JWT token only once (never stored in plain text)
         return {
@@ -1044,7 +1046,8 @@ def rotate_service_account_token(
         global_user_state.rotate_service_account_token(
             token_id=token_body.token_id,
             new_token_hash=token_data['token_hash'],
-            new_expires_at=token_data['expires_at'])
+            new_expires_at=token_data['expires_at'],
+            new_last_four=token_data['last_four'])
 
         # Return the new JWT token only once (never stored in plain text)
         return {

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -156,6 +156,7 @@ class TokenService:
             'token_id': token_id,
             'token': full_token,
             'token_hash': token_hash,
+            'last_four': full_token[-4:],
             'creator_user_id': creator_user_id,
             'service_account_user_id': service_account_user_id,
             'token_name': token_name,

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '020'  # add is_managed column to cluster_history
+GLOBAL_USER_STATE_VERSION = '021'  # add last_four column to service_account_tokens
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
@@ -55,7 +55,8 @@ class TestServiceAccountDatabaseOperations:
                     created_at=1234567890,
                     expires_at=1234567890 + 2592000,
                     creator_user_hash='user456',
-                    service_account_user_id='sa789')
+                    service_account_user_id='sa789',
+                    last_four=None)
                 mock_session.execute.assert_called_once_with(
                     mock_insert.values.return_value)
                 mock_session.commit.assert_called_once()
@@ -103,6 +104,7 @@ class TestServiceAccountDatabaseOperations:
         mock_row.expires_at = 1234567890 + 2592000
         mock_row.creator_user_hash = 'user456'
         mock_row.service_account_user_id = 'sa789'
+        mock_row.last_four = None
 
         mock_session.query.return_value.filter_by.return_value.first.return_value = mock_row
 
@@ -116,7 +118,8 @@ class TestServiceAccountDatabaseOperations:
             'last_used_at': 1234567900,
             'expires_at': 1234567890 + 2592000,
             'creator_user_hash': 'user456',
-            'service_account_user_id': 'sa789'
+            'service_account_user_id': 'sa789',
+            'last_four': None,
         }
         mock_session.query.assert_called_once()
 
@@ -141,6 +144,7 @@ class TestServiceAccountDatabaseOperations:
         mock_row.expires_at = 1234567890 + 2592000
         mock_row.creator_user_hash = 'user456'
         mock_row.service_account_user_id = 'sa789'
+        mock_row.last_four = None
 
         mock_filter = mock_session.query.return_value.filter_by
         mock_filter.return_value.first.return_value = mock_row
@@ -155,7 +159,8 @@ class TestServiceAccountDatabaseOperations:
             'last_used_at': 1234567900,
             'expires_at': 1234567890 + 2592000,
             'creator_user_hash': 'user456',
-            'service_account_user_id': 'sa789'
+            'service_account_user_id': 'sa789',
+            'last_four': None,
         }
         # The query must filter by token_hash, not token_id. This is what
         # makes rotation work: after rotation the DB row keeps the original
@@ -184,6 +189,7 @@ class TestServiceAccountDatabaseOperations:
         mock_row1.expires_at = None
         mock_row1.creator_user_hash = 'user1'
         mock_row1.service_account_user_id = 'sa1'
+        mock_row1.last_four = None
 
         mock_row2 = mock.Mock()
         mock_row2.token_id = 'token2'
@@ -194,6 +200,7 @@ class TestServiceAccountDatabaseOperations:
         mock_row2.expires_at = 1234567890 + 2592000
         mock_row2.creator_user_hash = 'user2'
         mock_row2.service_account_user_id = 'sa2'
+        mock_row2.last_four = None
 
         mock_session.query.return_value.all.return_value = [
             mock_row1, mock_row2


### PR DESCRIPTION
## Summary

- **CLI**: Detect unicode dash characters (em dash `—`, en dash `–`, etc.) in entrypoint arguments and warn the user. This happens when commands are copy-pasted from rich-text sources (docs, Notion, iOS keyboard), causing `sky launch` to silently misinterpret arguments.

- **Dashboard SA page**: Two improvements to the Service Accounts token table:
  1. **Expired tokens** now show *when* they expired inline as a red status pill ("Expired 3 days ago"), matching the common `bg-red-100 text-red-800 rounded-full` badge pattern used across the dashboard.
  2. **Last 4 characters** of the token are displayed next to the token name (`····abcd`) for easy identification.

- **Backend**: Added `last_four` column to `service_account_tokens` table (migration 021), populated on token create and rotate. All getter functions and API endpoints updated to surface the field.

## Test plan

- [x] Unit tests pass: `test_global_user_state_service_accounts.py` (18 passed), `test_token_service.py` (17 passed)
- [x] Dashboard builds successfully (`npm run build`)
- [ ] Manual: Create a service account token → verify last 4 chars appear next to name
- [ ] Manual: Create a token with short expiry → wait for expiry → verify red "Expired X ago" pill appears in the Expires column
- [ ] Manual: Rotate a token → verify last 4 chars update
- [ ] Manual: Copy a `sky launch` command from a rich-text source with em dashes → verify yellow warning is printed

Slack context:
- https://assemble-platforms.slack.com/archives/C07PVLJSXD0/p1781834011346609
- https://assemble-platforms.slack.com/archives/C0A3RFD7TV1/p1776979736398809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjSMqNjkFLgtcmG3se1N5p