### PR TITLE
[Jobs] Add status_override column + generic status_expr read seam

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1817,7 +1817,10 @@ def get_managed_jobs_with_filters(
         'job_name': spot_table.c.job_name,
         'name': spot_table.c.job_name,
         'submitted_at': spot_table.c.submitted_at,
-        'status': spot_table.c.status,
+        # Sort by the refined status (status_expr) when provided, so the order
+        # matches the displayed/grouped status instead of the raw column.
+        'status':
+            (status_expr if status_expr is not None else spot_table.c.status),
         'job_duration': spot_table.c.job_duration,
         'duration': spot_table.c.job_duration,
         'recovery_count': spot_table.c.recovery_count,

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -107,6 +107,14 @@ spot_table = sqlalchemy.Table(
     sqlalchemy.Column('is_primary_in_job_group',
                       sqlalchemy.Boolean,
                       server_default=None),
+    # Optional plugin-provided override for the user-facing status. The core
+    # state machine never reads this column; it always uses `status`. Read
+    # paths (status counts, status filter, returned status) may surface this
+    # value instead of `status` via the optional `status_expr` seam, so a
+    # plugin can present a refined status (e.g. show a still-launching job as
+    # PENDING while it waits in an external scheduler queue) without altering
+    # the underlying job lifecycle. NULL means "no override".
+    sqlalchemy.Column('status_override', sqlalchemy.Text, server_default=None),
 )
 
 job_info_table = sqlalchemy.Table(
@@ -1503,8 +1511,15 @@ def build_managed_jobs_with_filters_no_status_query(
     count_only: bool = False,
     count_unique_jobs: bool = False,
     status_count: bool = False,
+    status_expr: Optional['sqlalchemy.ColumnElement'] = None,
 ) -> sqlalchemy.Select:
     """Build a query to get managed jobs from the database with filters.
+
+    status_expr is an optional SQLAlchemy expression used in place of the raw
+    ``spot.status`` column whenever a user-facing status is needed (the
+    status-count grouping column). It lets a caller surface a refined status
+    (e.g. a plugin override) without changing the underlying column. When None,
+    the raw ``spot.status`` column is used.
 
     submitted_after / submitted_before are epoch seconds (matching the
     ``submitted_at`` column) and restrict the result to jobs submitted within
@@ -1529,7 +1544,9 @@ def build_managed_jobs_with_filters_no_status_query(
     elif count_only:
         query = sqlalchemy.select(sqlalchemy.func.count().label('count'))  # pylint: disable=not-callable
     elif status_count:
-        query = sqlalchemy.select(spot_table.c.status,
+        status_col = (status_expr
+                      if status_expr is not None else spot_table.c.status)
+        query = sqlalchemy.select(status_col.label('status'),
                                   sqlalchemy.func.count().label('count'))  # pylint: disable=not-callable
     else:
         query = sqlalchemy.select(
@@ -1617,8 +1634,14 @@ def build_managed_jobs_with_filters_query(
     submitted_before: Optional[float] = None,
     count_only: bool = False,
     count_unique_jobs: bool = False,
+    status_expr: Optional['sqlalchemy.ColumnElement'] = None,
 ) -> sqlalchemy.Select:
-    """Build a query to get managed jobs from the database with filters."""
+    """Build a query to get managed jobs from the database with filters.
+
+    See build_managed_jobs_with_filters_no_status_query for the meaning of
+    status_expr; here it is also used to match the ``statuses`` filter against
+    the refined status instead of the raw ``spot.status`` column.
+    """
     query = build_managed_jobs_with_filters_no_status_query(
         fields=fields,
         job_ids=job_ids,
@@ -1632,9 +1655,12 @@ def build_managed_jobs_with_filters_query(
         submitted_before=submitted_before,
         count_only=count_only,
         count_unique_jobs=count_unique_jobs,
+        status_expr=status_expr,
     )
     if statuses is not None:
-        query = query.where(spot_table.c.status.in_(statuses))
+        status_col = (status_expr
+                      if status_expr is not None else spot_table.c.status)
+        query = query.where(status_col.in_(statuses))
     return query
 
 
@@ -1649,8 +1675,13 @@ def get_status_count_with_filters(
     skip_finished: bool = False,
     submitted_after: Optional[float] = None,
     submitted_before: Optional[float] = None,
+    status_expr: Optional['sqlalchemy.ColumnElement'] = None,
 ) -> Dict[str, int]:
-    """Get the status count of the managed jobs with filters."""
+    """Get the status count of the managed jobs with filters.
+
+    status_expr, when provided, replaces the raw ``spot.status`` column as the
+    grouping key, so counts are bucketed by the refined user-facing status.
+    """
     query = build_managed_jobs_with_filters_no_status_query(
         fields=fields,
         job_ids=job_ids,
@@ -1663,8 +1694,11 @@ def get_status_count_with_filters(
         submitted_after=submitted_after,
         submitted_before=submitted_before,
         status_count=True,
+        status_expr=status_expr,
     )
-    query = query.group_by(spot_table.c.status)
+    status_col = (status_expr
+                  if status_expr is not None else spot_table.c.status)
+    query = query.group_by(status_col)
     results: Dict[str, int] = {}
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
@@ -1751,8 +1785,15 @@ def get_managed_jobs_with_filters(
     limit: Optional[int] = None,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
+    status_expr: Optional['sqlalchemy.ColumnElement'] = None,
 ) -> Tuple[List[Dict[str, Any]], int]:
     """Get managed jobs from the database with filters.
+
+    status_expr, when provided, is used to match the ``statuses`` filter
+    against a refined user-facing status instead of the raw ``spot.status``
+    column (see build_managed_jobs_with_filters_no_status_query). The returned
+    rows still carry the raw ``status``; callers that want the refined value in
+    the result should surface it separately.
 
     Pagination is by unique jobs (spot_job_id), not by tasks. This means
     if you request page 1 with limit 10, you get all tasks for 10 unique jobs.
@@ -1804,6 +1845,7 @@ def get_managed_jobs_with_filters(
         submitted_after=submitted_after,
         submitted_before=submitted_before,
         count_unique_jobs=True,
+        status_expr=status_expr,
     )
     with orm.Session(engine) as session:
         total = session.execute(count_query).fetchone()[0]
@@ -1827,6 +1869,7 @@ def get_managed_jobs_with_filters(
             skip_finished=skip_finished,
             submitted_after=submitted_after,
             submitted_before=submitted_before,
+            status_expr=status_expr,
         ).with_only_columns(spot_table.c.spot_job_id).group_by(
             spot_table.c.spot_job_id)
 
@@ -1869,6 +1912,7 @@ def get_managed_jobs_with_filters(
             user_hashes=user_hashes,
             statuses=statuses,
             skip_finished=skip_finished,
+            status_expr=status_expr,
         )
     else:
         # No pagination - get all jobs
@@ -1884,6 +1928,7 @@ def get_managed_jobs_with_filters(
             skip_finished=skip_finished,
             submitted_after=submitted_after,
             submitted_before=submitted_before,
+            status_expr=status_expr,
         )
 
     # Apply sorting

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -67,6 +67,7 @@ if typing.TYPE_CHECKING:
     from google.protobuf import json_format
     import grpc
     import psutil
+    import sqlalchemy
 
     import sky
     from sky import dag as dag_lib
@@ -2407,6 +2408,7 @@ def get_managed_job_queue(
     sort_order: Optional[str] = None,
     submitted_after: Optional[float] = None,
     submitted_before: Optional[float] = None,
+    status_expr: Optional['sqlalchemy.ColumnElement'] = None,
 ) -> Dict[str, Any]:
     """Get the managed job queue.
 
@@ -2455,6 +2457,7 @@ def get_managed_job_queue(
         skip_finished=skip_finished,
         submitted_after=submitted_after,
         submitted_before=submitted_before,
+        status_expr=status_expr,
     )
 
     jobs, total = managed_job_state.get_managed_jobs_with_filters(
@@ -2473,6 +2476,7 @@ def get_managed_job_queue(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        status_expr=status_expr,
     )
 
     if cluster_handle_required:

--- a/sky/schemas/db/spot_jobs/021_add_status_override.py
+++ b/sky/schemas/db/spot_jobs/021_add_status_override.py
@@ -1,0 +1,39 @@
+"""Add status_override column to spot table.
+
+This migration adds an optional status_override column to the spot table. The
+core managed-job state machine never reads it; read paths may surface it in
+place of `status` via the optional status_expr seam, letting a plugin present a
+refined user-facing status without changing the job lifecycle.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-06-24
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '021'
+down_revision: Union[str, Sequence[str], None] = '020'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add status_override column to spot table."""
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('spot',
+                                             'status_override',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    """No downgrade logic."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,7 @@ GLOBAL_USER_STATE_VERSION = '020'  # add is_managed column to cluster_history
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
-SPOT_JOBS_VERSION = '020'  # add indexes for pool dashboard queries
+SPOT_JOBS_VERSION = '021'  # add status_override column to spot table
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -1135,3 +1135,79 @@ class TestMultiTaskStatusFilterCharacterization:
             state.ManagedJobStatus.SUCCEEDED, state.ManagedJobStatus.RUNNING
         }
         assert total == 1
+
+
+class TestStatusExprSeam:
+    """The optional status_expr seam lets a caller surface a refined
+    user-facing status (e.g. a plugin override) in the status counts and the
+    status filter without changing the raw spot.status column."""
+
+    def _seed(self, engine):
+        import sqlalchemy
+        rows = [
+            # (job_id, status, status_override)
+            (1, 'STARTING', 'PENDING'),  # queued -> surfaces as PENDING
+            (2, 'STARTING', None),  # genuinely starting
+            (3, 'RUNNING', 'PENDING'),  # stale override -> must stay RUNNING
+            (4, 'PENDING', None),  # real pending
+            (5, 'SUCCEEDED', None),
+        ]
+        with engine.begin() as conn:
+            for jid, st, ov in rows:
+                conn.execute(state.spot_table.insert().values(
+                    spot_job_id=jid,
+                    task_id=0,
+                    job_name=f'j{jid}',
+                    status=st,
+                    status_override=ov))
+
+    @staticmethod
+    def _override_expr():
+        import sqlalchemy
+        spot = state.spot_table
+        starting = state.ManagedJobStatus.STARTING.value
+        return sqlalchemy.case((sqlalchemy.and_(
+            spot.c.status == starting,
+            spot.c.status_override.isnot(None)), spot.c.status_override),
+                               else_=spot.c.status)
+
+    def test_status_override_column_exists(self, _mock_managed_jobs_db_conn):
+        import sqlalchemy
+        cols = [
+            c['name'] for c in sqlalchemy.inspect(
+                _mock_managed_jobs_db_conn).get_columns('spot')
+        ]
+        assert 'status_override' in cols
+
+    def test_counts_collapse_with_status_expr(self, _mock_managed_jobs_db_conn):
+        self._seed(_mock_managed_jobs_db_conn)
+        raw = state.get_status_count_with_filters()
+        assert raw.get('STARTING') == 2 and raw.get('PENDING') == 1
+        collapsed = state.get_status_count_with_filters(
+            status_expr=self._override_expr())
+        # job1 STARTING -> PENDING; job3 stays RUNNING (stale override ignored)
+        assert collapsed.get('PENDING') == 2
+        assert collapsed.get('STARTING') == 1
+        assert collapsed.get('RUNNING') == 1
+
+    def test_status_filter_with_status_expr(self, _mock_managed_jobs_db_conn):
+        self._seed(_mock_managed_jobs_db_conn)
+        expr = self._override_expr()
+        pending, _ = state.get_managed_jobs_with_filters(statuses=['PENDING'],
+                                                         status_expr=expr,
+                                                         page=1,
+                                                         limit=50)
+        assert sorted(j['job_id'] for j in pending) == [1, 4]
+        starting, _ = state.get_managed_jobs_with_filters(statuses=['STARTING'],
+                                                          status_expr=expr,
+                                                          page=1,
+                                                          limit=50)
+        assert sorted(j['job_id'] for j in starting) == [2]
+
+    def test_status_expr_none_is_noop(self, _mock_managed_jobs_db_conn):
+        self._seed(_mock_managed_jobs_db_conn)
+        # Without the seam, behaviour is unchanged: raw statuses are used.
+        starting, _ = state.get_managed_jobs_with_filters(statuses=['STARTING'],
+                                                          page=1,
+                                                          limit=50)
+        assert sorted(j['job_id'] for j in starting) == [1, 2]

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -1211,3 +1211,42 @@ class TestStatusExprSeam:
                                                           page=1,
                                                           limit=50)
         assert sorted(j['job_id'] for j in starting) == [1, 2]
