### PR TITLE
[API] Measure executor queue-wait per-enqueue, not since request creation

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -245,16 +245,10 @@ class RequestWorker:
                 time.sleep(0.1)
                 return
             request_id, ignore_return_value, _ = request_element
-            request = api_requests.get_request(request_id,
-                                               fields=['status', 'created_at'])
+            request = api_requests.get_request(request_id, fields=['status'])
             assert request is not None, f'Request with ID {request_id} is None'
             if request.status == api_requests.RequestStatus.CANCELLED:
                 return
-            if metrics_utils.METRICS_ENABLED:
-                metrics_utils.SKY_APISERVER_QUEUE_WAIT_SECONDS.labels(
-                    schedule_type=self.schedule_type.value,).observe(
-                        max(0,
-                            time.time() - request.created_at))
             del request
             logger.info(f'[{self}] Submitting request: {request_id}')
             # Start additional process to run the request, so that it can be

--- a/sky/server/requests/queues/base.py
+++ b/sky/server/requests/queues/base.py
@@ -3,9 +3,11 @@
 import abc
 import multiprocessing
 import queue as queue_lib
+import time
 from typing import List, Optional, Tuple
 
 from sky import sky_logging
+from sky.metrics import utils as metrics_utils
 from sky.server.requests import requests as api_requests
 from sky.server.requests.queues import local_queue
 from sky.server.requests.queues import mp_queue
@@ -13,9 +15,31 @@ from sky.utils import common_utils
 
 logger = sky_logging.init_logger(__name__)
 
+# The element stored inside the in-memory queues: the public request tuple
+# plus the wall-clock time it was enqueued, so get() can report how long the
+# entry actually waited for a worker. The enqueue timestamp is set
+# afresh on every put(), including re-enqueues (requeue, retry/backoff,
+# broken-pool), so the recorded wait excludes time spent paused or running.
+_InternalItem = Tuple[Tuple[str, bool, bool], float]
+
+
+def _observe_queue_wait(schedule_type: str, enqueued_at: float) -> None:
+    """Record time the just-dequeued entry spent waiting in the queue."""
+    if not metrics_utils.METRICS_ENABLED:
+        return
+    metrics_utils.SKY_APISERVER_QUEUE_WAIT_SECONDS.labels(
+        schedule_type=schedule_type).observe(max(0,
+                                                 time.time() - enqueued_at))
+
 
 class QueueBackend(abc.ABC):
-    """Abstract queue backend."""
+    """Abstract queue backend.
+
+    Each backend is responsible for emitting
+    ``SKY_APISERVER_QUEUE_WAIT_SECONDS`` from ``get()`` (measuring the time
+    between enqueue and dequeue of the returned entry), so the metric reflects
+    true queue residency regardless of the backend's storage.
+    """
 
     @abc.abstractmethod
     def put(self, item: Tuple[str, bool, bool]) -> None:
@@ -30,7 +54,11 @@ class QueueBackend(abc.ABC):
 
     @abc.abstractmethod
     def get(self) -> Optional[Tuple[str, bool, bool]]:
-        """Non-blocking get. Returns None if queue is empty."""
+        """Non-blocking get. Returns None if queue is empty.
+
+        Implementations must emit ``SKY_APISERVER_QUEUE_WAIT_SECONDS`` for the
+        dequeued entry (see ``_observe_queue_wait``).
+        """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -71,16 +99,22 @@ class LocalQueueBackend(QueueBackend):
 
     def __init__(self, queue_name: str):
         super().__init__()
+        # queue_name is the schedule type ('long' / 'short'); used as the
+        # metric label when reporting queue wait.
+        self._schedule_type = queue_name
         self._queue = local_queue.get_queue(queue_name)
 
     def put(self, item: Tuple[str, bool, bool]) -> None:
-        self._queue.put(item)
+        internal: _InternalItem = (item, time.time())
+        self._queue.put(internal)
 
     def get(self) -> Optional[Tuple[str, bool, bool]]:
         try:
-            return self._queue.get(block=False)
+            item, enqueued_at = self._queue.get(block=False)
         except queue_lib.Empty:
             return None
+        _observe_queue_wait(self._schedule_type, enqueued_at)
+        return item
 
     def qsize(self) -> int:
         return self._queue.qsize()
@@ -93,16 +127,22 @@ class MultiprocessingQueueBackend(QueueBackend):
                  queue_name: str,
                  port: int = mp_queue.DEFAULT_QUEUE_MANAGER_PORT):
         super().__init__()
