### PR TITLE
[Dashboard] Standardize table empty states with a shared component

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -1203,8 +1203,8 @@ export function ClusterTable({
                   }
                   description={
                     showHistory
-                      ? 'No clusters in the selected time range.'
-                      : 'Launch a cluster to run your workloads.'
+                      ? 'No clusters in the selected time range'
+                      : 'Launch a cluster to run your workloads'
                   }
                 />
               )}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -33,7 +33,9 @@ import {
   TableHead,
   TableBody,
   TableCell,
+  EmptyTableState,
 } from '@/components/ui/table';
+import { isForceEmpty } from '@/lib/utils';
 import {
   getClusters,
   getClusterHistory,
@@ -42,6 +44,7 @@ import {
 import { getWorkspaces } from '@/data/connectors/workspaces';
 import { sortData } from '@/data/utils';
 import { SquareCode, Terminal, RotateCwIcon, Brackets } from 'lucide-react';
+import { ServerIcon } from '@/components/elements/icons';
 import { relativeTime } from '@/components/utils';
 import { Layout } from '@/components/elements/layout';
 import {
@@ -1179,7 +1182,7 @@ export function ClusterTable({
                     </div>
                   </TableCell>
                 </TableRow>
-              ) : paginatedData.length > 0 ? (
+              ) : paginatedData.length > 0 && !isForceEmpty() ? (
                 paginatedData.map((item, index) => {
                   return (
                     <TableRow key={index}>
@@ -1192,14 +1195,18 @@ export function ClusterTable({
                   );
                 })
               ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={totalColSpan}
-                    className="text-center py-6 text-gray-500"
-                  >
-                    {showHistory ? 'No clusters found' : 'No active clusters'}
-                  </TableCell>
-                </TableRow>
+                <EmptyTableState
+                  colSpan={totalColSpan}
+                  icon={<ServerIcon className="w-5 h-5" />}
+                  title={
+                    showHistory ? 'No clusters found' : 'No active clusters'
+                  }
+                  description={
+                    showHistory
+                      ? 'No clusters in the selected time range.'
+                      : 'Launch a cluster to run your workloads.'
+                  }
+                />
               )}
             </TableBody>
           </Table>

--- a/sky/dashboard/src/components/elements/EmptyState.jsx
+++ b/sky/dashboard/src/components/elements/EmptyState.jsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Inbox } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+// Standardized empty-state block: a generously sized, centered column with a
+// subtle neutral icon, a title, and an optional description and action. Used
+// both inside tables (via EmptyTableState) and as a full-section placeholder.
+//
+// Colors are inline hex on purpose — the dashboard's theme CSS variables can
+// resolve to white in some render contexts, which would make the text and
+// icon disappear.
+export function EmptyState({
+  title,
+  description,
+  icon,
+  action,
+  minHeight = 280,
+  className,
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center px-6 text-center',
+        className
+      )}
+      style={{ minHeight }}
+    >
+      <div
+        className="flex items-center justify-center"
+        style={{
+          width: 40,
+          height: 40,
+          marginBottom: 16,
+          borderRadius: 9999,
+          backgroundColor: '#f9fafb',
+          border: '1px solid #e5e7eb',
+          color: '#9ca3af',
+        }}
+      >
+        {icon || <Inbox size={20} strokeWidth={1.75} />}
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 500, color: '#111827' }}>
+        {title}
+      </div>
+      {description ? (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 14,
+            lineHeight: 1.55,
+            color: '#6b7280',
+            maxWidth: 460,
+          }}
+        >
+          {description}
+        </div>
+      ) : null}
+      {action ? <div style={{ marginTop: 20 }}>{action}</div> : null}
+    </div>
+  );
+}

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -6,6 +6,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { CircularProgress } from '@mui/material';
 import { Layout } from '@/components/elements/layout';
+import { EmptyState } from '@/components/elements/EmptyState';
+import { ServerIcon } from '@/components/elements/icons';
 import {
   AlertTriangleIcon,
   RotateCwIcon,
@@ -789,6 +791,16 @@ export function ContextDetails({
                   );
                 })}
               </div>
