### PR TITLE
[Jobs] Wait after acquiring the consolidation lock before recovery

### DIFF
--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -23,6 +23,21 @@ logger = sky_logging.init_logger(__name__)
 _LOCK_PROBE_INTERVAL_SECONDS = 5
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 
+# How long to wait after acquiring the consolidation-mode lock before running
+# recovery. During a rolling update the new leader blocks on acquire() while
+# the old API server still holds the lock. The lock is released when the old
+# main process exits, but that pod's job controllers are detached subprocesses
+# (start_new_session=True), so they are not killed until the container itself
+# is torn down a moment later. If recovery ran in that residual window, it would
+# reset jobs that the still-alive (but about-to-die) old controllers can briefly
+# re-claim, stamping their soon-dead PIDs back onto the jobs;
+# update_managed_jobs_statuses would then mark those jobs FAILED_CONTROLLER (a
+# split brain across the upgrade overlap). Waiting here lets the old container
+# finish terminating before we reset and re-adopt its jobs. The recovery signal
+# file stays in place during the wait, so no controllers are started and no job
+# is marked FAILED_CONTROLLER in the meantime.
+_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS = 10
+
 
 class ManagedJobRefreshDaemonThread(threading.Thread):
     """Leader-elected thread that runs ha_recovery + ManagedJobEvent.
@@ -81,13 +96,36 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
-        try:
-            if not self._lock.is_locked():
-                logger.info(
-                    f'Acquiring the consolidation mode lock: {self._lock}')
-                self._lock.acquire()
-                logger.info('Consolidation mode lock acquired')
 
+        if not self._lock.is_locked():
+            logger.info(f'Acquiring the consolidation mode lock: {self._lock}')
+            self._lock.acquire()
+            logger.info('Consolidation mode lock acquired')
+
+        # Wait briefly before recovery so a prior leader (e.g. the old pod
+        # during a rolling update) is fully gone first; see the comment on
+        # _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS. The signal file touched above
+        # stays in place, gating controller starts and the FAILED_CONTROLLER
+        # sweep until recovery completes.
+        if _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS > 0:
+            logger.info(
+                f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after '
+                'acquiring the consolidation mode lock before running '
+                'recovery, to let any previous leader finish shutting down')
+            time.sleep(_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS)
+
+        # The wait above widens the window between acquiring the lock and
+        # running recovery, during which the lock's underlying session could go
+        # silently stale (PostgresLock only). Re-verify we still hold the lock
+        # before recovery; otherwise another replica may have taken it and
+        # could be recovering concurrently, so step down rather than run a
+        # second recovery loop. _suicide_on_lock_loss re-touches the signal
+        # file and SIGTERMs the process, so leave the file in place here.
+        if not self._lock_still_held():
+            self._suicide_on_lock_loss()
+            return
+
+        try:
             managed_job_utils.ha_recovery_for_consolidation_mode()
         finally:
             signal_file.unlink(missing_ok=True)

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -93,6 +93,14 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # its process and could mark the job FAILED_CONTROLLER. The signal
         # file makes update_managed_jobs_statuses and the scheduler's
         # controller-start path early-return until recovery completes.
+        # NOTE: the acquire is deliberately NOT inside the try/finally that
+        # wraps recovery below. The finally unlinks the signal file, but the
+        # lock-loss step-down path (_suicide_on_lock_loss) re-touches it to
+        # keep controllers gated through the shutdown drain — so that path must
+        # not be followed by an unlink. Scoping the finally to recovery only
+        # keeps those two concerns from fighting. It also means a raise from
+        # acquire() leaves the gate file in place while run() retries, which is
+        # what we want (controller starts stay gated until we hold the lock).
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
@@ -102,17 +110,16 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             self._lock.acquire()
             logger.info('Consolidation mode lock acquired')
 
-        # Wait briefly before recovery so a prior leader (e.g. the old pod
-        # during a rolling update) is fully gone first; see the comment on
+        # Wait before recovery so a prior leader (e.g. the old pod during a
+        # rolling update) is fully gone first; see the comment on
         # _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS. The signal file touched above
         # stays in place, gating controller starts and the FAILED_CONTROLLER
         # sweep until recovery completes.
-        if _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS > 0:
-            logger.info(
-                f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after '
-                'acquiring the consolidation mode lock before running '
-                'recovery, to let any previous leader finish shutting down')
-            time.sleep(_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS)
+        logger.info(
+            f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after acquiring '
+            'the consolidation mode lock before running recovery, to let any '
+            'previous leader finish shutting down')
+        time.sleep(_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS)
 
         # The wait above widens the window between acquiring the lock and
         # running recovery, during which the lock's underlying session could go

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -36,7 +36,7 @@ _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 # finish terminating before we reset and re-adopt its jobs. The recovery signal
 # file stays in place during the wait, so no controllers are started and no job
 # is marked FAILED_CONTROLLER in the meantime.
-_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS = 10
+_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS = 15
 
 
 class ManagedJobRefreshDaemonThread(threading.Thread):

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -266,7 +266,8 @@ class TestOuterLoopExceptionHandling:
 
 
 class TestBecomeLeaderOrdering:
-    """The recovery signal file must exist BEFORE the lock is acquired.
+    """The recovery signal file must exist BEFORE the lock is acquired, and
+    recovery must wait briefly after acquiring it.
 
     During a rolling update we block on acquire() while the old API server
     still holds the lock. If the gate file is missing in that window, a
@@ -274,6 +275,11 @@ class TestBecomeLeaderOrdering:
     server's update_managed_jobs_statuses, which could mark the job
     FAILED_CONTROLLER. The signal file gates controller starts, so it must
     be touched up-front, not after we win the lock.
+
+    After acquiring the lock we also wait briefly before recovery: the old
+    pod's detached controllers can outlive the lock release by a moment, and
+    recovery resetting jobs while they are still alive lets them re-claim and
+    re-stamp soon-dead PIDs (split brain across the upgrade overlap).
     """
 
     def test_signal_file_touched_before_lock_acquire(self, tmp_path,
@@ -288,6 +294,7 @@ class TestBecomeLeaderOrdering:
                                     instance=True,
                                     spec_set=True)
         lock.is_locked.return_value = False
