### PR TITLE
[Debug Dump] Collect Prometheus server container logs

### DIFF
--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -61,9 +61,17 @@ _KUEUE_QUEUE_NAME_LABEL = 'kueue.x-k8s.io/queue-name'
 # other half of the DCGM<->pod join) carries `kube-state-metrics` in its name.
 # DCGM exporter's namespace varies by installer, so it's matched by name
 # substring. See _dump_gpu_metrics_pods for the full object set (pods, the
-# prometheus config, the PVC, and the DCGM DaemonSet).
+# prometheus-server container logs, the prometheus config, the PVC, and the
+# DCGM DaemonSet).
 _GPU_METRICS_NAMESPACE = 'skypilot'
 _PROMETHEUS_SERVER_NAME_PREFIX = 'skypilot-prometheus-server'
+# The Prometheus container within the server pod (the chart runs a
+# `configmap-reload` sidecar alongside it); we collect this container's logs.
+_PROMETHEUS_SERVER_CONTAINER = 'prometheus-server'
+# Tail bound for the collected container logs -- enough to hold a full WAL
+# replay (roughly one line per segment) plus startup, without letting a chatty
+# or long-lived server bloat the dump.
+_PROMETHEUS_LOG_TAIL_LINES = 2000
 _KUBE_STATE_METRICS_NAME_SUBSTR = 'kube-state-metrics'
 _DCGM_EXPORTER_NAME_SUBSTR = 'dcgm-exporter'
 
@@ -161,6 +169,7 @@ def dump_context_resources(context: Optional[str],
                                # bare or unreachable context stays visible
           gpu_metrics/         # if present:
             prometheus-server.yaml
+            <pod>.log  <pod>.previous.log  # prometheus-server container logs
             dcgm-exporter.yaml
           kueue/               # if Kueue is installed on the context:
             localqueues.yaml  clusterqueues.yaml
@@ -249,6 +258,11 @@ def _fail_fast(api: Any) -> Any:
 def _write_yaml(path: str, obj: Any) -> None:
     with open(path, 'w', encoding='utf-8') as f:
         f.write(yaml_utils.dump_yaml_str(obj))
+
+
+def _write_text(path: str, text: str) -> None:
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(text)
 
 
 def _strip_managed_fields(obj_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -457,6 +471,10 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
     Into ``<output_dir>/gpu_metrics/``:
       - prometheus-server: the metrics Prometheus server pod (helm release
         ``skypilot-prometheus`` in the ``skypilot`` namespace).
+      - ``<pod>.log`` / ``<pod>.previous.log``: the prometheus-server
+        container's own logs (current and, if it has restarted, the previous
+        instance) -- the WAL-replay progress and startup panics the pod
+        object's restart *reason* alone can't show.
       - kube-state-metrics: the chart's KSM pod -- the source of
         ``kube_pod_labels``, the other half of the DCGM<->pod join.
       - dcgm-exporter: the DCGM exporter pods, matched by name substring across
@@ -514,6 +532,40 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
             _write_yaml(
                 os.path.join(out_dir, filename),
                 [_with_type_meta(to_dict(p), 'v1', 'Pod') for p in matched])
+
+    # The prometheus-server container's own logs -- the only place the WAL
+    # replay progress ("Replaying WAL...", per-segment loads) and any
+    # panic/abort message surface; the pod object shows *that* it restarted,
+    # not *why* it died mid-startup. Grab the current container's tail and, when
+    # it has restarted, the previous (terminated) container's logs too -- the
+    # latter holds the boot-to-crash output of the instance that actually
+    # failed. Best-effort and tail-bounded.
+    for pod in prom_pods:
+        pod_name = pod.metadata.name
+        for previous in (False, True):
+            suffix = '.previous' if previous else ''
+            resource = f'gpu_metrics/{pod_name}{suffix}.log'
+            try:
+                pod_log = core.read_namespaced_pod_log(
+                    name=pod_name,
+                    namespace=_GPU_METRICS_NAMESPACE,
+                    container=_PROMETHEUS_SERVER_CONTAINER,
+                    previous=previous,
+                    tail_lines=_PROMETHEUS_LOG_TAIL_LINES,
+                    _request_timeout=kubernetes.API_TIMEOUT)
+            except kubernetes.api_exception() as e:
+                # A 400 on previous=True just means the container has never
+                # restarted (no previous instance) -- expected, not an error.
+                if not (previous and e.status == 400):
+                    _record_error(errors, resource, e)
+                continue
+            except Exception as e:  # pylint: disable=broad-except
+                _record_error(errors, resource, e)
+                continue
+            if pod_log:
+                os.makedirs(out_dir, exist_ok=True)
+                _write_text(os.path.join(out_dir, f'{pod_name}{suffix}.log'),
+                            pod_log)
 
     # The config + topology behind the pods. The prometheus.yml ConfigMap and
     # the Prometheus PVC(s) are namespace-scoped (minimal RBAC); the

--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -542,6 +542,7 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
     # failed. Best-effort and tail-bounded.
     for pod in prom_pods:
         pod_name = pod.metadata.name
+        current_log = None
         for previous in (False, True):
             suffix = '.previous' if previous else ''
             resource = f'gpu_metrics/{pod_name}{suffix}.log'
@@ -553,6 +554,24 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
                     previous=previous,
                     tail_lines=_PROMETHEUS_LOG_TAIL_LINES,
                     _request_timeout=kubernetes.API_TIMEOUT)
