### PR TITLE
[Jobs] Don't re-issue STARTING for resumed JobGroup tasks on controller restart

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1148,21 +1148,32 @@ class JobController:
             force_transit_to_recovering = False
 
     async def _prepare_job_group_task_for_launch(
-        self, task: 'sky.Task', task_id: int, job_group_name: str,
-        other_job_names: List[str]
+        self,
+        task: 'sky.Task',
+        task_id: int,
+        job_group_name: str,
+        other_job_names: List[str],
+        set_starting: bool = True,
     ) -> Tuple[str, recovery_strategy.StrategyExecutor]:
         """Prepare a JobGroup task for launch.
 
         This function:
         1. Injects a wait script to ensure networking is ready
         2. Creates the recovery strategy executor
-        3. Sets task state to STARTING
+        3. Sets task state to STARTING (only when ``set_starting`` is True)
 
         Args:
             task: Task to prepare.
             task_id: Task ID.
             job_group_name: JobGroup name.
             other_job_names: Other task names in the group (to wait for).
+            set_starting: Whether to transition the task to STARTING. Must be
+                False when resuming a task the controller was already running
+                before a restart: such a task is past PENDING, so the guarded
+                PENDING->STARTING update in set_starting matches no rows and
+                raises, wrongly failing the whole group as FAILED_CONTROLLER.
+                Mirrors the single-task path, which only sets STARTING when
+                ``not is_resume``.
 
         Returns:
             Tuple of (cluster_name, executor). cluster_name is always
@@ -1209,18 +1220,24 @@ class JobController:
             file_mounts_blob_id=managed_job_state.get_file_mounts_blob_id(
                 self._job_id))
 
-        callback_func = managed_job_utils.event_callback_func(
-            job_id=self._job_id, task_id=task_id, task=task)
-        resources_str = backend_utils.get_task_resources_str(
-            task, is_managed_job=True)
-        await managed_job_state.set_starting_async(
-            self._job_id,
-            task_id,
-            self._backend.run_timestamp,
-            time.time(),
-            resources_str=resources_str,
-            specs=_build_task_specs(executor),
-            callback_func=callback_func)
+        # Only transition to STARTING for a fresh launch. A resumed task is
+        # already past PENDING, so set_starting's guarded PENDING->STARTING
+        # update would match no rows and raise, wrongly failing the task as
+        # FAILED_CONTROLLER. The monitor loop drives state for resumed tasks
+        # via force_transit_to_recovering instead.
+        if set_starting:
+            callback_func = managed_job_utils.event_callback_func(
+                job_id=self._job_id, task_id=task_id, task=task)
+            resources_str = backend_utils.get_task_resources_str(
+                task, is_managed_job=True)
+            await managed_job_state.set_starting_async(
+                self._job_id,
+                task_id,
+                self._backend.run_timestamp,
+                time.time(),
+                resources_str=resources_str,
+                specs=_build_task_specs(executor),
+                callback_func=callback_func)
 
         return cluster_name, executor
 
@@ -1411,8 +1428,15 @@ class JobController:
 
                 # Get list of other job names (excluding current task)
                 other_job_names = [t.name for t in tasks if t.name != task.name]
+                # Only set STARTING for fresh launches (None/PENDING). Resumed
+                # tasks (STARTING/RUNNING/RECOVERING) are already past PENDING;
+                # re-issuing STARTING would fail the group as FAILED_CONTROLLER.
                 name, executor = await self._prepare_job_group_task_for_launch(
-                    task, task_id, job_group_name, other_job_names)
+                    task,
+                    task_id,
+                    job_group_name,
+                    other_job_names,
+                    set_starting=needs_launch(task_id))
                 cluster_names.append(name)
                 strategy_executors.append(executor)
 

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -18,6 +18,7 @@ import pytest
 
 from sky.jobs import state as managed_job_state
 from sky.jobs.controller import ControllerManager
+from sky.jobs.controller import JobController
 from sky.utils import common
 
 
@@ -1077,3 +1078,71 @@ class TestDownloadLogsForCancelledJob:
                 0, mock_handle_0, None)
             controller.download_log_and_stream.assert_any_call(
                 1, mock_handle_1, None)
+
+
+class TestJobGroupResumeDoesNotReissueStarting:
+    """Regression: a resumed JobGroup task must not be re-issued STARTING.
+
+    On controller restart, ``_run_job_group`` resumes every non-terminal task.
+    A task that was already past PENDING (STARTING/RUNNING/RECOVERING) must NOT
+    have ``set_starting`` re-issued: ``set_starting`` only transitions
+    PENDING->STARTING, so re-issuing it matches no rows and raises
+    ``ManagedJobStatusError``, which the controller escalates to
+    FAILED_CONTROLLER and tears the whole group down. The single-task path
+    already guards this with ``if not is_resume``; the JobGroup path mirrors it
+    via ``set_starting=needs_launch(task_id)``.
+    """
+
+    def _make_controller(self):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._dag = MagicMock()
+        task = MagicMock()
+        task.name = 'job-a'
+        task.envs = {}
+        task.run = 'echo hi'
+        controller._dag.tasks = [task]
+        controller._backend = MagicMock()
+        controller._backend.run_timestamp = 'run-ts'
+        controller.starting = set()
+        controller.starting_lock = MagicMock()
+        controller.starting_signal = MagicMock()
+        return controller, task
+
+    async def _prepare(self, controller, task, set_starting):
+        with patch('sky.jobs.controller.job_group_networking') as net, \
+             patch('sky.jobs.controller.managed_job_utils') as utils, \
+             patch('sky.jobs.controller.recovery_strategy') as recovery, \
+             patch('sky.jobs.controller.managed_job_state') as state, \
+             patch('sky.jobs.controller.backend_utils'), \
+             patch('sky.jobs.controller._build_task_specs', return_value={}):
+            net.generate_wait_for_networking_script.return_value = ''
+            net.generate_inline_networking_setup_script.return_value = ''
+            utils.generate_managed_job_cluster_name.return_value = 'job-a-1'
+            recovery.StrategyExecutor.make.return_value = MagicMock()
+            state.get_file_mounts_blob_id.return_value = None
+            state.set_starting_async = AsyncMock()
+
+            cluster_name, _ = await (
+                JobController._prepare_job_group_task_for_launch(
+                    controller, task, 0, 'group', [],
+                    set_starting=set_starting))
+            return cluster_name, state.set_starting_async
+
+    @pytest.mark.asyncio
+    async def test_resume_skips_set_starting(self):
+        """set_starting=False (resumed task) must not call set_starting."""
+        controller, task = self._make_controller()
+        cluster_name, set_starting_async = await self._prepare(
+            controller, task, set_starting=False)
+        assert cluster_name == 'job-a-1'
+        set_starting_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fresh_launch_sets_starting(self):
+        """set_starting=True (fresh launch) must call set_starting."""
+        controller, task = self._make_controller()
+        _, set_starting_async = await self._prepare(controller,
+                                                    task,
+                                                    set_starting=True)
+        set_starting_async.assert_awaited_once()


### PR DESCRIPTION
## Summary

When the managed jobs controller restarts while a JobGroup has in-flight tasks, `_run_job_group` resumes every non-terminal task. The prepare loop called `set_starting` for all of them, but `set_starting` only transitions
`PENDING -> STARTING`. A task already past PENDING (`STARTING`/`RUNNING`/`RECOVERING`) matched no rows, raising `ManagedJobStatusError`, which the controller escalated to `FAILED_CONTROLLER` and tore down the otherwise-healthy group.


The fix gates `set_starting` on `needs_launch(task_id)` so only fresh (`None`/`PENDING`) tasks transition to STARTING; resumed tasks skip it and are driven by the monitor loop's `force_transit_to_recovering` path, mirroring the single-task contract.

## Test plan

- Added `TestJobGroupResumeDoesNotReissueStarting` in `tests/unit_tests/test_sky/jobs/test_controller.py`: asserts `_prepare_job_group_task_for_launch` skips `set_starting` on resume (`set_starting=False`) and still issues it on a fresh launch (`set_starting=True`).
- Manual end-to-end: launched a 2-task JobGroup, then restarted the controller while both tasks were `STARTING`.
  - Before: the group went to `FAILED_CONTROLLER` with `Failed to set the task to starting. (0 rows updated ...)`.
  - After: the group recovered cleanly `STARTING -> RECOVERING -> RUNNING`.
- `bash format.sh --files sky/jobs/controller.py` -> pylint 10.00/10, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