+
+    def test_sort_by_status_uses_status_expr(self, _mock_managed_jobs_db_conn):
+        # sort_by='status' must order by the refined status (the paginated
+        # subquery sorts by MAX(status_expr); the final query by status_expr).
+        self._seed(_mock_managed_jobs_db_conn)
+        expr = self._override_expr()
+        # Refined status per seeded job (job1 is raw STARTING but refined
+        # PENDING; job3 is RUNNING with a stale override -> stays RUNNING).
+        refined = {
+            1: 'PENDING',
+            2: 'STARTING',
+            3: 'RUNNING',
+            4: 'PENDING',
+            5: 'SUCCEEDED'
+        }
+        asc, _ = state.get_managed_jobs_with_filters(
+            status_expr=expr,
+            page=1,
+            limit=50,
+            sort_by='status',
+            sort_order='asc',
+            fields=['job_id', 'status', 'task_id'])
+        seq = [refined[j['job_id']] for j in asc]
+        assert seq == sorted(seq), seq  # ascending by REFINED status
+        order = [j['job_id'] for j in asc]
+        # The queued job (raw STARTING, refined PENDING) sorts before a
+        # genuinely STARTING job and a RUNNING job -- which would NOT hold if
+        # the sort fell back to the raw spot.status column.
+        assert order.index(1) < order.index(2)  # PENDING before STARTING
+        assert order.index(1) < order.index(3)  # PENDING before RUNNING
+        desc, _ = state.get_managed_jobs_with_filters(
+            status_expr=expr,
+            page=1,
+            limit=50,
+            sort_by='status',
+            sort_order='desc',
+            fields=['job_id', 'status', 'task_id'])
+        seq_d = [refined[j['job_id']] for j in desc]
+        assert seq_d == sorted(seq_d, reverse=True), seq_d

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -692,7 +692,8 @@ class TestDumpManagedJobQueue:
                                                sort_by=None,
                                                sort_order=None,
                                                submitted_after=None,
