### PR TITLE
[Slurm] Mount storage at provision time so FUSE mounts survive proctrack/cgroup

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -47,6 +47,7 @@ from sky.clouds import kubernetes as k8s_cloud
 from sky.clouds.utils import gcp_utils
 from sky.dag import DEFAULT_EXECUTION
 from sky.data import data_utils
+from sky.data import mounting_utils
 from sky.data import storage as storage_lib
 from sky.provision import common as provision_common
 from sky.provision import constants as provision_constants
@@ -3901,7 +3902,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             controller_utils.replace_skypilot_config_path_in_file_mounts(
                 launched_resources.cloud, all_file_mounts)
             self._execute_file_mounts(handle, all_file_mounts)
-            self._execute_storage_mounts(handle, storage_mounts)
+            # Storage MOUNT may already have been done at provision time (e.g.
+            # Slurm mounts from the persistent batch job so the FUSE daemon
+            # survives proctrack/cgroup). Metadata is still recorded below --
+            # it is a local DB write that `sky start` relies on.
+            if handle.provision_runtime_metadata.storage_mounts_synced:
+                logger.info('Skipping storage mounts: provisioner reported '
+                            'they are already mounted.')
+            else:
+                self._execute_storage_mounts(handle, storage_mounts)
             self._set_storage_mounts_metadata(handle.cluster_name,
                                               storage_mounts)
 
@@ -6378,18 +6387,16 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         if storage_mounts is None:
             return
 
-        # Process only mount mode objects here. COPY mode objects have been
-        # converted to regular copy file mounts and thus have been handled
-        # in the '_execute_file_mounts' method.
-        storage_mounts = {
-            path: storage_mount
-            for path, storage_mount in storage_mounts.items()
-            if storage_mount.mode in storage_lib.MOUNTABLE_STORAGE_MODES
-        }
+        # Construct each mountable store and build its mount command (COPY-mode
+        # storages are skipped here -- they are handled as regular file mounts
+        # in '_execute_file_mounts'). Shared with the Slurm provision-time
+        # template_override so the two paths stay in sync.
+        mount_specs = mounting_utils.resolve_mount_commands(
+            storage_mounts, cluster_name=handle.cluster_name)
 
         # Handle cases when there aren't any Storages with either MOUNT or
         # MOUNT_CACHED mode.
-        if not storage_mounts:
+        if not mount_specs:
             return
         start = time.time()
         runners = handle.get_command_runners()
@@ -6397,41 +6404,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             str(handle.launched_resources.cloud))
         log_path = os.path.join(self.log_dir, 'storage_mounts.log')
 
-        plural = 's' if len(storage_mounts) > 1 else ''
+        plural = 's' if len(mount_specs) > 1 else ''
         rich_utils.force_update_status(
             ux_utils.spinner_message(
-                f'Mounting {len(storage_mounts)} storage{plural}', log_path))
+                f'Mounting {len(mount_specs)} storage{plural}', log_path))
 
