### PR TITLE
[Test] Fail fast in smoke wait-loops on terminal job failure

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -14,7 +14,7 @@ import time
 import traceback
 from types import MethodType
 from typing import (Any, BinaryIO, Callable, Dict, Generator, List, NamedTuple,
-                    Optional, Sequence, Set, Tuple, Union)
+                    Optional, Sequence, Set, Tuple, Type, Union)
 from unittest.mock import patch
 import uuid
 
@@ -145,6 +145,24 @@ def _statuses_to_str(statuses: Sequence[enum.Enum]):
         return statuses[0].value
 
 
+def _failure_statuses_str(status_enum: Type[enum.Enum],
+                          target_statuses: Sequence[enum.Enum]) -> str:
+    """Terminal failure statuses to fail fast on, excluding the target(s).
+
+    Once a job reaches a terminal failure status that is not one of the
+    statuses being waited for, it can never reach the target, so the wait
+    command should stop polling instead of waiting for the full timeout.
+    Returns a pipe-joined alternation, or a sentinel that never matches a real
+    status when there is nothing to fail fast on.
+    """
+    targets = set(target_statuses)
+    failures = [
+        status.value for status in status_enum if status.is_terminal() and
+        status.value != 'SUCCEEDED' and status not in targets
+    ]
+    return '|'.join(failures) if failures else '__NO_FAILURE_STATUS__'
+
+
 _WAIT_UNTIL_CLUSTER_STATUS_CONTAINS = (
     # A while loop to wait until the cluster status
     # becomes certain status, with timeout.
@@ -243,6 +261,18 @@ _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID = (
     '  fi; '
     'done <<< "$current_status"; '
     'if [ "$found" -eq 1 ]; then break; fi; '  # Break outer loop if match found
+    # Fail fast: if the job has reached a terminal failure status that is not
+    # one of the target statuses, it can never reach the target, so stop
+    # polling instead of waiting for the full timeout.
+    'failed=0; '
+    'while read -r line; do '
+    '  if [[ "$line" =~ ^({job_failure_status})$ ]]; then '
+    '    echo "Job reached terminal failure status $line while waiting for \'{job_status}\'."; '
+    '    failed=1; '
+    '    break; '
+    '  fi; '
+    'done <<< "$current_status"; '
+    'if [ "$failed" -eq 1 ]; then echo "Current queue: $current_queue"; exit 1; fi; '
     'echo "Waiting for job status to contain {job_status}, current status: $current_status"; '
     'echo "Current queue: $current_queue"; '
     'sleep 10; '
@@ -265,6 +295,7 @@ def get_cmd_wait_until_job_status_contains_matching_job_id(
         cluster_name=cluster_name,
         job_id=job_id,
         job_status=_statuses_to_str(job_status),
+        job_failure_status=_failure_statuses_str(sky.JobStatus, job_status),
         timeout=timeout)
     if all_users:
         cmd = cmd.replace('sky queue ', 'sky queue -u ')
@@ -276,6 +307,7 @@ def get_cmd_wait_until_job_status_contains_without_matching_job(
     return _WAIT_UNTIL_JOB_STATUS_CONTAINS_WITHOUT_MATCHING_JOB.format(
         cluster_name=cluster_name,
         job_status=_statuses_to_str(job_status),
+        job_failure_status=_failure_statuses_str(sky.JobStatus, job_status),
         timeout=timeout)
 
 
@@ -286,6 +318,7 @@ def get_cmd_wait_until_job_status_contains_matching_job_name(
         cluster_name=cluster_name,
         job_name=job_name,
         job_status=_statuses_to_str(job_status),
+        job_failure_status=_failure_statuses_str(sky.JobStatus, job_status),
         timeout=timeout)
 
 
@@ -308,6 +341,8 @@ def get_cmd_wait_until_managed_job_status_contains_matching_job_name(
     return _WAIT_UNTIL_MANAGED_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME.format(
         job_name=job_name,
         job_status=_statuses_to_str(job_status),
+        job_failure_status=_failure_statuses_str(sky.ManagedJobStatus,
+                                                 job_status),
         timeout=timeout,
         gap_seconds=gap_seconds)
 


### PR DESCRIPTION
## Summary

The job wait helpers (`get_cmd_wait_until_*_job_status_contains_*`) poll `sky (jobs) queue` until the target status appears or the timeout elapses. If a job reaches a terminal failure status (`FAILED`, `FAILED_SETUP`, `FAILED_PRECHECKS`, `FAILED_NO_RESOURCE`, `FAILED_CONTROLLER`, `CANCELLED`) it can never reach a target like `SUCCEEDED`, yet the loop keeps polling for the full timeout (often 10 min), wasting minutes per failing test.

Add an early exit: when the matched job is in a terminal failure status that is **not** one of the statuses being waited for, print the status + queue and exit non-zero immediately. Tests that legitimately wait for a failure status are unaffected — the target status is excluded from the fail-fast set.

## Test plan

- Generated the wait command for a job waiting on `SUCCEEDED` and ran it against captured `sky jobs queue` output:
  - Job in a terminal failure status → exits non-zero immediately instead of polling until timeout.
  - Job in `SUCCEEDED` → reports target reached, exits 0.
  - Job still running → keeps polling (unchanged).
- Verified a helper waiting for a failure status (e.g. `FAILED`) excludes that status from the fail-fast set, so it still waits as before.
- All four `get_cmd_wait_until_*` variants format without error; `yapf`/`isort` clean.

---
Part of a 3-PR series cleaning up the smoke-test failure path:
- #9999 — match job by name in any column
- #9996 — fail fast on terminal job failure (this PR)
- #10000 — bound failed-job log fetch on teardown