### PR TITLE
[Core] Preserve file mount blobs on API server restart

### DIFF
--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -112,8 +112,43 @@ class LocalFilesystemBlobStorage(bs.BlobStorage):
         return users
 
     def reset_on_startup(self) -> None:
-        """Called on server startup to clean up ephemeral client state."""
-        logger.debug('clearing local API server client directory at '
-                     f'{server_common.API_SERVER_CLIENT_DIR.expanduser()}')
-        shutil.rmtree(server_common.API_SERVER_CLIENT_DIR.expanduser(),
-                      ignore_errors=True)
+        """Called on server startup to clean up ephemeral client state.
+
+        We clear the transient per-request state (uploaded task YAMLs and the
+        legacy non-blob file_mounts upload dirs) so that a freshly started
+        server begins from a clean slate, matching the request DB reset.
+
+        We deliberately preserve ``file_mounts/blobs/``: blobs are
+        content-addressed, atomically committed and may still be referenced by
+        a non-terminal managed job that outlived the server restart. Wiping
+        them here would break job recovery (the controller resolves the blob on
+        relaunch) even though the dir is on persistent storage. Their lifecycle
+        is owned by the reference-aware GC in
+        ``server.cleanup_unreferenced_file_mounts`` instead.
+        """
+        clients_dir = server_common.API_SERVER_CLIENT_DIR.expanduser()
+        logger.debug('clearing transient local API server client state at '
+                     f'{clients_dir} (preserving file_mounts/blobs)')
+        if not clients_dir.exists():
+            return
+        for user_dir in clients_dir.iterdir():
+            if not user_dir.is_dir():
+                continue
+            # Uploaded task YAMLs are tied to request ids that do not survive
+            # the restart.
+            shutil.rmtree(user_dir / 'tasks', ignore_errors=True)
+            # Under file_mounts/, keep only the content-addressed blobs dir;
+            # everything else is legacy per-request upload state.
+            file_mounts_dir = user_dir / 'file_mounts'
+            if not file_mounts_dir.is_dir():
+                continue
+            for entry in file_mounts_dir.iterdir():
+                if entry.name == 'blobs':
+                    continue
+                if entry.is_dir():
+                    shutil.rmtree(entry, ignore_errors=True)
+                else:
+                    try:
+                        entry.unlink()
+                    except OSError:
+                        pass

--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -114,41 +114,46 @@ class LocalFilesystemBlobStorage(bs.BlobStorage):
     def reset_on_startup(self) -> None:
         """Called on server startup to clean up ephemeral client state.
 
-        We clear the transient per-request state (uploaded task YAMLs and the
-        legacy non-blob file_mounts upload dirs) so that a freshly started
+        Everything under each client dir is transient per-request state
+        (uploaded task YAMLs, ephemeral user logs in ``sky_logs``, legacy
+        non-blob file mount uploads, ...) and is wiped so a freshly started
         server begins from a clean slate, matching the request DB reset.
 
-        We deliberately preserve ``file_mounts/blobs/``: blobs are
+        The sole exception is ``file_mounts/blobs/``: blobs are
         content-addressed, atomically committed and may still be referenced by
-        a non-terminal managed job that outlived the server restart. Wiping
-        them here would break job recovery (the controller resolves the blob on
-        relaunch) even though the dir is on persistent storage. Their lifecycle
+        a non-terminal managed job that outlived the restart (the job
+        controller resolves the blob on relaunch). Wiping them would break job
+        recovery even though they live on persistent storage; their lifecycle
         is owned by the reference-aware GC in
-        ``server.cleanup_unreferenced_file_mounts`` instead.
+        ``server.cleanup_unreferenced_file_mounts``.
+
+        We preserve via an allowlist (keep only ``file_mounts/blobs``) rather
+        than enumerating what to delete, so any future transient directory is
+        cleaned up by default.
         """
         clients_dir = server_common.API_SERVER_CLIENT_DIR.expanduser()
         logger.debug('clearing transient local API server client state at '
                      f'{clients_dir} (preserving file_mounts/blobs)')
         if not clients_dir.exists():
             return
+
+        def _remove(path: pathlib.Path) -> None:
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+
         for user_dir in clients_dir.iterdir():
             if not user_dir.is_dir():
                 continue
-            # Uploaded task YAMLs are tied to request ids that do not survive
-            # the restart.
-            shutil.rmtree(user_dir / 'tasks', ignore_errors=True)
-            # Under file_mounts/, keep only the content-addressed blobs dir;
-            # everything else is legacy per-request upload state.
-            file_mounts_dir = user_dir / 'file_mounts'
-            if not file_mounts_dir.is_dir():
-                continue
-            for entry in file_mounts_dir.iterdir():
-                if entry.name == 'blobs':
-                    continue
-                if entry.is_dir():
-                    shutil.rmtree(entry, ignore_errors=True)
+            for entry in user_dir.iterdir():
+                if entry.name == 'file_mounts' and entry.is_dir():
+                    # Preserve only the content-addressed blobs within.
+                    for fm_entry in entry.iterdir():
+                        if fm_entry.name != 'blobs':
+                            _remove(fm_entry)
                 else:
-                    try:
-                        entry.unlink()
-                    except OSError:
-                        pass
+                    _remove(entry)

--- a/tests/unit_tests/test_sky/server/blob/test_local_blob_storage.py
+++ b/tests/unit_tests/test_sky/server/blob/test_local_blob_storage.py
@@ -12,6 +12,11 @@ def _make_client_tree(root: pathlib.Path, user: str, blob_id: str,
     # Transient uploaded task YAML.
     (user_dir / 'tasks').mkdir(parents=True)
     (user_dir / 'tasks' / 'task1.yaml').write_text('name: test')
+    # Transient ephemeral user logs.
+    (user_dir / 'sky_logs').mkdir(parents=True)
+    (user_dir / 'sky_logs' / 'download.log').write_text('some logs')
+    # Stray top-level file (exercises the file-removal branch).
+    (user_dir / 'stray.tmp').write_text('stray')
     file_mounts = user_dir / 'file_mounts'
     # Legacy per-request (non-blob) upload dir + zip.
     (file_mounts / upload_id).mkdir(parents=True)
@@ -42,8 +47,10 @@ def test_reset_on_startup_preserves_blobs(tmp_path):
     # Blob and its coordination dirs survive.
     assert (file_mounts / 'blobs' / blob_id / 'mount.txt').exists()
     assert (file_mounts / 'blobs' / '.locks').is_dir()
-    # Transient per-request state is wiped.
+    # All other transient state is wiped, including future/unknown dirs.
     assert not (user_dir / 'tasks').exists()
+    assert not (user_dir / 'sky_logs').exists()
+    assert not (user_dir / 'stray.tmp').exists()
     assert not (file_mounts / upload_id).exists()
     assert not (file_mounts / f'{upload_id}.zip').exists()
 

--- a/tests/unit_tests/test_sky/server/blob/test_local_blob_storage.py
+++ b/tests/unit_tests/test_sky/server/blob/test_local_blob_storage.py
@@ -1,0 +1,59 @@
+"""Tests for sky.server.blob.local_blob_storage."""
+import pathlib
+from unittest import mock
+
+from sky.server.blob import local_blob_storage
+
+
+def _make_client_tree(root: pathlib.Path, user: str, blob_id: str,
+                      upload_id: str) -> pathlib.Path:
+    """Create a representative clients/<user>/ tree and return the user dir."""
+    user_dir = root / user
+    # Transient uploaded task YAML.
+    (user_dir / 'tasks').mkdir(parents=True)
+    (user_dir / 'tasks' / 'task1.yaml').write_text('name: test')
+    file_mounts = user_dir / 'file_mounts'
+    # Legacy per-request (non-blob) upload dir + zip.
+    (file_mounts / upload_id).mkdir(parents=True)
+    (file_mounts / upload_id / 'data.txt').write_text('legacy')
+    (file_mounts / f'{upload_id}.zip').write_text('legacy zip')
+    # Content-addressed blob that must survive a restart.
+    (file_mounts / 'blobs' / blob_id).mkdir(parents=True)
+    (file_mounts / 'blobs' / blob_id / 'mount.txt').write_text('keep me')
+    # Blob upload coordination dirs.
+    (file_mounts / 'blobs' / '.locks').mkdir()
+    return user_dir
+
+
+def test_reset_on_startup_preserves_blobs(tmp_path):
+    """Startup reset clears transient state but keeps file_mounts/blobs."""
+    clients_dir = tmp_path / 'clients'
+    user = 'a58d87ee'
+    blob_id = '9babf19afa16a62c5fb1aee0c243531f2658c630'
+    upload_id = 'deadbeef'
+    user_dir = _make_client_tree(clients_dir, user, blob_id, upload_id)
+
+    storage = local_blob_storage.LocalFilesystemBlobStorage()
+    with mock.patch.object(local_blob_storage.server_common,
+                           'API_SERVER_CLIENT_DIR', clients_dir):
+        storage.reset_on_startup()
+
+    file_mounts = user_dir / 'file_mounts'
+    # Blob and its coordination dirs survive.
+    assert (file_mounts / 'blobs' / blob_id / 'mount.txt').exists()
+    assert (file_mounts / 'blobs' / '.locks').is_dir()
+    # Transient per-request state is wiped.
+    assert not (user_dir / 'tasks').exists()
+    assert not (file_mounts / upload_id).exists()
+    assert not (file_mounts / f'{upload_id}.zip').exists()
+
+
+def test_reset_on_startup_no_clients_dir(tmp_path):
+    """Reset is a no-op when the clients dir does not exist."""
+    clients_dir = tmp_path / 'does_not_exist'
+    storage = local_blob_storage.LocalFilesystemBlobStorage()
+    with mock.patch.object(local_blob_storage.server_common,
+                           'API_SERVER_CLIENT_DIR', clients_dir):
+        # Should not raise.
+        storage.reset_on_startup()
+    assert not clients_dir.exists()


### PR DESCRIPTION
The blob can be referenced by a running jobs, clean up blobs on restart will cause the job cannot be recovered.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)