### PR TITLE
[Dashboard] Show Duration on the managed job detail page

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1375,6 +1375,12 @@ function JobDetailsContent({
         </div>
       </div>
       <div>
+        <div className="text-gray-600 font-medium text-base">Duration</div>
+        <div className="text-base mt-1">
+          {formatDuration(jobData.job_duration)}
+        </div>
+      </div>
+      <div>
         <div className="text-gray-600 font-medium text-base">
           Requested Resources
         </div>


### PR DESCRIPTION
## Summary

The managed jobs table (`/jobs`) has a **Duration** column (e.g. `2h 32m`), but the job **detail page** metadata section did not show duration at all. This adds a `Duration` field to the detail page, placed right after **Submitted** to match the table's column order.

It uses the same `formatDuration(jobData.job_duration)` the table renders with, so the two views are always consistent:
- `0s` for not-yet-started (PENDING / STARTING) jobs — `job_duration` is `0`, not `null`, so it shows `0s` exactly like the table (not `-`).
- A live-updating value while RUNNING.
- The accumulated actual run time across recoveries (uses `job_duration`, not the wall-clock `total_duration`), so a job that ran, then went back to recovering/pending shows its accumulated runtime — identical to the table.
<img width="604" height="557" alt="Screenshot 2026-06-22 at 08 35 55" src="https://github.com/user-attachments/assets/b07c75b3-5d49-47b0-856f-4b4a2ee0a81d" />

## Test plan

Verified against a local API server with mock managed jobs seeded in each lifecycle state, comparing the detail page to the `/jobs` table:

| State | Table Duration | Detail page Duration |
|-------|----------------|----------------------|
| Pending | `0s` | `0s` |
| Starting | `0s` | `0s` |
| Running | `2h …m` (live) | `2h …m` (live) |
| Succeeded | `1h 5m` | `1h 5m` |
| Recovering (ran, then went back; accumulated runtime) | `2h 10m` | `2h 10m` |

In every state the detail page's Duration matches the table exactly.