-        for dst, storage_obj in storage_mounts.items():
-            storage_obj.construct()
-            if not os.path.isabs(dst) and not dst.startswith('~/'):
-                dst = f'{SKY_REMOTE_WORKDIR}/{dst}'
-            # Raised when the bucket is externall removed before re-mounting
-            # with sky start.
-            if not storage_obj.stores:
-                with ux_utils.print_exception_no_traceback():
-                    raise exceptions.StorageExternalDeletionError(
-                        f'The bucket, {storage_obj.name!r}, could not be '
-                        f'mounted on cluster {handle.cluster_name!r}. Please '
-                        'verify that the bucket exists. The cluster started '
-                        'successfully without mounting the bucket.')
-            # Get the first store and use it to mount
-            store = list(storage_obj.stores.values())[0]
-            assert store is not None, storage_obj
-            if storage_obj.mode == storage_lib.StorageMode.MOUNT:
-                read_only = bool(storage_obj.mount_config and
-                                 storage_obj.mount_config.read_only)
-                mount_cmd = store.mount_command(dst, read_only=read_only)
-                action_message = 'Mounting'
-            else:
-                assert storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED
-                mount_cmd = store.mount_cached_command(
-                    dst, config=storage_obj.resolve_mount_cached_config())
-                action_message = 'Mounting cached mode'
-            src_print = (storage_obj.source
-                         if storage_obj.source else storage_obj.name)
-            if isinstance(src_print, list):
-                src_print = ', '.join(src_print)
+        for dst, mount_cmd, action_message, src_print in mount_specs:
             try:
                 backend_utils.parallel_data_transfer_to_nodes(
                     runners,

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -1,7 +1,6 @@
 """Helper functions for object store mounting in Sky Storage"""
 import hashlib
 import os
-import random
 import shlex
 import textwrap
 import typing
@@ -957,6 +956,65 @@ def get_mounting_script(
     return script
 
 
+def resolve_mount_commands(
+    storage_mounts: Optional[typing.Dict[str, 'storage.Storage']],
+    cluster_name: Optional[str] = None,
+) -> typing.List[typing.Tuple[str, str, str, Optional[str]]]:
+    """Builds the mount command for each MOUNT / MOUNT_CACHED storage.
+
+    For each mountable storage, this constructs the store (which validates /
+    materializes the bucket) and generates its mount command, returning a list
+    of ``(dst, mount_cmd, action_message, src_print)`` tuples (COPY-mode
+    storages are skipped — they are handled as regular file mounts).
+
+    NOTE: ``storage_obj.construct()`` has cloud-side effects (bucket existence
+    checks / creation), so call this on the API server, never inside a remote
+    subprocess. Shared by the runtime path
+    (``CloudVmRayBackend._execute_storage_mounts``) and the Slurm
+    provision-time ``template_override``, so the two stay in sync.
+
+    Raises:
+        exceptions.StorageExternalDeletionError: if a bucket no longer exists.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.data import storage as storage_lib
+
+    specs: typing.List[typing.Tuple[str, str, str, Optional[str]]] = []
+    if not storage_mounts:
+        return specs
+    on_cluster = f' on cluster {cluster_name!r}' if cluster_name else ''
+    for dst, storage_obj in storage_mounts.items():
+        if storage_obj.mode not in storage_lib.MOUNTABLE_STORAGE_MODES:
+            continue
+        storage_obj.construct()
+        if not os.path.isabs(dst) and not dst.startswith('~/'):
+            dst = f'{constants.SKY_REMOTE_WORKDIR}/{dst}'
+        # Raised when the bucket is externally removed before (re-)mounting.
+        if not storage_obj.stores:
+            raise exceptions.StorageExternalDeletionError(
+                f'The bucket, {storage_obj.name!r}, could not be mounted'
+                f'{on_cluster}. Please verify that the bucket exists.')
+        # Get the first store and use it to mount.
+        store = list(storage_obj.stores.values())[0]
+        assert store is not None, storage_obj
+        if storage_obj.mode == storage_lib.StorageMode.MOUNT:
+            read_only = bool(storage_obj.mount_config and
+                             storage_obj.mount_config.read_only)
+            mount_cmd = store.mount_command(dst, read_only=read_only)
+            action_message = 'Mounting'
+        else:
+            assert storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED
+            mount_cmd = store.mount_cached_command(
+                dst, config=storage_obj.resolve_mount_cached_config())
+            action_message = 'Mounting cached mode'
+        src_print = (storage_obj.source
+                     if storage_obj.source else storage_obj.name)
+        if isinstance(src_print, list):
+            src_print = ', '.join(src_print)
+        specs.append((dst, mount_cmd, action_message, src_print))
+    return specs
+
+
 def get_mounting_command(
     mount_path: str,
     install_cmd: str,
@@ -983,11 +1041,19 @@ def get_mounting_command(
     script = get_mounting_script(mount_path, mount_cmd, install_cmd,
                                  version_check_cmd)
 
-    # While these commands are run sequentially for each storage object,
-    # we add random int to be on the safer side and avoid collisions.
-    script_path = f'~/.sky/mount_{random.randint(0, 1000000)}.sh'
-    command = (f'echo {shlex.quote(script)} > {script_path} && '
-               f'chmod +x {script_path} && '
-               f'bash {script_path} && '
-               f'rm {script_path}')
+    # Write the script to a unique temp file (via mktemp) and execute it.
+    # mktemp -- rather than a Python-baked random name -- keeps the path
+    # unique *per process*, which matters when the SAME generated command runs
+    # concurrently on multiple nodes that share a filesystem (e.g. Slurm
+    # provision-time mounting from one `srun --nodes=N` step, where ~ is the
+    # shared cluster home). A baked name collides across those nodes: they race
+    # on the same file and the trailing `rm` fails on all but one, which (under
+    # `set -e`) kills those tasks and their freshly-spawned FUSE daemons.
+    # Falls back to TMPDIR if ~/.sky is unavailable.
+    command = ('mount_script=$(mktemp ~/.sky/mount_XXXXXX.sh 2>/dev/null || '
+               'mktemp -t sky_mount_XXXXXX.sh) && '
+               f'echo {shlex.quote(script)} > "$mount_script" && '
+               'chmod +x "$mount_script" && '
+               'bash "$mount_script" && '
+               'rm "$mount_script"')
     return command

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -389,6 +389,16 @@ def cleanup_custom_multi_network(
     raise NotImplementedError
 
 
+# Register built-in provisioners that expose a template_override hook. Done
+# here (not in the submodule) because submodules are imported above before
+# register_provisioner is defined. Plugins register their own via install().
+register_provisioner(
+    'slurm',
+    module=slurm,
+    template_override=slurm.template_override,
+)
+
+
 @_route_to_cloud_impl
 def open_ports(
     provider_name: str,

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -114,6 +114,12 @@ class ProvisionRuntimeMetadata:
     # Whether the task's file_mounts have already been synced to the
     # cluster by the provisioner.
     file_mounts_synced: bool = False
+    # Whether the task's MOUNT-mode storages have already been mounted on the
+    # cluster by the provisioner. Used by Slurm, which mounts at provision time
+    # from the persistent batch job so the FUSE daemon survives proctrack/
+    # cgroup step teardown. Narrower than ``file_mounts_synced``: COPY-mode
+    # file_mounts still sync at runtime.
+    storage_mounts_synced: bool = False
     # Whether the user's ``setup`` commands have already been run on the
     # cluster by the provisioner.
     setup_done: bool = False

--- a/sky/provision/slurm/__init__.py
+++ b/sky/provision/slurm/__init__.py
@@ -8,5 +8,10 @@ from sky.provision.slurm.instance import open_ports
 from sky.provision.slurm.instance import query_instances
 from sky.provision.slurm.instance import run_instances
 from sky.provision.slurm.instance import stop_instances
+from sky.provision.slurm.instance import template_override
 from sky.provision.slurm.instance import terminate_instances
 from sky.provision.slurm.instance import wait_instances
+
+# Note: template_override is registered in sky/provision/__init__.py (after
+# register_provisioner is defined), since this module is imported there before
+# that definition exists.

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -5,6 +5,7 @@ import shlex
 import tempfile
 import threading
 import time
+import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import colorama
@@ -26,9 +27,18 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 
+if typing.TYPE_CHECKING:
+    from sky import provision as provision_lib
+    from sky import resources as resources_lib
+    from sky import task as task_lib
+
 logger = sky_logging.init_logger(__name__)
 
 PROVISION_SCRIPTS_DIRECTORY_NAME = '.sky_provision'
+
+# The cluster-config Jinja template Slurm uses (under sky/templates/). Kept in
+# sync with _get_cluster_config_template() in cloud_vm_ray_backend.
+_SLURM_CLUSTER_CONFIG_TEMPLATE = 'slurm-ray.yml.j2'
 
 
 def _sbatch_log_path(base_dir: str, job_id: str) -> str:
@@ -306,6 +316,118 @@ def _wait_for_job_ready(
 
 
 @timeline.event
+def _relay_storage_mount_creds(
+    login_node_runner: command_runner.SSHCommandRunner,
+    sky_cluster_home_dir: str,
+    storage_mount_creds: Dict[str, str],
+    creds_ready_signal: str,
+) -> None:
+    """Copies cloud-credential files onto the shared cluster home, then signals.
+
+    The sbatch storage-mount block resolves ``~`` to ``sky_cluster_home_dir``,
+    so a credential whose remote path is ``~/.aws/credentials`` is placed at
+    ``{sky_cluster_home_dir}/.aws/credentials``; the shared filesystem makes it
+    visible to every compute node. Finally touches ``creds_ready_signal`` to
+    release the waiting sbatch mount block -- always, even with no creds, so
+    env-auth mounts (which need no credential file) still proceed.
+    """
+    for remote_path, local_path in storage_mount_creds.items():
+        rel = (remote_path[2:]
+               if remote_path.startswith('~/') else remote_path.lstrip('/'))
+        dest = f'{sky_cluster_home_dir}/{rel}'
+        rc, stdout, stderr = login_node_runner.run(
+            f'mkdir -p {shlex.quote(os.path.dirname(dest))}',
+            require_outputs=True,
+            stream_logs=False)
+        subprocess_utils.handle_returncode(
+            rc,
+            'mkdir',
+            f'Failed to create credential dir for {dest} on the Slurm cluster.',
+            stderr=f'{stdout}\n{stderr}')
+        login_node_runner.rsync(local_path, dest, up=True, stream_logs=False)
+    rc, stdout, stderr = login_node_runner.run(
+        f'mkdir -p {shlex.quote(sky_cluster_home_dir)} && '
+        f'touch {shlex.quote(creds_ready_signal)}',
+        require_outputs=True,
+        stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        'touch',
+        'Failed to signal credential readiness on the Slurm cluster.',
+        stderr=f'{stdout}\n{stderr}')
+
+
+def template_override(
+    task: 'task_lib.Task',
+    to_provision: 'resources_lib.Resources',
+    *,
+    _extra_launch_context: Dict[str, Any],
+    _is_launched_by_jobs_controller: bool,
+) -> Optional['provision_lib.TemplateSpec']:
+    """Bakes storage MOUNT into provisioning for Slurm.
+
+    Slurm runs every ``runner.run()`` as an ephemeral ``srun`` step, and under
+    ``proctrack/cgroup`` the FUSE daemon a mount spawns is killed when that
+    step exits, leaving a stale mount. Mounting at provision time instead lets
+    the sbatch script launch the daemon inside the persistent batch job, where
+    it lives for the cluster's lifetime.
+
+    This hook injects the per-store mount commands and the cloud-credential
+    file list into the cluster YAML's ``provider`` block; ``run_instances``
+    relays the creds and runs the mounts from the batch job, then reports
+    ``storage_mounts_synced=True`` so the backend skips the runtime mount.
+
+    Returns ``None`` (use the default template unchanged) when the task has no
+    MOUNT / MOUNT_CACHED storage.
+    """
+    # Lazy imports: avoid import cycles and keep provision import light.
+    # pylint: disable=import-outside-toplevel
+    from sky import check as sky_check
+    from sky import clouds as sky_clouds
+    from sky import provision as provision_lib
+    from sky.data import mounting_utils
+
+    del _extra_launch_context, _is_launched_by_jobs_controller
+
+    # Container clusters mount inside the container (a separate execution
+    # context), which provision-time baking does not handle yet; only bake
+    # mounts for non-container clusters here.
+    if to_provision.extract_docker_image() is not None:
+        return None
+
+    # ``construct()`` (inside resolve_mount_commands) has cloud-side effects;
+    # it runs here on the API server, never in the provisioner subprocess.
+    mount_specs = mounting_utils.resolve_mount_commands(task.storage_mounts)
+    if not mount_specs:
+        # Nothing to mount -- fall back to the default template untouched.
+        return None
+
+    mount_blocks = []
+    for dst, mount_cmd, _action_message, src_print in mount_specs:
+        mount_blocks.append(f'# Mount {src_print} -> {dst}\n{mount_cmd}')
+    storage_mounts_setup = '\n'.join(mount_blocks)
+
+    # Cloud-credential files the mounts may need (e.g. R2/CoreWeave keys).
+    # Kubernetes/SSH only emit kubeconfig, which storage mounting never needs;
+    # Slurm itself has no credential file. ``run_instances`` relays these onto
+    # the compute nodes before mounting.
+    storage_mount_creds = sky_check.get_cloud_credential_file_mounts(
+        excluded_clouds=[
+            sky_clouds.Slurm(),
+            sky_clouds.Kubernetes(),
+            sky_clouds.SSH()
+        ])
+
+    return provision_lib.TemplateSpec(
+        template_path=_SLURM_CLUSTER_CONFIG_TEMPLATE,
+        variables={
+            'storage_mounts_setup': storage_mounts_setup,
+            'storage_mount_creds': storage_mount_creds,
+            'fuse_required': True,
+        },
+    )
+
+
 def _create_virtual_instance(
         region: str, cluster_name: str, cluster_name_on_cloud: str,
         config: common.ProvisionConfig) -> common.ProvisionRecord:
@@ -498,6 +620,51 @@ def _create_virtual_instance(
     slurm_marker_file = (
         f'{sky_cluster_home_dir}/{slurm_utils.SLURM_MARKER_FILE}')
 
+    # Storage MOUNT baked into provisioning (set by template_override; only for
+    # non-container clusters). When present, the sbatch script mounts the
+    # buckets from a persistent srun step (the FUSE daemon survives proctrack/
+    # cgroup), and we report storage_mounts_synced=True so the backend skips
+    # the runtime mount. Credentials are relayed to the shared cluster home
+    # below, before the sbatch mount block runs (gated on creds_ready_signal).
+    storage_mounts_setup = provider_config.get('storage_mounts_setup')
+    storage_mount_creds: Dict[str,
+                              str] = (provider_config.get('storage_mount_creds')
+                                      or {})
+    storage_baked = bool(storage_mounts_setup)
+    creds_ready_signal = f'{sky_cluster_home_dir}/.sky_creds_ready'
+    storage_mount_done_dir = f'{sky_cluster_home_dir}/.sky_storage_mount_done'
+    storage_mount_block = ''
+    if storage_baked:
+        # Runs on every node and stays alive (``exec sleep infinity``) so the
+        # daemons it spawns are children of this persistent step. HOME is set
+        # to the shared cluster home so ``~`` matches how runtime tasks (via
+        # SlurmCommandRunner) see it, and so relayed creds resolve.
+        mount_inner = (f'cd {sky_cluster_home_dir} && export HOME="$PWD"\n'
+                       f'set -e\n'
+                       f'{storage_mounts_setup}\n'
+                       f'touch {storage_mount_done_dir}/$SLURM_PROCID\n'
+                       f'exec sleep infinity')
+        label = '--label ' if num_nodes > 1 else ''
+        storage_mount_block = (
+            f'echo "[storage] waiting for credential relay..."\n'
+            f'while [ ! -f {creds_ready_signal} ]; do sleep 0.5; done\n'
+            f'rm -rf {storage_mount_done_dir} && mkdir -p '
+            f'{storage_mount_done_dir}\n'
+            f'echo "[storage] mounting on {num_nodes} node(s)..."\n'
+            f'srun --overlap {label}--unbuffered --nodes={num_nodes} '
+            f'--ntasks-per-node=1 bash -c {shlex.quote(mount_inner)} &\n'
+            f'STORAGE_MOUNT_PID=$!\n'
+            f'while true; do\n'
+            f'  ready=$(ls -1 {storage_mount_done_dir} 2>/dev/null | wc -l)\n'
+            f'  if [ "$ready" -ge "{num_nodes}" ]; then break; fi\n'
+            f'  if ! kill -0 $STORAGE_MOUNT_PID 2>/dev/null; then\n'
+            f'    echo "[storage] mount step exited before mounting"\n'
+            f'    wait $STORAGE_MOUNT_PID; exit 1\n'
+            f'  fi\n'
+            f'  sleep 1\n'
+            f'done\n'
+            f'echo "[storage] mounted on all nodes"')
+
     # For non-Docker Hub registries, pyxis/enroot requires '#' separator
     # between registry and path. See:
     # https://github.com/NVIDIA/pyxis/wiki/Usage#registry-syntax
@@ -681,6 +848,7 @@ echo '{proctrack_type or "unknown"}' > {sky_cluster_home_dir}/{skylet_constants.
 # Suppress login messages.
 touch {sky_cluster_home_dir}/.hushlogin
 {container_block}
+{storage_mount_block}
 {f'touch {ready_signal}' if container_image is None else ''}
 {'sleep infinity' if container_image is None else 'wait'}
 """
@@ -708,6 +876,15 @@ touch {sky_cluster_home_dir}/.hushlogin
     logger.debug(f'Successfully submitted Slurm job {job_id} to partition '
                  f'{partition} for cluster {cluster_name_on_cloud} '
                  f'with {num_nodes} nodes')
+
+    if storage_baked:
+        # Relay cloud-credential files onto the shared cluster home (visible to
+        # all compute nodes) so the sbatch mount block can use them, then
+        # release that block (it waits on creds_ready_signal). Writes go
+        # through the login node, which shares the filesystem with the compute
+        # nodes; no Slurm step needed.
+        _relay_storage_mount_creds(login_node_runner, sky_cluster_home_dir,
+                                   storage_mount_creds, creds_ready_signal)
 
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                         _on_pending)
@@ -759,13 +936,18 @@ touch {sky_cluster_home_dir}/.hushlogin
                          f'=== End of Slurm job logs ===')
         raise e
 
