### PR TITLE
[Examples] Add two-cluster coding-agent RL rollout example on sandboxes

### DIFF
--- a/llm/coding-agent-rl-rollout/README.md
+++ b/llm/coding-agent-rl-rollout/README.md
@@ -1,0 +1,55 @@
+# Two-cluster coding-agent RL rollouts on SkyPilot sandboxes
+
+A minimal coding-agent RL inner loop split across two Kubernetes clusters:
+
+- a **model server** (any OpenAI-compatible endpoint — e.g. vLLM serving a coder
+  model) runs on a **GPU cluster**;
+- **rollout sandboxes** run on a (cheap, CPU) **sandbox cluster** and dial the
+  model server across the cluster boundary to fix a bug;
+- each diff is graded in a fresh **anti-cheat eval sandbox** that starts clean,
+  so only the model-produced diff affects the reward;
+- rollouts fan out concurrently, so raising `--num-sandboxes` also exercises
+  sandbox-cluster autoscaling.
+
+> Requires the SkyPilot **sandbox feature** (the `sky.sandbox` SDK) and a
+> SkyPilot API server the SDK can reach.
+
+## Files
+
+| File | Role |
+|------|------|
+| `run_split_cluster.py` | the driver: fan out rollouts on the sandbox cluster, grade, report rewards |
+| `skypilot_backend.py` | `SkyPilotSandbox` — implements the vime async `Sandbox` protocol over `sky.sandbox` |
+| `agent_openai.py` | the agent that runs *inside* each rollout sandbox (OpenAI client → model server) |
+| `gpu_model_server.yaml` | example vLLM serving job for the GPU cluster |
+| `expose_model_server.sh` | exposes the model server via a LoadBalancer; prints the `/v1` URL |
+
+## Run
+
+```bash
+# 1. Serve a model on the GPU cluster (detached). --ports creates the service.
+sky launch -c model-server -d --infra k8s/<gpu-context> \
+  llm/coding-agent-rl-rollout/gpu_model_server.yaml
+
+# 2. Expose it for the sandbox cluster to reach; capture the endpoint.
+eval "$(./llm/coding-agent-rl-rollout/expose_model_server.sh <gpu-context> | grep HEAD_URL)"
+#  -> HEAD_URL=http://<ip>:8000/v1
+
+# 3. Run rollouts on the sandbox cluster against the model server.
+cd llm/coding-agent-rl-rollout
+python run_split_cluster.py --head-url "$HEAD_URL" \
+  --sandbox-context <cpu-context> --num-sandboxes 1     # smoke test
+python run_split_cluster.py --head-url "$HEAD_URL" \
+  --sandbox-context <cpu-context> --num-sandboxes 32    # fan out / autoscale
+```
+
+The driver prints per-rollout rewards and a summary (`rollouts=N solved=M
+mean_reward=… wall=…s`). Rollout and eval sandboxes are given an auto-reap
+`timeout` so an abandoned run cleans itself up.
+
+## The task
+
+A buggy `add()` that subtracts instead of adds. The agent reads
+`PROBLEM_STATEMENT.md`, edits `calc.py`, and the diff is graded against an
+authoritative `test_calc.py` that is re-laid-down clean in the eval sandbox —
+so the agent can't win by editing the test.

