### PR TITLE
[Test] Fix test_debug_dump_recent timeout on busy shared servers

### DIFF
--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -250,8 +250,14 @@ def test_debug_dump_recent(generic_cloud: str):
     test = smoke_tests_utils.Test(
         'debug_dump_recent',
         [
-            # Create a debug dump with --recent-minutes (no clusters/jobs needed)
-            'sky debug-dump --recent-minutes 60 --output /tmp/test_debug_dump_recent.zip',
+            # Any positive value works for --recent-minutes: the server always
+            # injects a handful of system daemon request IDs into every dump
+            # regardless of the time window, so request_count > 0 is always
+            # satisfied. We use 5 rather than 60 because on a shared CI server
+            # that runs tests continuously, a 60-minute window collects
+            # thousands of user requests and takes 5+ minutes to zip up,
+            # blowing the per-command timeout.
+            'sky debug-dump --recent-minutes 5 --output /tmp/test_debug_dump_recent.zip',
             # Verify the zip file was created and is a valid zip
             'test -f /tmp/test_debug_dump_recent.zip',
             's=$(unzip -l /tmp/test_debug_dump_recent.zip) && echo "$s" && '
@@ -286,7 +292,9 @@ def test_debug_dump_recent(generic_cloud: str):
         ],
         teardown='rm -f /tmp/test_debug_dump_recent.zip && '
         'rm -rf /tmp/test_debug_dump_recent',
-        timeout=2 * 60,
+        # On shared staging servers the dump collects active managed jobs via
+        # controller SSH, which takes several minutes. 10 minutes is safe.
+        timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Summary

- `--recent-minutes 60` → `--recent-minutes 5`
- `timeout=2 * 60` → `timeout=10 * 60`

## Why

The test consistently times out on shared CI servers:

1. **Too much data**: Busy staging servers accumulate ~2000+ requests per 60-minute window. Collecting them all takes 5+ minutes, exceeding the 2-minute per-command timeout (zip file never created, `test -f` then fails).

2. **Controller SSH**: Even with a shorter window, active managed jobs trigger an SSH into the jobs controller to collect debug data — this takes several minutes on shared servers.

**`--recent-minutes 5` is sufficient**: System daemons run every ~30s, so 5-minute windows always satisfy `request_count > 0`. The `--recent-minutes` feature is still fully exercised.

**10-minute timeout is safe**: The dump with a 5-minute window completes in ~4 minutes on a busy shared server with active managed jobs.

## Tested

Verified against staging (shared server, active CI, multiple managed jobs):
- `--recent-minutes 5` collects 179 requests, 31 clusters, 7 managed jobs
- All JSON assertions pass (`requested`, `collected`, `request_count > 0`, `server_info` fields)
- Completes in ~4 minutes (safely under new 10-minute timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)