### PR TITLE
[Core] Extract external links from job logs server-side

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4639,6 +4639,72 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         statuses = job_lib.load_statuses_payload(stdout)
         return statuses
 
+    def get_job_metadata(
+        self,
+        handle: CloudVmRayResourceHandle,
+        job_ids: Optional[List[int]] = None,
+    ) -> Dict[int, dict]:
+        """Best-effort fetch of per-job ``metadata`` from the cluster's skylet.
+
+        Reuses the existing job-queue read, whose payload already carries each
+        job's metadata JSON, over gRPC when available and SSH otherwise, so it
+        also works on non-gRPC clusters. Returns ``{}`` on any failure:
+        metadata-derived links are best-effort and the controller's
+        terminal-state log scan is the guarantee. Older clusters do not populate
+        the harvested-URL metadata, so they simply yield nothing here.
+        """
+        # (job_id, metadata) pairs; metadata is a JSON string (gRPC) or an
+        # already-decoded dict (SSH payload via load_job_queue).
+        raw_metadata: List[Any] = []
+        used_grpc = False
+        if handle.is_grpc_enabled_with_flag:
+            try:
+                request = jobsv1_pb2.GetJobQueueRequest(all_jobs=True)
+                response = backend_utils.invoke_skylet_with_retries(
+                    lambda: SkyletClient(handle.get_grpc_channel()
+                                        ).get_job_queue(request))
+                raw_metadata = [
+                    (job.job_id, job.metadata) for job in response.jobs
+                ]
+                used_grpc = True
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
+                logger.debug('gRPC job metadata fetch failed, falling back to '
+                             f'SSH: {e}')
+        if not used_grpc:
+            code = job_lib.JobLibCodeGen.get_job_queue(None, True)
+            try:
+                returncode, stdout, stderr = self.run_on_head(
+                    handle,
+                    code,
+                    require_outputs=True,
+                    separate_stderr=True,
+                    stream_logs=False)
+                if returncode != 0 or not stdout:
+                    logger.debug('SSH job metadata fetch failed '
+                                 f'(returncode={returncode}): {stderr}')
+                    return {}
+                raw_metadata = [(record['job_id'], record.get('metadata'))
+                                for record in job_lib.load_job_queue(stdout)]
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'SSH job metadata fetch failed: {e}')
+                return {}
+        # Empty set means "all jobs"; a non-empty set filters to those ids.
+        wanted = set(job_ids or [])
+        result: Dict[int, dict] = {}
+        for job_id, metadata in raw_metadata:
+            if wanted and job_id not in wanted:
+                continue
+            if isinstance(metadata, str):
+                if not metadata:
+                    continue
+                try:
+                    metadata = json.loads(metadata)
+                except (ValueError, TypeError):
+                    continue
+            if isinstance(metadata, dict) and metadata:
+                result[job_id] = metadata
+        return result
+
     def cancel_jobs(self,
                     handle: CloudVmRayResourceHandle,
                     jobs: Optional[List[int]],

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4667,7 +4667,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     (job.job_id, job.metadata) for job in response.jobs
                 ]
                 used_grpc = True
-            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except Exception as e:  # pylint: disable=broad-except
+                # Best-effort: any gRPC/channel failure (including a tunnel
+                # RuntimeError raised by get_grpc_channel) should fall back to
+                # the SSH path below rather than propagate.
                 logger.debug('gRPC job metadata fetch failed, falling back to '
                              f'SSH: {e}')
         if not used_grpc:

--- a/sky/core.py
+++ b/sky/core.py
@@ -1,5 +1,6 @@
 """SDK functions for cluster/job management."""
 import concurrent.futures
+import json
 import shlex
 import typing
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
@@ -38,6 +39,7 @@ from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import controller_utils
 from sky.utils import debug_utils
+from sky.utils import log_links
 from sky.utils import resources_utils
 from sky.utils import rich_utils
 from sky.utils import status_lib
@@ -1201,6 +1203,21 @@ def autostop(
 # ==================
 
 
+def _annotate_job_links(jobs: List[Dict[str, Any]]) -> None:
+    """Compute each job's external links from its harvested-URL metadata.
+
+    Matching against the configured dashboard.external_links patterns happens
+    here, server-side, in one place. URLs are harvested into job metadata by the
+    cluster's skylet, so a link is surfaced even if no one streamed the logs.
+    """
+    patterns = log_links.get_patterns()
+    for job in jobs:
+        meta = job.get('metadata') or {}
+        urls = meta.get(log_links.EXTRACTED_URLS_METADATA_KEY)
+        job['links'] = (log_links.match_links(urls, patterns)
+                        if patterns and isinstance(urls, list) else {})
+
+
 def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
                    backend: backends.CloudVmRayBackend,
                    user_hash: Optional[str],
@@ -1228,11 +1245,14 @@ def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
                     'resources': job_info.resources,
                     'log_path': job_info.log_path,
                     'user_hash': job_info.username,
+                    'metadata': (json.loads(job_info.metadata)
+                                 if job_info.metadata else {}),
                 }
                 # Copied from job_lib.load_job_queue.
                 user = global_user_state.get_user(job_dict['user_hash'])
                 job_dict['username'] = user.name if user is not None else None
                 jobs.append(job_dict)