-    return common.ProvisionRecord(provider_name='slurm',
-                                  region=region,
-                                  zone=partition,
-                                  cluster_name=cluster_name_on_cloud,
-                                  head_instance_id=created_instance_ids[0],
-                                  resumed_instance_ids=[],
-                                  created_instance_ids=created_instance_ids)
+    return common.ProvisionRecord(
+        provider_name='slurm',
+        region=region,
+        zone=partition,
+        cluster_name=cluster_name_on_cloud,
+        head_instance_id=created_instance_ids[0],
+        resumed_instance_ids=[],
+        created_instance_ids=created_instance_ids,
+        # The sbatch script mounted the buckets from the persistent batch job,
+        # so the backend can skip the runtime storage-mount step.
+        runtime_metadata=common.ProvisionRuntimeMetadata(
+            storage_mounts_synced=storage_baked))
 
 
 @common_utils.retry

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -14,6 +14,14 @@ provider:
   cluster: "{{slurm_cluster}}"
   partition: "{{slurm_partition}}"
   provision_timeout: {{provision_timeout}}
+{% if storage_mounts_setup is defined and storage_mounts_setup %}
+  # Storage MOUNT baked into provisioning (Slurm template_override): the FUSE
+  # daemon is launched by the persistent batch job so it survives proctrack/
+  # cgroup step teardown. Consumed in sky/provision/slurm/instance.py.
+  storage_mounts_setup: {{storage_mounts_setup | tojson}}
+  storage_mount_creds: {{storage_mount_creds | tojson}}
+  fuse_required: {{fuse_required | tojson}}
+{% endif %}
 
   ssh:
     hostname: {{ssh_hostname}}

