### PR TITLE
[Jobs] Add metric for managed jobs stuck PENDING due to a system stall

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1201,6 +1201,95 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
         return [row[0] for row in rows if row[0] is not None]
 
 
+def get_pending_stall_candidates(
+) -> List[Tuple[Optional[str], Optional[str], int, float]]:
+    """Managed jobs stuck with a PENDING task due to a system issue.
+
+    A job is a *stall candidate* when all of the following hold:
+    - It is actively launching, i.e. ``schedule_state`` is LAUNCHING. This is
+      the state the controller is in only *after* it has acquired a launch slot
+      and is driving ``sky.launch`` (see ``scheduler.scheduled_launch``); a
+      launch that makes progress leaves it within seconds (the task moves to
+      STARTING). We deliberately do NOT include ALIVE: a multi-task job waiting
+      for a launch slot between tasks sits in *bare* ALIVE (the slot-wait in
+      ``scheduled_launch`` happens before the LAUNCHING transition), which is a
+      legitimate queue wait we must not alert on and is indistinguishable in the
+      DB from a controller hung in ALIVE. WAITING / INACTIVE (queued) and DONE
+      (terminal) are excluded for the same "not actively launching" reason. (A
+      controller that *dies* in any claimed state is already caught by the
+      FAILED_CONTROLLER liveness check; this detector targets the crash-loop /
+      multiplexed case where the pid looks alive but the launch never lands.)
+    - It still has a task in PENDING (``end_at`` unset).
+    - No task is currently progressing, i.e. no task is in a non-terminal,
+      non-PENDING status (STARTING / RUNNING / RECOVERING / WINDING_DOWN /
+      CANCELLING, or the legacy SUBMITTED). Defining "progressing" as the
+      complement of the terminal set means an unforeseen status reads as
+      progressing and suppresses a false alert rather than causing one. This
+      excludes the normal case where an earlier task of a multi-task DAG is
+      still running while later tasks sit in PENDING.
+
+    Returns one ``(workspace, user_hash, spot_job_id, last_event_ts)`` tuple
+    per candidate, where ``last_event_ts`` is the job's most recent
+    ``job_events.timestamp`` as unix seconds. The caller derives "seconds since
+    last progress" (``now - last_event_ts``) at scrape time so the value stays
+    fresh between cache refreshes; the staleness threshold lives in the alert
+    rule, not here. ``last_event_ts`` advances naturally across task handoffs
+    (a SUCCEEDED event is fresh), so a healthy inter-task gap reads as a small
+    age while a dead/looping controller accrues silence.
+    """
+    terminal_status_values = [
+        status.value for status in ManagedJobStatus.terminal_statuses()
+    ]
+    spot_active = sqlalchemy.alias(spot_table)
+    pending_exists = sqlalchemy.exists().where(
+        sqlalchemy.and_(
+            spot_table.c.spot_job_id == job_info_table.c.spot_job_id,
+            spot_table.c.status == ManagedJobStatus.PENDING.value,
+            spot_table.c.end_at.is_(None),
+        ))
+    progressing_exists = sqlalchemy.exists().where(
+        sqlalchemy.and_(
+            spot_active.c.spot_job_id == job_info_table.c.spot_job_id,
+            spot_active.c.status.not_in(terminal_status_values),
+            spot_active.c.status != ManagedJobStatus.PENDING.value,
+        ))
+    driving = (job_info_table.c.schedule_state ==
+               ManagedJobScheduleState.LAUNCHING.value)
+
+    # Correlated scalar subquery for each candidate's most-recent event. It is
+    # evaluated only for the rows that pass the driving/pending/progressing
+    # filters below (LAUNCHING is transient and tiny), so it is an index lookup
+    # on job_events(spot_job_id) -- not a full GROUP BY of the whole (30-day
+    # retention) job_events table on every scrape.
+    last_event_ts = sqlalchemy.select(
+        sqlalchemy.func.max(job_events_table.c.timestamp)).where(
+            job_events_table.c.spot_job_id ==
+            job_info_table.c.spot_job_id).scalar_subquery()
+    query = sqlalchemy.select(
+        job_info_table.c.workspace,
+        job_info_table.c.user_hash,
+        job_info_table.c.spot_job_id,
+        last_event_ts.label('last_ts'),
+    ).where(sqlalchemy.and_(driving, pending_exists, ~progressing_exists))
+
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(query).fetchall()
+
+    result: List[Tuple[Optional[str], Optional[str], int, float]] = []
+    for workspace, user_hash, spot_job_id, last_ts in rows:
+        if last_ts is None:
+            continue
+        # job_events.timestamp comes back as a datetime: UTC-aware on Postgres,
+        # naive (local) on SQLite (which ignores timezone=True). timestamp()
+        # yields consistent UTC-epoch seconds either way (a naive value is read
+        # as local time), matching time.time() in the collector that derives
+        # `now - last_event_ts`.
+        last_unix = last_ts.timestamp()
+        result.append((workspace, user_hash, spot_job_id, last_unix))
+    return result
+
+
 def _get_all_task_ids_statuses(
         job_id: int) -> List[Tuple[int, ManagedJobStatus]]:
     engine = _db_manager.get_engine()

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -271,6 +271,14 @@ def _label_or_default(value: Optional[str], default: str) -> str:
     return value if value else default
 
 
