### PR TITLE
[Serve] Fix consolidation-mode detection in wait_service_registration codegen subprocess

### DIFF
--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -157,7 +157,6 @@ def start_controller() -> None:
 
     This requires that the env file is already set up.
     """
-    os.environ[constants.OVERRIDE_CONSOLIDATION_MODE] = 'true'
     logs_dir = os.path.expanduser(
         managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
     os.makedirs(logs_dir, exist_ok=True)
@@ -168,7 +167,15 @@ def start_controller() -> None:
     run_controller_cmd = (f'{sys.executable} -u -m'
                           f'sky.jobs.controller {controller_uuid}')
 
-    run_cmd = (f'{activate_python_env_cmd}'
+    # Bake IS_SKYPILOT_JOB_CONTROLLER into the shell command rather than
+    # mutating os.environ. Setting os.environ here was harmless before
+    # PR #9731 (the daemon ran in a child process with its own isolated env),
+    # but after #9731 the daemon runs as a main-process thread — the mutation
+    # leaks permanently into the API server's os.environ and causes
+    # serve_utils.is_consolidation_mode() to return True for all serve
+    # requests, even when serve consolidation mode is not configured.
+    run_cmd = (f'export {constants.OVERRIDE_CONSOLIDATION_MODE}=true; '
+               f'{activate_python_env_cmd}'
                f'{run_controller_cmd}')
 
     logger.info(f'Running controller with command: {run_cmd}')

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -2159,9 +2159,8 @@ class ServeCodeGen:
         # 300-second CONTROLLER_SETUP_TIMEOUT. Bake OVERRIDE_CONSOLIDATION_MODE
         # into the shell command so the subprocess always sees the correct mode.
         if is_consolidation_mode(pool):
-            cmd = (
-                f'export {skylet_constants.OVERRIDE_CONSOLIDATION_MODE}=true; '
-                + cmd)
+            cmd = (f'export {skylet_constants.OVERRIDE_CONSOLIDATION_MODE}'
+                   f'=true; {cmd}')
         return cmd
 
     @classmethod

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -2150,7 +2150,19 @@ class ServeCodeGen:
             f'{service_name!r}, {job_id}, **kwargs)',
             'print(msg, end="", flush=True)'
         ]
-        return cls._build(code)
+        cmd = cls._build(code)
+        # When running in consolidation mode, the codegen subprocess inherits
+        # SKYPILOT_GLOBAL_CONFIG pointing to the client override config, which
+        # lacks serve.controller.consolidation_mode=true. The subprocess would
+        # then read the server config from the client override path and
+        # incorrectly conclude it is NOT in consolidation mode, causing a
+        # 300-second CONTROLLER_SETUP_TIMEOUT. Bake OVERRIDE_CONSOLIDATION_MODE
+        # into the shell command so the subprocess always sees the correct mode.
+        if is_consolidation_mode(pool):
+            cmd = (
+                f'export {skylet_constants.OVERRIDE_CONSOLIDATION_MODE}=true; '
+                + cmd)
+        return cmd
 
     @classmethod
     def stream_replica_logs(cls, service_name: str, replica_id: int,


### PR DESCRIPTION
## What broke and why

**Regression introduced by**: #9731 (merged 2026-06-23)

PR #9731 moved the `managed-job-status-refresh` daemon from the executor task queue (child process with isolated `os.environ`) into a **persistent main-process thread**. Inside that thread, `scheduler.start_controller()` called:

```python
os.environ[constants.OVERRIDE_CONSOLIDATION_MODE] = 'true'  # IS_SKYPILOT_JOB_CONTROLLER=true
```

Before #9731, the executor's finally block restored `os.environ` after every daemon request — so this mutation was always cleaned up. After #9731, the thread runs outside the executor with no cleanup, so **`IS_SKYPILOT_JOB_CONTROLLER=true` leaks permanently into the API server process's `os.environ`**.

`serve_utils.is_consolidation_mode(pool=False)` checks `IS_SKYPILOT_JOB_CONTROLLER` first and returns `True` if set. So any API server in jobs-consolidation mode (i.e. started with `--deploy`, the standard production deployment) **also** silently treats serve as running in consolidation mode — even though serve has its own independent flag.

## User impact

**Any user running `sky serve up` against a `--deploy` API server after #9731 gets a hard 300-second timeout failure.**

`--deploy` auto-enables jobs consolidation mode, which now also leaks into serve. The serve controller is spawned locally (consolidation path), but the `wait_service_registration` codegen subprocess miscounts as non-consolidation and waits 300 s for a `job_lib` job status that never comes. After 300 s:

```
RuntimeError: Failed to wait for service initialization. Please check the logs above for more details.
```

Controller-side log says:

```
Failed to start the controller process for the service '...' within 300 seconds.
```

## Two-part fix

### Fix 1 — root cause: stop `start_controller()` from polluting the parent's env (`sky/jobs/scheduler.py`)

Instead of `os.environ[OVERRIDE_CONSOLIDATION_MODE] = 'true'` (which mutates the shared process env), bake the export into the shell command so only the controller subprocess receives it:

```python
run_cmd = f'export {constants.OVERRIDE_CONSOLIDATION_MODE}=true; {activate_python_env_cmd}{run_controller_cmd}'
```

This restores the pre-#9731 isolation: the API server's `os.environ` is never touched, so `is_consolidation_mode()` for serve returns the correct config-driven value again.

### Fix 2 — defense in depth: codegen subprocess robustness (`sky/serve/serve_utils.py`)

Even with Fix 1, if serve *is* legitimately in consolidation mode, the `wait_service_registration` codegen subprocess can still get the wrong answer. It inherits `SKYPILOT_GLOBAL_CONFIG` from the worker's per-request context (a path to the client override file, e.g. `/tmp/tmpifw1oova.yaml`). When `reload_config()` runs in the subprocess, `_reload_config_as_server()` uses `SKYPILOT_GLOBAL_CONFIG` to locate the server config and reads the client override instead of `~/.sky/config.yaml`. That override has no `serve.controller.consolidation_mode=true`, so `is_consolidation_mode()` returns `False` in the subprocess even when the parent correctly sees `True`.

Fix: evaluate `is_consolidation_mode(pool)` in the API server context (correct), then bake `export IS_SKYPILOT_JOB_CONTROLLER=true` into the generated shell command when True. The subprocess always detects the same mode regardless of `SKYPILOT_GLOBAL_CONFIG`.

## Test plan

- [ ] Nightly `--remote-server --kubernetes` smoke tests: `test_skyserve_llm`, `test_skyserve_readiness_timeout_fail`, `test_skyserve_https` — all three failed in [build 11412](https://buildkite.com/skypilot-1/smoke-tests/builds/11412) starting from the build containing #9731

🤖 Generated with [Claude Code](https://claude.com/claude-code)