### PR TITLE
[debug dump] collect managed-jobs controller submit-job logs

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1234,11 +1234,9 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
                 logger.warning('Skipping submit-job log with unrecognized '
                                f'name: {log_file.name}')
                 continue
-            # Interval membership, no range expansion. Both the per-file range
-            # count and len(requested) are tiny for a -j dump, and the directory
-            # scan dominates regardless -- so the simple nested check is fine.
-            # Sorting + bisecting requested would only pay off for a large
-            # requested set, which doesn't occur here.
+            # Test if any requested job id is in the submission ranges.
+            # Requests and submission ranges are likely small, no nested check is likely OK.
+            # TODO (ishankaul1) - Add a more efficient check if needed.
             if any(start <= req <= end
                    for start, end in submission_ranges
                    for req in requested):

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -978,6 +978,12 @@ def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
     _collect_controller_system_log_paths(file_paths, errors,
                                          seen_controller_uuids)
 
+    # Submission logs (submit-job-*.log): each records the "Started N
+    # controllers" count for one submission (the controller over-count
+    # signal), scoped to the requested jobs like the controller_system
+    # logs above.
+    _collect_controller_submit_log_paths(file_paths, errors, job_ids)
+
     return {
         'inline_data': inline_data,
         'file_paths': file_paths,
@@ -1152,6 +1158,77 @@ def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],
                 file_paths.append({
                     'remote_path': str(log_file),
                     'relative_path': f'managed_jobs/controller_system/'
+                                     f'{log_file.name}',
+                })
+
+
+def _parse_submit_log_job_ids(job_ids_str: str) -> Set[int]:
+    """Parse the id portion of a submit-job log filename into job ids.
+
+    Inverse of sky.jobs.server.core._job_ids_to_str: a comma-separated list
+    of single ids (``584``) or inclusive ranges (``580-588``). Raises
+    ValueError on an unrecognized shape so the caller can skip the file.
+    """
+    job_ids: Set[int] = set()
+    for token in job_ids_str.split(','):
+        token = token.strip()
+        if not token:
+            continue
+        if '-' in token:
+            start_str, _, end_str = token.partition('-')
+            job_ids.update(range(int(start_str), int(end_str) + 1))
+        else:
+            job_ids.add(int(token))
+    return job_ids
+
+
+def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
+                                         errors: List[Dict[str, str]],
+                                         job_ids: List[int]) -> None:
+    """Collect managed-job submission log file paths (submit-job-*.log).
+
+    Each submission writes ``~/sky_logs/managed_jobs/submit-job-<ids>.log``
+    (see sky.jobs.server.core), where ``<ids>`` is the submission's job-id set
+    formatted as comma-separated singletons/ranges. This per-submission log
+    records the "Started N controllers" count -- the over-count signal that
+    pins leaked controllers to a specific submission -- and is not
+    reconstructable from the per-job ``<jobid>.log`` or ``job_info``.
+
+    Scoped to ``job_ids``: we list ``submit-job-*.log`` but only collect
+    submissions whose id-set intersects the requested jobs. Unlike
+    _collect_controller_system_log_paths -- which builds exact
+    ``controller_<uuid>.log`` paths from the relevant UUID set and never lists
+    the directory -- a job id cannot be mapped back to its submission filename
+    without listing: the job may have been submitted in a multi-job batch whose
+    file is range-named (e.g. ``submit-job-580-588.log``). So the listing is
+    unavoidable; what stays bounded is the expensive part -- the set of files
+    rsynced -- not the directory scan.
+    """
+    requested = set(job_ids)
+    if not requested:
+        return
+    prefix, suffix = 'submit-job-', '.log'
+    with _catch_to_errors(errors, 'managed_jobs', 'controller_submit_logs'):
+        submit_logs_dir = (
+            pathlib.Path(constants.SKY_LOGS_DIRECTORY).expanduser() /
+            'managed_jobs')
+        if not submit_logs_dir.is_dir():
+            return
+        for log_file in submit_logs_dir.glob(f'{prefix}*{suffix}'):
+            ids_str = log_file.name[len(prefix):-len(suffix)]
+            try:
+                submission_ids = _parse_submit_log_job_ids(ids_str)
+            except ValueError:
+                # The only writer is sky.jobs.server.core with a fixed format,
+                # so an unparseable name is unexpected -- surface it rather than
+                # silently guess which jobs the submission covered.
+                logger.warning('Skipping submit-job log with unrecognized '
+                               f'name: {log_file.name}')
+                continue
+            if submission_ids & requested:
+                file_paths.append({
+                    'remote_path': str(log_file),
+                    'relative_path': f'managed_jobs/controller_submit_logs/'
                                      f'{log_file.name}',
                 })
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1235,7 +1235,7 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
                                f'name: {log_file.name}')
                 continue
             # Test if any requested job id is in the submission ranges.