+# Hard upper bound on rows emitted by sky_managed_jobs_pending_stall_seconds,
+# mirroring _TIME_IN_STATE_MAX_SERIES for clusters: a churn/retry storm could
+# briefly produce many simultaneously-stalled job_id series; capping defends
+# Prometheus's series budget. Oldest (most-stuck, most-alertable) jobs survive
+# the cap.
+_PENDING_STALL_MAX_SERIES = 100
+
+
 class ManagedJobsCollector:
     """Collector for managed job state metrics.
 
@@ -295,18 +303,30 @@ class ManagedJobsCollector:
         self._cache_ttl = _COLLECTOR_CACHE_TTL_SECONDS
         # List of (workspace, user_hash, cloud, status, count) tuples.
         self._cached_rows: list = []
+        # List of (workspace, user_hash, spot_job_id, last_event_ts) tuples for
+        # jobs stuck with a PENDING task due to a system stall.
+        self._cached_stall_rows: list = []
 
     def _refresh(self):
         # pylint: disable=import-outside-toplevel
         from sky.jobs import state as managed_job_state
         self._cached_rows = (
             managed_job_state.get_status_counts_by_workspace_user_cloud())
+        self._cached_stall_rows = (
+            managed_job_state.get_pending_stall_candidates())
 
     def describe(self):
         yield prom_core.GaugeMetricFamily(
             'sky_managed_jobs_count', ('Current count of managed job tasks by '
                                        'workspace, user, status, and cloud.'),
             labels=['workspace', 'user', 'status', 'cloud'])
+        yield prom_core.GaugeMetricFamily(
+            'sky_managed_jobs_pending_stall_seconds',
+            ('Seconds since a job with a PENDING task last made any progress, '
+             'for jobs the scheduler is actively launching (LAUNCHING) but '
+             'where no task is progressing -- a system stall, not a legitimate '
+             'queue or resource wait. Alert on this exceeding a threshold.'),
+            labels=['workspace', 'user', 'job_id'])
 
     def collect(self):
         now = time.time()
@@ -318,6 +338,7 @@ class ManagedJobsCollector:
                     logger.exception('Failed to collect managed jobs metrics')
                 self._last_scrape_time = now
             rows = self._cached_rows
+            stall_rows = self._cached_stall_rows
 
         counts: dict = {}
         for workspace, user_hash, cloud, status, count in rows:
@@ -334,6 +355,25 @@ class ManagedJobsCollector:
         for (workspace, user, status, cloud), count in counts.items():
             metric.add_metric([workspace, user, status, cloud], count)
         yield metric
+
+        # Seconds-since-last-progress per stalled job. Computed against `now`
+        # at scrape time so it stays fresh between cache refreshes (only the
+        # candidate set is cached). Cap the series count (oldest/most-stuck
+        # first) to defend Prometheus's series budget against a churn storm.
+        stall_metric = prom_core.GaugeMetricFamily(
+            'sky_managed_jobs_pending_stall_seconds',
+            ('Seconds since a stalled-PENDING job last made progress, by '
+             'workspace, user, and job_id'),
+            labels=['workspace', 'user', 'job_id'])
+        capped = sorted(stall_rows,
+                        key=lambda r: r[3])[:_PENDING_STALL_MAX_SERIES]
+        for workspace, user_hash, spot_job_id, last_event_ts in capped:
+            ws_label = _label_or_default(workspace, _NULL_WORKSPACE_LABEL)
+            user_label = _label_or_default(user_hash, _NULL_LABEL)
+            stall_metric.add_metric(
+                [ws_label, user_label, str(spot_job_id)],
+                max(0.0, now - last_event_ts))
+        yield stall_metric
 
 
 # Transient statuses we report time-in-state for. UP / STOPPED are steady

--- a/tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py
@@ -33,9 +33,17 @@ class TestManagedJobsCollector:
 
             families = list(collector.collect())
 
-        assert len(families) == 1
+        # collect() yields the status-count family and the pending-stall family.
+        by_name = {f.name: f for f in families}
+        assert set(by_name) == {
+            'sky_managed_jobs_count',
+            'sky_managed_jobs_pending_stall_seconds',
+        }
+        # No stall candidates were seeded, so that family has no samples.
+        assert list(
+            by_name['sky_managed_jobs_pending_stall_seconds'].samples) == []
 
-        status_family = families[0]
+        status_family = by_name['sky_managed_jobs_count']
         assert status_family.name == 'sky_managed_jobs_count'
         samples = {(s.labels['workspace'], s.labels['user'], s.labels['status'],
                     s.labels['cloud']): s.value for s in status_family.samples}
@@ -85,16 +93,21 @@ class TestManagedJobsCollector:
                 raise RuntimeError('DB error')
             collector._cached_rows = [('ws', 'u', 'AWS', 'RUNNING', 1)]
 
+        def _count_family(families):
+            return next(
+                f for f in families if f.name == 'sky_managed_jobs_count')
+
         with patch.object(collector, '_refresh', side_effect=failing_refresh):
             # First collect fails, should yield empty metrics
             families = list(collector.collect())
-            assert len(families) == 1
-            assert list(families[0].samples) == []
+            assert list(_count_family(families).samples) == []
 
             # Second collect retries (not skipped by zero TTL)
             families = list(collector.collect())
-            assert len(families) == 1
-            samples = {s.labels['status']: s.value for s in families[0].samples}
+            samples = {
+                s.labels['status']: s.value
+                for s in _count_family(families).samples
+            }
             assert samples == {'RUNNING': 1}
 
         assert call_count == 2
@@ -105,6 +118,7 @@ class TestManagedJobsCollector:
         families = list(collector.describe())
         names = [f.name for f in families]
         assert 'sky_managed_jobs_count' in names
+        assert 'sky_managed_jobs_pending_stall_seconds' in names
 
 
 class TestManagedJobsLimitMetrics:

--- a/tests/unit_tests/test_sky/jobs/test_pending_stall_metric.py
+++ b/tests/unit_tests/test_sky/jobs/test_pending_stall_metric.py
@@ -1,0 +1,149 @@
+"""Unit tests for get_pending_stall_candidates (stuck-PENDING detection)."""
+
+import contextlib
+import datetime
+import time
+
+import filelock
+import pytest
+import sqlalchemy
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sky.jobs import state
+
+
+@pytest.fixture
+def _db(tmp_path, monkeypatch):
+    db_path = tmp_path / 'managed_jobs_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(_section: str):
+        lock_path = tmp_path / f'.{_section}.lock'
+        with filelock.FileLock(str(lock_path), timeout=10):
+            yield
+
+    monkeypatch.setattr(state.migration_utils, 'db_lock', _tmp_db_lock)
+    monkeypatch.setattr(state._db_manager, '_engine', engine)
+    monkeypatch.setattr(state._db_manager, '_engine_async', async_engine)
+    state.create_table(engine)
+    yield engine
+
+
+def _seed_job(engine, *, schedule_state, tasks, last_event_age_s):
+    """Seed one job. tasks = list of (task_id, status_str)."""
+    job_id = state.set_job_info_without_job_id(name='j',
+                                               workspace='ws',
+                                               entrypoint='e',
+                                               pool=None,
+                                               pool_hash=None,
+                                               user_hash='u')
+    # Match the codebase convention: job_events.timestamp is written as a naive
+    # datetime.datetime.now() (see state.add_job_event).
+    event_ts = (datetime.datetime.now() -
+                datetime.timedelta(seconds=last_event_age_s))
+    with engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.update(state.job_info_table).where(
+                state.job_info_table.c.spot_job_id == job_id).values(
+                    schedule_state=schedule_state))
+        for task_id, status in tasks:
+            conn.execute(
+                sqlalchemy.insert(state.spot_table).values(
+                    spot_job_id=job_id,
+                    task_id=task_id,
+                    task_name=f't{task_id}',
+                    status=status,
+                    end_at=None))
+        # One event row per job is enough; the query takes MAX(timestamp).
+        conn.execute(
+            sqlalchemy.insert(state.job_events_table).values(
+                spot_job_id=job_id,
+                task_id=0,
+                new_status=tasks[0][1],
+                timestamp=event_ts))
+    return job_id
+
+
+_LAUNCHING = state.ManagedJobScheduleState.LAUNCHING.value
+_ALIVE = state.ManagedJobScheduleState.ALIVE.value
+_WAITING = state.ManagedJobScheduleState.WAITING.value
+
+
+def _by_job(rows):
+    """rows = [(workspace, user, job_id, last_ts)] -> {job_id: last_ts}."""
+    return {job_id: last_ts for _, _, job_id, last_ts in rows}
+
+
+def test_single_task_stall_is_detected(_db):
+    jid = _seed_job(_db,
+                    schedule_state=_LAUNCHING,
+                    tasks=[(0, 'PENDING')],
+                    last_event_age_s=1000)
+    rows = state.get_pending_stall_candidates()
+    assert len(rows) == 1
+    workspace, user, job_id, last_ts = rows[0]
+    assert job_id == jid
+    assert workspace == 'ws' and user == 'u'
+    # Caller derives seconds = now - last_ts; ~1000s here.
+    assert time.time() - last_ts > 900
+
+
+def test_revert_check_states_and_progress_guards(_db):
+    # (1) stalled single-task LAUNCHING -> candidate
+    j1 = _seed_job(_db,
+                   schedule_state=_LAUNCHING,
+                   tasks=[(0, 'PENDING')],
+                   last_event_age_s=1000)
+    # (2) healthy pipeline: task0 RUNNING -> NOT candidate (active task)
+    _seed_job(_db,
+              schedule_state=_ALIVE,
+              tasks=[(0, 'RUNNING'), (1, 'PENDING')],
+              last_event_age_s=1000)
+    # (3) legitimately queued WAITING -> NOT candidate (not launching)
+    _seed_job(_db,
+              schedule_state=_WAITING,
+              tasks=[(0, 'PENDING')],
+              last_event_age_s=1000)
+    # (4) bare ALIVE between tasks (multi-task slot-wait) -> NOT candidate.
+    # This is the false-positive guard: a job waiting for a launch slot for its
+    # next task sits in bare ALIVE; we only flag LAUNCHING. If `driving`
+    # regressed to include ALIVE, this would wrongly appear.
+    _seed_job(_db,
+              schedule_state=_ALIVE,
+              tasks=[(0, 'SUCCEEDED'), (1, 'PENDING')],
+              last_event_age_s=1000)
+    # (5) multi-task job that died launching its next task (LAUNCHING) ->
+    # candidate.
+    j5 = _seed_job(_db,
+                   schedule_state=_LAUNCHING,
+                   tasks=[(0, 'SUCCEEDED'), (1, 'PENDING')],
+                   last_event_age_s=500)
+    # (6) fresh LAUNCHING -> still a candidate (the function applies no time
+    # filter; the alert threshold does), with a small age.
+    j6 = _seed_job(_db,
+                   schedule_state=_LAUNCHING,
+                   tasks=[(0, 'PENDING')],
+                   last_event_age_s=5)
+
+    by_job = _by_job(state.get_pending_stall_candidates())
+    # Only 1, 5, 6 qualify. If `driving` regressed to include ALIVE, (4) would
+    # wrongly appear. If the progressing guard regressed, (2) would too.
+    assert set(by_job) == {j1, j5, j6}
+    assert time.time() - by_job[j1] > 900  # stalled
+    assert time.time() - by_job[j6] < 60  # fresh; rule won't fire on it
+
+
+def test_no_candidates_returns_empty(_db):
+    _seed_job(_db,
+              schedule_state=_ALIVE,
+              tasks=[(0, 'RUNNING'), (1, 'PENDING')],
+              last_event_age_s=1000)
+    _seed_job(_db,
+              schedule_state=_WAITING,
+              tasks=[(0, 'PENDING')],
+              last_event_age_s=1000)
+    assert state.get_pending_stall_candidates() == []

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -984,7 +984,9 @@ def test_managed_jobs_collector_emits_workspace_user_status_cloud():
         ('ws-a', 'u1', 'AWS', 'ManagedJobStatus.FAILED', 2),
     ]
     with patch('sky.jobs.state.get_status_counts_by_workspace_user_cloud',
-               return_value=rows):
+               return_value=rows), \
+         patch('sky.jobs.state.get_pending_stall_candidates',
+               return_value=[]):
         collector = metrics.ManagedJobsCollector()
         samples = _collect_to_dict(collector)
 
@@ -1005,6 +1007,8 @@ def test_managed_jobs_collector_emits_workspace_user_status_cloud():
 
 def test_managed_jobs_collector_handles_empty_db():
     with patch('sky.jobs.state.get_status_counts_by_workspace_user_cloud',
+               return_value=[]), \
+         patch('sky.jobs.state.get_pending_stall_candidates',
                return_value=[]):
         collector = metrics.ManagedJobsCollector()
         samples = _collect_to_dict(collector)


### PR DESCRIPTION
## Summary

A managed job can sit in `PENDING` not because it's legitimately queued or waiting for resources, but because the controller crashed or is crash-looping before it could start the task. `FAILED_CONTROLLER` doesn't catch this: controllers are multiplexed, so the shared process stays alive (or the pool is topped back up) and the liveness check passes while the job never progresses.

This adds a scrape-time, DB-backed gauge to surface it:

- `state.get_pending_stall_candidates()` — jobs whose `schedule_state` is `LAUNCHING` (the controller has a slot and is driving `sky.launch`) that still have a `PENDING` task and **no task progressing**, with the job's most recent `job_events` timestamp.
- `ManagedJobsCollector` emits `sky_managed_jobs_pending_stall_seconds{workspace,user,job_id} = now - last_event_ts` at scrape time, capped at 100 series.

A healthy launch leaves `LAUNCHING` within seconds, and a multi-task job waiting for a launch slot between tasks sits in `ALIVE` (excluded), so this doesn't false-fire on legitimate queue/resource waits. Operators alert on the gauge exceeding a threshold.

## Test plan

- Unit tests over a seeded jobs DB — the `LAUNCHING` stall and the multi-task "died launching the next task" case fire; bare-`ALIVE` slot-wait, healthy `RUNNING` pipeline, `WAITING` queue, and fresh `LAUNCHING` do **not**:
  ```
  pytest tests/unit_tests/test_sky/jobs/test_pending_stall_metric.py
  ```
- Manual: consolidation-mode server with `SKY_API_SERVER_METRICS_ENABLED=1`, held a job in `LAUNCHING+PENDING`, confirmed `sky_managed_jobs_pending_stall_seconds` climbs on `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