--- a/tests/unit_tests/slurm/test_provision_mount.py
+++ b/tests/unit_tests/slurm/test_provision_mount.py
@@ -1,0 +1,105 @@
+"""Tests for Slurm provision-time storage MOUNT baking.
+
+The Slurm provisioner mounts storage from the persistent batch job (so the
+FUSE daemon survives proctrack/cgroup) and reports storage_mounts_synced=True
+so the backend skips the runtime mount. These tests cover the template_override
+hook and the shared mount-command helper without a real cluster.
+"""
+from unittest import mock
+
+from sky.data import mounting_utils
+from sky.provision import common
+from sky.provision.slurm import instance as slurm_instance
+
+
+def _make_storage(mode, mount_cmd, *, name='bkt', source='s3://bkt',
+                  read_only=False):
+    """A minimal stand-in for a storage.Storage with one store."""
+    store = mock.MagicMock()
+    store.mount_command.return_value = mount_cmd
+    store.mount_cached_command.return_value = mount_cmd
+    storage_obj = mock.MagicMock()
+    storage_obj.mode = mode
+    storage_obj.stores = {'s3': store}
+    storage_obj.name = name
+    storage_obj.source = source
+    storage_obj.mount_config = mock.MagicMock(read_only=read_only)
+    storage_obj.construct = mock.MagicMock()
+    return storage_obj
+
+
+def test_resolve_mount_commands_mount_mode():
+    from sky.data import storage as storage_lib
+    storage_obj = _make_storage(storage_lib.StorageMode.MOUNT, 'GOOFYS_CMD')
+    specs = mounting_utils.resolve_mount_commands({'/mnt/data': storage_obj})
+    assert len(specs) == 1
+    dst, mount_cmd, action, src = specs[0]
+    assert dst == '/mnt/data'
+    assert mount_cmd == 'GOOFYS_CMD'
+    assert 'Mounting' in action
+    assert src == 's3://bkt'
+    storage_obj.construct.assert_called_once()
+
+
+def test_resolve_mount_commands_skips_copy_mode():
+    from sky.data import storage as storage_lib
+
+    # COPY mode is not in MOUNTABLE_STORAGE_MODES -> skipped.
+    storage_obj = _make_storage(storage_lib.StorageMode.COPY, 'X')
+    assert mounting_utils.resolve_mount_commands({'/mnt': storage_obj}) == []
+
+
+def test_template_override_no_storage_returns_none():
+    """No storage -> use the default template unchanged."""
+    task = mock.MagicMock()
+    task.storage_mounts = {}
+    to_provision = mock.MagicMock()
+    to_provision.extract_docker_image.return_value = None
+    assert slurm_instance.template_override(
+        task, to_provision, _extra_launch_context={},
+        _is_launched_by_jobs_controller=False) is None
+
+
+def test_template_override_container_returns_none():
+    """Container clusters mount inside the container -> runtime fallback."""
+    task = mock.MagicMock()
+    to_provision = mock.MagicMock()
+    to_provision.extract_docker_image.return_value = 'docker:ubuntu'
+    with mock.patch.object(mounting_utils, 'resolve_mount_commands') as m:
+        result = slurm_instance.template_override(
+            task, to_provision, _extra_launch_context={},
+            _is_launched_by_jobs_controller=False)
+    assert result is None
+    # Should short-circuit before generating mount commands.
+    m.assert_not_called()
+
+
+def test_template_override_bakes_mounts():
+    """With MOUNT storage: returns a TemplateSpec injecting the mount shell."""
+    task = mock.MagicMock()
+    to_provision = mock.MagicMock()
+    to_provision.extract_docker_image.return_value = None
+    specs = [('/mnt/data', 'GOOFYS_MOUNT_CMD', 'Mounting', 's3://bkt')]
+    with mock.patch.object(mounting_utils, 'resolve_mount_commands',
+                           return_value=specs), \
+         mock.patch('sky.check.get_cloud_credential_file_mounts',
+                    return_value={'~/.aws/credentials': '/local/creds'}):
+        spec = slurm_instance.template_override(
+            task, to_provision, _extra_launch_context={},
+            _is_launched_by_jobs_controller=False)
+    assert spec is not None
+    assert spec.template_path == slurm_instance._SLURM_CLUSTER_CONFIG_TEMPLATE
+    assert 'GOOFYS_MOUNT_CMD' in spec.variables['storage_mounts_setup']
+    assert '/mnt/data' in spec.variables['storage_mounts_setup']
+    assert spec.variables['fuse_required'] is True
+    assert spec.variables['storage_mount_creds'] == {
+        '~/.aws/credentials': '/local/creds'
+    }
+
+
+def test_runtime_metadata_has_storage_mounts_synced():
+    """The narrow flag exists and defaults False."""
+    md = common.ProvisionRuntimeMetadata()
+    assert md.storage_mounts_synced is False
+    assert common.ProvisionRuntimeMetadata(
+        storage_mounts_synced=True).storage_mounts_synced is True


