### PR TITLE
[client] Bound read timeout on streaming API requests to detect dead connections

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -63,6 +63,18 @@ _FILE_UPLOAD_LOCK_DIR = '~/.sky/locks/file_uploads'
 # Connection timeout when sending requests to the API server.
 API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS = 5
 
+# Read timeout (seconds allowed between bytes from the server) for streaming
+# requests to the API server's heartbeat-emitting endpoints (e.g. /api/stream
+# log following). The server sends a heartbeat every 30s on these streams
+# (sky/server/stream_utils.py:_HEARTBEAT_INTERVAL, added for #5750) to keep the
+# connection busy through idle-timeout proxies/CDNs. This client-side read
+# timeout is the counterpart: set well above the 30s heartbeat so a healthy
+# stream never trips it, but a dead/stalled connection (no heartbeat received
+# for this long) raises ReadTimeout and is retried on a fresh connection instead
+# of blocking forever. NOT applied to heartbeat-less long-poll endpoints (e.g.
+# /api/get), which may legitimately block on a slow request with no output.
+API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS = 120  # 4x the 30s heartbeat
+
 
 def download_logs_from_api_server(
         paths_on_api_server: Iterable[str],

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1165,7 +1165,7 @@ def tail_logs(
         json=json.loads(body.model_dump_json()),
         stream=True,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None))
+                 client_common.API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS))
     request_id: server_common.RequestId[int] = server_common.get_request_id(
         response)
     if preload_content:
@@ -1225,7 +1225,7 @@ def tail_provision_logs(cluster_name: str,
         params=params,
         stream=True,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None))
+                 client_common.API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS))
     # Check for HTTP errors before streaming the response
     if response.status_code != 200:
         with ux_utils.print_exception_no_traceback():
@@ -2442,7 +2442,7 @@ def stream_and_get(
         params=params,
         retry=False,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None),
+                 client_common.API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS),
         stream=True)
     if response.status_code in [404, 400]:
         detail = response.json().get('detail')

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -543,7 +543,8 @@ def tail_logs(
         '/jobs/logs',
         json=json.loads(body.model_dump_json()),
         stream=True,
-        timeout=(5, None))
+        timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
+                 client_common.API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS))
     request_id: server_common.RequestId[int] = server_common.get_request_id(
         response)
     if preload_content:

--- a/tests/unit_tests/test_sky/server/test_rest_stream_timeout.py
+++ b/tests/unit_tests/test_sky/server/test_rest_stream_timeout.py
@@ -1,0 +1,145 @@
+"""Regression tests for streaming read-timeout behavior in the API client.
+
+Background: streaming reads (`/api/stream` log following, etc.) were issued with
+no read timeout, so a streaming connection that silently stalls -- a proxy/CDN
+drops the long-lived connection, or the peer goes away mid-stream without
+closing -- left the client blocked in ``recv()`` forever. The server sends a
+heartbeat every ``stream_utils._HEARTBEAT_INTERVAL`` seconds on these streams to
+keep them busy; the client-side fix is a read timeout comfortably above that
+interval, so a healthy stream never trips it but a dead one raises a (retryable)
+error instead of hanging. See PR #9990.
+"""
+import socket
+import threading
+import time
+
+import pytest
+import requests
+
+from sky.client import common as client_common
+from sky.server import rest
+from sky.server import stream_utils
+
+
+class _SilentStreamServer:
+    """Sends HTTP 200 + one chunk, then holds the socket open and silent.
+
+    This mimics a dead/stalled stream: the response started, but no further
+    bytes (not even a heartbeat) ever arrive and the peer never closes.
+    """
+
+    def __init__(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(('127.0.0.1', 0))
+        self._sock.listen(8)
+        self.port = self._sock.getsockname()[1]
+        self._conns = []  # hold accepted sockets open (never send more, never close)
+        self._stop = False
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        self._sock.settimeout(0.5)
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            conn.settimeout(5)
+            data = b''
+            try:
+                while b'\r\n\r\n' not in data:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+                conn.sendall(b'HTTP/1.1 200 OK\r\n'
+                             b'Content-Type: text/plain\r\n'
+                             b'Transfer-Encoding: chunked\r\n\r\n'
+                             b'3\r\nhi\n\r\n')  # one chunk, then silence
+            except OSError:
+                continue
+            self._conns.append(conn)
+
+    @property
+    def url(self):
+        return f'http://127.0.0.1:{self.port}/api/stream'
+
+    def close(self):
+        self._stop = True
+        for c in self._conns:
+            try:
+                c.close()  # unblock any client stuck reading this socket
+            except OSError:
+                pass
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def silent_stream_server(monkeypatch):
+    # Make sure localhost is not routed through any ambient HTTP proxy, which
+    # would otherwise intercept the connection and mask the behavior.
+    for var in ('http_proxy', 'https_proxy', 'all_proxy', 'HTTP_PROXY',
+                'HTTPS_PROXY', 'ALL_PROXY'):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv('NO_PROXY', '*')
+    server = _SilentStreamServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def _consume_stream(url, read_timeout):
+    resp = rest._session.request('GET',
+                                 url,
+                                 stream=True,
+                                 timeout=(5, read_timeout))
+    for _ in resp.iter_lines():
+        pass
+
+
+def test_streaming_read_timeout_fires_on_silent_stream(silent_stream_server):
+    """A read timeout detects a silently-stalled stream promptly (raises a
+    retryable RequestException) instead of blocking forever."""
+    read_timeout = 2
+    start = time.monotonic()
+    with pytest.raises(requests.exceptions.RequestException) as exc_info:
+        _consume_stream(silent_stream_server.url, read_timeout)
+    elapsed = time.monotonic() - start
+    assert elapsed < read_timeout + 5, f'raised too late: {elapsed:.1f}s'
+    # Surfaces as a timeout (a read timeout during streaming iteration is
+    # reported as ConnectionError("Read timed out"), still a RequestException).
+    assert 'timed out' in str(exc_info.value).lower()
+
+
+def test_no_read_timeout_blocks_forever(silent_stream_server):
+    """Without a read timeout the same silent stream never returns within a
+    generous window -- the hang this fix guards against."""
+    done = threading.Event()
+
+    def run():
+        try:
+            _consume_stream(silent_stream_server.url, None)
+        except Exception:  # pylint: disable=broad-except
+            pass
+        finally:
+            done.set()
+
+    threading.Thread(target=run, daemon=True).start()
+    # The read-timeout case above returns in ~2s; still blocked at 4s => hang.
+    assert not done.wait(timeout=4), 'stream returned without a read timeout'
+
+
+def test_stream_read_timeout_exceeds_server_heartbeat():
+    """Design invariant: the client streaming read timeout must stay above the
+    server's stream heartbeat interval, so a healthy (idle-but-heartbeating)
+    stream never trips it."""
+    assert (client_common.API_SERVER_REQUEST_STREAM_READ_TIMEOUT_SECONDS >
+            stream_utils._HEARTBEAT_INTERVAL)


### PR DESCRIPTION
## Problem

`sky status`, `sky logs`, and `sky jobs/serve logs` stream their results from the
API server's `/api/stream` (and `/logs`, `/provision_logs`) endpoints. The client
makes these streaming reads with **no read timeout**:

```python
timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS, None)
#                                                                      ^^^^ read = unbounded
```

`requests`/`aiohttp` with an unbounded read wait **forever** for the next byte.
So if a streaming connection silently dies, the client blocks in `recv()`
indefinitely instead of erroring or retrying.

## When does this happen / who hits it

- Affects clients talking to a **remote API server** that sits behind a
  **reverse proxy / load balancer / CDN** with an idle-connection timeout (a
  common production deployment). Local/direct API servers rarely hit it.
- Triggered on the **long-lived streaming requests** above, when the connection
  is **silently dropped or stalled mid-stream** — e.g. a proxy/CDN idle timeout,
  a transient network drop, a laptop sleep / VPN switch, or the server being
  rolled while a stream is open.
- **More likely under server load:** streaming responses stay open longer (so
  there's a wider window for a drop), there are more concurrent streams, and
  event-loop pressure can delay the server's keepalive heartbeat (below) past
  the proxy's idle limit, causing the proxy to drop the "idle" stream.
- Symptom for the user: `sky status`/`sky logs` appears to hang with no output
  and never returns until Ctrl-C.

## Evidence

**1. A real `sky status` wedged ~20 min.** Kernel stack of the hung process
(`/proc/<pid>/stack`):
```
sk_wait_data
tcp_recvmsg_locked      <- blocked reading the response socket, indefinitely
tcp_recvmsg -> inet_recvmsg -> sock_recvmsg -> sock_read_iter -> vfs_read -> ksys_read
open fd 3u: protocol: TCP   (the connection to the API server)
```
`ps` showed the same process at `etime` 1229s.

**2. The server/target were healthy — a fresh call returned instantly.** Running
the same command again (new connection) returned in <2s. So it was a single
half-dead connection, not a slow server or a real problem with the query.

**3. Deterministic demonstration of the mechanism.** A client request against a
TCP listener that accepts but sends nothing — unbounded blocks forever, bounded
raises promptly (the principle this PR applies to the streaming reads):
```
no read timeout              -> blocks indefinitely
timeout=(connect=3, read=3)  -> raises in ~3s
```

## Root cause & fix

The server **already sends a heartbeat every 30s** on these streams
(`sky/server/stream_utils.py:_HEARTBEAT_INTERVAL`, added in #5750) precisely to
keep the connection busy through idle-timeout proxies. The missing piece is the
**client-side counterpart**: a read timeout above the heartbeat interval.

This sets the streaming read timeout to **4× the heartbeat (120s)**:
- A healthy stream receives a heartbeat every 30s, which resets the read timer,
  so the 120s timeout **never fires** — no regression to live streaming.
- A dead/stalled stream (no heartbeat for 120s) raises `ReadTimeout`, which the
  streaming SDK functions already treat as transient (`retry_transient_errors`)
  and **retry on a fresh connection** — which, as shown above, succeeds.
- Heartbeat-less long-poll endpoints (`/api/get`) are **left unbounded**, since
  they may legitimately block on a slow request that produces no intermediate
  output.

## Why this layer (vs. alternatives)

- **Not a blanket default read timeout** on all requests: it would break the
  long-poll `/api/get` (legitimately slow) and any slow synchronous endpoint.
- **Not TCP keepalive (`SO_KEEPALIVE`)**: keepalive only detects a *TCP-dead*
  peer, not a proxy that holds the socket open while forwarding no data; a read
  timeout catches **both**, and it composes with the heartbeat the server
  already sends. (HTTP keep-alive / connection reuse is already on and is
  unrelated — it doesn't detect dead connections.)

## Open questions for reviewers

1. Is **4× the heartbeat (120s)** the right margin? Under extreme load the
   server could delay a heartbeat; too tight → false `ReadTimeout` + retry, too
   loose → slower detection.
2. Should the heartbeat interval be a **shared constant** so the client read
   timeout is provably coupled to it (rather than two independently-chosen
   numbers)?
3. Completeness: the same one-line change applies to the other `/api/stream`
   readers (`sky/jobs/client/sdk.py`, `sky/serve/client/*`) — include here, or a
   follow-up?

## Test plan

- [ ] Unit test: a stalled streaming endpoint raises `ReadTimeout` within ~the
      timeout instead of hanging.
- [ ] `sky logs`/`sky jobs logs`/`sky serve logs` following stays connected while
      idle (heartbeat keeps the 120s timer reset).
- [ ] Normal `sky status` latency unaffected; `/api/get` long-poll on a slow
      request is not prematurely timed out.
