### PR TITLE
[Core] Treat null-valued secrets as secret references

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -119,16 +119,17 @@ def _resolve_managed_secrets(dag: 'sky.Dag') -> None:
             continue
 
         ext_ctx = plugins.get_extension_context()
-        if ext_ctx is None:
-            raise RuntimeError(
-                'Task references managed_secrets but no plugin system '
-                'is available.')
-        provider = ext_ctx.managed_secrets_provider
+        provider = (ext_ctx.managed_secrets_provider
+                    if ext_ctx is not None else None)
         if provider is None:
+            names = ', '.join(
+                sorted(ref.name for ref in task.managed_secret_refs))
             raise RuntimeError(
-                'Task references managed_secrets but no managed secrets '
-                'provider is configured. Install a secrets management '
-                'plugin.')
+                f'No value available for secret(s): {names}. A secret with '
+                'no inline value must be provided at launch with the '
+                '--secret flag (e.g. --secret NAME=value), or resolved by a '
+                'managed secrets provider. No managed secrets provider is '
+                'configured.')
 
         # The provider.resolve() is async; run it from this sync context.
         resolved = asyncio.run(

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -123,7 +123,7 @@ def _resolve_managed_secrets(dag: 'sky.Dag') -> None:
                     if ext_ctx is not None else None)
         if provider is None:
             names = ', '.join(
-                sorted(ref.name for ref in task.managed_secret_refs))
+                sorted(set(ref.name for ref in task.managed_secret_refs)))
             raise RuntimeError(
                 f'No value available for secret(s): {names}. A secret with '
                 'no inline value must be provided at launch with the '

--- a/sky/task.py
+++ b/sky/task.py
@@ -301,8 +301,12 @@ def redact_task_yaml_dict(task_yaml: Dict[str, Any]) -> None:
             pass
         else:
             task_yaml['secrets'] = {
-                k: (None if k.startswith('secrets:') else '<redacted>')
-                for k in raw_secrets
+                # Managed secret refs (``secrets:`` prefix or null value) have
+                # no inline value to redact; keep them null so the YAML stays
+                # launchable. Inline secret values are redacted.
+                k: (None if
+                    (k.startswith('secrets:') or v is None) else '<redacted>')
+                for k, v in raw_secrets.items()
             }
     docker_config = task_yaml.get('resources', {}).get('_docker_login_config',
                                                        {})
@@ -714,17 +718,11 @@ class Task:
                         f'To set it to be empty, use an empty string ({k}: "" '
                         f'in task YAML or --env {k}="" in CLI).')
 
-        raw_secrets_check = config.get('secrets')
-        if isinstance(raw_secrets_check, dict):
-            for k, v in raw_secrets_check.items():
-                if v is None and not k.startswith('secrets:'):
-                    with ux_utils.print_exception_no_traceback():
-                        raise ValueError(
-                            f'Secret variable {k!r} is None. Please set a '
-                            'value for it in task YAML or with --secret flag.'
-                            f' To set it to be empty, use an empty string '
-                            f'({k}: "" in task YAML or '
-                            f'--secret {k}="" in CLI).')
+        # Unlike envs, a null-valued secret in dict form (e.g. ``API_KEY:``
+        # with no value) is not an error: it is treated as a managed secret
+        # reference, resolved at launch time from a CLI ``--secret`` override
+        # or a managed secrets provider. It is turned into a ManagedSecretRef
+        # below.
 
         # Fill in any Task.envs into file_mounts (src/dst paths, storage
         # name/source).
@@ -732,6 +730,13 @@ class Task:
         secrets_for_subst = config.get('secrets', {})
         if isinstance(secrets_for_subst, list):
             secrets_for_subst = {}  # Array form has no inline values
+        else:
+            # Null-valued secrets are managed references with no inline value
+            # to substitute (their value is only known after resolution), so
+            # exclude them from variable substitution.
+            secrets_for_subst = {
+                k: v for k, v in secrets_for_subst.items() if v is not None
+            }
         env_and_secrets = env_vars.copy()
         env_and_secrets.update(secrets_for_subst)
         if config.get('file_mounts') is not None:
