### PR TITLE
[Test] Match job by name in any column in smoke wait-loops

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -251,8 +251,13 @@ _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID = (
 _WAIT_UNTIL_JOB_STATUS_CONTAINS_WITHOUT_MATCHING_JOB = _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID.replace(
     'awk "\\$1 == \\"{job_id}\\"', 'awk "')
 
+# Match the job by name in *any* column. `sky (jobs) queue` shifts the NAME
+# column depending on whether the USER (-u) and WORKSPACE (>1 workspace)
+# columns are shown, so a fixed column index is not reliable.
 _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME = _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID.replace(
-    'awk "\\$1 == \\"{job_id}\\"', 'awk "\\$2 == \\"{job_name}\\"')
+    'awk "\\$1 == \\"{job_id}\\"',
+    'awk "{{matched=0; for (i=1; i<=NF; i++) if (\\$i == \\"{job_name}\\") matched=1}} matched'
+)
 
 
 def get_cmd_wait_until_job_status_contains_matching_job_id(
@@ -292,12 +297,10 @@ def get_cmd_wait_until_job_status_contains_matching_job_name(
 # Managed job functions
 
 _WAIT_UNTIL_MANAGED_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME = _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME.replace(
-    'sky queue {cluster_name}', 'sky jobs queue').replace(
-        'awk "\\$2 == \\"{job_name}\\"',
-        'awk "\\$2 == \\"{job_name}\\" || \\$3 == \\"{job_name}\\"').replace(
-            _ALL_JOB_STATUSES,
-            _ALL_MANAGED_JOB_STATUSES).replace('sleep 10',
-                                               'sleep {gap_seconds}')
+    'sky queue {cluster_name}',
+    'sky jobs queue').replace(_ALL_JOB_STATUSES,
+                              _ALL_MANAGED_JOB_STATUSES).replace(
+                                  'sleep 10', 'sleep {gap_seconds}')
 
 
 def get_cmd_wait_until_managed_job_status_contains_matching_job_name(


### PR DESCRIPTION
## Summary

The name-matching smoke wait helpers (`get_cmd_wait_until_*_job_status_contains_matching_job_name`) parse `sky (jobs) queue` with awk and look for the job `NAME` in a fixed column (`$2`/`$3`). The `NAME` column position is not stable:

- a `USER` column is added with `-u`,
- a `WORKSPACE` column is added when more than one workspace exists,

which shifts `NAME` to the right. When that happens the fixed-index match finds nothing, the loop's `current_status` stays empty, and it polls until the timeout even though the job exists and may already be done.

Match the job name in **any** column instead of a fixed index.

## Test plan

- Reproduced against a real `sky jobs queue` table with a `WORKSPACE` column (NAME in `$4`): the old `$2/$3` match returns empty; the new any-column match returns the correct status.
- Confirmed the generated wait commands still format and parse correctly; single-workspace layout (NAME in `$3`) continues to work.

---
Part of a 3-PR series cleaning up the smoke-test failure path:
- #9999 — match job by name in any column
- #9996 — fail fast on terminal job failure
- #10000 — bound failed-job log fetch on teardown