### PR TITLE
[Jobs] Support `--num-jobs` without a pool

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5940,16 +5940,32 @@ def jobs_launch(
         job_ids_str = ','.join(map(str, sorted(job_ids)))
         dashboard_hint = ''
         if not server_common.is_api_server_local():
-            query = urllib.parse.urlencode({
-                'property': 'pool',
-                'operator': ':',
-                'value': pool,
-            })
+            if pool is not None:
+                query = urllib.parse.urlencode({
+                    'property': 'pool',
+                    'operator': ':',
+                    'value': pool,
+                })
+                starting_page = f'jobs?{query}'
+                show_jobs_label = 'Show all jobs in the pool:'
+            else:
+                starting_page = 'jobs'
+                show_jobs_label = 'Show all jobs:'
             dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(), starting_page=f'jobs?{query}')
-            dashboard_hint = (
-                f'\n{ux_utils.INDENT_SYMBOL}Show all jobs in the pool:'
-                f'\t\t{ux_utils.BOLD}{dashboard_url}'
+                server_common.get_server_url(), starting_page=starting_page)
+            dashboard_hint = (f'\n{ux_utils.INDENT_SYMBOL}{show_jobs_label}'
+                              f'\t\t{ux_utils.BOLD}{dashboard_url}'
+                              f'{ux_utils.RESET_BOLD}')
+        if pool is not None:
+            cancel_hint = (
+                f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all jobs on the '
+                f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
+                f'{ux_utils.RESET_BOLD}')
+        else:
+            cancel_job_ids = ' '.join(map(str, sorted(job_ids)))
+            cancel_hint = (
+                f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all these jobs:'
+                f'\t{ux_utils.BOLD}sky jobs cancel {cancel_job_ids}'
                 f'{ux_utils.RESET_BOLD}')
         click.secho(f'Jobs submitted with IDs: {colorama.Fore.CYAN}'
                     f'{job_ids_str}{colorama.Style.RESET_ALL}.'
@@ -5961,9 +5977,7 @@ def jobs_launch(
                     f'\n{ux_utils.INDENT_SYMBOL}To stream controller logs:\t\t'
                     f'{ux_utils.BOLD}sky jobs logs --controller <job-id>'
                     f'{ux_utils.RESET_BOLD}'
-                    f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all jobs on the '
-                    f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
-                    f'{ux_utils.RESET_BOLD}')
+                    f'{cancel_hint}')
 
 
 # Value the ``-s``/``--status`` option takes when given with no argument. It is

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5811,8 +5811,6 @@ def jobs_launch(
 
       sky jobs launch 'echo hello!'
     """
-    if pool is None and num_jobs is not None:
-        raise click.UsageError('Cannot specify --num-jobs without --pool.')
     if num_jobs is not None and num_jobs < 1:
         raise click.UsageError(
             f'--num-jobs must be a positive integer. Got: {num_jobs}.')
@@ -5891,6 +5889,11 @@ def jobs_launch(
                 f'pool, please use `sky jobs pool apply {pool} new-pool.yaml`. '
                 f'{colorama.Style.RESET_ALL}')
         print_setup_fm_warning = False
+    elif num_jobs is not None and num_jobs > 1:
+        click.secho(
+            f'Submitting {colorama.Fore.CYAN}{num_jobs}'
+            f'{colorama.Style.RESET_ALL} managed jobs. Each job will be '
+            'launched on its own cluster.')
 
     # Optimize info is only show if _need_confirmation.
     if not yes:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -69,6 +69,7 @@ from sky.client.cli import deprecation_utils
 from sky.client.cli import flags
 from sky.client.cli import table_utils
 from sky.client.cli import utils as cli_utils
+from sky.jobs import utils as managed_job_utils
 from sky.jobs.state import ManagedJobStatus
 from sky.provision.kubernetes import constants as kubernetes_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -5937,7 +5938,7 @@ def jobs_launch(
         # TODO(tian): This can be very long. Considering have a "group id"
         # and query all job ids with the same group id.
         # Sort job ids to ensure consistent ordering.
-        job_ids_str = ','.join(map(str, sorted(job_ids)))
+        job_ids_str = managed_job_utils.format_job_ids_as_ranges(job_ids)
         dashboard_hint = ''
         if not server_common.is_api_server_local():
             if pool is not None:
@@ -5962,10 +5963,9 @@ def jobs_launch(
                 f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
                 f'{ux_utils.RESET_BOLD}')
         else:
-            cancel_job_ids = ' '.join(map(str, sorted(job_ids)))
             cancel_hint = (
                 f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all these jobs:'
-                f'\t{ux_utils.BOLD}sky jobs cancel {cancel_job_ids}'
+                f'\t{ux_utils.BOLD}sky jobs cancel <job-ids>'
                 f'{ux_utils.RESET_BOLD}')
         click.secho(f'Jobs submitted with IDs: {colorama.Fore.CYAN}'
                     f'{job_ids_str}{colorama.Style.RESET_ALL}.'

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -82,9 +82,6 @@ def launch(
         raise click.UsageError('Pools are not supported in your API server. '
                                'Please upgrade to a newer API server to use '
                                'pools.')
-    if pool is None and num_jobs is not None:
-        raise click.UsageError('Cannot specify num_jobs without pool.')
-
     dag = dag_utils.convert_entrypoint_to_dag(task)
 
     if name is not None:
@@ -96,7 +93,8 @@ def launch(
             at_client_side=True) as dag:
         sdk.validate(dag)
         if _need_confirmation:
-            job_identity = 'a managed job'
+            job_identity = ('a managed job'
+                            if num_jobs is None else f'{num_jobs} managed jobs')
             if pool is None:
                 optimize_request_id = sdk.optimize(dag)
                 sdk.stream_and_get(optimize_request_id)
@@ -112,8 +110,6 @@ def launch(
                 click.secho(
                     f'Use resources from pool {pool!r}: {job_resources_str}.',
                     fg='green')
-                if num_jobs is not None:
-                    job_identity = f'{num_jobs} managed jobs'
             prompt = f'Launching {job_identity} {dag.name!r}. Proceed?'
             if prompt is not None:
                 click.confirm(prompt,

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -216,26 +216,7 @@ def _upload_files_to_controller(dag: 'sky.Dag') -> Dict[str, str]:
 
 
 def _job_ids_to_str(job_ids: Optional[List[int]]) -> str:
-    if not job_ids:
-        return ''
-
-    if len(job_ids) == 1:
-        return str(job_ids[0])
-
-    job_ids = sorted(job_ids)
-    ranges = []
-    start = prev = job_ids[0]
-
-    for n in job_ids[1:]:
-        if n == prev + 1:
-            prev = n
-            continue
-        ranges.append(f'{start}-{prev}' if start != prev else str(start))
-        start = prev = n
-
-    # append last range
-    ranges.append(f'{start}-{prev}' if start != prev else str(start))
-    return ','.join(ranges)
+    return managed_job_utils.format_job_ids_as_ranges(job_ids)
 
 
 class _DefaultManagedJobRunner:

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -881,9 +881,6 @@ def launch(
         controller=controller,
         task_resources=sum([list(t.resources) for t in dag.tasks], []))
 
-    if num_jobs and pool is None:
-        raise ValueError('Cannot specify num_jobs without pool.')
-
     num_jobs = num_jobs if num_jobs is not None else 1
     # We do this assignment after applying the admin policy, so that we don't
     # need to serialize the pool name in the dag. The dag object will be

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2752,6 +2752,36 @@ def _get_job_status_from_tasks(
     return managed_task_status, current_task_id
 
 
+def format_job_ids_as_ranges(job_ids: Optional[List[int]]) -> str:
+    """Formats job IDs as a compact comma-separated list of ranges.
+
+    Contiguous IDs are collapsed into ``start-end`` ranges, e.g.
+    ``[1, 2, 3, 5, 6]`` becomes ``'1-3,5-6'``. This keeps the output readable
+    when many jobs are submitted at once (e.g. ``sky jobs launch --num-jobs``).
+    Returns an empty string for empty input.
+    """
+    if not job_ids:
+        return ''
+
+    if len(job_ids) == 1:
+        return str(job_ids[0])
+
+    job_ids = sorted(job_ids)
+    ranges = []
+    start = prev = job_ids[0]
+
+    for n in job_ids[1:]:
+        if n == prev + 1:
+            prev = n
+            continue
+        ranges.append(f'{start}-{prev}' if start != prev else str(start))
+        start = prev = n
+
+    # append last range
+    ranges.append(f'{start}-{prev}' if start != prev else str(start))
+    return ','.join(ranges)
+
+
 @typing.overload
 def format_job_table(
     tasks: List[Dict[str, Any]],

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -120,6 +120,102 @@ def test_managed_jobs_basic(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_num_jobs_without_pool(generic_cloud: str):
+    """`sky jobs launch --num-jobs N` works without a pool.
+
+    Regression test for the lifted pool-only restriction on --num-jobs: with no
+    --pool, N independent managed jobs must be submitted, each on its own
+    cluster, with SKYPILOT_NUM_JOBS=N and a distinct SKYPILOT_JOB_RANK in
+    [0, N). It also checks the CLI output uses the non-pool variants (no
+    `--pool None` / `value=None` hints).
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    num_jobs = 2
+    timeout = smoke_tests_utils.get_timeout(generic_cloud)
+    # The API server DB is shared across tests, so we can't assume the job IDs
+    # are 1..num_jobs. All num_jobs jobs share the same name (a known
+    # limitation), so we resolve their IDs by name from `sky jobs queue`.
+    ids_file = f'/tmp/num_jobs_no_pool_ids_{name}.txt'
+    job_config = textwrap.dedent("""\
+        run: |
+          echo "SKYPILOT_NUM_JOBS_VALUE=${SKYPILOT_NUM_JOBS}"
+          echo "SKYPILOT_JOB_RANK_VALUE=${SKYPILOT_JOB_RANK}"
+        """)
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as job_yaml:
+        job_yaml.write(job_config)
+        job_yaml.flush()
+        # Launch num_jobs jobs without a pool and assert the output is the
+        # non-pool variant: no pool-only hints, and the multi-job notice.
+        launch_cmd = (
+            f's=$(sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} {job_yaml.name} '
+            f'--num-jobs {num_jobs} -y -d); echo "$s"; '
+            # Non-pool multi-job notice is printed.
+            'echo "$s" | grep "Each job will be launched on its own cluster"; '
+            # No pool-specific hints leaked when there is no pool.
+            '! echo "$s" | grep -- "--pool None"; '
+            '! echo "$s" | grep "value=None"; '
+            '! echo "$s" | grep "in the pool"')
+        # Resolve the num_jobs job IDs by name (col 2 or 3 of `sky jobs queue`).
+        capture_ids_cmd = (
+            's=$(sky jobs queue); echo "$s"; echo "$s" | '
+            'awk -v n=' + name + ' \'($2==n)||($3==n){print $1}\' | '
+            f'sort -un > {ids_file}; cat {ids_file}; '
+            f'cnt=$(wc -l < {ids_file}); '
+            f'if [ "$cnt" -ne {num_jobs} ]; then '
+            f'  echo "Expected {num_jobs} jobs named {name}, found $cnt"; '
+            '  exit 1; fi')
+        # Wait for every job (by ID) to reach SUCCEEDED, failing fast on a bad
+        # status. Uses the controller log, like wait_until_job_status_by_id.
+        wait_all_cmd = (
+            f'start_time=$SECONDS; while read jid; do while true; do '
+            f'  if (( $SECONDS - $start_time > {timeout} )); then '
+            '    echo "Timeout waiting for job $jid"; sky jobs queue; exit 1; fi; '
+            '  s=$(sky jobs logs --controller "$jid" --no-follow 2>&1); '
+            '  echo "$s"; '
+            '  if echo "$s" | grep -q "Job status: JobStatus.SUCCEEDED"; then '
+            '    break; fi; '
+            '  if echo "$s" | grep -qE "Job status: JobStatus.(FAILED|CANCELLED'
+            '|FAILED_SETUP|FAILED_CONTROLLER)"; then '
+            '    echo "Job $jid hit a bad status"; sky jobs queue; exit 1; fi; '
+            '  sleep 10; '
+            f'done; done < {ids_file}')
+        # Check each job logged SKYPILOT_NUM_JOBS=num_jobs, and that the set of
+        # SKYPILOT_JOB_RANK values is exactly {0, ..., num_jobs-1} (distinct).
+        check_envs_cmd = (
+            'ranks=""; while read jid; do '
+            '  s=$(sky jobs logs "$jid" --no-follow 2>&1); echo "$s"; '
+            f'  echo "$s" | grep "SKYPILOT_NUM_JOBS_VALUE={num_jobs}"; '
+            '  r=$(echo "$s" | sed -n '
+            '"s/.*SKYPILOT_JOB_RANK_VALUE=\\([0-9]*\\).*/\\1/p" | head -n1); '
+            '  ranks="$ranks $r"; '
+            f'done < {ids_file}; '
+            'sorted=$(echo $ranks | tr " " "\\n" | sort -un | tr "\\n" " " | '
+            'sed "s/ *$//"); echo "ranks: [$sorted]"; '
+            f'expected=$(seq 0 {num_jobs - 1} | tr "\\n" " " | sed "s/ *$//"); '
+            'if [ "$sorted" != "$expected" ]; then '
+            '  echo "Expected distinct ranks [$expected], got [$sorted]"; '
+            '  exit 1; fi; echo "Ranks are distinct and correct."')
+        test = smoke_tests_utils.Test(
+            'managed-jobs-num-jobs-without-pool',
+            [
+                launch_cmd,
+                capture_ids_cmd,
+                wait_all_cmd,
+                # Give the job logs a moment to be fully flushed.
+                'sleep 20',
+                check_envs_cmd,
+            ],
+            f'sky jobs cancel -y -n {name}',
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            timeout=timeout,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
     """Test that logs are accessible after a managed job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/unit_tests/test_sky/test_cli_launch_validation.py
+++ b/tests/unit_tests/test_sky/test_cli_launch_validation.py
@@ -3,6 +3,8 @@
 These tests cover validation that should fire *before* any server call,
 rejecting obviously-malformed flag values with actionable errors.
 """
+from unittest import mock
+
 from click import testing as cli_testing
 
 from sky.client.cli import command
@@ -18,6 +20,25 @@ def test_jobs_launch_num_jobs_must_be_positive():
             ['--pool', 'mypool', '--num-jobs', bad, 'echo', 'hi'])
         assert result.exit_code != 0
         assert '--num-jobs' in result.output
+
+
+def test_jobs_launch_num_jobs_allowed_without_pool():
+    # --num-jobs without --pool should be accepted: it submits N independent
+    # managed jobs, each on its own cluster. The CLI must not reject it with a
+    # usage error; it should reach the launch call with pool=None.
+    runner = cli_testing.CliRunner()
+    with mock.patch.object(command.managed_jobs, 'launch') as mock_launch, \
+            mock.patch.object(command, '_async_call_or_wait') as mock_wait:
+        mock_wait.return_value = ([1, 2], None)
+        result = runner.invoke(command.jobs_launch,
+                               ['--num-jobs', '2', '-y', 'echo', 'hi'])
+    assert 'Cannot specify --num-jobs without --pool' not in result.output
+    assert mock_launch.called
+    # launch(dag, name, pool, num_jobs, ...): pool positional is None,
+    # num_jobs positional is 2.
+    args, kwargs = mock_launch.call_args
+    assert args[2] is None  # pool
+    assert args[3] == 2  # num_jobs
 
 
 def test_env_file_must_exist():

--- a/tests/unit_tests/test_sky/test_cli_launch_validation.py
+++ b/tests/unit_tests/test_sky/test_cli_launch_validation.py
@@ -54,9 +54,9 @@ def test_jobs_launch_multi_job_output_without_pool_has_no_pool_hints():
             mock.patch.object(command.server_common, 'get_dashboard_url',
                               side_effect=lambda url, starting_page:
                               f'https://server/dashboard/{starting_page}'):
-        mock_wait.return_value = ([1, 2], None)
+        mock_wait.return_value = ([1, 2, 3], None)
         result = runner.invoke(command.jobs_launch,
-                               ['--num-jobs', '2', '-y', 'echo', 'hi'])
+                               ['--num-jobs', '3', '-y', 'echo', 'hi'])
     assert result.exit_code == 0, result.output
     # No pool-specific output.
     assert 'property=pool' not in result.output
