### PR TITLE
[Test] Add --exclusive flag for serial server-mutating smoke tests

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -155,6 +155,12 @@ def _parse_args(args: Optional[str] = None):
     parser.add_argument('--submodule-base-branch')
     parser.add_argument('--dependency', nargs='?', const='', default='all')
     parser.add_argument('--concurrency', type=int)
+    # Select only tests marked `exclusive` and serialize them (one step at a
+    # time). Exclusive tests mutate shared server state, so they must not run
+    # concurrently with other tests or each other. Without this flag, exclusive
+    # tests are excluded from the (parallel) pipeline entirely. Generator-only
+    # flag: not forwarded to pytest.
+    parser.add_argument('--exclusive', action='store_true')
 
     # pytest_native: args the generate_pipeline parser does not recognise
     # (e.g. --no-resource-heavy).  They are conftest-registered pytest flags
@@ -227,13 +233,17 @@ def _parse_args(args: Optional[str] = None):
 
     return (default_clouds_to_run, parsed_args.k, extra_args,
             parsed_args.concurrency, parsed_args.env_file
-            is not None, pytest_native)
+            is not None, parsed_args.exclusive, pytest_native)
 
 
 def _extract_marked_tests(
-    file_path: str, args: str, default_clouds_to_run: List[str],
-    k_value: Optional[str], extra_args: List[str]
-) -> Dict[str, Tuple[List[str], List[str], List[Optional[str]], List[str],
+    file_path: str,
+    args: str,
+    default_clouds_to_run: List[str],
+    k_value: Optional[str],
+    extra_args: List[str],
+    exclusive_run: bool = False
+) -> Dict[str, Tuple[List[str], List[str], List[Optional[str]], List[List[str]],
                      List[bool]]]:
     """Extract test functions and filter clouds using pytest.mark
     from a Python test file.
@@ -306,6 +316,13 @@ def _extract_marked_tests(
 
     function_cloud_map = {}
     for function_name, marks in function_name_marks_map.items():
+        # Partition exclusive vs normal tests. Exclusive-marked tests run only
+        # in an --exclusive run (serialized) and are excluded from normal
+        # parallel runs; non-exclusive tests are excluded from --exclusive runs.
+        # The two never share a pipeline, so server-mutating tests never run
+        # alongside others.
+        if ('exclusive' in marks) != exclusive_run:
+            continue
         clouds_to_include = []
         run_on_cloud_kube_backend = ('resource_heavy' in marks and
                                      'kubernetes' in default_clouds_to_run)
@@ -364,7 +381,7 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     steps = []
     generated_steps_set = set()
     (default_clouds_to_run, k_value, extra_args, concurrency, has_env_file,
-     pytest_native) = _parse_args(args)
+     exclusive, pytest_native) = _parse_args(args)
     # Pass a clean arg string: extra_args (conftest-registered flags extracted
     # from the generate_pipeline parser) + pytest_native (conftest-registered
     # flags the generate_pipeline parser did not recognise).
@@ -375,13 +392,22 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     pytest_collect_args = shlex.join(extra_args + list(pytest_native))
     function_cloud_map = _extract_marked_tests(test_file, pytest_collect_args,
                                                default_clouds_to_run, k_value,
-                                               extra_args)
+                                               extra_args, exclusive)
     concurrency_limit = None
     build_id = None
-    if has_env_file:
+    concurrency_group = None
+    if exclusive:
+        # Exclusive tests mutate shared server state, so the whole
+        # exclusive-only run is serialized to one step at a time, regardless of
+        # --concurrency / --env-file.
+        concurrency_limit = 1
+        build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
+        concurrency_group = f'exclusive-smoke-test-{build_id}'
+    elif has_env_file:
         concurrency_limit = (concurrency if concurrency is not None else
                              DEFAULT_ENV_FILE_CONCURRENCY_LIMIT)
         build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
+        concurrency_group = f'env-file-smoke-test-{build_id}'
     for test_function, clouds_queues_param in function_cloud_map.items():
         for cloud, queue, param, extra_args, no_auto_retry in zip(
                 *clouds_queues_param):
@@ -410,7 +436,7 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
             }
             if concurrency_limit is not None:
                 step['concurrency'] = concurrency_limit
-                step['concurrency_group'] = f'env-file-smoke-test-{build_id}'
+                step['concurrency_group'] = concurrency_group
             if no_auto_retry:
                 # Disable automatic retries but allow manual retries.
                 step['retry'] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,10 @@ def pytest_configure(config):
         'markers', 'no_auto_retry: mark test to disable automatic retries '
         'in Buildkite CI (manual retries still allowed)')
     config.addinivalue_line('markers', 'batch: mark test as sky batch specific')
+    config.addinivalue_line(
+        'markers', 'exclusive: mark test that mutates shared server state and '
+        'must run serially; selected only by the pipeline generator\'s '
+        '--exclusive flag and excluded from normal parallel runs')
     for cloud in all_clouds_in_smoke_tests:
         cloud_keyword = cloud_to_pytest_keyword[cloud]
         config.addinivalue_line(

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -151,6 +151,7 @@ def test_cli_invalid_config_details(generic_cloud: str):
         timeout=smoke_tests_utils.get_timeout(generic_cloud))
     smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
+
 def test_cli_auto_retry(generic_cloud: str):
     """Test that cli auto retry works."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -151,7 +151,6 @@ def test_cli_invalid_config_details(generic_cloud: str):
         timeout=smoke_tests_utils.get_timeout(generic_cloud))
     smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