-            # Requests and submission ranges are likely small, no nested check is likely OK.
+            # Requests and submission ranges are likely small, so nested check is likely OK.
             # TODO (ishankaul1) - Add a more efficient check if needed.
             if any(start <= req <= end
                    for start, end in submission_ranges

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1162,24 +1162,31 @@ def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],
                 })
 
 
-def _parse_submit_log_job_ids(job_ids_str: str) -> Set[int]:
-    """Parse the id portion of a submit-job log filename into job ids.
+def _parse_submit_log_job_ranges(job_ids_str: str) -> List[Tuple[int, int]]:
+    """Parse a submit-job log filename's id portion into inclusive ranges.
 
-    Inverse of sky.jobs.server.core._job_ids_to_str: a comma-separated list
-    of single ids (``584``) or inclusive ranges (``580-588``). Raises
-    ValueError on an unrecognized shape so the caller can skip the file.
+    Inverse of sky.jobs.server.core._job_ids_to_str: a comma-separated list of
+    single ids (``584``) or inclusive ranges (``580-588``), returned as
+    (start, end) tuples. Ranges are kept intact rather than expanded into a set
+    of ints -- a filename like ``submit-job-1-100000000.log`` would otherwise
+    blow up memory. Raises ValueError on an unrecognized or inverted range so
+    the caller can skip the file.
     """
-    job_ids: Set[int] = set()
+    ranges: List[Tuple[int, int]] = []
     for token in job_ids_str.split(','):
         token = token.strip()
         if not token:
             continue
         if '-' in token:
             start_str, _, end_str = token.partition('-')
-            job_ids.update(range(int(start_str), int(end_str) + 1))
+            start, end = int(start_str), int(end_str)
+            if start > end:
+                raise ValueError(f'Inverted range: {token!r}')
+            ranges.append((start, end))
         else:
-            job_ids.add(int(token))
-    return job_ids
+            val = int(token)
+            ranges.append((val, val))
+    return ranges
 
 
 def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
@@ -1215,9 +1222,11 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
         if not submit_logs_dir.is_dir():
             return
         for log_file in submit_logs_dir.glob(f'{prefix}*{suffix}'):
+            if not log_file.is_file():
+                continue
             ids_str = log_file.name[len(prefix):-len(suffix)]
             try:
-                submission_ids = _parse_submit_log_job_ids(ids_str)
+                submission_ranges = _parse_submit_log_job_ranges(ids_str)
             except ValueError:
                 # The only writer is sky.jobs.server.core with a fixed format,
                 # so an unparseable name is unexpected -- surface it rather than
@@ -1225,7 +1234,14 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
                 logger.warning('Skipping submit-job log with unrecognized '
                                f'name: {log_file.name}')
                 continue
-            if submission_ids & requested:
+            # Interval membership, no range expansion. Both the per-file range
+            # count and len(requested) are tiny for a -j dump, and the directory
+            # scan dominates regardless -- so the simple nested check is fine.
+            # Sorting + bisecting requested would only pay off for a large
+            # requested set, which doesn't occur here.
+            if any(start <= req <= end
+                   for start, end in submission_ranges
+                   for req in requested):
                 file_paths.append({
                     'remote_path': str(log_file),
                     'relative_path': f'managed_jobs/controller_submit_logs/'

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1201,6 +1201,17 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
     pins leaked controllers to a specific submission -- and is not
     reconstructable from the per-job ``<jobid>.log`` or ``job_info``.
 
+    Consolidation mode only: ``submit-job-*.log`` is written solely by
+    ``_consolidated_launch``. In non-consolidation mode the submission runs as a
+    Ray job on the controller cluster and its output goes to
+    ``~/sky_logs/managed_jobs/job-id-<N>/controller.log`` (what ``sky jobs logs
+    --controller`` downloads), which this path does not collect -- so the glob
+    below simply finds nothing. The over-count signal is not lost, though:
+    ``maybe_start_controllers`` also runs in the controller skylet's
+    reconciliation loop, logging "Started N controllers" to the controller
+    cluster's ``skylet.log``, which the dump already collects.
+    TODO(ishankaul1): also collect controller.log for non-consolidation mode.
+
     Scoped to ``job_ids``: we list ``submit-job-*.log`` but only collect
     submissions whose id-set intersects the requested jobs. Unlike
     _collect_controller_system_log_paths -- which builds exact

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1235,7 +1235,8 @@ def _collect_controller_submit_log_paths(file_paths: List[Dict[str, str]],
                                f'name: {log_file.name}')
                 continue
             # Test if any requested job id is in the submission ranges.
-            # Requests and submission ranges are likely small, so nested check is likely OK.
+            # Requests and submission ranges are likely small,
+            # so nested check is likely OK.
             # TODO (ishankaul1) - Add a more efficient check if needed.
             if any(start <= req <= end
                    for start, end in submission_ranges

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -1104,6 +1104,98 @@ class TestControllerSystemLogScoping:
         assert errors == []
 
 
+class TestParseSubmitLogJobIds:
+    """Inverse of sky.jobs.server.core._job_ids_to_str."""
+
+    def test_single_id(self):
+        assert utils._parse_submit_log_job_ids('584') == {584}
+
+    def test_inclusive_range(self):
+        assert utils._parse_submit_log_job_ids('580-583') == {
+            580, 581, 582, 583
+        }
+
+    def test_mixed_singletons_and_ranges(self):
+        assert utils._parse_submit_log_job_ids('1,5-7,10') == {1, 5, 6, 7, 10}
+
+    def test_malformed_raises(self):
+        with pytest.raises(ValueError):
+            utils._parse_submit_log_job_ids('not-an-int')
+
+
+class TestControllerSubmitLogScoping:
+    """Scope managed_jobs/controller_submit_logs/submit-job-*.log to the
+    submissions whose job-id set includes a requested job (mirrors the
+    controller_system scoping; avoids dragging a long-lived controller's
+    entire submission history into every dump).
+    """
+
+    def _setup(self, tmpdir, filenames):
+        """Create ``<tmpdir>/managed_jobs/<filename>`` for each filename."""
+        mj_dir = pathlib.Path(tmpdir) / 'managed_jobs'
+        mj_dir.mkdir()
+        for name in filenames:
+            (mj_dir / name).write_text('Started 9 controllers\n')
+
+    def _run(self, tmpdir, job_ids):
+        file_paths: list = []
+        errors: list = []
+        with mock.patch('sky.jobs.utils.constants.SKY_LOGS_DIRECTORY', tmpdir):
+            utils._collect_controller_submit_log_paths(file_paths, errors,
+                                                       job_ids)
+        return file_paths, errors
+
+    def test_includes_only_submissions_with_a_requested_job(self):
+        """A singleton match and a range that *contains* the job both count;
+        an unrelated submission is excluded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup(
+                tmpdir,
+                [
+                    'submit-job-584.log',
+                    'submit-job-580-588.log',  # range contains 584
+                    'submit-job-999.log',  # unrelated
+                ])
+            file_paths, errors = self._run(tmpdir, [584])
+        rel = sorted(p['relative_path'] for p in file_paths)
+        assert rel == [
+            'managed_jobs/controller_submit_logs/submit-job-580-588.log',
+            'managed_jobs/controller_submit_logs/submit-job-584.log',
+        ]
+        assert errors == []
+
+    def test_empty_job_ids_collects_nothing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup(tmpdir, ['submit-job-1.log'])
+            file_paths, errors = self._run(tmpdir, [])
+        assert file_paths == []
+        assert errors == []
+
+    def test_missing_dir_is_noop(self):
+        """No managed_jobs dir (controller never submitted) is benign."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_paths, errors = self._run(tmpdir, [1])
+        assert file_paths == []
+        assert errors == []
+
+    def test_unparseable_filename_skipped_with_warning(self):
+        """A filename that doesn't parse is skipped with a warning, not an
+        errors-list entry (it's not a collection failure)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup(tmpdir, [
+                'submit-job-weird.log',
+                'submit-job-7.log',
+            ])
+            with mock.patch('sky.jobs.utils.logger') as mock_logger:
+                file_paths, errors = self._run(tmpdir, [7])
+        rel = [p['relative_path'] for p in file_paths]
+        assert rel == ['managed_jobs/controller_submit_logs/submit-job-7.log']
+        assert errors == []
+        # The unparseable name is surfaced, not silently dropped.
+        assert mock_logger.warning.call_count == 1
+        assert 'submit-job-weird.log' in mock_logger.warning.call_args[0][0]
+
+
 class TestCleanupExpiredApiAccessTokens:
     """Unit tests for the expired managed-job token sweep."""
 

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -1104,23 +1104,34 @@ class TestControllerSystemLogScoping:
         assert errors == []
 
 