### PR DESCRIPTION
## Summary

On Slurm clusters using `ProctrackType=proctrack/cgroup`, storage `MOUNT` (goofys/gcsfuse/rclone) was mounted from an ephemeral `srun` step and then silently died — cgroup tears down the step's process tree on exit, killing the FUSE daemon and leaving a stale `Transport endpoint is not connected` mount. (On `proctrack/linuxproc` it happened to survive.)

This mounts storage **at provision time, from the persistent batch job**, so the daemon lives for the cluster's lifetime:

- A Slurm `template_override` hook builds the per-store mount commands and gathers the cloud-credential files, passing them through the cluster config as extra vars (no template swap).
- `run_instances` relays the credentials onto the cluster and runs the mounts on all nodes from a persistent `srun` step inside the batch job.
- New `ProvisionRuntimeMetadata.storage_mounts_synced` lets the backend skip the runtime storage-mount step when the provisioner already mounted.
- The per-store mount-command generation is factored into a shared helper so the provision-time and runtime paths stay in sync.
- The mount scratch-script path now uses `mktemp` so concurrent multi-node mounts on a shared filesystem don't race on the same file.

Scope: non-container clusters; container clusters fall back to the existing runtime path (tracked separately).

## Test plan

- Unit tests for the mount-command helper and the `template_override` hook (mount/skip/container cases), plus the new metadata flag.
- Manual end-to-end on a `proctrack/cgroup` Slurm cluster: launched single-node and multi-node tasks with an S3 `MOUNT`, confirmed the run task reads bucket contents through the mount, the backend skips the runtime mount, and `sky down` tears the daemon down cleanly on every node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171VFjTPgydnyWw9NBj5Z6s