@@ -772,7 +777,11 @@ class Task:
                 managed_from_secrets.append(
                     ManagedSecretRef(name=name, scope_override=scope))
         elif isinstance(raw_secrets, dict):
-            # Dict form: split inline values vs secrets: prefix refs
+            # Dict form: split inline values vs managed refs. A managed ref is
+            # either an explicit ``secrets:``-prefixed key or any key with a
+            # null value (no inline value means the value is resolved at launch
+            # time from a CLI ``--secret`` override or a managed secrets
+            # provider).
             for key, value in raw_secrets.items():
                 if key.startswith('secrets:'):
                     if value is not None:
@@ -785,6 +794,11 @@ class Task:
                                 '\'secrets:\' prefix.')
                     ref_name = key[len('secrets:'):]
                     name, scope = _parse_secret_name(ref_name)
+                    managed_from_secrets.append(
+                        ManagedSecretRef(name=name, scope_override=scope))
+                elif value is None:
+                    # Bare ``KEY:`` with no value -> managed secret reference.
+                    name, scope = _parse_secret_name(key)
                     managed_from_secrets.append(
                         ManagedSecretRef(name=name, scope_override=scope))
                 else:

--- a/sky/task.py
+++ b/sky/task.py
@@ -727,9 +727,10 @@ class Task:
         # Fill in any Task.envs into file_mounts (src/dst paths, storage
         # name/source).
         env_vars = config.get('envs', {})
-        secrets_for_subst = config.get('secrets', {})
-        if isinstance(secrets_for_subst, list):
-            secrets_for_subst = {}  # Array form has no inline values
+        secrets_for_subst = config.get('secrets')
+        if secrets_for_subst is None or isinstance(secrets_for_subst, list):
+            # ``secrets:`` (null) or array form have no inline values.
+            secrets_for_subst = {}
         else:
             # Null-valued secrets are managed references with no inline value
             # to substitute (their value is only known after resolution), so

--- a/tests/unit_tests/test_sky/test_cli_secrets.py
+++ b/tests/unit_tests/test_sky/test_cli_secrets.py
@@ -271,12 +271,15 @@ def test_null_secrets_override_with_cli():
         os.unlink(yaml_file)
 
 
-def test_null_secrets_without_cli_override_fails():
-    """Test that null secrets without CLI override fail appropriately."""
+def test_null_secrets_without_cli_override_become_managed_refs():
+    """Null secrets without a CLI override parse into managed secret refs.
+
+    The value is resolved at launch time (CLI ``--secret`` override or a
+    managed secrets provider) instead of failing during parsing.
+    """
     import os
     import tempfile
 