@@ -65,7 +65,31 @@ def test_jobs_launch_multi_job_output_without_pool_has_no_pool_hints():
     assert 'in the pool' not in result.output
     # Non-pool variants are present instead.
     assert 'Show all jobs:' in result.output
-    assert 'sky jobs cancel 1 2' in result.output
+
+
+def test_jobs_launch_many_jobs_output_collapses_ids_and_uses_placeholder():
+    # With many jobs, the submitted-IDs line collapses contiguous IDs into a
+    # range, and the cancel hint uses a `<job-ids>` placeholder rather than
+    # dumping every id.
+    runner = cli_testing.CliRunner()
+    job_ids = list(range(2711, 3511))  # 800 contiguous ids, like the report
+    with mock.patch.object(command.managed_jobs, 'launch'), \
+            mock.patch.object(command, '_async_call_or_wait') as mock_wait, \
+            mock.patch.object(command.server_common, 'is_api_server_local',
+                              return_value=False), \
+            mock.patch.object(command.server_common, 'get_server_url',
+                              return_value='https://server'), \
+            mock.patch.object(command.server_common, 'get_dashboard_url',
+                              return_value='https://server/dashboard/jobs'):
+        mock_wait.return_value = (job_ids, None)
+        result = runner.invoke(command.jobs_launch,
+                               ['--num-jobs', '800', '-y', 'echo', 'hi'])
+    assert result.exit_code == 0, result.output
+    # Submitted IDs collapse to a single range.
+    assert 'Jobs submitted with IDs: 2711-3510' in result.output
+    # The cancel hint is a placeholder, not the full id list.
+    assert 'sky jobs cancel <job-ids>' in result.output
+    assert '2711 2712 2713' not in result.output
 
 
 def test_env_file_must_exist():

