### PR TITLE
[Test] minimal.yaml: use `pip list` instead of `conda env list`

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -853,9 +853,9 @@ VALIDATE_LAUNCH_OUTPUT = (
     # ├── Waiting for task resources on 1 node.
     # └── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
     # (setup pid=1277) running setup
-    # (min, pid=1277) # conda environments:
-    # (min, pid=1277) #
-    # (min, pid=1277) base                  *  /opt/conda
+    # (min, pid=1277) Package    Version
+    # (min, pid=1277) ---------- -------
+    # (min, pid=1277) pip        24.0
     # (min, pid=1277)
     # (min, pid=1277) task run finish
     # ✓ Job finished (status: SUCCEEDED).

--- a/tests/test_yamls/minimal.yaml
+++ b/tests/test_yamls/minimal.yaml
@@ -4,5 +4,5 @@ setup: |
   echo "running setup"
 
 run: |
-  conda env list
+  pip list
   echo "task run finish"


### PR DESCRIPTION
## Summary

The `minimal.yaml` smoke-test task fixture listed the environment with `conda env list` in its `run` command, which assumes conda is installed in the task runtime. Switch to `pip list` so the minimal fixture doesn't depend on conda being present, keeping equivalent behavior — a trivial command that lists the environment before the `task run finish` marker.

`minimal.yaml` is used across many smoke tests, so I audited the assertions: `VALIDATE_LAUNCH_OUTPUT` validates only the `(min, pid=` log prefix and the `task run finish` line (not the conda-specific output), and the `task run finish` greps elsewhere are unaffected. Updated the illustrative output comment in `smoke_tests_utils.py` to match.

## Tested

Fixture-only change; assertions audited as above. Will run through smoke CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
