### PR TITLE
[Dashboard] Add recovery count to managed job detail page

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1381,6 +1381,10 @@ function JobDetailsContent({
         </div>
       </div>
       <div>
+        <div className="text-gray-600 font-medium text-base">Recoveries</div>
+        <div className="text-base mt-1">{jobData.recoveries || 0}</div>
+      </div>
+      <div>
         <div className="text-gray-600 font-medium text-base">
           Requested Resources
         </div>


### PR DESCRIPTION
## Summary
- Add a "Recoveries" field to the managed job detail page's Details section, so the recovery count is visible at a glance instead of only in the jobs list.
- Renders the job's recovery count (0 when the job hasn't recovered).

## Test plan
- Ran the dashboard locally against an API server and opened a managed job detail page. Verified the Recoveries field renders in the Details grid: shows the count for a recovered job, and 0 when there are no recoveries.
