### PR TITLE
[Core] Add provision.conda_auto_activate config option

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -65,6 +65,7 @@ Below is the configuration syntax and some example values. See detailed explanat
   :ref:`provision <config-yaml-provision>`:
     :ref:`ssh_timeout <config-yaml-provision-ssh-timeout>`: 10
     :ref:`install_conda <config-yaml-provision-install-conda>`: false
+    :ref:`conda_auto_activate <config-yaml-provision-conda-auto-activate>`: false
 
   :ref:`kubernetes <config-yaml-kubernetes>`:
     :ref:`ports <config-yaml-kubernetes-ports>`: loadbalancer
@@ -712,6 +713,32 @@ Example:
   Default SkyPilot images often come with conda preinstalled.
   To fully avoid installing conda, use a custom Docker image that does not have conda preinstalled
   along with ``install_conda: false``.
+
+.. _config-yaml-provision-conda-auto-activate:
+
+``provision.conda_auto_activate``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to auto-activate the conda ``base`` environment on the remote cluster (optional).
+
+By default, SkyPilot auto-activates the conda ``base`` environment on clusters that do not
+use a custom Docker image. This is convenient for conda-based workflows, but it also makes
+``base`` the implicit target of ``uv`` and ``pip`` commands run in setup/run scripts and
+interactive shells, which is undesirable for workflows that manage their own environments
+(e.g. ``uv``-first projects).
+
+When set to ``false``, conda is still installed (unless ``install_conda: false``), but the
+``base`` environment is not auto-activated, so tools like ``uv`` and ``pip`` no longer
+resolve to it implicitly.
+
+Default: ``true`` (``false`` when a custom Docker image is used).
+
+Example:
+
+.. code-block:: yaml
+
+  provision:
+    conda_auto_activate: false
 
 .. _config-yaml-aws:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -731,6 +731,12 @@ When set to ``false``, conda is still installed (unless ``install_conda: false``
 ``base`` environment is not auto-activated, so tools like ``uv`` and ``pip`` no longer
 resolve to it implicitly.
 
+.. note::
+
+  This option controls conda *auto-activation*. Images that bake ``CONDA_PREFIX``
+  into the container environment itself (rather than activating ``base`` via
+  ``conda init``) keep ``base`` as the implicit target regardless of this option.
+
 Default: ``true`` (``false`` when a custom Docker image is used).
 
 Example:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -984,8 +984,17 @@ def write_cluster_config(
 
     # We disable conda auto-activation if the user has specified a docker image
     # to use, which is likely to already have a conda environment activated.
-    conda_auto_activate = ('true' if to_provision.extract_docker_image() is None
-                           else 'false')
+    # Users can override this default via the `provision.conda_auto_activate`
+    # config, e.g. to keep conda installed but inactive so it does not become
+    # the implicit target of `uv`/`pip` in uv-first workflows.
+    conda_auto_activate_config = skypilot_config.get_nested(
+        ('provision', 'conda_auto_activate'), None)
+    if conda_auto_activate_config is not None:
+        conda_auto_activate = ('true'
+                               if conda_auto_activate_config else 'false')
+    else:
+        conda_auto_activate = (
+            'true' if to_provision.extract_docker_image() is None else 'false')
     is_custom_docker = ('true' if to_provision.extract_docker_image()
                         is not None else 'false')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -987,14 +987,11 @@ def write_cluster_config(
     # Users can override this default via the `provision.conda_auto_activate`
     # config, e.g. to keep conda installed but inactive so it does not become
     # the implicit target of `uv`/`pip` in uv-first workflows.
-    conda_auto_activate_config = skypilot_config.get_nested(
+    auto_activate = skypilot_config.get_nested(
         ('provision', 'conda_auto_activate'), None)
-    if conda_auto_activate_config is not None:
-        conda_auto_activate = ('true'
-                               if conda_auto_activate_config else 'false')
-    else:
-        conda_auto_activate = (
-            'true' if to_provision.extract_docker_image() is None else 'false')
+    if auto_activate is None:
+        auto_activate = to_provision.extract_docker_image() is None
+    conda_auto_activate = 'true' if auto_activate else 'false'
     is_custom_docker = ('true' if to_provision.extract_docker_image()
                         is not None else 'false')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -989,6 +989,12 @@ def write_cluster_config(
     # the implicit target of `uv`/`pip` in uv-first workflows.
     auto_activate = skypilot_config.get_nested(
         ('provision', 'conda_auto_activate'), None)
+    # Whether the user explicitly set the option. When they did, the preference
+    # is applied even on images that already ship conda on PATH (where the
+    # install block that normally sets it is skipped); see
+    # CONDA_INSTALLATION_COMMANDS.
+    conda_auto_activate_explicit = ('true'
+                                    if auto_activate is not None else 'false')
     if auto_activate is None:
         auto_activate = to_provision.extract_docker_image() is None
     conda_auto_activate = 'true' if auto_activate else 'false'
@@ -1191,7 +1197,9 @@ def write_cluster_config(
             'conda_installation_commands':
                 constants.CONDA_INSTALLATION_COMMANDS.replace(
                     '{conda_auto_activate}', conda_auto_activate).replace(
-                        '{is_custom_docker}', is_custom_docker)
+                        '{is_custom_docker}', is_custom_docker).replace(
+                            '{conda_auto_activate_explicit}',
+                            conda_auto_activate_explicit)
                 if install_conda else '',
             # UV setup
             'uv_installation_commands': constants.UV_INSTALLATION_COMMANDS,

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -285,6 +285,21 @@ CONDA_INSTALLATION_COMMANDS = (
     'if [ "{is_custom_docker}" = "false" ]; then '
     'grep "# >>> conda initialize >>>" ~/.bashrc || '
     '{ conda init && source ~/.bashrc; };'
+    'fi;'
+    # The block above only sets auto_activate_base when conda is freshly
+    # installed (the `which conda` short-circuit). On images that already ship
+    # conda on PATH (e.g. the AWS DLAMI), that block is skipped and the setting
+    # would never take effect. So apply the preference here too, but only when
+    # the user explicitly set `provision.conda_auto_activate`, to avoid
+    # overriding conda config baked into custom images. Deactivating here also
+    # keeps base out of this provisioning shell (and thus the Ray runtime).
+    # Caller should replace {conda_auto_activate_explicit} / {conda_auto_activate}.  # pylint: disable=line-too-long
+    'if [ "{conda_auto_activate_explicit}" = "true" ] && '
+    'command -v conda > /dev/null 2>&1; then '
+    'conda config --set auto_activate_base {conda_auto_activate}; '
+    'if [ "{conda_auto_activate}" = "false" ]; then '
+    'conda deactivate 2> /dev/null || true; '
+    'fi;'
     'fi;')
 
 UV_INSTALLATION_COMMANDS = (

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -266,10 +266,15 @@ CONDA_INSTALLATION_COMMANDS = (
     # Caller should replace {conda_auto_activate} with either true or false.
     'conda config --set auto_activate_base {conda_auto_activate} && '
     'conda activate base; }; '
-    # If conda was not installed and the image is a docker image,
-    # we deactivate any active conda environment we set.
-    # Caller should replace {is_custom_docker} with either true or false.
-    'if [ "{is_custom_docker}" = "true" ]; then '
+    # Deactivate the base env we just activated when either (a) the image is a
+    # custom docker image (it likely manages its own env), or (b) the user
+    # disabled conda auto-activation via `provision.conda_auto_activate: false`.
+    # Otherwise base stays active in this chained provisioning shell and leaks
+    # into the Ray runtime (and therefore into user setup/run jobs), where it
+    # becomes the implicit target of `uv`/`pip`.
+    # Caller should replace {is_custom_docker} / {conda_auto_activate}.
+    'if [ "{is_custom_docker}" = "true" ] || '
+    '[ "{conda_auto_activate}" = "false" ]; then '
     'conda deactivate;'
     'fi;'
     '}; '

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2586,6 +2586,9 @@ def get_config_schema():
             'install_conda': {
                 'type': 'boolean',
             },
+            'conda_auto_activate': {
+                'type': 'boolean',
+            },
         }
     }
 

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -525,6 +525,34 @@ def test_custom_default_conda_env(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+def test_conda_auto_activate_disabled(generic_cloud: str):
+    """`provision.conda_auto_activate: false` keeps conda base inactive.
+
+    On the default image SkyPilot otherwise auto-activates conda `base`, which
+    makes it the implicit target of `uv`/`pip`. With the option disabled, the
+    run/exec environment must not have `base` active (CONDA_PREFIX unset). The
+    task YAML self-asserts and exits non-zero if base is active.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    yaml_path = 'tests/test_yamls/test_conda_auto_activate_disabled.yaml'
+    test = smoke_tests_utils.Test(
+        'conda_auto_activate_disabled',
+        [
+            f'sky launch -c {name} -y {smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'--infra {generic_cloud} {yaml_path}',
+            f'sky logs {name} 1 --status',
+            f'sky exec {name} {yaml_path}',
+            f'sky logs {name} 2 --status',
+        ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud),
+        config_dict={'provision': {
+            'conda_auto_activate': False
+        }},
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.kubernetes
 def test_kubernetes_docker_image_and_ssh():
     """Test K8s docker image ID interchangeability with/without prefix."""

--- a/tests/test_yamls/test_conda_auto_activate_disabled.yaml
+++ b/tests/test_yamls/test_conda_auto_activate_disabled.yaml
@@ -1,0 +1,16 @@
+# Used by tests/smoke_tests/test_images.py::test_conda_auto_activate_disabled.
+# Launched with `provision.conda_auto_activate: false`. On the default image
+# SkyPilot otherwise auto-activates the conda `base` env, which makes it the
+# implicit target of `uv`/`pip`. The run asserts that `base` is not active
+# (CONDA_PREFIX unset) in the task environment.
+resources:
+  cpus: 2+
+
+run: |
+  echo "CONDA_PREFIX=[${CONDA_PREFIX}]"
+  echo "CONDA_DEFAULT_ENV=[${CONDA_DEFAULT_ENV}]"
+  if [ -n "${CONDA_PREFIX}" ]; then
+    echo "FAIL: conda base is auto-activated (CONDA_PREFIX=${CONDA_PREFIX})"
+    exit 1
+  fi
+  echo "PASS: conda base is not auto-activated"

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -659,10 +659,13 @@ def test_conda_installation_deactivates_base_when_auto_activate_disabled():
     runtime / user jobs (where `uv`/`pip` would resolve to it implicitly).
     """
 
-    def render(conda_auto_activate: str, is_custom_docker: str) -> str:
+    def render(conda_auto_activate: str,
+               is_custom_docker: str,
+               explicit: str = 'false') -> str:
         return constants.CONDA_INSTALLATION_COMMANDS.replace(
-            '{conda_auto_activate}',
-            conda_auto_activate).replace('{is_custom_docker}', is_custom_docker)
+            '{conda_auto_activate}', conda_auto_activate).replace(
+                '{is_custom_docker}', is_custom_docker).replace(
+                    '{conda_auto_activate_explicit}', explicit)
 
     # Disabled on a non-docker image: set auto_activate_base false AND
     # deactivate. The deactivate guard's conda_auto_activate clause (the only
@@ -682,3 +685,11 @@ def test_conda_installation_deactivates_base_when_auto_activate_disabled():
     # clause is tautological).
     custom_docker = render('true', 'true')
     assert 'if [ "true" = "true" ]' in custom_docker
+
+    # Explicitly set by the user: the preference is also applied outside the
+    # install block (guarded by `command -v conda`), so it takes effect on
+    # images that already ship conda on PATH, where the install block is
+    # skipped. When not explicitly set, that stanza never fires.
+    explicit_disabled = render('false', 'false', explicit='true')
+    assert 'if [ "true" = "true" ] && command -v conda' in explicit_disabled
+    assert 'if [ "false" = "true" ] && command -v conda' in enabled

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -12,6 +12,7 @@ from sky import skypilot_config
 from sky.backends import backend_utils
 from sky.exceptions import ClusterNotUpError
 from sky.resources import Resources
+from sky.skylet import constants
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import status_lib
@@ -647,3 +648,37 @@ def test_make_safe_symlink_command_leaves_target_unquoted():
         source='/etc/config', target='~/.sky/file_mounts/etc/config')
     assert 'ln -s ~/.sky/file_mounts/etc/config /etc/config' in cmd
     assert "'~/.sky/file_mounts/etc/config'" not in cmd
+
+
+def test_conda_installation_deactivates_base_when_auto_activate_disabled():
+    """Rendered conda commands deactivate base when auto-activate is disabled.
+
+    When `provision.conda_auto_activate` resolves to false, the base env must
+    be both set to not auto-activate and deactivated within the chained
+    provisioning shell, otherwise it stays active and leaks into the Ray
+    runtime / user jobs (where `uv`/`pip` would resolve to it implicitly).
+    """
+
+    def render(conda_auto_activate: str, is_custom_docker: str) -> str:
+        return constants.CONDA_INSTALLATION_COMMANDS.replace(
+            '{conda_auto_activate}',
+            conda_auto_activate).replace('{is_custom_docker}', is_custom_docker)
+
+    # Disabled on a non-docker image: set auto_activate_base false AND
+    # deactivate. The deactivate guard's conda_auto_activate clause (the only
+    # guard with a `||`) is tautological here, so the deactivate fires.
+    disabled = render('false', 'false')
+    assert 'conda config --set auto_activate_base false' in disabled
+    assert 'conda deactivate' in disabled
+    assert '|| [ "false" = "false" ]' in disabled
+
+    # Enabled on a non-docker image: base stays active. Neither deactivate
+    # guard clause is tautological, so the deactivate branch never fires.
+    enabled = render('true', 'false')
+    assert 'conda config --set auto_activate_base true' in enabled
+    assert '|| [ "false" = "false" ]' not in enabled
+
+    # Custom docker images keep deactivating base, as before (the first guard
+    # clause is tautological).
+    custom_docker = render('true', 'true')
+    assert 'if [ "true" = "true" ]' in custom_docker

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -664,8 +664,9 @@ def test_conda_installation_deactivates_base_when_auto_activate_disabled():
                explicit: str = 'false') -> str:
         return constants.CONDA_INSTALLATION_COMMANDS.replace(
             '{conda_auto_activate}', conda_auto_activate).replace(
-                '{is_custom_docker}', is_custom_docker).replace(
-                    '{conda_auto_activate_explicit}', explicit)
+                '{is_custom_docker}',
+                is_custom_docker).replace('{conda_auto_activate_explicit}',
+                                          explicit)
 
     # Disabled on a non-docker image: set auto_activate_base false AND
     # deactivate. The deactivate guard's conda_auto_activate clause (the only


### PR DESCRIPTION
## Summary

SkyPilot auto-activates the conda `base` environment on clusters that do not use a custom Docker image. This is convenient for conda-based workflows, but it makes `base` the implicit target of `uv`/`pip` commands run in `setup`/`run` scripts and interactive shells. For users who manage their own environments (e.g. uv-first projects), this is surprising: a `uv pip install` from a directory without a `.venv` silently installs into conda `base` instead of erroring or using the intended environment.

This PR adds a `provision.conda_auto_activate` config option so users can keep conda installed but not auto-activated.

- `sky/backends/backend_utils.py`: `conda_auto_activate` now honors `provision.conda_auto_activate` when set, falling back to the existing default (`true`, except `false` for custom Docker images).
- `sky/skylet/constants.py`: the post-install `conda deactivate` guard now also fires when `conda_auto_activate` is `false`. This is required because the install commands explicitly run `conda activate base`; without deactivating, `base` stays active in the chained provisioning shell and leaks into the Ray runtime (and therefore into user `setup`/`run` jobs), even though `auto_activate_base` is set to false for new shells.
- `sky/utils/schemas.py`: schema entry for the new option.
- Docs (`config.rst`) + a unit test.

Default behavior is unchanged.

## Test plan

- Added `tests/unit_tests/test_backend_utils.py::test_conda_installation_deactivates_base_when_auto_activate_disabled`: asserts the rendered conda commands set `auto_activate_base false` and deactivate `base` when the option is `false`, while preserving the existing custom-Docker deactivate behavior.
- Manual: launched a Kubernetes cluster with `provision.conda_auto_activate: false`. Verified `CONDA_PREFIX` is unset and `uv` resolves cleanly (no longer binds to conda `base`) in both `run` commands and interactive SSH, and that a user-created `.venv` is used correctly. Verified that with the option unset, behavior is unchanged (`base` still auto-activated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