+            _annotate_job_links(jobs)
             return jobs
         except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
             logger.debug(f'gRPC failed, falling back to SSH: {e}')
@@ -1249,7 +1269,9 @@ def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
         f'{handle.cluster_name}.',
         stderr=f'{jobs_payload + stderr}',
         stream_logs=True)
-    return job_lib.load_job_queue(jobs_payload)
+    jobs = job_lib.load_job_queue(jobs_payload)
+    _annotate_job_links(jobs)
+    return jobs
 
 
 @usage_lib.entrypoint

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -410,6 +410,8 @@ export async function getClusterJobs({ clusterName, workspace }) {
         logs: '',
         workspace: workspace || 'default',
         git_commit: job.metadata?.git_commit || '-',
+        // External links extracted server-side from the job's logs.
+        links: job.links || {},
       };
     });
     return jobData;

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -137,6 +137,20 @@ export function JobDetailPage() {
     scanLines(displayLines);
   }, [displayLines, scanLines]);
 
+  // Merge server-computed links (extracted from the full log, authoritative)
+  // with client-extracted links (DB first), so a link surfaces even if the
+  // user never streamed the line it appeared on.
+  const combinedExternalLinks = useMemo(() => {
+    const jobRecord = clusterJobData?.find((j) => j.id == job);
+    const combined = { ...(jobRecord?.links || {}) };
+    for (const [label, url] of Object.entries(extractedLinks)) {
+      if (!(label in combined)) {
+        combined[label] = url;
+      }
+    }
+    return combined;
+  }, [clusterJobData, job, extractedLinks]);
+
   const handleRefreshLogs = () => {
     setLogsRefreshToken((token) => token + 1);
   };
@@ -313,14 +327,14 @@ export function JobDetailPage() {
                         )}
                       </div>
                     </div>
