### PR TITLE
[Jobs] Classify user-job FAILED_DRIVER as FAILED, not FAILED_CONTROLLER

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -984,12 +984,20 @@ class JobController:
                         managed_job_status = (
                             managed_job_state.ManagedJobStatus.FAILED_SETUP)
                     elif job_status == job_lib.JobStatus.FAILED_DRIVER:
-                        # FAILED_DRIVER is kind of an internal error, so we mark
-                        # this as FAILED_CONTROLLER, even though the failure is
-                        # not strictly within the controller.
+                        # FAILED_DRIVER means the user job's driver process on
+                        # the remote cluster died, most commonly because the
+                        # user workload ran the node out of memory (e.g. a Ray
+                        # OutOfMemoryError). This is a failure of the user
+                        # workload, not of the jobs controller, so we classify
+                        # it as FAILED (not FAILED_CONTROLLER) to avoid firing
+                        # spurious controller-failure alerts. Like any other
+                        # user-job failure, whether it is retried is decided by
+                        # should_restart_on_failure() below (i.e. by
+                        # max_restarts_on_errors / recover_on_exit_codes), which
+                        # defaults to no retry -- appropriate here since an OOM
+                        # is deterministic and would likely recur on recovery.
                         managed_job_status = (
-                            managed_job_state.ManagedJobStatus.FAILED_CONTROLLER
-                        )
+                            managed_job_state.ManagedJobStatus.FAILED)
                         failure_reason = (
                             'The job driver on the remote cluster failed. This '
                             'can be caused by the job taking too much memory '

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -19,7 +19,9 @@ import pytest
 from sky.jobs import state as managed_job_state
 from sky.jobs.controller import ControllerManager
 from sky.jobs.controller import JobController
+from sky.skylet import job_lib
 from sky.utils import common
+from sky.utils import status_lib
 
 
 class TestNormalJobRecovery:
@@ -1146,3 +1148,96 @@ class TestJobGroupResumeDoesNotReissueStarting:
                                                     task,
                                                     set_starting=True)
         set_starting_async.assert_awaited_once()
