### PR TITLE
[Debug Dump] Collect Kubernetes resources in debug dump

### DIFF
--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -1,0 +1,423 @@
+"""Best-effort collection of a cluster's Kubernetes resources for debug dumps.
+
+When the API server dumps a cluster that runs on Kubernetes, we also snapshot
+the related k8s objects -- the pods, their events, the Services/Deployments/etc.
+SkyPilot creates during instance creation, and (if Kueue is in use) the gang
+Workload -- so an operator can inspect the cluster the way they would with
+``kubectl get -o yaml``, without needing kubectl access to the user's cluster.
+
+This module is intentionally provider-specific and self-contained: the generic
+dump path (``sky.utils.debug_utils``) discovers a cluster's k8s coordinates from
+its command runners and delegates the actual API queries here. Every query is
+best-effort -- a failure is recorded and returned, never raised, so one missing
+or inaccessible object can't abort the surrounding dump.
+"""
+import functools
+import os
+import traceback
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from sky import sky_logging
+from sky.adaptors import kubernetes
+from sky.provision import constants as provision_constants
+from sky.utils import yaml_utils
+
+logger = sky_logging.init_logger(__name__)
+
+# Kueue groups SkyPilot's pods (labeled kueue.x-k8s.io/pod-group-name=<cluster
+# name on cloud> by templates/kubernetes-ray.yml.j2) into one Workload, which it
+# names after that pod-group -- i.e. the Workload's metadata.name *is* the
+# cluster's on-cloud name. The Workload itself carries no per-cluster label, so
+# we select it by name (matching how SkyPilot's Kueue integration locates it).
+# Kueue CRD group + the versions to try newest-first for the custom objects
+# API. Kueue is currently on v1beta2 (was v1beta1); trying newest-first lets us
+# work across the Kueue versions OSS users run. An unserved version 404s and we
+# fall through; prepend 'v1' here when Kueue graduates. See _dump_kueue_objects.
+_KUEUE_GROUP = 'kueue.x-k8s.io'
+_KUEUE_VERSIONS = ('v1beta2', 'v1beta1')
+_KUEUE_WORKLOADS_PLURAL = 'workloads'
+# Label SkyPilot stamps on a cluster's pods when (and only when) a Kueue queue
+# is configured (templates/kubernetes-ray.yml.j2). Its presence is the reliable
+# "this cluster is using Kueue" signal -- more reliable than a Workload, which a
+# using-Kueue cluster can transiently lack (creation race, GC, pod-integration
+# off).
+_KUEUE_QUEUE_NAME_LABEL = 'kueue.x-k8s.io/queue-name'
+
+# Keys in a serialized Secret whose values must never leave the cluster.
+_SECRET_REDACTED_KEYS = ('data', 'stringData')
+# `kubectl apply` records the full last-applied manifest in this annotation --
+# for a Secret that includes its data/stringData verbatim (stringData even in
+# plaintext). SkyPilot creates Secrets via the API, not `kubectl apply`, so its
+# Secrets won't carry it, but we redact it so the dump never leaks values
+# regardless of how a labeled Secret was created.
+_LAST_APPLIED_ANNOTATION = 'kubectl.kubernetes.io/last-applied-configuration'
+_REDACTED = '<redacted>'
+
+
+def dump_cluster_resources(context: Optional[str], namespace: str,
+                           cluster_name_on_cloud: str,
+                           output_dir: str) -> List[Dict[str, str]]:
+    """Snapshot a Kubernetes cluster's related resources into ``output_dir``.
+
+    Writes (best-effort, skipping anything that doesn't exist)::
+
+        <output_dir>/
+          pods/<pod>.yaml      # full pod spec + status
+          events/<pod>.yaml    # events involving each pod
+          services.yaml        # resources carrying the skypilot-cluster-name
+          deployments.yaml     #   label -- i.e. what SkyPilot created during
+          ...                  #   instance creation
+          kueue/               # Kueue objects, if Kueue is in use:
+            workloads.yaml     #   this cluster's Workload(s)
+            localqueues.yaml   #   the namespace's LocalQueues
+            clusterqueues.yaml #   cluster-scoped quota config (+flavors,
+            ...                #   topologies)
+
+    Args:
+        context: kube context the cluster lives in (None = current context).
+        namespace: namespace the cluster's resources live in.
+        cluster_name_on_cloud: value of the ``skypilot-cluster-name`` label,
+            used to select this cluster's pods and the resources SkyPilot
+            created for it.
+        output_dir: directory to write the resource files into.
+
+    Returns:
+        A list of error records, each ``{'resource', 'error', 'traceback'}``,
+        for queries that failed. ``resource`` is dump-relative (e.g.
+        ``kubernetes/pods/<pod>``) so the caller can prefix it with the cluster
+        name. Empty if everything succeeded (or simply didn't exist).
+    """
+    errors: List[Dict[str, str]] = []
+    os.makedirs(output_dir, exist_ok=True)
+
+    # The ApiClient turns typed k8s model objects into kubectl-style dicts
+    # (camelCase keys), so the dumped YAML matches `kubectl get -o yaml`.
+    api_client = kubernetes.api_client(context)
+
+    def to_dict(obj: Any) -> Dict[str, Any]:
+        return _strip_managed_fields(api_client.sanitize_for_serialization(obj))
+
+    pods = _dump_pods(context, namespace, cluster_name_on_cloud, output_dir,
+                      to_dict, errors)
+    _dump_labeled_resources(context, namespace, cluster_name_on_cloud,
+                            output_dir, to_dict, errors)
+    # Only dump Kueue objects if this cluster is actually using Kueue -- its
+    # pods carry the queue-name label, which is the same signal Kueue uses to
+    # decide whether to manage a pod, so the two conditions coincide. (A
+    # using-Kueue cluster can transiently lack a Workload, so the label -- not
+    # the Workload -- is the reliable signal.) Caveat: a cluster with Kueue's
+    # non-default manageJobsWithoutQueueName=true would have even its unlabeled
+    # pods managed by Kueue; this gate would then skip Kueue for a cluster it
+    # does affect. We accept that to avoid noise in the common case.
+    uses_kueue = any(
+        _KUEUE_QUEUE_NAME_LABEL in (getattr(pod.metadata, 'labels', None) or {})
+        for pod in pods)
+    if uses_kueue:
+        _dump_kueue_objects(context, namespace, cluster_name_on_cloud,
+                            output_dir, errors)
+    return errors
+
+
+def _record_error(errors: List[Dict[str, str]], resource: str,
+                  e: Exception) -> None:
+    logger.debug(f'Failed to collect {resource}: {e}')
+    errors.append({
+        'resource': resource,
+        'error': str(e),
+        'traceback': traceback.format_exc(),
+    })
+
+
+def _write_yaml(path: str, obj: Any) -> None:
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(yaml_utils.dump_yaml_str(obj))
+
+
+def _strip_managed_fields(obj_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop metadata.managedFields from a serialized object.
+
+    managedFields is verbose server-side-apply bookkeeping that ``kubectl get
+    -o yaml`` hides by default; it's pure noise in a debug dump and can inflate
+    each object several-fold. Mutates and returns ``obj_dict``.
+    """
+    metadata = obj_dict.get('metadata')
+    if isinstance(metadata, dict):
+        metadata.pop('managedFields', None)
+    return obj_dict
+
+
+def _with_type_meta(obj_dict: Dict[str, Any], api_version: str,
+                    kind: str) -> Dict[str, Any]:
+    """Prepend apiVersion/kind to a serialized object.
+
+    Kubernetes populates TypeMeta (apiVersion/kind) only on the List wrapper,
+    not on the individual items returned by a ``list_*`` call, so objects we
+    collect via a list lack the ``kind:``/``apiVersion:`` header that a
+    ``kubectl get -o yaml`` shows (objects fetched via a ``read_*`` GET, like
+    pods, already carry it). We know the type from the call we made, so stamp it
+    on. They go first because dump_yaml_str preserves insertion order (it does
+    not sort keys), and apiVersion/kind conventionally lead a manifest.
+    """
+    rest = {
+        k: v for k, v in obj_dict.items() if k not in ('apiVersion', 'kind')
+    }
+    return {'apiVersion': api_version, 'kind': kind, **rest}
+
+
+def _dump_pods(context: Optional[str], namespace: str,
+               cluster_name_on_cloud: str, output_dir: str,
+               to_dict: Callable[[Any], Dict[str, Any]],
+               errors: List[Dict[str, str]]) -> List[Any]:
+    """Dump the cluster's pods (spec/status) and the events involving them.
+
+    Both come from a single ``list`` call each -- pods by the
+    skypilot-cluster-name label, events by a namespace-wide pod-event query
+    filtered to those pods -- so this is two API calls regardless of node count,
+    rather than one (or two) per pod. List items carry no TypeMeta, so
+    apiVersion/kind are stamped back on (see _with_type_meta).
+
+    Returns the pod objects (so the caller can inspect their labels, e.g. to
+    decide whether the cluster is using Kueue).
+    """
+    core = kubernetes.core_api(context)
+    label_selector = (f'{provision_constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                      f'{cluster_name_on_cloud}')
+
+    # Pods: one list call by label gets the head + all workers.
+    pods = []
+    try:
+        pods = core.list_namespaced_pod(
+            namespace,
+            label_selector=label_selector,
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'kubernetes/pods', e)
+    if pods:
+        pods_dir = os.path.join(output_dir, 'pods')
+        os.makedirs(pods_dir, exist_ok=True)
+        for pod in pods:
+            _write_yaml(os.path.join(pods_dir, f'{pod.metadata.name}.yaml'),
+                        _with_type_meta(to_dict(pod), 'v1', 'Pod'))
+
+    # Events: one namespace-wide query for pod events (server-side narrowed to
+    # Pods), filtered client-side to this cluster's pods and grouped per pod --
+    # there's no field selector for "name in (...)", and a per-pod query would
+    # be one call per pod.
+    pod_names = {pod.metadata.name for pod in pods}
+    if not pod_names:
+        return pods
+    try:
+        events = core.list_namespaced_event(
+            namespace,
+            field_selector='involvedObject.kind=Pod',
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'kubernetes/events', e)
+        return pods
+
+    events_by_pod: Dict[str, List[Any]] = {}
+    for event in events:
+        name = event.involved_object.name
+        if name in pod_names:
+            events_by_pod.setdefault(name, []).append(event)
+    if events_by_pod:
+        events_dir = os.path.join(output_dir, 'events')
+        os.makedirs(events_dir, exist_ok=True)
+        for name, pod_events in events_by_pod.items():
+            _write_yaml(os.path.join(events_dir, f'{name}.yaml'), [
+                _with_type_meta(to_dict(ev), 'v1', 'Event') for ev in pod_events
+            ])
+    return pods
+
+
+def _dump_labeled_resources(context: Optional[str], namespace: str,
+                            cluster_name_on_cloud: str, output_dir: str,
+                            to_dict: Callable[[Any], Dict[str, Any]],
+                            errors: List[Dict[str, str]]) -> None:
+    """Dump the resources SkyPilot created for this cluster.
+
+    Everything SkyPilot creates during instance creation carries the
+    ``skypilot-cluster-name`` label (it's how teardown finds them), so a single
+    label selector covers Services and any other kinds we create now or later.
+    """
+    label_selector = (f'{provision_constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                      f'{cluster_name_on_cloud}')
+    core = kubernetes.core_api(context)
+
+    # (filename, apiVersion, kind, lister) for the kinds SkyPilot may create.
+    # Listing a kind we didn't create just returns an empty list, so an
+    # over-broad sweep is safe and future-proofs us against new resource kinds.
+    # The apiVersion/kind are stamped onto each object (see _with_type_meta):
+    # items from a list_* call carry no TypeMeta, so without this the dump
+    # wouldn't match `kubectl get -o yaml`.
+    kinds: List[Tuple[str, str, str, Callable[[], List[Any]]]] = [
+        ('services.yaml', 'v1', 'Service', lambda: core.list_namespaced_service(
+            namespace,
+            label_selector=label_selector,
+            _request_timeout=kubernetes.API_TIMEOUT).items),
+        ('deployments.yaml', 'apps/v1', 'Deployment',
+         lambda: kubernetes.apps_api(context).list_namespaced_deployment(
+             namespace,
+             label_selector=label_selector,
+             _request_timeout=kubernetes.API_TIMEOUT).items),
+        ('persistent_volume_claims.yaml', 'v1', 'PersistentVolumeClaim',
+         lambda: core.list_namespaced_persistent_volume_claim(
+             namespace,
+             label_selector=label_selector,
+             _request_timeout=kubernetes.API_TIMEOUT).items),
+        ('config_maps.yaml', 'v1', 'ConfigMap',
+         lambda: core.list_namespaced_config_map(namespace,
+                                                 label_selector=label_selector,
+                                                 _request_timeout=kubernetes.
+                                                 API_TIMEOUT).items),
+        ('ingresses.yaml', 'networking.k8s.io/v1', 'Ingress',
+         lambda: kubernetes.networking_api(context).list_namespaced_ingress(
+             namespace,
+             label_selector=label_selector,
+             _request_timeout=kubernetes.API_TIMEOUT).items),
+    ]
+    # TODO(ishan): serialization is all-or-nothing per kind -- if to_dict throws
+    # on one item, the whole <kind>.yaml is dropped (recorded as a single
+    # error). Per-item isolation would be more robust but noisier; revisit if a
+    # single malformed object proves to lose useful siblings. Same applies to
+    # the secrets block below.
+    for filename, api_version, kind, lister in kinds:
+        try:
+            items = lister()
+            if not items:
+                continue
+            _write_yaml(os.path.join(output_dir, filename), [
+                _with_type_meta(to_dict(item), api_version, kind)
+                for item in items
+            ])
+        except Exception as e:  # pylint: disable=broad-except
+            _record_error(errors, f'kubernetes/{filename}', e)
+
+    # Secrets are dumped separately so their values can be redacted -- we want
+    # the metadata (which secrets exist, their keys) for debugging, never the
+    # contents.
+    try:
+        secrets = core.list_namespaced_secret(
+            namespace,
+            label_selector=label_selector,
+            _request_timeout=kubernetes.API_TIMEOUT).items
+        if secrets:
+            redacted = []
+            for secret in secrets:
+                secret_dict = _with_type_meta(to_dict(secret), 'v1', 'Secret')
+                for key in _SECRET_REDACTED_KEYS:
+                    values = secret_dict.get(key)
+                    if values:
+                        secret_dict[key] = {k: _REDACTED for k in values}
+                # The last-applied-configuration annotation embeds the data, so
+                # redact it too (see _LAST_APPLIED_ANNOTATION).
+                annotations = secret_dict.get('metadata', {}).get('annotations')
+                if annotations and _LAST_APPLIED_ANNOTATION in annotations:
+                    annotations[_LAST_APPLIED_ANNOTATION] = _REDACTED
+                redacted.append(secret_dict)
+            _write_yaml(os.path.join(output_dir, 'secrets.yaml'), redacted)
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'kubernetes/secrets', e)
+
+
+def _resolve_kueue_version(api: Any, namespace: str,
+                           errors: List[Dict[str, str]]) -> Optional[str]:
+    """Return the newest Kueue CRD version the cluster serves, or None.
+
+    Probes the workloads CRD with _KUEUE_VERSIONS newest-first. A 404 means that
+    version isn't served, so we try the next; if every version 404s the CRD
+    isn't installed at all -- the cluster doesn't use Kueue -- and we return
+    None so the caller skips silently. A non-404 failure is recorded.
+    """
+    for version in _KUEUE_VERSIONS:
+        try:
+            api.list_namespaced_custom_object(
+                group=_KUEUE_GROUP,
+                version=version,
+                namespace=namespace,
+                plural=_KUEUE_WORKLOADS_PLURAL,
+                limit=1,
+                _request_timeout=kubernetes.API_TIMEOUT)
+            return version
+        except kubernetes.api_exception() as e:
+            if e.status == 404:
+                continue
+            _record_error(errors, 'kubernetes/kueue/workloads', e)
+            return None
+        except Exception as e:  # pylint: disable=broad-except
+            _record_error(errors, 'kubernetes/kueue/workloads', e)
+            return None
+    return None
+
+
+def _dump_kueue_objects(context: Optional[str], namespace: str,
+                        cluster_name_on_cloud: str, output_dir: str,
+                        errors: List[Dict[str, str]]) -> None:
+    """Dump the Kueue objects relevant to this cluster, if Kueue is in use.
+
+    Into ``<output_dir>/kueue/``:
+      - workloads: this cluster's Workload(s), by the pod-group label.
+      - localqueues: the namespace's LocalQueues (the queues it can submit to).
+      - clusterqueues/resourceflavors/topologies: cluster-scoped quota config,
+        dumped whole -- admission/preemption depends on the full picture (e.g.
+        borrowing across ClusterQueues), and these carry no per-cluster label.
+
+    The custom objects API returns plain dicts, so no serialization is needed.
+    The served CRD version is resolved once (see _resolve_kueue_version); if
+    Kueue isn't installed we skip everything.
+    """
+    api = kubernetes.custom_objects_api(context)
+    version = _resolve_kueue_version(api, namespace, errors)
+    if version is None:
+        logger.debug('Kueue CRDs not served; cluster is not using Kueue, '
+                     'skipping.')
+        return
+
+    # The Workload's name is the cluster's on-cloud name (Kueue names the
+    # pod-group Workload after the group); it carries no per-cluster label, so
+    # select it by name -- a field selector returns an empty list (not a 404)
+    # when absent.
+    workload_selector = f'metadata.name={cluster_name_on_cloud}'
+    kueue_dir = os.path.join(output_dir, 'kueue')
+
+    # (filename, lister). The Workload is scoped to this cluster by name;
+    # LocalQueues to the namespace; the rest are cluster-scoped (listed whole).
+    # A CRD a given Kueue version doesn't serve 404s and is skipped.
+    list_namespaced = functools.partial(api.list_namespaced_custom_object,
+                                        group=_KUEUE_GROUP,
+                                        version=version,
+                                        namespace=namespace,
+                                        _request_timeout=kubernetes.API_TIMEOUT)
+    list_cluster = functools.partial(api.list_cluster_custom_object,
+                                     group=_KUEUE_GROUP,
+                                     version=version,
+                                     _request_timeout=kubernetes.API_TIMEOUT)
+    listers: List[Tuple[str, Callable[[], Any]]] = [
+        ('workloads.yaml', lambda: list_namespaced(
+            plural='workloads', field_selector=workload_selector)),
+        ('localqueues.yaml', lambda: list_namespaced(plural='localqueues')),
+        ('clusterqueues.yaml', lambda: list_cluster(plural='clusterqueues')),
+        ('resourceflavors.yaml',
+         lambda: list_cluster(plural='resourceflavors')),
+        ('topologies.yaml', lambda: list_cluster(plural='topologies')),
+    ]
+    for filename, lister in listers:
+        try:
+            response = lister()
+        except kubernetes.api_exception() as e:
+            if e.status == 404:
+                # This CRD isn't served at the resolved version; skip it.
+                continue
+            _record_error(errors, f'kubernetes/kueue/{filename}', e)
+            continue
+        except Exception as e:  # pylint: disable=broad-except
+            _record_error(errors, f'kubernetes/kueue/{filename}', e)
+            continue
+
+        # Custom-object items are already dicts (no to_dict), so strip
+        # managedFields here too.
+        items = response.get('items', []) if isinstance(response, dict) else []
+        if items:
+            os.makedirs(kueue_dir, exist_ok=True)
+            _write_yaml(os.path.join(kueue_dir, filename),
+                        [_strip_managed_fields(item) for item in items])

--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -1,18 +1,26 @@
-"""Best-effort collection of a cluster's Kubernetes resources for debug dumps.
+"""Best-effort collection of Kubernetes resources for debug dumps.
 
 When the API server dumps a cluster that runs on Kubernetes, we also snapshot
-the related k8s objects -- the pods, their events, the Services/Deployments/etc.
-SkyPilot creates during instance creation, and (if Kueue is in use) the gang
-Workload -- so an operator can inspect the cluster the way they would with
-``kubectl get -o yaml``, without needing kubectl access to the user's cluster.
+the related k8s objects so an operator can inspect them like
+``kubectl get -o yaml`` without needing kubectl access to the user's cluster.
+There are two entry points, split by scope:
+
+- ``dump_cluster_resources`` -- a single SkyPilot cluster's own resources (pods,
+  events, the Services/Deployments/etc. it created, and its 1:1 Kueue Workload).
+  Namespace-scoped, so it works even under minimal (namespace-only) RBAC.
+- ``dump_context_resources`` -- the cluster-WIDE infra that is *not* tied to any
+  one SkyPilot cluster (GPU-metrics pods, the non-Workload Kueue objects). The
+  caller fetches this once per unique kube context, not once per cluster. These
+  are cluster-wide API calls, so they need broader RBAC and are best-effort.
 
 This module is intentionally provider-specific and self-contained: the generic
-dump path (``sky.utils.debug_utils``) discovers a cluster's k8s coordinates from
-its command runners and delegates the actual API queries here. Every query is
-best-effort -- a failure is recorded and returned, never raised, so one missing
-or inaccessible object can't abort the surrounding dump.
+dump path (``sky.utils.debug_utils``) discovers the k8s coordinates and
+delegates the API queries here. Every query is best-effort -- a failure is
+recorded and returned, never raised, so one missing or inaccessible object
+can't abort the surrounding dump.
 """
 import functools
+import json
 import os
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -32,7 +40,8 @@ logger = sky_logging.init_logger(__name__)
 # Kueue CRD group + the versions to try newest-first for the custom objects
 # API. Kueue is currently on v1beta2 (was v1beta1); trying newest-first lets us
 # work across the Kueue versions OSS users run. An unserved version 404s and we
-# fall through; prepend 'v1' here when Kueue graduates. See _dump_kueue_objects.
+# fall through; prepend 'v1' here when Kueue graduates. See
+# _resolve_kueue_version.
 _KUEUE_GROUP = 'kueue.x-k8s.io'
 _KUEUE_VERSIONS = ('v1beta2', 'v1beta1')
 _KUEUE_WORKLOADS_PLURAL = 'workloads'
@@ -42,6 +51,18 @@ _KUEUE_WORKLOADS_PLURAL = 'workloads'
 # using-Kueue cluster can transiently lack (creation race, GC, pod-integration
 # off).
 _KUEUE_QUEUE_NAME_LABEL = 'kueue.x-k8s.io/queue-name'
+
+# GPU-metrics observability pods, useful for debugging a cluster's GPU metrics
+# (see the API server GPU-metrics setup docs). These are cluster-wide infra, not
+# per-SkyPilot-cluster, so they're dumped whenever present. The metrics
+# Prometheus is installed as helm release `skypilot-prometheus` in the
+# `skypilot` namespace, so its server pods are named `skypilot-prometheus-server
+# -*` (the prefix excludes the chart's kube-state-metrics pod). DCGM exporter's
+# namespace varies by installer, so it's matched by name substring. Both are
+# found in a single cluster-wide pod list (see _dump_gpu_metrics_pods).
+_GPU_METRICS_NAMESPACE = 'skypilot'
+_PROMETHEUS_SERVER_NAME_PREFIX = 'skypilot-prometheus-server'
+_DCGM_EXPORTER_NAME_SUBSTR = 'dcgm-exporter'
 
 # Keys in a serialized Secret whose values must never leave the cluster.
 _SECRET_REDACTED_KEYS = ('data', 'stringData')
@@ -57,21 +78,23 @@ _REDACTED = '<redacted>'
 def dump_cluster_resources(context: Optional[str], namespace: str,
                            cluster_name_on_cloud: str,
                            output_dir: str) -> List[Dict[str, str]]:
-    """Snapshot a Kubernetes cluster's related resources into ``output_dir``.
+    """Snapshot a SkyPilot cluster's *own* Kubernetes resources into output_dir.
 
-    Writes (best-effort, skipping anything that doesn't exist)::
+    Per-cluster and entirely namespace-scoped (works under minimal RBAC). Writes
+    (best-effort, skipping anything that doesn't exist)::
 
         <output_dir>/
           pods/<pod>.yaml      # full pod spec + status
           events/<pod>.yaml    # events involving each pod
           services.yaml        # resources carrying the skypilot-cluster-name
           deployments.yaml     #   label -- i.e. what SkyPilot created during
-          ...                  #   instance creation
-          kueue/               # Kueue objects, if Kueue is in use:
-            workloads.yaml     #   this cluster's Workload(s)
-            localqueues.yaml   #   the namespace's LocalQueues
-            clusterqueues.yaml #   cluster-scoped quota config (+flavors,
-            ...                #   topologies)
+          ...                  #   instance creation (PVCs, ConfigMaps,
+          secrets.yaml         #   Secrets [redacted], Ingresses)
+          kueue/workloads.yaml # this cluster's Kueue Workload, if it uses Kueue
+
+    Cluster-WIDE k8s info (GPU-metrics pods, the non-Workload Kueue objects) is
+    not tied to one cluster; it's collected once per kube context by
+    ``dump_context_resources``, not here.
 
     Args:
         context: kube context the cluster lives in (None = current context).
@@ -97,24 +120,92 @@ def dump_cluster_resources(context: Optional[str], namespace: str,
     def to_dict(obj: Any) -> Dict[str, Any]:
         return _strip_managed_fields(api_client.sanitize_for_serialization(obj))
 
-    pods = _dump_pods(context, namespace, cluster_name_on_cloud, output_dir,
-                      to_dict, errors)
+    pods, reachable = _dump_pods(context, namespace, cluster_name_on_cloud,
+                                 output_dir, to_dict, errors)
+    if not reachable:
+        # The context is defunct (the pod list couldn't connect). Skip the
+        # remaining per-cluster calls rather than stacking one timeout each.
+        return errors
     _dump_labeled_resources(context, namespace, cluster_name_on_cloud,
                             output_dir, to_dict, errors)
-    # Only dump Kueue objects if this cluster is actually using Kueue -- its
-    # pods carry the queue-name label, which is the same signal Kueue uses to
-    # decide whether to manage a pod, so the two conditions coincide. (A
-    # using-Kueue cluster can transiently lack a Workload, so the label -- not
-    # the Workload -- is the reliable signal.) Caveat: a cluster with Kueue's
-    # non-default manageJobsWithoutQueueName=true would have even its unlabeled
-    # pods managed by Kueue; this gate would then skip Kueue for a cluster it
-    # does affect. We accept that to avoid noise in the common case.
+    # Only dump the Workload if this cluster is actually using Kueue -- its pods
+    # carry the queue-name label, which is the same signal Kueue uses to decide
+    # whether to manage a pod, so the two conditions coincide. (A using-Kueue
+    # cluster can transiently lack a Workload, so the label -- not the Workload
+    # -- is the reliable signal.) Caveat: a cluster with Kueue's non-default
+    # manageJobsWithoutQueueName=true would have even its unlabeled pods managed
+    # by Kueue; this gate would then skip it. We accept that to avoid noise in
+    # the common case.
     uses_kueue = any(
         _KUEUE_QUEUE_NAME_LABEL in (getattr(pod.metadata, 'labels', None) or {})
         for pod in pods)
     if uses_kueue:
-        _dump_kueue_objects(context, namespace, cluster_name_on_cloud,
-                            output_dir, errors)
+        _dump_workload(context, namespace, cluster_name_on_cloud, output_dir,
+                       errors)
+    return errors
+
+
+def dump_context_resources(context: Optional[str],
+                           output_dir: str) -> List[Dict[str, str]]:
+    """Snapshot cluster-WIDE k8s infra for a kube context into output_dir.
+
+    These objects are shared by every SkyPilot cluster on the context, so the
+    caller fetches them once per unique context (not per cluster). Writes
+    (best-effort)::
+
+        <output_dir>/
+          context.json         # always: {context, reachable} -- so even a
+                               # bare or unreachable context stays visible
+          gpu_metrics/         # if present:
+            prometheus-server.yaml
+            dcgm-exporter.yaml
+          kueue/               # if Kueue is installed on the context:
+            localqueues.yaml  clusterqueues.yaml
+            resourceflavors.yaml  topologies.yaml
+
+    These are cluster-wide API calls (``list_pod_for_all_namespaces`` /
+    cluster-scoped custom-object lists), so they need broader RBAC than the
+    per-cluster path and are best-effort. The first call doubles as a
+    reachability gate: a connection/timeout error means the context is defunct,
+    so we record it and skip the rest (see ``_dump_gpu_metrics_pods``) rather
+    than stacking timeouts.
+
+    Returns error records with ``resource`` relative to ``output_dir`` (e.g.
+    ``gpu_metrics/prometheus-server``) for the caller to prefix with the
+    context.
+    """
+    errors: List[Dict[str, str]] = []
+    os.makedirs(output_dir, exist_ok=True)
+
+    api_client = kubernetes.api_client(context)
+
+    def to_dict(obj: Any) -> Dict[str, Any]:
+        return _strip_managed_fields(api_client.sanitize_for_serialization(obj))
+
+    reachable = _dump_gpu_metrics_pods(context, output_dir, to_dict, errors)
+    # If the context's first cluster-wide call failed to even connect, it's
+    # defunct -- skip the Kueue calls too rather than racking up more timeouts.
+    if reachable:
+        _dump_kueue_cluster_objects(context, output_dir, errors)
+
+    # Always drop a marker recording the context + whether it was reachable.
+    # Without it, a reachable context with no cluster-wide infra (or an
+    # unreachable one) leaves an empty dir, which the dump's zip omits -- so a
+    # reader couldn't tell "checked, nothing here" from "never checked". The
+    # marker guarantees every context the dump touched is visible.
+    try:
+        with open(os.path.join(output_dir, 'context.json'),
+                  'w',
+                  encoding='utf-8') as f:
+            json.dump({
+                'context': context,
+                'reachable': reachable
+            },
+                      f,
+                      indent=2,
+                      default=str)
+    except OSError as e:
+        _record_error(errors, 'context.json', e)
     return errors
 
 
@@ -126,6 +217,30 @@ def _record_error(errors: List[Dict[str, str]], resource: str,
         'error': str(e),
         'traceback': traceback.format_exc(),
     })
+
+
+def _fail_fast(api: Any) -> Any:
+    """Disable urllib3 connection retries on a freshly-built k8s client.
+
+    ``_request_timeout`` bounds a single connect attempt, but urllib3 retries a
+    failed connection ~3x by default -- so against a defunct context each call
+    takes ~4x the timeout (~20s for a 5s timeout), and the per-cluster path
+    stacks several such calls into minutes. These are best-effort diagnostic
+    reads where a connection failure should fail fast, not be retried, so we set
+    retries=0 on the client's connection pool (debug-only -- real API calls keep
+    their retries). Mutating ``connection_pool_kw`` takes effect because the
+    per-host pool is created lazily on the first request. Best-effort: if the
+    client internals differ, we leave retries as-is rather than crash.
+
+    Returns ``api`` for call-site chaining, e.g.
+    ``_fail_fast(kubernetes.core_api(context))``.
+    """
+    client = getattr(api, 'api_client', api)
+    try:
+        client.rest_client.pool_manager.connection_pool_kw['retries'] = 0
+    except AttributeError:
+        pass
+    return api
 
 
 def _write_yaml(path: str, obj: Any) -> None:
@@ -167,7 +282,7 @@ def _with_type_meta(obj_dict: Dict[str, Any], api_version: str,
 def _dump_pods(context: Optional[str], namespace: str,
                cluster_name_on_cloud: str, output_dir: str,
                to_dict: Callable[[Any], Dict[str, Any]],
-               errors: List[Dict[str, str]]) -> List[Any]:
+               errors: List[Dict[str, str]]) -> Tuple[List[Any], bool]:
     """Dump the cluster's pods (spec/status) and the events involving them.
 
     Both come from a single ``list`` call each -- pods by the
@@ -176,20 +291,30 @@ def _dump_pods(context: Optional[str], namespace: str,
     rather than one (or two) per pod. List items carry no TypeMeta, so
     apiVersion/kind are stamped back on (see _with_type_meta).
 
-    Returns the pod objects (so the caller can inspect their labels, e.g. to
-    decide whether the cluster is using Kueue).
+    Returns ``(pods, reachable)``. ``pods`` lets the caller inspect labels (e.g.
+    to decide whether the cluster is using Kueue). ``reachable`` is False only
+    when the pod list -- the first call against the context -- failed to even
+    connect (a defunct context); the caller uses it to skip this cluster's
+    remaining calls rather than stacking timeouts. Any other failure (e.g. RBAC)
+    leaves ``reachable`` True so the rest of the dump still proceeds.
     """
-    core = kubernetes.core_api(context)
+    core = _fail_fast(kubernetes.core_api(context))
     label_selector = (f'{provision_constants.TAG_SKYPILOT_CLUSTER_NAME}='
                       f'{cluster_name_on_cloud}')
 
-    # Pods: one list call by label gets the head + all workers.
+    # Pods: one list call by label gets the head + all workers. This is the
+    # first call against the context, so it doubles as the reachability gate.
     pods = []
     try:
         pods = core.list_namespaced_pod(
             namespace,
             label_selector=label_selector,
             _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.max_retry_error() as e:
+        # Couldn't connect -- the context is defunct. Signal the caller to skip
+        # this cluster's remaining calls rather than stack timeouts.
+        _record_error(errors, 'kubernetes/pods', e)
+        return [], False
     except Exception as e:  # pylint: disable=broad-except
         _record_error(errors, 'kubernetes/pods', e)
     if pods:
@@ -205,7 +330,7 @@ def _dump_pods(context: Optional[str], namespace: str,
     # be one call per pod.
     pod_names = {pod.metadata.name for pod in pods}
     if not pod_names:
-        return pods
+        return pods, True
     try:
         events = core.list_namespaced_event(
             namespace,
@@ -213,7 +338,7 @@ def _dump_pods(context: Optional[str], namespace: str,
             _request_timeout=kubernetes.API_TIMEOUT).items
     except Exception as e:  # pylint: disable=broad-except
         _record_error(errors, 'kubernetes/events', e)
-        return pods
+        return pods, True
 
     events_by_pod: Dict[str, List[Any]] = {}
     for event in events:
@@ -227,7 +352,7 @@ def _dump_pods(context: Optional[str], namespace: str,
             _write_yaml(os.path.join(events_dir, f'{name}.yaml'), [
                 _with_type_meta(to_dict(ev), 'v1', 'Event') for ev in pod_events
             ])
-    return pods
+    return pods, True
 
 
 def _dump_labeled_resources(context: Optional[str], namespace: str,
@@ -242,7 +367,7 @@ def _dump_labeled_resources(context: Optional[str], namespace: str,
     """
     label_selector = (f'{provision_constants.TAG_SKYPILOT_CLUSTER_NAME}='
                       f'{cluster_name_on_cloud}')
-    core = kubernetes.core_api(context)
+    core = _fail_fast(kubernetes.core_api(context))
 
     # (filename, apiVersion, kind, lister) for the kinds SkyPilot may create.
     # Listing a kind we didn't create just returns an empty list, so an
@@ -255,11 +380,11 @@ def _dump_labeled_resources(context: Optional[str], namespace: str,
             namespace,
             label_selector=label_selector,
             _request_timeout=kubernetes.API_TIMEOUT).items),
-        ('deployments.yaml', 'apps/v1', 'Deployment',
-         lambda: kubernetes.apps_api(context).list_namespaced_deployment(
-             namespace,
-             label_selector=label_selector,
-             _request_timeout=kubernetes.API_TIMEOUT).items),
+        ('deployments.yaml', 'apps/v1', 'Deployment', lambda: _fail_fast(
+            kubernetes.apps_api(context)).list_namespaced_deployment(
+                namespace,
+                label_selector=label_selector,
+                _request_timeout=kubernetes.API_TIMEOUT).items),
         ('persistent_volume_claims.yaml', 'v1', 'PersistentVolumeClaim',
          lambda: core.list_namespaced_persistent_volume_claim(
              namespace,
@@ -271,10 +396,11 @@ def _dump_labeled_resources(context: Optional[str], namespace: str,
                                                  _request_timeout=kubernetes.
                                                  API_TIMEOUT).items),
         ('ingresses.yaml', 'networking.k8s.io/v1', 'Ingress',
-         lambda: kubernetes.networking_api(context).list_namespaced_ingress(
-             namespace,
-             label_selector=label_selector,
-             _request_timeout=kubernetes.API_TIMEOUT).items),
+         lambda: _fail_fast(kubernetes.networking_api(context)).
+         list_namespaced_ingress(namespace,
+                                 label_selector=label_selector,
+                                 _request_timeout=kubernetes.API_TIMEOUT).items
+        ),
     ]
     # TODO(ishan): serialization is all-or-nothing per kind -- if to_dict throws
     # on one item, the whole <kind>.yaml is dropped (recorded as a single
@@ -320,98 +446,179 @@ def _dump_labeled_resources(context: Optional[str], namespace: str,
         _record_error(errors, 'kubernetes/secrets', e)
 
 
-def _resolve_kueue_version(api: Any, namespace: str,
-                           errors: List[Dict[str, str]]) -> Optional[str]:
+def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
+                           to_dict: Callable[[Any], Dict[str, Any]],
+                           errors: List[Dict[str, str]]) -> bool:
+    """Dump the GPU-metrics observability pods, if present.
+
+    Into ``<output_dir>/gpu_metrics/``:
+      - prometheus-server: the metrics Prometheus server pod (helm release
+        ``skypilot-prometheus`` in the ``skypilot`` namespace).
+      - dcgm-exporter: the DCGM exporter pods, matched by name substring across
+        all namespaces (the namespace varies by installer).
+
+    These are cluster-wide infra (not per-SkyPilot-cluster), so they're dumped
+    whenever present -- an absent component just yields no file. Both are found
+    from a single cluster-wide pod list (DCGM's namespace varies, so it can't be
+    scoped, and we reuse that list for Prometheus too). Best-effort.
+
+    Returns whether the context was *reachable*: False if the (first
+    cluster-wide) list call timed out / couldn't connect -- the caller uses this
+    to skip further cluster-wide calls on a defunct context. A reachable context
+    that errors for another reason (e.g. RBAC 403) still returns True.
+    """
+    core = _fail_fast(kubernetes.core_api(context))
+    try:
+        all_pods = core.list_pod_for_all_namespaces(
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.max_retry_error() as e:
+        # Couldn't connect -- the context is likely defunct. Signal the caller
+        # to skip the remaining cluster-wide calls rather than stack timeouts.
+        _record_error(errors, 'gpu_metrics', e)
+        return False
+    except Exception as e:  # pylint: disable=broad-except
+        # Reachable, but the call failed (e.g. RBAC 403); record and continue.
+        _record_error(errors, 'gpu_metrics', e)
+        return True
+
+    prom_pods = [
+        p for p in all_pods
+        if p.metadata.namespace == _GPU_METRICS_NAMESPACE and
+        p.metadata.name.startswith(_PROMETHEUS_SERVER_NAME_PREFIX)
+    ]
+    dcgm_pods = [
+        p for p in all_pods if _DCGM_EXPORTER_NAME_SUBSTR in p.metadata.name
+    ]
+    out_dir = os.path.join(output_dir, 'gpu_metrics')
+    for filename, matched in [('prometheus-server.yaml', prom_pods),
+                              ('dcgm-exporter.yaml', dcgm_pods)]:
+        if matched:
+            os.makedirs(out_dir, exist_ok=True)
+            _write_yaml(
+                os.path.join(out_dir, filename),
+                [_with_type_meta(to_dict(p), 'v1', 'Pod') for p in matched])
+    return True
+
+
+def _resolve_kueue_version(probe: Callable[[str],
+                                           None], errors: List[Dict[str, str]],
+                           error_resource: str) -> Optional[str]:
     """Return the newest Kueue CRD version the cluster serves, or None.
 
-    Probes the workloads CRD with _KUEUE_VERSIONS newest-first. A 404 means that
-    version isn't served, so we try the next; if every version 404s the CRD
-    isn't installed at all -- the cluster doesn't use Kueue -- and we return
-    None so the caller skips silently. A non-404 failure is recorded.
+    ``probe(version)`` makes a cheap list call for that version and raises on
+    failure; the per-cluster caller probes the namespaced ``workloads`` plural,
+    the per-context caller probes the cluster-scoped ``clusterqueues`` plural --
+    so each stays within its RBAC scope. We try _KUEUE_VERSIONS newest-first: a
+    404 means that version isn't served, so we try the next; if every version
+    404s the CRD isn't installed -- Kueue isn't in use -- and we return None so
+    the caller skips silently. A non-404 failure is recorded under
+    ``error_resource``.
     """
     for version in _KUEUE_VERSIONS:
         try:
-            api.list_namespaced_custom_object(
-                group=_KUEUE_GROUP,
-                version=version,
-                namespace=namespace,
-                plural=_KUEUE_WORKLOADS_PLURAL,
-                limit=1,
-                _request_timeout=kubernetes.API_TIMEOUT)
+            probe(version)
             return version
         except kubernetes.api_exception() as e:
             if e.status == 404:
                 continue
-            _record_error(errors, 'kubernetes/kueue/workloads', e)
+            _record_error(errors, error_resource, e)
             return None
         except Exception as e:  # pylint: disable=broad-except
-            _record_error(errors, 'kubernetes/kueue/workloads', e)
+            _record_error(errors, error_resource, e)
             return None
     return None
 
 
-def _dump_kueue_objects(context: Optional[str], namespace: str,
-                        cluster_name_on_cloud: str, output_dir: str,
-                        errors: List[Dict[str, str]]) -> None:
-    """Dump the Kueue objects relevant to this cluster, if Kueue is in use.
+def _dump_workload(context: Optional[str], namespace: str,
+                   cluster_name_on_cloud: str, output_dir: str,
+                   errors: List[Dict[str, str]]) -> None:
+    """Dump this cluster's Kueue Workload (1:1, named cluster_name_on_cloud).
 
-    Into ``<output_dir>/kueue/``:
-      - workloads: this cluster's Workload(s), by the pod-group label.
-      - localqueues: the namespace's LocalQueues (the queues it can submit to).
-      - clusterqueues/resourceflavors/topologies: cluster-scoped quota config,
-        dumped whole -- admission/preemption depends on the full picture (e.g.
-        borrowing across ClusterQueues), and these carry no per-cluster label.
-
-    The custom objects API returns plain dicts, so no serialization is needed.
-    The served CRD version is resolved once (see _resolve_kueue_version); if
-    Kueue isn't installed we skip everything.
+    Kueue names the pod-group Workload after the group, which SkyPilot sets to
+    the cluster's on-cloud name -- so the Workload's metadata.name *is*
+    cluster_name_on_cloud, and we select it by name (a field selector returns an
+    empty list, not a 404, when absent). Namespace-scoped, so it stays within
+    the per-cluster RBAC scope. The cluster-wide Kueue config (queues, flavors,
+    topologies) is dumped once per context by ``_dump_kueue_cluster_objects``.
     """
-    api = kubernetes.custom_objects_api(context)
-    version = _resolve_kueue_version(api, namespace, errors)
+    api = _fail_fast(kubernetes.custom_objects_api(context))
+
+    def _probe(version: str) -> None:
+        api.list_namespaced_custom_object(
+            group=_KUEUE_GROUP,
+            version=version,
+            namespace=namespace,
+            plural=_KUEUE_WORKLOADS_PLURAL,
+            limit=1,
+            _request_timeout=kubernetes.API_TIMEOUT)
+
+    version = _resolve_kueue_version(_probe, errors,
+                                     'kubernetes/kueue/workloads')
     if version is None:
-        logger.debug('Kueue CRDs not served; cluster is not using Kueue, '
-                     'skipping.')
+        logger.debug('Kueue CRDs not served; skipping Workload.')
         return
+    try:
+        response = api.list_namespaced_custom_object(
+            group=_KUEUE_GROUP,
+            version=version,
+            namespace=namespace,
+            plural=_KUEUE_WORKLOADS_PLURAL,
+            field_selector=f'metadata.name={cluster_name_on_cloud}',
+            _request_timeout=kubernetes.API_TIMEOUT)
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'kubernetes/kueue/workloads', e)
+        return
+    items = response.get('items', []) if isinstance(response, dict) else []
+    if items:
+        kueue_dir = os.path.join(output_dir, 'kueue')
+        os.makedirs(kueue_dir, exist_ok=True)
+        _write_yaml(os.path.join(kueue_dir, 'workloads.yaml'),
+                    [_strip_managed_fields(item) for item in items])
 
-    # The Workload's name is the cluster's on-cloud name (Kueue names the
-    # pod-group Workload after the group); it carries no per-cluster label, so
-    # select it by name -- a field selector returns an empty list (not a 404)
-    # when absent.
-    workload_selector = f'metadata.name={cluster_name_on_cloud}'
-    kueue_dir = os.path.join(output_dir, 'kueue')
 
-    # (filename, lister). The Workload is scoped to this cluster by name;
-    # LocalQueues to the namespace; the rest are cluster-scoped (listed whole).
-    # A CRD a given Kueue version doesn't serve 404s and is skipped.
-    list_namespaced = functools.partial(api.list_namespaced_custom_object,
-                                        group=_KUEUE_GROUP,
-                                        version=version,
-                                        namespace=namespace,
-                                        _request_timeout=kubernetes.API_TIMEOUT)
+def _dump_kueue_cluster_objects(context: Optional[str], output_dir: str,
+                                errors: List[Dict[str, str]]) -> None:
+    """Dump a context's cluster-WIDE Kueue config (not tied to one cluster).
+
+    Into ``<output_dir>/kueue/``: LocalQueues, ClusterQueues, ResourceFlavors,
+    Topologies -- the shared quota picture admission/preemption depends on. All
+    via the cluster-scoped list endpoint, which returns objects across every
+    namespace (including for the namespaced LocalQueue). Needs cluster-wide
+    RBAC; best-effort. The served CRD version is resolved once via a
+    cluster-scoped probe.
+    """
+    api = _fail_fast(kubernetes.custom_objects_api(context))
+
+    def _probe(version: str) -> None:
+        api.list_cluster_custom_object(group=_KUEUE_GROUP,
+                                       version=version,
+                                       plural='clusterqueues',
+                                       limit=1,
+                                       _request_timeout=kubernetes.API_TIMEOUT)
+
+    version = _resolve_kueue_version(_probe, errors, 'kueue')
+    if version is None:
+        logger.debug('Kueue CRDs not served on context; skipping.')
+        return
     list_cluster = functools.partial(api.list_cluster_custom_object,
                                      group=_KUEUE_GROUP,
                                      version=version,
                                      _request_timeout=kubernetes.API_TIMEOUT)
-    listers: List[Tuple[str, Callable[[], Any]]] = [
-        ('workloads.yaml', lambda: list_namespaced(
-            plural='workloads', field_selector=workload_selector)),
-        ('localqueues.yaml', lambda: list_namespaced(plural='localqueues')),
-        ('clusterqueues.yaml', lambda: list_cluster(plural='clusterqueues')),
-        ('resourceflavors.yaml',
-         lambda: list_cluster(plural='resourceflavors')),
-        ('topologies.yaml', lambda: list_cluster(plural='topologies')),
-    ]
-    for filename, lister in listers:
+    kueue_dir = os.path.join(output_dir, 'kueue')
+    for filename, plural in [('localqueues.yaml', 'localqueues'),
+                             ('clusterqueues.yaml', 'clusterqueues'),
+                             ('resourceflavors.yaml', 'resourceflavors'),
+                             ('topologies.yaml', 'topologies')]:
         try:
-            response = lister()
+            response = list_cluster(plural=plural)
         except kubernetes.api_exception() as e:
             if e.status == 404:
                 # This CRD isn't served at the resolved version; skip it.
                 continue
-            _record_error(errors, f'kubernetes/kueue/{filename}', e)
+            _record_error(errors, f'kueue/{filename}', e)
             continue
         except Exception as e:  # pylint: disable=broad-except
-            _record_error(errors, f'kubernetes/kueue/{filename}', e)
+            _record_error(errors, f'kueue/{filename}', e)
             continue
 
         # Custom-object items are already dicts (no to_dict), so strip

--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -57,11 +57,14 @@ _KUEUE_QUEUE_NAME_LABEL = 'kueue.x-k8s.io/queue-name'
 # per-SkyPilot-cluster, so they're dumped whenever present. The metrics
 # Prometheus is installed as helm release `skypilot-prometheus` in the
 # `skypilot` namespace, so its server pods are named `skypilot-prometheus-server
-# -*` (the prefix excludes the chart's kube-state-metrics pod). DCGM exporter's
-# namespace varies by installer, so it's matched by name substring. Both are
-# found in a single cluster-wide pod list (see _dump_gpu_metrics_pods).
+# -*`; the chart's kube-state-metrics pod (the source of `kube_pod_labels`, the
+# other half of the DCGM<->pod join) carries `kube-state-metrics` in its name.
+# DCGM exporter's namespace varies by installer, so it's matched by name
+# substring. See _dump_gpu_metrics_pods for the full object set (pods, the
+# prometheus config, the PVC, and the DCGM DaemonSet).
 _GPU_METRICS_NAMESPACE = 'skypilot'
 _PROMETHEUS_SERVER_NAME_PREFIX = 'skypilot-prometheus-server'
+_KUBE_STATE_METRICS_NAME_SUBSTR = 'kube-state-metrics'
 _DCGM_EXPORTER_NAME_SUBSTR = 'dcgm-exporter'
 
 # Keys in a serialized Secret whose values must never leave the cluster.
@@ -454,8 +457,16 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
     Into ``<output_dir>/gpu_metrics/``:
       - prometheus-server: the metrics Prometheus server pod (helm release
         ``skypilot-prometheus`` in the ``skypilot`` namespace).
+      - kube-state-metrics: the chart's KSM pod -- the source of
+        ``kube_pod_labels``, the other half of the DCGM<->pod join.
       - dcgm-exporter: the DCGM exporter pods, matched by name substring across
         all namespaces (the namespace varies by installer).
+      - prometheus-config: the rendered ``prometheus.yml`` ConfigMap -- scrape
+        intervals/timeouts, the KSM scrape job, and the federation match.
+      - prometheus-pvcs: the Prometheus PVC(s) -- storage/disk-bound failures.
+      - dcgm-exporter-daemonset: the DCGM exporter DaemonSet -- its
+        desired-vs-ready and tolerations show why some GPU nodes report no
+        metrics.
 
     These are cluster-wide infra (not per-SkyPilot-cluster), so they're dumped
     whenever present -- an absent component just yields no file. Both are found
@@ -486,17 +497,74 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
         if p.metadata.namespace == _GPU_METRICS_NAMESPACE and
         p.metadata.name.startswith(_PROMETHEUS_SERVER_NAME_PREFIX)
     ]
+    ksm_pods = [
+        p for p in all_pods
+        if p.metadata.namespace == _GPU_METRICS_NAMESPACE and
+        _KUBE_STATE_METRICS_NAME_SUBSTR in p.metadata.name
+    ]
     dcgm_pods = [
         p for p in all_pods if _DCGM_EXPORTER_NAME_SUBSTR in p.metadata.name
     ]
     out_dir = os.path.join(output_dir, 'gpu_metrics')
     for filename, matched in [('prometheus-server.yaml', prom_pods),
+                              ('kube-state-metrics.yaml', ksm_pods),
                               ('dcgm-exporter.yaml', dcgm_pods)]:
         if matched:
             os.makedirs(out_dir, exist_ok=True)
             _write_yaml(
                 os.path.join(out_dir, filename),
                 [_with_type_meta(to_dict(p), 'v1', 'Pod') for p in matched])
+
+    # The config + topology behind the pods. The prometheus.yml ConfigMap and
+    # the Prometheus PVC(s) are namespace-scoped (minimal RBAC); the
+    # DCGM-exporter DaemonSet is cluster-wide. All best-effort -- absent or
+    # forbidden just yields no file (a missing ConfigMap 404s -> treated as
+    # absent).
+    try:
+        cm = core.read_namespaced_config_map(
+            name=_PROMETHEUS_SERVER_NAME_PREFIX,
+            namespace=_GPU_METRICS_NAMESPACE,
+            _request_timeout=kubernetes.API_TIMEOUT)
+        os.makedirs(out_dir, exist_ok=True)
+        _write_yaml(os.path.join(out_dir, 'prometheus-config.yaml'),
+                    _with_type_meta(to_dict(cm), 'v1', 'ConfigMap'))
+    except kubernetes.api_exception() as e:
+        if e.status != 404:
+            _record_error(errors, 'gpu_metrics/prometheus-config', e)
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'gpu_metrics/prometheus-config', e)
+
+    try:
+        pvcs = core.list_namespaced_persistent_volume_claim(
+            namespace=_GPU_METRICS_NAMESPACE,
+            _request_timeout=kubernetes.API_TIMEOUT).items
+        if pvcs:
+            os.makedirs(out_dir, exist_ok=True)
+            _write_yaml(
+                os.path.join(out_dir, 'prometheus-pvcs.yaml'), [
+                    _with_type_meta(to_dict(v), 'v1', 'PersistentVolumeClaim')
+                    for v in pvcs
+                ])
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'gpu_metrics/prometheus-pvcs', e)
+
+    try:
+        dcgm_ds = [
+            d for d in kubernetes.apps_api(context).
+            list_daemon_set_for_all_namespaces(
+                _request_timeout=kubernetes.API_TIMEOUT).items
+            if _DCGM_EXPORTER_NAME_SUBSTR in d.metadata.name
+        ]
+        if dcgm_ds:
+            os.makedirs(out_dir, exist_ok=True)
+            _write_yaml(
+                os.path.join(out_dir, 'dcgm-exporter-daemonset.yaml'), [
+                    _with_type_meta(to_dict(d), 'apps/v1', 'DaemonSet')
+                    for d in dcgm_ds
+                ])
+    except Exception as e:  # pylint: disable=broad-except
+        _record_error(errors, 'gpu_metrics/dcgm-exporter-daemonset', e)
+
     return True
 
 

--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -540,28 +540,26 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
             _request_timeout=kubernetes.API_TIMEOUT).items
         if pvcs:
             os.makedirs(out_dir, exist_ok=True)
-            _write_yaml(
-                os.path.join(out_dir, 'prometheus-pvcs.yaml'), [
-                    _with_type_meta(to_dict(v), 'v1', 'PersistentVolumeClaim')
-                    for v in pvcs
-                ])
+            _write_yaml(os.path.join(out_dir, 'prometheus-pvcs.yaml'), [
+                _with_type_meta(to_dict(v), 'v1', 'PersistentVolumeClaim')
+                for v in pvcs
+            ])
     except Exception as e:  # pylint: disable=broad-except
         _record_error(errors, 'gpu_metrics/prometheus-pvcs', e)
 
     try:
         dcgm_ds = [
-            d for d in kubernetes.apps_api(context).
-            list_daemon_set_for_all_namespaces(
-                _request_timeout=kubernetes.API_TIMEOUT).items
+            d for d in kubernetes.apps_api(
+                context).list_daemon_set_for_all_namespaces(
+                    _request_timeout=kubernetes.API_TIMEOUT).items
             if _DCGM_EXPORTER_NAME_SUBSTR in d.metadata.name
         ]
         if dcgm_ds:
             os.makedirs(out_dir, exist_ok=True)
-            _write_yaml(
-                os.path.join(out_dir, 'dcgm-exporter-daemonset.yaml'), [
-                    _with_type_meta(to_dict(d), 'apps/v1', 'DaemonSet')
-                    for d in dcgm_ds
-                ])
+            _write_yaml(os.path.join(out_dir, 'dcgm-exporter-daemonset.yaml'), [
+                _with_type_meta(to_dict(d), 'apps/v1', 'DaemonSet')
+                for d in dcgm_ds
+            ])
     except Exception as e:  # pylint: disable=broad-except
         _record_error(errors, 'gpu_metrics/dcgm-exporter-daemonset', e)
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1028,49 +1028,44 @@ def _collect_cluster_kubernetes_resources(
             })
 
 
-def _dump_kube_contexts_info(
-        cluster_names: Set[str],
-        dump_dir: str,
-        errors: Optional[List[Dict[str, str]]] = None) -> None:
-    """Dump cluster-WIDE k8s objects once per unique kube context.
+def _dump_kube_contexts_info(dump_dir: str,
+                             errors: Optional[List[Dict[str,
+                                                        str]]] = None) -> None:
+    """Dump cluster-WIDE k8s objects once per allowed kube context.
 
     The GPU-metrics pods (Prometheus server, DCGM exporter) and the non-Workload
     Kueue objects (ClusterQueues / LocalQueues / ResourceFlavors / Topologies)
-    are shared across all SkyPilot clusters on a kube context -- fetching them
-    per cluster would re-fetch identical objects N times. So we dedup the dumped
-    clusters down to their unique contexts and fetch each once into
-    ``kubernetes_contexts/<sanitized-context>/``.
+    are shared across all SkyPilot clusters on a kube context, so we fetch them
+    once per context into ``kubernetes_contexts/<sanitized-context>/``.
+
+    Source of truth is ``Kubernetes.existing_allowed_contexts()`` -- the same
+    set ``sky check`` uses -- *not* contexts derived from the dumped clusters. A
+    context with no SkyPilot clusters (e.g. a freshly onboarded tenant) is still
+    scraped, so its GPU-metrics / Kueue config can be debugged before anything
+    runs there. ``None`` in the list means in-cluster auth (see
+    _sanitize_context_name).
 
     Robustness (tenants can have defunct contexts that time out): every call is
     5s-bounded, the per-context fetch fast-fails on the first connection error,
     and contexts are fetched in parallel -- so N dead contexts cost ~5s, not
     ~5s*calls*N. Best-effort: errors are recorded, never aborts the dump.
     """
-    if not cluster_names:
+    try:
+        contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to list allowed Kubernetes contexts: {e}')
+        if errors is not None:
+            errors.append({
+                'component': 'kubernetes_contexts',
+                'resource': 'allowed_contexts',
+                'error': str(e),
+                'traceback': _full_traceback(),
+            })
         return
 
-    # Dedup the dumped clusters down to their unique kube contexts. Keyed by a
-    # sentinel for the in-cluster (None) context so it dedups too.
-    contexts: Dict[Any, Optional[str]] = {}
-    for cluster_name in cluster_names:
-        try:
-            cluster_record = global_user_state.get_cluster_from_name(
-                cluster_name)
-            handle = cluster_record.get('handle') if cluster_record else None
-            if handle is None:
-                continue
-            coords = _kube_coordinates_for_handle(handle)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.debug(f'Failed to resolve kube context for cluster '
-                         f'{cluster_name!r}: {e}')
-            continue
-        if coords is None:
-            continue
-        context = coords[0]
-        contexts.setdefault('__in_cluster__' if context is None else context,
-                            context)
-
-    if not contexts:
+    # Dedupe defensively while preserving order (None = in-cluster is allowed).
+    unique_contexts = list(dict.fromkeys(contexts))
+    if not unique_contexts:
         return
 
     contexts_root = os.path.join(dump_dir, 'kubernetes_contexts')
@@ -1091,7 +1086,6 @@ def _dump_kube_contexts_info(
                 'traceback': _full_traceback(),
             }]
 
-    unique_contexts = list(contexts.values())
     num_threads = min(len(unique_contexts), 8)
     results = subprocess_utils.run_in_parallel(_dump_one, unique_contexts,
                                                num_threads)
@@ -1506,11 +1500,9 @@ def _build_debug_dump(
                        dump_dir,
                        errors=errors)
     # Cluster-wide k8s objects (GPU-metrics pods, Kueue quota config), fetched
-    # once per unique kube context across the dumped clusters rather than per
-    # cluster. Must run after _dump_cluster_info so it dedups the same clusters.
-    _dump_kube_contexts_info(debug_dump_context['cluster_names'],
-                             dump_dir,
-                             errors=errors)
+    # once per allowed kube context (source of truth: existing_allowed_contexts,
+    # so a context with no SkyPilot clusters is still captured).
+    _dump_kube_contexts_info(dump_dir, errors=errors)
     _dump_managed_job_info(debug_dump_context['managed_job_ids'],
                            dump_dir,
                            errors=errors)

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -22,11 +22,13 @@ from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import kubernetes
 from sky.backends import backend_utils
 from sky.backends.cloud_vm_ray_backend import CloudVmRayBackend
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.server import core as managed_jobs_core
 from sky.provision.kubernetes import debug as kubernetes_debug
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.server import constants as server_constants
 from sky.server import daemons
 from sky.server.requests import request_names
@@ -1045,6 +1047,12 @@ def _dump_kube_contexts_info(dump_dir: str,
     runs there. ``None`` in the list means in-cluster auth (see
     _sanitize_context_name).
 
+    We additionally always include the API server's own in-cluster context
+    (when running in-cluster), even if ``existing_allowed_contexts()`` drops it
+    -- which it does when ``allowed_contexts`` is an explicit list that omits
+    it, or ``SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false`` hides
+    it as a compute target. Its GPU-manager / Kueue config is worth dumping.
+
     Robustness (tenants can have defunct contexts that time out): every call is
     5s-bounded, the per-context fetch fast-fails on the first connection error,
     and contexts are fetched in parallel -- so N dead contexts cost ~5s, not
@@ -1062,6 +1070,13 @@ def _dump_kube_contexts_info(dump_dir: str,
                 'traceback': _full_traceback(),
             })
         return
+
+    # Always dump the API server's own in-cluster context, even when it's been
+    # excluded as a compute target (explicit allowed_contexts list, or
+    # SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false). The dedupe
+    # below drops it if existing_allowed_contexts() already surfaced it.
+    if kubernetes_utils.is_incluster_config_available():
+        contexts = list(contexts) + [kubernetes.in_cluster_context_name()]
 
     # Dedupe defensively while preserving order (None = in-cluster is allowed).
     unique_contexts = list(dict.fromkeys(contexts))

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -15,6 +15,7 @@ import zipfile
 
 import sky
 from sky import check as sky_check
+from sky import clouds
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
@@ -23,11 +24,13 @@ from sky.backends import backend_utils
 from sky.backends.cloud_vm_ray_backend import CloudVmRayBackend
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.server import core as managed_jobs_core
+from sky.provision.kubernetes import debug as kubernetes_debug
 from sky.server import constants as server_constants
 from sky.server import daemons
 from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants as skylet_constants
+from sky.utils import command_runner
 from sky.utils import common
 from sky.utils import controller_utils
 from sky.utils import debug_dump_helpers
@@ -894,6 +897,86 @@ def _collect_cluster_skylet_log(
             f'Failed to collect skylet log for cluster {cluster_name}', e)
 
 
+def _collect_cluster_kubernetes_resources(
+        cluster_name: str,
+        cluster_dir: str,
+        handle: Any,
+        errors: Optional[List[Dict[str, str]]] = None) -> None:
+    """Snapshot a Kubernetes cluster's related k8s objects into the dump.
+
+    For clusters on Kubernetes, capture the pods, their events, the resources
+    SkyPilot created (Services, etc.), and any Kueue Workload -- the same things
+    you'd reach for with ``kubectl get -o yaml`` when debugging. No-op for
+    clusters on other clouds.
+
+    Unlike the skylet log (which is rsynced off a reachable node and so only
+    works on UP clusters), these come from the kube API server, which answers
+    even when the cluster is broken -- pod events on a failed launch are exactly
+    what we want -- so the caller doesn't gate this on cluster status.
+
+    Best-effort: every failure is recorded in ``errors`` and never aborts the
+    dump.
+    """
+    launched_resources = getattr(handle, 'launched_resources', None)
+    cloud = getattr(launched_resources, 'cloud', None)
+    if not isinstance(cloud, clouds.Kubernetes):
+        logger.debug(f'Cluster {cluster_name!r} is not on Kubernetes; '
+                     f'skipping k8s resource dump')
+        return
+
+    # Resolve the cluster's k8s context + namespace from its command runners.
+    # For a Kubernetes cluster every runner is a KubernetesCommandRunner
+    # carrying its pod's (context, namespace); they're cluster-wide identical,
+    # so runners[0] suffices. (The dump finds the cluster's objects by the
+    # skypilot-cluster-name label, so we don't need the individual pod names.)
+    # This reuses the request-scoped cache populated by the skylet-log
+    # collection, so it's a cheap call here.
+    try:
+        runners = handle.get_command_runners()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to get command runners for cluster '
+                       f'{cluster_name}: {e}')
+        if errors is not None:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{cluster_name}/kubernetes',
+                'error': str(e),
+                'traceback': _full_traceback()
+            })
+        return
+
+    # Typed as Any (like ``handle``/``runners``): the runner's k8s coordinates
+    # are assigned via nested tuple-unpacking in KubernetesCommandRunner, which
+    # mypy can't see across this module's skipped import.
+    k8s_runners: List[Any] = [
+        r for r in runners
+        if isinstance(r, command_runner.KubernetesCommandRunner)
+    ]
+    if not k8s_runners:
+        logger.debug(f'No Kubernetes command runners for cluster '
+                     f'{cluster_name!r}; skipping k8s resource dump')
+        return
+
+    context = k8s_runners[0].context
+    namespace = k8s_runners[0].namespace
+    output_dir = os.path.join(cluster_dir, 'kubernetes')
+
+    k8s_errors = kubernetes_debug.dump_cluster_resources(
+        context=context,
+        namespace=namespace,
+        cluster_name_on_cloud=handle.cluster_name_on_cloud,
+        output_dir=output_dir)
+
+    if errors is not None:
+        for err in k8s_errors:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{cluster_name}/{err["resource"]}',
+                'error': err['error'],
+                'traceback': err['traceback'],
+            })
+
+
 def _dump_cluster_info(cluster_names: Set[str],
                        dump_dir: str,
                        errors: Optional[List[Dict[str, str]]] = None) -> None:
@@ -1007,6 +1090,14 @@ def _dump_cluster_info(cluster_names: Set[str],
         else:
             logger.debug(f'Skipping skylet log for cluster {cluster_name!r} '
                          f'(status={status})')
+
+        # For Kubernetes clusters, also snapshot the related k8s objects (pods,
+        # events, Services, Kueue Workload, ...). Gated only on having a handle,
+        # not on status: these come from the kube API server, so they're
+        # reachable -- and most useful -- even when the cluster isn't UP.
+        if handle is not None:
+            _collect_cluster_kubernetes_resources(cluster_name, cluster_dir,
+                                                  handle, errors)
 
     logger.debug('Exiting _dump_cluster_info')
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -918,16 +918,16 @@ def _kube_coordinates_for_handle(
         return None
 
     runners = handle.get_command_runners()
-    # Typed as Any (like ``handle``/``runners``): the runner's k8s coordinates
-    # are assigned via nested tuple-unpacking in KubernetesCommandRunner, which
-    # mypy can't see across this module's skipped import.
     k8s_runners: List[Any] = [
         r for r in runners
         if isinstance(r, command_runner.KubernetesCommandRunner)
     ]
     if not k8s_runners:
         return None
-    return k8s_runners[0].context, k8s_runners[0].namespace
+    runner = k8s_runners[0]
+    assert isinstance(runner, command_runner.KubernetesCommandRunner), runner
+    # .context/.namespace are set via tuple-unpacking mypy can't track.
+    return runner.context, runner.namespace  # type: ignore[attr-defined]
 
 
 def _sanitize_context_name(context: Optional[str]) -> str:
@@ -1508,16 +1508,16 @@ def _build_debug_dump(
     # Dump all sections
     errors = debug_dump_context['errors']
     _dump_server_info(dump_dir, errors=errors)
+    # Cluster-wide k8s objects (GPU-metrics pods, Kueue quota config), fetched
+    # once per allowed kube context (source of truth: existing_allowed_contexts,
+    # so a context with no SkyPilot clusters is still captured).
+    _dump_kube_contexts_info(dump_dir, errors=errors)
     _dump_request_id_info(debug_dump_context['request_ids'],
                           dump_dir,
                           errors=errors)
     _dump_cluster_info(debug_dump_context['cluster_names'],
                        dump_dir,
                        errors=errors)
-    # Cluster-wide k8s objects (GPU-metrics pods, Kueue quota config), fetched
-    # once per allowed kube context (source of truth: existing_allowed_contexts,
-    # so a context with no SkyPilot clusters is still captured).
-    _dump_kube_contexts_info(dump_dir, errors=errors)
     _dump_managed_job_info(debug_dump_context['managed_job_ids'],
                            dump_dir,
                            errors=errors)

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1,12 +1,14 @@
 """Debug dump utilities for troubleshooting SkyPilot issues."""
 import collections
 import datetime
+import hashlib
 import json
 import logging
 import os
 import pathlib
 import platform
 import posixpath
+import re
 import shutil
 import time
 import traceback
@@ -897,17 +899,66 @@ def _collect_cluster_skylet_log(
             f'Failed to collect skylet log for cluster {cluster_name}', e)
 
 
+def _kube_coordinates_for_handle(
+        handle: Any) -> Optional[Tuple[Optional[str], str]]:
+    """Resolve a cluster handle's (kube context, namespace), or None.
+
+    Returns None for clusters that aren't on Kubernetes (or whose runners can't
+    be resolved). For a Kubernetes cluster every command runner is a
+    KubernetesCommandRunner carrying its pod's (context, namespace); they're
+    cluster-wide identical, so runners[0] suffices. get_command_runners()
+    rebuilds from the cached cluster_info (no live API call), so this is cheap
+    and safe even when the context is defunct.
+    """
+    launched_resources = getattr(handle, 'launched_resources', None)
+    cloud = getattr(launched_resources, 'cloud', None)
+    if not isinstance(cloud, clouds.Kubernetes):
+        return None
+
+    runners = handle.get_command_runners()
+    # Typed as Any (like ``handle``/``runners``): the runner's k8s coordinates
+    # are assigned via nested tuple-unpacking in KubernetesCommandRunner, which
+    # mypy can't see across this module's skipped import.
+    k8s_runners: List[Any] = [
+        r for r in runners
+        if isinstance(r, command_runner.KubernetesCommandRunner)
+    ]
+    if not k8s_runners:
+        return None
+    return k8s_runners[0].context, k8s_runners[0].namespace
+
+
+def _sanitize_context_name(context: Optional[str]) -> str:
+    """Map a kube context to a filesystem-safe directory name.
+
+    The in-cluster context (``None``) maps to ``in-cluster``. Otherwise we
+    replace path/colon/whitespace chars and append a short hash of the raw name
+    so two contexts that sanitize to the same string don't collide.
+    """
+    if context is None:
+        return 'in-cluster'
+    safe = re.sub(r'[^A-Za-z0-9._-]', '_', context)
+    digest = hashlib.sha1(context.encode('utf-8')).hexdigest()[:8]
+    return f'{safe}-{digest}'
+
+
 def _collect_cluster_kubernetes_resources(
         cluster_name: str,
         cluster_dir: str,
         handle: Any,
         errors: Optional[List[Dict[str, str]]] = None) -> None:
-    """Snapshot a Kubernetes cluster's related k8s objects into the dump.
+    """Snapshot a Kubernetes cluster's per-cluster k8s objects into the dump.
 
     For clusters on Kubernetes, capture the pods, their events, the resources
-    SkyPilot created (Services, etc.), and any Kueue Workload -- the same things
-    you'd reach for with ``kubectl get -o yaml`` when debugging. No-op for
-    clusters on other clouds.
+    SkyPilot created (Services, etc.), and this cluster's Kueue Workload -- the
+    same things you'd reach for with ``kubectl get -o yaml`` when debugging.
+    No-op for clusters on other clouds.
+
+    These calls are all namespace-scoped, so they work under SkyPilot's minimal
+    (namespace-only) RBAC. Cluster-WIDE objects shared across SkyPilot clusters
+    (GPU-metrics pods, the Kueue quota config) are collected once per context by
+    ``_dump_kube_contexts_info`` instead; we drop a ``context.json`` here so a
+    reader can find them.
 
     Unlike the skylet log (which is rsynced off a reachable node and so only
     works on UP clusters), these come from the kube API server, which answers
@@ -917,22 +968,8 @@ def _collect_cluster_kubernetes_resources(
     Best-effort: every failure is recorded in ``errors`` and never aborts the
     dump.
     """
-    launched_resources = getattr(handle, 'launched_resources', None)
-    cloud = getattr(launched_resources, 'cloud', None)
-    if not isinstance(cloud, clouds.Kubernetes):
-        logger.debug(f'Cluster {cluster_name!r} is not on Kubernetes; '
-                     f'skipping k8s resource dump')
-        return
-
-    # Resolve the cluster's k8s context + namespace from its command runners.
-    # For a Kubernetes cluster every runner is a KubernetesCommandRunner
-    # carrying its pod's (context, namespace); they're cluster-wide identical,
-    # so runners[0] suffices. (The dump finds the cluster's objects by the
-    # skypilot-cluster-name label, so we don't need the individual pod names.)
-    # This reuses the request-scoped cache populated by the skylet-log
-    # collection, so it's a cheap call here.
     try:
-        runners = handle.get_command_runners()
+        coords = _kube_coordinates_for_handle(handle)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get command runners for cluster '
                        f'{cluster_name}: {e}')
@@ -945,20 +982,13 @@ def _collect_cluster_kubernetes_resources(
             })
         return
 
-    # Typed as Any (like ``handle``/``runners``): the runner's k8s coordinates
-    # are assigned via nested tuple-unpacking in KubernetesCommandRunner, which
-    # mypy can't see across this module's skipped import.
-    k8s_runners: List[Any] = [
-        r for r in runners
-        if isinstance(r, command_runner.KubernetesCommandRunner)
-    ]
-    if not k8s_runners:
-        logger.debug(f'No Kubernetes command runners for cluster '
-                     f'{cluster_name!r}; skipping k8s resource dump')
+    if coords is None:
+        logger.debug(
+            f'Cluster {cluster_name!r} is not on Kubernetes (or has no '
+            f'k8s runners); skipping k8s resource dump')
         return
 
-    context = k8s_runners[0].context
-    namespace = k8s_runners[0].namespace
+    context, namespace = coords
     output_dir = os.path.join(cluster_dir, 'kubernetes')
 
     k8s_errors = kubernetes_debug.dump_cluster_resources(
@@ -966,6 +996,27 @@ def _collect_cluster_kubernetes_resources(
         namespace=namespace,
         cluster_name_on_cloud=handle.cluster_name_on_cloud,
         output_dir=output_dir)
+
+    # Drop a mapping file pointing at the per-context dump of this cluster's
+    # cluster-wide objects. Best-effort -- never let it abort the dump.
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, 'context.json'),
+                  'w',
+                  encoding='utf-8') as f:
+            json.dump(
+                {
+                    'context': context,
+                    'namespace': namespace,
+                    'cluster_name_on_cloud': handle.cluster_name_on_cloud,
+                    'context_dir': f'kubernetes_contexts/'
+                                   f'{_sanitize_context_name(context)}',
+                },
+                f,
+                indent=2,
+                default=str)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to write context.json for {cluster_name!r}: {e}')
 
     if errors is not None:
         for err in k8s_errors:
@@ -975,6 +1026,86 @@ def _collect_cluster_kubernetes_resources(
                 'error': err['error'],
                 'traceback': err['traceback'],
             })
+
+
+def _dump_kube_contexts_info(
+        cluster_names: Set[str],
+        dump_dir: str,
+        errors: Optional[List[Dict[str, str]]] = None) -> None:
+    """Dump cluster-WIDE k8s objects once per unique kube context.
+
+    The GPU-metrics pods (Prometheus server, DCGM exporter) and the non-Workload
+    Kueue objects (ClusterQueues / LocalQueues / ResourceFlavors / Topologies)
+    are shared across all SkyPilot clusters on a kube context -- fetching them
+    per cluster would re-fetch identical objects N times. So we dedup the dumped
+    clusters down to their unique contexts and fetch each once into
+    ``kubernetes_contexts/<sanitized-context>/``.
+
+    Robustness (tenants can have defunct contexts that time out): every call is
+    5s-bounded, the per-context fetch fast-fails on the first connection error,
+    and contexts are fetched in parallel -- so N dead contexts cost ~5s, not
+    ~5s*calls*N. Best-effort: errors are recorded, never aborts the dump.
+    """
+    if not cluster_names:
+        return
+
+    # Dedup the dumped clusters down to their unique kube contexts. Keyed by a
+    # sentinel for the in-cluster (None) context so it dedups too.
+    contexts: Dict[Any, Optional[str]] = {}
+    for cluster_name in cluster_names:
+        try:
+            cluster_record = global_user_state.get_cluster_from_name(
+                cluster_name)
+            handle = cluster_record.get('handle') if cluster_record else None
+            if handle is None:
+                continue
+            coords = _kube_coordinates_for_handle(handle)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to resolve kube context for cluster '
+                         f'{cluster_name!r}: {e}')
+            continue
+        if coords is None:
+            continue
+        context = coords[0]
+        contexts.setdefault('__in_cluster__' if context is None else context,
+                            context)
+
+    if not contexts:
+        return
+
+    contexts_root = os.path.join(dump_dir, 'kubernetes_contexts')
+    os.makedirs(contexts_root, exist_ok=True)
+
+    def _dump_one(context: Optional[str]) -> List[Dict[str, str]]:
+        # run_in_parallel re-raises the first exception, so swallow everything
+        # into the returned error list.
+        try:
+            output_dir = os.path.join(contexts_root,
+                                      _sanitize_context_name(context))
+            return kubernetes_debug.dump_context_resources(
+                context=context, output_dir=output_dir)
+        except Exception as e:  # pylint: disable=broad-except
+            return [{
+                'resource': 'kubernetes_contexts',
+                'error': str(e),
+                'traceback': _full_traceback(),
+            }]
+
+    unique_contexts = list(contexts.values())
+    num_threads = min(len(unique_contexts), 8)
+    results = subprocess_utils.run_in_parallel(_dump_one, unique_contexts,
+                                               num_threads)
+
+    if errors is not None:
+        for context, ctx_errors in zip(unique_contexts, results):
+            sanitized = _sanitize_context_name(context)
+            for err in ctx_errors:
+                errors.append({
+                    'component': 'kubernetes_contexts',
+                    'resource': f'{sanitized}/{err["resource"]}',
+                    'error': err['error'],
+                    'traceback': err['traceback'],
+                })
 
 
 def _dump_cluster_info(cluster_names: Set[str],
@@ -1374,6 +1505,12 @@ def _build_debug_dump(
     _dump_cluster_info(debug_dump_context['cluster_names'],
                        dump_dir,
                        errors=errors)
+    # Cluster-wide k8s objects (GPU-metrics pods, Kueue quota config), fetched
+    # once per unique kube context across the dumped clusters rather than per
+    # cluster. Must run after _dump_cluster_info so it dedups the same clusters.
+    _dump_kube_contexts_info(debug_dump_context['cluster_names'],
+                             dump_dir,
+                             errors=errors)
     _dump_managed_job_info(debug_dump_context['managed_job_ids'],
                            dump_dir,
                            errors=errors)

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -17,6 +17,10 @@ class _FakeApiException(Exception):
         super().__init__(f'status={status}')
 
 
+class _FakeMaxRetryError(Exception):
+    """Stand-in for urllib3's MaxRetryError (a connection/timeout failure)."""
+
+
 def _obj(marker):
     """A fake k8s model object; sanitize_for_serialization keys off _marker."""
     return SimpleNamespace(_marker=marker)
@@ -45,6 +49,16 @@ def _events(*involved_pod_names):
     ])
 
 
