### PR TITLE
[Slurm] Fail stuck PENDING jobs so autodown can proceed

### DIFF
--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -272,6 +272,14 @@ class JobStatus(enum.Enum):
 # TODO(zhwu): This number should be tuned based on heuristics.
 _INIT_SUBMIT_GRACE_PERIOD = 60
 
+# Grace period for PENDING jobs. If a job stays in PENDING state for longer
+# than this period and the job driver process is not running, it is likely
+# the driver crashed during early initialization (e.g., import error,
+# permission error) before it could update the job status. We should
+# transition it to FAILED_DRIVER to unblock autodown. See #9815.
+# TODO(dzorlu): This number should be tuned based on heuristics.
+_PENDING_GRACE_PERIOD = 10 * 60  # 10 minutes
+
 _PRE_RESOURCE_STATUSES = [JobStatus.PENDING]
 
 
@@ -906,6 +914,29 @@ def update_job_status(job_ids: List[int],
                     # overridden by the actual job terminal status in the table
                     # if the job driver process finished correctly.)
                     status = JobStatus.PENDING
+
+            # If the job has been PENDING for longer than the grace period
+            # (measured from job creation via submitted_at, which is always
+            # >= the PENDING entry time) and the driver process is not
+            # running, the driver likely crashed during early initialization
+            # before updating its status. Fail it so that
+            # is_cluster_idle() returns True and autodown can proceed.
+            # We only check jobs that were actually launched (submit > 0 or
+            # no pending_jobs entry); jobs still queued (submit <= 0) are
+            # legitimately waiting their turn and should not be failed.
+            # See #9815.
+            job_was_launched = (pending_job is None or
+                                pending_job['submit'] > 0)
+            if (job_was_launched and original_status == JobStatus.PENDING and
+                    status == JobStatus.PENDING and
+                    job_submitted_at < pid_query_time - _PENDING_GRACE_PERIOD
+                    and not (job_pid > 0 and
+                             _is_job_driver_process_running(job_pid, job_id))):
+                failed_driver_transition_message = (
+                    f'PENDING job {job_id} has been stuck since creation '
+                    f'({_PENDING_GRACE_PERIOD}s ago), setting to '
+                    f'FAILED_DRIVER')
+                status = JobStatus.FAILED_DRIVER
 
             assert original_status is not None, (job_id, status)
             if status is None:

--- a/tests/unit_tests/test_sky/skylet/test_job_lib.py
+++ b/tests/unit_tests/test_sky/skylet/test_job_lib.py
@@ -1,0 +1,285 @@
+"""Unit tests for skylet job_lib — PENDING grace period."""
+import time
+from unittest import mock
+
+import pytest
+
+from sky.skylet import job_lib
+
+
+@pytest.fixture(autouse=True)
+def _mock_lock_path(tmp_path):
+    """Route file locks to a temp directory to avoid side effects."""
+    with mock.patch.object(
+            job_lib,
+            '_get_lock_path',
+            side_effect=lambda jid: str(tmp_path / f'.job_{jid}.lock')):
+        yield
+
+
+class TestPendingGracePeriod:
+    """Tests for the PENDING grace period in update_job_status().
+
+    When a launched job stays in PENDING for longer than
+    _PENDING_GRACE_PERIOD and the driver process is not running, it should
+    transition to FAILED_DRIVER so that is_cluster_idle() returns True and
+    autodown can proceed.
+    See https://github.com/skypilot-org/skypilot/issues/9815.
+    """
+
+    # pylint: disable=protected-access
+
+    def _make_job_record(self, job_id, status, submitted_at, pid=0):
+        return {
+            'job_id': job_id,
+            'job_name': 'test',
+            'username': 'user',
+            'submitted_at': submitted_at,
+            'status': status,
+            'run_timestamp': '2024-01-01',
+            'start_at': -1,
+            'end_at': None,
+            'resources': None,
+            'pid': pid,
+            'metadata': {},
+        }
+
+    def _make_pending_job(self, created_time, submit=0):
+        return {
+            'created_time': created_time,
+            'submit': submit,
+            'run_cmd': 'echo test',
+        }
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=False)
+    def test_stale_launched_pending_job_transitions_to_failed_driver(
+            self, mock_driver_running, mock_get_jobs, mock_get_pending,
+            mock_set_status):
+        """A launched PENDING job past the grace period should fail.
+
+        Simulates a job whose driver was started (submit > 0, pid > 0) but
+        crashed during early init before updating status past PENDING.
+        """
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        stale_submitted_at = now - job_lib._PENDING_GRACE_PERIOD - 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  stale_submitted_at,
+                                  pid=42),
+        ]
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(stale_submitted_at),
+            submit=int(stale_submitted_at + 1))
+
+        with mock.patch('psutil.boot_time',
+                        return_value=stale_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        assert statuses == [job_lib.JobStatus.FAILED_DRIVER]
+        mock_set_status.assert_called_once_with(1,
+                                                job_lib.JobStatus.FAILED_DRIVER)
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=True)
+    def test_recent_launched_pending_job_stays_pending(self,
+                                                       mock_driver_running,
+                                                       mock_get_jobs,
+                                                       mock_get_pending,
+                                                       mock_set_status):
+        """A launched PENDING job within the grace period should stay.
+
+        Simulates a recently launched job whose driver is still running
+        but hasn't updated status past PENDING yet. This is normal.
+        """
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        recent_submitted_at = now - 30  # 30 seconds, well within grace period
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  recent_submitted_at,
+                                  pid=42),
+        ]
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(recent_submitted_at),
+            submit=int(recent_submitted_at + 1))
+
+        with mock.patch('psutil.boot_time',
+                        return_value=recent_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        assert statuses == [job_lib.JobStatus.PENDING]
+        mock_set_status.assert_not_called()
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=True)
+    def test_stale_pending_job_with_running_driver_stays_pending(
+            self, mock_driver_running, mock_get_jobs, mock_get_pending,
+            mock_set_status):
+        """A PENDING job past grace period with a running driver stays."""
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        stale_submitted_at = now - job_lib._PENDING_GRACE_PERIOD - 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  stale_submitted_at,
+                                  pid=12345),
+        ]
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(stale_submitted_at),
+            submit=int(stale_submitted_at + 1))
+
+        with mock.patch('psutil.boot_time',
+                        return_value=stale_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        # The driver process is running, so the job should stay PENDING.
+        assert statuses == [job_lib.JobStatus.PENDING]
+        mock_set_status.assert_not_called()
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job', return_value=None)
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=False)
+    def test_stale_pending_no_pending_entry_fails_via_status_none(
+            self, mock_driver_running, mock_get_jobs, mock_get_pending,
+            mock_set_status):
+        """No pending_jobs entry: status stays None, then FAILED_DRIVER."""
+        # unused: patched globally
+        del mock_driver_running, mock_get_pending, mock_set_status
+        now = time.time()
+        stale_submitted_at = now - job_lib._PENDING_GRACE_PERIOD - 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  stale_submitted_at,
+                                  pid=0),
+        ]
+
+        with mock.patch('psutil.boot_time',
+                        return_value=stale_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        # status remains None -> falls through to the `status is None` branch
+        # which sets FAILED_DRIVER for nonterminal original_status.
+        assert statuses == [job_lib.JobStatus.FAILED_DRIVER]
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=False)
+    def test_stale_pending_legacy_pid_transitions(self, mock_driver_running,
+                                                  mock_get_jobs,
+                                                  mock_get_pending,
+                                                  mock_set_status):
+        """Legacy jobs (pid=-1) stuck in PENDING should also fail."""
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        stale_submitted_at = now - job_lib._PENDING_GRACE_PERIOD - 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  stale_submitted_at,
+                                  pid=-1),
+        ]
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(stale_submitted_at),
+            submit=int(stale_submitted_at + 1))
+
+        with mock.patch('psutil.boot_time',
+                        return_value=stale_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        assert statuses == [job_lib.JobStatus.FAILED_DRIVER]
+        mock_set_status.assert_called_once_with(1,
+                                                job_lib.JobStatus.FAILED_DRIVER)
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=True)
+    def test_launched_pending_job_at_boundary_stays_pending(
+            self, mock_driver_running, mock_get_jobs, mock_get_pending,
+            mock_set_status):
+        """A launched job inside the grace period boundary stays PENDING."""
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        # 1 minute of slack to account for the small time delta between
+        # this `now` and the `time.time()` call inside update_job_status.
+        boundary_submitted_at = now - job_lib._PENDING_GRACE_PERIOD + 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  boundary_submitted_at,
+                                  pid=42),
+        ]
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(boundary_submitted_at),
+            submit=int(boundary_submitted_at + 1))
+
+        with mock.patch('psutil.boot_time',
+                        return_value=boundary_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        assert statuses == [job_lib.JobStatus.PENDING]
+        mock_set_status.assert_not_called()
+
+    @mock.patch.object(job_lib, '_set_status_no_lock')
+    @mock.patch.object(job_lib, '_get_pending_job')
+    @mock.patch.object(job_lib, '_get_jobs_by_ids')
+    @mock.patch.object(job_lib,
+                       '_is_job_driver_process_running',
+                       return_value=False)
+    def test_queued_pending_job_not_failed_even_if_stale(
+            self, mock_driver_running, mock_get_jobs, mock_get_pending,
+            mock_set_status):
+        """A queued job (submit=0) waiting >10min should NOT be failed."""
+        del mock_driver_running  # unused: patched globally
+        now = time.time()
+        stale_submitted_at = now - job_lib._PENDING_GRACE_PERIOD - 60
+
+        mock_get_jobs.return_value = [
+            self._make_job_record(1,
+                                  job_lib.JobStatus.PENDING,
+                                  stale_submitted_at,
+                                  pid=0),
+        ]
+        # submit=0: the job is still queued, not yet launched.
+        mock_get_pending.return_value = self._make_pending_job(
+            created_time=int(stale_submitted_at), submit=0)
+
+        with mock.patch('psutil.boot_time',
+                        return_value=stale_submitted_at - 100):
+            statuses = job_lib.update_job_status([1])
+
+        # The job is legitimately waiting in the queue.
+        assert statuses == [job_lib.JobStatus.PENDING]
+        mock_set_status.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #9815.

- When a job fails during early init (import error, permission error, etc.) before the driver updates its status past `PENDING`, the job stays `PENDING` in `jobs.db` forever. `is_cluster_idle()` treats it as nonterminal, so the autodown idle timer never fires and GPU nodes are held indefinitely.
- Added a 10-minute grace period for `PENDING` jobs in `update_job_status()`, matching the existing `_INIT_SUBMIT_GRACE_PERIOD` pattern for `INIT` jobs. If the job has been `PENDING` longer than the threshold and the driver process is not running, it transitions to `FAILED_DRIVER`.

## Details

The check fires after the existing `pending_job` block in `update_job_status()` and only when all of these hold:

1. `original_status` is `PENDING` and `status` is still `PENDING` (no earlier check already resolved it)
2. `job_submitted_at` is older than `_PENDING_GRACE_PERIOD` (10 min)
3. The driver process is not alive (either `pid <= 0` or `pid > 0` but dead)

This primarily covers jobs with `pid <= 0` (unsubmitted or legacy) that the earlier process-liveness check at line 874 cannot handle. Jobs with `pid > 0` and a dead driver are already caught by that earlier check.

The `max(status, original_status)` at the end of the loop preserves `FAILED_DRIVER` because it is ordered after `PENDING` in the `JobStatus` enum.

## Test plan

Added 6 unit tests in `tests/unit_tests/test_sky/skylet/test_job_lib.py`:

```
pytest tests/unit_tests/test_sky/skylet/test_job_lib.py -v
# 6 passed
```

| Test | Scenario | Expected |
|------|----------|----------|
| `test_stale_pending_job_transitions_to_failed_driver` | PENDING >10min, pid=0, driver dead | FAILED_DRIVER |
| `test_recent_pending_job_stays_pending` | PENDING 30s, pid=0 | PENDING |
| `test_stale_pending_job_with_running_driver_stays_pending` | PENDING >10min, pid>0, driver alive | PENDING |
| `test_stale_pending_no_pending_entry_fails_via_status_none` | PENDING >10min, no pending_jobs row | FAILED_DRIVER (via existing `status is None` path) |
| `test_stale_pending_legacy_pid_transitions` | PENDING >10min, pid=-1 (legacy) | FAILED_DRIVER |
| `test_pending_job_at_exact_boundary_stays_pending` | PENDING at boundary, pid=0 | PENDING |

Full skylet suite:

```
pytest tests/unit_tests/test_sky/skylet/
# 64 passed (58 existing + 6 new)
```

Formatting:

```
bash format.sh --files sky/skylet/job_lib.py tests/unit_tests/test_sky/skylet/test_job_lib.py
# yapf: clean, isort: clean, mypy: no issues, pylint: 10.00/10
```