-                                               submitted_before=None):
+                                               submitted_before=None,
+                                               status_expr=None):
             # Apply pre-filters aligned with utils.get_managed_job_queue
             prefiltered = _apply_pre_filters(jobs, accessible_workspaces,
                                              job_ids, user_hashes,
@@ -717,7 +718,8 @@ class TestDumpManagedJobQueue:
                                                user_hashes,
                                                skip_finished,
                                                submitted_after=None,
-                                               submitted_before=None):
+                                               submitted_before=None,
+                                               status_expr=None):
             # Compute status counts after applying non-paginated filters
             prefiltered = _apply_pre_filters(jobs, accessible_workspaces,
                                              job_ids, user_hashes,


### PR DESCRIPTION
## Summary

Adds a generic seam so a plugin can surface a **refined user-facing managed-job
status** in the status counts and the status filter, without touching the
underlying job lifecycle.

- New nullable `spot.status_override` column (migration `021`). The core
  managed-job state machine never reads it; it always uses `status`.
- New optional `status_expr` parameter threaded through the managed-jobs read
  path — `build_managed_jobs_with_filters_*`, `get_status_count_with_filters`,
  `get_managed_jobs_with_filters`, and `get_managed_job_queue`. When provided,
  `status_expr` is used in place of the raw `spot.status` column for the
  status-count grouping and the status filter. Defaults to `None`, so behavior
  is byte-identical when unused.

### Why

On the Managed Jobs dashboard, a queued job can be shown as `PENDING` by a
plugin (e.g. a job whose pod is gated in an external scheduler queue while the
controller is still launching). Previously that label was applied per-row at
read time only, so it could not be reflected in the SQL-level status counts or
the status filter — the status bar showed `PENDING: 0` while rows displayed
`PENDING`, and the counts/filter didn't scale with a per-row live lookup. This
seam lets the plugin reflect the refined status consistently in counts + filter
+ badge, in SQL, at any scale. (The plugin side lives in the closed-source
plugins repo.)

## Test plan

- New unit tests `tests/unit_tests/test_sky/jobs/test_jobs_state.py::TestStatusExprSeam`:
  - `status_override` column present after migration.
  - `status_expr` collapses status counts (e.g. STARTING+override -> PENDING),
    and a stale override on a non-STARTING row is ignored.
  - status filter maps PENDING/STARTING via `status_expr`.
  - `status_expr=None` is a no-op (back-compat).
- Updated `test_server_queue.py` mocks for the new `status_expr` kwarg.
- Full `tests/unit_tests/test_sky/jobs/` suite passes (115).
- Migration `021` applies on an existing `020` DB (SQLite verified); no schema
  change when the seam is unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