+def _all_ns_pods(*ns_name_pairs):
+    """A fake cluster-wide pod list (for list_pod_for_all_namespaces); each item
+    is a (namespace, name) pair."""
+    return SimpleNamespace(items=[
+        SimpleNamespace(_marker='pod',
+                        metadata=SimpleNamespace(namespace=ns, name=name))
+        for ns, name in ns_name_pairs
+    ])
+
+
 @pytest.fixture
 def k8s_apis(monkeypatch):
     """Patch every kubernetes adaptor call the module makes.
@@ -54,6 +68,7 @@ def k8s_apis(monkeypatch):
     """
     core = mock.MagicMock()
     core.list_namespaced_pod.return_value = _pods()
+    core.list_pod_for_all_namespaces.return_value = _all_ns_pods()
     core.list_namespaced_event.return_value = _events()
     core.list_namespaced_service.return_value = _list()
     core.list_namespaced_persistent_volume_claim.return_value = _list()
@@ -97,6 +112,8 @@ def k8s_apis(monkeypatch):
                         lambda *a, **k: api_client)
     monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
                         lambda: _FakeApiException)
+    monkeypatch.setattr('sky.adaptors.kubernetes.max_retry_error',
+                        lambda: _FakeMaxRetryError)
 
     return SimpleNamespace(core=core,
                            apps=apps,
@@ -107,10 +124,16 @@ def k8s_apis(monkeypatch):
 
 
 def _run(tmp_path):
+    """Run the per-cluster (namespace-scoped) dump."""
     return debug.dump_cluster_resources(context='ctx',
                                         namespace='ns',
                                         cluster_name_on_cloud='cluster-abc',
                                         output_dir=str(tmp_path))
+
+
+def _run_context(tmp_path):
+    """Run the per-context (cluster-wide) dump."""
+    return debug.dump_context_resources(context='ctx', output_dir=str(tmp_path))
 
 
 def test_dumps_pods_with_type_meta(tmp_path, k8s_apis):
@@ -198,6 +221,67 @@ def test_empty_resource_kinds_are_skipped(tmp_path, k8s_apis):
     assert not (tmp_path / 'kueue').exists()
 
 
+def test_per_cluster_makes_no_cluster_scoped_calls(tmp_path, k8s_apis):
+    """RBAC invariant: the per-cluster dump must stay namespace-scoped so it
+    works under SkyPilot's minimal (namespace-only) RBAC -- it must never make a
+    cluster-wide call (those live only in the per-context path)."""
+    # A cluster that uses Kueue exercises the custom-object path too.
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    k8s_apis.kueue_items['workloads'] = [{'metadata': {'name': 'wl'}}]
+
+    _run(tmp_path)
+
+    k8s_apis.core.list_pod_for_all_namespaces.assert_not_called()
+    k8s_apis.custom.list_cluster_custom_object.assert_not_called()
+
+
+def test_context_gpu_metrics_pods_dumped(tmp_path, k8s_apis):
+    """The metrics Prometheus server (skypilot ns) and DCGM exporter (any ns, by
+    name substring) are captured under gpu_metrics/ from one cluster-wide list;
+    the chart's kube-state-metrics and unrelated pods are excluded."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'),
+        ('skypilot', 'skypilot-prometheus-kube-state-metrics-xyz'),
+        ('gpu-operator', 'nvidia-dcgm-exporter-9q2lp'),
+        ('default', 'some-unrelated-pod'),
+    )
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    gdir = tmp_path / 'gpu_metrics'
+    prom = yaml_utils.read_yaml(str(gdir / 'prometheus-server.yaml'))
+    assert (prom['apiVersion'], prom['kind']) == ('v1', 'Pod')
+    dcgm = yaml_utils.read_yaml(str(gdir / 'dcgm-exporter.yaml'))
+    assert (dcgm['apiVersion'], dcgm['kind']) == ('v1', 'Pod')
+    # Only the two matched kinds are written (KSM + unrelated pods excluded).
+    assert sorted(p.name for p in gdir.iterdir()) == [
+        'dcgm-exporter.yaml', 'prometheus-server.yaml'
+    ]
+
+
+def test_context_gpu_metrics_absent_produces_no_dir(tmp_path, k8s_apis):
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('default', 'unrelated-pod'))
+
+    _run_context(tmp_path)
+
+    assert not (tmp_path / 'gpu_metrics').exists()
+
+
+def test_context_empty_writes_only_reachable_marker(tmp_path, k8s_apis):
+    # No GPU-metrics pods, no Kueue objects -> a reachable-but-bare context
+    # writes no resource dirs, but still drops a context.json marker (so the
+    # context stays visible in the dump even though the zip omits empty dirs).
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    assert not (tmp_path / 'gpu_metrics').exists()
+    assert not (tmp_path / 'kueue').exists()
+    marker = yaml_utils.read_yaml(str(tmp_path / 'context.json'))
+    assert marker == {'context': 'ctx', 'reachable': True}
+
+
 def test_secret_values_are_redacted(tmp_path, k8s_apis):
     k8s_apis.core.list_namespaced_secret.return_value = _list('secret')
     # The real sanitize_for_serialization would surface the secret's data,
@@ -262,10 +346,10 @@ def test_kueue_workload_dumped_scoped_to_cluster(tmp_path, k8s_apis):
     assert wl_calls[0].kwargs['field_selector'] == 'metadata.name=cluster-abc'
 
 
-def test_kueue_dumps_queues_flavors_and_topologies(tmp_path, k8s_apis):
-    """Beyond the Workload, the namespace's LocalQueues and the cluster-scoped
-    ClusterQueues/ResourceFlavors/Topologies are captured under kueue/."""
-    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+def test_context_dumps_queues_flavors_and_topologies(tmp_path, k8s_apis):
+    """The cluster-wide Kueue config -- LocalQueues, ClusterQueues,
+    ResourceFlavors, Topologies -- is captured once per context under kueue/,
+    all via the cluster-scoped list endpoint."""
     k8s_apis.kueue_items.update({
         'localqueues': [{
             'metadata': {
@@ -289,7 +373,7 @@ def test_kueue_dumps_queues_flavors_and_topologies(tmp_path, k8s_apis):
         }],
     })
 
-    errors = _run(tmp_path)
+    errors = _run_context(tmp_path)
 
     assert not errors
     kdir = tmp_path / 'kueue'
@@ -313,12 +397,80 @@ def test_kueue_dumps_queues_flavors_and_topologies(tmp_path, k8s_apis):
             'name': 'rack'
         }
     }
-    # Cluster-scoped kinds are fetched via the cluster (not namespaced) API.
+    # Every kind -- including the namespaced LocalQueue -- is fetched via the
+    # cluster-scoped (not namespaced) API, so one call per kind covers all
+    # namespaces; the per-context path makes no namespaced custom-object calls.
     cluster_plurals = {
         c.kwargs['plural']
         for c in k8s_apis.custom.list_cluster_custom_object.call_args_list
     }
-    assert {'clusterqueues', 'resourceflavors', 'topologies'} <= cluster_plurals
+    assert {'localqueues', 'clusterqueues', 'resourceflavors', 'topologies'
+           } <= cluster_plurals
+    # 'workloads' is per-cluster, never fetched here.
+    assert 'workloads' not in cluster_plurals
+    k8s_apis.custom.list_namespaced_custom_object.assert_not_called()
+
+
+def test_context_kueue_uses_cluster_scoped_probe_and_falls_back(
+        tmp_path, k8s_apis):
+    """The per-context Kueue version probe is cluster-scoped (clusterqueues) and
+    falls back v1beta2 -> v1beta1, keeping the per-context path off the
+    namespaced API entirely."""
+    k8s_apis.kueue_items['clusterqueues'] = [{'metadata': {'name': 'cq'}}]
+
+    def _cluster(*args, **kwargs):
+        del args
+        if kwargs['version'] == 'v1beta2':
+            raise _FakeApiException(status=404)
+        return {'items': list(k8s_apis.kueue_items.get(kwargs['plural'], []))}
+
+    k8s_apis.custom.list_cluster_custom_object.side_effect = _cluster
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    assert (tmp_path / 'kueue' / 'clusterqueues.yaml').exists()
+    # The probe is the cluster-scoped clusterqueues list, tried newest-first.
+    probe_versions = [
+        c.kwargs['version']
+        for c in k8s_apis.custom.list_cluster_custom_object.call_args_list
+        if c.kwargs['plural'] == 'clusterqueues'
+    ]
+    assert probe_versions[:2] == ['v1beta2', 'v1beta1']
+    k8s_apis.custom.list_namespaced_custom_object.assert_not_called()
+
+
+def test_context_kueue_non_404_failure_is_recorded(tmp_path, k8s_apis):
+    # A non-404 on the cluster-scoped probe is recorded under the 'kueue'
+    # resource (context-relative, no 'kubernetes/' prefix).
+    k8s_apis.custom.list_cluster_custom_object.side_effect = (_FakeApiException(
+        status=500))
+
+    errors = _run_context(tmp_path)
+
+    assert len(errors) == 1
+    assert errors[0]['resource'] == 'kueue'
+
+
+def test_context_broken_skips_kueue(tmp_path, k8s_apis):
+    """A defunct context (connection/timeout on the first cluster-wide call)
+    fast-fails: it records the failure and skips the remaining cluster-wide
+    calls rather than stacking timeouts."""
+    k8s_apis.core.list_pod_for_all_namespaces.side_effect = _FakeMaxRetryError(
+        'connection refused')
+
+    errors = _run_context(tmp_path)
+
+    # The reachability failure is recorded against gpu_metrics...
+    assert len(errors) == 1
+    assert errors[0]['resource'] == 'gpu_metrics'
+    # ...and the Kueue calls are skipped entirely (no stacked timeouts).
+    k8s_apis.custom.list_cluster_custom_object.assert_not_called()
+    assert not (tmp_path / 'kueue').exists()
+    # The marker still records the context as unreachable, so a defunct context
+    # is visible in the dump rather than silently absent.
+    marker = yaml_utils.read_yaml(str(tmp_path / 'context.json'))
+    assert marker == {'context': 'ctx', 'reachable': False}
 
 
 def test_kueue_falls_back_to_older_version(tmp_path, k8s_apis):
@@ -397,13 +549,38 @@ def test_kueue_skipped_when_cluster_not_using_kueue(tmp_path, k8s_apis):
 
 
 def test_pod_list_failure_is_recorded(tmp_path, k8s_apis):
+    # A non-connection error (e.g. a transient/unexpected failure) is recorded,
+    # but the context is still reachable, so the dump continues for everything
+    # else (labeled resources, Kueue).
     k8s_apis.core.list_namespaced_pod.side_effect = RuntimeError('boom')
 
     errors = _run(tmp_path)
 
-    # The pod-list failure is recorded; the dump still continues for everything
-    # else (labeled resources, Kueue).
     pod_errs = [e for e in errors if e['resource'] == 'kubernetes/pods']
     assert len(pod_errs) == 1
     assert pod_errs[0]['error'] == 'boom'
     assert 'traceback' in pod_errs[0]
+    # The dump continued past pods (labeled-resource sweep was attempted).
+    k8s_apis.core.list_namespaced_service.assert_called()
+
+
+def test_defunct_context_fast_fails_per_cluster(tmp_path, k8s_apis):
+    """If the pod list -- the first call -- can't even connect, the context is
+    defunct; the per-cluster dump must bail immediately rather than stack one
+    timeout per remaining call (services, deployments, ... Kueue)."""
+    k8s_apis.core.list_namespaced_pod.side_effect = _FakeMaxRetryError(
+        'connection timed out')
+
+    errors = _run(tmp_path)
+
+    # The connection failure is recorded against pods...
+    assert len(errors) == 1
+    assert errors[0]['resource'] == 'kubernetes/pods'
+    # ...and none of the cluster's other calls are attempted (no stacked
+    # timeouts), so nothing else is written.
+    k8s_apis.core.list_namespaced_service.assert_not_called()
+    k8s_apis.apps.list_namespaced_deployment.assert_not_called()
+    k8s_apis.core.list_namespaced_event.assert_not_called()
+    k8s_apis.custom.list_namespaced_custom_object.assert_not_called()
+    assert not (tmp_path / 'services.yaml').exists()
+    assert not (tmp_path / 'kueue').exists()

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -1,0 +1,409 @@
+"""Tests for sky.provision.kubernetes.debug (cluster resource dump)."""
+from types import SimpleNamespace
+from typing import Dict
+from unittest import mock
+
+import pytest
+
+from sky.provision.kubernetes import debug
+import sky.utils.yaml_utils as yaml_utils
+
+
+class _FakeApiException(Exception):
+    """Stand-in for kubernetes.client.rest.ApiException."""
+
+    def __init__(self, status):
+        self.status = status
+        super().__init__(f'status={status}')
+
+
+def _obj(marker):
+    """A fake k8s model object; sanitize_for_serialization keys off _marker."""
+    return SimpleNamespace(_marker=marker)
+
+
+def _list(*markers):
+    return SimpleNamespace(items=[_obj(m) for m in markers])
+
+
+def _pods(*names, kueue=False):
+    """A fake pod list (for list_namespaced_pod). With kueue=True the pods carry
+    the queue-name label that marks the cluster as using Kueue."""
+    labels = {'kueue.x-k8s.io/queue-name': 'q'} if kueue else {}
+    return SimpleNamespace(items=[
+        SimpleNamespace(_marker='pod',
+                        metadata=SimpleNamespace(name=n, labels=dict(labels)))
+        for n in names
+    ])
+
+
+def _events(*involved_pod_names):
+    """A fake event list (for list_namespaced_event); each references a pod."""
+    return SimpleNamespace(items=[
+        SimpleNamespace(_marker='evt', involved_object=SimpleNamespace(name=n))
+        for n in involved_pod_names
+    ])
+
+
+@pytest.fixture
+def k8s_apis(monkeypatch):
+    """Patch every kubernetes adaptor call the module makes.
+
+    Returns the individual API mocks so each test configures its own return
+    values; defaults are empty lists / a happy-path pod read.
+    """
+    core = mock.MagicMock()
+    core.list_namespaced_pod.return_value = _pods()
+    core.list_namespaced_event.return_value = _events()
+    core.list_namespaced_service.return_value = _list()
+    core.list_namespaced_persistent_volume_claim.return_value = _list()
+    core.list_namespaced_config_map.return_value = _list()
+    core.list_namespaced_secret.return_value = _list()
+
+    apps = mock.MagicMock()
+    apps.list_namespaced_deployment.return_value = _list()
+
+    networking = mock.MagicMock()
+    networking.list_namespaced_ingress.return_value = _list()
+
+    custom = mock.MagicMock()
+    # Kueue objects keyed by plural; tests populate this. Both the namespaced
+    # and cluster-scoped list calls dispatch on the `plural` kwarg, so the probe
+    # (workloads) succeeds by default -> Kueue is treated as installed.
+    kueue_items: Dict[str, list] = {}
+
+    def _list_custom(*args, **kwargs):
+        del args
+        return {'items': list(kueue_items.get(kwargs['plural'], []))}
+
+    custom.list_namespaced_custom_object.side_effect = _list_custom
+    custom.list_cluster_custom_object.side_effect = _list_custom
+
+    api_client = mock.MagicMock()
+    # kubectl-style serialization: just surface the object's marker.
+    api_client.sanitize_for_serialization.side_effect = (lambda obj: {
+        'marker': obj._marker
+    })
+
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *a, **k: core)
+    monkeypatch.setattr('sky.adaptors.kubernetes.apps_api',
+                        lambda *a, **k: apps)
+    monkeypatch.setattr('sky.adaptors.kubernetes.networking_api',
+                        lambda *a, **k: networking)
+    monkeypatch.setattr('sky.adaptors.kubernetes.custom_objects_api',
+                        lambda *a, **k: custom)
+    monkeypatch.setattr('sky.adaptors.kubernetes.api_client',
+                        lambda *a, **k: api_client)
+    monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
+                        lambda: _FakeApiException)
+
+    return SimpleNamespace(core=core,
+                           apps=apps,
+                           networking=networking,
+                           custom=custom,
+                           kueue_items=kueue_items,
+                           api_client=api_client)
+
+
+def _run(tmp_path):
+    return debug.dump_cluster_resources(context='ctx',
+                                        namespace='ns',
+                                        cluster_name_on_cloud='cluster-abc',
+                                        output_dir=str(tmp_path))
+
+
+def test_dumps_pods_with_type_meta(tmp_path, k8s_apis):
+    # Pods come from one list-by-label call (head + workers).
+    k8s_apis.core.list_namespaced_pod.return_value = _pods(
+        'c-head', 'c-worker1')
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    for name in ('c-head', 'c-worker1'):
+        dumped = yaml_utils.read_yaml(str(tmp_path / 'pods' / f'{name}.yaml'))
+        # List items lack TypeMeta, so apiVersion/kind are stamped back on.
+        assert (dumped['apiVersion'], dumped['kind']) == ('v1', 'Pod')
+        assert dumped['marker'] == 'pod'
+    # One list call, scoped to this cluster by label.
+    _, kwargs = k8s_apis.core.list_namespaced_pod.call_args
+    assert kwargs['label_selector'] == 'skypilot-cluster-name=cluster-abc'
+
+
+def test_events_filtered_to_cluster_pods_and_grouped(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_pod.return_value = _pods(
+        'c-head', 'c-worker1')
+    # Namespace-wide pod events: two for c-head, none for c-worker1, one for an
+    # unrelated pod.
+    k8s_apis.core.list_namespaced_event.return_value = _events(
+        'c-head', 'c-head', 'other-cluster-pod')
+
+    _run(tmp_path)
+
+    # Only our pods' events are written, grouped per pod; the unrelated pod and
+    # the pod with no events produce no file.
+    assert (tmp_path / 'events' / 'c-head.yaml').exists()
+    assert not (tmp_path / 'events' / 'c-worker1.yaml').exists()
+    assert not (tmp_path / 'events' / 'other-cluster-pod.yaml').exists()
+    # The query is one namespace-wide call narrowed to Pod events server-side.
+    _, kwargs = k8s_apis.core.list_namespaced_event.call_args
+    assert kwargs['field_selector'] == 'involvedObject.kind=Pod'
+    # c-head got both of its events (multi-doc YAML).
+    docs = yaml_utils.read_yaml_all(str(tmp_path / 'events' / 'c-head.yaml'))
+    assert len(docs) == 2
+    assert docs[0]['kind'] == 'Event'
+
+
+def test_labeled_resources_use_cluster_label(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_service.return_value = _list('svc')
+
+    _run(tmp_path)
+
+    assert (tmp_path / 'services.yaml').exists()
+    _, kwargs = k8s_apis.core.list_namespaced_service.call_args
+    assert kwargs['label_selector'] == 'skypilot-cluster-name=cluster-abc'
+
+
+def test_labeled_resources_carry_type_meta(tmp_path, k8s_apis):
+    """List-sourced objects get apiVersion/kind stamped on (k8s omits TypeMeta
+    on items returned from a list_* call), so the dump matches kubectl -o yaml.
+    """
+    k8s_apis.core.list_namespaced_service.return_value = _list('svc')
+    k8s_apis.apps.list_namespaced_deployment.return_value = _list('dep')
+
+    _run(tmp_path)
+
+    svc = yaml_utils.read_yaml(str(tmp_path / 'services.yaml'))
+    assert svc['apiVersion'] == 'v1'
+    assert svc['kind'] == 'Service'
+    # The original serialized fields are preserved alongside the stamped meta.
+    assert svc['marker'] == 'svc'
+    # apiVersion/kind lead the document (dump preserves insertion order).
+    assert list(svc)[:2] == ['apiVersion', 'kind']
+
+    dep = yaml_utils.read_yaml(str(tmp_path / 'deployments.yaml'))
+    assert (dep['apiVersion'], dep['kind']) == ('apps/v1', 'Deployment')
+
+
+def test_empty_resource_kinds_are_skipped(tmp_path, k8s_apis):
+    # All listers default to empty -> no resource files written.
+    _run(tmp_path)
+
+    for name in ('services.yaml', 'deployments.yaml', 'config_maps.yaml',
+                 'persistent_volume_claims.yaml', 'ingresses.yaml',
+                 'secrets.yaml'):
+        assert not (tmp_path / name).exists()
+    # Kueue probe succeeds (installed) but there are no objects -> no kueue dir.
+    assert not (tmp_path / 'kueue').exists()
+
+
+def test_secret_values_are_redacted(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_secret.return_value = _list('secret')
+    # The real sanitize_for_serialization would surface the secret's data,
+    # stringData, and the last-applied-configuration annotation (which embeds
+    # the data); emulate that so the redaction path has something to scrub.
+    last_applied = 'kubectl.kubernetes.io/last-applied-configuration'
+    k8s_apis.api_client.sanitize_for_serialization.side_effect = lambda obj: {
+        'metadata': {
+            'name': 's',
+            'annotations': {
+                last_applied: '{"stringData":{"note":"plaintext"}}',
+                'keep-me': 'ok',
+            },
+        },
+        'data': {
+            'token': 'c2VjcmV0',
+            'password': 'aHVudGVyMg=='
+        },
+        'stringData': {
+            'note': 'plaintext'
+        },
+    }
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    dumped = yaml_utils.read_yaml(str(tmp_path / 'secrets.yaml'))
+    assert dumped['data'] == {'token': '<redacted>', 'password': '<redacted>'}
+    assert dumped['stringData'] == {'note': '<redacted>'}
+    # The data-bearing annotation is redacted; unrelated annotations are kept.
+    assert dumped['metadata']['annotations'][last_applied] == '<redacted>'
+    assert dumped['metadata']['annotations']['keep-me'] == 'ok'
+
+
+def test_kueue_workload_dumped_scoped_to_cluster(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    # Include managedFields to confirm it's stripped from custom objects too.
+    k8s_apis.kueue_items['workloads'] = [{
+        'metadata': {
+            'name': 'wl',
+            'managedFields': [{
+                'manager': 'kueue'
+            }],
+        }
+    }]
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    path = tmp_path / 'kueue' / 'workloads.yaml'
+    assert path.exists()
+    # managedFields stripped -> just the metadata we care about remains.
+    assert yaml_utils.read_yaml(str(path)) == {'metadata': {'name': 'wl'}}
+    # The Workload is scoped to this cluster by name (Kueue names the pod-group
+    # Workload after the cluster), newest version first.
+    wl_calls = [
+        c for c in k8s_apis.custom.list_namespaced_custom_object.call_args_list
+        if c.kwargs['plural'] == 'workloads' and 'field_selector' in c.kwargs
+    ]
+    assert wl_calls
+    assert wl_calls[0].kwargs['version'] == 'v1beta2'
+    assert wl_calls[0].kwargs['field_selector'] == 'metadata.name=cluster-abc'
+
+
+def test_kueue_dumps_queues_flavors_and_topologies(tmp_path, k8s_apis):
+    """Beyond the Workload, the namespace's LocalQueues and the cluster-scoped
+    ClusterQueues/ResourceFlavors/Topologies are captured under kueue/."""
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    k8s_apis.kueue_items.update({
+        'localqueues': [{
+            'metadata': {
+                'name': 'user-queue'
+            }
+        }],
+        'clusterqueues': [{
+            'metadata': {
+                'name': 'cluster-queue'
+            }
+        }],
+        'resourceflavors': [{
+            'metadata': {
+                'name': 'default-flavor'
+            }
+        }],
+        'topologies': [{
+            'metadata': {
+                'name': 'rack'
+            }
+        }],
+    })
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    kdir = tmp_path / 'kueue'
+    assert yaml_utils.read_yaml(str(kdir / 'localqueues.yaml')) == {
+        'metadata': {
+            'name': 'user-queue'
+        }
+    }
+    assert yaml_utils.read_yaml(str(kdir / 'clusterqueues.yaml')) == {
+        'metadata': {
+            'name': 'cluster-queue'
+        }
+    }
+    assert yaml_utils.read_yaml(str(kdir / 'resourceflavors.yaml')) == {
+        'metadata': {
+            'name': 'default-flavor'
+        }
+    }
+    assert yaml_utils.read_yaml(str(kdir / 'topologies.yaml')) == {
+        'metadata': {
+            'name': 'rack'
+        }
+    }
+    # Cluster-scoped kinds are fetched via the cluster (not namespaced) API.
+    cluster_plurals = {
+        c.kwargs['plural']
+        for c in k8s_apis.custom.list_cluster_custom_object.call_args_list
+    }
+    assert {'clusterqueues', 'resourceflavors', 'topologies'} <= cluster_plurals
+
+
+def test_kueue_falls_back_to_older_version(tmp_path, k8s_apis):
+    # v1beta2 isn't served (404); the version probe falls back to v1beta1.
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    k8s_apis.kueue_items['workloads'] = [{'metadata': {'name': 'wl'}}]
+
+    def _ns(*args, **kwargs):
+        del args
+        if kwargs['version'] == 'v1beta2':
+            raise _FakeApiException(status=404)
+        return {'items': list(k8s_apis.kueue_items.get(kwargs['plural'], []))}
+
+    def _cluster(*args, **kwargs):
+        del args
+        return {'items': list(k8s_apis.kueue_items.get(kwargs['plural'], []))}
+
+    k8s_apis.custom.list_namespaced_custom_object.side_effect = _ns
+    k8s_apis.custom.list_cluster_custom_object.side_effect = _cluster
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    assert (tmp_path / 'kueue' / 'workloads.yaml').exists()
+    versions = [
+        c.kwargs['version']
+        for c in k8s_apis.custom.list_namespaced_custom_object.call_args_list
+    ]
+    # Probe tried v1beta2 (404) then resolved v1beta1; the dump used v1beta1.
+    assert versions[:2] == ['v1beta2', 'v1beta1']
+    assert all(v == 'v1beta1' for v in versions[1:])
+
+
+def test_kueue_crd_absent_is_not_an_error(tmp_path, k8s_apis):
+    # Cluster uses Kueue (labeled pods), but the CRD isn't served at any version
+    # -> Kueue isn't actually installed; skip without error.
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    k8s_apis.custom.list_namespaced_custom_object.side_effect = (
+        _FakeApiException(status=404))
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    assert not (tmp_path / 'kueue').exists()
+    # Only the version probe ran (both versions) before giving up; no list of
+    # cluster-scoped kinds was attempted.
+    assert k8s_apis.custom.list_namespaced_custom_object.call_count == 2
+    k8s_apis.custom.list_cluster_custom_object.assert_not_called()
+
+
+def test_kueue_non_404_failure_is_recorded(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head', kueue=True)
+    k8s_apis.custom.list_namespaced_custom_object.side_effect = (
+        _FakeApiException(status=500))
+
+    errors = _run(tmp_path)
+
+    assert len(errors) == 1
+    assert errors[0]['resource'] == 'kubernetes/kueue/workloads'
+
+
+def test_kueue_skipped_when_cluster_not_using_kueue(tmp_path, k8s_apis):
+    """Kueue may be installed cluster-wide, but if this cluster's pods don't
+    carry the queue-name label we don't touch Kueue at all -- no kueue/ dir, no
+    custom-objects API calls."""
+    k8s_apis.core.list_namespaced_pod.return_value = _pods('c-head')  # no label
+    # Even with Kueue objects present cluster-wide...
+    k8s_apis.kueue_items['clusterqueues'] = [{'metadata': {'name': 'cq'}}]
+
+    errors = _run(tmp_path)
+
+    assert not errors
+    assert not (tmp_path / 'kueue').exists()
+    k8s_apis.custom.list_namespaced_custom_object.assert_not_called()
+    k8s_apis.custom.list_cluster_custom_object.assert_not_called()
+
+
+def test_pod_list_failure_is_recorded(tmp_path, k8s_apis):
+    k8s_apis.core.list_namespaced_pod.side_effect = RuntimeError('boom')
+
+    errors = _run(tmp_path)
+
+    # The pod-list failure is recorded; the dump still continues for everything
+    # else (labeled resources, Kueue).
+    pod_errs = [e for e in errors if e['resource'] == 'kubernetes/pods']
+    assert len(pod_errs) == 1
+    assert pod_errs[0]['error'] == 'boom'
+    assert 'traceback' in pod_errs[0]

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -74,9 +74,11 @@ def k8s_apis(monkeypatch):
     core.list_namespaced_persistent_volume_claim.return_value = _list()
     core.list_namespaced_config_map.return_value = _list()
     core.list_namespaced_secret.return_value = _list()
+    core.read_namespaced_config_map.side_effect = _FakeApiException(404)
 
     apps = mock.MagicMock()
     apps.list_namespaced_deployment.return_value = _list()
+    apps.list_daemon_set_for_all_namespaces.return_value = _list()
 
     networking = mock.MagicMock()
     networking.list_namespaced_ingress.return_value = _list()
@@ -236,9 +238,9 @@ def test_per_cluster_makes_no_cluster_scoped_calls(tmp_path, k8s_apis):
 
 
 def test_context_gpu_metrics_pods_dumped(tmp_path, k8s_apis):
-    """The metrics Prometheus server (skypilot ns) and DCGM exporter (any ns, by
-    name substring) are captured under gpu_metrics/ from one cluster-wide list;
-    the chart's kube-state-metrics and unrelated pods are excluded."""
+    """The metrics Prometheus server, the chart's kube-state-metrics, and the
+    DCGM exporter (any ns, by name substring) are captured under gpu_metrics/
+    from one cluster-wide list; unrelated pods are excluded."""
     k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
         ('skypilot', 'skypilot-prometheus-server-abc123'),
         ('skypilot', 'skypilot-prometheus-kube-state-metrics-xyz'),
@@ -252,12 +254,46 @@ def test_context_gpu_metrics_pods_dumped(tmp_path, k8s_apis):
     gdir = tmp_path / 'gpu_metrics'
     prom = yaml_utils.read_yaml(str(gdir / 'prometheus-server.yaml'))
     assert (prom['apiVersion'], prom['kind']) == ('v1', 'Pod')
+    ksm = yaml_utils.read_yaml(str(gdir / 'kube-state-metrics.yaml'))
+    assert (ksm['apiVersion'], ksm['kind']) == ('v1', 'Pod')
     dcgm = yaml_utils.read_yaml(str(gdir / 'dcgm-exporter.yaml'))
     assert (dcgm['apiVersion'], dcgm['kind']) == ('v1', 'Pod')
-    # Only the two matched kinds are written (KSM + unrelated pods excluded).
+    # The three matched pod kinds are written; the unrelated pod is excluded,
+    # and the config/PVC/DaemonSet are absent (404 / empty) in this fixture.
     assert sorted(p.name for p in gdir.iterdir()) == [
-        'dcgm-exporter.yaml', 'prometheus-server.yaml'
+        'dcgm-exporter.yaml', 'kube-state-metrics.yaml',
+        'prometheus-server.yaml'
     ]
+
+
+def test_context_gpu_metrics_config_and_topology_dumped(tmp_path, k8s_apis):
+    """The prometheus ConfigMap (rendered prometheus.yml), the Prometheus
+    PVC(s), and the DCGM-exporter DaemonSet are captured under gpu_metrics/
+    alongside the pods -- the config + topology behind the metrics pipeline."""
+    k8s_apis.core.read_namespaced_config_map.side_effect = None
+    k8s_apis.core.read_namespaced_config_map.return_value = _obj('cm')
+    k8s_apis.core.list_namespaced_persistent_volume_claim.return_value = _list(
+        'pvc')
+    k8s_apis.apps.list_daemon_set_for_all_namespaces.return_value = (
+        SimpleNamespace(items=[
+            SimpleNamespace(
+                _marker='ds',
+                metadata=SimpleNamespace(name='nvidia-dcgm-exporter')),
+            SimpleNamespace(_marker='unrelated',
+                            metadata=SimpleNamespace(name='some-other-ds')),
+        ]))
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    gdir = tmp_path / 'gpu_metrics'
+    cm = yaml_utils.read_yaml(str(gdir / 'prometheus-config.yaml'))
+    assert (cm['apiVersion'], cm['kind']) == ('v1', 'ConfigMap')
+    pvc = yaml_utils.read_yaml(str(gdir / 'prometheus-pvcs.yaml'))
+    assert (pvc['apiVersion'], pvc['kind']) == ('v1', 'PersistentVolumeClaim')
+    ds = yaml_utils.read_yaml(str(gdir / 'dcgm-exporter-daemonset.yaml'))
+    assert (ds['apiVersion'], ds['kind']) == ('apps/v1', 'DaemonSet')
+    assert ds['marker'] == 'ds'  # only the dcgm-exporter DS, not some-other-ds
 
 
 def test_context_gpu_metrics_absent_produces_no_dir(tmp_path, k8s_apis):

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -276,9 +276,9 @@ def test_context_gpu_metrics_config_and_topology_dumped(tmp_path, k8s_apis):
         'pvc')
     k8s_apis.apps.list_daemon_set_for_all_namespaces.return_value = (
         SimpleNamespace(items=[
-            SimpleNamespace(
-                _marker='ds',
-                metadata=SimpleNamespace(name='nvidia-dcgm-exporter')),
+            SimpleNamespace(_marker='ds',
+                            metadata=SimpleNamespace(
+                                name='nvidia-dcgm-exporter')),
             SimpleNamespace(_marker='unrelated',
                             metadata=SimpleNamespace(name='some-other-ds')),
         ]))

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2814,6 +2814,14 @@ class TestCollectClusterKubernetesResources:
                                      output_dir=os.path.join(
                                          str(tmp_path), 'kubernetes'))
         assert not errors
