### PR TITLE
[Jobs] Add on_before_recovery runtime hook

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4681,12 +4681,18 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         else:
             logger.info('No jobs cancelled. They may be in terminal states.')
 
-    def sync_down_logs(
-            self,
-            handle: CloudVmRayResourceHandle,
-            job_ids: Optional[List[str]],
-            local_dir: str = constants.SKY_LOGS_DIRECTORY) -> Dict[str, str]:
+    def sync_down_logs(self,
+                       handle: CloudVmRayResourceHandle,
+                       job_ids: Optional[List[str]],
+                       local_dir: str = constants.SKY_LOGS_DIRECTORY,
+                       head_only: bool = False) -> Dict[str, str]:
         """Sync down logs for the given job_ids.
+
+        Args:
+            head_only: if True, rsync only from the head node. The head's
+                ``run.log`` already aggregates every node's task output, so
+                this captures the full log without touching workers -- which
+                may be unreachable (e.g. a node died, triggering recovery).
 
         Returns:
             A dictionary mapping job_id to log path.
@@ -4762,6 +4768,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             local_log_dirs.append(local_log_dir)
 
         runners = handle.get_command_runners()
+        if head_only:
+            # Head's run.log already aggregates all nodes' output; rsyncing
+            # only the head avoids exec-ing into workers that may be gone.
+            runners = runners[:1]
 
         def _rsync_down(args) -> None:
             """Rsync down logs from remote nodes.

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -604,6 +604,23 @@ function JobDetails() {
                         ))}
                       </SelectContent>
                     </Select>
+                    {/* Slot for plugins to add extra log filters beside the
+                        node picker. jobId/taskId mirror the jobs.detail.logs
+                        context exactly (the per-task object's id for
+                        multi-task jobs) so a plugin can key shared state on
+                        the same identity as the log pane below. */}
+                    <PluginSlot
+                      name="jobs.detail.logfilters"
+                      context={{
+                        jobId: (isMultiTask
+                          ? allTasks[selectedTaskIndex]
+                          : detailJobData
+                        )?.id,
+                        taskId: isMultiTask ? selectedTaskIndex : null,
+                        isController: false,
+                        refreshTrigger: refreshLogsFlag,
+                      }}
+                    />
                     {!logsSlotHasPlugin && (
                       <span className="text-xs text-gray-500">
                         (Logs are not streaming; click refresh to fetch the

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1087,6 +1087,17 @@ class JobController:
                             'unrecoverable error. Try to recover the job by'
                             ' restarting the job/cluster.')
 
+            # Before tearing down or relaunching, give the runtime a chance
+            # to capture the about-to-be-lost run's logs while the cluster
+            # is (best-effort) still reachable. Side-effecting and best-
+            # effort: a failure here must never block recovery.
+            try:
+                managed_job_runtime.on_before_recovery(handle, self._backend,
+                                                       self._job_id, task_id)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning('on_before_recovery hook failed (continuing '
+                               f'recovery): {e}')
+
             # When the handle is None, the cluster should be cleaned up already.
             if handle is not None:
                 resources = handle.launched_resources

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1088,15 +1088,16 @@ class JobController:
                             ' restarting the job/cluster.')
 
             # Before tearing down or relaunching, give the runtime a chance
-            # to capture the about-to-be-lost run's logs while the cluster
-            # is (best-effort) still reachable. Side-effecting and best-
-            # effort: a failure here must never block recovery.
-            try:
-                managed_job_runtime.on_before_recovery(handle, self._backend,
-                                                       self._job_id, task_id)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.warning('on_before_recovery hook failed (continuing '
-                               f'recovery): {e}')
+            # to capture the about-to-be-lost run's logs. Side-effecting
+            # and best-effort: a failure here must never block recovery.
+            if managed_job_runtime.is_registered():
+                try:
+                    await asyncio.to_thread(
+                        managed_job_runtime.on_before_recovery, handle,
+                        self._backend, self._job_id, task_id)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning('on_before_recovery hook failed (continuing '
+                                   f'recovery): {e}')
 
             # When the handle is None, the cluster should be cleaned up already.
             if handle is not None:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -762,6 +762,11 @@ class JobController:
             # Get job status (skip on first iteration if forcing recovery)
             job_status = None
             transient_job_check_error_reason = None
+            # Per-node exit codes of the failed run, populated only when
+            # recovery is triggered by a job failure (not an infra-level
+            # failure like preemption). Reset each iteration so a stale
+            # value never leaks into the on_before_recovery hook.
+            exit_codes: Optional[List[int]] = None
 
             if not force_transit_to_recovering:
                 await asyncio.sleep(
@@ -1094,7 +1099,7 @@ class JobController:
                 try:
                     await asyncio.to_thread(
                         managed_job_runtime.on_before_recovery, handle,
-                        self._backend, self._job_id, task_id)
+                        self._backend, self._job_id, task_id, exit_codes)
                 except Exception as e:  # pylint: disable=broad-except
                     logger.warning('on_before_recovery hook failed (continuing '
                                    f'recovery): {e}')

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1099,7 +1099,8 @@ class JobController:
                 try:
                     await asyncio.to_thread(
                         managed_job_runtime.on_before_recovery, handle,
-                        self._backend, self._job_id, task_id, exit_codes)
+                        self._backend, self._job_id, task_id, exit_codes,
+                        job_id_on_pool_cluster)
                 except Exception as e:  # pylint: disable=broad-except
                     logger.warning('on_before_recovery hook failed (continuing '
                                    f'recovery): {e}')

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -80,6 +80,23 @@ class ManagedJobRuntime(Protocol):
         """Download logs to a local file. Returns the path or None."""
         ...
 
