### PR TITLE
[Server] Only record queue-wait time on first dequeue

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -250,7 +250,15 @@ class RequestWorker:
             assert request is not None, f'Request with ID {request_id} is None'
             if request.status == api_requests.RequestStatus.CANCELLED:
                 return
-            if metrics_utils.METRICS_ENABLED:
+            # Only record queue-wait time on the first dequeue (still PENDING).
+            # A request that pauses to wait on an external condition is parked
+            # in WAITING and re-enqueued once ready; that wait is spent outside
+            # the queue (in the monitor thread), not contending for a worker.
+            # Observing it again would measure `now - created_at`, folding the
+            # entire wait into queue-wait time and inflating the metric, which
+            # is meant to reflect time spent queued for a free worker.
+            if (metrics_utils.METRICS_ENABLED and
+                    request.status == api_requests.RequestStatus.PENDING):
                 metrics_utils.SKY_APISERVER_QUEUE_WAIT_SECONDS.labels(
                     schedule_type=self.schedule_type.value,).observe(
                         max(0,


### PR DESCRIPTION
`sky_apiserver_queue_wait_seconds` is observed every time a request is dequeued, always as `now - request.created_at`. This is wrong for requests that pause and re-enqueue: a request that raises `ExecutionRetryableError` is parked in `WAITING`, waits on its continue-condition (or a fixed backoff) in the monitor thread, then is put back on the queue. That wait happens outside the queue and does not contend for a worker, yet on the next dequeue it gets folded into `now - created_at` and re-observed — inflating the histogram with time that has nothing to do with queue saturation.

This restricts the observation to the first dequeue, when the request is still `PENDING`. Re-enqueued requests (`WAITING`) and broken-pool retries (`FAILED`) are skipped, so the metric reflects only the time a request spends queued waiting for a free worker, which is what it is meant to measure.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manually traced the retry/requeue path in `RequestWorker.handle_task_result`: status is set to `WAITING` before re-enqueue and never reset to `PENDING`, so the new guard correctly observes once on initial schedule and skips every requeue.
