### PR TITLE
[Jobs] Fix managed-job log GC on PostgreSQL and cover all terminal states

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3366,7 +3366,9 @@ def get_controller_logs_to_clean(retention_seconds: int,
 
     The controller logs will only cleaned when:
     - the job schedule state is DONE
-    - AND the end time of the latest task is older than the retention period
+    - AND either the end time of the latest task is older than the retention
+      period, or the job has no end time at all (it was cancelled before it
+      ever ran, so there is no log to retain)
 
     Unlike task logs, controller logs do not require local_log_file to be set.
     A controller log file is written for every job the controller processes
@@ -3393,11 +3395,18 @@ def get_controller_logs_to_clean(retention_seconds: int,
                     )).group_by(
                         job_info_table.c.spot_job_id,
                         job_info_table.c.current_cluster_name,
-                    ).having(
-                        sqlalchemy.func.max(
-                            spot_table.c.end_at).isnot(None),).having(
-                                sqlalchemy.func.max(spot_table.c.end_at) < (
-                                    now - retention_seconds)).limit(batch_size))
+                    ).
+            having(
+                # A job cancelled while still PENDING (via
+                # set_pending_cancelled) reaches DONE with end_at never
+                # set. It never ran, so it has no controller log to
+                # retain -- clean it immediately. Filtering it out here
+                # instead would leave it forever uncleaned and re-scanned
+                # by the group-by on every GC cycle.
+                sqlalchemy.or_(
+                    sqlalchemy.func.max(spot_table.c.end_at).is_(None),
+                    sqlalchemy.func.max(spot_table.c.end_at) <
+                    (now - retention_seconds))).limit(batch_size))
         rows = result.fetchall()
         return [{'job_id': row[0]} for row in rows]
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3364,6 +3364,15 @@ def get_controller_logs_to_clean(retention_seconds: int,
     The controller logs will only cleaned when:
     - the job schedule state is DONE
     - AND the end time of the latest task is older than the retention period
+
+    Unlike task logs, controller logs do not require local_log_file to be set.
+    A controller log file is written for every job the controller processes
+    (during provisioning, recovery, etc.), regardless of whether the task ever
+    produced a downloaded log. Gating on local_log_file would leave controller
+    logs of jobs that terminate without a downloaded task log -- e.g. those that
+    end as FAILED_CONTROLLER on a controller crash, or are cancelled before the
+    task starts -- uncleaned forever. The DONE schedule state plus a finished
+    end_at is sufficient to know the controller has exited and its log is final.
     """
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
@@ -3377,7 +3386,6 @@ def get_controller_logs_to_clean(retention_seconds: int,
                     sqlalchemy.and_(
                         job_info_table.c.schedule_state.is_(
                             ManagedJobScheduleState.DONE.value),
-                        spot_table.c.local_log_file.isnot(None),
                         job_info_table.c.controller_logs_cleaned_at.is_(None),
                     )).group_by(
                         job_info_table.c.spot_job_id,

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3339,8 +3339,11 @@ def get_task_logs_to_clean(retention_seconds: int,
                 )).
             where(
                 sqlalchemy.and_(
-                    job_info_table.c.schedule_state.is_(
-                        ManagedJobScheduleState.DONE.value),
+                    # Use ==, not .is_(): on PostgreSQL `IS <string>` is a
+                    # syntax error (IS only accepts NULL/TRUE/FALSE), which
+                    # would make the whole GC query raise on every run.
+                    job_info_table.c.schedule_state ==
+                    ManagedJobScheduleState.DONE.value,
                     spot_table.c.end_at.isnot(None),
                     spot_table.c.end_at < (now - retention_seconds),
                     spot_table.c.logs_cleaned_at.is_(None),
@@ -3384,8 +3387,8 @@ def get_controller_logs_to_clean(retention_seconds: int,
                     job_info_table.c.spot_job_id == spot_table.c.spot_job_id,
                 )).where(
                     sqlalchemy.and_(
-                        job_info_table.c.schedule_state.is_(
-                            ManagedJobScheduleState.DONE.value),
+                        job_info_table.c.schedule_state ==
+                        ManagedJobScheduleState.DONE.value,
                         job_info_table.c.controller_logs_cleaned_at.is_(None),
                     )).group_by(
                         job_info_table.c.spot_job_id,

--- a/tests/unit_tests/test_sky/jobs/test_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_state.py
@@ -331,6 +331,51 @@ def test_get_controller_logs_to_clean_basic(_mock_managed_jobs_db_conn):
     assert len(res2) == 2
 
 
+def test_get_controller_logs_to_clean_without_local_log_file(
+        _mock_managed_jobs_db_conn):
+    """Controller logs are cleaned even when no task log was downloaded.
+
+    Jobs that terminate without a downloaded task log -- e.g. those ending as
+    FAILED_CONTROLLER on a controller crash, or cancelled before the task
+    starts -- still have a controller log file on disk. They must be eligible
+    for controller-log GC despite local_log_file being NULL.
+    """
+    now = time.time()
+    retention = 60
+    engine = state._db_manager.get_engine()
+
+    # Job cancelled before the task ran: terminal, old end_at, no local log.
+    job_cancelled = _insert_job_info(engine, controller_logs_cleaned_at=None)
+    _insert_task(
+        engine,
+        job_cancelled,
+        0,
+        status=ManagedJobStatus.CANCELLED,
+        end_at=now - 200,
+        local_log_file=None,
+        logs_cleaned_at=None,
+    )
+    state.scheduler_set_done(job_cancelled)
+
+    # Job that crashed the controller: terminal, old end_at, no local log.
+    job_failed_controller = _insert_job_info(engine,
+                                             controller_logs_cleaned_at=None)
+    _insert_task(
+        engine,
+        job_failed_controller,
+        0,
+        status=ManagedJobStatus.FAILED_CONTROLLER,
+        end_at=now - 150,
+        local_log_file=None,
+        logs_cleaned_at=None,
+    )
+    state.scheduler_set_done(job_failed_controller)
+
+    res = state.get_controller_logs_to_clean(retention, batch_size=10)
+    job_ids = {r['job_id'] for r in res}
+    assert job_ids == {job_cancelled, job_failed_controller}
+
+
 def test_set_controller_logs_cleaned(_mock_managed_jobs_db_conn):
     now = time.time()
 

--- a/tests/unit_tests/test_sky/jobs/test_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_state.py
@@ -286,7 +286,9 @@ def test_get_controller_logs_to_clean_basic(_mock_managed_jobs_db_conn):
     )
     state.scheduler_set_done(job_c)
 
-    # Job D: terminal but end_at is None -> does not qualify
+    # Job D: terminal with end_at None (e.g. cancelled while PENDING) -> still
+    # qualifies, so its controller log row is cleaned rather than re-scanned
+    # forever.
     job_d = _insert_job_info(engine, controller_logs_cleaned_at=None)
     _insert_task(
         engine,
@@ -301,7 +303,7 @@ def test_get_controller_logs_to_clean_basic(_mock_managed_jobs_db_conn):
 
     res = state.get_controller_logs_to_clean(retention, batch_size=10)
     job_ids = {r['job_id'] for r in res}
-    assert job_ids == {job_a}
+    assert job_ids == {job_a, job_d}
 
     # Batch size respected: clone more qualifying jobs
     job_e = _insert_job_info(engine, controller_logs_cleaned_at=None)
@@ -335,23 +337,27 @@ def test_get_controller_logs_to_clean_without_local_log_file(
         _mock_managed_jobs_db_conn):
     """Controller logs are cleaned even when no task log was downloaded.
 
-    Jobs that terminate without a downloaded task log -- e.g. those ending as
-    FAILED_CONTROLLER on a controller crash, or cancelled before the task
-    starts -- still have a controller log file on disk. They must be eligible
-    for controller-log GC despite local_log_file being NULL.
+    Jobs that terminate without a downloaded task log must still be eligible for
+    controller-log GC despite local_log_file being NULL:
+    - FAILED_CONTROLLER on a controller crash: end_at is set, controller log
+      exists on disk.
+    - Cancelled while still PENDING (set_pending_cancelled): end_at is never
+      set, so max(end_at) is NULL; it must be cleaned immediately rather than
+      filtered out and re-scanned forever.
     """
     now = time.time()
     retention = 60
     engine = state._db_manager.get_engine()
 
-    # Job cancelled before the task ran: terminal, old end_at, no local log.
+    # Job cancelled before the task ran: terminal, end_at never set, no local
+    # log (mirrors set_pending_cancelled, which leaves end_at NULL).
     job_cancelled = _insert_job_info(engine, controller_logs_cleaned_at=None)
     _insert_task(
         engine,
         job_cancelled,
         0,
         status=ManagedJobStatus.CANCELLED,
-        end_at=now - 200,
+        end_at=None,
         local_log_file=None,
         logs_cleaned_at=None,
     )


### PR DESCRIPTION
## Summary

Managed-job controller/task log retention (`sky/jobs/log_gc.py`) was not cleaning logs. Two bugs:

1. **GC query raised on PostgreSQL.** Both `get_task_logs_to_clean` and `get_controller_logs_to_clean` compared `schedule_state` with `.is_(ManagedJobScheduleState.DONE.value)`, which renders as `schedule_state IS 'DONE'`. PostgreSQL only allows `IS` with `NULL`/`TRUE`/`FALSE`, so every GC cycle raised `syntax error at or near "'DONE'"` and **no logs were ever cleaned** on PG-backed deployments (for any terminal state). SQLite accepts `IS <string>`, so the existing unit tests never caught it. Fixed by using `==`.

2. **Controller logs of jobs without a downloaded task log were never cleaned.** `get_controller_logs_to_clean` also required `local_log_file IS NOT NULL`. That column is only set when a task log is downloaded (success / user-code failure / cancellation of a running task), so jobs that terminate without one — e.g. ending as `FAILED_CONTROLLER` on a controller crash, or cancelled before the task starts — were excluded forever, even though a per-job controller log file exists on disk for them. `schedule_state == DONE` plus a finished `end_at` is sufficient to know the controller has exited and its log is final. The task-log query keeps the `local_log_file` check (a NULL there means there is no downloaded task log to clean).

## Tested

- [x] Code formatting: `bash format.sh`
- [x] Unit tests: `pytest tests/unit_tests/test_sky/jobs/test_state.py -k logs_to_clean` — existing tests pass; added `test_get_controller_logs_to_clean_without_local_log_file` covering `CANCELLED` / `FAILED_CONTROLLER` jobs with `local_log_file=None`.
- [x] Verified against a Postgres-backed deployment: before the fix, the GC log showed `Error GC controller logs for job: (psycopg2.errors.SyntaxError) syntax error at or near "'DONE'"` on every cycle and `controller_logs_cleaned_at` was unset for all jobs (logs accumulated on disk). The fixed queries (`==`) run without error and select the expected backlog of terminal jobs across all states.