### PR TITLE
[Jobs] Support glob patterns in `sky jobs cancel -n`

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -299,7 +299,7 @@ Cancel managed jobs.
 **Options:**
 
 - `--config` — Path to a config file or a single key-value pair. To add multiple key-value pairs add multiple flags (e.g. --config nested.key1=val1 --config nested.key2=val2).
-- `--name`, `-n` — Managed job name to cancel.
+- `--name`, `-n` — Managed job name to cancel. Supports glob patterns, in which case all jobs whose name matches the pattern are cancelled.
 - `--pool`, `-p` — Pool name to cancel.
 - `JOB_IDS` — integer
 - `--graceful` — Wait for MOUNT_CACHED uploads to complete before stopping/terminating. Will cancel current jobs first.

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6297,7 +6297,9 @@ def jobs_queue(verbose: bool,
               '-n',
               required=False,
               type=str,
-              help='Managed job name to cancel.')
+              help='Managed job name to cancel. Supports glob patterns '
+              '(e.g. \'my-job-*\'), in which case all matching jobs are '
+              'cancelled.')
 @click.option('--pool',
               '-p',
               required=False,
@@ -6331,6 +6333,9 @@ def jobs_cancel(
 
       # Cancel managed job with name 'my-job'
       $ sky jobs cancel -n my-job
+      \b
+      # Cancel all managed jobs whose name matches the glob pattern 'my-job-*'
+      $ sky jobs cancel -n 'my-job-*'
       \b
       # Cancel managed jobs with IDs 1, 2, 3
       $ sky jobs cancel 1 2 3

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6297,8 +6297,8 @@ def jobs_queue(verbose: bool,
               '-n',
               required=False,
               type=str,
-              help='Managed job name to cancel. Supports glob patterns '
-              '(e.g. \'my-job-*\'), in which case all matching jobs are '
+              help='Managed job name to cancel. Supports glob patterns, in '
+              'which case all jobs whose name matches the pattern are '
               'cancelled.')
 @click.option('--pool',
               '-p',

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -308,26 +308,6 @@ system_config_table = sqlalchemy.Table(
 )
 
 
-def _glob_to_similar(glob_pattern):
-    """Converts a glob pattern to a PostgreSQL LIKE pattern."""
-
-    # Escape special LIKE characters that are not special in glob
-    glob_pattern = glob_pattern.replace('%', '\\%').replace('_', '\\_')
-
-    # Convert glob wildcards to LIKE wildcards
-    like_pattern = glob_pattern.replace('*', '%').replace('?', '_')
-
-    # Handle character classes, including negation
-    def replace_char_class(match):
-        group = match.group(0)
-        if group.startswith('[!'):
-            return '[^' + group[2:-1] + ']'
-        return group
-
-    like_pattern = re.sub(r'\[(!)?.*?\]', replace_char_class, like_pattern)
-    return like_pattern
-
-
 def create_table(engine: sqlalchemy.engine.Engine):
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
@@ -1604,16 +1584,8 @@ def get_glob_cluster_names(
     engine = _db_manager.get_engine()
     assert cluster_name is not None, 'cluster_name cannot be None'
     with orm.Session(engine) as session:
-        if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
-            query = session.query(cluster_table.c.name).filter(
-                cluster_table.c.name.op('GLOB')(cluster_name))
-        elif (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
-             ):
-            query = session.query(cluster_table.c.name).filter(
-                cluster_table.c.name.op('SIMILAR TO')(
-                    _glob_to_similar(cluster_name)))
-        else:
-            raise ValueError('Unsupported database dialect')
+        query = session.query(cluster_table.c.name).filter(
+            db_utils.glob_filter(engine, cluster_table.c.name, cluster_name))
         if workspaces_filter is not None:
             query = query.filter(
                 cluster_table.c.workspace.in_(workspaces_filter))
@@ -2830,16 +2802,9 @@ def get_glob_storage_name(storage_name: str) -> List[str]:
     engine = _db_manager.get_engine()
     assert storage_name is not None, 'storage_name cannot be None'
     with orm.Session(engine) as session:
-        if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
-            rows = session.query(storage_table).filter(
-                storage_table.c.name.op('GLOB')(storage_name)).all()
-        elif (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
-             ):
-            rows = session.query(storage_table).filter(
-                storage_table.c.name.op('SIMILAR TO')(
-                    _glob_to_similar(storage_name))).all()
-        else:
-            raise ValueError('Unsupported database dialect')
+        rows = session.query(storage_table).filter(
+            db_utils.glob_filter(engine, storage_table.c.name,
+                                 storage_name)).all()
     return [row.name for row in rows]
 
 

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -387,7 +387,8 @@ def cancel(
     Please refer to sky.cli.job_cancel for documentation.
 
     Args:
-        name: Name of the managed job to cancel.
+        name: Name of the managed job to cancel. Supports glob patterns
+            (e.g. ``my-job-*``), in which case all matching jobs are cancelled.
         job_ids: IDs of the managed jobs to cancel.
         all: Whether to cancel all managed jobs.
         all_users: Whether to cancel all managed jobs from all users.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1103,12 +1103,16 @@ def set_local_log_file(job_id: int, task_id: Optional[int],
 # ======== utility functions ========
 def get_nonterminal_job_ids_by_name(name: Optional[str],
                                     user_hash: Optional[str] = None,
-                                    all_users: bool = False) -> List[int]:
+                                    all_users: bool = False,
+                                    match_glob: bool = False) -> List[int]:
     """Get non-terminal job ids by name.
 
     If name is None:
     1. if all_users is False, get for the given user_hash
     2. otherwise, get for all users
+
+    If match_glob is True, ``name`` is treated as a glob pattern (e.g.
+    ``my-job-*``) and all jobs whose name matches the pattern are returned.
     """
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
@@ -1138,11 +1142,20 @@ def get_nonterminal_job_ids_by_name(name: Optional[str],
             # We match the job name from `job_info` for the jobs submitted after
             # #1982, and from `spot` for the jobs submitted before #1982, whose
             # job_info is not available.
+            if match_glob:
+                name_match = db_utils.glob_filter(engine, job_info_table.c.name,
+                                                  name)
+                task_name_match = db_utils.glob_filter(engine,
+                                                       spot_table.c.task_name,
+                                                       name)
+            else:
+                name_match = job_info_table.c.name == name
+                task_name_match = spot_table.c.task_name == name
             where_conditions.append(
                 sqlalchemy.or_(
-                    job_info_table.c.name == name,
+                    name_match,
                     sqlalchemy.and_(job_info_table.c.name.is_(None),
-                                    spot_table.c.task_name == name),
+                                    task_name_match),
                 ))
         query = query.where(sqlalchemy.and_(*where_conditions)).order_by(
             spot_table.c.spot_job_id.desc())

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1277,11 +1277,28 @@ def cancel_job_by_name(job_name: str,
                        current_workspace: Optional[str] = None,
                        graceful: bool = False,
                        graceful_timeout: Optional[int] = None) -> str:
-    """Cancel a job by name."""
-    job_ids = managed_job_state.get_nonterminal_job_ids_by_name(job_name)
+    """Cancel managed job(s) by name.
+
+    If ``job_name`` is a glob pattern (e.g. contains ``*``/``?``/``[``), it is
+    treated as a glob pattern and all running jobs whose name matches the
+    pattern are cancelled. Otherwise it is matched as an exact name, in which
+    case matching more than one running job is ambiguous and reported as an
+    error.
+
+    Glob detection uses the same ``ux_utils.is_glob_pattern`` helper as
+    ``sky down``, so a name is interpreted as a pattern under the same rules.
+    """
+    match_glob = ux_utils.is_glob_pattern(job_name)
+    job_ids = managed_job_state.get_nonterminal_job_ids_by_name(
+        job_name, match_glob=match_glob)
     if not job_ids:
+        if match_glob:
+            return f'No running job found matching name pattern {job_name!r}.'
         return f'No running job found with name {job_name!r}.'
-    if len(job_ids) > 1:
+    if not match_glob and len(job_ids) > 1:
+        # Exact-name match is ambiguous when it hits multiple jobs; ask the
+        # user to disambiguate. With a glob pattern, matching multiple jobs is
+        # the expected behavior, so we cancel all of them.
         return (f'{colorama.Fore.RED}Multiple running jobs found '
                 f'with name {job_name!r}.\n'
                 f'Job IDs: {job_ids}{colorama.Style.RESET_ALL}')
@@ -1289,6 +1306,10 @@ def cancel_job_by_name(job_name: str,
                             current_workspace=current_workspace,
                             graceful=graceful,
                             graceful_timeout=graceful_timeout)
+    if match_glob:
+        plural = 's' if len(job_ids) > 1 else ''
+        return (f'Pattern {job_name!r} matched {len(job_ids)} '
+                f'running job{plural}. {msg}')
     return f'{job_name!r} {msg}'
 
 

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -72,9 +72,15 @@ def glob_to_sql_similar_pattern(glob_pattern: str) -> str:
     those are passed through (with glob's ``[!...]`` negation rewritten to SQL's
     ``[^...]``).
     """
-    # Escape special SIMILAR TO characters that are not special in glob, so a
-    # literal '%'/'_' in a job/cluster name is not treated as a wildcard.
-    glob_pattern = glob_pattern.replace('%', '\\%').replace('_', '\\_')
+    # ``SIMILAR TO`` is regex-like: besides the SQL wildcards '%'/'_', it treats
+    # '|', '+', '(', ')', '{', '}' as operators. None of these are special in
+    # glob, so escape them (and the escape character itself, first) to keep them
+    # literal -- otherwise a name like 'my-job-(1)' or 'job+v2' would cause a
+    # SQL syntax error or match incorrectly. We do this before translating the
+    # glob wildcards below so we don't escape the '%'/'_' we are about to emit.
+    glob_pattern = glob_pattern.replace('\\', '\\\\')
+    for char in ['%', '_', '|', '+', '(', ')', '{', '}']:
+        glob_pattern = glob_pattern.replace(char, '\\' + char)
 
     # Convert glob wildcards to SIMILAR TO wildcards.
     like_pattern = glob_pattern.replace('*', '%').replace('?', '_')

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -4,6 +4,7 @@ import contextlib
 import enum
 import os
 import pathlib
+import re
 import sqlite3
 import threading
 import typing
@@ -60,6 +61,49 @@ class UniqueConstraintViolationError(Exception):
 class SQLAlchemyDialect(enum.Enum):
     SQLITE = 'sqlite'
     POSTGRESQL = 'postgresql'
+
+
+def glob_to_sql_similar_pattern(glob_pattern: str) -> str:
+    """Converts a glob pattern to a PostgreSQL ``SIMILAR TO`` pattern.
+
+    PostgreSQL has no native glob operator (unlike SQLite's ``GLOB``), so we
+    translate glob wildcards into ``SIMILAR TO`` wildcards. ``SIMILAR TO``
+    supports character classes (``[...]``) with the same syntax as glob, so
+    those are passed through (with glob's ``[!...]`` negation rewritten to SQL's
+    ``[^...]``).
+    """
+    # Escape special SIMILAR TO characters that are not special in glob, so a
+    # literal '%'/'_' in a job/cluster name is not treated as a wildcard.
+    glob_pattern = glob_pattern.replace('%', '\\%').replace('_', '\\_')
+
+    # Convert glob wildcards to SIMILAR TO wildcards.
+    like_pattern = glob_pattern.replace('*', '%').replace('?', '_')
+
+    # Handle character classes, including negation ([!...] -> [^...]).
+    def replace_char_class(match):
+        group = match.group(0)
+        if group.startswith('[!'):
+            return '[^' + group[2:-1] + ']'
+        return group
+
+    like_pattern = re.sub(r'\[(!)?.*?\]', replace_char_class, like_pattern)
+    return like_pattern
+
+
+def glob_filter(engine: sqlalchemy.engine.Engine, column: 'sqlalchemy.Column',
+                glob_pattern: str) -> 'sqlalchemy.sql.elements.ColumnElement':
+    """Builds a SQLAlchemy filter matching ``column`` against a glob pattern.
+
+    Uses SQLite's native ``GLOB`` operator, or PostgreSQL's ``SIMILAR TO`` with
+    the pattern translated by :func:`glob_to_sql_similar_pattern`.
+    """
+    if engine.dialect.name == SQLAlchemyDialect.SQLITE.value:
+        return column.op('GLOB')(glob_pattern)
+    elif engine.dialect.name == SQLAlchemyDialect.POSTGRESQL.value:
+        return column.op('SIMILAR TO')(
+            glob_to_sql_similar_pattern(glob_pattern))
+    else:
+        raise ValueError(f'Unsupported database dialect: {engine.dialect.name}')
 
 
 @contextlib.contextmanager

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -1250,3 +1250,65 @@ class TestStatusExprSeam:
             fields=['job_id', 'status', 'task_id'])
         seq_d = [refined[j['job_id']] for j in desc]
         assert seq_d == sorted(seq_d, reverse=True), seq_d
+
+
+class TestGetNonterminalJobIdsByName:
+    """Tests for state.get_nonterminal_job_ids_by_name, incl. glob matching.
+
+    The seeded jobs have these names/statuses (see ``_seed_test_jobs``):
+      - job1: 'test-job-a' (PENDING, nonterminal)
+      - job2: 'test-job-b' (STARTING, nonterminal)
+      - job3: 'test-job-a' (RUNNING, nonterminal)
+      - job4: 'test-job-c' (SUCCEEDED, terminal)
+      - job5: 'test-job-d' (FAILED, terminal)
+    """
+
+    def test_exact_name_match(self, _seed_test_jobs):
+        ids = state.get_nonterminal_job_ids_by_name('test-job-a',
+                                                    all_users=True)
+        assert set(ids) == {
+            _seed_test_jobs['job_id1'], _seed_test_jobs['job_id3']
+        }
+
+    def test_exact_name_no_glob_expansion(self, _seed_test_jobs):
+        # Without match_glob, '*' is a literal and matches nothing.
+        ids = state.get_nonterminal_job_ids_by_name('test-job-*',
+                                                    all_users=True)
+        assert ids == []
+
+    def test_glob_star_matches_multiple(self, _seed_test_jobs):
+        ids = state.get_nonterminal_job_ids_by_name('test-job-*',
+                                                    all_users=True,
+                                                    match_glob=True)
+        # Matches the three nonterminal jobs; terminal jobs are excluded.
+        assert set(ids) == {
+            _seed_test_jobs['job_id1'],
+            _seed_test_jobs['job_id2'],
+            _seed_test_jobs['job_id3'],
+        }
+
+    def test_glob_question_mark(self, _seed_test_jobs):
+        ids = state.get_nonterminal_job_ids_by_name('test-job-?',
+                                                    all_users=True,
+                                                    match_glob=True)
+        assert set(ids) == {
+            _seed_test_jobs['job_id1'],
+            _seed_test_jobs['job_id2'],
+            _seed_test_jobs['job_id3'],
+        }
+
+    def test_glob_char_class(self, _seed_test_jobs):
+        ids = state.get_nonterminal_job_ids_by_name('test-job-[ab]',
+                                                    all_users=True,
+                                                    match_glob=True)
+        assert set(ids) == {
+            _seed_test_jobs['job_id1'],
+            _seed_test_jobs['job_id2'],
+            _seed_test_jobs['job_id3'],
+        }
+
+    def test_glob_no_match(self, _seed_test_jobs):
+        ids = state.get_nonterminal_job_ids_by_name('nomatch-*',
+                                                    all_users=True,
+                                                    match_glob=True)
+        assert ids == []

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1321,3 +1321,80 @@ class TestIsRelayedStatusPayloadLine:
     def test_plain_log_line_not_detected(self):
         assert jobs_utils._is_relayed_status_payload_line(
             'Preparing SkyPilot runtime (1/3)\n') is False
+
+
+class TestCancelJobByName:
+    """Tests for jobs_utils.cancel_job_by_name, incl. glob patterns."""
+
+    def test_exact_name_single_match(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name',
+                            lambda name, match_glob=False: [7])
+        captured = {}
+
+        def fake_cancel(job_ids, **kwargs):
+            captured['job_ids'] = job_ids
+            return 'cancelled.'
+
+        monkeypatch.setattr(jobs_utils, 'cancel_jobs_by_id', fake_cancel)
+        msg = jobs_utils.cancel_job_by_name('my-job')
+        assert captured['job_ids'] == [7]
+        assert msg == "'my-job' cancelled."
+
+    def test_exact_name_no_match(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name',
+                            lambda name, match_glob=False: [])
+        msg = jobs_utils.cancel_job_by_name('my-job')
+        assert msg == "No running job found with name 'my-job'."
+
+    def test_exact_name_multiple_is_ambiguous(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name',
+                            lambda name, match_glob=False: [1, 2])
+        # Should NOT cancel; returns an ambiguity error instead.
+        monkeypatch.setattr(
+            jobs_utils, 'cancel_jobs_by_id',
+            lambda *a, **k: pytest.fail('should not cancel on ambiguous name'))
+        msg = jobs_utils.cancel_job_by_name('my-job')
+        assert 'Multiple running jobs found' in msg
+        assert '[1, 2]' in msg
+
+    def test_glob_pattern_passes_match_glob(self, monkeypatch):
+        seen = {}
+
+        def fake_get_ids(name, match_glob=False):
+            seen['name'] = name
+            seen['match_glob'] = match_glob
+            return [1, 2, 3]
+
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name', fake_get_ids)
+        captured = {}
+
+        def fake_cancel(job_ids, **kwargs):
+            captured['job_ids'] = job_ids
+            return 'cancelled.'
+
+        monkeypatch.setattr(jobs_utils, 'cancel_jobs_by_id', fake_cancel)
+        msg = jobs_utils.cancel_job_by_name('my-job-*')
+        assert seen == {'name': 'my-job-*', 'match_glob': True}
+        # All matched jobs are cancelled (no ambiguity error for globs).
+        assert captured['job_ids'] == [1, 2, 3]
+        assert "Pattern 'my-job-*' matched 3 running jobs." in msg
+
+    def test_glob_pattern_single_match(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name',
+                            lambda name, match_glob=False: [5])
+        monkeypatch.setattr(jobs_utils, 'cancel_jobs_by_id',
+                            lambda job_ids, **kwargs: 'cancelled.')
+        msg = jobs_utils.cancel_job_by_name('my-job-?')
+        assert "Pattern 'my-job-?' matched 1 running job." in msg
+
+    def test_glob_pattern_no_match(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state,
+                            'get_nonterminal_job_ids_by_name',
+                            lambda name, match_glob=False: [])
+        msg = jobs_utils.cancel_job_by_name('nomatch-*')
+        assert msg == "No running job found matching name pattern 'nomatch-*'."

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -428,3 +428,66 @@ class TestGetEngine:
             # Parent directory should be created
             expected_dir = runtime_dir / '.sky'
             assert expected_dir.exists()
+
+
+class TestGlobHelpers:
+    """Tests for the glob -> SQL helpers in db_utils."""
+
+    @pytest.mark.parametrize(
+        'glob_pattern,expected',
+        [
+            # '*' -> '%', '?' -> '_'
+            ('my-job-*', 'my-job-%'),
+            ('job-?', 'job-_'),
+            # Literal SQL wildcards are escaped so they are not treated as wildcards.
+            ('a%b_c', 'a\\%b\\_c'),
+            # Character classes pass through; negation [!..] -> [^..].
+            ('job-[ab]', 'job-[ab]'),
+            ('job-[!ab]', 'job-[^ab]'),
+        ])
+    def test_glob_to_sql_similar_pattern(self, glob_pattern, expected):
+        assert db_utils.glob_to_sql_similar_pattern(glob_pattern) == expected
+
+    def _make_names_engine(self):
+        engine = sqlalchemy.create_engine('sqlite:///:memory:')
+        metadata = sqlalchemy.MetaData()
+        table = sqlalchemy.Table('items', metadata,
+                                 sqlalchemy.Column('name', sqlalchemy.Text))
+        metadata.create_all(engine)
+        names = ['job-a', 'job-b', 'job-ab', 'other', 'job_literal']
+        with engine.begin() as conn:
+            conn.execute(table.insert(), [{'name': n} for n in names])
+        return engine, table
+
+    def test_glob_filter_sqlite_star(self):
+        engine, table = self._make_names_engine()
+        with engine.connect() as conn:
+            stmt = sqlalchemy.select(table.c.name).where(
+                db_utils.glob_filter(engine, table.c.name, 'job-*'))
+            matched = {row[0] for row in conn.execute(stmt)}
+        assert matched == {'job-a', 'job-b', 'job-ab'}
+
+    def test_glob_filter_sqlite_question_mark(self):
+        engine, table = self._make_names_engine()
+        with engine.connect() as conn:
+            stmt = sqlalchemy.select(table.c.name).where(
+                db_utils.glob_filter(engine, table.c.name, 'job-?'))
+            matched = {row[0] for row in conn.execute(stmt)}
+        assert matched == {'job-a', 'job-b'}
+
+    def test_glob_filter_sqlite_underscore_is_literal(self):
+        # An underscore in the pattern (not as glob's '?') should match a
+        # literal underscore, not any single character.
+        engine, table = self._make_names_engine()
+        with engine.connect() as conn:
+            stmt = sqlalchemy.select(table.c.name).where(
+                db_utils.glob_filter(engine, table.c.name, 'job_*'))
+            matched = {row[0] for row in conn.execute(stmt)}
+        assert matched == {'job_literal'}
+
+    def test_glob_filter_unsupported_dialect(self):
+        engine = mock.MagicMock()
+        engine.dialect.name = 'mysql'
+        column = mock.MagicMock()
+        with pytest.raises(ValueError, match='Unsupported database dialect'):
+            db_utils.glob_filter(engine, column, 'foo-*')

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -441,6 +441,13 @@ class TestGlobHelpers:
             ('job-?', 'job-_'),
             # Literal SQL wildcards are escaped so they are not treated as wildcards.
             ('a%b_c', 'a\\%b\\_c'),
+            # SIMILAR TO regex operators that are literal in glob are escaped.
+            ('job-(a)', 'job-\\(a\\)'),
+            ('job-a+b', 'job-a\\+b'),
+            ('a|b', 'a\\|b'),
+            ('job-{1}', 'job-\\{1\\}'),
+            # A literal backslash is escaped (doubled) before other escaping.
+            ('a\\b', 'a\\\\b'),
             # Character classes pass through; negation [!..] -> [^..].
             ('job-[ab]', 'job-[ab]'),
             ('job-[!ab]', 'job-[^ab]'),


### PR DESCRIPTION
## Summary

* `sky jobs cancel -n <name>` previously matched managed job names **exactly**, so cancelling several similarly-named jobs meant looking up and listing each job ID. `sky down` already supports glob patterns for clusters; this brings the same capability to managed job cancellation.
* Glob detection reuses the same `ux_utils.is_glob_pattern` helper as `sky down`, and matching is pushed into the DB via a shared helper (SQLite `GLOB` / PostgreSQL `SIMILAR TO`) rather than client-side `fnmatch`.
* A bare (non-glob) name that matches multiple running jobs still reports the existing "ambiguous, specify a job ID" error — only an explicit pattern opts into cancelling all matches. This guard exists for jobs (but not clusters) because job names are not unique, whereas cluster names are a primary key.

Closes skypilot-org/skypilot#7163.

### What changed

* `sky/utils/db/db_utils.py` — new shared glob→SQL helpers `glob_to_sql_similar_pattern` and `glob_filter`.
* `sky/global_user_state.py` — refactored existing cluster/storage globbing onto the shared helper; removed the duplicate private `_glob_to_similar`.
* `sky/jobs/state.py` — `get_nonterminal_job_ids_by_name(..., match_glob=False)` glob-matches both `job_info.name` and the legacy `spot.task_name` column.
* `sky/jobs/utils.py` — `cancel_job_by_name` detects glob patterns and cancels all matches; keeps the exact-name ambiguity error.
* `sky/client/cli/command.py`, `sky/jobs/client/sdk.py` — help text, example, and docstring.

### Backward compatibility

The behavior lives entirely on the jobs controller, reached identically by both the gRPC and legacy-codegen cancel paths via `cancel_job_by_name`. No protobuf / codegen / RPC / CLI / SDK signature changes were needed, so no API version bump. A new client talking to an old controller degrades gracefully — the pattern is matched exactly, finds nothing, and says so.

## Test plan

Added unit tests:

* `db_utils` glob helpers, including end-to-end SQLite `GLOB` matching and the glob→`SIMILAR TO` translation.
* `get_nonterminal_job_ids_by_name(match_glob=True)` against seeded jobs (`*`, `?`, `[...]`, no-match; terminal jobs excluded).
* `cancel_job_by_name` dispatch: exact single match, exact no-match, exact-multiple ambiguity error, glob multi-cancel, glob single match, glob no-match.

```
pytest tests/unit_tests/test_sky/utils/test_db_utils.py::TestGlobHelpers \
       tests/unit_tests/test_sky/jobs/test_jobs_state.py::TestGetNonterminalJobIdsByName \
       tests/unit_tests/test_sky/jobs/test_utils.py::TestCancelJobByName
```

All pass. `format.sh` clean (yapf/isort/mypy; pylint 10/10 on changed source).

Manual verification:

```bash
# Launch a few similarly-named managed jobs
sky jobs launch -n train-llama-1 ...
sky jobs launch -n train-llama-2 ...

# Cancel them all with a pattern
sky jobs cancel -n 'train-llama-*'
# -> Pattern 'train-llama-*' matched 2 running jobs. ...

# Exact bare name still behaves as before (ambiguous -> error if >1)
sky jobs cancel -n train-llama-1
```

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)