### PR TITLE
[Kubernetes] Always annotate pods with the original launching user

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -301,8 +301,15 @@ available_node_types:
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
             kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
             {% endif %}
-        {% if k8s_kueue_local_queue_name or k8s_enable_gpudirect_tcpx or k8s_enable_gpudirect_tcpxo or k8s_enable_gpudirect_rdma %}
         annotations:
+          # The skypilot-user *label* (above) sanitizes characters that are
+          # invalid in Kubernetes label values (e.g. '@' and '.'), so a
+          # username like alice@example.com is recorded as aliceexamplecom.
+          # Always also record the original, uncleaned username as an
+          # annotation (annotation values have no such charset restrictions)
+          # so consumers can recover the exact username regardless of config.
+          skypilot-user: "{{ original_user }}"
+        {% if k8s_kueue_local_queue_name or k8s_enable_gpudirect_tcpx or k8s_enable_gpudirect_tcpxo or k8s_enable_gpudirect_rdma %}
           skypilot-workspace: {{ workspace }}
           {% if priority_class is not none %}
           skypilot-priority-class: {{priority_class}}
@@ -313,7 +320,6 @@ available_node_types:
           {% if k8s_max_run_duration_seconds %}
           provreq.kueue.x-k8s.io/maxRunDurationSeconds: "{{k8s_max_run_duration_seconds|string}}"
           {% endif %}
-          skypilot-user: "{{ original_user }}"
           {% endif %}
         # https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx
         # Values from google cloud guide


### PR DESCRIPTION
## Summary

SkyPilot stamps the launching user onto Kubernetes pods in two ways:
- the `skypilot-user` **label**, whose value is sanitized to satisfy Kubernetes label-value charset rules (e.g. `alice@example.com` is stored as `aliceexamplecom`); and
- the `skypilot-user` **annotation**, which preserves the original, uncleaned value.

The annotation was only emitted when a Kueue local queue was configured, so on a normal cluster the verbatim username was unavailable and consumers had to fall back to the lossy label.

This moves the `skypilot-user` annotation out of the Kueue-gated block so that **every** SkyPilot-launched pod carries the original username regardless of cluster configuration. Annotation values have no charset restrictions, so this is the natural place to keep the exact value. The label is unchanged, and the `skypilot-workspace`, priority-class, Kueue, and GPUDirect annotations keep their existing emission conditions.

## Test plan

Rendered `sky/templates/kubernetes-ray.yml.j2` with Jinja2 (the same path `common_utils.fill_template` uses) and parsed the result as YAML across:
- no special config (no Kueue, no GPUDirect)
- Kueue local queue set
- GPUDirect TCPX
- Kueue + priority class + max run duration

In every case the pod carries exactly one `skypilot-user` annotation (original value, e.g. `alice@example.com`) and one `skypilot-user` label (sanitized, e.g. `aliceexamplecom`), with no duplicate keys and `skypilot-workspace`/Kueue/GPUDirect annotations unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)