+                if not pod_log:
+                    continue
+                if not previous:
+                    current_log = pod_log
+                elif pod_log == current_log:
+                    # In a fast crash-loop the two reads can land on the same
+                    # container instance: mid-CrashLoopBackOff (no running
+                    # container) kubelet resolves both previous=False and
+                    # previous=True to the last-terminated instance, and a
+                    # restart can also fall between the reads. Drop a previous
+                    # log that's a byte-for-byte duplicate of the current one --
+                    # it adds nothing.
+                    continue
+                # Keep the write inside the try so a local OSError (full disk,
+                # permissions) is recorded best-effort, not propagated.
+                os.makedirs(out_dir, exist_ok=True)
+                _write_text(os.path.join(out_dir, f'{pod_name}{suffix}.log'),
+                            pod_log)
             except kubernetes.api_exception() as e:
                 # A 400 on previous=True just means the container has never
                 # restarted (no previous instance) -- expected, not an error.
@@ -562,10 +581,6 @@ def _dump_gpu_metrics_pods(context: Optional[str], output_dir: str,
             except Exception as e:  # pylint: disable=broad-except
                 _record_error(errors, resource, e)
                 continue
-            if pod_log:
-                os.makedirs(out_dir, exist_ok=True)
-                _write_text(os.path.join(out_dir, f'{pod_name}{suffix}.log'),
-                            pod_log)
 
     # The config + topology behind the pods. The prometheus.yml ConfigMap and
     # the Prometheus PVC(s) are namespace-scoped (minimal RBAC); the

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -359,6 +359,44 @@ def test_context_prometheus_log_failure_is_recorded(tmp_path, k8s_apis):
     assert ('gpu_metrics/skypilot-prometheus-server-abc123.log' in resources)
 
 
+def test_context_prometheus_logs_dedupes_identical_previous(tmp_path, k8s_apis):
+    """A fast crash-loop can make the current and previous reads resolve to the
+    same container instance; a byte-identical previous log is dropped, not
+    written as a confusing duplicate."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'))
+    # Both previous=False and previous=True return the same bytes.
+    k8s_apis.core.read_namespaced_pod_log.return_value = 'same boot log\n'
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    gdir = tmp_path / 'gpu_metrics'
+    assert (gdir / 'skypilot-prometheus-server-abc123.log').read_text() == (
+        'same boot log\n')
+    assert not (gdir /
+                'skypilot-prometheus-server-abc123.previous.log').exists()
+
+
+def test_context_prometheus_log_write_error_is_recorded(tmp_path, k8s_apis,
+                                                        monkeypatch):
+    """A local write failure (e.g. full disk) is recorded best-effort rather
+    than propagating out and aborting the rest of the dump."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'))
+    k8s_apis.core.read_namespaced_pod_log.return_value = 'boot log\n'
+
+    def _boom(*_args, **_kwargs):
+        raise OSError('No space left on device')
+
+    monkeypatch.setattr(debug, '_write_text', _boom)
+
+    errors = _run_context(tmp_path)
+
+    resources = {e['resource'] for e in errors}
+    assert 'gpu_metrics/skypilot-prometheus-server-abc123.log' in resources
+
+
 def test_context_gpu_metrics_absent_produces_no_dir(tmp_path, k8s_apis):
     k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
         ('default', 'unrelated-pod'))

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -75,6 +75,7 @@ def k8s_apis(monkeypatch):
     core.list_namespaced_config_map.return_value = _list()
     core.list_namespaced_secret.return_value = _list()
     core.read_namespaced_config_map.side_effect = _FakeApiException(404)
