### PR TITLE
[SSH] Pass k3s installer env through sudo

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy.py
+++ b/sky/ssh_node_pools/deploy/deploy.py
@@ -8,7 +8,7 @@ import shlex
 import shutil
 import tempfile
 import textwrap
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import colorama
 import yaml
@@ -42,6 +42,20 @@ def success_message(message):
 def force_update_status(message):
     """Force update rich spinner status."""
     rich_utils.force_update_status(ux_utils.spinner_message(message))
+
+
+def _sudo_env_assignment(name: str, value: str) -> str:
+    """Return a sudo command environment assignment."""
+    if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*', name) is None:
+        raise ValueError(f'Invalid environment variable name: {name}')
+    return f'{name}={shlex.quote(value)}'
+
+
+def _sudo_k3s_install_cmd(env_vars: List[Tuple[str, str]]) -> str:
+    """Build a sudo command that preserves k3s installer environment."""
+    env = ' '.join(
+        _sudo_env_assignment(name, value) for name, value in env_vars)
+    return f'sudo -A {env} sh -'
 
 
 def run(cleanup: bool = False,
@@ -490,7 +504,11 @@ def deploy_single_cluster(cluster_name,
             agent_history_workers_info = None
         tls_sans = ' '.join(
             f'--tls-san={n}' for n in [head_node] + ha_server_nodes)
-        k3s_ha_exec = (f'INSTALL_K3S_EXEC=\'server --cluster-init {tls_sans}\'')
+        k3s_head_install_env = [
+            ('K3S_TOKEN', k3s_token),
+            ('K3S_NODE_NAME', head_node),
+            ('INSTALL_K3S_EXEC', f'server --cluster-init {tls_sans}'),
+        ]
         progress_message(
             f'HA mode enabled: 3 servers + {len(agent_worker_nodes)} agents')
     else:
@@ -502,7 +520,11 @@ def deploy_single_cluster(cluster_name,
         agent_worker_use_ssh_config = worker_use_ssh_config
         agent_history_workers_info = history_workers_info
         tls_sans = ''
-        k3s_ha_exec = ''
+        k3s_head_install_env = [
+            ('K3S_TOKEN', k3s_token),
+            ('K3S_NODE_NAME', head_node),
+        ]
+    k3s_head_install_cmd = _sudo_k3s_install_cmd(k3s_head_install_env)
 
     # Check if head node has a GPU
     install_gpu = False
@@ -510,7 +532,7 @@ def deploy_single_cluster(cluster_name,
         f'Deploying SkyPilot runtime on head node ({head_node}).')
     cmd = f"""
         {askpass_block}
-        curl -sfL https://get.k3s.io | K3S_TOKEN={k3s_token} K3S_NODE_NAME={head_node} {k3s_ha_exec} sudo -E -A sh - &&
+        curl -sfL https://get.k3s.io | {k3s_head_install_cmd} &&
         mkdir -p ~/.kube &&
         sudo -A cp /etc/rancher/k3s/k3s.yaml ~/.kube/config &&
         sudo -A chown $(id -u):$(id -g) ~/.kube/config &&
@@ -1205,12 +1227,16 @@ def start_server_node(node,
 
     Returns: (node, success, has_gpu) tuple."""
     logger.info(f'Joining HA server node ({node}).')
+    k3s_install_cmd = _sudo_k3s_install_cmd([
+        ('K3S_NODE_NAME', node),
+        ('INSTALL_K3S_EXEC',
+         f'server {tls_sans} --node-label skypilot-ip={node}'),
+        ('K3S_URL', f'https://{master_addr}:6443'),
+        ('K3S_TOKEN', k3s_token),
+    ])
     cmd = f"""
             {askpass_block}
-            curl -sfL https://get.k3s.io | K3S_NODE_NAME={node} \
-                INSTALL_K3S_EXEC='server {tls_sans} --node-label skypilot-ip={node}' \
-                K3S_URL=https://{master_addr}:6443 \
-                K3S_TOKEN={k3s_token} sudo -E -A sh -
+            curl -sfL https://get.k3s.io | {k3s_install_cmd}
         """
     result = deploy_utils.run_remote(node,
                                      cmd,
@@ -1243,10 +1269,15 @@ def start_agent_node(node,
     """Start a k3s agent node.
     Returns: if the start is successful, and whether the node has a GPU."""
     logger.info(f'Deploying worker node ({node}).')
+    k3s_install_cmd = _sudo_k3s_install_cmd([
+        ('K3S_NODE_NAME', node),
+        ('INSTALL_K3S_EXEC', f'agent --node-label skypilot-ip={node}'),
+        ('K3S_URL', f'https://{master_addr}:6443'),
+        ('K3S_TOKEN', k3s_token),
+    ])
     cmd = f"""
             {askpass_block}
-            curl -sfL https://get.k3s.io | K3S_NODE_NAME={node} INSTALL_K3S_EXEC='agent --node-label skypilot-ip={node}' \
-                K3S_URL=https://{master_addr}:6443 K3S_TOKEN={k3s_token} sudo -E -A sh -
+            curl -sfL https://get.k3s.io | {k3s_install_cmd}
         """
     result = deploy_utils.run_remote(node,
                                      cmd,

--- a/tests/unit_tests/test_ssh_node_pools_deploy.py
+++ b/tests/unit_tests/test_ssh_node_pools_deploy.py
@@ -2,6 +2,62 @@
 
 from sky.ssh_node_pools.deploy import deploy
 
+_AGENT_EXEC_ENV = (
+    'INSTALL_K3S_EXEC=\'agent --node-label skypilot-ip=worker-1\'')
+
+
+def test_sudo_k3s_install_cmd_passes_env_after_sudo():
+    """Regression: sudo-rs does not preserve k3s env with sudo -E."""
+    cmd = deploy._sudo_k3s_install_cmd([
+        ('K3S_NODE_NAME', 'worker-1'),
+        ('INSTALL_K3S_EXEC', 'agent --node-label skypilot-ip=worker-1'),
+        ('K3S_URL', 'https://10.0.0.1:6443'),
+        ('K3S_TOKEN', 'token'),
+    ])
+
+    assert cmd.startswith('sudo -A ')
+    assert cmd.endswith(' sh -')
+    assert 'sudo -E' not in cmd
+    assert cmd.index('sudo -A ') < cmd.index('K3S_NODE_NAME=worker-1')
+    assert _AGENT_EXEC_ENV in cmd
+    assert 'K3S_URL=https://10.0.0.1:6443' in cmd
+    assert 'K3S_TOKEN=token' in cmd
+
+
+def test_start_agent_node_installs_k3s_with_sudo_env(monkeypatch):
+    """Verify the worker join command does not rely on sudo env preservation."""
+    captured = {}
+
+    def fake_run_remote(node, cmd, user, ssh_key, use_ssh_config=False):
+        del user, ssh_key
+        captured['node'] = node
+        captured['cmd'] = cmd
+        captured['use_ssh_config'] = use_ssh_config
+        return 'ok'
+
+    monkeypatch.setattr(deploy.deploy_utils, 'run_remote', fake_run_remote)
+    monkeypatch.setattr(deploy.deploy_utils, 'check_gpu',
+                        lambda *args, **kwargs: False)
+
+    result = deploy.start_agent_node('worker-1',
+                                     master_addr='10.0.0.1',
+                                     k3s_token='token',
+                                     user='ubuntu',
+                                     ssh_key='~/.ssh/id_rsa',
+                                     askpass_block='export SUDO_ASKPASS=x',
+                                     use_ssh_config=True)
+
+    assert result == ('worker-1', True, False)
+    assert captured['node'] == 'worker-1'
+    assert captured['use_ssh_config'] is True
+    cmd = captured['cmd']
+    assert 'curl -sfL https://get.k3s.io | sudo -A ' in cmd
+    assert 'sudo -E' not in cmd
+    assert 'K3S_NODE_NAME=worker-1' in cmd
+    assert _AGENT_EXEC_ENV in cmd
+    assert 'K3S_URL=https://10.0.0.1:6443' in cmd
+    assert 'K3S_TOKEN=token' in cmd
+
 
 def test_prometheus_install_cmd_contains_required_fields():
     askpass_block = 'echo "askpass"'


### PR DESCRIPTION
## Summary

Fixes #9680.

This changes SSH node-pool k3s install commands to pass installer environment variables after `sudo -A` instead of relying on `sudo -E`.

That matters for sudo-rs / Ubuntu 26.04 behavior, where preserving the caller environment through sudo is no longer reliable for this path. The k3s installer now receives values such as `INSTALL_K3S_EXEC`, `K3S_NODE_NAME`, `K3S_URL`, and `K3S_TOKEN` directly in the privileged shell command.

## Testing

```bash
python -m py_compile sky/ssh_node_pools/deploy/deploy.py tests/unit_tests/test_ssh_node_pools_deploy.py
pytest -q -n 0 tests/unit_tests/test_ssh_node_pools_deploy.py
git diff --check
```

## Practical verification

Local environment used for the practical check:

- macOS 15.3, Darwin 24.3.0, arm64
- Python 3.12.2 at `/opt/anaconda3/bin/python`
- local sudo is sudo 1.9.13p2, not sudo-rs

I exercised the `start_agent_node()` path with `deploy_utils.run_remote` mocked and captured the generated k3s install command.

The generated worker install command now contains:

```text
sudo -A K3S_NODE_NAME=... INSTALL_K3S_EXEC=... K3S_URL=... K3S_TOKEN=... sh -
```

and does not contain:

```text
sudo -E
```

This verifies the SkyPilot command generation path locally. I did not claim an end-to-end Ubuntu 26.04 / sudo-rs VM run from this machine.
