### PR TITLE
[Dashboard] Render "-" for empty user/resources in clusters table

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -995,12 +995,16 @@ export function ClusterTable({
       ),
       renderCell: (item) => (
         <TableCell>
-          <NonCapitalizedTooltip
-            content={item.resources_str_full || item.resources_str || '-'}
-            className="text-sm text-muted-foreground"
-          >
-            <span>{item.resources_str || '-'}</span>
-          </NonCapitalizedTooltip>
+          {item.resources_str_full || item.resources_str ? (
+            <NonCapitalizedTooltip
+              content={item.resources_str_full || item.resources_str}
+              className="text-sm text-muted-foreground"
+            >
+              <span>{item.resources_str || '-'}</span>
+            </NonCapitalizedTooltip>
+          ) : (
+            <span>-</span>
+          )}
         </TableCell>
       ),
     },

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -906,7 +906,11 @@ export function ClusterTable({
       ),
       renderCell: (item) => (
         <TableCell>
-          <UserDisplay username={item.user} userHash={item.user_hash} />
+          {item.user ? (
+            <UserDisplay username={item.user} userHash={item.user_hash} />
+          ) : (
+            '-'
+          )}
         </TableCell>
       ),
     },
@@ -992,10 +996,10 @@ export function ClusterTable({
       renderCell: (item) => (
         <TableCell>
           <NonCapitalizedTooltip
-            content={item.resources_str_full || item.resources_str}
+            content={item.resources_str_full || item.resources_str || '-'}
             className="text-sm text-muted-foreground"
           >
-            <span>{item.resources_str}</span>
+            <span>{item.resources_str || '-'}</span>
           </NonCapitalizedTooltip>
         </TableCell>
       ),


### PR DESCRIPTION
## Summary
- The **User** and **Resources** columns in the clusters table rendered blank when their values were missing, unlike other columns that show `-`.
- Fall back to `-` so empty cells are consistent across the table: the User cell renders `-` when there is no user, and Resources renders `-` (in both the cell and its tooltip) when `resources_str` is absent.

## Test plan
- Build the dashboard (`npm --prefix sky/dashboard run build`) and open the clusters page.
- For any row missing a user or resources value (e.g. certain terminated/history rows), the cell now shows `-` instead of a blank cell, matching the Duration/Priority/Autostop columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)