### PR TITLE
[Server] Tolerate unresolvable request entrypoint in Request.decode

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -45,6 +45,20 @@ from sky.utils.db import db_utils
 
 logger = sky_logging.init_logger(__name__)
 
+
+def _unresolved_entrypoint(*args, **kwargs):
+    """Placeholder for a request entrypoint that could not be unpickled.
+
+    Used by ``Request.decode`` when the encoded entrypoint references a symbol
+    this (older) client does not have. The entrypoint is never invoked on the
+    client; this only guards the unlikely case of someone calling it.
+    """
+    raise RuntimeError(
+        'This request entrypoint could not be resolved on the client, likely '
+        'due to a client/server version mismatch. Upgrade the SkyPilot client '
+        'to match the API server version.')
+
+
 # Tables in task.db.
 REQUEST_TABLE = 'requests'
 COL_CLUSTER_NAME = 'cluster_name'
@@ -330,6 +344,27 @@ class Request:
                 exc_info=e)
             raise
 
+    @staticmethod
+    def _decode_entrypoint(encoded_entrypoint: str) -> Callable:
+        """Unpickle the entrypoint, tolerating an unresolvable reference.
+
+        The entrypoint is a server-side callable that is pickled by reference
+        (module + qualname). The client deserializes it for bookkeeping but
+        never invokes it. When the client is older than the server, the server
+        may reference a symbol this client does not have (e.g. a newly-added
+        ``sky.core`` function), which makes unpickling raise ``AttributeError``
+        /``ImportError``. Since the value is never called on the client, fall
+        back to a placeholder instead of failing the whole request.
+        """
+        try:
+            return decoders.decode_and_unpickle(encoded_entrypoint)
+        except (AttributeError, ImportError) as e:
+            logger.debug(
+                'Could not resolve the request entrypoint while decoding '
+                f'(likely a client/server version skew): {e}. The entrypoint '
+                'is not used on the client, so falling back to a placeholder.')
+            return _unresolved_entrypoint
+
     @classmethod
     def decode(cls, payload: payloads.RequestPayload) -> 'Request':
         """Deserialize the SkyPilot API request."""
@@ -337,7 +372,7 @@ class Request:
             return cls(
                 request_id=payload.request_id,
                 name=payload.name,
-                entrypoint=decoders.decode_and_unpickle(payload.entrypoint),
+                entrypoint=cls._decode_entrypoint(payload.entrypoint),
                 request_body=decoders.decode_and_unpickle(payload.request_body),
                 status=RequestStatus(payload.status),
                 return_value=orjson.loads(payload.return_value),

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -13,8 +13,8 @@ import sqlite3
 import threading
 import time
 import traceback
-from typing import (Any, Callable, Dict, Generator, List, NamedTuple, Optional,
-                    Set, Tuple)
+from typing import (Any, Callable, Dict, Generator, List, NamedTuple, NoReturn,
+                    Optional, Set, Tuple)
 import uuid
 
 import anyio
@@ -46,7 +46,7 @@ from sky.utils.db import db_utils
 logger = sky_logging.init_logger(__name__)
 
 
-def _unresolved_entrypoint(*args, **kwargs):
+def _unresolved_entrypoint(*args: Any, **kwargs: Any) -> NoReturn:
     """Placeholder for a request entrypoint that could not be unpickled.
 
     Used by ``Request.decode`` when the encoded entrypoint references a symbol
@@ -345,7 +345,7 @@ class Request:
             raise
 
     @staticmethod
-    def _decode_entrypoint(encoded_entrypoint: str) -> Callable:
+    def _decode_entrypoint(encoded_entrypoint: str) -> Optional[Callable]:
         """Unpickle the entrypoint, tolerating an unresolvable reference.
 
         The entrypoint is a server-side callable that is pickled by reference

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -345,7 +345,7 @@ class Request:
             raise
 
     @staticmethod
-    def _decode_entrypoint(encoded_entrypoint: str) -> Optional[Callable]:
+    def _decode_entrypoint(encoded_entrypoint: str) -> Callable:
         """Unpickle the entrypoint, tolerating an unresolvable reference.
 
         The entrypoint is a server-side callable that is pickled by reference


### PR DESCRIPTION
## Problem

`Request.encode()` pickles the request `entrypoint` **by reference** (module + qualname), and the client unpickles it in `Request.decode()` on the `/api/get` path — but the client **never invokes** the entrypoint. When the client is older than the server, the server can reference a symbol the client lacks (e.g. a newly-added `sky.core` function), so the by-reference unpickle raises `AttributeError`/`ImportError` and fails the entire request.

This is the mechanism behind the `sky.down` crash after #9916:

```
AttributeError: Can't get attribute 'user_initiated_down' on <module 'sky.core'>
```

## Fix

Decode the entrypoint through a small helper that falls back to a placeholder callable when the reference can't be resolved. Since the entrypoint is never called on the client, degrading gracefully is correct, and it hardens against **any** future server-only entrypoint symbol reintroducing this class of version-skew breakage.

The placeholder raises a clear "upgrade your client" error only if it is ever (unexpectedly) invoked.

## Relationship to #9945

#9945 is the targeted fix for the specific `sky.down` regression (it makes the server emit an entrypoint reference older clients already have). This PR is defense-in-depth at the decode layer so the general pattern can't bite again. They are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)