+        # A context.json mapping is dropped pointing at the per-context dump.
+        with open(os.path.join(str(tmp_path), 'kubernetes', 'context.json'),
+                  encoding='utf-8') as f:
+            mapping = json.load(f)
+        assert mapping['context'] == 'ctx'
+        assert mapping['namespace'] == 'ns'
+        assert mapping['cluster_name_on_cloud'] == 'cluster-abc'
+        assert mapping['context_dir'].startswith('kubernetes_contexts/')
 
     def test_provider_errors_are_prefixed_with_cluster(self, tmp_path):
         """Errors from the provider are re-tagged with component + cluster."""
@@ -2864,5 +2872,178 @@ class TestCollectClusterKubernetesResources:
             debug_utils._collect_cluster_kubernetes_resources(
                 'mycluster', str(tmp_path), handle, errors)
 
+        dump.assert_not_called()
+        assert not errors
+
+
+class TestSanitizeContextName:
+    """Tests for _sanitize_context_name (context -> safe dir name)."""
+
+    def test_none_maps_to_in_cluster(self):
+        assert debug_utils._sanitize_context_name(None) == 'in-cluster'
+
+    def test_unsafe_chars_replaced_and_hash_suffixed(self):
+        out = debug_utils._sanitize_context_name(
+            'gke_proj_us-central1-c_my-cluster')
+        # Path-safe, and a short hash distinguishes contexts that would
+        # otherwise collide after sanitization.
+        assert '/' not in out
+        assert out.startswith('gke_proj_us-central1-c_my-cluster-')
+
+    def test_distinct_contexts_get_distinct_dirs(self):
+        # Two contexts that sanitize to the same prefix still differ via hash.
+        a = debug_utils._sanitize_context_name('a/b')
+        b = debug_utils._sanitize_context_name('a:b')
+        assert a != b
+
+    def test_stable_for_same_input(self):
+        assert (debug_utils._sanitize_context_name('ctx-x') ==
+                debug_utils._sanitize_context_name('ctx-x'))
+
+
+class TestDumpKubeContextsInfo:
+    """Tests for _dump_kube_contexts_info (per-context cluster-wide dump)."""
+
+    def _k8s_record(self, context, namespace='ns'):
+        runner = mock.MagicMock(spec=command_runner.KubernetesCommandRunner)
+        runner.context = context
+        runner.namespace = namespace
+        handle = mock.Mock()
+        handle.launched_resources.cloud = clouds.Kubernetes()
+        handle.get_command_runners.return_value = [runner]
+        return {'handle': handle}
+
+    def _non_k8s_record(self):
+        handle = mock.Mock()
+        handle.launched_resources.cloud = mock.Mock()  # not Kubernetes
+        return {'handle': handle}
+
+    def test_dedups_clusters_to_unique_contexts(self, tmp_path):
+        """Two clusters on the same context => the context is fetched once."""
+        records = {
+            'c1': self._k8s_record('ctx-a'),
+            'c2': self._k8s_record('ctx-a'),
+        }
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=[]) as dump:
+            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
+                                                 errors)
+
+        dump.assert_called_once()
+        assert dump.call_args.kwargs['context'] == 'ctx-a'
+        assert not errors
+
+    def test_distinct_contexts_each_fetched(self, tmp_path):
+        records = {
+            'c1': self._k8s_record('ctx-a'),
+            'c2': self._k8s_record('ctx-b'),
+        }
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=[]) as dump:
+            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
+                                                 errors)
+
+        fetched = {c.kwargs['context'] for c in dump.call_args_list}
+        assert fetched == {'ctx-a', 'ctx-b'}
+
+    def test_non_kubernetes_clusters_are_skipped(self, tmp_path):
+        records = {'c1': self._non_k8s_record()}
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
+                       ) as dump:
+            debug_utils._dump_kube_contexts_info({'c1'}, str(tmp_path), errors)
+
+        dump.assert_not_called()
+        # No k8s contexts => the kubernetes_contexts/ dir isn't created.
+        assert not (tmp_path / 'kubernetes_contexts').exists()
+        assert not errors
+
+    def test_in_cluster_context_maps_to_single_dir(self, tmp_path):
+        """A None (in-cluster) context dedups and writes into 'in-cluster'."""
+        records = {
+            'c1': self._k8s_record(None),
+            'c2': self._k8s_record(None),
+        }
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=[]) as dump:
+            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
+                                                 errors)
+
+        dump.assert_called_once()
+        assert dump.call_args.kwargs['context'] is None
+        assert dump.call_args.kwargs['output_dir'].endswith(
+            os.path.join('kubernetes_contexts', 'in-cluster'))
+
+    def test_provider_errors_are_prefixed_with_context(self, tmp_path):
+        records = {'c1': self._k8s_record('ctx-a')}
+        provider_errors = [{
+            'resource': 'gpu_metrics',
+            'error': 'forbidden',
+            'traceback': 'tb',
+        }]
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=provider_errors):
+            debug_utils._dump_kube_contexts_info({'c1'}, str(tmp_path), errors)
+
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'kubernetes_contexts'
+        # Prefixed with the sanitized context dir name.
+        assert errors[0]['resource'].endswith('/gpu_metrics')
+        assert errors[0]['resource'].startswith('ctx-a-')
+        assert errors[0]['error'] == 'forbidden'
+
+    def test_one_broken_context_does_not_abort_others(self, tmp_path):
+        """run_in_parallel re-raises the first exception; the per-context task
+        must swallow it so a broken context can't abort the others' dumps."""
+        records = {
+            'good': self._k8s_record('ctx-good'),
+            'bad': self._k8s_record('ctx-bad'),
+        }
+
+        def _dump(context, output_dir):
+            del output_dir
+            if context == 'ctx-bad':
+                raise RuntimeError('context timed out')
+            return []
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name',
+                               side_effect=lambda n: records[n]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        side_effect=_dump):
+            debug_utils._dump_kube_contexts_info({'good', 'bad'}, str(tmp_path),
+                                                 errors)
+
+        # The bad context's failure is recorded, the good one still ran.
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'kubernetes_contexts'
+        assert errors[0]['resource'].startswith('ctx-bad-')
+        assert 'timed out' in errors[0]['error']
+
+    def test_empty_cluster_names_is_noop(self, tmp_path):
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
+                       ) as dump:
+            debug_utils._dump_kube_contexts_info(set(), str(tmp_path), errors)
         dump.assert_not_called()
         assert not errors

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2902,87 +2902,63 @@ class TestSanitizeContextName:
 
 
 class TestDumpKubeContextsInfo:
