### PR TITLE
[Core] Skip last_creation_yaml in bulk cluster-history queries

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2368,34 +2368,39 @@ def get_clusters_from_history(
     if days is not None:
         cutoff_time = int(time.time()) - (days * 24 * 60 * 60)
 
+    # last_creation_yaml / last_creation_command hold the full task YAML and
+    # launch command for each history row. In aggregate these are by far the
+    # largest columns (a 30-day report can span thousands of clusters), yet
+    # only targeted by-hash / by-name lookups (e.g. a single cluster's detail
+    # view) actually read them. Bulk reports such as `sky cost-report` and the
+    # dashboard history list never use them, so fetch them only for filtered
+    # queries to avoid loading every cluster's YAML into memory.
+    include_creation_yaml = (not abbreviate_response and
+                             (cluster_hashes is not None or
+                              cluster_names is not None))
+
     with orm.Session(engine) as session:
-        # Explicitly select columns from both tables to avoid ambiguity
-        if abbreviate_response:
-            query = session.query(
-                cluster_history_table.c.cluster_hash,
-                cluster_history_table.c.name, cluster_history_table.c.num_nodes,
-                cluster_history_table.c.launched_resources,
-                cluster_history_table.c.usage_intervals,
-                cluster_history_table.c.user_hash,
-                cluster_history_table.c.workspace.label('history_workspace'),
-                cluster_history_table.c.last_activity_time,
-                cluster_history_table.c.launched_at,
-                cluster_history_table.c.node_names, cluster_table.c.status,
-                cluster_table.c.workspace)
-        else:
-            query = session.query(
-                cluster_history_table.c.cluster_hash,
-                cluster_history_table.c.name, cluster_history_table.c.num_nodes,
-                cluster_history_table.c.launched_resources,
-                cluster_history_table.c.usage_intervals,
-                cluster_history_table.c.user_hash,
+        # Explicitly select columns from both tables to avoid ambiguity.
+        selected_columns = [
+            cluster_history_table.c.cluster_hash,
+            cluster_history_table.c.name,
+            cluster_history_table.c.num_nodes,
+            cluster_history_table.c.launched_resources,
+            cluster_history_table.c.usage_intervals,
+            cluster_history_table.c.user_hash,
+            cluster_history_table.c.workspace.label('history_workspace'),
+            cluster_history_table.c.last_activity_time,
+            cluster_history_table.c.launched_at,
+            cluster_history_table.c.node_names,
+            cluster_table.c.status,
+            cluster_table.c.workspace,
+        ]
+        if include_creation_yaml:
+            selected_columns.extend([
                 cluster_history_table.c.last_creation_yaml,
                 cluster_history_table.c.last_creation_command,
-                cluster_history_table.c.workspace.label('history_workspace'),
-                cluster_history_table.c.last_activity_time,
-                cluster_history_table.c.launched_at,
-                cluster_history_table.c.node_names, cluster_table.c.status,
-                cluster_table.c.workspace)
+            ])
+        query = session.query(*selected_columns)
 
         query = query.select_from(
             cluster_history_table.join(cluster_table,
@@ -2499,7 +2504,7 @@ def get_clusters_from_history(
             'last_event': last_event,
             'node_names': common_utils.get_display_node_names(row.node_names),
         }
-        if not abbreviate_response:
+        if include_creation_yaml:
             record['last_creation_yaml'] = row.last_creation_yaml
             record['last_creation_command'] = row.last_creation_command
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2507,6 +2507,13 @@ def get_clusters_from_history(
         if include_creation_yaml:
             record['last_creation_yaml'] = row.last_creation_yaml
             record['last_creation_command'] = row.last_creation_command
+        elif not abbreviate_response:
+            # Preserve the dict schema for non-abbreviated callers: these keys
+            # were always present (possibly None) before we stopped fetching
+            # the heavy columns on bulk paths. The columns were not selected
+            # here, so this is None at zero memory cost.
+            record['last_creation_yaml'] = None
+            record['last_creation_command'] = None
 
         records.append(record)
 

--- a/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
@@ -102,3 +102,33 @@ def test_history_excludes_managed_after_termination(tmp_path, monkeypatch):
         'regular', 'my-job-1'
     }
     assert _history_names(exclude_managed_clusters=True) == {'regular'}
+
+
+def test_creation_yaml_only_fetched_for_filtered_queries(tmp_path, monkeypatch):
+    """last_creation_yaml / last_creation_command are the largest history
+    columns and are only consumed by targeted by-hash / by-name lookups
+    (single-cluster detail views). Bulk reports (cost report, history list)
+    must omit them so the query does not load every cluster's YAML.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('regular', is_managed=False)
+
+    # Bulk (unfiltered) report: heavy YAML / command columns are not fetched.
+    bulk = global_user_state.get_clusters_from_history()
+    assert bulk, 'expected at least one history record'
+    assert all('last_creation_yaml' not in r for r in bulk)
+    assert all('last_creation_command' not in r for r in bulk)
+
+    # Targeted lookup by hash: the full record (incl. YAML) is returned.
+    cluster_hash = bulk[0]['cluster_hash']
+    by_hash = global_user_state.get_clusters_from_history(
+        cluster_hashes=[cluster_hash])
+    assert by_hash
+    assert all('last_creation_yaml' in r for r in by_hash)
+    assert all('last_creation_command' in r for r in by_hash)
+
+    # Targeted lookup by name also returns the full record.
+    by_name = global_user_state.get_clusters_from_history(
+        cluster_names=['regular'])
+    assert by_name
+    assert all('last_creation_yaml' in r for r in by_name)

--- a/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_history_managed.py
@@ -106,18 +106,32 @@ def test_history_excludes_managed_after_termination(tmp_path, monkeypatch):
 
 def test_creation_yaml_only_fetched_for_filtered_queries(tmp_path, monkeypatch):
     """last_creation_yaml / last_creation_command are the largest history
-    columns and are only consumed by targeted by-hash / by-name lookups
-    (single-cluster detail views). Bulk reports (cost report, history list)
-    must omit them so the query does not load every cluster's YAML.
+    columns and are only *fetched* from the DB for targeted by-hash / by-name
+    lookups (single-cluster detail views). Bulk reports (cost report, history
+    list) must not load every cluster's YAML.
+
+    The non-abbreviated dict schema is preserved regardless: the keys remain
+    present (None) on bulk non-abbreviated queries so existing callers do not
+    hit a KeyError; they are only dropped entirely for abbreviated responses,
+    matching the pre-existing behavior.
     """
     _fresh_db(tmp_path, monkeypatch)
     _add_cluster('regular', is_managed=False)
 
-    # Bulk (unfiltered) report: heavy YAML / command columns are not fetched.
+    # Bulk (unfiltered) non-abbreviated report: heavy columns are not fetched,
+    # but the keys remain present (None) to keep the dict schema stable.
     bulk = global_user_state.get_clusters_from_history()
     assert bulk, 'expected at least one history record'
-    assert all('last_creation_yaml' not in r for r in bulk)
-    assert all('last_creation_command' not in r for r in bulk)
+    assert all(r['last_creation_yaml'] is None for r in bulk)
+    assert all(r['last_creation_command'] is None for r in bulk)
+
+    # Abbreviated bulk report (dashboard summary): keys are omitted entirely,
+    # as before.
+    abbreviated = global_user_state.get_clusters_from_history(
+        abbreviate_response=True)
+    assert abbreviated
+    assert all('last_creation_yaml' not in r for r in abbreviated)
+    assert all('last_creation_command' not in r for r in abbreviated)
 
     # Targeted lookup by hash: the full record (incl. YAML) is returned.
     cluster_hash = bulk[0]['cluster_hash']


### PR DESCRIPTION
## Summary

`get_clusters_from_history` fetched `last_creation_yaml` and `last_creation_command` (the full task YAML and launch command) for every row on the non-abbreviated path. Only targeted by-hash / by-name lookups (single-cluster detail views) actually read these fields; bulk callers — `sky cost-report` and the dashboard cluster-history list — loaded the YAML for every historical cluster and then discarded it. On a history table with several thousand rows this is the dominant memory cost of the query (the YAML strings far outweigh every other column combined).

This change fetches `last_creation_yaml` / `last_creation_command` only for filtered (by hash or name) queries, which are exactly the lookups that display them. Bulk reports now skip the columns entirely. The dashboard single-cluster detail view (which calls the endpoint with `cluster_hashes` / `cluster_names`) is unaffected.

## Test plan

- Added unit test `test_creation_yaml_only_fetched_for_filtered_queries`: an unfiltered report omits both fields; by-hash and by-name lookups return them.
- `pytest tests/unit_tests/test_sky/test_global_user_state_history_managed.py tests/unit_tests/test_sky/test_cost_report.py tests/unit_tests/test_sky/utils/test_cost_report_controllers.py tests/unit_tests/test_sky/test_global_user_state_batched_clusters.py` all pass.

## Verification

Measured `get_clusters_from_history` over a history table with ~5k rows (30-day window), running the query both with and without the YAML columns and recording peak RSS delta plus the top `tracemalloc` allocation:

| Query | Peak RSS delta | Top allocation |
| --- | --- | --- |
| Before (fetch `last_creation_yaml`) | +422 MiB | 195 MiB buffering the YAML column (SQLAlchemy cursor) |
| After (skip it on the bulk path) | ~0 MiB | 4.7 MiB |

The raw `last_creation_yaml` payload across all rows was ~215 MiB, previously loaded and discarded on every bulk report. This is the single dominant chunk of the bulk-query memory and the change removes it. (The full `sky cost-report` flow additionally deserializes resources and computes cost per row; that is out of scope for this PR.)
