### PR TITLE
[Jobs] Fix SAWarning when cancelling a pending managed job

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1046,11 +1046,15 @@ def set_pending_cancelled(job_id: int):
     engine = _db_manager.get_engine()
     count = 0
     with orm.Session(engine) as session:
-        # Subquery to get the spot_job_ids that match the joined condition
-        subquery = session.query(spot_table.c.job_id).join(
-            job_info_table,
-            spot_table.c.spot_job_id == job_info_table.c.spot_job_id
-        ).filter(
+        # Subquery to get the spot_job_ids that match the joined condition.
+        # Build it as a select() construct (rather than Query.subquery()) so it
+        # can be passed directly to in_() without SQLAlchemy emitting a
+        # "Coercing Subquery object into a select()" warning.
+        subquery = sqlalchemy.select(spot_table.c.job_id).select_from(
+            spot_table.join(
+                job_info_table,
+                spot_table.c.spot_job_id == job_info_table.c.spot_job_id)
+        ).where(
             spot_table.c.spot_job_id == job_id,
             spot_table.c.status == ManagedJobStatus.PENDING.value,
             # Note: it's possible that a WAITING job actually needs to be
@@ -1063,7 +1067,7 @@ def set_pending_cancelled(job_id: int):
                 job_info_table.c.schedule_state ==
                 ManagedJobScheduleState.INACTIVE.value,
             ),
-        ).subquery()
+        )
 
         count = session.query(spot_table).filter(
             spot_table.c.job_id.in_(subquery)).update(


### PR DESCRIPTION
## Summary

Cancelling a managed job that is still `PENDING`/`WAITING` prints a noisy SQLAlchemy warning to the user's CLI:

```
sky/jobs/state.py:1069: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly
  spot_table.c.job_id.in_(subquery)).update(
Job with ID 681 is scheduled to be cancelled.
```

The cancel itself succeeds — this is purely a cosmetic warning, but it surfaces in the user-facing CLI output and looks alarming.

**Root cause:** `set_pending_cancelled()` built its subquery with the legacy `session.query(...).subquery()` API, which produces a `Subquery` object. SQLAlchemy 2.0 deprecates passing a `Subquery` to `in_()` and coerces it with a warning.

**Fix:** Rebuild the subquery with `sqlalchemy.select(...).select_from(...).where(...)` so a `Select` construct is passed to `in_()` directly. This matches the pattern already used elsewhere in this module (e.g. `non_terminal_job_ids_subquery`). The generated SQL and behavior are unchanged.

## Test plan

- Reproduced the exact warning string with the old construction against SQLAlchemy 2.0.49.
- Confirmed the new construction raises no warning (verified with `warnings.simplefilter('error')`) and compiles to equivalent SQL:
  ```sql
  UPDATE spot SET status='CANCELLED' WHERE spot.job_id IN
    (SELECT spot.job_id FROM spot JOIN job_info ON spot.spot_job_id = job_info.spot_job_id
     WHERE spot.spot_job_id = ? AND spot.status = 'PENDING'
       AND (job_info.schedule_state = 'WAITING' OR job_info.schedule_state = 'INACTIVE'))
  ```
- Ran `format.sh` on the changed file.