-class TestParseSubmitLogJobIds:
-    """Inverse of sky.jobs.server.core._job_ids_to_str."""
+class TestParseSubmitLogJobRanges:
+    """Inverse of sky.jobs.server.core._job_ids_to_str (kept as intervals)."""
 
     def test_single_id(self):
-        assert utils._parse_submit_log_job_ids('584') == {584}
+        assert utils._parse_submit_log_job_ranges('584') == [(584, 584)]
 
     def test_inclusive_range(self):
-        assert utils._parse_submit_log_job_ids('580-583') == {
-            580, 581, 582, 583
-        }
+        assert utils._parse_submit_log_job_ranges('580-583') == [(580, 583)]
 
     def test_mixed_singletons_and_ranges(self):
-        assert utils._parse_submit_log_job_ids('1,5-7,10') == {1, 5, 6, 7, 10}
+        assert utils._parse_submit_log_job_ranges('1,5-7,10') == [(1, 1),
+                                                                  (5, 7),
+                                                                  (10, 10)]
+
+    def test_large_range_is_not_expanded(self):
+        # A huge range must stay a single interval, never expand to a set of
+        # ints (that would risk OOM on a malicious/fat-fingered filename).
+        assert utils._parse_submit_log_job_ranges('1-100000000') == [
+            (1, 100000000)
+        ]
 
     def test_malformed_raises(self):
         with pytest.raises(ValueError):
