### PR TITLE
[Docker] Bump base image to Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Install Google Cloud SDK using APT
-FROM python:3.10.19-slim AS gcloud-apt-install
+FROM python:3.11-slim AS gcloud-apt-install
 
 # Keep in sync with _GCLOUD_VERSION in sky/clouds/gcp.py. Pinned so the apt
 # install layer doesn't bake in a stale version via buildx registry caching
@@ -24,7 +24,7 @@ RUN apt-get update && \
 
 
 # Stage 2: Process the source code for INSTALL_FROM_SOURCE
-FROM python:3.10.19-slim AS process-source
+FROM python:3.11-slim AS process-source
 
 # Control installation method - default to install from source
 ARG INSTALL_FROM_SOURCE=true
@@ -75,7 +75,7 @@ RUN cd /skypilot && \
 
 
 # Stage 3: Main image
-FROM python:3.10.19-slim
+FROM python:3.11-slim
 
 ARG INSTALL_FROM_SOURCE=true
 


### PR DESCRIPTION
## Summary

Bump the release Docker image base from `python:3.10.19-slim` to `python:3.11-slim` (all three build stages).

Motivation: the API server's guaranteed executor workers live for the lifetime of the process, so their RSS only grows to the high-water mark of the heaviest request handled and is never reclaimed. #9964 adds opt-in worker recycling via `ProcessPoolExecutor`'s `max_tasks_per_child`, which only exists on **Python 3.11+** — on 3.10 it is a no-op. Moving the released image to 3.11 lets deployments actually use that knob, and picks up 3.11 interpreter performance improvements.

SkyPilot already advertises support for Python 3.11–3.13 (`setup.py` classifiers), and the dev image (`dev/...`) already runs `python:3.11-slim`, so 3.11 is a well-exercised target.

## Test plan

- CI builds the Docker image on this base; the existing unit/smoke suites already run under Python 3.11.
- Verified no other 3.10-specific references remain in the `Dockerfile` (only the three `FROM` lines referenced the interpreter).