-    """Tests for _dump_kube_contexts_info (per-context cluster-wide dump)."""
+    """Tests for _dump_kube_contexts_info.
 
-    def _k8s_record(self, context, namespace='ns'):
-        runner = mock.MagicMock(spec=command_runner.KubernetesCommandRunner)
-        runner.context = context
-        runner.namespace = namespace
-        handle = mock.Mock()
-        handle.launched_resources.cloud = clouds.Kubernetes()
-        handle.get_command_runners.return_value = [runner]
-        return {'handle': handle}
+    Source of truth is Kubernetes.existing_allowed_contexts() (not the dumped
+    clusters), so these patch that classmethod.
+    """
 
-    def _non_k8s_record(self):
-        handle = mock.Mock()
-        handle.launched_resources.cloud = mock.Mock()  # not Kubernetes
-        return {'handle': handle}
+    @staticmethod
+    def _patch_allowed(contexts):
+        return mock.patch.object(debug_utils.clouds.Kubernetes,
+                                 'existing_allowed_contexts',
+                                 return_value=contexts)
 
-    def test_dedups_clusters_to_unique_contexts(self, tmp_path):
-        """Two clusters on the same context => the context is fetched once."""
-        records = {
-            'c1': self._k8s_record('ctx-a'),
-            'c2': self._k8s_record('ctx-a'),
-        }
+    def test_dumps_each_allowed_context(self, tmp_path):
         errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
