### PR TITLE
[Test] Bound failed-job log fetch on failure teardown

### DIFF
--- a/tests/smoke_tests/scripts/fetch_failed_job_logs.sh
+++ b/tests/smoke_tests/scripts/fetch_failed_job_logs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# Script to fetch logs for all failed jobs in the queue
+# Script to fetch controller logs for recently-failed jobs in the queue.
 # Usage: ./fetch_failed_job_logs.sh
+#
+# On a long-lived/shared API server the queue can contain many old failed
+# jobs from unrelated runs. The queue is ordered newest-first, so we only
+# fetch logs for the most recent failed jobs (the ones the failing test just
+# created) and bound each fetch with a timeout, instead of serially fetching
+# every failed job on the server.
+MAX_FAILED_JOBS="${SKYPILOT_FETCH_FAILED_JOB_LOGS_LIMIT:-5}"
+PER_LOG_TIMEOUT="${SKYPILOT_FETCH_FAILED_JOB_LOGS_TIMEOUT:-60}"
 
 # First, display the full sky jobs queue -a -u output
 echo "=== Job Queue ==="
@@ -39,10 +47,11 @@ header_found && /^[0-9]+/ {
         print job_id " " status
     }
 }
-' | while read -r job_id status; do
+' | head -n "$MAX_FAILED_JOBS" | while read -r job_id status; do
     if [ -n "$job_id" ] && [ -n "$status" ]; then
         echo "Fetching job id $job_id controller logs, status: $status"
-        sky jobs logs --controller "$job_id"
+        timeout "$PER_LOG_TIMEOUT" sky jobs logs --controller "$job_id" || \
+            echo "(controller log fetch for job $job_id timed out or failed)"
         echo "---"
     fi
 done


### PR DESCRIPTION
## Summary

On smoke-test failure, `run_one_test` runs `fetch_failed_job_logs.sh`, which does `sky jobs queue -a -u` (all jobs, all users) and then **serially** runs `sky jobs logs --controller <id>` for every `FAILED*` job in the queue, with no per-fetch timeout. On a long-lived/shared API server the queue accumulates many old failed jobs from unrelated runs, so this can take minutes fetching logs for jobs that have nothing to do with the failing test.

The queue is ordered newest-first, so only fetch logs for the most recent failed jobs (the ones the failing test just created) and bound each fetch with a timeout. Both limits are env-configurable: `SKYPILOT_FETCH_FAILED_JOB_LOGS_LIMIT` (default 5) and `SKYPILOT_FETCH_FAILED_JOB_LOGS_TIMEOUT` (default 60s).

## Motivation

In one run against a shared server, this teardown took roughly 5 minutes on its own — almost entirely spent pulling controller logs one job at a time for every failed job in the queue, most of which were unrelated to the test that failed. Beyond the wasted time, dumping logs for other jobs and users mixes their output into the failing test's log, so an error from an unrelated job's controller log can look like it belongs to the test under investigation and send debugging down the wrong path. Scoping the fetch to the test's own recent failures keeps the output relevant and fast.

## Test plan

- `bash -n` clean.
- Verified the awk + `head` selection against a queue mixing recent and old failed jobs: only the newest (capped) `FAILED*` jobs are selected, `SUCCEEDED` skipped, and the just-failed job (newest) is always included.

---
Part of a 3-PR series cleaning up the smoke-test failure path:
- #9999 — match job by name in any column
- #9996 — fail fast on terminal job failure
- #10000 — bound failed-job log fetch on teardown