### PR TITLE
[Dashboard] Pin dashboard API version to server API_VERSION

### DIFF
--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -44,18 +44,19 @@ export const TIMEOUT = 10000;
 export const API_URL = '/api/v1';
 export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 
-// The API_VERSION this dashboard build was written against. Sent on every
-// outgoing API request via the `X-SkyPilot-API-Version` header so the
-// server can identify the dashboard as a contemporary (non-legacy) client
-// and run the workspace resolver / surface new error types like
-// `WorkspaceAmbiguousError`. This is a deliberate hardcode — the dashboard
-// is bundled with the server release, so its API contract level is fixed at
-// build time; tracking the server's runtime API_VERSION instead would let
-// a cached old dashboard mis-report support for features it lacks.
-// Keep in sync with sky/server/constants.py:API_VERSION when (and only
-// when) this dashboard adds new server-side feature support that older
-// dashboard builds cannot handle.
-export const CLIENT_API_VERSION = '53';
+// The SkyPilot API version this dashboard advertises, sent on every outgoing
+// request via the `X-SkyPilot-API-Version` header so the server can identify
+// the dashboard as a contemporary (non-legacy) client and run the workspace
+// resolver / surface new error types like `WorkspaceAmbiguousError`.
+//
+// This MUST equal sky/server/constants.py:API_VERSION. The dashboard ships
+// with the server, so the two bump together (see the backward-compatibility
+// guideline). It is a build-time hardcode rather than the server's runtime
+// version on purpose: an already-loaded older dashboard kept across a server
+// upgrade then still reports its own build's version, not the new server's, so
+// it can't over-report support for wire formats its code doesn't handle.
+// Enforced by tests/unit_tests/test_api_version_consistency.py.
+export const CLIENT_API_VERSION = '55';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/tests/unit_tests/test_api_version_consistency.py
+++ b/tests/unit_tests/test_api_version_consistency.py
@@ -1,0 +1,35 @@
+"""Guard: client-advertised API version stays in lockstep with the server.
+
+The dashboard hardcodes the API version it sends in the
+``X-SkyPilot-API-Version`` header (sky/dashboard/.../constants.jsx). It ships
+with the server, so it must equal sky/server/constants.py:API_VERSION. This
+test fails if the two drift -- e.g. someone bumps ``API_VERSION`` for a new
+API change without bumping the dashboard in the same change.
+
+Both values are read by parsing the source files (no ``import sky``) so the
+check stays hermetic and free of import side effects.
+"""
+import pathlib
+import re
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SERVER_CONSTANTS = _REPO_ROOT / 'sky' / 'server' / 'constants.py'
+_DASHBOARD_CONSTANTS = (_REPO_ROOT / 'sky' / 'dashboard' / 'src' / 'data' /
+                        'connectors' / 'constants.jsx')
+
+
+def _extract_int(path: pathlib.Path, pattern: str) -> int:
+    match = re.search(pattern, path.read_text(), re.MULTILINE)
+    assert match is not None, f'{pattern!r} not found in {path}'
+    return int(match.group(1))
+
+
+def test_dashboard_client_api_version_matches_server():
+    server_version = _extract_int(_SERVER_CONSTANTS,
+                                  r'^API_VERSION\s*=\s*(\d+)')
+    dashboard_version = _extract_int(_DASHBOARD_CONSTANTS,
+                                     r"CLIENT_API_VERSION\s*=\s*'(\d+)'")
+    assert dashboard_version == server_version, (
+        f'Dashboard CLIENT_API_VERSION ({dashboard_version}) != server '
+        f'API_VERSION ({server_version}). Bump {_DASHBOARD_CONSTANTS} in '
+        f'lockstep (see the backward-compatibility guideline).')

--- a/tests/unit_tests/test_api_version_consistency.py
+++ b/tests/unit_tests/test_api_version_consistency.py
@@ -19,7 +19,7 @@ _DASHBOARD_CONSTANTS = (_REPO_ROOT / 'sky' / 'dashboard' / 'src' / 'data' /
 
 
 def _extract_int(path: pathlib.Path, pattern: str) -> int:
-    match = re.search(pattern, path.read_text(), re.MULTILINE)
+    match = re.search(pattern, path.read_text(encoding='utf-8'), re.MULTILINE)
     assert match is not None, f'{pattern!r} not found in {path}'
     return int(match.group(1))
 


### PR DESCRIPTION
## Summary
- Bump the dashboard's `CLIENT_API_VERSION` from 53 to 55 so it matches the server's `API_VERSION` (they had drifted).
- Add a unit test that fails if `CLIENT_API_VERSION` and `API_VERSION` ever diverge, keeping the dashboard's advertised API version in lockstep with the server.

The dashboard ships with the server, so its advertised API version must equal `API_VERSION` (per the backward-compatibility guideline). It stays a build-time hardcode rather than the server's runtime version on purpose: an older dashboard kept loaded across a server upgrade then reports its own build's version instead of over-reporting support for wire formats its code doesn't handle. The test parses the source files (no `import sky`) so it stays hermetic.

## Test plan
- `pytest tests/unit_tests/test_api_version_consistency.py` passes; reverting the bump (CLIENT_API_VERSION back to 53) makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)