--- a/tests/unit_tests/test_sky/test_cli_launch_validation.py
+++ b/tests/unit_tests/test_sky/test_cli_launch_validation.py
@@ -41,6 +41,33 @@ def test_jobs_launch_num_jobs_allowed_without_pool():
     assert args[3] == 2  # num_jobs
 
 
+def test_jobs_launch_multi_job_output_without_pool_has_no_pool_hints():
+    # A multi-job launch without a pool must not emit pool-specific hints:
+    # no `value=None` dashboard filter, and no `sky jobs cancel --pool None`.
+    runner = cli_testing.CliRunner()
+    with mock.patch.object(command.managed_jobs, 'launch'), \
+            mock.patch.object(command, '_async_call_or_wait') as mock_wait, \
+            mock.patch.object(command.server_common, 'is_api_server_local',
+                              return_value=False), \
+            mock.patch.object(command.server_common, 'get_server_url',
+                              return_value='https://server'), \
+            mock.patch.object(command.server_common, 'get_dashboard_url',
+                              side_effect=lambda url, starting_page:
+                              f'https://server/dashboard/{starting_page}'):
+        mock_wait.return_value = ([1, 2], None)
+        result = runner.invoke(command.jobs_launch,
+                               ['--num-jobs', '2', '-y', 'echo', 'hi'])
+    assert result.exit_code == 0, result.output
+    # No pool-specific output.
+    assert 'property=pool' not in result.output
+    assert 'value=None' not in result.output
+    assert '--pool None' not in result.output
+    assert 'in the pool' not in result.output
+    # Non-pool variants are present instead.
+    assert 'Show all jobs:' in result.output
+    assert 'sky jobs cancel 1 2' in result.output
+
+
 def test_env_file_must_exist():
     # --env-file on a non-existent path previously returned {} silently
     # (dotenv's default behavior) and the user never learned the file


