### PR TITLE
Executor should not skip WAITING requests

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -704,9 +704,11 @@ def _request_execution_wrapper(request_id: str,
         # the try block to ensure we have the KeyboardInterrupt handling.
         with api_requests.update_request(request_id) as request_task:
             assert request_task is not None, request_id
-            if request_task.status != api_requests.RequestStatus.PENDING:
-                logger.debug(f'Request is already {request_task.status.value}, '
-                             f'skipping execution')
+            if (request_task.status
+                    not in api_requests.RequestStatus.executable_statuses()):
+                logger.warning(
+                    f'Request is already {request_task.status.value}, '
+                    f'skipping execution')
                 return
             log_path = request_task.log_path
             request_task.pid = pid

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -92,6 +92,18 @@ class RequestStatus(enum.Enum):
         """Statuses of requests that are not finished yet."""
         return [cls.PENDING, cls.WAITING, cls.RUNNING]
 
+    @classmethod
+    def executable_statuses(cls) -> List['RequestStatus']:
+        """Statuses from which a dequeued request may start executing.
+
+        A request is enqueued as PENDING. It may also be re-enqueued while in
+        WAITING -- the state it is parked in while waiting to resume (e.g. a
+        retry backoff or an external continue-condition). In both cases the
+        worker should pick it up and run it. Any other status (RUNNING, a
+        finished status, or CANCELLED) means the request must not be executed.
+        """
+        return [cls.PENDING, cls.WAITING]
+
 
 _STATUS_TO_COLOR = {
     RequestStatus.PENDING: colorama.Fore.BLUE,

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -296,6 +296,70 @@ def test_requests_scheduling(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+# ---- Test retry-until-up WAITING request is re-executed -----
+# Regression test for a re-enqueued WAITING request being silently dropped.
+#
+# When `--retry-until-up` provisioning exhausts all launchable resources it
+# raises ExecutionRetryableError, which yields the worker and parks the request
+# in WAITING, then re-enqueues it for another attempt. The execution wrapper
+# must run the re-enqueued WAITING request (not just PENDING ones); previously
+# it skipped anything that was not PENDING, so the request was consumed off the
+# queue, never re-executed, and stranded in WAITING forever.
+#
+# Kubernetes-only: feasibility checks node *capacity* (not free *allocatable*),
+# so a request whose per-node size fits a node but whose node *count* exceeds
+# what the cluster can schedule passes feasibility, then has its pods sit
+# Pending and fails provisioning -> the retry/WAITING path. Requesting many
+# 1-CPU nodes makes this size-independent (1 CPU fits any node; 100 nodes fit
+# no single smoke node), and the Pending pods consume no allocatable, so they
+# do not disturb other tests sharing the cluster.
+@pytest.mark.kubernetes
+def test_retry_until_up_waiting_request_is_reexecuted(generic_cloud: str):
+    del generic_cloud  # Kubernetes-specific; see comment above.
+    name = smoke_tests_utils.get_cluster_name()
+    req_file = f'/tmp/{name}.req'
+    # Capture the async launch's request id so we can poll its status.
+    launch = (
+        f'req=$(sky launch -c {name} --infra kubernetes --cpus 1 '
+        f'--num-nodes 100 --retry-until-up -y --async "echo regression" '
+        f"| grep -oE 'request: [0-9a-f-]+' | head -1 | awk '{{print $2}}'); "
+        f'echo "captured request id: $req"; test -n "$req"; '
+        f'echo "$req" > {req_file}')
+
+    def _wait_for_status(status: str, timeout: int) -> str:
+        # Poll the specific request until it reaches `status`. -a so WAITING
+        # (hidden by the default active filter) is shown.
+        return (
+            f'req=$(cat {req_file}); start=$SECONDS; '
+            f'until sky api status -a "$req" | grep -qw {status}; do '
+            f'  if [ $((SECONDS - start)) -gt {timeout} ]; then '
+            f'    echo "timed out waiting for request to reach {status}"; '
+            f'    sky api status -a "$req"; exit 1; '
+            f'  fi; '
+            f'  sleep 5; '
+            f'done; echo "request reached {status}"')
+
+    test = smoke_tests_utils.Test(
+        'test_retry_until_up_waiting_request_is_reexecuted',
+        [
+            launch,
+            # First the request runs (1st provision attempt), fails to schedule
+            # 100 nodes, and parks in WAITING.
+            _wait_for_status('WAITING', timeout=300),
+            # The fix: the re-enqueued WAITING request must run again. Any
+            # RUNNING observed after WAITING is a re-execution. Pre-fix the
+            # request is stranded in WAITING and this times out.
+            _wait_for_status('RUNNING', timeout=300),
+        ],
+        teardown=(f'req=$(cat {req_file} 2>/dev/null); '
+                  f'sky api cancel -y "$req" 2>/dev/null || true; '
+                  f'sky down -y {name} 2>/dev/null || true; '
+                  f'rm -f {req_file}'),
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test, check_sky_status=False)
+
+
 # ---- Test recent request tracking -----
 # We mark this test as no_remote_server since it requires a dedicated API server
 # for the test otherwise we can't make any guarantees about the most recent

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -296,26 +296,15 @@ def test_requests_scheduling(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
-# ---- Test retry-until-up WAITING request is re-executed -----
-# Regression test for a re-enqueued WAITING request being silently dropped.
-#
-# When `--retry-until-up` provisioning exhausts all launchable resources it
-# raises ExecutionRetryableError, which yields the worker and parks the request
-# in WAITING, then re-enqueues it for another attempt. The execution wrapper
-# must run the re-enqueued WAITING request (not just PENDING ones); previously
-# it skipped anything that was not PENDING, so the request was consumed off the
-# queue, never re-executed, and stranded in WAITING forever.
-#
-# Kubernetes-only: feasibility checks node *capacity* (not free *allocatable*),
-# so a request whose per-node size fits a node but whose node *count* exceeds
-# what the cluster can schedule passes feasibility, then has its pods sit
-# Pending and fails provisioning -> the retry/WAITING path. Requesting many
-# 1-CPU nodes makes this size-independent (1 CPU fits any node; 100 nodes fit
-# no single smoke node), and the Pending pods consume no allocatable, so they
-# do not disturb other tests sharing the cluster.
+# Regression: a --retry-until-up launch that exhausts launchable resources
+# parks its request in WAITING and re-enqueues it; the worker must re-execute
+# it (previously it ran only PENDING requests, so the re-enqueued one was
+# dropped). Kubernetes-only and size-independent: 1-CPU nodes fit any node's
+# capacity (pass feasibility) but 100 of them fit no single smoke node, so the
+# pods stay Pending and provisioning fails into the retry/WAITING path.
 @pytest.mark.kubernetes
 def test_retry_until_up_waiting_request_is_reexecuted(generic_cloud: str):
-    del generic_cloud  # Kubernetes-specific; see comment above.
+    del generic_cloud  # Kubernetes-specific.
     name = smoke_tests_utils.get_cluster_name()
     req_file = f'/tmp/{name}.req'
     # Capture the async launch's request id so we can poll its status.
@@ -327,28 +316,24 @@ def test_retry_until_up_waiting_request_is_reexecuted(generic_cloud: str):
         f'echo "$req" > {req_file}')
 
     def _wait_for_status(status: str, timeout: int) -> str:
-        # Poll the specific request until it reaches `status`. -a so WAITING
-        # (hidden by the default active filter) is shown.
-        return (
-            f'req=$(cat {req_file}); start=$SECONDS; '
-            f'until sky api status -a "$req" | grep -qw {status}; do '
-            f'  if [ $((SECONDS - start)) -gt {timeout} ]; then '
-            f'    echo "timed out waiting for request to reach {status}"; '
-            f'    sky api status -a "$req"; exit 1; '
-            f'  fi; '
-            f'  sleep 5; '
-            f'done; echo "request reached {status}"')
+        # -a so WAITING (hidden by the default active filter) is shown.
+        return (f'req=$(cat {req_file}); start=$SECONDS; '
+                f'until sky api status -a "$req" | grep -qw {status}; do '
+                f'  if [ $((SECONDS - start)) -gt {timeout} ]; then '
+                f'    echo "timed out waiting for request to reach {status}"; '
+                f'    sky api status -a "$req"; exit 1; '
+                f'  fi; '
+                f'  sleep 5; '
+                f'done; echo "request reached {status}"')
 
     test = smoke_tests_utils.Test(
         'test_retry_until_up_waiting_request_is_reexecuted',
         [
             launch,
-            # First the request runs (1st provision attempt), fails to schedule
-            # 100 nodes, and parks in WAITING.
+            # 1st attempt fails to schedule 100 nodes -> parks in WAITING.
             _wait_for_status('WAITING', timeout=300),
-            # The fix: the re-enqueued WAITING request must run again. Any
-            # RUNNING observed after WAITING is a re-execution. Pre-fix the
-            # request is stranded in WAITING and this times out.
+            # The fix: any RUNNING after WAITING is the re-execution. Pre-fix
+            # the request is stranded in WAITING and this times out.
             _wait_for_status('RUNNING', timeout=300),
         ],
         teardown=(f'req=$(cat {req_file} 2>/dev/null); '

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -177,7 +177,9 @@ async def test_api_cancel_race_condition(isolated_database):
 
 
 @pytest.mark.asyncio
-async def test_waiting_request_is_executed_not_skipped(mock_fd_operations):
+async def test_waiting_request_is_executed_not_skipped(mock_fd_operations,
+                                                       mock_global_user_state,
+                                                       mock_skypilot_config):
     """A dequeued WAITING request must execute, not be skipped.
 
     WAITING is the state a request is parked in while waiting to resume (retry

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -176,6 +176,35 @@ async def test_api_cancel_race_condition(isolated_database):
     assert updated.status == requests_lib.RequestStatus.CANCELLED
 
 
+@pytest.mark.asyncio
+async def test_waiting_request_is_executed_not_skipped(mock_fd_operations):
+    """A dequeued WAITING request must execute, not be skipped.
+
+    WAITING is the state a request is parked in while waiting to resume (retry
+    backoff or an external continue-condition). When such a request is
+    re-enqueued and dequeued, the execution wrapper must pick it up and run it
+    just like PENDING. Regression test: the guard previously accepted only
+    PENDING, so a re-enqueued WAITING request was silently dropped and stranded.
+    """
+    req = requests_lib.Request(request_id='waiting-executes',
+                               name='test',
+                               entrypoint=_success_entrypoint,
+                               request_body=payloads.RequestBody(),
+                               status=requests_lib.RequestStatus.WAITING,
+                               created_at=0.0,
+                               user_id='test-user')
+    await requests_lib.create_if_not_exists_async(req)
+
+    executor._request_execution_wrapper('waiting-executes',
+                                        ignore_return_value=False)
+
+    # The request ran to completion instead of being skipped while WAITING.
+    updated = requests_lib.get_request('waiting-executes')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.SUCCEEDED
+    assert updated.return_value == 'success'
+
+
 def _test_isolation_worker_fn(expected_env_a: str, expected_env_b: str,
                               expected_labels: dict, **kwargs):
     """Worker that verifies it sees the correct env vars and config overrides."""


### PR DESCRIPTION
A request parked in WAITING (waiting to resume from a retry backoff or an external continue-condition) is re-enqueued onto the task queue once it is ready to run again. But _request_execution_wrapper only proceeded when the dequeued request was PENDING and silently skipped everything else, so a re-enqueued WAITING request was dropped on the floor: its queue entry was consumed, no worker ran it, and it was stranded in WAITING forever with nothing left to reschedule it.

Add RequestStatus.executable_statuses() = {PENDING, WAITING} and gate the wrapper on it, so a dequeued WAITING request transitions to RUNNING and executes like PENDING. Other statuses (RUNNING, finished, CANCELLED) are still skipped. Also raise the skip log from debug to warning so an unexpected skip is visible instead of silent.

Tested: added test_waiting_request_is_executed_not_skipped asserting a dequeued WAITING request runs to SUCCEEDED.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