+            </div>
+          )}
+
+          {nodesInContext.length === 0 && (
+            <div className="rounded-md border border-gray-200 shadow-sm">
+              <EmptyState
+                icon={<ServerIcon className="w-5 h-5" />}
+                title="No nodes found"
+                description="No nodes are available in this context."
+              />
             </div>
           )}
 

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -799,7 +799,7 @@ export function ContextDetails({
               <EmptyState
                 icon={<ServerIcon className="w-5 h-5" />}
                 title="No nodes found"
-                description="No nodes are available in this context."
+                description="No nodes are available in this context"
               />
             </div>
           )}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2535,7 +2535,7 @@ export function ManagedJobsTable({
                           <EmptyState
                             icon={<BriefcaseIcon className="w-5 h-5" />}
                             title="No active jobs"
-                            description="Launch a managed job to run it with automatic recovery."
+                            description="Launch a managed job to run it with automatic recovery"
                             minHeight={0}
                           />
                         ))}
@@ -2948,7 +2948,7 @@ export function ClusterJobs({
                 colSpan={8}
                 icon={<BriefcaseIcon className="w-5 h-5" />}
                 title="No jobs found"
-                description="Submit a job to run it on this cluster."
+                description="Submit a job to run it on this cluster"
               />
             )}
           </TableBody>
@@ -3246,7 +3246,7 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
                 colSpan={poolColumnCount}
                 icon={<Layers size={20} strokeWidth={1.75} />}
                 title="No pools found"
-                description="Create a pool to share workers across jobs."
+                description="Create a pool to share workers across jobs"
               />
             )}
           </TableBody>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -17,7 +17,11 @@ import {
   TableHead,
   TableBody,
   TableCell,
+  EmptyTableState,
 } from '@/components/ui/table';