--- a/llm/coding-agent-rl-rollout/agent_openai.py
+++ b/llm/coding-agent-rl-rollout/agent_openai.py
@@ -1,0 +1,107 @@
+"""In-sandbox coding agent that drives an OpenAI-compatible model endpoint.
+
+This runs *inside* a rollout sandbox and dials the model server over HTTP (the
+``--base-url`` points at the server's ``/v1`` endpoint). It reads the bug,
+asks the model for the corrected file, and writes it back. Kept dependency-light
+(``openai`` + stdlib) so it installs quickly in a fresh sandbox.
+
+Usage (inside the sandbox):
+    python agent_openai.py --base-url http://<model-server-ip>:8000/v1 \\
+        --model model --workdir /home/agent/repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+
+PROMPT_TEMPLATE = """You are fixing a bug in a small Python project.
+
+PROBLEM:
+{problem}
+
+Current contents of `calc.py`:
+```python
+{calc}
+```
+
+Return the COMPLETE corrected contents of `calc.py` and nothing else, in a
+single ```python code block. Only fix the bug described; do not change the
+public API or edit the tests.
+"""
+
+_CODE_BLOCK = re.compile(r"```(?:python)?\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_code(text: str) -> str | None:
+    blocks = _CODE_BLOCK.findall(text or "")
+    if not blocks:
+        return None
+    # The corrected file is the longest python block (avoids stray snippets).
+    return max(blocks, key=len).strip() + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url",
+                    required=True,
+                    help="OpenAI-compatible /v1 base URL")
+    ap.add_argument("--model", default="model")
+    ap.add_argument("--workdir", default="/home/agent/repo")
+    ap.add_argument("--api-key",
+                    default=os.environ.get("OPENAI_API_KEY", "vime"))
+    ap.add_argument("--timeout", type=float, default=120.0)
+    args = ap.parse_args()
+
+    # Imported here so a missing dep gives a clear message in the sandbox.
+    from openai import OpenAI
+
+    calc_path = os.path.join(args.workdir, "calc.py")
+    problem_path = os.path.join(args.workdir, "PROBLEM_STATEMENT.md")
+    with open(calc_path) as f:
+        calc = f.read()
+    problem = ""
+    if os.path.exists(problem_path):
+        with open(problem_path) as f:
+            problem = f.read()
+
+    client = OpenAI(base_url=args.base_url,
+                    api_key=args.api_key,
+                    timeout=args.timeout)
+    t0 = time.time()
+    print(f"[agent] calling {args.base_url} (model={args.model})...",
+          flush=True)
+    resp = client.chat.completions.create(
+        model=args.model,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a precise senior Python engineer."
+            },
+            {
+                "role": "user",
+                "content": PROMPT_TEMPLATE.format(problem=problem, calc=calc)
+            },
+        ],
+        temperature=0.0,
+        max_tokens=2048,
+    )
+    text = resp.choices[0].message.content or ""
+    print(f"[agent] model responded in {time.time() - t0:.1f}s", flush=True)
+
+    fixed = _extract_code(text)
+    if not fixed:
+        print("[agent] ERROR: no code block in model response:\n" + text[:500],
+              file=sys.stderr)
+        return 2
+    with open(calc_path, "w") as f:
+        f.write(fixed)
+    print(f"[agent] wrote {len(fixed)} bytes to calc.py", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llm/coding-agent-rl-rollout/expose_model_server.sh
+++ b/llm/coding-agent-rl-rollout/expose_model_server.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Expose the vLLM model-server pod (launched by gpu_model_server.yaml on the GPU
+# cluster) via a LoadBalancer Service, and print the reachable /v1 base URL to
+# pass to run_split_cluster.py --head-url.
+#
+# A public LoadBalancer (the default here) is the simplest way for a sandbox
+# cluster to reach a model server in a different cluster when the two can't
+# share a private network. Front it with auth if it must be internet-facing.
+#
+# Usage: ./expose_model_server.sh <gpu-context> [pod-name-substr] [port]
+set -euo pipefail
+CTX="${1:?usage: expose_model_server.sh <gpu-context> [pod-name-substr] [port]}"
+MATCH="${2:-vime-model-server}"
+PORT="${3:-8000}"
+NS=default
+SVC=vime-model-server-lb
+
+# Find the running model-server pod (SkyPilot names job/cluster pods after the
+# cluster).
+POD=$(kubectl --context "$CTX" -n "$NS" get pods --field-selector=status.phase=Running \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -i "$MATCH" | head -1)
+if [[ -z "$POD" ]]; then
+  echo "No running pod matching '$MATCH' in $CTX/$NS" >&2; exit 1
+fi
+echo "model-server pod: $POD"
+
+# Build a selector from a stable label SkyPilot sets on the pod.
+SELKEY=$(kubectl --context "$CTX" -n "$NS" get pod "$POD" -o json \
+  | python3 -c "import sys,json;l=json.load(sys.stdin)['metadata']['labels'];
+k=[x for x in ('skypilot-cluster','skypilot-cluster-name','run') if x in l];
+print(k[0] if k else '')")
+if [[ -z "$SELKEY" ]]; then
+  echo "Could not find a skypilot-cluster label on $POD; labels were:" >&2
+  kubectl --context "$CTX" -n "$NS" get pod "$POD" --show-labels >&2; exit 1
+fi
+SELVAL=$(kubectl --context "$CTX" -n "$NS" get pod "$POD" -o jsonpath="{.metadata.labels.$SELKEY}")
+echo "selector: $SELKEY=$SELVAL"
+
+cat <<EOF | kubectl --context "$CTX" apply -f - >/dev/null
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SVC
+  namespace: $NS
+spec:
+  type: LoadBalancer
+  selector:
+    $SELKEY: "$SELVAL"
+  ports:
+  - name: http
+    port: $PORT
+    targetPort: $PORT
+EOF
+
+echo -n "waiting for external IP"
+for _ in $(seq 1 60); do
+  IP=$(kubectl --context "$CTX" -n "$NS" get svc "$SVC" -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  [[ -n "$IP" ]] && break
+  echo -n "."; sleep 5
+done
+echo
+[[ -z "${IP:-}" ]] && { echo "LB IP not assigned yet" >&2; exit 1; }
+echo "HEAD_URL=http://${IP}:${PORT}/v1"

--- a/llm/coding-agent-rl-rollout/gpu_model_server.yaml
+++ b/llm/coding-agent-rl-rollout/gpu_model_server.yaml
@@ -1,0 +1,27 @@
+# Serve a coder model with vLLM (OpenAI-compatible API) on a GPU. The rollout
+# sandboxes in run_split_cluster.py dial this server to fix the bug.
+#
+# Launch on your GPU cluster/context, e.g.:
+#   sky launch -c model-server -d --infra k8s/<gpu-context> \
+#     llm/coding-agent-rl-rollout/gpu_model_server.yaml
+#
+# Then expose it for the sandbox cluster to reach (expose_model_server.sh) and
+# pass the resulting /v1 URL to the driver via --head-url.
+
+name: vime-model-server
+
+resources:
+  accelerators: A100:1
+  image_id: docker:vllm/vllm-openai:v0.6.6
+  ports: 8000
+
+envs:
+  MODEL: Qwen/Qwen2.5-Coder-7B-Instruct
+
+run: |
+  export HF_HUB_ENABLE_HF_TRANSFER=1
+  vllm serve "$MODEL" \
+    --served-model-name model \
+    --host 0.0.0.0 --port 8000 \
+    --max-model-len 16384 \
+    --gpu-memory-utilization 0.90

--- a/llm/coding-agent-rl-rollout/run_split_cluster.py
+++ b/llm/coding-agent-rl-rollout/run_split_cluster.py
@@ -1,0 +1,275 @@
+"""Two-cluster RL rollout driver: CPU sandboxes + a GPU model server.
+
+A minimal coding-agent RL inner loop split across two Kubernetes clusters:
+
+  - a model server (any OpenAI-compatible endpoint, e.g. vLLM serving a coder
+    model on GPUs) runs on a GPU cluster and is reached over HTTP at --head-url;
+  - rollout sandboxes run on a (cheap, CPU) sandbox cluster and dial the model
+    server to fix a bug; each diff is graded in a fresh "anti-cheat" eval
+    sandbox that starts clean, so only the model-produced diff affects reward;
+  - rollouts fan out concurrently, so this also exercises sandbox-cluster
+    autoscaling as --num-sandboxes grows.
+
+Files in this example:
+  - run_split_cluster.py  : this driver
+  - skypilot_backend.py   : SkyPilotSandbox (vime Sandbox protocol over sky.sandbox)
+  - agent_openai.py       : the agent that runs inside each rollout sandbox
+  - gpu_model_server.yaml : example vLLM serving job for the GPU cluster
+  - expose_model_server.sh: exposes the model server via a LoadBalancer
+
+Bring up the model server (see gpu_model_server.yaml + expose_model_server.sh)
+and pass its `/v1` URL:
+
+    python run_split_cluster.py \\
+        --head-url http://<model-server-ip>:8000/v1 \\
+        --model my-model \\
+        --sandbox-context <cpu-cluster-context> \\
+        --num-sandboxes 8
+
+Requires the SkyPilot sandbox feature (the ``sky.sandbox`` SDK) and a SkyPilot
+API server reachable by the SDK.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import concurrent.futures
+import os
+import secrets
+import textwrap
+import time
+from typing import Optional, Tuple
+
+try:
+    import sky.sandbox as sandbox  # public SDK: ``import sky; sky.sandbox...``
+except ImportError:
+    import sky_sandbox as sandbox
+
+from skypilot_backend import SkyPilotSandbox
+
+RID = secrets.token_hex(3)
+IMAGE = 'python:3.12'
+WORKDIR = '/home/agent/repo'
+AGENT = 'agent'
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+# --- the task ---------------------------------------------------------------
+# A buggy add(); the test expects real addition. The canonical test is
+# authoritative and is re-laid-down fresh in the eval sandbox, so the agent
+# cannot win by editing the test.
+BUGGY_CALC = textwrap.dedent('''\
+    def add(a, b):
+        # BUG: subtracts instead of adding.
+        return a - b
+
+
+    def mul(a, b):
+        return a * b
+    ''')
+
+CANONICAL_TEST = textwrap.dedent('''\
+    from calc import add, mul
+
+
+    def test_add():
+        assert add(2, 3) == 5
+        assert add(-1, 1) == 0
+        assert add(0, 0) == 0
+
+
+    def test_mul():
+        assert mul(2, 3) == 6
+    ''')
+
+PROBLEM_STATEMENT = textwrap.dedent('''\
+    The `add` function in `calc.py` returns the wrong result: it subtracts
+    instead of adding. Fix `calc.py` so that `add(a, b)` returns the sum of its
+    arguments and the test suite in `test_calc.py` passes. Only edit `calc.py`.
+    ''')
+
+
+def log(msg: str) -> None:
+    print(f'[{time.strftime("%H:%M:%S")}] {msg}', flush=True)
+
+
+# --- task helpers -----------------------------------------------------------
+
+
+async def ensure_agent_user(sb: SkyPilotSandbox, workdir: str) -> None:
+    await sb.exec(
+        f'id -u {AGENT} >/dev/null 2>&1 || '
+        f'useradd -m -d /home/{AGENT} -s /bin/bash {AGENT}; '
+        f'mkdir -p {workdir}; chown -R {AGENT}:{AGENT} /home/{AGENT} {workdir}',
+        user='root',
+        timeout=60,
+        check=True)
+
+
+async def setup_repo(sb: SkyPilotSandbox, workdir: str) -> None:
+    log(f'laying down buggy repo at {workdir}...')
+    await sb.write_file(f'{workdir}/calc.py', BUGGY_CALC, user=AGENT)
+    await sb.write_file(f'{workdir}/test_calc.py', CANONICAL_TEST, user=AGENT)
+    await sb.write_file(f'{workdir}/PROBLEM_STATEMENT.md',
+                        PROBLEM_STATEMENT,
+                        user=AGENT)
+    await sb.exec(
+        f'cd {workdir} && git init -q && git config user.email a@e.co && '
+        'git config user.name a && git add -A && git commit -q -m initial',
+        user=AGENT,
+        timeout=60,
+        check=True)
+
+
+async def bootstrap_agent_tools(sb: SkyPilotSandbox) -> None:
+    # git for diffing, openai for the agent loop. Public egress covers apt+pypi.
+    await sb.exec(
+        'export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && '
+        'apt-get install -y -qq git >/dev/null && pip install -q openai >/dev/null',
+        user='root',
+        timeout=300,
+        check=True)
+
+
+async def run_model_agent(sb: SkyPilotSandbox, *, head_url: str,
+                          model: str) -> int:
+    # Ship the in-sandbox agent into the pod and run it against the model server.
+    with open(os.path.join(_HERE, 'agent_openai.py')) as f:
+        agent_src = f.read()
+    await sb.write_file(f'/home/{AGENT}/agent_openai.py', agent_src, user=AGENT)
+    ec, out, err = await sb.exec(
+        f'cd {WORKDIR} && python /home/{AGENT}/agent_openai.py '
+        f'--base-url {head_url} --model {model} --workdir {WORKDIR} 2>&1',
+        user=AGENT,
+        timeout=300)
+    for line in (out or err).strip().splitlines()[-4:]:
+        print('      | ' + line, flush=True)
+    return ec
+
+
+async def git_diff(sb: SkyPilotSandbox, workdir: str) -> str:
+    # Only the proposed source fix; exclude the test so the agent can't cheat,
+    # and avoid byte-compiled files that break `git apply` downstream.
+    _, out, _ = await sb.exec(
+        f"cd {workdir} && git add -N . && "
+        "git diff -- '*.py' ':(exclude)test_calc.py'",
+        user=AGENT,
+        timeout=60)
+    return out
+
+
+async def evaluate(diff_text: str, *, image: str,
+                   context: Optional[str]) -> Tuple[float, bool, bool]:
+    """Grade the diff in a fresh sandbox. Returns (reward, solved, applied)."""
+    name = f'vime-eval-{RID}-{secrets.token_hex(2)}'
+    async with SkyPilotSandbox(image=image,
+                               name=name,
+                               context_name=context,
+                               timeout=1800) as ev:
+        await ensure_agent_user(ev, WORKDIR)
+        await ev.write_file(f'{WORKDIR}/calc.py', BUGGY_CALC, user=AGENT)
+        await ev.write_file(f'{WORKDIR}/test_calc.py',
+                            CANONICAL_TEST,
+                            user=AGENT)
+        await ev.exec(
+            f'cd {WORKDIR} && git init -q && git config user.email e@e.co && '
+            'git config user.name e && git add -A && git commit -q -m base',
+            user=AGENT,
+            timeout=60,
+            check=True)
+        if not diff_text.strip():
+            return 0.0, False, True
+        await ev.write_file(f'{WORKDIR}/model.patch', diff_text, user=AGENT)
+        ec, _, _ = await ev.exec(
+            f'cd {WORKDIR} && git apply --whitespace=nowarn model.patch',
+            user=AGENT,
+            timeout=60)
+        if ec != 0:
+            return 0.0, False, False
+        await ev.exec('pip install -q pytest >/dev/null 2>&1',
+                      user='root',
+                      timeout=300,
+                      check=True)
+        ec, _, _ = await ev.exec(f'cd {WORKDIR} && python -m pytest -q',
+                                 user=AGENT,
+                                 timeout=300)
+        return (1.0 if ec == 0 else 0.0), ec == 0, True
+
+
+async def one_rollout(idx: int, *, head_url: str, model: str,
+                      sandbox_context: Optional[str], image: str) -> dict:
+    name = f'vime-roll-{RID}-{idx:03d}'
+    t0 = time.time()
+    rec = {'name': name, 'reward': 0.0, 'solved': False, 'error': None}
+    try:
+        async with SkyPilotSandbox(image=image,
+                                   name=name,
+                                   context_name=sandbox_context,
+                                   timeout=1800) as sb:
+            await ensure_agent_user(sb, WORKDIR)
+            await setup_repo(sb, WORKDIR)
+            await bootstrap_agent_tools(sb)
+            await run_model_agent(sb, head_url=head_url, model=model)
+            diff = await git_diff(sb, WORKDIR)
+        reward, solved, _ = await evaluate(diff,
+                                           image=image,
+                                           context=sandbox_context)
+        rec.update(reward=reward,
+                   solved=solved,
+                   secs=round(time.time() - t0, 1))
+        log(f'{name}: REWARD={reward} solved={solved} ({rec["secs"]}s)')
+    except Exception as e:  # noqa: BLE001 - isolate per-rollout failures
+        rec['error'] = f'{type(e).__name__}: {e}'
+        log(f'{name}: FAILED {rec["error"]}')
+    return rec
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--head-url',
+                    required=True,
+                    help='OpenAI-compatible model server, e.g. '
+                    'http://<ip>:8000/v1')
+    ap.add_argument('--model', default='model')
+    ap.add_argument('--num-sandboxes', type=int, default=1)
+    ap.add_argument('--sandbox-context',
+                    default=None,
+                    help='Kubernetes context for the rollout sandboxes '
+                    '(default: current kubeconfig context)')
+    ap.add_argument('--image', default=IMAGE)
+    args = ap.parse_args()
+
+    # The SDK's async create/exec wrap a sync client via asyncio.to_thread,
+    # whose default executor is ~cpu+4 workers; widen it so the rollouts fan
+    # out at once rather than in small waves.
+    asyncio.get_running_loop().set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(64, args.num_sandboxes * 3)))
+
+    t0 = time.time()
+    log(f'launching {args.num_sandboxes} rollout(s) against {args.head_url} '
+        f'(sandbox context: {args.sandbox_context or "current"})')
+    try:
+        results = await asyncio.gather(
+            *(one_rollout(i,
+                          head_url=args.head_url,
+                          model=args.model,
+                          sandbox_context=args.sandbox_context,
+                          image=args.image) for i in range(args.num_sandboxes)))
+    finally:
+        await sandbox.aclose()
+
+    solved = sum(1 for r in results if r.get('solved'))
+    rewards = [r['reward'] for r in results]
+    errors = [r for r in results if r.get('error')]
+    log('=' * 60)
+    log(f'rollouts={len(results)}  solved={solved}  '
+        f'mean_reward={sum(rewards) / max(1, len(rewards)):.3f}  '
+        f'errors={len(errors)}  wall={time.time() - t0:.1f}s')
+    for r in errors:
+        log(f'  ERROR {r["name"]}: {r["error"]}')
+    log('=' * 60)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/llm/coding-agent-rl-rollout/skypilot_backend.py
+++ b/llm/coding-agent-rl-rollout/skypilot_backend.py
@@ -1,0 +1,222 @@
+"""A SkyPilot-sandbox backend for vime's ``Sandbox`` protocol.
+
+vime's coding-agent RL example is written against a tiny async ``Sandbox``
+protocol::
+
+    @runtime_checkable
+    class Sandbox(Protocol):
+        sandbox_id: str
+        async def __aenter__(self) -> "Sandbox": ...
+        async def __aexit__(self, exc_type, exc, tb) -> None: ...
+        async def exec(self, cmd, *, user="root", env=None,
+                       timeout=120, check=False) -> tuple[int, str, str]: ...
+        async def write_file(self, sandbox_path, content, *, user="root") -> None: ...
+        async def read_file(self, sandbox_path, *, user="root") -> str: ...
+
+Any backend that satisfies this protocol is a drop-in. ``SkyPilotSandbox`` below
+is such a backend, implemented on the public SkyPilot sandbox SDK
+(``sky.sandbox``).
+
+Four impedance mismatches between the two interfaces are handled here:
+
+1. vime ``exec`` takes a shell string; the SDK ``exec`` takes argv tokens and
+   runs them directly via the kubernetes exec stream (no shell). We wrap the
+   string in ``bash -lc``.
+2. vime ``exec`` has a ``user`` kwarg; the SDK has none. Non-root commands are
+   run via ``runuser -u <user>``.
+3. vime ``exec`` has a per-call ``env``; the SDK has none. We inline the env as
+   literal ``export K=V;`` statements ahead of the command (literal values, so
+   nothing gets clobbered when dropping to another user).
+4. vime ``write_file`` accepts a host ``Path``; we stream it via the SDK's
+   ``write_bytes`` and ``chown`` to the target user afterwards.
+
+Requires the SkyPilot sandbox feature (the ``sky.sandbox`` SDK) and a SkyPilot
+API server reachable by the SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import secrets as _secrets_mod
+import shlex
+from typing import Dict, List, Optional, Tuple, Union
+
+try:
+    import sky.sandbox as sandbox  # public SDK: ``import sky; sky.sandbox...``
+except ImportError:
+    # The Sandbox SDK also ships a top-level ``sky_sandbox`` shim.
+    import sky_sandbox as sandbox
+
+FileContent = Union[str, bytes, Path]
+ExecResult = Tuple[int, str, str]
+
+
+def _gen_name(prefix: str = 'vime') -> str:
+    return f'{prefix}-{_secrets_mod.token_hex(4)}'
+
+
+class SkyPilotSandbox:
+    """vime ``Sandbox`` protocol over a SkyPilot sandbox.
+
+    Args:
+        image: Ad-hoc container image (cold start, no warm pool). Mutually
+            exclusive with ``pool``. Defaults to ``python:3.12`` when neither is
+            given.
+        pool: Warm pool to launch into instead of an ad-hoc image.
+        name: Sandbox name. Auto-generated if omitted.
+        cpus / memory_gb: Resource shape for an ad-hoc (``image``) launch.
+        env: Plain env vars baked into the pod at create time.
+        context_name / namespace: Kubernetes target. ``None`` uses the current
+            kubeconfig context / its bound namespace.
+        timeout: Server-side auto-reap max lifetime (seconds). Recommended for
+            rollouts so an abandoned sandbox cleans itself up.
+        ready_timeout: How long ``__aenter__`` waits for the pod to become
+            exec-able before giving up.
+    """
+
+    def __init__(
+        self,
+        image: Optional[str] = None,
+        *,
+        pool: Optional[str] = None,
+        name: Optional[str] = None,
+        cpus: Optional[float] = None,
+        memory_gb: Optional[float] = None,
+        env: Optional[Dict[str, str]] = None,
+        context_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        timeout: Optional[float] = None,
+        ready_timeout: float = 300.0,
+    ) -> None:
+        if image and pool:
+            raise ValueError('Pass either image or pool, not both.')
+        if not image and not pool:
+            image = 'python:3.12'
+        self._image = image
+        self._pool = pool
+        self._name = name or _gen_name()
+        self._cpus = cpus
+        self._memory_gb = memory_gb
+        self._env = dict(env or {})
+        self._context_name = context_name
+        self._namespace = namespace
+        self._timeout = timeout
+        self._ready_timeout = ready_timeout
+        # vime protocol attribute; set for real after start().
+        self.sandbox_id: str = self._name
+        self._sb: Optional[sandbox.Sandbox] = None
+
+    # --- lifecycle --------------------------------------------------------
+
+    async def start(self) -> 'SkyPilotSandbox':
+        kwargs: Dict[str, object] = dict(
+            name=self._name,
+            env=self._env or None,
+            context_name=self._context_name,
+            namespace=self._namespace,
+            timeout=self._timeout,
+        )
+        if self._image:
+            kwargs.update(image=self._image,
+                          cpus=self._cpus,
+                          memory_gb=self._memory_gb)
+        else:
+            kwargs['pool'] = self._pool
+        self._sb = await sandbox.create.aio(**kwargs)
+        self.sandbox_id = self._sb.name
+        if self._sb.status == 'FAILED':
+            raise RuntimeError(f'Sandbox {self._sb.name} failed to create: '
+                               f'{self._sb.error_message}')
+        await self._wait_ready()
+        return self
+
+    async def _wait_ready(self) -> None:
+        """Poll a trivial exec until the pod accepts commands."""
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + self._ready_timeout
+        last_err: Optional[BaseException] = None
+        while loop.time() < deadline:
+            try:
+                res = await self._sb.exec.aio('true', timeout_seconds=15)
+                if int(res.get('exit_code', -1)) == 0:
+                    return
+            except Exception as e:  # noqa: BLE001 - pod not ready yet
+                last_err = e
+            await asyncio.sleep(3)
+        raise TimeoutError(
+            f'Sandbox {self.sandbox_id} not exec-able within '
+            f'{self._ready_timeout:.0f}s; last error: {last_err}')
+
+    async def __aenter__(self) -> 'SkyPilotSandbox':
+        return await self.start()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._sb is not None:
+            try:
+                await self._sb.terminate.aio(wait=False)
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+
+    # --- protocol ---------------------------------------------------------
+
+    async def exec(
+        self,
+        cmd: str,
+        *,
+        user: str = 'root',
+        env: Optional[Dict[str, str]] = None,
+        timeout: int = 120,
+        check: bool = False,
+    ) -> ExecResult:
+        exports = ''
+        if env:
+            exports = ''.join(
+                f'export {k}={shlex.quote(str(v))}; ' for k, v in env.items())
+        payload = exports + cmd
+        if user and user != 'root':
+            argv = ['runuser', '-u', user, '--', 'bash', '-lc', payload]
+        else:
+            argv = ['bash', '-lc', payload]
+        assert self._sb is not None, 'sandbox not started'
+        res = await self._sb.exec.aio(*argv, timeout_seconds=timeout)
+        ec = int(res.get('exit_code', -1))
+        out = res.get('stdout', '') or ''
+        err = res.get('stderr', '') or ''
+        if check and ec != 0:
+            raise RuntimeError(f'exec failed (exit {ec}) for command: {cmd}\n'
+                               f'--- stdout ---\n{out}\n--- stderr ---\n{err}')
+        return ec, out, err
+
+    async def write_file(
+        self,
+        sandbox_path: str,
+        content: FileContent,
+        *,
+        user: str = 'root',
+    ) -> None:
+        assert self._sb is not None, 'sandbox not started'
+        # Ensure the parent dir exists (write streams a single file).
+        parent = os.path.dirname(sandbox_path.rstrip('/'))
+        if parent:
+            await self.exec(f'mkdir -p {shlex.quote(parent)}', user='root')
+        if isinstance(content, Path):
+            await self._sb.write_bytes.aio(content.read_bytes(), sandbox_path)
+        elif isinstance(content, (bytes, bytearray)):
+            await self._sb.write_bytes.aio(bytes(content), sandbox_path)
+        else:
+            await self._sb.write_text.aio(str(content), sandbox_path)
+        if user and user != 'root':
+            await self.exec(
+                f'chown {shlex.quote(user)}:{shlex.quote(user)} '
+                f'{shlex.quote(sandbox_path)}',
+                user='root',
+            )
+
+    async def read_file(self, sandbox_path: str, *, user: str = 'root') -> str:
+        assert self._sb is not None, 'sandbox not started'
+        # The SDK reads server-side as root, so `user` does not change the read;
+        # it is part of the protocol signature.
+        del user
+        return await self._sb.read_text.aio(sandbox_path)


### PR DESCRIPTION
## Summary

Adds `llm/coding-agent-rl-rollout`, a minimal **coding-agent RL rollout** example that runs across **two Kubernetes clusters**:

- a **model server** (vLLM, OpenAI-compatible) on a **GPU cluster**, and
- **rollout sandboxes** on a cheap **CPU sandbox cluster** that dial the model over HTTP to fix a bug.

Each rollout's diff is graded in a fresh **anti-cheat eval sandbox** (clean repo + the authoritative test, only the model's diff applied), and rollouts fan out concurrently — so raising `--num-sandboxes` also exercises sandbox-cluster autoscaling. Reward is `1.0` if every test passes, else `0.0`.

It complements [`llm/rl-code-execution-sandbox`](../rl-code-execution-sandbox) (single cluster, sandboxes used for *reward* computation): here the coding **agent runs inside the sandbox**, and the topology is a **GPU/CPU split** — the cost-efficient shape for agentic RL (a few GPUs serving the policy + a large fleet of cheap CPU rollout sandboxes).

Uses the [SkyPilot Sandbox](https://docs.skypilot.co/en/latest/docs/sandboxes.html) SDK (`sky.sandbox.create.aio` / `sb.exec.aio`).

## Files

| File | Role |
|------|------|
| `run_split_cluster.py` | the fan-out driver: create rollout sandbox → agent fixes the bug → grade → reward |
| `skypilot_backend.py` | `SkyPilotSandbox` — a small async `Sandbox`-protocol backend over `sky.sandbox` (drop-in for rollout frameworks such as [vime](https://github.com/vllm-project/vime)) |
| `agent_openai.py` | the agent that runs *inside* each rollout sandbox (OpenAI client → model server) |
| `gpu_model_server.yaml` | example vLLM serving job for the GPU cluster |
| `expose_model_server.sh` | exposes the model server via a LoadBalancer; prints the `/v1` URL |

## Run

```bash
# 1. Serve a model on the GPU cluster (detached).
sky launch -c model-server -d --infra k8s/<gpu-context> \
  llm/coding-agent-rl-rollout/gpu_model_server.yaml
# 2. Expose it; capture the endpoint.
eval "$(./llm/coding-agent-rl-rollout/expose_model_server.sh <gpu-context> | grep HEAD_URL)"
# 3. Run rollouts on the sandbox cluster against the model.
cd llm/coding-agent-rl-rollout
python run_split_cluster.py --head-url "$HEAD_URL" \
  --sandbox-context <cpu-context> --num-sandboxes 8
```

Requires the SkyPilot sandbox feature (the `sky.sandbox` SDK).

## Test plan

- `yapf` + `isort` clean; the Python files compile.
- Validated end-to-end on two Kubernetes clusters (a GPU cluster serving Qwen2.5-Coder-7B + a CPU sandbox cluster): a single rollout and a 40-way fan-out both reached `REWARD=1.0` (40/40 solved), with the sandbox node pool autoscaling to absorb the burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
