### PR TITLE
[Jobs] Add `sky jobs describe` to show a managed job's YAML and metadata

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6291,6 +6291,134 @@ def jobs_queue(verbose: bool,
             f'--all to show all managed jobs) {colorama.Style.RESET_ALL} ')
 
 
+def _prettify_managed_job_yaml(raw_yaml: str) -> str:
+    """Re-format a stored managed-job YAML for display and re-submission.
+
+    The stored YAML is the user-specified config re-serialized by PyYAML, which
+    renders multi-line ``run``/``setup`` blocks as folded single-quote scalars
+    (ugly but valid). It may also carry an internal ``_metadata`` block in the
+    fallback path where a task has no source YAML (``Task._to_yaml_config``);
+    that field is internal-only and ``from_yaml_config`` reads it back on
+    re-launch, which would leak a stale ``git_commit`` into the reproduced job.
+    Mirror what the dashboard does (``formatJobYaml``): parse each document,
+    drop ``_metadata``, and re-dump with literal block style so the result
+    reads like the original and can be fed straight back into
+    ``sky jobs launch``. Returns the raw string unchanged if it cannot be
+    parsed.
+    """
+
+    class _BlockStyleDumper(yaml.SafeDumper):
+        pass
+
+    def _str_representer(dumper, data):
+        # Use block literal style for any multi-line string so `run`/`setup`
+        # render as `|` blocks instead of folded single-quote scalars.
+        style = '|' if '\n' in data else None
+        return dumper.represent_scalar('tag:yaml.org,2002:str',
+                                       data,
+                                       style=style)
+
+    _BlockStyleDumper.add_representer(str, _str_representer)
+
+    try:
+        docs = list(yaml_utils.safe_load_all(raw_yaml))
+    except yaml.YAMLError:
+        return raw_yaml.rstrip('\n')
+    cleaned = []
+    for doc in docs:
+        if isinstance(doc, dict):
+            doc = {k: v for k, v in doc.items() if k != '_metadata'}
+        cleaned.append(doc)
+    return yaml.dump_all(cleaned,
+                         Dumper=_BlockStyleDumper,
+                         sort_keys=False,
+                         default_flow_style=False).rstrip('\n')
+
+
+@jobs.command('describe', cls=_DocumentedCodeCommand)
+@flags.config_option(expose_value=False)
+@click.argument('job_id', type=int, required=True)
+@click.option('--yaml',
+              'yaml_only',
+              is_flag=True,
+              default=False,
+              help='Print only the original task YAML to stdout, so it can be '
+              'redirected to a file and re-submitted with `sky jobs launch`.')
+@click.option(
+    '--refresh',
+    '-r',
+    is_flag=True,
+    default=False,
+    help='Query the latest status, restarting the jobs controller if stopped.')
+@flags.output_format_option()
+@usage_lib.entrypoint
+def jobs_describe(job_id: int,
+                  yaml_only: bool,
+                  refresh: bool,
+                  output_format: str = 'table'):
+    """Show the details of a managed job.
+
+    Shows everything recorded for a single managed job, including the original
+    (unexpanded) task YAML, the entrypoint command, and the workdir git commit
+    captured at submission time. This lets you inspect and reproduce a job from
+    the CLI without opening the dashboard.
+
+    To reproduce a job, dump its YAML and relaunch it:
+
+    .. code-block:: bash
+
+      sky jobs describe 576 --yaml > job.yaml
+      sky jobs launch job.yaml
+
+    Use ``--yaml`` to print only the task YAML, or ``-o json`` for the full
+    record as JSON.
+    """
+    if yaml_only and output_format == flags.OUTPUT_FORMAT_JSON:
+        raise click.UsageError(
+            '`--yaml` and `--output json` are mutually exclusive.')
+
+    # Look the job up across all users (within accessible workspaces), mirroring
+    # `sky status <cluster>`: when a specific entity is named, the owner filter
+    # is dropped so the lookup succeeds regardless of who submitted it.
+    request_id = managed_jobs.describe(job_id=job_id,
+                                       refresh=refresh,
+                                       all_users=True)
+    # describe wraps queue_v2, which returns
+    # (records, total, status_counts, total_no_filter). The request streams
+    # server-side log lines (e.g. "Job status: RUNNING") as it refreshes; send
+    # them to a throwaway stream so they never mix into --yaml / -o json
+    # stdout, which must stay clean for redirection.
+    null_stream = io.StringIO()
+    with rich_utils.client_status('[cyan]Fetching managed job[/]'):
+        records, _, _, _ = sdk.stream_and_get(request_id,
+                                              output_stream=null_stream)
+    if not records:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'Managed job {job_id} not found.')
+
+    if yaml_only:
+        user_yaml = records[0].user_yaml
+        if not user_yaml:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'No task YAML was recorded for managed job {job_id}.')
+        click.echo(_prettify_managed_job_yaml(user_yaml))
+        return
+
+    if output_format == flags.OUTPUT_FORMAT_JSON:
+        click.echo(
+            json.dumps([r.model_dump(mode='json') for r in records], indent=2))
+        return
+
+    pretty_yaml = (_prettify_managed_job_yaml(records[0].user_yaml)
+                   if records[0].user_yaml else None)
+    click.echo(
+        table_utils.format_managed_job_details(records, user_yaml=pretty_yaml))
+    click.echo(f'\n{colorama.Style.DIM}To get just the task YAML:\n'
+               f'  sky jobs describe {job_id} --yaml\n'
+               f'{colorama.Style.RESET_ALL}')
+
+
 @jobs.command('cancel', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @click.option('--name',

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -45,6 +45,74 @@ def format_job_queue(jobs: List[responses.ClusterJobRecord]):
     return job_table
 
 
+def format_managed_job_details(records: List[responses.ManagedJobRecord],
+                               user_yaml: Optional[str] = None) -> str:
+    """Format a single managed job's details for display.
+
+    Renders job-level metadata (status, resources, entrypoint, git commit,
+    etc.) followed by the original task YAML, similar to ``kubectl describe``.
+    Mirrors the dashboard's job detail view (two resource lines — requested vs.
+    used — plus external links). ``records`` is the queue result filtered to
+    one job; a pipeline has one record per task that all share the same user
+    YAML.
+
+    Args:
+        records: the per-task records for a single job.
+        user_yaml: the task YAML to show. Falls back to the raw stored YAML on
+            the record; callers should pass a display-formatted version.
+    """
+    primary = records[0]
+    if user_yaml is None:
+        user_yaml = primary.user_yaml
+
+    git_commit = (primary.metadata or {}).get('git_commit')
+
+    status_str = primary.status.colored_str() if primary.status else '-'
+    duration = log_utils.readable_time_duration(primary.start_at,
+                                                primary.end_at,
+                                                absolute=True)
+    recoveries = ('-'
+                  if primary.recovery_count is None else primary.recovery_count)
+    # Two resource lines, matching the dashboard: what the user asked for, and
+    # what the cluster actually ran (empty once a terminal job's handle is
+    # gone).
+    requested = primary.resources or '-'
+    used = (primary.cluster_resources_full or primary.cluster_resources or '-')
+
+    rows = [
+        ('Name', primary.job_name or '-'),
+        ('Status', status_str),
+        ('User', primary.user_name or '-'),
+        ('Workspace', primary.workspace or '-'),
+        ('Pool', primary.pool or '-'),
+        ('Submitted', log_utils.readable_time_duration(primary.submitted_at)),
+        ('Duration', duration or '-'),
+        ('Recoveries', recoveries),
+        ('Requested', requested),
+        ('Resources', used),
+        ('Infra', primary.infra or '-'),
+        ('Entrypoint', primary.entrypoint or '-'),
+    ]
+    # Only show git commit / failure / links when present (like the dashboard),
+    # rather than padding the view with empty '-' rows.
+    if git_commit:
+        rows.append(('Git commit', git_commit))
+    if primary.failure_reason:
+        rows.append(('Failure', primary.failure_reason))
+    if primary.links:
+        links_str = ', '.join(
+            f'{label}: {url}' for label, url in primary.links.items())
+        rows.append(('Links', links_str))
+
+    width = max(len(key) for key, _ in rows)
+    lines = [f'Managed job {primary.job_id}', '']
+    lines += [f'  {key.ljust(width)}   {value}' for key, value in rows]
+
+    if user_yaml:
+        lines += ['', 'Task YAML', '-' * 50, user_yaml.rstrip('\n')]
+    return '\n'.join(lines)
+
+
 def format_storage_table(storages: List[responses.StorageRecord],
                          show_all: bool = False) -> str:
     """Format the storage table for display.

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -3,6 +3,7 @@ import pathlib
 
 from sky.jobs.client.sdk import cancel
 from sky.jobs.client.sdk import dashboard
+from sky.jobs.client.sdk import describe
 from sky.jobs.client.sdk import download_logs
 from sky.jobs.client.sdk import download_logs_streaming
 from sky.jobs.client.sdk import launch
@@ -39,6 +40,7 @@ __all__ = [
     'ManagedJobStatus',
     # Core
     'cancel',
+    'describe',
     'launch',
     'queue',
     'queue_v2',

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -281,6 +281,51 @@ def queue_v2(
     return server_common.get_request_id(response=response)
 
 
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
+def describe(
+    job_id: int,
+    refresh: bool = False,
+    all_users: bool = True,
+) -> server_common.RequestId[Tuple[List[responses.ManagedJobRecord], int, Dict[
+        str, int], int]]:
+    """Gets detailed information for a single managed job.
+
+    A thin convenience wrapper over :func:`queue_v2` that filters to a single
+    job id. It requests all fields (``fields=None``) rather than the trimmed
+    set the list view uses, so the heavy per-job fields the list omits for
+    performance are included: the original (unexpanded) user YAML, the
+    entrypoint, and the metadata blob carrying the workdir git commit recorded
+    at submission time. No dedicated server endpoint is required.
+
+    Please refer to sky.cli.job_describe for documentation.
+
+    Args:
+        job_id: ID of the managed job to describe.
+        refresh: Whether to restart the jobs controller if it is stopped.
+        all_users: Whether to look the job up across all users (within the
+            caller's accessible workspaces). Defaults to True, mirroring
+            ``sky status <cluster>``: when a specific job id is named the owner
+            filter is dropped so the lookup succeeds regardless of submitter.
+
+    Returns:
+        The request ID of the queue request.
+
+    Request Returns:
+        The same structure as :func:`queue_v2`, filtered to the single job: a
+        tuple of ``(job_records, total, status_counts, total_no_filter)``.
+        ``job_records`` is an empty list if no job with ``job_id`` is found.
+
+    Request Raises:
+        sky.exceptions.ClusterNotUpError: the jobs controller is not up or
+          does not exist.
+    """
+    # fields=None: fetch every field. The server selects all columns it knows
+    # (so this is forward/backward compatible — an explicit list could name a
+    # field an older server lacks), and ManagedJobRecord ignores extras.
+    return queue_v2(refresh=refresh, all_users=all_users, job_ids=[job_id])
+
+
 # Deprecated. Please use queue_v2 instead for better performance.
 # In https://github.com/skypilot-org/skypilot/pull/7695, the `queue` function
 # is updated to return new typed data for performance improvement if the API

--- a/tests/unit_tests/test_sky/test_cli_jobs_describe.py
+++ b/tests/unit_tests/test_sky/test_cli_jobs_describe.py
@@ -1,0 +1,251 @@
+"""Tests for `sky jobs describe <job-id>`.
+
+Covers the human-readable detail view, the `--yaml` clean-stdout path used for
+re-submission, `-o json`, the not-found error, and argument forwarding to the
+SDK.
+"""
+import json
+from unittest import mock
+
+from click import testing as cli_testing
+
+from sky.client.cli import command
+from sky.jobs import state as job_state
+from sky.schemas.api import responses
+
+_USER_YAML = ('name: my-llama-finetune\n'
+              'resources:\n'
+              '  accelerators: A100:8\n'
+              'run: |\n'
+              '  python train.py --lr 3e-4\n')
+
+
+def _make_job_record(job_id=576, **kwargs):
+    defaults = dict(
+        job_id=job_id,
+        task_id=0,
+        job_name='my-llama-finetune',
+        task_name='my-llama-finetune',
+        status=job_state.ManagedJobStatus.FAILED,
+        submitted_at=1700000000.0,
+        workspace='default',
+        resources='1x A100:8',
+        recovery_count=2,
+        user_name='cory',
+        entrypoint='python train.py --lr 3e-4',
+        user_yaml=_USER_YAML,
+        metadata={'git_commit': 'a1b2c3d'},
+    )
+    defaults.update(kwargs)
+    return responses.ManagedJobRecord(**defaults)
+
+
+def _install(monkeypatch, records, capture=None, stream_capture=None):
+    """Mock describe + stream_and_get; optionally capture call kwargs."""
+
+    def fake_describe(**kw):
+        if capture is not None:
+            capture.update(kw)
+        return 'req-1'
+
+    def fake_stream_and_get(*a, **kw):
+        if stream_capture is not None:
+            stream_capture.update(kw)
+        return (records, len(records), {}, len(records))
+
+    monkeypatch.setattr('sky.jobs.describe', fake_describe)
+    monkeypatch.setattr('sky.client.sdk.stream_and_get', fake_stream_and_get)
+
+
+def test_describe_human_view_shows_yaml_commit_and_entrypoint(monkeypatch):
+    """The default view must surface the YAML, git commit, and entrypoint.
+
+    Revert check: if the renderer dropped user_yaml or git_commit, these
+    asserts fail.
+    """
+    _install(monkeypatch, [_make_job_record()])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe, ['576'])
+
+    assert result.exit_code == 0, result.output
+    assert 'Managed job 576' in result.output
+    # Entrypoint and the workdir git commit are rendered.
+    assert 'python train.py --lr 3e-4' in result.output
+    assert 'a1b2c3d' in result.output
+    # The original YAML body is included.
+    assert 'name: my-llama-finetune' in result.output
+    assert 'accelerators: A100:8' in result.output
+    assert 'sky jobs describe 576 --yaml' in result.output
+    assert 'Entrypoint' in result.output
+    assert 'Git commit' in result.output
+
+
+def test_describe_shows_requested_and_used_resources_and_links(monkeypatch):
+    """Mirror the dashboard: requested vs. used resources, plus external links.
+
+    Revert check: collapse back to a single 'Resources' line / drop the links
+    row and these asserts fail.
+    """
+    record = _make_job_record(
+        resources='1x A100:8',
+        cluster_resources='1x AWS(p4d.24xlarge, A100:8)',
+        links={'Grafana': 'https://grafana.example/d/abc'},
+    )
+    _install(monkeypatch, [record])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe, ['576'])
+
+    assert result.exit_code == 0, result.output
+    assert 'Requested' in result.output
+    assert '1x A100:8' in result.output  # requested
+    assert 'p4d.24xlarge' in result.output  # used / cluster resources
+    assert 'Grafana: https://grafana.example/d/abc' in result.output
+
+
+def test_describe_omits_git_commit_row_when_absent(monkeypatch):
+    """No git commit recorded -> no 'Git commit' row (not a '-' placeholder).
+
+    Matches how Links is handled. Revert check: render it unconditionally and
+    the 'Git commit' label would appear even with no commit.
+    """
+    _install(monkeypatch, [_make_job_record(metadata=None)])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe, ['576'])
+
+    assert result.exit_code == 0, result.output
+    assert 'Git commit' not in result.output
+
+
+def test_describe_yaml_only_is_clean_for_resubmission(monkeypatch):
+    """`--yaml` prints only the YAML, with no header/hint/decoration.
+
+    This output is meant to be redirected to a file and fed back into
+    `sky jobs launch`, so any extra text would corrupt it.
+    """
+    _install(monkeypatch, [_make_job_record()])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '--yaml'])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == _USER_YAML.strip()
+    assert 'Managed job' not in result.output
+    assert 'Reproduce' not in result.output
+    assert 'git checkout' not in result.output
+
+
+def test_describe_yaml_only_errors_when_yaml_missing(monkeypatch):
+    """Old jobs without a recorded YAML get a clear error, not empty output."""
+    _install(monkeypatch, [_make_job_record(user_yaml=None)])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '--yaml'])
+
+    assert result.exit_code != 0
+    assert 'No task YAML' in str(result.exception)
+
+
+def test_describe_json_output(monkeypatch):
+    """`-o json` emits the full record including user_yaml and entrypoint."""
+    _install(monkeypatch, [_make_job_record()])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '-o', 'json'])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert len(parsed) == 1
+    assert parsed[0]['job_id'] == 576
+    assert parsed[0]['user_yaml'] == _USER_YAML
+    assert parsed[0]['entrypoint'] == 'python train.py --lr 3e-4'
+    assert parsed[0]['metadata']['git_commit'] == 'a1b2c3d'
+
+
+def test_describe_not_found_errors(monkeypatch):
+    """A missing job exits non-zero with a clear error."""
+    _install(monkeypatch, [])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe, ['999'])
+
+    assert result.exit_code != 0
+    assert 'not found' in str(result.exception)
+
+
+def test_describe_yaml_and_json_mutually_exclusive(monkeypatch):
+    _install(monkeypatch, [_make_job_record()])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '--yaml', '-o', 'json'])
+
+    assert result.exit_code != 0
+    assert 'mutually exclusive' in result.output
+
+
+def test_describe_yaml_is_prettified_and_strips_metadata(monkeypatch):
+    """A stored YAML with folded scalars + _metadata is cleaned up.
+
+    The stored `user_yaml` is re-serialized by the server with multi-line
+    `run`/`setup` as folded single-quote scalars. It can also carry an internal
+    `_metadata` block (the no-source-YAML fallback in `Task._to_yaml_config`),
+    which would otherwise round-trip a stale `git_commit` back via
+    `from_yaml_config` on re-launch. describe must re-format to block literal
+    style and drop `_metadata` (mirroring the dashboard) so the output reads
+    like the original and is re-submittable. Revert check: without the prettify
+    step the folded scalar / `_metadata` survive and these asserts fail.
+    """
+    import yaml
+    ugly = yaml.safe_dump({
+        '_metadata': {
+            'git_commit': 'abc'
+        },
+        'name': 'train',
+        'run': 'echo a\necho b\n',
+    })
+    _install(monkeypatch, [_make_job_record(user_yaml=ugly)])
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '--yaml'])
+
+    assert result.exit_code == 0, result.output
+    # Block literal style, not folded single-quote scalar with blank lines.
+    assert 'run: |' in result.output
+    assert "run: '" not in result.output
+    # Internal metadata is removed.
+    assert '_metadata' not in result.output
+    assert 'git_commit' not in result.output
+    # Still valid, re-submittable YAML.
+    parsed = yaml.safe_load(result.output)
+    assert parsed['run'] == 'echo a\necho b\n'
+
+
+def test_describe_suppresses_streamed_logs(monkeypatch):
+    """The queue request's streamed logs are redirected off stdout.
+
+    The refresh streams lines like 'Job status: RUNNING'; without an
+    output_stream they would corrupt --yaml / -o json. Revert check: drop the
+    output_stream kwarg and this fails.
+    """
+    stream_capture = {}
+    _install(monkeypatch, [_make_job_record()], stream_capture=stream_capture)
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe,
+                                            ['576', '--yaml'])
+
+    assert result.exit_code == 0, result.output
+    assert stream_capture.get('output_stream') is not None
+
+
+def test_describe_forwards_job_id_and_queries_all_users(monkeypatch):
+    """job_id reaches the SDK, and the lookup is always across all users.
+
+    Mirrors `sky status <cluster>`: naming a specific entity drops the owner
+    filter so the lookup succeeds regardless of submitter.
+    """
+    capture = {}
+    _install(monkeypatch, [_make_job_record(job_id=42)], capture=capture)
+
+    result = cli_testing.CliRunner().invoke(command.jobs_describe, ['42'])
+
+    assert result.exit_code == 0, result.output
+    assert capture['job_id'] == 42
+    assert capture['all_users'] is True


### PR DESCRIPTION
## Summary

Adds a `describe`-style command so CLI/API-only users can inspect and reproduce a managed job without opening the dashboard — similar to `kubectl describe pod` and MosaicML's `mcli describe run`.

- **New `sky jobs describe <job-id>` CLI command** and **`sky.jobs.describe` SDK method**, showing a single managed job's original task YAML, entrypoint, git commit, requested vs. used resources, and external links.
- `--yaml` prints just the task YAML (clean stdout, suitable for `> job.yaml` and re-submission with `sky jobs launch`); `-o json` emits the full record.
- **Reuses the existing `/jobs/queue/v2` endpoint** (filters to one job id, fetches all fields) — no new server route and no API version bump, so it works against existing servers (the dashboard already fetches a single job's YAML the same way).
- Mirrors the dashboard's job detail view: re-formats the stored YAML to block-literal style and strips the internal `_metadata` (which is internal-only and would otherwise round-trip a stale `git_commit` back via `from_yaml_config` on re-launch); shows requested vs. used resources; surfaces external links; and queries across all users within accessible workspaces, like `sky status <cluster>`.

The streamed status lines from the queue refresh are sent to a throwaway stream so `--yaml` / `-o json` stdout stays clean for redirection.

## Test plan

- `pytest tests/unit_tests/test_sky/test_cli_jobs_describe.py` — 11 tests covering: the human-readable detail view; `--yaml` clean-stdout for re-submission; YAML prettify + `_metadata` strip; streamed-log suppression; requested/used resources + links; git-commit row omitted when absent; `-o json`; `--yaml`/`-o json` mutual exclusion; not-found error; and SDK argument forwarding (always queries all users).
- Manual:
  - `sky jobs describe <id>` — detail view renders.
  - `sky jobs describe <id> --yaml > job.yaml && sky jobs launch job.yaml` — clean, re-submittable YAML.
  - `sky jobs describe <id> -o json` — valid JSON with `user_yaml`, `entrypoint`, `metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
