### PR TITLE
[Examples] managed_job.yaml: use `pip list` instead of `conda env list`

### DIFF
--- a/examples/managed_job.yaml
+++ b/examples/managed_job.yaml
@@ -5,7 +5,7 @@ setup: |
   pip install tqdm
 
 run: |
-  conda env list
+  pip list
   echo "start counting"
   python -u - << EOF
   import time


### PR DESCRIPTION
## Summary

`examples/managed_job.yaml`'s `run` began with `conda env list`, which assumes conda is installed in the task runtime. The example already uses `pip` (it does `pip install tqdm` in `setup`), so switch the listing command to `pip list` — equivalent behavior (a trivial command listing the environment before `echo "start counting"`), with one fewer conda dependency in the examples.

No smoke-test assertion depends on the conda output — the tests that launch this example (`test_managed_jobs_basic`, `_cancelled_job_logs`, `_logs_sync_down`) grep for `start counting` / `Cluster launched:` / job-queue statuses, not the listing output.

## Tested

Trivial example change; assertion-safe as above. Will run through smoke CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