+        # queue_name is the schedule type ('long' / 'short'); used as the
+        # metric label when reporting queue wait.
+        self._schedule_type = queue_name
         self._queue = mp_queue.get_queue(queue_name, port)
 
     def put(self, item: Tuple[str, bool, bool]) -> None:
-        self._queue.put(item)
+        internal: _InternalItem = (item, time.time())
+        self._queue.put(internal)
 
     def get(self) -> Optional[Tuple[str, bool, bool]]:
         try:
-            return self._queue.get(block=False)
+            item, enqueued_at = self._queue.get(block=False)
         except queue_lib.Empty:
             return None
+        _observe_queue_wait(self._schedule_type, enqueued_at)
+        return item
 
     def qsize(self) -> int:
         return self._queue.qsize()

--- a/sky/server/requests/queues/base.py
+++ b/sky/server/requests/queues/base.py
@@ -24,12 +24,20 @@ _InternalItem = Tuple[Tuple[str, bool, bool], float]
 
 
 def _observe_queue_wait(schedule_type: str, enqueued_at: float) -> None:
-    """Record time the just-dequeued entry spent waiting in the queue."""
+    """Record time the just-dequeued entry spent waiting in the queue.
+
+    Metric emission must never disrupt the dequeue path, so any failure
+    (label mismatch, client error) is logged and swallowed.
+    """
     if not metrics_utils.METRICS_ENABLED:
         return
-    metrics_utils.SKY_APISERVER_QUEUE_WAIT_SECONDS.labels(
-        schedule_type=schedule_type).observe(max(0,
-                                                 time.time() - enqueued_at))
+    try:
+        metrics_utils.SKY_APISERVER_QUEUE_WAIT_SECONDS.labels(
+            schedule_type=schedule_type).observe(
+                max(0,
+                    time.time() - enqueued_at))
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f'Failed to observe queue wait metric: {e}')
 
 
 class QueueBackend(abc.ABC):