+        with self._patch_allowed(['ctx-a', 'ctx-b']), \
              mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
                         return_value=[]) as dump:
-            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
-                                                 errors)
-
-        dump.assert_called_once()
-        assert dump.call_args.kwargs['context'] == 'ctx-a'
-        assert not errors
-
-    def test_distinct_contexts_each_fetched(self, tmp_path):
-        records = {
-            'c1': self._k8s_record('ctx-a'),
-            'c2': self._k8s_record('ctx-b'),
-        }
-        errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
-             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
-                        return_value=[]) as dump:
-            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
-                                                 errors)
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
 
         fetched = {c.kwargs['context'] for c in dump.call_args_list}
         assert fetched == {'ctx-a', 'ctx-b'}
-
-    def test_non_kubernetes_clusters_are_skipped(self, tmp_path):
-        records = {'c1': self._non_k8s_record()}
-        errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
-             mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
-                       ) as dump:
-            debug_utils._dump_kube_contexts_info({'c1'}, str(tmp_path), errors)
-
-        dump.assert_not_called()
-        # No k8s contexts => the kubernetes_contexts/ dir isn't created.
-        assert not (tmp_path / 'kubernetes_contexts').exists()
         assert not errors
 
-    def test_in_cluster_context_maps_to_single_dir(self, tmp_path):
-        """A None (in-cluster) context dedups and writes into 'in-cluster'."""
-        records = {
-            'c1': self._k8s_record(None),
-            'c2': self._k8s_record(None),
-        }
+    def test_allowed_context_with_no_clusters_is_still_dumped(self, tmp_path):
+        """The whole point of Ask #1: a context in allowed_contexts is scraped
+        even with zero SkyPilot clusters on it (fresh-onboarding case). No
+        cluster state is consulted at all."""
         errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