+
+
+class TestUserJobStatusClassification:
+    """Tests for how a terminal *user-job* status (on the worker cluster) is
+    classified into a ManagedJobStatus by the controller monitoring loop.
+
+    Regression coverage for SKY-5941: a user job that ends in
+    JobStatus.FAILED_DRIVER (e.g. the user workload OOM'd and the Ray driver
+    crashed) must be classified as ManagedJobStatus.FAILED, NOT
+    FAILED_CONTROLLER -- the controller is healthy, the user workload failed.
+    """
+
+    def _make_controller(self):
+        """Build a JobController without running __init__ (which needs a DB)."""
+        controller = JobController.__new__(JobController)
+        controller._job_id = 1
+        controller._pool = None
+        controller._backend = MagicMock()
+        # Methods exercised on the FAILED path; stub them out.
+        controller.download_log_and_stream = MagicMock()
+        controller._get_cluster_job_exit_codes = AsyncMock(return_value=[])
+        controller._cleanup_cluster = AsyncMock()
+        return controller
+
+    async def _run_until_terminal(self, controller, worker_job_status):
+        """Drive _monitor_one_task through one iteration for a terminal
+        worker-cluster job status with the cluster UP, returning the
+        set_failed_async mock so the caller can assert the classification."""
+        mock_task = MagicMock()
+        mock_task.name = 'test-task'
+        mock_task.num_nodes = 1
+
+        # No retries: deterministic OOM-style failures should not be retried.
+        executor = MagicMock()
+        executor.should_restart_on_failure.return_value = False
+        executor.max_restarts_on_errors = 0
+
+        handle = MagicMock()
+
+        with patch('asyncio.sleep', new=AsyncMock()), \
+             patch('sky.backends.backend_utils.async_check_network_connection',
+                   new=AsyncMock()), \
+             patch('sky.jobs.utils.get_job_status',
+                   new=AsyncMock(return_value=(worker_job_status, None))), \
+             patch('sky.jobs.utils.try_to_get_job_end_time',
+                   return_value=12345.0), \
+             patch('sky.backends.backend_utils.refresh_cluster_status_handle',
+                   return_value=(status_lib.ClusterStatus.UP, handle)), \
+             patch('sky.jobs.state.set_failed_async',
+                   new=AsyncMock()) as mock_set_failed:
+
+            succeeded = await controller._monitor_one_task(
+                task_id=0,
+                task=mock_task,
+                cluster_name='test-cluster',
+                executor=executor,
+                callback_func=MagicMock(),
+            )
+
+        # A failed user job means the task did not succeed and is not retried.
+        assert succeeded is False
+        executor.should_restart_on_failure.assert_called_once()
+        mock_set_failed.assert_called_once()
+        return mock_set_failed
+
+    @pytest.mark.asyncio
+    async def test_failed_driver_maps_to_failed_not_controller(self):
+        """FAILED_DRIVER (user-job OOM / Ray driver crash) -> FAILED."""
+
+        controller = self._make_controller()
+        mock_set_failed = await self._run_until_terminal(
+            controller, job_lib.JobStatus.FAILED_DRIVER)
+
+        failure_type = mock_set_failed.call_args.kwargs['failure_type']
+        assert failure_type == managed_job_state.ManagedJobStatus.FAILED, (
+            'FAILED_DRIVER must be classified as FAILED, not '
+            f'FAILED_CONTROLLER; got {failure_type}')
+        assert (failure_type !=
+                managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
+        # The failure is clearly surfaced to the user via failure_reason.
+        failure_reason = mock_set_failed.call_args.kwargs['failure_reason']
+        assert 'job driver on the remote cluster failed' in failure_reason
+
+    @pytest.mark.asyncio
+    async def test_plain_failed_user_job_maps_to_failed(self):
+        """A normal user-code FAILED still maps to FAILED (sanity check)."""
+
+        controller = self._make_controller()
+        mock_set_failed = await self._run_until_terminal(
+            controller, job_lib.JobStatus.FAILED)
+
+        failure_type = mock_set_failed.call_args.kwargs['failure_type']
+        assert failure_type == managed_job_state.ManagedJobStatus.FAILED


### PR DESCRIPTION
## Summary

When a managed job's underlying user job ends in `JobStatus.FAILED_DRIVER` — the job's driver process on the remote cluster died, most commonly because the user workload ran the node out of memory (e.g. a Ray `OutOfMemoryError` crashing the driver) — the controller previously classified the managed job as `FAILED_CONTROLLER`.

This is misleading and noisy:
- The jobs **controller** itself is healthy; it's the **user workload** that failed.
- It trips controller-failure paths for what is really a user-side OOM/crash.

This PR remaps that case to `ManagedJobStatus.FAILED`, keeping the informative failure reason so the user still sees *why* it failed (driver crash / likely out of memory, suggest adding more memory/CPU/disk).

Retry behavior is **unchanged**: whether the job is retried is still decided solely by `should_restart_on_failure()` (i.e. `max_restarts_on_errors` / `recover_on_exit_codes`), which defaults to no retry — appropriate for a deterministic OOM that would likely recur on recovery.

## Test plan

- Added regression tests in `tests/unit_tests/test_sky/jobs/test_controller.py` that drive the real `_monitor_one_task` loop and assert:
  - `FAILED_DRIVER` → `ManagedJobStatus.FAILED` (and *not* `FAILED_CONTROLLER`)
  - the failure reason is surfaced to the user
  - the job is not retried
  - sanity: a plain user-code `FAILED` still maps to `FAILED`
  - `pytest tests/unit_tests/test_sky/jobs/test_controller.py` → 31 passed; `format.sh` clean.

- Manual end-to-end on a real API server + Kubernetes:
  1. Launched a managed job and waited for `RUNNING`.
  2. Killed the user job's driver process on the worker cluster, so the skylet marked the underlying job `FAILED_DRIVER`.
  3. **Before:** managed job ended `FAILED_CONTROLLER`. **After this change:** managed job ends `FAILED` with `#RECOVERIES = 0` and the driver-failure reason shown via `sky jobs logs --controller`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)