+        lock.is_session_alive.return_value = True
         thread._lock = lock
 
         order = []
@@ -301,21 +308,96 @@ class TestBecomeLeaderOrdering:
 
         lock.acquire.side_effect = on_acquire
 
+        def on_sleep(*args, **kwargs):
+            order.append('sleep')
+
         def recovery_and_stop():
             order.append('recovery')
             # Raise to skip the infinite event loop that follows recovery.
             raise RuntimeError('stop before event loop')
 
-        with mock.patch.object(mjrt.managed_job_utils,
-                               'ha_recovery_for_consolidation_mode',
-                               side_effect=recovery_and_stop):
+        with mock.patch.object(mjrt.time, 'sleep', side_effect=on_sleep), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'ha_recovery_for_consolidation_mode',
+                                  side_effect=recovery_and_stop):
             with pytest.raises(RuntimeError, match='stop before event loop'):
                 thread._become_leader_and_run()
 
-        # Recovery runs only after the lock is acquired.
-        assert order == ['acquire', 'recovery']
+        # Recovery runs only after the lock is acquired AND after the wait.
+        assert order == ['acquire', 'sleep', 'recovery']
         # The finally block removes the gate file even when recovery fails.
         assert not signal_file.exists()
+
+    def test_waits_for_configured_duration_before_recovery(
+            self, tmp_path, monkeypatch):
+        """The wait must use _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS, and the
+        gate file must still be present while we wait (so controllers stay
+        gated and update_managed_jobs_statuses does not fire)."""
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+        monkeypatch.setattr(mjrt, '_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS', 7)
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        lock.is_locked.return_value = False
+        lock.is_session_alive.return_value = True
+        thread._lock = lock
+
+        slept = []
+
+        def on_sleep(seconds, *args, **kwargs):
+            # The gate file must still be in place during the wait.
+            assert signal_file.exists(), (
+                'signal file must persist through the post-acquire wait')
+            slept.append(seconds)
+
+        with mock.patch.object(mjrt.time, 'sleep', side_effect=on_sleep), \
+                mock.patch.object(
+                    mjrt.managed_job_utils,
+                    'ha_recovery_for_consolidation_mode',
+                    side_effect=RuntimeError('stop before event loop')):
+            with pytest.raises(RuntimeError, match='stop before event loop'):
+                thread._become_leader_and_run()
+
+        assert slept == [7]
+
+    def test_steps_down_if_lock_lost_during_wait(self, tmp_path, monkeypatch):
+        """If the lock session goes stale during the post-acquire wait, we
+        must NOT run recovery — another replica may now hold the lock. Step
+        down via _suicide_on_lock_loss and leave the gate file in place (the
+        suicide path re-touches it to keep controllers gated)."""
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        lock.is_locked.return_value = False
+        # Session is dead by the time we re-check after the wait.
+        lock.is_session_alive.return_value = False
+        thread._lock = lock
+
+        with mock.patch.object(mjrt.time, 'sleep'), \
+                mock.patch.object(
+                    mjrt.managed_job_utils,
+                    'ha_recovery_for_consolidation_mode') as recovery, \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_suicide_on_lock_loss') as suicide:
+            thread._become_leader_and_run()
+
+        suicide.assert_called_once()
+        recovery.assert_not_called()
+        # The gate file is NOT removed on the step-down path; the suicide
+        # routine owns re-touching it for the shutdown drain.
+        assert signal_file.exists()
 
 
 class TestStart:


### PR DESCRIPTION
## Summary

In consolidation mode the managed-job-status-refresh thread is leader-elected via the consolidation-mode lock: the leader runs `ha_recovery_for_consolidation_mode()` (resetting jobs whose controller process is no longer alive and re-adopting them) and the periodic status sweep. #9731 moved this loop into the API server's main process so the lock is held until that process exits, which re-couples lock release to container teardown.

A residual race remains across a rolling restart. The lock is released when the old API server's main process exits, but that pod's job controllers are launched **detached** (`start_new_session=True`), so they are not killed until the container itself is torn down a moment later. If the new leader acquires the lock and runs recovery inside that small window, it resets jobs that the still-alive (but about-to-die) old controllers can briefly re-claim — stamping their soon-dead PIDs back onto the jobs. The next `update_managed_jobs_statuses` sweep then sees those PIDs gone and marks the (otherwise healthy) jobs `FAILED_CONTROLLER` — a split brain across the upgrade overlap.

This PR makes the new leader **wait briefly after acquiring the consolidation lock before running recovery**, so the prior container — and its controllers — is fully gone first. The recovery signal file is already touched before `acquire()` and removed only after recovery, so during the wait no controllers are started and the `FAILED_CONTROLLER` sweep stays gated; in-flight controllers keep running untouched. The only effect is that recovery of genuinely-dead controllers is delayed by a few seconds on leader startup.

The wait also widens the gap between acquiring the lock and running recovery, during which the lock's underlying session could go silently stale (PostgresLock). So after the wait we re-verify we still hold the lock before recovering; if not, we step down (kill local controllers + SIGTERM) rather than run a second recovery loop concurrently with a new leader, reusing the existing lock-loss path.

## Changes

- `sky/jobs/managed_job_refresh_thread.py`: add `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS` (10s); in `_become_leader_and_run`, sleep after acquiring the lock and re-check `_lock_still_held()` before running recovery. Restructured so the recovery-path signal-file cleanup no longer clobbers the re-touch done by the step-down path.

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py` — 17 passed. New cases:
  - recovery runs only after both the lock acquire **and** the wait (`acquire → sleep → recovery`);
  - the wait uses `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS` and the signal gate file is present throughout the wait;
  - if the lock session goes stale during the wait, we step down via the lock-loss path, do **not** run recovery, and leave the gate file in place.
- `format.sh` clean on changed files (yapf/isort/pylint 10.00/10).
- Manual reasoning / end-to-end: the destructive interleaving is a rolling-restart timing race; exercising it requires holding in-flight managed jobs across an old→new API-server rollover with overlapping pods. Covered by the rolling-upgrade recovery test being productized separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