+        with self._patch_allowed(['ctx-fresh']), \
+             mock.patch.object(debug_utils.global_user_state,
+                               'get_cluster_from_name') as get_cluster, \
              mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
                         return_value=[]) as dump:
-            debug_utils._dump_kube_contexts_info({'c1', 'c2'}, str(tmp_path),
-                                                 errors)
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
+
+        dump.assert_called_once()
+        assert dump.call_args.kwargs['context'] == 'ctx-fresh'
+        # The per-context path no longer derives contexts from clusters.
+        get_cluster.assert_not_called()
+
+    def test_dedupes_repeated_contexts(self, tmp_path):
+        errors: List[Dict[str, str]] = []
+        with self._patch_allowed(['ctx-a', 'ctx-a']), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=[]) as dump:
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
+
+        dump.assert_called_once()
+        assert dump.call_args.kwargs['context'] == 'ctx-a'
+
+    def test_in_cluster_none_maps_to_in_cluster_dir(self, tmp_path):
+        """existing_allowed_contexts returns None for in-cluster auth."""
+        errors: List[Dict[str, str]] = []
+        with self._patch_allowed([None]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
+                        return_value=[]) as dump:
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
 
         dump.assert_called_once()
         assert dump.call_args.kwargs['context'] is None
@@ -2990,19 +2966,16 @@ class TestDumpKubeContextsInfo:
             os.path.join('kubernetes_contexts', 'in-cluster'))
 
     def test_provider_errors_are_prefixed_with_context(self, tmp_path):
