### PR TITLE
[Logs] Add external log read-back hook for tail_logs

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -1430,10 +1430,24 @@ def tail_logs(cluster_name: str,
 
     """
     # Check the status of the cluster.
-    handle = backend_utils.check_cluster_available(
-        cluster_name,
-        operation='tailing logs',
-    )
+    try:
+        handle = backend_utils.check_cluster_available(
+            cluster_name,
+            operation='tailing logs',
+        )
+    except (exceptions.ClusterNotUpError, exceptions.ClusterDoesNotExist):
+        # The cluster is gone; if a log reader is registered, stream the logs
+        # back from the external store instead.
+        from sky import logs  # pylint: disable=import-outside-toplevel
+        reader = logs.get_log_reader()
+        if reader is not None:
+            returncode = reader.read_cluster_job_logs(cluster_name,
+                                                      job_id,
+                                                      follow=follow,
+                                                      tail=tail)
+            if returncode is not None:
+                return returncode
+        raise
     backend = backend_utils.get_backend_from_handle(handle)
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)

--- a/sky/logs/__init__.py
+++ b/sky/logs/__init__.py
@@ -6,6 +6,19 @@ from sky import skypilot_config
 from sky.logs.agent import LoggingAgent
 from sky.logs.aws import CloudwatchLoggingAgent
 from sky.logs.gcp import GCPLoggingAgent
+from sky.logs.reader import get_log_reader
+from sky.logs.reader import LogReader
+from sky.logs.reader import register_log_reader
+
+__all__ = [
+    'LoggingAgent',
+    'CloudwatchLoggingAgent',
+    'GCPLoggingAgent',
+    'LogReader',
+    'get_log_reader',
+    'register_log_reader',
+    'get_logging_agent',
+]
 
 
 def get_logging_agent() -> Optional[LoggingAgent]:

--- a/sky/logs/reader.py
+++ b/sky/logs/reader.py
@@ -1,0 +1,46 @@
+"""Interface for reading job logs back from an external logging store.
+
+When a job's cluster is stopped or terminated, its logs can no longer be read
+from the cluster. If the logs were forwarded to an external store, a registered
+``LogReader`` streams them back. Register one with ``register_log_reader()``.
+"""
+import abc
+from typing import Optional
+
+
+class LogReader(abc.ABC):
+    """Reads job logs back from an external logging store."""
+
+    @abc.abstractmethod
+    def read_cluster_job_logs(self, cluster_name: str, job_id: Optional[int], *,
+                              follow: bool, tail: int) -> Optional[int]:
+        """Streams a cluster job's logs from the external store to stdout.
+
+        Args:
+            cluster_name: The display name of the cluster the job ran on.
+            job_id: The job id, or None for the latest job.
+            follow: Whether to follow the log. An external store is historical,
+                so this may be treated as a no-op.
+            tail: Number of lines from the end to stream; 0 means all.
+
+        Returns:
+            The exit code to report for the job if logs were streamed (matching
+            tail_logs' return value), or None if no logs were produced, in which
+            case the caller raises its original error. A reader that cannot
+            determine the job's status from the store should return 0.
+        """
+        raise NotImplementedError
+
+
+_log_reader: Optional[LogReader] = None
+
+
+def register_log_reader(reader: LogReader) -> None:
+    """Registers the process-global external log reader."""
+    global _log_reader
+    _log_reader = reader
+
+
+def get_log_reader() -> Optional[LogReader]:
+    """Returns the registered external log reader, or None if unset."""
+    return _log_reader

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -113,3 +113,64 @@ class TestEnabledCloudsWorkspacePermission:
              mock.patch('sky.core.skypilot_config.local_active_workspace_ctx'):
             core.enabled_clouds(workspace=None)
         mock_check.assert_not_called()
+
+
+class _FakeLogReader:
+    """A LogReader stub recording its call and returning a fixed exit code."""
+
+    def __init__(self, result) -> None:
+        self.result = result
+        self.calls = []
+
+    def read_cluster_job_logs(self, cluster_name, job_id, *, follow, tail):
+        self.calls.append((cluster_name, job_id, follow, tail))
+        return self.result
+
+
+@mock.patch('sky.backends.backend_utils.check_cluster_available')
+def test_tail_logs_readback_when_cluster_not_up(
+        mock_check_cluster_available) -> None:
+    """When the cluster is not up, the reader's exit code is returned."""
+    mock_check_cluster_available.side_effect = exceptions.ClusterNotUpError(
+        'not up', cluster_status=None)
+    reader = _FakeLogReader(result=0)
+    with mock.patch('sky.logs.get_log_reader', return_value=reader):
+        ret = core.tail_logs('test-cluster', job_id=7, follow=False, tail=10)
+    assert ret == 0
+    assert reader.calls == [('test-cluster', 7, False, 10)]
+
+
+@mock.patch('sky.backends.backend_utils.check_cluster_available')
+def test_tail_logs_readback_propagates_exit_code(
+        mock_check_cluster_available) -> None:
+    """A non-zero exit code from the reader is propagated (not masked)."""
+    mock_check_cluster_available.side_effect = exceptions.ClusterDoesNotExist(
+        'gone')
+    reader = _FakeLogReader(result=100)
+    with mock.patch('sky.logs.get_log_reader', return_value=reader):
+        ret = core.tail_logs('test-cluster', job_id=None, follow=True, tail=0)
+    assert ret == 100
+    assert reader.calls == [('test-cluster', None, True, 0)]
+
+
+@mock.patch('sky.backends.backend_utils.check_cluster_available')
+def test_tail_logs_reraises_when_no_reader(
+        mock_check_cluster_available) -> None:
+    """With no reader registered, the original error is preserved."""
+    mock_check_cluster_available.side_effect = exceptions.ClusterNotUpError(
+        'not up', cluster_status=None)
+    with mock.patch('sky.logs.get_log_reader', return_value=None):
+        with pytest.raises(exceptions.ClusterNotUpError):
+            core.tail_logs('test-cluster', job_id=7)
+
+
+@mock.patch('sky.backends.backend_utils.check_cluster_available')
+def test_tail_logs_reraises_when_reader_finds_nothing(
+        mock_check_cluster_available) -> None:
+    """A reader that returns None falls through to the original error."""
+    mock_check_cluster_available.side_effect = exceptions.ClusterDoesNotExist(
+        'gone')
+    reader = _FakeLogReader(result=None)
+    with mock.patch('sky.logs.get_log_reader', return_value=reader):
+        with pytest.raises(exceptions.ClusterDoesNotExist):
+            core.tail_logs('test-cluster', job_id=7)


### PR DESCRIPTION
Add a `LogReader` interface and a process-global registry in `sky/logs`, mirroring the write-side `LoggingAgent`/`get_logging_agent`. When a job's cluster is stopped or terminated, `core.tail_logs` delegates to a registered reader to stream the logs back from an external store, and falls back to the existing error when no reader is registered. No reader is registered by default, so behavior is unchanged.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): `pytest tests/unit_tests/test_core.py -k tail_logs` (4 passed)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