### PR DESCRIPTION
## Summary

`sky jobs launch --num-jobs N` was restricted to pool submissions: the CLI, client SDK, and server each raised an error if `--num-jobs` was given without `--pool`. This PR lifts that restriction so `--num-jobs N` works without a pool, submitting N independent managed jobs (each on its own cluster).

The submission machinery was already pool-agnostic:
- The local (consolidation) and remote submission paths both plumb `num_jobs` through with `pool_hash=None`.
- `SKYPILOT_NUM_JOBS` and the per-job `SKYPILOT_JOB_RANK` env vars are set for all jobs regardless of pool.
- Concurrency is already throttled by the jobs scheduler's default path (`get_number_of_jobs_controllers()`), so without a pool the jobs queue as `PENDING` and start as controller capacity frees — the same behavior as launching N jobs individually.

So the only change needed was removing the three guards, plus two output fixes the guards were masking:
- The launch confirmation prompt now reports the job count regardless of pool (previously only set in the pool branch).
- The "Jobs submitted" summary no longer emits pool-only hints when there is no pool — previously it showed a dashboard link filtered by `value=None` and `sky jobs cancel --pool None`. Without a pool it now links to the unfiltered jobs page and suggests `sky jobs cancel <job-ids>`.
- A short notice is printed for the non-pool multi-job case.

## Changes

- `sky/client/cli/command.py`: remove the CLI guard; branch the multi-job summary hints on pool presence; add a non-pool multi-job notice.
- `sky/jobs/client/sdk.py`: remove the client-side guard; report job count in the confirmation prompt regardless of pool.
- `sky/jobs/server/core.py`: remove the server-side guard.
- `tests/unit_tests/test_sky/test_cli_launch_validation.py`: tests that `--num-jobs` without `--pool` is accepted and reaches launch with `pool=None`, and that the multi-job output contains no pool-specific hints when there is no pool.

## Test plan

- `pytest tests/unit_tests/test_sky/test_cli_launch_validation.py` — passes.
- Manual: `sky jobs launch --num-jobs 3 'echo hi'` (no `--pool`) against a remote API server creates 3 managed jobs, each on its own cluster, with distinct `SKYPILOT_JOB_RANK` (0–2) and `SKYPILOT_NUM_JOBS=3`; the summary shows the unfiltered "Show all jobs" link and a `sky jobs cancel <ids>` hint.