### PR TITLE
[Kubernetes] Give late-binding PVCs more provision time; don't misreport WaitForFirstConsumer as a binding failure

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -668,17 +668,32 @@ class Kubernetes(clouds.Cloud):
             per_node_timeout = 10
             max_timeout = 2400
         elif volume_mounts is not None:
+            has_pvc = False
+            has_rwx_pvc = False
             for volume_mount in volume_mounts:
                 if (volume_mount.volume_config.type ==
                         volume_lib.VolumeType.PVC.value):
+                    has_pvc = True
                     if (volume_mount.volume_config.config.get(
                             'access_mode', '') ==
                             volume_lib.VolumeAccessMode.READ_WRITE_MANY.value):
-                        # GKE may take several minutes to provision a PV
-                        # supporting READ_WRITE_MANY with filestore.
-                        base_timeout = 180
-                        max_timeout = 240
+                        has_rwx_pvc = True
                         break
+            if has_rwx_pvc:
+                # GKE may take several minutes to provision a PV
+                # supporting READ_WRITE_MANY with filestore.
+                base_timeout = 180
+                max_timeout = 240
+            elif has_pvc:
+                # Even ReadWriteOnce PVCs can take meaningfully longer than the
+                # 10s default to come up: storage classes that use late binding
+                # (volumeBindingMode: WaitForFirstConsumer, e.g. kind's
+                # local-path and many cloud defaults) only bind the PVC once the
+                # consumer pod is scheduled, after which the provisioner still
+                # has to create the volume. Give that more room before failing
+                # over so a healthy-but-slow provision is not misread as an
+                # unschedulable pod / PVC binding failure.
+                base_timeout = 30
 
         return int(
             min(base_timeout + (per_node_timeout * (num_nodes - 1)),

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -280,12 +280,29 @@ def _get_pvc_binding_status(namespace: str, context: Optional[str],
                                                                 pvc_name,
                                                                 reverse=False)
                 event_messages = []
+                has_binding_failure = False
+                saw_wait_for_consumer = False
                 for event in sorted_events:
+                    if event.reason == 'WaitForFirstConsumer':
+                        saw_wait_for_consumer = True
+                    if event.type == 'Warning' or event.reason == (
+                            'ProvisioningFailed'):
+                        has_binding_failure = True
                     if event.type == 'Warning' or event.reason in (
                             'ProvisioningFailed', 'WaitForFirstConsumer'):
                         msg = event.message or ''
                         if msg:
                             event_messages.append(f'{event.reason}: {msg}')
+                # A PVC backed by a WaitForFirstConsumer storage class stays
+                # Pending by design until its consumer pod is scheduled, after
+                # which the volume is provisioned and bound. That is normal
+                # late binding in progress, not a binding failure, so don't
+                # surface it as a PVC error (otherwise a healthy-but-slow
+                # provision on such a storage class is misreported as a binding
+                # issue). Genuine problems still emit Warning/ProvisioningFailed
+                # events and are reported below.
+                if saw_wait_for_consumer and not has_binding_failure:
+                    continue
                 pending_info = f'{pvc_name} (phase: Pending)'
                 if event_messages:
                     # Take the most recent event message

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -884,6 +884,46 @@ def test_get_pvc_binding_status_pending_pvc(monkeypatch):
     assert 'test-namespace' in result
 
 
+def test_get_pvc_binding_status_wait_for_first_consumer(monkeypatch):
+    """A PVC pending only on WaitForFirstConsumer is not a binding failure.
+
+    Late-binding storage classes (volumeBindingMode: WaitForFirstConsumer,
+    e.g. kind's local-path) keep the PVC Pending until its consumer pod is
+    scheduled. That is normal in-progress provisioning, not a binding issue,
+    so _get_pvc_binding_status must not surface it as an error.
+    """
+    pod = mock.MagicMock()
+    pvc_claim = mock.MagicMock()
+    pvc_claim.claim_name = 'test-pvc'
+    volume = mock.MagicMock()
+    volume.persistent_volume_claim = pvc_claim
+    pod.spec.volumes = [volume]
+
+    # Mock the PVC as pending
+    pvc = mock.MagicMock()
+    pvc.status.phase = 'Pending'
+
+    # The only event is a benign Normal WaitForFirstConsumer event.
+    pvc_event = mock.MagicMock()
+    pvc_event.type = 'Normal'
+    pvc_event.reason = 'WaitForFirstConsumer'
+    pvc_event.message = ('waiting for first consumer to be created before '
+                         'binding')
+    pvc_events = mock.MagicMock()
+    pvc_events.items = [pvc_event]
+
+    core_api_mock = mock.MagicMock()
+    core_api_mock.read_namespaced_persistent_volume_claim.return_value = pvc
+    core_api_mock.list_namespaced_event.return_value = pvc_events
+
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *args, **kwargs: core_api_mock)
+
+    result = instance._get_pvc_binding_status('test-namespace', 'test-context',
+                                              pod)
+    assert result is None
+
+
 def test_raise_pod_scheduling_errors_pvc_unbound(monkeypatch):
     """Test that _raise_pod_scheduling_errors surfaces PVC binding issues."""
     error_message = '0/3 nodes are available: 3 pod has unbound immediate PersistentVolumeClaims.'

--- a/tests/unit_tests/kubernetes/test_provision_timeout.py
+++ b/tests/unit_tests/kubernetes/test_provision_timeout.py
@@ -1,0 +1,65 @@
+"""Tests for Kubernetes._calculate_provision_timeout."""
+import types
+
+from sky.clouds import kubernetes
+from sky.utils import volume as volume_lib
+
+_calc = kubernetes.Kubernetes._calculate_provision_timeout
+
+
+def _pvc_mount(access_mode: str):
+    return types.SimpleNamespace(volume_config=types.SimpleNamespace(
+        type=volume_lib.VolumeType.PVC.value,
+        config={'access_mode': access_mode},
+    ))
+
+
+def _hostpath_mount():
+    return types.SimpleNamespace(volume_config=types.SimpleNamespace(
+        type=volume_lib.VolumeType.HOSTPATH.value,
+        config={},
+    ))
+
+
+def test_provision_timeout_no_volumes():
+    """Default single-node timeout when there are no volume mounts."""
+    assert _calc(1, None, False, False) == 10
+
+
+def test_provision_timeout_rwo_pvc_extended():
+    """ReadWriteOnce PVCs get more room than the 10s default.
+
+    Late-binding storage classes (WaitForFirstConsumer) only bind the PVC
+    once the consumer pod is scheduled, and the provisioner then creates the
+    volume, so a slow-but-healthy provision must not be misread as
+    unschedulable.
+    """
+    mounts = [_pvc_mount(volume_lib.VolumeAccessMode.READ_WRITE_ONCE.value)]
+    assert _calc(1, mounts, False, False) == 30
+
+
+def test_provision_timeout_rwx_pvc_largest():
+    """ReadWriteMany (e.g. GKE filestore) keeps the longest timeout."""
+    mounts = [_pvc_mount(volume_lib.VolumeAccessMode.READ_WRITE_MANY.value)]
+    assert _calc(1, mounts, False, False) == 180
+
+
+def test_provision_timeout_mixed_pvc_prefers_rwx():
+    """A mix of RWO and RWX PVCs uses the longer RWX timeout."""
+    mounts = [
+        _pvc_mount(volume_lib.VolumeAccessMode.READ_WRITE_ONCE.value),
+        _pvc_mount(volume_lib.VolumeAccessMode.READ_WRITE_MANY.value),
+    ]
+    assert _calc(1, mounts, False, False) == 180
+
+
+def test_provision_timeout_non_pvc_volume_uses_default():
+    """A non-PVC volume mount (e.g. hostPath) does not extend the timeout."""
+    mounts = [_hostpath_mount()]
+    assert _calc(1, mounts, False, False) == 10
+
+
+def test_provision_timeout_queueing_overrides_all():
+    """Queueing returns the long queue-managed timeout regardless of PVCs."""
+    mounts = [_pvc_mount(volume_lib.VolumeAccessMode.READ_WRITE_ONCE.value)]
+    assert _calc(1, mounts, False, True) == 24 * 60 * 60


### PR DESCRIPTION
## Summary

Fixes a flake in `test_volumes_on_kubernetes` (nightly k8s smoke tests) and the misleading error behind it.

The test launches a pod with 4 **ReadWriteOnce** PVCs on kind's `standard` storage class (`rancher.io/local-path`, `volumeBindingMode: WaitForFirstConsumer`). Such a PVC stays `Pending` *by design* until its consumer pod is scheduled, after which the provisioner creates and binds the volume.

Two problems caused the flake:

1. **`provision_timeout` was only 10s for ReadWriteOnce PVCs.** The 180–240s bump in `_calculate_provision_timeout` applied **only** to `READ_WRITE_MANY`. On a loaded CI host, `WaitForFirstConsumer` binding + scheduling for several PVCs exceeds 10s, so `_wait_for_pods_to_schedule` times out → failover → launch fails.
2. **The timeout was mislabeled as a PVC binding failure.** `_get_pvc_binding_status` flagged *any* `Pending` PVC — including one waiting purely on `WaitForFirstConsumer` — as `PVC binding issue detected …`, which is normal late binding in progress, not a failure. (This also contradicted the existing benign `WaitForFirstConsumer` classification in `instance.py`.)

### Evidence (measured on the actual CI VM)

| Scenario | Launch time | Outcome |
|---|---|---|
| Idle host (live measurement) | pod scheduled 6.1s / 4 PVCs bound 5.1s | — |
| Idle host (passing retry) | ~6.0s (`04:53:31.5 → 04:53:37.5`) | ✅ under 10s |
| Under nightly load (failing run) | >10.5s (`04:23:35.554 → 04:23:46.088`) | ❌ hit the 10s gate |

The failing run consumed ~60% of the 10s budget on an idle box; nightly contention across 5 kind clusters on one host tips it over. The same commit passed on retry with no code change → timing flake.

## Changes

- `sky/clouds/kubernetes.py`: extend `provision_timeout` to **30s** for any PVC-backed launch (not just RWX). 30s ≈ 5× the idle baseline and 3× the default, while still failing fast for genuinely unschedulable pods.
- `sky/provision/kubernetes/instance.py`: in `_get_pvc_binding_status`, treat a PVC that is `Pending` *solely* on a `WaitForFirstConsumer` event (no `Warning`/`ProvisioningFailed`) as late binding in progress, not a binding failure. Genuine failures still emit `Warning`/`ProvisioningFailed` and are reported as before.

## Test plan

- `pytest tests/unit_tests/kubernetes/test_provision.py -k pvc` — all pass, incl. new `test_get_pvc_binding_status_wait_for_first_consumer` and the existing genuine-failure test (unchanged behavior).
- `pytest tests/unit_tests/kubernetes/test_provision_timeout.py` — new, covers RWO/RWX/mixed/non-PVC/queueing cases.
- `format.sh` clean (yapf/isort/mypy/pylint).
- Manual verification on the failing CI host: confirmed `standard` SC is `WaitForFirstConsumer`/local-path and measured the 6s provisioning latency.

Failed build: https://buildkite.com/skypilot-1/smoke-tests/builds/11456

🤖 Generated with [Claude Code](https://claude.com/claude-code)