### PR TITLE
[Server] Always exit on graceful shutdown even if request drain fails

### DIFF
--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -125,35 +125,69 @@ class Server(uvicorn.Server):
 
     def _graceful_shutdown(self, sig: int, frame: Union[FrameType,
                                                         None]) -> None:
-        """Perform graceful shutdown."""
-        time.sleep(_GRACE_WAIT_SECONDS)
-        # Block new requests so that we can wait until all on-going requests
-        # are finished. Note that /api/$verb operations are still allowed in
-        # this stage to ensure the client can still operate the on-going
-        # requests, e.g. /api/logs, /api/cancel, etc.
-        logger.info('Block new requests being submitted in worker '
-                    f'{os.getpid()}.')
-        state.set_block_requests(True)
-        # Ensure the shutting_down are set on all workers before next step.
-        # TODO(aylei): hacky, need a reliable solution.
-        time.sleep(1)
+        """Perform graceful shutdown.
 
-        lock = filelock.FileLock(_GRACEFUL_SHUTDOWN_LOCK_PATH)
-        # Elect a coordinator process to handle on-going requests check
-        with lock.acquire():
-            logger.info(f'Worker {os.getpid()} elected as shutdown coordinator')
-            self._wait_requests()
+        Runs in a separate daemon thread. This must *always* end by setting
+        ``should_exit`` and forwarding the exit to the parent handler, even if
+        draining on-going requests fails or hangs. ``set_block_requests(True)``
+        is set early so new requests are rejected while we drain; if we then
+        failed to exit (e.g. the request backend / database is unreachable and
+        the drain raises), the worker would stay up rejecting every request
+        forever. The try/finally below guarantees the process still exits and
+        gets restarted, clearing the block.
+        """
+        try:
+            time.sleep(_GRACE_WAIT_SECONDS)
+            # Block new requests so that we can wait until all on-going
+            # requests are finished. Note that /api/$verb operations are still
+            # allowed in this stage to ensure the client can still operate the
+            # on-going requests, e.g. /api/logs, /api/cancel, etc.
+            logger.info('Block new requests being submitted in worker '
+                        f'{os.getpid()}.')
+            state.set_block_requests(True)
+            # Ensure the shutting_down are set on all workers before next step.
+            # TODO(aylei): hacky, need a reliable solution.
+            time.sleep(1)
 
-        logger.info('Shutting down server...')
-        self.should_exit = True
-        super().handle_exit(sig, frame)
+            lock = filelock.FileLock(_GRACEFUL_SHUTDOWN_LOCK_PATH)
+            # Elect a coordinator process to handle on-going requests check.
+            # Bound the wait: a coordinator stuck draining (e.g. blocked on an
+            # unreachable database) must not keep the other workers from
+            # exiting.
+            try:
+                with lock.acquire(timeout=_WAIT_REQUESTS_TIMEOUT_SECONDS):
+                    logger.info(
+                        f'Worker {os.getpid()} elected as shutdown coordinator')
+                    self._wait_requests()
+            except filelock.Timeout:
+                logger.warning(
+                    f'Worker {os.getpid()} timed out waiting for the shutdown '
+                    'coordinator lock; proceeding to exit without draining.')
+        except Exception:  # pylint: disable=broad-except
+            # A drain failure must never prevent the worker from exiting.
+            logger.exception('Error during graceful shutdown drain; '
+                             'proceeding to exit anyway.')
+        finally:
+            logger.info('Shutting down server...')
+            self.should_exit = True
+            super().handle_exit(sig, frame)
 
     def _wait_requests(self) -> None:
-        """Wait until all on-going requests are finished or cancelled."""
+        """Wait until all on-going requests are finished or cancelled.
+
+        Best-effort: if the request backend is unreachable (e.g. database
+        outage) we log and stop draining so the shutdown can still proceed.
+        """
         start_time = time.time() - _GRACE_WAIT_SECONDS
         while True:
-            requests = (request_storage.get_request_backend().
-                        get_shutdown_active_requests())
+            try:
+                requests = (request_storage.get_request_backend().
+                            get_shutdown_active_requests())
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'Failed to query on-going requests during shutdown; '
+                    'stopping drain and proceeding to exit.')
+                break
             if not requests:
                 break
             logger.info(f'{len(requests)} on-going requests '

--- a/tests/unit_tests/test_uvicorn_graceful_shutdown.py
+++ b/tests/unit_tests/test_uvicorn_graceful_shutdown.py
@@ -1,0 +1,80 @@
+"""Tests for graceful shutdown of the API server uvicorn wrapper.
+
+The server worker sets ``block_requests`` early during graceful shutdown so
+that new requests are rejected while in-flight requests drain. If the drain
+step then fails to complete (e.g. the request backend / database is
+unreachable), the worker must still exit so it can be restarted and clear the
+block -- otherwise it stays up rejecting every request forever.
+"""
+import signal
+from unittest import mock
+
+import filelock
+import uvicorn
+
+from sky.server import uvicorn as sky_uvicorn
+
+
+async def _dummy_app(scope, receive, send):  # pylint: disable=unused-argument
+    pass
+
+
+def _make_server() -> sky_uvicorn.Server:
+    return sky_uvicorn.Server(uvicorn.Config(app=_dummy_app))
+
+
+def _patch_fast(monkeypatch) -> None:
+    # Skip the real sleeps and the block-requests side effect.
+    monkeypatch.setattr(sky_uvicorn.time, 'sleep', lambda *_a, **_k: None)
+    monkeypatch.setattr(sky_uvicorn.state, 'set_block_requests',
+                        lambda *_a, **_k: None)
+
+
+def test_graceful_shutdown_exits_when_backend_unreachable(monkeypatch):
+    """A drain failure must not prevent the worker from exiting."""
+    server = _make_server()
+    _patch_fast(monkeypatch)
+
+    backend = mock.Mock()
+    backend.get_shutdown_active_requests.side_effect = RuntimeError('db down')
+    monkeypatch.setattr(sky_uvicorn.request_storage, 'get_request_backend',
+                        lambda: backend)
+
+    server._graceful_shutdown(signal.SIGTERM, None)  # pylint: disable=protected-access
+
+    assert server.should_exit is True
+
+
+def test_graceful_shutdown_exits_when_no_requests(monkeypatch):
+    """The happy path still exits cleanly."""
+    server = _make_server()
+    _patch_fast(monkeypatch)
+
+    backend = mock.Mock()
+    backend.get_shutdown_active_requests.return_value = []
+    monkeypatch.setattr(sky_uvicorn.request_storage, 'get_request_backend',
+                        lambda: backend)
+
+    server._graceful_shutdown(signal.SIGTERM, None)  # pylint: disable=protected-access
+
+    assert server.should_exit is True
+
+
+def test_graceful_shutdown_exits_when_coordinator_lock_times_out(monkeypatch):
+    """A worker that cannot acquire the coordinator lock still exits."""
+    server = _make_server()
+    _patch_fast(monkeypatch)
+
+    class _StuckLock:
+
+        def __init__(self, *_a, **_k):
+            pass
+
+        def acquire(self, *_a, **_k):
+            raise filelock.Timeout('lock held')
+
+    monkeypatch.setattr(sky_uvicorn.filelock, 'FileLock', _StuckLock)
+
+    server._graceful_shutdown(signal.SIGTERM, None)  # pylint: disable=protected-access
+
+    assert server.should_exit is True


### PR DESCRIPTION
## Summary

During graceful shutdown, an API server worker sets `block_requests=True` early so new requests are rejected while in-flight requests drain, then drains by querying the request backend for active requests. The drain runs in a daemon thread with no error handling. If the request backend (database) is unreachable at that moment, the query raises — or the per-pod coordinator filelock blocks — so the thread dies before `should_exit` is ever set. The worker then stays up indefinitely, rejecting every request with "server is shutting down", and never exits to be restarted and clear the block. A transient backend outage during shutdown thus turns into a permanently wedged worker.

This wraps the drain in `try/finally` so `should_exit` and `handle_exit` always run, bounds the coordinator-lock acquire with a timeout, and makes the active-requests query best-effort so a backend outage stops the drain instead of propagating out of the thread. A failed drain now still lets the process exit and be restarted.

## Test

- [x] Code formatting: `bash format.sh` / pre-commit
- [x] New unit tests: `pytest tests/unit_tests/test_uvicorn_graceful_shutdown.py` — covers backend-unreachable, no-requests, and coordinator-lock-timeout paths; all assert the worker still sets `should_exit`