-                    {Object.keys(extractedLinks).length > 0 && (
+                    {Object.keys(combinedExternalLinks).length > 0 && (
                       <div className="col-span-2">
                         <div className="text-gray-600 font-medium text-base">
                           External Links
                         </div>
                         <div className="text-base mt-1">
                           <div className="flex flex-wrap gap-4">
-                            {Object.entries(extractedLinks).map(
+                            {Object.entries(combinedExternalLinks).map(
                               ([label, url]) => {
                                 const normalizedUrl = normalizeUrl(url);
                                 return (

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -49,6 +49,7 @@ from sky.utils import context
 from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
+from sky.utils import log_links
 from sky.utils import status_lib
 from sky.utils import ux_utils
 from sky.utils.plugin_extensions import ExternalClusterFailure
@@ -67,6 +68,13 @@ logger = sky_logging.init_logger('sky.jobs.controller')
 
 _background_tasks: Set[asyncio.Task] = set()
 _background_tasks_lock: asyncio.Lock = asyncio.Lock()
+
+# Live external-link polling cadence/cap. A matching URL is printed early in a
+# run, so we attempt extraction roughly once a minute and give up after a
+# bounded number of tries; the terminal-state log scan is the guarantee. This
+# bounds SSH round-trips on non-gRPC clusters (one job-queue read per attempt).
+_LIVE_LINK_POLL_EVERY = 4  # ~1 attempt per 4 status polls (~60s)
+_LIVE_LINK_MAX_ATTEMPTS = 30  # give up live updates after ~30 attempts
 
 
 async def create_background_task(coro: typing.Coroutine) -> None:
@@ -295,6 +303,10 @@ class JobController:
             # completes.
             managed_job_state.set_local_log_file(self._job_id, task_id,
                                                  local_log_file)
+            # Scan the complete downloaded log for external links and persist
+            # them. The full log on local disk is the definitive source, so a
+            # link surfaces even if the user never streamed it.
+            self._extract_and_store_log_links(task_id, local_log_file)
 
         log_file = None
         if managed_job_runtime.is_registered():
@@ -316,6 +328,88 @@ class JobController:
                 f'task {task_id}')
 
         logger.info(f'\n== End of logs (ID: {self._job_id}) ==')
+
+    def _extract_and_store_log_links(self, task_id: Optional[int],
+                                     local_log_file: str) -> None:
+        """Scan a downloaded job log for external links and persist them.
+
+        Runs once per downloaded log (on every terminal-state and on-demand
+        download). Matching against the live ``dashboard.external_links`` config
+        happens here, in one place; the result is merged into ``spot.links``,
+        which the dashboard renders. Best-effort: never let it break the log
+        download path.
+        """
+        if task_id is None:
+            return
+        try:
+            patterns = log_links.get_patterns()
+            if not patterns:
+                return
+            if not local_log_file or not os.path.exists(local_log_file):
+                return
+            with open(local_log_file, 'r', encoding='utf-8',
+                      errors='replace') as f:
+                links = log_links.extract_links_from_lines(f, patterns)
+            if links:
+                managed_job_state.update_links(self._job_id, task_id, links)
+                logger.debug(f'Extracted external links from log: {links}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'Failed to extract external links from log file '
+                f'{local_log_file}: {common_utils.format_exception(e)}')
+
+    async def _update_live_log_links(self, task_id: Optional[int],
+                                     cluster_name: Optional[str],
+                                     job_id_on_pool_cluster: Optional[int],
+                                     found_labels: Set[str]) -> bool:
+        """Best-effort: surface external links from a running job's logs.
+
+        Reads candidate URLs harvested by the worker's skylet from job metadata
+        and matches them against the configured patterns here (one matcher, live
+        config), merging matches into ``spot.links``. The terminal-state scan is
+        the definitive backstop, so this only makes links appear sooner; any
+        failure is swallowed.
+
+        Returns True when there is nothing left to do (every configured pattern
+        has matched, or none are configured), so the caller can stop polling.
+        """
+        if task_id is None or cluster_name is None:
+            return True
+        try:
+            patterns = log_links.get_patterns()
+            if not patterns:
+                return True
+            if len(found_labels) >= len(patterns):
+                return True
+            handle = await asyncio.to_thread(
+                global_user_state.get_handle_from_cluster_name, cluster_name)
+            if handle is None:
+                return False
+            job_ids = ([job_id_on_pool_cluster]
+                       if job_id_on_pool_cluster is not None else None)
+            metadata_by_job = await asyncio.to_thread(
+                self._backend.get_job_metadata, handle, job_ids)
+            candidates: List[str] = []
+            for meta in metadata_by_job.values():
+                urls = meta.get(log_links.EXTRACTED_URLS_METADATA_KEY)
+                if isinstance(urls, list):
+                    candidates.extend(urls)
+            if candidates:
+                new_links = {
+                    label: url
+                    for label, url in log_links.match_links(
+                        candidates, patterns).items()
+                    if label not in found_labels
+                }
+                if new_links:
+                    await managed_job_state.update_links_async(
+                        self._job_id, task_id, new_links)
+                    found_labels.update(new_links.keys())
+            return len(found_labels) >= len(patterns)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug('Failed to update live external links: '
+                         f'{common_utils.format_exception(e)}')
+            return False
 
     async def _cleanup_cluster(self, cluster_name: Optional[str]) -> None:
         if cluster_name is None:
@@ -757,6 +851,12 @@ class JobController:
 
         transient_job_check_error_start_time = None
         job_check_backoff = None
+        # External-link labels already surfaced for this task, so we stop
+        # polling the worker's metadata once every pattern has matched.
+        live_link_labels: Set[str] = set()
+        live_link_done = False
+        live_link_attempts = 0
+        live_link_poll_counter = 0
 
         while True:
             # Get job status (skip on first iteration if forcing recovery)
@@ -797,6 +897,21 @@ class JobController:
                         f'Exception: {common_utils.format_exception(fetch_e)}\n'
                         f'Traceback: {traceback.format_exc()}')
                     # Fall through to recovery logic below
+
+                # While the job is running, surface external links harvested
+                # from its logs (best-effort; the terminal-state scan is the
+                # guarantee). Throttled and capped so a job that never prints a
+                # matching URL does not trigger a job-queue read on every poll
+                # (which is an SSH round-trip on non-gRPC clusters).
+                if (job_status is not None and not job_status.is_terminal() and
+                        not live_link_done and
+                        live_link_attempts < _LIVE_LINK_MAX_ATTEMPTS):
+                    live_link_poll_counter += 1
+                    if live_link_poll_counter % _LIVE_LINK_POLL_EVERY == 1:
+                        live_link_attempts += 1
+                        live_link_done = await self._update_live_log_links(
+                            task_id, cluster_name, job_id_on_pool_cluster,
+                            live_link_labels)
 
             # When job status check fails, we need to retry to avoid false alarm
             # for job failure, as it could be a transient error for

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3118,6 +3118,38 @@ async def update_links_async(job_id: int, task_id: int,
             # Transaction commits automatically when exiting the context
 
 
+@db_retries.retry
+def update_links(job_id: int, task_id: Optional[int], links: Dict[str,
+                                                                  str]) -> None:
+    """Synchronous version of update_links_async.
+
+    Merges ``links`` into the existing ``spot.links`` JSON for the given task.
+    Used by the controller's terminal-state log scan, which runs in a worker
+    thread (no running event loop) via ``asyncio.to_thread``.
+    """
+    if task_id is None or not links:
+        return
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        select_query = sqlalchemy.select(spot_table.c.links).where(
+            sqlalchemy.and_(spot_table.c.spot_job_id == job_id,
+                            spot_table.c.task_id == task_id))
+        # Row-level locking for PostgreSQL; SQLite relies on database-level
+        # write locking. Mirrors update_links_async.
+        if engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value:
+            select_query = select_query.with_for_update()
+        existing_links_row = session.execute(select_query).fetchone()
+        existing_links = {}
+        if existing_links_row and existing_links_row[0]:
+            existing_links = existing_links_row[0]
+        existing_links.update(links)
+        session.query(spot_table).filter(
+            sqlalchemy.and_(spot_table.c.spot_job_id == job_id,
+                            spot_table.c.task_id == task_id)).update(
+                                {spot_table.c.links: existing_links})
+        session.commit()
+
+
 async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
     """Set tasks in the job as cancelling, if they are in non-terminal
     states."""

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -160,6 +160,10 @@ class ClusterJobRecord(ResponseBaseModel):
     status: job_lib.JobStatus
     log_path: str
     metadata: Dict[str, Any] = {}
+    # External links extracted from the job's logs (label -> url). Computed
+    # server-side by matching URLs harvested into `metadata` against the
+    # configured dashboard.external_links patterns.
+    links: Dict[str, str] = {}
 
 
 class UploadStatus(enum.Enum):

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -158,7 +158,7 @@ MANAGED_JOB_ID_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}MANAGED_JOB_ID'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '38'  # managed job table supports submitted_at time-range.
+SKYLET_VERSION = '39'  # add external-link log-scan skylet event.
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -233,8 +233,12 @@ class JobLogLinkScanEvent(SkyletEvent):
                 continue
             harvested = self._harvested.get(job_id, [])
             offset = self._offsets.get(job_id, 0)
+            # Stop once enough URLs are harvested, or once the remaining byte
+            # budget is tiny: a small trailing read may contain no newline,
+            # which would never advance the offset and would re-read the same
+            # bytes every tick.
             if (len(harvested) >= log_links.DEFAULT_CANDIDATE_CAP or
-                    offset >= self._MAX_SCAN_BYTES):
+                    self._MAX_SCAN_BYTES - offset < 1024):
                 continue
             run_log = os.path.join(os.path.expanduser(log_dir), 'run.log')
             try:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import time
 import traceback
-from typing import Optional
+from typing import Dict, List, Optional
 
 import psutil
 
@@ -188,6 +188,77 @@ class UsageHeartbeatReportEvent(SkyletEvent):
             use_spot=_bool_env('SKYPILOT_HEARTBEAT_USE_SPOT'),
             instance_type=os.environ.get('SKYPILOT_HEARTBEAT_INSTANCE_TYPE'),
         )
+
+
+class JobLogLinkScanEvent(SkyletEvent):
+    """Harvest candidate URLs from running jobs' logs into job metadata.
+
+    Scanning at the producer (this cluster) means an external link printed by a
+    task is captured into the local jobs.db ``metadata`` even if no one ever
+    streams the logs. The controller / API server read these candidates and
+    match them against the configured ``dashboard.external_links`` patterns;
+    matching deliberately does not happen here, so the worker needs no config.
+
+    Incremental and bounded: only newly written bytes are scanned each tick, up
+    to a per-job byte budget, and scanning stops once enough distinct URLs have
+    been harvested. The controller's terminal-state scan reads the complete log
+    as the definitive backstop, so anything missed here is still recovered.
+    """
+    EVENT_INTERVAL_SECONDS = 60
+
+    # Stop scanning a job's log past this many bytes; links of interest are
+    # printed early, and this bounds work for chatty multi-GB logs.
+    _MAX_SCAN_BYTES = 10 * 1024 * 1024
+
+    def __init__(self) -> None:
+        super().__init__()
+        # job_id -> byte offset already scanned in run.log.
+        self._offsets: Dict[int, int] = {}
+        # job_id -> distinct candidate URLs already harvested.
+        self._harvested: Dict[int, List[str]] = {}
+
+    def _run(self) -> None:
+        # Imported lazily so this stays cheap; only newer skylets register the
+        # event, so the import always resolves where it runs.
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import log_links
+        job_log_dirs = job_lib.get_nonterminal_job_log_dirs()
+        active_ids = set(job_log_dirs)
+        # Drop bookkeeping for jobs that are no longer active.
+        for job_id in [j for j in self._offsets if j not in active_ids]:
+            self._offsets.pop(job_id, None)
+            self._harvested.pop(job_id, None)
+        for job_id, log_dir in job_log_dirs.items():
+            if log_dir is None:
+                continue
+            harvested = self._harvested.get(job_id, [])
+            offset = self._offsets.get(job_id, 0)
+            if (len(harvested) >= log_links.DEFAULT_CANDIDATE_CAP or
+                    offset >= self._MAX_SCAN_BYTES):
+                continue
+            run_log = os.path.join(os.path.expanduser(log_dir), 'run.log')
+            try:
+                with open(run_log, 'rb') as f:
+                    f.seek(offset)
+                    chunk = f.read(self._MAX_SCAN_BYTES - offset)
+            except OSError:
+                continue
+            # Only consume complete lines so a URL is never split across a chunk
+            # boundary (and thus skipped once we advance the offset).
+            last_newline = chunk.rfind(b'\n')
+            if last_newline == -1:
+                continue
+            consumed = last_newline + 1
+            self._offsets[job_id] = offset + consumed
+            lines = chunk[:consumed].decode('utf-8',
+                                            errors='replace').split('\n')
+            new_harvested = log_links.extract_candidate_urls(lines,
+                                                             existing=harvested)
+            self._harvested[job_id] = new_harvested
+            if len(new_harvested) != len(harvested):
+                job_lib.update_job_metadata(
+                    job_id,
+                    {log_links.EXTRACTED_URLS_METADATA_KEY: new_harvested})
 
 
 class StopEvent(SkyletEvent):

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -445,6 +445,42 @@ def get_log_dir_for_job(job_id: int) -> Optional[str]:
 
 
 @init_db
+def update_job_metadata(job_id: int, updates: Dict[str, Any]) -> None:
+    """Merge ``updates`` into the job's ``metadata`` JSON.
+
+    Read-modify-write under the per-job lock so concurrent writers (e.g. the
+    log-link scan event and a status update) do not clobber each other. No-op if
+    the job row does not exist, so this is safe to call from any node -- a
+    worker node's local DB has no row for the job.
+    """
+    assert _DB is not None
+    if not updates:
+        return
+    with filelock.FileLock(_get_lock_path(job_id)):
+        row = _DB.cursor.execute('SELECT metadata FROM jobs WHERE job_id=(?)',
+                                 (job_id,)).fetchone()
+        if row is None:
+            return
+        metadata = json.loads(row[0]) if row[0] else {}
+        metadata.update(updates)
+        _DB.cursor.execute('UPDATE jobs SET metadata=(?) WHERE job_id=(?)',
+                           (json.dumps(metadata), job_id))
+        _DB.conn.commit()
+
+
+@init_db
+def get_nonterminal_job_log_dirs() -> Dict[int, Optional[str]]:
+    """Return a ``{job_id: log_dir}`` map for all non-terminal jobs.
+
+    Used by the skylet log-link scan event to find each running job's run.log.
+    """
+    assert _DB is not None
+    jobs = _get_jobs(user_hash=None,
+                     status_list=JobStatus.nonterminal_statuses())
+    return {job['job_id']: get_log_dir_for_job(job['job_id']) for job in jobs}
+
+
+@init_db
 def _set_status_no_lock(job_id: int, status: JobStatus) -> None:
     """Setting the status of the job in the database."""
     assert _DB is not None

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -43,6 +43,9 @@ EVENTS = [
     events.ServiceUpdateEvent(pool=True),
     # Report usage heartbeat every 10 minutes.
     events.UsageHeartbeatReportEvent(),
+    # Harvest external-link URLs from running jobs' logs into job metadata so
+    # the controller / API server can surface them without log streaming.
+    events.JobLogLinkScanEvent(),
 ]
 
 

--- a/sky/utils/log_links.py
+++ b/sky/utils/log_links.py
@@ -1,0 +1,198 @@
+"""Extract external links from job logs (server/controller side).
+
+This is the Python counterpart of
+``sky/dashboard/src/utils/externalLinks.js``. The dashboard renders external
+links from the database (authoritative) and only falls back to its own
+client-side scan for clusters too old to populate the DB. To keep the two in
+agreement, the tokenization, ANSI stripping, and the built-in W&B pattern here
+MUST stay identical to the JS implementation.
+
+Two responsibilities are intentionally separated:
+
+- ``extract_candidate_urls`` harvests URL-shaped tokens with no knowledge of
+  patterns or config. It is safe to run on a worker skylet (which does not have
+  the admin ``dashboard.external_links`` config).
+- ``get_patterns``/``match_links``/``extract_links_from_lines`` do the pattern
+  matching against the live config. These run on the controller / API server,
+  so matching happens in exactly one place against one config source.
+"""
+import re
+from typing import Dict, Iterable, List, Optional, Pattern
+
+from sky import sky_logging
+from sky import skypilot_config
+
+logger = sky_logging.init_logger(__name__)
+
+# Key under which the worker skylet stashes harvested candidate URLs in the
+# local jobs.db ``metadata`` JSON. The controller / API server read this key and
+# match the URLs against the configured patterns.
+EXTRACTED_URLS_METADATA_KEY = 'extracted_urls'
+
+# Mirror of BUILTIN_URL_PATTERNS in externalLinks.js. Anchored so a token must
+# be exactly a W&B run URL (and not, e.g., the project page).
+BUILTIN_PATTERNS: Dict[str, str] = {
+    # Matches W&B SaaS (wandb.ai) and dedicated tenants (<tenant>.wandb.io).
+    'W&B Run': (r'^https://(?:wandb\.ai|[^/]+\.wandb\.io)'
+                r'/[^/]+/[^/]+/runs/[^/]+$'),
+}
+
+# Mirror of stripAnsiCodes() in dashboard/src/components/utils.jsx.
+_ANSI_RE = re.compile(r'\x1b\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGKH]')
+
+# Mirror of the token split in extractLinksFromLogs(): whitespace plus the
+# common delimiters that bracket a URL in log output.
+_TOKEN_SPLIT_RE = re.compile(r'[\s"\'<>()\[\]{},;]+')
+
+# Trailing punctuation stripped from each token (mirror of JS).
+_TRAILING_PUNCT_RE = re.compile(r'[.,:;!?]+$')
+
+# Only http(s) tokens are candidate URLs (used by the worker harvest, which has
+# no patterns to test against).
+_URL_PREFIX_RE = re.compile(r'^https?://')
+
+# Bound the number of distinct candidate URLs retained by the worker harvest so
+# a chatty log cannot bloat ``jobs.metadata``. Links of interest are printed
+# early in a run, so insertion order keeps them. The controller's terminal scan
+# reads the complete (uncapped) log, so this cap never affects final
+# correctness, only how quickly a link shows up live.
+DEFAULT_CANDIDATE_CAP = 200
+
+
+def _strip_ansi(line: str) -> str:
+    return _ANSI_RE.sub('', line)
+
+
+def extract_candidate_urls(
+    lines: Iterable[str],
+    existing: Optional[List[str]] = None,
+    cap: int = DEFAULT_CANDIDATE_CAP,
+) -> List[str]:
+    """Return distinct http(s) URL tokens found in the given log lines.
+
+    No pattern matching or config is required, so this is safe to run on a
+    worker skylet. Tokenization mirrors ``extractLinksFromLogs`` in the
+    dashboard.
+
+    Args:
+        lines: Log lines to scan.
+        existing: URLs already harvested (preserved and de-duplicated against).
+        cap: Maximum number of distinct URLs to retain.
+
+    Returns:
+        Distinct URL tokens in first-seen order.
+    """
+    urls: List[str] = list(existing or [])
+    seen = set(urls)
+    for line in lines:
+        if len(urls) >= cap:
+            break
+        if not isinstance(line, str):
+            continue
+        for token in _TOKEN_SPLIT_RE.split(_strip_ansi(line)):
+            clean = _TRAILING_PUNCT_RE.sub('', token)
+            if not clean or not _URL_PREFIX_RE.match(clean):
+                continue
+            if clean not in seen:
+                seen.add(clean)
+                urls.append(clean)
+                if len(urls) >= cap:
+                    break
+    return urls
+
+
+def compile_admin_patterns(entries: Optional[list]) -> Dict[str, Pattern]:
+    """Compile ``dashboard.external_links`` entries into a label -> regex map.
+
+    Mirrors ``compileCustomPatterns`` in externalLinks.js. Invalid regexes are
+    skipped with a warning so one bad entry does not break extraction.
+    """
+    compiled: Dict[str, Pattern] = {}
+    if not isinstance(entries, list):
+        return compiled
+    for entry in entries:
+        if (not isinstance(entry, dict) or
+                not isinstance(entry.get('label'), str) or
+                not isinstance(entry.get('regex'), str)):
+            continue
+        try:
+            compiled[entry['label']] = re.compile(entry['regex'])
+        except re.error as e:
+            logger.warning(
+                'Skipping dashboard.external_links entry with invalid regex '
+                f'for label {entry["label"]!r}: {e}')
+    return compiled
+
+
+def get_patterns() -> Dict[str, Pattern]:
+    """Built-in patterns plus admin-configured ``dashboard.external_links``.
+
+    Admin entries override built-ins on a label collision, matching the
+    dashboard's merge order.
+    """
+    patterns: Dict[str, Pattern] = {
+        label: re.compile(regex) for label, regex in BUILTIN_PATTERNS.items()
+    }
+    entries = skypilot_config.get_nested(('dashboard', 'external_links'), [])
+    patterns.update(compile_admin_patterns(entries))
+    return patterns
+
+
+def match_links(candidate_urls: Iterable[str],
+                patterns: Dict[str, Pattern]) -> Dict[str, str]:
+    """Match candidate URLs against patterns, returning a label -> url map.
+
+    For each pattern, the first candidate URL that matches wins (mirroring the
+    first-match-wins behavior of ``extractLinksFromLogs``). Used by the live
+    path, where the controller already has URL tokens harvested by the worker.
+    """
+    links: Dict[str, str] = {}
+    if not patterns:
+        return links
+    for url in candidate_urls:
+        if len(links) == len(patterns):
+            break
+        for label, pattern in patterns.items():
+            if label in links:
+                continue
+            # ``pattern.search`` mirrors JS ``RegExp.test`` (unanchored); the
+            # built-in pattern carries its own ^...$ anchors.
+            if pattern.search(url):
+                links[label] = url
+                break
+    return links
+
+
+def extract_links_from_lines(
+    lines: Iterable[str],
+    patterns: Dict[str, Pattern],
+    existing: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Scan log lines and return a label -> url map of matched links.
+
+    Faithful port of ``extractLinksFromLogs`` in externalLinks.js: tokenize each
+    line, test each token against every not-yet-matched pattern, and stop early
+    once every pattern has matched. Used by the controller's terminal-state scan
+    of a complete downloaded log.
+    """
+    links: Dict[str, str] = dict(existing or {})
+    if not patterns:
+        return links
+    found = set(links.keys())
+    for line in lines:
+        if len(found) == len(patterns):
+            break
+        if not isinstance(line, str):
+            continue
+        for token in _TOKEN_SPLIT_RE.split(_strip_ansi(line)):
+            clean = _TRAILING_PUNCT_RE.sub('', token)
+            if not clean:
+                continue
+            for label, pattern in patterns.items():
+                if label in found:
+                    continue
+                if pattern.search(clean):
+                    links[label] = clean
+                    found.add(label)
+                    break
+    return links

--- a/tests/unit_tests/test_log_links.py
+++ b/tests/unit_tests/test_log_links.py
@@ -1,0 +1,172 @@
+"""Tests for sky.utils.log_links.
+
+These mirror sky/dashboard/src/utils/externalLinks.test.js so the Python
+(server/controller) extractor and the JS (dashboard fallback) extractor stay in
+agreement.
+"""
+import re
+
+from sky.utils import log_links
+
+WANDB_URL = 'https://wandb.ai/test-entity/test-project/runs/abc12345'
+WANDB_LINE = ('(wandb-link-test, pid=886) wandb: 🚀 View run b300-smoke-test '
+              f'at: {WANDB_URL}')
+
+
+def _builtin_patterns():
+    return {
+        label: re.compile(regex)
+        for label, regex in log_links.BUILTIN_PATTERNS.items()
+    }
+
+
+class TestExtractLinksFromLines:
+    """Port of the extractLinksFromLogs JS test cases."""
+
+    def test_extracts_wandb_run_url_from_prefixed_line(self):
+        links = log_links.extract_links_from_lines(
+            ['Starting fake training run...', WANDB_LINE], _builtin_patterns())
+        assert links == {'W&B Run': WANDB_URL}
+
+    def test_ignores_non_run_wandb_urls(self):
+        links = log_links.extract_links_from_lines([
+            'wandb: ⭐️ View project at: '
+            'https://wandb.ai/test-entity/test-project'
+        ], _builtin_patterns())
+        assert not links
+
+    def test_strips_ansi_escape_codes_around_url(self):
+        ansi_line = f'\x1b[36mwandb:\x1b[0m View run at: {WANDB_URL}\x1b[0m'
+        links = log_links.extract_links_from_lines([ansi_line],
+                                                   _builtin_patterns())
+        assert links == {'W&B Run': WANDB_URL}
+
+    def test_skips_non_string_entries_without_throwing(self):
+        links = log_links.extract_links_from_lines(
+            [None, 42, {
+                'msg': 'metadata'
+            }, WANDB_LINE], _builtin_patterns())
+        assert links == {'W&B Run': WANDB_URL}
+
+    def test_preserves_existing_matches(self):
+        existing = {'W&B Run': 'https://wandb.ai/a/b/runs/first'}
+        links = log_links.extract_links_from_lines([WANDB_LINE],
+                                                   _builtin_patterns(),
+                                                   existing=dict(existing))
+        assert links == existing
+
+    def test_no_patterns_returns_empty(self):
+        assert not log_links.extract_links_from_lines([WANDB_LINE], {})
+
+
+class TestExtractCandidateUrls:
+    """Worker-side candidate-URL harvesting."""
+
+    def test_harvests_distinct_http_urls_in_order(self):
+        urls = log_links.extract_candidate_urls([
+            'see https://a.com/x and https://b.com/y',
+            'again https://a.com/x',
+        ])
+        assert urls == ['https://a.com/x', 'https://b.com/y']
+
+    def test_strips_trailing_punctuation_and_ansi(self):
+        urls = log_links.extract_candidate_urls(
+            [f'\x1b[36mView run at: {WANDB_URL}.\x1b[0m'])
+        assert urls == [WANDB_URL]
+
+    def test_ignores_non_http_tokens(self):
+        urls = log_links.extract_candidate_urls(
+            ['ftp://x.com file:///etc/passwd just-text'])
+        assert not urls
+
+    def test_respects_cap(self):
+        lines = [f'https://example.com/{i}' for i in range(10)]
+        urls = log_links.extract_candidate_urls(lines, cap=3)
+        assert len(urls) == 3
+
+    def test_preserves_existing(self):
+        urls = log_links.extract_candidate_urls(['https://b.com/y'],
+                                                existing=['https://a.com/x'])
+        assert urls == ['https://a.com/x', 'https://b.com/y']
+
+    def test_skips_non_string_entries(self):
+        urls = log_links.extract_candidate_urls([None, 42, WANDB_LINE])
+        assert urls == [WANDB_URL]
+
+
+class TestMatchLinks:
+    """Matching pre-harvested candidate URLs against patterns."""
+
+    def test_first_matching_candidate_wins(self):
+        links = log_links.match_links([
+            'https://wandb.ai/e/p', WANDB_URL, 'https://wandb.ai/e2/p2/runs/z'
+        ], _builtin_patterns())
+        assert links == {'W&B Run': WANDB_URL}
+
+    def test_no_patterns_returns_empty(self):
+        assert not log_links.match_links([WANDB_URL], {})
+
+    def test_admin_pattern_matches(self):
+        patterns = {'MLflow': re.compile(r'^https://mlflow\.example\.com/.+$')}
+        links = log_links.match_links(['https://mlflow.example.com/runs/42'],
+                                      patterns)
+        assert links == {'MLflow': 'https://mlflow.example.com/runs/42'}
+
+
+class TestCompileAdminPatterns:
+    """Compiling admin-configured dashboard.external_links entries."""
+
+    def test_compiles_valid_entries(self):
+        compiled = log_links.compile_admin_patterns([{
+            'label': 'X',
+            'regex': r'^https://x\.com/.+$'
+        }])
+        assert set(compiled) == {'X'}
+        assert compiled['X'].search('https://x.com/abc')
+
+    def test_skips_invalid_regex(self):
+        compiled = log_links.compile_admin_patterns([{
+            'label': 'Bad',
+            'regex': r'('
+        }, {
+            'label': 'Good',
+            'regex': r'^https://good\.com/.+$'
+        }])
+        assert set(compiled) == {'Good'}
+
+    def test_skips_malformed_entries(self):
+        assert not log_links.compile_admin_patterns(
+            [None, {}, {
+                'label': 'no-regex'
+            }, 'str'])
+        assert not log_links.compile_admin_patterns(None)
+
+
+class TestGetPatterns:
+    """Combining built-in and admin patterns from config."""
+
+    def test_includes_builtins(self, monkeypatch):
+        monkeypatch.setattr(log_links.skypilot_config, 'get_nested',
+                            lambda *a, **k: [])
+        patterns = log_links.get_patterns()
+        assert 'W&B Run' in patterns
+        assert patterns['W&B Run'].search(WANDB_URL)
+
+    def test_merges_admin_patterns(self, monkeypatch):
+        monkeypatch.setattr(
+            log_links.skypilot_config, 'get_nested', lambda *a, **k: [{
+                'label': 'MLflow',
+                'regex': r'^https://mlflow\.example\.com/.+$'
+            }])
+        patterns = log_links.get_patterns()
+        assert {'W&B Run', 'MLflow'}.issubset(set(patterns))
+
+    def test_admin_overrides_builtin_on_collision(self, monkeypatch):
+        monkeypatch.setattr(
+            log_links.skypilot_config, 'get_nested', lambda *a, **k: [{
+                'label': 'W&B Run',
+                'regex': r'^https://override\.example\.com/.+$'
+            }])
+        patterns = log_links.get_patterns()
+        assert patterns['W&B Run'].search('https://override.example.com/x')
+        assert not patterns['W&B Run'].search(WANDB_URL)


### PR DESCRIPTION
## Summary

External links (W&B run URLs and admin-configured `dashboard.external_links` patterns) were only extracted **client-side** in the dashboard from streamed log lines. If the user never streamed the line a link was printed on (or it scrolled out of the capped streaming buffer), the link never appeared. This moves extraction **server-side** and persists results to the DB so links surface regardless of whether logs were streamed.

- **Shared matcher** (`sky/utils/log_links.py`): the Python counterpart of `externalLinks.js` (same ANSI stripping, token split, anchored built-in W&B pattern, and admin `dashboard.external_links` patterns). Matching happens in exactly one place against the live config; the worker only harvests candidate URLs.
- **Worker harvest**: a new `JobLogLinkScanEvent` skylet event incrementally scans each running job's `run.log` and stores candidate URLs in the existing `jobs.metadata` column (bounded; no schema change, so no skylet-DB migration).
- **Managed jobs**: the controller scans the complete downloaded log at terminal state, and while the job runs reads harvested candidates over the existing job-queue read (gRPC or SSH), merging matches into the existing `spot.links` column via `update_links_async`.
- **Cluster (non-managed) jobs**: the API server matches harvested candidates from job metadata into a new `links` field on the cluster job record.
- **Dashboard**: renders the DB-provided links, keeping the existing client-side scan as a fallback for clusters too old to harvest.

No new DB columns and no Alembic/migration changes (reuses the existing `jobs.metadata` and `spot.links` columns); the metadata transport reuses the existing job-queue RPC (additive only). Old clusters degrade gracefully: no harvest, and the controller's terminal-state scan still produces links for managed jobs.

## Test plan

- Unit tests: `pytest tests/unit_tests/test_log_links.py` (ports the `externalLinks.test.js` cases for parity, plus candidate-harvest, matching, admin-pattern, and config tests).
- Manual end-to-end on Kubernetes:
  - A cluster job that prints a W&B run URL: the worker harvests it into `metadata`, and `sky queue` / the dashboard show the extracted link **while the job is still running, without streaming logs**.
  - A managed job that prints a W&B run URL: after it completes, the controller's terminal-state scan populates `spot.links` and the link shows in `sky jobs queue` / the dashboard.
- `bash format.sh` passes (pylint 10.00/10, mypy clean, ESLint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
