### PR TITLE
[Server] Fix sky.down breaking older clients via new entrypoint symbol

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -856,13 +856,6 @@ def _graceful_job_cancel(handle: backends.ResourceHandle,
         logger.debug(f'All MOUNT_CACHED uploads completed on {cluster_name!r}')
 
 
-def user_initiated_down(cluster_name: str,
-                        purge: bool = False,
-                        graceful: bool = False,
-                        graceful_timeout: Optional[int] = None) -> None:
-    down(cluster_name, purge, graceful, graceful_timeout, user_initiated=True)
-
-
 @usage_lib.entrypoint
 def down(cluster_name: str,
          purge: bool = False,

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -45,6 +45,21 @@ from sky.utils.db import db_utils
 
 logger = sky_logging.init_logger(__name__)
 
+
+def _entrypoint_name(entrypoint: Optional[Callable]) -> str:
+    """Get a human-readable name for a request entrypoint.
+
+    The entrypoint may be a ``functools.partial`` (e.g. the ``/down`` endpoint
+    uses ``functools.partial(core.down, ...)``), which has no ``__name__``;
+    fall back to the wrapped function's name in that case.
+    """
+    if entrypoint is None:
+        return ''
+    if isinstance(entrypoint, functools.partial):
+        entrypoint = entrypoint.func
+    return getattr(entrypoint, '__name__', '')
+
+
 # Tables in task.db.
 REQUEST_TABLE = 'requests'
 COL_CLUSTER_NAME = 'cluster_name'
@@ -275,7 +290,7 @@ class Request:
         return payloads.RequestPayload(
             request_id=self.request_id,
             name=self.name,
-            entrypoint=self.entrypoint.__name__,
+            entrypoint=_entrypoint_name(self.entrypoint),
             request_body=self.request_body.model_dump_json(),
             status=_status_value_for_client(self.status.value),
             return_value=orjson.dumps(None).decode('utf-8'),
@@ -396,8 +411,7 @@ def encode_requests(requests: List[Request]) -> List[payloads.RequestPayload]:
         payload = payloads.RequestPayload(
             request_id=request.request_id,
             name=request.name,
-            entrypoint=request.entrypoint.__name__
-            if request.entrypoint is not None else '',
+            entrypoint=_entrypoint_name(request.entrypoint),
             request_body=request.request_body.model_dump_json()
             if request.request_body is not None else
             orjson.dumps(None).decode('utf-8'),

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -6,6 +6,7 @@ import base64
 from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import datetime
+import functools
 import hashlib
 import html
 import json
@@ -1867,7 +1868,12 @@ async def down(request: fastapi.Request,
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_DOWN,
         request_body=down_body,
-        func=core.user_initiated_down,
+        # Use functools.partial(core.down, ...) rather than a dedicated
+        # core.user_initiated_down wrapper so the entrypoint pickled into the
+        # request record references core.down -- a symbol older clients have.
+        # A wrapper that only exists on newer servers fails to unpickle on
+        # older clients in Request.decode(). See #9916.
+        func=functools.partial(core.down, user_initiated=True),
         schedule_type=requests_lib.ScheduleType.SHORT,
         request_cluster_name=down_body.cluster_name,
         auth_user=request.state.auth_user,


### PR DESCRIPTION
## Problem

A user running `sky.down` against a newer API server (one that includes #9916) hit:

```
AttributeError: Can't get attribute 'user_initiated_down' on <module 'sky.core' from '.../site-packages/sky/core.py'>
```

### Root cause

#9916 routed the `/down` endpoint through a brand-new top-level function `core.user_initiated_down`. The request record's `entrypoint` is pickled **by reference** (module + qualname) in `Request.encode()` (`sky/server/requests/requests.py`), and the client **eagerly unpickles** it in `Request.decode()` on the `/api/get` path — even though the client never actually invokes the entrypoint.

An older client that predates #9916 has no `sky.core.user_initiated_down`, so the by-reference unpickle fails. Any newly-added top-level entrypoint symbol breaks older clients the same way.

## Fix

Use `functools.partial(core.down, user_initiated=True)` as the entrypoint instead of a dedicated wrapper. The pickled reference is now `core.down` — a symbol older clients already have — while server behavior is identical (the cluster-event emission lives inside `down()`, gated on `user_initiated`). The now-unused `user_initiated_down` wrapper is removed.

## Compatibility

- **Older clients** unpickle `functools.partial(core.down, ...)` fine (they have `core.down`) and never call it, so `sky.down` no longer breaks.
- **Server behavior** is unchanged: `core.down(user_initiated=True, **down_body)`.

A complementary client-side hardening (make `Request.decode` tolerant of an unresolvable, never-invoked entrypoint) is sent as a separate PR so future server-only entrypoint symbols can't reintroduce this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)