-    import pytest
     import yaml
 
     from sky.client.cli.command import (
@@ -284,8 +287,8 @@ def test_null_secrets_without_cli_override_fails():
 
     # Create YAML with null secrets
     yaml_content = {
-        'name': 'test-null-fail',
-        'run': 'echo "Should fail"',
+        'name': 'test-null-managed-ref',
+        'run': 'echo "resolved at launch"',
         'secrets': {
             'API_KEY': None
         }
@@ -297,11 +300,12 @@ def test_null_secrets_without_cli_override_fails():
         yaml_file = f.name
 
     try:
-        # Should fail without CLI override
-        with pytest.raises(ValueError,
-                           match="Secret variable 'API_KEY' is None"):
-            _make_task_or_dag_from_entrypoint_with_overrides(
-                entrypoint=(yaml_file,), secret=None)
+        task_obj = _make_task_or_dag_from_entrypoint_with_overrides(
+            entrypoint=(yaml_file,), secret=None)
+        assert task_obj.secrets == {}
+        refs = task_obj.managed_secret_refs
+        assert len(refs) == 1
+        assert refs[0].name == 'API_KEY'
     finally:
         os.unlink(yaml_file)
 

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -392,13 +392,21 @@ def test_from_yaml_config_secrets_type_conversion():
     assert task.get_plaintext_secrets(task_obj.secrets)['EMPTY_KEY'] == ''
 
 
-def test_from_yaml_config_secrets_validation():
-    """Test validation of secrets during YAML parsing."""
-    # Test None secret value
+def test_from_yaml_config_null_secret_becomes_managed_ref():
+    """A null secret value (no inline value) becomes a managed secret ref.
+
+    It is resolved at launch time (CLI ``--secret`` override or a managed
+    secrets provider) rather than rejected during YAML parsing.
+    """
     config = {'run': 'echo hello', 'secrets': {'API_KEY': None}}
 
-    with pytest.raises(ValueError, match='Secret variable.*is None'):
-        task.Task.from_yaml_config(config)
+    task_obj = task.Task.from_yaml_config(config)
+
+    assert task_obj.secrets == {}
+    refs = task_obj.managed_secret_refs
+    assert len(refs) == 1
+    assert refs[0].name == 'API_KEY'
+    assert refs[0].scope_override is None
 
 
 def test_task_initialization_with_secrets():
@@ -466,19 +474,26 @@ def test_from_yaml_config_null_secrets_with_override():
     assert task_obj.envs == {'PUBLIC_VAR': 'public-value'}
 
 
-def test_from_yaml_config_null_secrets_without_override_fails():
-    """Test that null secrets without override fail appropriately."""
+def test_from_yaml_config_null_secrets_without_override_become_managed_refs():
+    """Without a CLI override, a null secret parses into a managed ref.
+
+    The value is resolved at launch time; enforcement of a missing value
+    moved from parse time to resolution time.
+    """
     config = {
-        'name': 'test-null-fail',
+        'name': 'test-null-managed-ref',
         'run': 'echo hello',
         'secrets': {
             'API_KEY': None
         }
     }
 
-    # Should fail without override
-    with pytest.raises(ValueError, match="Secret variable 'API_KEY' is None"):
-        task.Task.from_yaml_config(config)
+    task_obj = task.Task.from_yaml_config(config)
+
+    assert task_obj.secrets == {}
+    refs = task_obj.managed_secret_refs
+    assert len(refs) == 1
+    assert refs[0].name == 'API_KEY'
 
 
 def test_from_yaml_config_partial_null_secrets_override():

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -409,6 +409,22 @@ def test_from_yaml_config_null_secret_becomes_managed_ref():
     assert refs[0].scope_override is None
 
 
+def test_from_yaml_config_null_or_empty_secrets_section():
+    """A null/empty ``secrets:`` section parses cleanly (no crash)."""
+    # ``secrets:`` with no value parses to None in YAML.
+    task_obj = task.Task.from_yaml_config({
+        'run': 'echo hello',
+        'secrets': None
+    })
+    assert task_obj.secrets == {}
+    assert not task_obj.managed_secret_refs
+
+    # Empty dict form.
+    task_obj = task.Task.from_yaml_config({'run': 'echo hello', 'secrets': {}})
+    assert task_obj.secrets == {}
+    assert not task_obj.managed_secret_refs
+
+
 def test_task_initialization_with_secrets():
     """Test Task initialization with secrets parameter."""
     secrets = {'API_KEY': 'secret123', 'DB_PASSWORD': 'password456'}


### PR DESCRIPTION
A dict-form secret with a null value (e.g. `API_KEY:` with no value) was rejected during YAML parsing. Treat it instead as a secret reference, resolved at launch time from a `--secret` CLI override or a registered managed secrets provider. This matches the existing `secrets:NAME` and `managed_secrets:` reference forms.

- A `--secret KEY=value` override still wins: overrides are applied before references are split out, so the entry stays inline.
- When no value can be resolved (no override and no provider, or the referenced secret does not exist), launch fails with a clear error.
- Skip null secret values during variable substitution, and keep them null during YAML redaction so redacted task YAML stays launchable.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