--- a/tests/unit_tests/test_sky/server/requests/queues/test_base.py
+++ b/tests/unit_tests/test_sky/server/requests/queues/test_base.py
@@ -1,0 +1,143 @@
+"""Tests for queue backends' queue-wait metric.
+
+The queue-wait metric must measure time between *enqueue* and *dequeue*, not
+time since request creation. These tests pin that contract for the in-memory
+``LocalQueueBackend``: the dequeued item is returned unchanged, and the wait
+recorded is measured from the (latest) ``put()`` — so a re-enqueue resets the
+reference and excludes any time the request spent paused or running.
+"""
+
+import socket
+import time
+from unittest import mock
+
+import pytest
+
+from sky.server.requests.queues import base
+
+
+def _patch_metric(monkeypatch):
+    """Enable metrics and swap in a mock histogram; return the mock."""
+    monkeypatch.setattr(base.metrics_utils, 'METRICS_ENABLED', True)
+    mock_hist = mock.MagicMock()
+    monkeypatch.setattr(base.metrics_utils, 'SKY_APISERVER_QUEUE_WAIT_SECONDS',
+                        mock_hist)
+    return mock_hist
+
+
+def test_local_backend_roundtrip_preserves_item(monkeypatch):
+    _patch_metric(monkeypatch)
+    backend = base.LocalQueueBackend('long')
+
+    item = ('req-1', False, True)
+    backend.put(item)
+    assert backend.get() == item
+    # Empty queue returns None without emitting.
+    assert backend.get() is None
+
+
+def test_local_backend_observes_wait_since_enqueue(monkeypatch):
+    mock_hist = _patch_metric(monkeypatch)
+    backend = base.LocalQueueBackend('short')
+
+    backend.put(('req-2', False, False))
+    time.sleep(0.05)
+    backend.get()
+
+    mock_hist.labels.assert_called_once_with(schedule_type='short')
+    (observed,), _ = mock_hist.labels.return_value.observe.call_args
+    # Wait reflects the ~50ms the entry sat in the queue, not 0 and not a
+    # request-creation timestamp.
+    assert observed >= 0.04
+
+
+def test_local_backend_requeue_resets_wait(monkeypatch):
+    """A re-enqueue measures only the new wait."""
+    mock_hist = _patch_metric(monkeypatch)
+    backend = base.LocalQueueBackend('long')
+
+    item = ('req-3', False, True)
+    # First enqueue sits a while, then is dequeued (simulating admit + run).
+    backend.put(item)
+    time.sleep(0.3)
+    assert backend.get() == item
+    # Re-enqueue and dequeue promptly: the second wait must be much smaller,
+    # independent of how long the first attempt took. Compare relative to the
+    # first wait rather than an absolute threshold to avoid CI flakiness.
+    backend.put(item)
+    backend.get()
+
+    observed = [
+        c[0][0] for c in mock_hist.labels.return_value.observe.call_args_list
+    ]
+    first_wait, second_wait = observed[0], observed[1]
+    assert first_wait >= 0.25
+    assert second_wait < first_wait / 2
+
+
+def test_local_backend_no_emit_when_metrics_disabled(monkeypatch):
+    monkeypatch.setattr(base.metrics_utils, 'METRICS_ENABLED', False)
+    mock_hist = mock.MagicMock()
+    monkeypatch.setattr(base.metrics_utils, 'SKY_APISERVER_QUEUE_WAIT_SECONDS',
+                        mock_hist)
+    backend = base.LocalQueueBackend('long')
+
+    backend.put(('req-4', False, False))
+    assert backend.get() == ('req-4', False, False)
+    mock_hist.labels.assert_not_called()
+
+
+@pytest.fixture()
+def mp_backend():
+    """A MultiprocessingQueueBackend backed by a live manager on a free port.
+
+    The cross-process backend adds pickling of the (item, enqueued_at) payload
+    over the manager, so it exercises a path LocalQueueBackend can't. get() runs
+    in this process, so metric patching via monkeypatch still applies.
+    """
+    sock = socket.socket()
+    sock.bind(('localhost', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    factory = base.MultiprocessingQueueFactory(port=port)
+    process = factory.start()
+    try:
+        yield factory.create_queue('long')
+    finally:
+        factory.stop(process)
+
+
+def test_mp_backend_roundtrip_and_observes_wait(mp_backend, monkeypatch):
+    mock_hist = _patch_metric(monkeypatch)
+
+    item = ('req-5', False, True)
+    mp_backend.put(item)
+    time.sleep(0.05)
+    # Item survives the pickle round-trip through the manager unchanged.
+    assert mp_backend.get() == item
+
+    mock_hist.labels.assert_called_once_with(schedule_type='long')
+    (observed,), _ = mock_hist.labels.return_value.observe.call_args
+    assert observed >= 0.04
+    # Empty queue returns None without emitting again.
+    assert mp_backend.get() is None
+    mock_hist.labels.assert_called_once()
+
+
+def test_mp_backend_requeue_resets_wait(mp_backend, monkeypatch):
+    mock_hist = _patch_metric(monkeypatch)
+
+    item = ('req-6', False, True)
+    mp_backend.put(item)
+    time.sleep(0.3)
+    assert mp_backend.get() == item
+    mp_backend.put(item)
+    assert mp_backend.get() == item
+
+    observed = [
+        c[0][0] for c in mock_hist.labels.return_value.observe.call_args_list
+    ]
+    first_wait, second_wait = observed[0], observed[1]
+    assert first_wait >= 0.25
+    assert second_wait < first_wait / 2


### PR DESCRIPTION
## Summary

- `sky_apiserver_queue_wait_seconds` observed `time.time() - request.created_at` at the moment a worker dequeued a request, so the metric measured *wall-clock time since the request row was created*, not time the entry actually waited for a free worker.
- A request that was picked up promptly but later re-enqueued (retry/backoff, `BrokenProcessPool`, or a precondition wait that holds the request out of the queue until a condition is met) reported a wait that swept in all the time it spent outside the queue. That inflated the P95 and produced false "executor pool full" signals on healthy servers.
- Fix: each `QueueBackend` now emits the metric from its own `get()`, measuring time between the entry's *enqueue* and *dequeue*. Every `put()` (including re-enqueues) stamps a fresh enqueue time, so paused/running time is naturally excluded and the histogram reflects true queue residency.

The emission moves out of `RequestWorker.process_request` and into the backends, giving a single, consistent emission site (`LocalQueueBackend` / `MultiprocessingQueueBackend`).

## Test plan

- New `tests/unit_tests/test_sky/server/requests/queues/test_base.py`:
  - round-trip preserves the dequeued item; empty `get()` emits nothing
  - observed wait reflects time since enqueue
  - a re-enqueue resets the reference so the second wait is far smaller than the first, independent of the first attempt's duration
  - no emission when metrics are disabled
  - the same contract exercised against `MultiprocessingQueueBackend` (cross-process payload round-trip via a live manager)
- `pytest tests/unit_tests/test_sky/server/requests/queues/test_base.py` → 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)