+import { EmptyState } from '@/components/elements/EmptyState';
+import { isForceEmpty } from '@/lib/utils';
+import { BriefcaseIcon } from '@/components/elements/icons';
 import {
   formatDuration,
   REFRESH_INTERVAL,
@@ -48,6 +52,7 @@ import {
   ChevronRightIcon,
   CheckIcon,
   InfoIcon,
+  Layers,
 } from 'lucide-react';
 import {
   handleJobAction,
@@ -2376,7 +2381,7 @@ export function ManagedJobsTable({
                     </div>
                   </TableCell>
                 </TableRow>
-              ) : paginatedData.length > 0 ? (
+              ) : paginatedData.length > 0 && !isForceEmpty() ? (
                 <>
                   {Array.from(groupedJobs.entries()).map(([jobId, tasks]) => {
                     const isMultiTask = tasks.length > 1;
@@ -2476,12 +2481,12 @@ export function ManagedJobsTable({
                   })}
                 </>
               ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={totalColSpan}
-                    className="text-center py-6"
-                  >
-                    <div className="flex flex-col items-center space-y-4">
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={totalColSpan} className="p-0">
+                    <div
+                      className="flex flex-col items-center justify-center space-y-4 px-6"
+                      style={{ minHeight: 280 }}
+                    >
                       {controllerLaunching && (
                         <div className="flex flex-col items-center space-y-2">
                           <p className="text-gray-700">
@@ -2527,7 +2532,12 @@ export function ManagedJobsTable({
                             </Button>
                           </div>
                         ) : (
-                          <p className="text-gray-500">No active jobs</p>
+                          <EmptyState
+                            icon={<BriefcaseIcon className="w-5 h-5" />}
+                            title="No active jobs"
+                            description="Launch a managed job to run it with automatic recovery."
+                            minHeight={0}
+                          />
                         ))}
                       {/* Desktop controller stopped message stays in table */}
                       {!isMobile && controllerStopped && (
@@ -2874,7 +2884,7 @@ export function ClusterJobs({
                   </div>
                 </TableCell>
               </TableRow>
-            ) : paginatedData.length > 0 ? (
+            ) : paginatedData.length > 0 && !isForceEmpty() ? (
               paginatedData.map((item) => (
                 <React.Fragment key={item.id}>
                   <TableRow
@@ -2934,14 +2944,12 @@ export function ClusterJobs({
                 </React.Fragment>
               ))
             ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={8}
-                  className="text-center py-6 text-gray-500"
-                >
-                  No jobs found
-                </TableCell>
-              </TableRow>
+              <EmptyTableState
+                colSpan={8}
+                icon={<BriefcaseIcon className="w-5 h-5" />}
+                title="No jobs found"
+                description="Submit a job to run it on this cluster."
+              />
             )}
           </TableBody>
         </Table>
@@ -3154,6 +3162,10 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
     return <SharedInfraBadges replicaInfo={replicaInfo} />;
   };
 
+  // Number of columns in the pools table header (Pool, Jobs, Workers,
+  // Worker Details, Worker Resources) — used for the empty-state colSpan.
+  const poolColumnCount = 5;
+
   return (
     <Card>
       <div className="overflow-x-auto rounded-lg">
@@ -3200,7 +3212,7 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
                   </div>
                 </TableCell>
               </TableRow>
-            ) : paginatedData.length > 0 ? (
+            ) : paginatedData.length > 0 && !isForceEmpty() ? (
               paginatedData.map((pool) => (
                 <TableRow key={pool.name}>
                   <TableCell>
@@ -3230,14 +3242,12 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
                 </TableRow>
               ))
             ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={5}
-                  className="text-center py-6 text-gray-500"
-                >
-                  No pools found
-                </TableCell>
-              </TableRow>
+              <EmptyTableState
+                colSpan={poolColumnCount}
+                icon={<Layers size={20} strokeWidth={1.75} />}
+                title="No pools found"
+                description="Create a pool to share workers across jobs."
+              />
             )}
           </TableBody>
         </Table>

--- a/sky/dashboard/src/components/ui/table.jsx
+++ b/sky/dashboard/src/components/ui/table.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { EmptyState } from '@/components/elements/EmptyState';
 
 const Table = React.forwardRef(({ className, ...props }, ref) => (
   <div className="relative w-full overflow-auto">
@@ -81,6 +82,20 @@ const TableCaption = React.forwardRef(({ className, ...props }, ref) => (
 ));
 TableCaption.displayName = 'TableCaption';
 
+// Standardized empty-state row for tables. Renders the shared EmptyState block
+// inside a full-width cell (the header row and pagination stay visible) instead
+// of a thin "No data" strip.
+const EmptyTableState = React.forwardRef(
+  ({ colSpan, className, ...emptyStateProps }, ref) => (
+    <TableRow ref={ref} className="hover:bg-transparent">
+      <TableCell colSpan={colSpan} className={cn('p-0', className)}>
+        <EmptyState {...emptyStateProps} />
+      </TableCell>
+    </TableRow>
+  )
+);
+EmptyTableState.displayName = 'EmptyTableState';
+
 export {
   Table,
   TableHeader,
@@ -90,4 +105,5 @@ export {
   TableRow,
   TableCell,
   TableCaption,
+  EmptyTableState,
 };

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -52,7 +52,10 @@ import {
   PlusIcon,
   MinusIcon,
   CopyIcon,
+  Users as UsersIcon,
 } from 'lucide-react';
+import { EmptyState } from '@/components/elements/EmptyState';
+import { isForceEmpty } from '@/lib/utils';
 import { Layout } from '@/components/elements/layout';
 import { useMobile } from '@/hooks/useMobile';
 import { useSidebar } from '@/components/elements/sidebar';
@@ -2241,20 +2244,27 @@ function UsersTable({
     );
   }
 
-  if (!filteredAndSortedUsers || filteredAndSortedUsers.length === 0) {
+  if (
+    !filteredAndSortedUsers ||
+    filteredAndSortedUsers.length === 0 ||
+    isForceEmpty()
+  ) {
     return (
-      <div className="text-center py-12">
-        <p className="text-lg font-semibold text-gray-500">
-          {filters.length > 0
-            ? 'No users match your filters.'
-            : 'No users found.'}
-        </p>
-        <p className="text-sm text-gray-400 mt-1">
-          {filters.length > 0
-            ? 'Try adjusting your filter criteria.'
-            : 'There are currently no users to display.'}
-        </p>
-      </div>
+      <Card>
+        <EmptyState
+          icon={<UsersIcon size={20} strokeWidth={1.75} />}
+          title={
+            filters.length > 0
+              ? 'No users match your filters'
+              : 'No users found'
+          }
+          description={
+            filters.length > 0
+              ? 'Try adjusting your filters.'
+              : 'Add a user to grant them access.'
+          }
+        />
+      </Card>
     );
   }
 
@@ -3127,20 +3137,22 @@ function ServiceAccountTokensView({
   return (
     <>
       {/* Tokens Table */}
-      {filteredTokens.length === 0 ? (
-        <div className="text-center py-12">
-          <KeyRoundIcon className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">
-            {searchQuery?.trim()
-              ? 'No tokens match your search'
-              : 'No service accounts'}
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            {searchQuery?.trim()
-              ? 'Try adjusting your search terms.'
-              : 'No service accounts have been created yet.'}
-          </p>
-        </div>
+      {filteredTokens.length === 0 || isForceEmpty() ? (
+        <Card>
+          <EmptyState
+            icon={<KeyRoundIcon size={20} strokeWidth={1.75} />}
+            title={
+              searchQuery?.trim()
+                ? 'No tokens match your search'
+                : 'No service accounts'
+            }
+            description={
+              searchQuery?.trim()
+                ? 'Try a different search term.'
+                : 'No service accounts have been created yet.'
+            }
+          />
+        </Card>
       ) : (
         <>
           <div className="text-sm text-gray-500 mb-2">

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2260,8 +2260,8 @@ function UsersTable({
           }
           description={
             filters.length > 0
-              ? 'Try adjusting your filters.'
-              : 'Add a user to grant them access.'
+              ? 'Try adjusting your filters'
+              : 'Add a user to grant them access'
           }
         />
       </Card>
@@ -3148,8 +3148,8 @@ function ServiceAccountTokensView({
             }
             description={
               searchQuery?.trim()
-                ? 'Try a different search term.'
-                : 'No service accounts have been created yet.'
+                ? 'Try a different search term'
+                : 'No service accounts have been created yet'
             }
           />
         </Card>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -17,11 +17,14 @@ import {
   TableHead,
   TableBody,
   TableCell,
+  EmptyTableState,
 } from '@/components/ui/table';
+import { isForceEmpty } from '@/lib/utils';
 import { getVolumes, deleteVolume } from '@/data/connectors/volumes';
 import { REFRESH_INTERVALS } from '@/lib/config';
 import { sortData } from '@/data/utils';
 import { RotateCwIcon, Trash2Icon, AlertTriangleIcon } from 'lucide-react';
+import { VolumeIcon } from '@/components/elements/icons';
 import { useMobile } from '@/hooks/useMobile';
 import { Card } from '@/components/ui/card';
 import {
@@ -757,7 +760,7 @@ function VolumesTable({
                     </div>
                   </TableCell>
                 </TableRow>
-              ) : paginatedData.length > 0 ? (
+              ) : paginatedData.length > 0 && !isForceEmpty() ? (
                 paginatedData.map((volume) => (
                   <TableRow key={volume.name}>
                     {visibleColumns.map((col) =>
@@ -768,14 +771,12 @@ function VolumesTable({
                   </TableRow>
                 ))
               ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={totalColSpan}
-                    className="text-center py-6 text-gray-500"
-                  >
-                    No volumes found
-                  </TableCell>
-                </TableRow>
+                <EmptyTableState
+                  colSpan={totalColSpan}
+                  icon={<VolumeIcon className="w-5 h-5" />}
+                  title="No volumes found"
+                  description="Create a volume to mount storage in your clusters and jobs."
+                />
               )}
             </TableBody>
           </Table>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -775,7 +775,7 @@ function VolumesTable({
                   colSpan={totalColSpan}
                   icon={<VolumeIcon className="w-5 h-5" />}
                   title="No volumes found"
-                  description="Create a volume to mount storage in your clusters and jobs."
+                  description="Create a volume to mount storage in your clusters and jobs"
                 />
               )}
             </TableBody>

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -21,7 +21,10 @@ import {
   TableHead,
   TableBody,
   TableCell,
+  EmptyTableState,
 } from '@/components/ui/table';
+import { EmptyState } from '@/components/elements/EmptyState';
+import { isForceEmpty } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { CircularProgress } from '@mui/material';
 import yaml from 'js-yaml';
@@ -892,13 +895,14 @@ export function Workspaces() {
       </div>
 
       {/* Workspaces Table */}
-      {workspaceDetails.length === 0 && !isInitialLoad ? (
-        <div className="text-center py-10">
-          <p className="text-lg text-gray-600">No workspaces found.</p>
-          <p className="text-sm text-gray-500 mt-2">
-            Create a cluster to see its workspace here.
-          </p>
-        </div>
+      {(workspaceDetails.length === 0 || isForceEmpty()) && !isInitialLoad ? (
+        <Card>
+          <EmptyState
+            icon={<BookDocIcon className="w-5 h-5" />}
+            title="No workspaces found"
+            description="Create a workspace to organize your clusters and jobs."
+          />
+        </Card>
       ) : (
         <Card>
           <div className="overflow-x-auto rounded-lg">
@@ -1059,14 +1063,12 @@ export function Workspaces() {
                     );
                   })
                 ) : (
-                  <TableRow>
-                    <TableCell
-                      colSpan={5}
-                      className="text-center py-6 text-gray-500"
-                    >
-                      No workspaces found
-                    </TableCell>
-                  </TableRow>
+                  <EmptyTableState
+                    colSpan={5}
+                    icon={<BookDocIcon className="w-5 h-5" />}
+                    title="No workspaces found"
+                    description="Create a workspace to organize your clusters and jobs."
+                  />
                 )}
               </TableBody>
             </Table>

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -900,7 +900,7 @@ export function Workspaces() {
           <EmptyState
             icon={<BookDocIcon className="w-5 h-5" />}
             title="No workspaces found"
-            description="Create a workspace to organize your clusters and jobs."
+            description="Create a workspace to organize your clusters and jobs"
           />
         </Card>
       ) : (
@@ -1067,7 +1067,7 @@ export function Workspaces() {
                     colSpan={5}
                     icon={<BookDocIcon className="w-5 h-5" />}
                     title="No workspaces found"
-                    description="Create a workspace to organize your clusters and jobs."
+                    description="Create a workspace to organize your clusters and jobs"
                   />
                 )}
               </TableBody>

--- a/sky/dashboard/src/lib/utils.js
+++ b/sky/dashboard/src/lib/utils.js
@@ -4,3 +4,11 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+// Dev/QA helper: when the dashboard URL carries `?empty=1` (or just `?empty`),
+// data tables render their empty state even when data exists, so empty-state
+// styling can be reviewed against a populated server. No effect otherwise.
+export function isForceEmpty() {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).has('empty');
+}


### PR DESCRIPTION
## Summary

- Add a reusable `EmptyState` block (a neutral icon in a 40px circle, a title, and an optional description and action) under `components/elements/`, plus an `EmptyTableState` helper in `components/ui/table.jsx` that renders it inside a full-width `colSpan` row so the column headers and pagination stay visible.
- Empty tables now show a vertically centered, fixed 280px region instead of collapsing to a thin "No data" strip.
- Applied to the clusters, jobs (managed jobs + pools), users (+ service-account tokens), volumes, and workspaces tables, with icons matching the nav and concise, action-first copy.
- Also add an empty state to the Infrastructure page's Nodes table, which previously rendered nothing when a context had no nodes.
- A `?empty` URL flag forces the empty state on populated tables so the styling can be reviewed without clearing real data. Colors are inline hex because the theme CSS variables can resolve to white in some render contexts.

## Test plan

- `npm run lint` and `npx prettier --check` on the touched files — both clean.
- `npm run build` — succeeds.
- `npm run dev`, then for each table visit `?empty=1`: the empty state renders (icon + title + description) centered in a 280px region with the column headers and pagination intact; removing the flag renders rows normally; no console errors. For Infrastructure, a context with no nodes shows the empty state instead of a blank section.

<img width="1505" height="727" alt="Screenshot 2026-06-29 at 4 34 11 PM" src="https://github.com/user-attachments/assets/a406389a-d1a3-431d-b762-2f5c07bfab40" />