-            utils._parse_submit_log_job_ids('not-an-int')
+            utils._parse_submit_log_job_ranges('not-an-int')
+
+    def test_inverted_range_raises(self):
+        with pytest.raises(ValueError):
+            utils._parse_submit_log_job_ranges('588-580')
 
 
 class TestControllerSubmitLogScoping:


### PR DESCRIPTION
## Summary
Adds the managed-jobs controller's per-submission `submit-job-*.log` files to the
debug dump. These logs record the "Started N controllers" count for each
submission — the signal for diagnosing a controller over-count, which is not
reconstructable from the per-job `<jobid>.log` or `job_info` already collected.

## Implementation
- Collected via the existing controller debug-dump manifest: the on-controller
  CodeGen (`collect_debug_dump_manifest`) globs
  `~/sky_logs/managed_jobs/submit-job-*.log` and adds matches to `file_paths`, so
  they ride the manifest's existing parallel rsync — no separate enumeration
  round-trip and no changes to `debug_utils.py`.
- Scoped to the requested jobs: filenames are parsed via the inverse of
  `_job_ids_to_str`, so a range-named batch like `submit-job-580-588.log` is
  matched when any requested job falls in the range — mirroring how
  `_collect_controller_system_log_paths` scopes, so a long-lived controller's
  entire submission history isn't dragged into every dump.

## Notes
`submit-job-*.log` is written in consolidation mode, where the submission runs on
the API server without a Ray runtime and is therefore logged to an explicit path.
In non-consolidation mode the analogous submission output is captured by Ray's
`controller.log`, and the "Started N controllers" signal also lands in the
controller's `skylet.log` (already collected by the dump), so non-consolidation
deployments aren't left without the signal.

## Test plan
- Unit tests (`tests/unit_tests/test_jobs_utils.py`):
  - `TestParseSubmitLogJobIds` — single id, inclusive range, mixed, malformed.
  - `TestControllerSubmitLogScoping` — range-contains match, unrelated excluded,
    empty `job_ids`, missing dir, unparseable filename → warned + skipped.
- Manual e2e (consolidation mode, local Kubernetes):
  1. Enable jobs consolidation mode; restart the API server.
  2. `sky jobs launch -n e2e --infra k8s -y "echo hi; sleep 45"`.
  3. `sky debug-dump -j <id> --output dump.zip`.
  4. Confirmed `managed_jobs/controller_submit_logs/submit-job-<id>.log` is present
     in the zip with the real submission-log contents.

  Also verified on a separate (non-consolidation) controller that the new code is
  installed and correctly collects zero submit-job logs (none exist in that mode)
  without error.