-@pytest.mark.exclusive
 def test_cli_auto_retry(generic_cloud: str):
     """Test that cli auto retry works."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -151,7 +151,7 @@ def test_cli_invalid_config_details(generic_cloud: str):
         timeout=smoke_tests_utils.get_timeout(generic_cloud))
     smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
-
+@pytest.mark.exclusive
 def test_cli_auto_retry(generic_cloud: str):
     """Test that cli auto retry works."""
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
## Summary

Smoke steps generated with `--env-file` run up to `DEFAULT_ENV_FILE_CONCURRENCY_LIMIT` (10) concurrently against the same shared API server. That is fine for independent tests, but some tests mutate the *whole* server (e.g. restart the deployment, kill replicas) and must not run alongside other tests — or each other — or they corrupt each other's runs.

This adds an `exclusive` pytest marker and a generator-only `--exclusive` flag to `generate_pipeline.py`:

- `--exclusive` generates a pipeline of **only** `exclusive`-marked tests and serializes them (`concurrency: 1`, group `exclusive-smoke-test-<build>`).
- A normal run (no `--exclusive`) **excludes** `exclusive`-marked tests.

The two sets never share a pipeline, so ordinary tests keep running in parallel (unchanged behavior) while exclusive tests get a clean, serial, one-at-a-time environment. `--exclusive` is a generator-only flag (not forwarded to pytest); the partition happens at pipeline-generation time, keyed on the `exclusive` mark already printed in the `Collected … with marks: […]` collection line. The marker is registered in `tests/conftest.py`.

No behavior change for any existing test or for runs without `--exclusive`.

## Usage

A test opts in by adding the `exclusive` marker — nothing else is required:

```python
import pytest

@pytest.mark.exclusive
def test_restarts_the_server(...):
    ...
```

Then:

- It runs **only** in an `--exclusive` pipeline (`pytest ... --exclusive` at generation time), serialized one step at a time.
- It is **excluded** from normal (parallel) pipelines.

So a marked test never runs concurrently with anything; an unmarked test behaves exactly as before.

## Test

- [x] Code formatting: `bash format.sh` (yapf, google style)
- [x] Generator logic verified locally: with a stubbed `conftest` + synthetic `pytest --collect-only` output, `_generate_pipeline` with `--exclusive` emits only the `exclusive`-marked test at `concurrency: 1` (group `exclusive-smoke-test-*`), and without it emits only the non-exclusive test at the default `--env-file` concurrency (group `env-file-smoke-test-*`). Confirmed `--exclusive` is not forwarded into the per-step `pytest` args.
- [ ] Smoke tests: N/A — this only changes pipeline generation, not test behavior.