+    core.read_namespaced_pod_log.return_value = ''
 
     apps = mock.MagicMock()
     apps.list_namespaced_deployment.return_value = _list()
@@ -294,6 +295,68 @@ def test_context_gpu_metrics_config_and_topology_dumped(tmp_path, k8s_apis):
     ds = yaml_utils.read_yaml(str(gdir / 'dcgm-exporter-daemonset.yaml'))
     assert (ds['apiVersion'], ds['kind']) == ('apps/v1', 'DaemonSet')
     assert ds['marker'] == 'ds'  # only the dcgm-exporter DS, not some-other-ds
+
+
+def test_context_prometheus_server_logs_collected(tmp_path, k8s_apis):
+    """The prometheus-server container's current and previous logs are written
+    under gpu_metrics/ as <pod>.log / <pod>.previous.log -- the WAL-replay
+    output the pod object can't show."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'))
+
+    def _read_log(**kwargs):
+        assert kwargs['container'] == 'prometheus-server'
+        assert kwargs['tail_lines'] == debug._PROMETHEUS_LOG_TAIL_LINES
+        return ('replaying WAL previous\n'
+                if kwargs['previous'] else 'level=info ready\n')
+
+    k8s_apis.core.read_namespaced_pod_log.side_effect = _read_log
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    gdir = tmp_path / 'gpu_metrics'
+    assert (gdir / 'skypilot-prometheus-server-abc123.log').read_text() == (
+        'level=info ready\n')
+    assert (gdir /
+            'skypilot-prometheus-server-abc123.previous.log').read_text() == (
+                'replaying WAL previous\n')
+
+
+def test_context_prometheus_logs_no_previous_is_not_an_error(
+        tmp_path, k8s_apis):
+    """A 400 on the previous-container read (the server has never restarted) is
+    expected: the current log is still written and no error is recorded."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'))
+
+    def _read_log(**kwargs):
+        if kwargs['previous']:
+            raise _FakeApiException(400)
+        return 'current only\n'
+
+    k8s_apis.core.read_namespaced_pod_log.side_effect = _read_log
+
+    errors = _run_context(tmp_path)
+
+    assert not errors
+    gdir = tmp_path / 'gpu_metrics'
+    assert (gdir / 'skypilot-prometheus-server-abc123.log').exists()
+    assert not (gdir /
+                'skypilot-prometheus-server-abc123.previous.log').exists()
+
+
+def test_context_prometheus_log_failure_is_recorded(tmp_path, k8s_apis):
+    """A non-400 failure reading the prometheus-server log is recorded (not
+    swallowed) so the dump's error manifest shows the gap."""
+    k8s_apis.core.list_pod_for_all_namespaces.return_value = _all_ns_pods(
+        ('skypilot', 'skypilot-prometheus-server-abc123'))
+    k8s_apis.core.read_namespaced_pod_log.side_effect = _FakeApiException(403)
+
+    errors = _run_context(tmp_path)
+
+    resources = {e['resource'] for e in errors}
+    assert ('gpu_metrics/skypilot-prometheus-server-abc123.log' in resources)
 
 
 def test_context_gpu_metrics_absent_produces_no_dir(tmp_path, k8s_apis):


### PR DESCRIPTION
## Summary

The GPU-metrics debug dump (added in #9937) collects the Prometheus server **pod object**, but the pod's restart `reason` alone doesn't explain why the server died during startup. The WAL-replay progress (`Replaying WAL...`, per-segment loads) and any panic/abort message live only in the container's own logs — so a server that crash-loops or stalls replaying a large WAL is hard to diagnose from the dump.

This collects the `prometheus-server` container's logs alongside the pod object, under `gpu_metrics/`:

- `<pod>.log` — the current container's logs.
- `<pod>.previous.log` — the previous (terminated) container's logs, when the server has restarted. This holds the boot-to-crash output of the instance that actually failed.

Best-effort and tail-bounded (2000 lines) so a chatty or long-lived server can't bloat the dump. A `400` on the previous-container read (the server has never restarted, so there is no previous instance) is treated as "no previous log", not an error.

## Test plan

New unit tests in `tests/unit_tests/kubernetes/test_debug.py`:
- current + previous logs are written as `<pod>.log` / `<pod>.previous.log`;
- a `400` on the previous read writes only the current log and records no error;
- a non-`400` read failure is recorded in the dump's error manifest.

```
pytest tests/unit_tests/kubernetes/test_debug.py
```
passes.