-        records = {'c1': self._k8s_record('ctx-a')}
         provider_errors = [{
             'resource': 'gpu_metrics',
             'error': 'forbidden',
             'traceback': 'tb',
         }]
         errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
+        with self._patch_allowed(['ctx-a']), \
              mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
                         return_value=provider_errors):
-            debug_utils._dump_kube_contexts_info({'c1'}, str(tmp_path), errors)
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
 
         assert len(errors) == 1
         assert errors[0]['component'] == 'kubernetes_contexts'
@@ -3014,10 +2987,6 @@ class TestDumpKubeContextsInfo:
     def test_one_broken_context_does_not_abort_others(self, tmp_path):
         """run_in_parallel re-raises the first exception; the per-context task
         must swallow it so a broken context can't abort the others' dumps."""
-        records = {
-            'good': self._k8s_record('ctx-good'),
-            'bad': self._k8s_record('ctx-bad'),
-        }
 
         def _dump(context, output_dir):
             del output_dir
@@ -3026,13 +2995,10 @@ class TestDumpKubeContextsInfo:
             return []
 
         errors: List[Dict[str, str]] = []
-        with mock.patch.object(debug_utils.global_user_state,
-                               'get_cluster_from_name',
-                               side_effect=lambda n: records[n]), \
+        with self._patch_allowed(['ctx-good', 'ctx-bad']), \
              mock.patch('sky.provision.kubernetes.debug.dump_context_resources',
                         side_effect=_dump):
-            debug_utils._dump_kube_contexts_info({'good', 'bad'}, str(tmp_path),
-                                                 errors)
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
 
         # The bad context's failure is recorded, the good one still ran.
         assert len(errors) == 1
@@ -3040,10 +3006,26 @@ class TestDumpKubeContextsInfo:
         assert errors[0]['resource'].startswith('ctx-bad-')
         assert 'timed out' in errors[0]['error']
 
-    def test_empty_cluster_names_is_noop(self, tmp_path):
+    def test_no_allowed_contexts_is_noop(self, tmp_path):
         errors: List[Dict[str, str]] = []
-        with mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
+        with self._patch_allowed([]), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
                        ) as dump:
-            debug_utils._dump_kube_contexts_info(set(), str(tmp_path), errors)
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
         dump.assert_not_called()
+        assert not (tmp_path / 'kubernetes_contexts').exists()
         assert not errors
+
+    def test_allowed_contexts_lookup_failure_is_recorded(self, tmp_path):
+        errors: List[Dict[str, str]] = []
+        with mock.patch.object(debug_utils.clouds.Kubernetes,
+                               'existing_allowed_contexts',
+                               side_effect=RuntimeError('kubeconfig boom')), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
+                       ) as dump:
+            debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
+
+        dump.assert_not_called()
+        assert len(errors) == 1
+        assert errors[0]['resource'] == 'allowed_contexts'
+        assert 'boom' in errors[0]['error']

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -11,10 +11,12 @@ import zipfile
 
 import pytest
 
+from sky import clouds
 from sky import exceptions
 from sky.server import constants as server_constants
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
+from sky.utils import command_runner
 from sky.utils import debug_dump_helpers
 from sky.utils import debug_utils
 from sky.utils import status_lib
@@ -2757,3 +2759,110 @@ class TestResolveRemoteSkyletLogPath:
         path = debug_utils._resolve_remote_skylet_log_path(runner, 'c')
 
         assert path == posixpath.join('~', skylet_constants.SKYLET_LOG_FILE)
+
+
+class TestCollectClusterKubernetesResources:
+    """Tests for the _collect_cluster_kubernetes_resources helper."""
+
+    def _k8s_handle(self, runners):
+        handle = mock.Mock()
+        handle.launched_resources.cloud = clouds.Kubernetes()
+        handle.cluster_name_on_cloud = 'cluster-abc'
+        handle.get_command_runners.return_value = runners
+        return handle
+
+    def _k8s_runner(self, context, namespace, pod_name):
+        runner = mock.MagicMock(spec=command_runner.KubernetesCommandRunner)
+        runner.context = context
+        runner.namespace = namespace
+        runner.pod_name = pod_name
+        return runner
+
+    def test_non_kubernetes_cluster_is_noop(self, tmp_path):
+        """A cluster on another cloud must not touch the k8s code path."""
+        handle = mock.Mock()
+        handle.launched_resources.cloud = mock.Mock()  # not a Kubernetes cloud
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources'
+                       ) as dump:
+            debug_utils._collect_cluster_kubernetes_resources(
+                'c', str(tmp_path), handle, errors)
+
+        dump.assert_not_called()
+        handle.get_command_runners.assert_not_called()
+        assert not errors
+
+    def test_delegates_with_coordinates_from_runners(self, tmp_path):
+        """Context/namespace are pulled off the k8s runners and passed through;
+        the dump finds the cluster's objects by label, so no pod names needed."""
+        runners = [
+            self._k8s_runner('ctx', 'ns', 'pod-head'),
+            self._k8s_runner('ctx', 'ns', 'pod-worker'),
+        ]
+        handle = self._k8s_handle(runners)
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources',
+                        return_value=[]) as dump:
+            debug_utils._collect_cluster_kubernetes_resources(
+                'mycluster', str(tmp_path), handle, errors)
+
+        dump.assert_called_once_with(context='ctx',
+                                     namespace='ns',
+                                     cluster_name_on_cloud='cluster-abc',
+                                     output_dir=os.path.join(
+                                         str(tmp_path), 'kubernetes'))
+        assert not errors
+
+    def test_provider_errors_are_prefixed_with_cluster(self, tmp_path):
+        """Errors from the provider are re-tagged with component + cluster."""
+        handle = self._k8s_handle([self._k8s_runner('ctx', 'ns', 'pod-head')])
+        provider_errors = [{
+            'resource': 'kubernetes/pods/pod-head',
+            'error': 'boom',
+            'traceback': 'tb',
+        }]
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources',
+                        return_value=provider_errors):
+            debug_utils._collect_cluster_kubernetes_resources(
+                'mycluster', str(tmp_path), handle, errors)
+
+        assert errors == [{
+            'component': 'clusters',
+            'resource': 'mycluster/kubernetes/pods/pod-head',
+            'error': 'boom',
+            'traceback': 'tb',
+        }]
+
+    def test_get_command_runners_failure_is_recorded(self, tmp_path):
+        """A k8s cluster whose runners can't be built records one error."""
+        handle = self._k8s_handle([])
+        handle.get_command_runners.side_effect = RuntimeError('unreachable')
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources'
+                       ) as dump:
+            debug_utils._collect_cluster_kubernetes_resources(
+                'mycluster', str(tmp_path), handle, errors)
+
+        dump.assert_not_called()
+        assert len(errors) == 1
+        assert errors[0]['resource'] == 'mycluster/kubernetes'
+        assert errors[0]['component'] == 'clusters'
+
+    def test_no_kubernetes_runners_is_noop(self, tmp_path):
+        """A k8s-cloud handle whose runners aren't KubernetesCommandRunners
+        (e.g. cluster info unavailable) is skipped without error."""
+        handle = self._k8s_handle([mock.Mock()])  # plain runner, wrong type
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources'
+                       ) as dump:
+            debug_utils._collect_cluster_kubernetes_resources(
+                'mycluster', str(tmp_path), handle, errors)
+
+        dump.assert_not_called()
+        assert not errors


### PR DESCRIPTION
## Summary

Extends `sky debug-dump`: for clusters running on Kubernetes, it now also snapshots the related Kubernetes objects so an operator can inspect them like `kubectl get -o yaml` without needing kubectl access to the user's cluster. Collection is **split by scope** so multi-cluster dumps don't re-fetch shared cluster-wide objects once per cluster:

**Per SkyPilot cluster** → `clusters/<name>/kubernetes/` (namespace-scoped, works under minimal RBAC):
- **Pods + events** — the cluster's pods (one list-by-label call) and the events involving them (one namespace-wide pod-event query, filtered/grouped per pod). Constant number of API calls regardless of node count.
- **Resources SkyPilot creates** — by the `skypilot-cluster-name` label: Services, Deployments, PVCs, ConfigMaps, Secrets, Ingresses.
- **`kueue/workloads.yaml`** — the cluster's 1:1 Workload, only when the cluster is actually using Kueue (its pods carry the `kueue.x-k8s.io/queue-name` label).
- **`context.json`** — `{context, namespace, cluster_name_on_cloud, context_dir}`, linking the cluster to its per-context dir.

**Per allowed kube context** → `kubernetes_contexts/<sanitized-context>/` (cluster-WIDE infra, fetched once per context):
- **`gpu_metrics/`** — the Prometheus server (`skypilot-prometheus-server-*`, ns `skypilot`) and DCGM-exporter pods (matched by name substring across namespaces).
- **`kueue/`** — the cluster-scoped ClusterQueues / LocalQueues / ResourceFlavors / Topologies. CRD versions tried newest-first (`v1beta2` → `v1beta1`).
- **`context.json`** — `{context, reachable}`.

**Why the split:** the GPU-metrics pods and the non-Workload Kueue objects aren't tied to any one SkyPilot cluster — collecting them per cluster re-fetched identical objects N times (10 clusters on one kube cluster → fetched 10×). They're collected once per context instead. The context set is sourced from `Kubernetes.existing_allowed_contexts()` (the same set `sky check` uses), **not** the dumped clusters — so a context with **no** SkyPilot clusters (e.g. a freshly onboarded tenant) is still captured, which is exactly when you want to debug its GPU-metrics / Kueue config.

**Robustness for defunct contexts** (tenants can have kube contexts that time out): retries are disabled on the debug clients so a failed call costs one ~5s timeout instead of urllib3's ~4× retry; both the per-context and per-cluster paths fast-fail on the first connection error; unique contexts are fetched in parallel; and a `context.json` marker is always written so a reachable-but-empty or unreachable context still shows up in the dump rather than vanishing.

**RBAC invariant:** the per-cluster path issues only namespace-scoped calls (works under SkyPilot's minimal namespace-only RBAC); all cluster-wide API calls (`list_pod_for_all_namespaces`, `list_cluster_custom_object`) live only in the per-context path and are best-effort.

Output matches `kubectl get -o yaml`: `apiVersion`/`kind` are stamped back onto list-sourced objects (k8s omits TypeMeta on list items) and `managedFields` is stripped. **Secrets are redacted** — `data`/`stringData` values and the `kubectl.kubernetes.io/last-applied-configuration` annotation (which can embed values in plaintext).

Generic orchestration (detection, context dedup, parallel fetch) lives in `sky/utils/debug_utils.py`; the Kubernetes queries + serialization live in `sky/provision/kubernetes/debug.py`.

**Known limitation (follow-up):** for a *defunct* context the new k8s-resource paths fast-fail (~5s), but the overall dump can still be slow due to two pre-existing paths — the skylet-log collection's `kubectl` call (`connect_timeout` maps to `--pod-running-timeout` for k8s, which doesn't bound API-server connect/discovery) and the `sky check` infra-choices probe in `_dump_server_info`. Fixes for those, plus parallelizing per-cluster fetches, are a follow-up PR.

## Test plan

- **Unit:** `pytest tests/unit_tests/kubernetes/test_debug.py tests/unit_tests/test_sky/utils/test_debug_utils.py` — all passing. Includes an RBAC-invariant test (per-cluster path makes no cluster-scoped calls), the Kueue gate, version fallback, secret redaction, defunct-context fast-fail, and that an allowed context with **no** clusters is still scraped (without consulting cluster state).
- **Manual, multi-cluster on GKE** — verified against live clusters across two scenarios:
  - **Allowed-context source of truth:** with 2 allowed contexts but a SkyPilot cluster on only one, the dump produced `kubernetes_contexts/` entries for **both** — the cluster-less context still scraped (marker + Kueue config).
  - 3 SkyPilot clusters across 2 kube contexts (one with Kueue + GPU metrics [Prometheus + a real DCGM exporter], one bare):
    - **Per-cluster Kueue gate:** only the queue-routed cluster has `kueue/workloads.yaml` (admitted Workload); the plain clusters have none, even on the Kueue-enabled context.
    - **Per-context:** `gpu_metrics/{prometheus-server,dcgm-exporter}.yaml` (real pods) + cluster-wide `kueue/{clusterqueues,localqueues,resourceflavors,topologies}.yaml`.
    - **Markers:** both contexts present; the bare context shows `reachable: true` with no resource dirs; non-Kubernetes clusters produce no `kubernetes/` dir; `errors.json` clean.
    - **Defunct context** (blackholed API server): the per-cluster and per-context paths each fast-fail in ~5s (verified by direct timing) and the marker records `reachable: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
