### PR TITLE
fix(azure): use azure.mgmt.network.SubResource for IPConfiguration subnet (was compute.SubResource) — unbreaks VM creation

### DIFF
--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -206,7 +206,7 @@ def _create_network_interface(
         name = f'{vm_name}-nic-private'
         ip_config = network.IPConfiguration(
             name=f'ip-config-private-{vm_name}',
-            subnet=compute.SubResource(id=provider_config['subnet']),
+            subnet=network.SubResource(id=provider_config['subnet']),
             private_ip_allocation_method=network.IPAllocationMethod.DYNAMIC)
     else:
         name = f'{vm_name}-nic-public'
@@ -223,7 +223,7 @@ def _create_network_interface(
                     f'with address {ip_poller.result().ip_address}.')
         ip_config = network.IPConfiguration(
             name=f'ip-config-public-{vm_name}',
-            subnet=compute.SubResource(id=provider_config['subnet']),
+            subnet=network.SubResource(id=provider_config['subnet']),
             private_ip_allocation_method=network.IPAllocationMethod.DYNAMIC,
             public_ip_address=network.PublicIPAddress(id=ip_poller.result().id))
 


### PR DESCRIPTION
## Problem

`sky launch --cloud azure` fails at VM creation with `Object of type SubResource is not JSON serializable` when resolved against current/new-generation `azure-mgmt-network` / `azure-mgmt-compute`. This blocks every Azure launch end-to-end.

## Root cause

`sky/provision/azure/instance.py::_create_network_interface` builds a **network** `IPConfiguration` whose `subnet` is a `compute.SubResource` (a model from the **azure-mgmt-compute** package):

```python
network = azure.azure_mgmt_models('network')
compute = azure.azure_mgmt_models('compute')
ip_config = network.IPConfiguration(
    name=...,
    subnet=compute.SubResource(id=provider_config['subnet']),   # cross-package model
    ...)
network_client.network_interfaces.begin_create_or_update(
    parameters=network.NetworkInterface(..., ip_configurations=[ip_config], ...))
```

The network SDK serializes the `NetworkInterface` body. With new-gen `azure-mgmt-network` (>=~25.x; reproducible with `31.0.0b1`) serialization goes through stdlib `json`, which has no encoder for a `compute.SubResource` nested in a network model → `TypeError`. It was latent under the older msrest-era SDKs. `azure-mgmt-compute==33.0.0` + `azure-mgmt-network==31.0.0b1` (what a fresh `pip install skypilot[azure]` resolves today) expose it. `azure-cli` version is irrelevant (confirmed: pinning `azure-cli<2.70` → 2.69.0 does not fix it).

## Fix

Use the network SDK's **own** `SubResource` — same package as `IPConfiguration`, serializes natively. `network` is already bound in the function, so this is a 2-line, drop-in change (both the internal-IP and public-IP branches).

`network.SubResource` exists in every `azure-mgmt-network` release sky supports, is constructed identically (`id=...`), and round-trips through the serializer (`as_dict()` → `{\id\: \...\}`).

## Reproduction

```bash
uv tool install "skypilot[azure]>=0.12,<0.13" --prerelease=allow   # resolves azure-mgmt-network 31.0.0b1
az login
sky launch --cloud azure --gpus T4:1 -y -- echo ok
# -> Failed to create instances: [TypeError] Object of type SubResource is not JSON serializable
```

Reproduces across every Azure region. Fails pre-VM-creation (no compute spend). After the patch, the VM is created and the cluster comes UP.

## Verification

Live: with the patch applied, `sky launch --cloud azure --gpus T4:1` provisions a `Standard_NC4as_T4_v3`; the NIC (the exact object that failed) is created; cluster reaches UP. (Azure eastus, 2026-06-28.)

## Notes

- `master` carries the same `compute.SubResource` usage (unfixed as of 2026-06-28).
- Independent of `azure-cli`; `skypilot[azure]` pulls `azure-mgmt-*` with floors but no ceilings, so a fresh resolve gets the new-gen SDKs that expose this.
- A downstream tool (mpl) carries the equivalent transform as a post-install patch today; converging upstream lets it retire that divergence.