### PR TITLE
[Logs] Deliver GCP logging credential to a readable remote path

### DIFF
--- a/sky/logs/gcp.py
+++ b/sky/logs/gcp.py
@@ -1,12 +1,21 @@
 """GCP logging agent."""
 
+import os
 from typing import Any, Dict, Optional
 
 import pydantic
 
 from sky.clouds import gcp
 from sky.logs.agent import FluentbitAgent
+from sky.skylet import constants
 from sky.utils import resources_utils
+
+# Remote path where a user-provided service-account key (logs.gcp.
+# credentials_file) is delivered. Fixed and home-relative so it is readable by
+# the cluster's runtime user regardless of where the key lives on the API
+# server (e.g. under another user's home, or behind a symlink).
+_REMOTE_CREDENTIAL_PATH = os.path.join(constants.LOGGING_CONFIG_DIR,
+                                       'gcp_credentials.json')
 
 
 class _GCPLoggingConfig(pydantic.BaseModel):
@@ -45,7 +54,7 @@ class GCPLoggingAgent(FluentbitAgent):
                           cluster_name: resources_utils.ClusterName) -> str:
         credential_path = gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH
         if self.config.credentials_file:
-            credential_path = self.config.credentials_file
+            credential_path = _REMOTE_CREDENTIAL_PATH
         # Set GOOGLE_APPLICATION_CREDENTIALS and check whether credentials
         # is valid.
         # Stackdriver only support service account credentials or credentials
@@ -87,6 +96,14 @@ class GCPLoggingAgent(FluentbitAgent):
         ).to_dict()
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
-        if self.config.credentials_file:
-            return {self.config.credentials_file: self.config.credentials_file}
-        return {}
+        if not self.config.credentials_file:
+            return {}
+        # Resolve to a concrete local file before upload: expanduser handles
+        # '~', and realpath resolves symlinks (e.g. a Kubernetes Secret mounted
+        # as a volume, which exposes the key through a symlink chain) and
+        # relative paths. Delivered to a fixed home-relative path so the
+        # cluster's runtime user can read it even when the source lives under
+        # another user's home (e.g. /root) on the API server.
+        local_path = os.path.realpath(
+            os.path.expanduser(self.config.credentials_file))
+        return {_REMOTE_CREDENTIAL_PATH: local_path}

--- a/tests/unit_tests/test_sky/logs/test_gcp.py
+++ b/tests/unit_tests/test_sky/logs/test_gcp.py
@@ -1,0 +1,72 @@
+"""Unit tests for sky.logs.gcp module."""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from sky.clouds import gcp
+from sky.logs.gcp import _REMOTE_CREDENTIAL_PATH
+from sky.logs.gcp import GCPLoggingAgent
+from sky.utils import resources_utils
+
+
+class TestGCPLoggingAgent(unittest.TestCase):
+    """Tests for GCPLoggingAgent credential handling."""
+
+    def setUp(self):
+        self.cluster_name = resources_utils.ClusterName(
+            'test-cluster', 'test-cluster-unique-id')
+
+    def test_get_credential_file_mounts_none(self):
+        """No credentials_file -> no logging-agent credential upload."""
+        agent = GCPLoggingAgent({})
+        self.assertEqual(agent.get_credential_file_mounts(), {})
+
+    def test_get_credential_file_mounts_resolves_symlink(self):
+        """A key behind a symlink (e.g. a K8s Secret volume) is uploaded by
+        its resolved real path, to the fixed home-relative destination."""
+        with tempfile.TemporaryDirectory() as d:
+            real = os.path.join(d, 'real-key.json')
+            with open(real, 'w', encoding='utf-8') as f:
+                f.write('{}')
+            link = os.path.join(d, 'link-key.json')
+            os.symlink(real, link)
+
+            agent = GCPLoggingAgent({'credentials_file': link})
+            self.assertEqual(agent.get_credential_file_mounts(),
+                             {_REMOTE_CREDENTIAL_PATH: os.path.realpath(real)})
+
+    def test_get_credential_file_mounts_expands_user(self):
+        """'~' in the configured path is expanded before upload."""
+        with tempfile.TemporaryDirectory() as home:
+            real = os.path.join(home, 'key.json')
+            with open(real, 'w', encoding='utf-8') as f:
+                f.write('{}')
+            with mock.patch.dict(os.environ, {'HOME': home}):
+                agent = GCPLoggingAgent({'credentials_file': '~/key.json'})
+                mounts = agent.get_credential_file_mounts()
+            self.assertEqual(mounts,
+                             {_REMOTE_CREDENTIAL_PATH: os.path.realpath(real)})
+
+    def test_setup_command_uses_remote_path_when_key_set(self):
+        """When a key is configured, GOOGLE_APPLICATION_CREDENTIALS points at
+        the delivered remote path, not the (server-side) source path."""
+        agent = GCPLoggingAgent({'credentials_file': '/server/only/key.json'})
+        cmd = agent.get_setup_command(self.cluster_name)
+        self.assertIn(
+            f'export GOOGLE_APPLICATION_CREDENTIALS={_REMOTE_CREDENTIAL_PATH}',
+            cmd)
+        self.assertNotIn('/server/only/key.json', cmd)
+
+    def test_setup_command_defaults_to_adc_when_no_key(self):
+        """Without a key, fall back to the default application-default path."""
+        agent = GCPLoggingAgent({})
+        cmd = agent.get_setup_command(self.cluster_name)
+        self.assertIn(
+            'export GOOGLE_APPLICATION_CREDENTIALS='
+            f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH}', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`logs.gcp.credentials_file` is uploaded to clusters and exported as `GOOGLE_APPLICATION_CREDENTIALS` for the fluent-bit stackdriver output. Two cases were broken:

- The credential was uploaded to the same path it has on the API server and used verbatim on the cluster. When that path is under a home the cluster's runtime user cannot read (e.g. `/root` while the cluster runs as a non-root user), fluent-bit cannot open the key and stackdriver initialization fails — silently, since on GKE the setup falls back to the metadata server and the agent still starts but never authenticates.
- The configured path may be a symlink (e.g. a Kubernetes Secret mounted as a volume); the file-mount upload does not follow it, so no real file lands on the cluster.

This resolves the configured path with `expanduser` + `realpath` (handling `~`, relative paths, and symlinks) and delivers the resolved file to a fixed home-relative location, `~/.sky/logging/gcp_credentials.json`, pointing `GOOGLE_APPLICATION_CREDENTIALS` there. Behavior is unchanged when no key is configured (application-default credentials / metadata server).

## Test

- New unit tests `tests/unit_tests/test_sky/logs/test_gcp.py`: symlink resolution, `~` expansion, and that the setup command exports `GOOGLE_APPLICATION_CREDENTIALS` to the remote path when a key is set (and to the application-default path otherwise). `pytest tests/unit_tests/test_sky/logs/test_gcp.py` — 5 passed.
- Manual (Kubernetes-hosted API server, non-root cluster user): confirmed that delivering the key to a home-relative path the runtime user can read is what lets the fluent-bit stackdriver output authenticate and ship task logs to Cloud Logging; the prior same-path behavior left the key unreadable and the agent failed to authenticate.