+    def on_before_recovery(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        backend: 'backends.CloudVmRayBackend',
+        job_id: int,
+        task_id: Optional[int],
+    ) -> None:
+        """Hook invoked just before a managed job recovers.
+
+        Called from the controller's recovery branch before the failing
+        cluster is torn down or relaunched, while it is (best-effort)
+        still reachable -- so a runtime can snapshot the about-to-be-lost
+        run's logs. Side-effecting; the return value is ignored, and the
+        caller swallows exceptions so a failure here never blocks
+        recovery."""
+        ...
+
     def tail_logs(
         self,
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
@@ -196,6 +213,22 @@ def download_logs(
     if _current is None:
         return None
     return _current.download_logs(handle, job_id, task_id)
+
+
+def on_before_recovery(
+    handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+    backend: 'backends.CloudVmRayBackend',
+    job_id: int,
+    task_id: Optional[int],
+) -> None:
+    if _current is None:
+        return
+    # Defensive: a runtime registered by an older plugin build may not
+    # implement this hook. Skip rather than crash on version skew.
+    hook = getattr(_current, 'on_before_recovery', None)
+    if hook is None:
+        return
+    hook(handle, backend, job_id, task_id)
 
 
 def tail_logs(

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -90,11 +90,11 @@ class ManagedJobRuntime(Protocol):
         """Hook invoked just before a managed job recovers.
 
         Called from the controller's recovery branch before the failing
-        cluster is torn down or relaunched, while it is (best-effort)
-        still reachable -- so a runtime can snapshot the about-to-be-lost
-        run's logs. Side-effecting; the return value is ignored, and the
-        caller swallows exceptions so a failure here never blocks
-        recovery."""
+        cluster is torn down or relaunched. The cluster may already be
+        unreachable when this fires; implementations must handle a
+        ``None`` handle and network timeouts gracefully. Side-effecting;
+        the return value is ignored, and the caller swallows exceptions
+        so a failure here never blocks recovery."""
         ...
 
     def tail_logs(
@@ -228,7 +228,7 @@ def on_before_recovery(
     hook = getattr(_current, 'on_before_recovery', None)
     if hook is None:
         return
-    hook(handle, backend, job_id, task_id)
+    hook(handle, backend, job_id, task_id)  # pylint: disable=not-callable
 
 
 def tail_logs(

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -86,15 +86,19 @@ class ManagedJobRuntime(Protocol):
         backend: 'backends.CloudVmRayBackend',
         job_id: int,
         task_id: Optional[int],
+        exit_codes: Optional[List[int]] = None,
     ) -> None:
         """Hook invoked just before a managed job recovers.
 
         Called from the controller's recovery branch before the failing
         cluster is torn down or relaunched. The cluster may already be
         unreachable when this fires; implementations must handle a
-        ``None`` handle and network timeouts gracefully. Side-effecting;
-        the return value is ignored, and the caller swallows exceptions
-        so a failure here never blocks recovery."""
+        ``None`` handle and network timeouts gracefully. ``exit_codes``
+        carries the failed run's per-node exit codes when recovery was
+        triggered by a job failure (``None`` for an infra-level failure
+        such as preemption). Side-effecting; the return value is ignored,
+        and the caller swallows exceptions so a failure here never blocks
+        recovery."""
         ...
 
     def tail_logs(
@@ -220,6 +224,7 @@ def on_before_recovery(
     backend: 'backends.CloudVmRayBackend',
     job_id: int,
     task_id: Optional[int],
+    exit_codes: Optional[List[int]] = None,
 ) -> None:
     if _current is None:
         return
@@ -228,7 +233,12 @@ def on_before_recovery(
     hook = getattr(_current, 'on_before_recovery', None)
     if hook is None:
         return
-    hook(handle, backend, job_id, task_id)  # pylint: disable=not-callable
+    hook(  # pylint: disable=not-callable
+        handle,
+        backend,
+        job_id,
+        task_id,
+        exit_codes=exit_codes)
 
 
 def tail_logs(

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -87,6 +87,7 @@ class ManagedJobRuntime(Protocol):
         job_id: int,
         task_id: Optional[int],
         exit_codes: Optional[List[int]] = None,
+        job_id_on_pool_cluster: Optional[int] = None,
     ) -> None:
         """Hook invoked just before a managed job recovers.
 
@@ -96,9 +97,12 @@ class ManagedJobRuntime(Protocol):
         ``None`` handle and network timeouts gracefully. ``exit_codes``
         carries the failed run's per-node exit codes when recovery was
         triggered by a job failure (``None`` for an infra-level failure
-        such as preemption). Side-effecting; the return value is ignored,
-        and the caller swallows exceptions so a failure here never blocks
-        recovery."""
+        such as preemption). ``job_id_on_pool_cluster`` is the job's id on
+        the (possibly shared) pool cluster; pass it through to log
+        downloads so a pool cluster running multiple jobs returns this
+        job's log and not another's. Side-effecting; the return value is
+        ignored, and the caller swallows exceptions so a failure here
+        never blocks recovery."""
         ...
 
     def tail_logs(
@@ -225,6 +229,7 @@ def on_before_recovery(
     job_id: int,
     task_id: Optional[int],
     exit_codes: Optional[List[int]] = None,
+    job_id_on_pool_cluster: Optional[int] = None,
 ) -> None:
     if _current is None:
         return
@@ -238,7 +243,8 @@ def on_before_recovery(
         backend,
         job_id,
         task_id,
-        exit_codes=exit_codes)
+        exit_codes=exit_codes,
+        job_id_on_pool_cluster=job_id_on_pool_cluster)
 
 
 def tail_logs(


### PR DESCRIPTION
## Summary

Adds extension points so a registered managed-jobs runtime can preserve a
recovering job's logs before its cluster is torn down, plus a dashboard slot to
surface them. When a managed job recovers, its previous run's logs are otherwise
lost with the replaced cluster; these hooks let a runtime snapshot them first.

Changes:

1. **`on_before_recovery` hook.** New
   `ManagedJobRuntime.on_before_recovery(handle, backend, job_id, task_id, exit_codes, job_id_on_pool_cluster)`
   protocol method + a module-level dispatch in `sky/jobs/runtime.py`. The
   controller (`sky/jobs/controller.py`) invokes it in `_monitor_one_task`'s
   recovery branch — before cleanup/relaunch, while the cluster is (best-effort)
   still reachable — via `asyncio.to_thread` (so the blocking log I/O never
   stalls the event loop) and gated on `is_registered()`.
   - `exit_codes`: the failed run's per-node exit codes (when recovery was
     triggered by a job failure), so the hook can record why each node exited.
   - `job_id_on_pool_cluster`: disambiguates which job's logs to pull on a
     shared pool cluster.

2. **`sync_down_logs(head_only=...)`.** `CloudVmRayBackend.sync_down_logs` gains
   a `head_only` option to rsync only the head node's `run.log` (which already
   aggregates every node's output via the runtime's log streaming). During a
   multi-node recovery a node is often already gone, and the all-node fan-out
   exec's into every node — so one unreachable node aborts the whole download.
   Head-only sidesteps that and still yields the full aggregated log.

3. **`jobs.detail.logfilters` dashboard slot.** A `PluginSlot` beside the log
   node picker so a plugin can contribute extra log filters, keyed on the same `jobId`/`taskId`
   context as the log pane.

Defensive: the dispatch skips runtimes predating the hook, and the controller
swallows hook exceptions so a failure never blocks recovery. No behavior change
on the default OSS path (no runtime registered) or for runtimes that don't
implement the hook.

## Test plan

- Existing managed-jobs unit tests pass.
- Verified the dispatch is a no-op with no runtime registered and under version
  skew (runtime lacking the method), and fires once per recovery otherwise.
- Verified `head_only` rsyncs only the head node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
