### PR TITLE
[Core] Mark non-security MD5/SHA1 hashes with usedforsecurity=False

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -707,7 +707,8 @@ def get_expirable_clouds(
 
 
 def _get_volume_name(path: str, cluster_name_on_cloud: str) -> str:
-    path_hash = hashlib.md5(path.encode()).hexdigest()[:6]
+    path_hash = hashlib.md5(path.encode(),
+                            usedforsecurity=False).hexdigest()[:6]
     return f'{cluster_name_on_cloud}-{path_hash}'
 
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -210,7 +210,8 @@ def _build_sky_wheel() -> pathlib.Path:
         # wheel content hash doesn't change.
         with open(wheel_path, 'rb') as f:
             contents = f.read()
-        hash_of_latest_wheel = hashlib.md5(contents).hexdigest()
+        hash_of_latest_wheel = hashlib.md5(contents,
+                                           usedforsecurity=False).hexdigest()
 
         wheel_dir = WHEEL_DIR / hash_of_latest_wheel
         wheel_dir.mkdir(parents=True, exist_ok=True)

--- a/sky/batch/io_formats.py
+++ b/sky/batch/io_formats.py
@@ -236,7 +236,8 @@ class JsonReader(InputReader):
 
     def download_batch(self, start_idx: int, end_idx: int,
                        cache_dir: str) -> List[Dict[str, Any]]:
-        path_hash = hashlib.md5(self.path.encode()).hexdigest()
+        path_hash = hashlib.md5(self.path.encode(),
+                                usedforsecurity=False).hexdigest()
         cache_path = os.path.join(cache_dir, f'dataset_{path_hash}.jsonl')
 
         if not os.path.exists(cache_path):

--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -113,7 +113,8 @@ def _get_az_mappings(aws_user_hash: str) -> Optional['pd.DataFrame']:
         # Write md5 of the az_mapping file to a file so we can check it for
         # any changes when uploading to the controller
         with open(az_mapping_path, 'r', encoding='utf-8') as f:
-            az_mapping_hash = hashlib.md5(f.read().encode()).hexdigest()
+            az_mapping_hash = hashlib.md5(f.read().encode(),
+                                          usedforsecurity=False).hexdigest()
         with open(az_mapping_md5_path, 'w', encoding='utf-8') as f:
             f.write(az_mapping_hash)
     else:
@@ -147,7 +148,8 @@ def _fetch_and_apply_az_mapping(df: common.LazyDataFrame) -> 'pd.DataFrame':
         user_identity_list = aws.AWS.get_active_user_identity()
         assert user_identity_list, user_identity_list
         user_identity = user_identity_list[0]
-        aws_user_hash = hashlib.md5(user_identity.encode()).hexdigest()[:8]
+        aws_user_hash = hashlib.md5(user_identity.encode(),
+                                    usedforsecurity=False).hexdigest()[:8]
     except (exceptions.CloudUserIdentityError, ImportError):
         # If failed to get user identity, or import aws dependencies, we use the
         # latest mapping file or the default mapping file.

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -291,7 +291,9 @@ def read_catalog(filename: str,
                         tmp_path = f.name
                     os.rename(tmp_path, catalog_path)
                     with open(meta_path + '.md5', 'w', encoding='utf-8') as f:
-                        f.write(hashlib.md5(r.text.encode()).hexdigest())
+                        f.write(
+                            hashlib.md5(r.text.encode(),
+                                        usedforsecurity=False).hexdigest())
             logger.debug(f'Updated {cloud} catalog {filename}.')
         return True
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1347,7 +1347,7 @@ class AWS(clouds.Cloud):
             # - aws credentials are not set, proceed anyway to get unified error
             #   message for users
             return cls._sts_get_caller_identity()
-        config_hash = hashlib.md5(stdout).hexdigest()[:8]
+        config_hash = hashlib.md5(stdout, usedforsecurity=False).hexdigest()[:8]
         # Getting aws identity cost ~1s, so we cache the result with the output of
         # `aws configure list` as cache key. Different `aws configure list` output
         # can have same aws identity, our assumption is the output would be stable

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -72,7 +72,8 @@ def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
     umask would otherwise lock the other user out.
     """
     uid = os.getuid() if hasattr(os, 'getuid') else 'default'
-    digest = hashlib.sha1(value.encode('utf-8')).hexdigest()[:16]
+    digest = hashlib.sha1(value.encode('utf-8'),
+                          usedforsecurity=False).hexdigest()[:16]
     path = os.path.join(tempfile.gettempdir(), f'{prefix}{uid}-{digest}')
     expected = value + '\n'
     try:

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -714,7 +714,8 @@ def get_mount_cached_cmd(
     # This is because the full path may be longer than
     # the filename length limit.
     # The hash is a non-negative integer in string form.
-    hashed_mount_path = hashlib.md5(mount_path.encode()).hexdigest()
+    hashed_mount_path = hashlib.md5(mount_path.encode(),
+                                    usedforsecurity=False).hexdigest()
     log_file_path = os.path.join(constants.RCLONE_MOUNT_CACHED_LOG_DIR,
                                  f'{hashed_mount_path}.log')
     create_log_cmd = (f'mkdir -p {constants.RCLONE_MOUNT_CACHED_LOG_DIR} && '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3367,10 +3367,12 @@ class AzureBlobStore(AbstractStore):
         """
         assert region is not None
         subscription_id = azure.get_subscription_id()
-        subscription_hash_obj = hashlib.md5(subscription_id.encode('utf-8'))
+        subscription_hash_obj = hashlib.md5(subscription_id.encode('utf-8'),
+                                            usedforsecurity=False)
         subscription_hash = subscription_hash_obj.hexdigest(
         )[:AzureBlobStore._SUBSCRIPTION_HASH_LENGTH]
-        region_hash_obj = hashlib.md5(region.encode('utf-8'))
+        region_hash_obj = hashlib.md5(region.encode('utf-8'),
+                                      usedforsecurity=False)
         region_hash = region_hash_obj.hexdigest()[:AzureBlobStore.
                                                   _REGION_HASH_LENGTH]
 

--- a/sky/provision/azure/config.py
+++ b/sky/provision/azure/config.py
@@ -44,7 +44,7 @@ def get_azure_sdk_function(client: Any, function_name: str) -> Callable:
 
 def get_cluster_id_and_nsg_name(resource_group: str,
                                 cluster_name_on_cloud: str) -> Tuple[str, str]:
-    hasher = hashlib.md5(resource_group.encode('utf-8'))
+    hasher = hashlib.md5(resource_group.encode('utf-8'), usedforsecurity=False)
     unique_id = hasher.hexdigest()[:UNIQUE_ID_LEN]
     # We use the cluster name + resource group hash as the
     # unique ID for the cluster, as we need to make sure that

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -5085,7 +5085,8 @@ def format_kubeconfig_exec_auth_with_cache(kubeconfig_path: str) -> str:
     with open(kubeconfig_path, 'r', encoding='utf-8') as file:
         config = yaml_utils.safe_load(file)
     normalized = yaml.dump(config, sort_keys=True)
-    hashed = hashlib.sha1(normalized.encode('utf-8')).hexdigest()
+    hashed = hashlib.sha1(normalized.encode('utf-8'),
+                          usedforsecurity=False).hexdigest()
     path = os.path.expanduser(
         f'{kubernetes_constants.SKY_K8S_EXEC_AUTH_KUBECONFIG_CACHE}/{hashed}.yaml'
     )

--- a/sky/provision/scp/instance.py
+++ b/sky/provision/scp/instance.py
@@ -223,7 +223,7 @@ def _worker(cluster_name_on_cloud: str):
 
 
 def _suffix(name: str, n: int = 5):
-    return hashlib.sha1(name.encode()).hexdigest()[:n]
+    return hashlib.sha1(name.encode(), usedforsecurity=False).hexdigest()[:n]
 
 
 def _get_instance_id(instance_name, cluster_name_on_cloud):

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -204,8 +204,11 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         """Extract user info from OAuth2 proxy response headers."""
         email_header = response.headers.get('X-Auth-Request-Email')
         if email_header:
-            user_hash = hashlib.md5(email_header.encode()).hexdigest(
-            )[:common_utils.USER_HASH_LENGTH]
+            # MD5 only derives a stable user id from the (non-secret) SSO
+            # email; auth itself is done by oauth2-proxy. Not a security use.
+            user_hash = hashlib.md5(email_header.encode(),
+                                    usedforsecurity=False).hexdigest(
+                                    )[:common_utils.USER_HASH_LENGTH]
             return models.User(id=user_hash,
                                name=email_header,
                                user_type=models.UserType.SSO.value)

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -206,9 +206,9 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         if email_header:
             # MD5 only derives a stable user id from the (non-secret) SSO
             # email; auth itself is done by oauth2-proxy. Not a security use.
-            user_hash = hashlib.md5(email_header.encode(),
-                                    usedforsecurity=False).hexdigest(
-                                    )[:common_utils.USER_HASH_LENGTH]
+            email_hash = hashlib.md5(email_header.encode(),
+                                     usedforsecurity=False).hexdigest()
+            user_hash = email_hash[:common_utils.USER_HASH_LENGTH]
             return models.User(id=user_hash,
                                name=email_header,
                                user_type=models.UserType.SSO.value)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -282,8 +282,11 @@ def _extract_user_from_header(
     if not user_name:
         return None
 
+    # MD5 only derives a stable user id from the (non-secret) user name;
+    # not a security use.
     user_hash = hashlib.md5(
-        user_name.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
+        user_name.encode(),
+        usedforsecurity=False).hexdigest()[:common_utils.USER_HASH_LENGTH]
     if proxy_config.enabled:
         return models.User(id=user_hash,
                            name=user_name,

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -182,8 +182,10 @@ class PermissionService:
             return
         username, password = basic_auth.split(':', 1)
         if username and password:
-            user_hash = hashlib.md5(
-                username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
+            # MD5 only derives a stable user id from the (non-secret)
+            # username; the password is checked separately. Not a security use.
+            user_hash = hashlib.md5(username.encode(), usedforsecurity=False
+                                   ).hexdigest()[:common_utils.USER_HASH_LENGTH]
             user_info = global_user_state.get_user(user_hash)
             if user_info:
                 logger.debug(f'Basic auth user {username} already exists')

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -287,8 +287,12 @@ def user_create(user_create_body: payloads.UserCreateBody) -> None:
 
     # Create user
     password_hash = server_common.crypt_ctx.hash(password)
+    # MD5 here only derives a stable user identifier from the (non-secret)
+    # username; it is not used for any security purpose (passwords use bcrypt
+    # via crypt_ctx).
     user_hash = hashlib.md5(
-        username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
+        username.encode(),
+        usedforsecurity=False).hexdigest()[:common_utils.USER_HASH_LENGTH]
     with _user_lock(user_hash):
         # Check if user already exists
         if global_user_state.get_user_by_name(username):
@@ -627,8 +631,11 @@ def user_import(user_import_body: payloads.UserImportBody) -> Dict[str, Any]:
                 # Password is plain text, hash it
                 password_hash = server_common.crypt_ctx.hash(password)
 
-            user_hash = hashlib.md5(
-                username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
+            # MD5 only derives a stable user identifier from the (non-secret)
+            # username; not a security use (passwords use bcrypt via crypt_ctx).
+            user_hash = hashlib.md5(username.encode(),
+                                    usedforsecurity=False).hexdigest()
+            user_hash = user_hash[:common_utils.USER_HASH_LENGTH]
 
             with _user_lock(user_hash):
                 global_user_state.add_or_update_user(

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -875,8 +875,8 @@ class CommandRunner:
             raise exceptions.CommandError(1, '', error_msg, None)
 
         # Remote script path (use a unique name to avoid conflicts)
-        script_hash = hashlib.md5(
-            f'{self.node_id}_{target_dir}'.encode()).hexdigest()[:8]
+        script_hash = hashlib.md5(f'{self.node_id}_{target_dir}'.encode(),
+                                  usedforsecurity=False).hexdigest()[:8]
         remote_script_path = f'/tmp/sky_git_clone_{script_hash}.sh'
 
         # Step 1: Transfer the script to remote machine using rsync
@@ -992,7 +992,8 @@ class SSHCommandRunner(CommandRunner):
         self.ssh_private_key = ssh_private_key
         self.ssh_control_name = (
             None if ssh_control_name is None else hashlib.md5(
-                ssh_control_name.encode()).hexdigest()[:_HASH_MAX_LENGTH])
+                ssh_control_name.encode(),
+                usedforsecurity=False).hexdigest()[:_HASH_MAX_LENGTH])
         self._ssh_proxy_command = ssh_proxy_command
         self._ssh_proxy_jump = ssh_proxy_jump
         self.disable_control_master = (

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -91,7 +91,10 @@ def is_valid_user_hash(user_hash: Optional[str]) -> bool:
 def generate_user_hash() -> str:
     """Generates a unique user-machine specific hash."""
     hash_str = user_and_hostname_hash()
-    user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:USER_HASH_LENGTH]
+    # MD5 only derives a stable machine-specific identifier, not a security
+    # use.
+    user_hash = hashlib.md5(
+        hash_str.encode(), usedforsecurity=False).hexdigest()[:USER_HASH_LENGTH]
     if not is_valid_user_hash(user_hash):
         # A fallback in case the hash is invalid.
         user_hash = uuid.uuid4().hex[:USER_HASH_LENGTH]
@@ -297,7 +300,9 @@ def make_cluster_name_on_cloud(display_name: str,
     if truncate_cluster_name.endswith('-'):
         truncate_cluster_name = truncate_cluster_name.rstrip('-')
     assert truncate_cluster_name_length > 0, (cluster_name_on_cloud, max_length)
-    display_name_hash = hashlib.md5(display_name.encode()).hexdigest()
+    # MD5 only derives a short suffix for the cluster name, not a security use.
+    display_name_hash = hashlib.md5(display_name.encode(),
+                                    usedforsecurity=False).hexdigest()
     # Use base36 to reduce the length of the hash.
     display_name_hash = base36_encode(display_name_hash)
     return (f'{truncate_cluster_name}'
@@ -650,7 +655,9 @@ def user_and_hostname_hash() -> str:
     The reason is AWS security group names are derived from this string, and
     thus changing the SG name makes these clusters unrecognizable.
     """
-    hostname_hash = hashlib.md5(socket.gethostname().encode()).hexdigest()[-4:]
+    # MD5 only derives a short hostname suffix, not a security use.
+    hostname_hash = hashlib.md5(socket.gethostname().encode(),
+                                usedforsecurity=False).hexdigest()[-4:]
     return f'{getpass.getuser()}-{hostname_hash}'
 
 

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -71,7 +71,8 @@ def cleanup(context: Optional[str] = None) -> Tuple[bool, str]:
 
 def get_node_hash(node_name: str):
     # Generates a 32 character md5 hash from a string
-    md5_hash = hashlib.md5(node_name.encode()).hexdigest()
+    md5_hash = hashlib.md5(node_name.encode(),
+                           usedforsecurity=False).hexdigest()
     return md5_hash[:32]
 
 


### PR DESCRIPTION
## Summary

- A weak-hash scanner flagged `hashlib.md5(username.encode())` in `sky/users/server.py` (CWE-328). Auditing the codebase, all `hashlib.md5`/`hashlib.sha1` calls fall into the same category: they derive **identifiers, cache keys, and resource names** from non-secret inputs — usernames/emails, file paths, region/subscription ids, cluster/host names, wheel & catalog contents. None of them protects a secret or makes an authentication decision (passwords use bcrypt via `crypt_ctx`; auth is enforced by oauth2-proxy / SSO).
- This passes `usedforsecurity=False` to every such call so scanners (CWE-328) stop flagging them. The flag is purely advisory — it does **not** change the digest output — so every derived user id, cache key, and resource name stays byte-for-byte identical. Zero behavior change, zero backward-compatibility impact.
- The 3 auth-path sites (`oauth2_proxy.py`, `server.py`, `permission.py`) also get a one-line comment clarifying MD5 is only an id label, not the auth mechanism.

`usedforsecurity` is available on Python 3.9+, which matches the project's minimum supported version.

One internal Ray launch-config hash (`sky/backends/monkey_patches/monkey_patch_ray_up.py`) was intentionally left untouched — it's a `.format()` template with placeholder variables that is not user-facing.

## Test plan

- `usedforsecurity=False` produces identical digests, verified:
  ```python
  import hashlib
  for s in ['alice', 'bob@x.com', 'somehost']:
      assert hashlib.md5(s.encode()).hexdigest() == \
             hashlib.md5(s.encode(), usedforsecurity=False).hexdigest()
  ```
- `format.sh` / pre-commit (yapf, isort, mypy, pylint) pass on all changed files.
- No functional change — existing unit tests covering user hashing, storage naming, and command runner paths continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)