### PR TITLE
[Serve] QueueLengthAutoscaler: target the non-terminal backlog instead of +/-1

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2445,6 +2445,52 @@ def get_pending_jobs_count_by_pool(pool: str) -> int:
         return result[0] if result else 0
 
 
+def get_nonterminal_jobs_count_by_pool(pool: str) -> int:
+    """Get the count of non-terminal jobs in a pool.
+
+    A non-terminal job is one that each needs or already holds a pool worker —
+    i.e. the desired number of replicas for the pool. Counts distinct
+    spot_job_id (per logical job, not per task). This is the aggregate (count)
+    analogue of get_nonterminal_job_ids_by_pool: it mirrors that helper's
+    predicate and join, returning a count instead of the id list.
+
+    Includes every non-terminal status (PENDING, STARTING, RUNNING, RECOVERING,
+    etc.); excludes the terminal statuses (SUCCEEDED, the FAILED* family,
+    CANCELLED). RUNNING is deliberately included: in
+    QueueLengthAutoscaler._generate_scaling_decisions the target is compared
+    against the current replica count, which itself includes the workers busy
+    with RUNNING jobs, so the target must reflect total worker occupancy (one
+    worker per non-terminal job), not just the queued backlog. Counting only
+    PENDING would under-provision whenever a new job arrives while existing
+    workers are busy, and would drain toward zero as the scheduler eagerly
+    moves a job PENDING -> RUNNING onto the first available worker.
+
+    Args:
+        pool: The pool name
+
+    Returns:
+        The number of distinct non-terminal jobs in the pool
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        # Mirror get_nonterminal_job_ids_by_pool's predicate + join, aggregated.
+        query = sqlalchemy.select(
+            sqlalchemy.func.count(  # pylint: disable=not-callable
+                spot_table.c.spot_job_id.distinct())).select_from(
+                    spot_table.outerjoin(
+                        job_info_table, spot_table.c.spot_job_id ==
+                        job_info_table.c.spot_job_id)).where(
+                            sqlalchemy.and_(
+                                ~spot_table.c.status.in_([
+                                    status.value for status in
+                                    ManagedJobStatus.terminal_statuses()
+                                ]),
+                                job_info_table.c.pool == pool,
+                            ))
+        result = session.execute(query).fetchone()
+        return result[0] if result else 0
+
+
 def get_nonterminal_job_ids_by_pool(pool: str,
                                     cluster_name: Optional[str] = None
                                    ) -> List[int]:

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -1122,58 +1122,46 @@ class QueueLengthAutoscaler(_AutoscalerWithHysteresis):
                     f'queue_length_threshold={self.queue_length_threshold}')
 
     def _calculate_target_num_replicas(self) -> int:
-        """Calculate target number of replicas based on queue length."""
-        queue_length = managed_job_state.get_pending_jobs_count_by_pool(
+        """Calculate target number of replicas based on non-terminal demand.
+
+        Targets the count of non-terminal jobs directly — the desired worker
+        count, since each non-terminal job needs or already holds a pool worker
+        — clipped to [min_replicas, max_replicas], instead of ramping by +/-1
+        per decision. This tracks total worker occupancy, so a new job arriving
+        while existing workers are busy drives a scale-up (the target is
+        compared against the busy-inclusive replica count in
+        _generate_scaling_decisions, so it must include RUNNING jobs), and the
+        signal is stable across a job's PENDING -> STARTING -> RUNNING
+        transitions (it no longer drains to zero as the scheduler eagerly moves
+        a job onto a worker). The hysteresis layer
+        (_set_target_num_replicas_with_hysteresis / upscale_delay) still gates
+        how fast we ramp toward this target; this method only sets what target
+        to ramp toward.
+        """
+        nonterminal = managed_job_state.get_nonterminal_jobs_count_by_pool(
             self._service_name)
         current_num_replicas = self.target_num_replicas
 
+        # Target the desired worker count directly. clip() clamps to
+        # [min_replicas, max_replicas], so:
+        #   - nonterminal == 0           -> target == min_replicas (an idle pool
+        #                                   can scale to 0 when min_replicas == 0).
+        #   - 0 < nonterminal <= max     -> target == nonterminal (one worker per
+        #                                   non-terminal job).
+        #   - nonterminal > max_replicas -> target == max_replicas (fan out fully
+        #                                   for a burst of N > max jobs).
+        # Because clip(nonterminal) >= min_replicas and (for nonterminal >= 1)
+        # >= 1, a pool never scales to zero while any job is non-terminal.
+        target_num_replicas = self._clip_target_num_replicas(nonterminal)
+
         logger.info(f'[QueueLengthAutoscaler] Pool "{self._service_name}": '
-                    f'queue_length={queue_length}, '
-                    f'threshold={self.queue_length_threshold}, '
+                    f'nonterminal={nonterminal}, '
                     f'current_target_replicas={current_num_replicas}, '
+                    f'target_replicas={target_num_replicas}, '
                     f'min_replicas={self.min_replicas}, '
                     f'max_replicas={self.max_replicas}')
 
-        # Determine target based on queue length vs threshold
-        if queue_length == 0:
-            # There are no pending jobs, we should quickly scale down to 0.
-            target_num_replicas = 0
-            decision = 'SCALE_DOWN_TO_ZERO'
-        elif queue_length > self.queue_length_threshold:
-            # Scale up by 1
-            # TODO(lloyd): we probably want support for scaling up by more than
-            # 1 in the future. We are punting on this currently because without
-            # an understanding of the workload the right number of replicas to
-            # scale up by is not clear and the user can just tweak the upscale
-            # delay to control the rate of scaling up.
-            target_num_replicas = current_num_replicas + 1
-            decision = 'SCALE_UP'
-        elif queue_length < self.queue_length_threshold:
-            # Scale down by 1
-            target_num_replicas = current_num_replicas - 1
-            decision = 'SCALE_DOWN'
-        else:
-            # Queue length equals threshold, keep current
-            target_num_replicas = current_num_replicas
-            decision = 'NO_CHANGE'
-        logger.info(f'[QueueLengthAutoscaler] Decision: {decision} '
-                    f'{current_num_replicas} -> {target_num_replicas}')
-
-        # Special case: if target_num_replicas is 0 and queue_length is greater
-        # than 0, we should not scale down to 0. This is to prevent the service
-        # from scaling to zero when there are jobs in the queue.
-        if target_num_replicas == 0 and queue_length > 0:
-            target_num_replicas = 1
-            logger.info('Preventing scale to zero since there are jobs in the'
-                        f'queue: {queue_length}')
-
-        clipped_target = self._clip_target_num_replicas(target_num_replicas)
-        if clipped_target != target_num_replicas:
-            logger.info(f'[QueueLengthAutoscaler] Clipped target: '
-                        f'{target_num_replicas} -> {clipped_target} '
-                        f'(bounds: [{self.min_replicas}, {self.max_replicas}])')
-
-        return clipped_target
+        return target_num_replicas
 
     def update_version(self, version: int, spec: 'service_spec.SkyServiceSpec',
                        update_mode: serve_utils.UpdateMode) -> None:


### PR DESCRIPTION
## Problem

The managed-jobs **pool** autoscaler (`QueueLengthAutoscaler`) under-provisions a burst. `_calculate_target_num_replicas` counts only `status == PENDING` and moves the target by **±1** per decision — the existing `TODO(lloyd)` ("punting on scaling up by more than 1").

Because the scheduler eagerly moves a job `PENDING → STARTING` onto the first available worker, the PENDING signal drains to ~0. The autoscaler then concludes "no demand", settles at ~1 worker, and can even `SCALE_DOWN_TO_ZERO` while a backlog still exists. A burst of `N > max_workers` jobs never fans out to `max_workers`.

Two coupled issues: the demand signal (PENDING-only) and the ±1 ramp. The key observation is that `_generate_scaling_decisions` compares the target against the **current replica count** — which includes the workers already busy with `RUNNING` jobs. So the target must reflect **total worker occupancy**, not just the queued backlog. Counting only PENDING also under-provisions whenever a new job arrives while existing workers are busy (target < current replicas → no scale-up), and is unstable because it collapses as jobs move `PENDING → RUNNING`.

## Fix

- Add `managed_job_state.get_nonterminal_jobs_count_by_pool` — the **count analogue** of the existing `get_nonterminal_job_ids_by_pool` (same `~terminal_statuses()` predicate + join, `count(distinct(spot_job_id))`). It is the count of distinct non-terminal jobs in the pool; each such job needs or holds a worker, so it **is** the desired replica count.
- `_calculate_target_num_replicas` now targets `clip(nonterminal, min_replicas, max_replicas)` directly instead of `current ± 1`.

The hysteresis layer (`_set_target_num_replicas_with_hysteresis` / `upscale_delay`) is unchanged and still gates *how fast* the pool ramps toward the target. Scale-down is likewise unchanged and remains **idle-only** (`_generate_scaling_decisions` Case 2 only tears down replicas with no non-terminal jobs), so a target drop never removes a busy worker. "No scale-to-zero while jobs are queued" becomes structural: `clip(nonterminal ≥ 1) ≥ 1`.

This counts the *same* non-terminal job set the autoscaler already uses for idle-detection, so the target and the scaling-decision comparison are finally in the same units.

## Behavior

- A burst of `N > max_workers` jobs fans out to `max_workers` in one upscale window (instead of ±1 per `upscale_delay`).
- New jobs arriving while existing workers are busy correctly trigger a scale-up (up to `max_workers`).
- An idle pool still scales to 0; `clip(., max_replicas)` means counting RUNNING can never exceed `max_replicas`.

## Notes

- `RUNNING` is deliberately included (it occupies a worker); `RECOVERING` etc. likewise. Terminal statuses are excluded. The count is `distinct(spot_job_id)` so a multi-task job counts once.
- No public API change; `queue_length_threshold` remains on the spec but is no longer consulted by the pool target calc.

Happy to add a unit test for `get_nonterminal_jobs_count_by_pool` and the target math if you'd like — wanted to get the approach in front of you first given the existing `TODO(lloyd)`.
