### PR TITLE
[Test] Make managed job status wait robust to the jobs queue WORKSPACE column

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -291,13 +291,39 @@ def get_cmd_wait_until_job_status_contains_matching_job_name(
 
 # Managed job functions
 
-_WAIT_UNTIL_MANAGED_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME = _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME.replace(
-    'sky queue {cluster_name}', 'sky jobs queue').replace(
-        'awk "\\$2 == \\"{job_name}\\"',
-        'awk "\\$2 == \\"{job_name}\\" || \\$3 == \\"{job_name}\\"').replace(
-            _ALL_JOB_STATUSES,
-            _ALL_MANAGED_JOB_STATUSES).replace('sleep 10',
-                                               'sleep {gap_seconds}')
+# Unlike `sky queue`, the `sky jobs queue` table has a variable number of
+# leading columns: the TASK column can be empty and a WORKSPACE column is
+# rendered whenever the displayed jobs span more than one workspace (see
+# `format_job_table` in sky/jobs/utils.py). Both shift the position of the
+# NAME column, so we match {job_name} in *any* column via an awk loop rather
+# than a fixed column index. This keeps the wait robust regardless of which
+# columns the server renders (e.g. on a shared server where jobs from
+# multiple workspaces are listed and the WORKSPACE column appears).
+_WAIT_UNTIL_MANAGED_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME = (
+    'start_time=$SECONDS; '
+    'while true; do '
+    'if (( $SECONDS - $start_time > {timeout} )); then '
+    '  echo "Timeout after {timeout} seconds waiting for job status \'{job_status}\'"; exit 1; '
+    'fi; '
+    'current_queue=$(sky jobs queue); '
+    'current_status=$(echo "$current_queue" | '
+    r'awk "{{name_found=0; '
+    r'for (i=1; i<=NF; i++) if (\$i == \"{job_name}\") name_found=1; '
+    r'if (name_found) for (i=1; i<=NF; i++) if (\$i ~ /^(' +
+    _ALL_MANAGED_JOB_STATUSES + r')$/) print \$i}}"); '
+    'found=0; '
+    'while read -r line; do '
+    '  if [[ "$line" =~ {job_status} ]]; then '
+    '    echo "Target job status {job_status} reached."; '
+    '    found=1; '
+    '    break; '
+    '  fi; '
+    'done <<< "$current_status"; '
+    'if [ "$found" -eq 1 ]; then break; fi; '
+    'echo "Waiting for job status to contain {job_status}, current status: $current_status"; '
+    'echo "Current queue: $current_queue"; '
+    'sleep {gap_seconds}; '
+    'done')
 
 
 def get_cmd_wait_until_managed_job_status_contains_matching_job_name(

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -220,7 +220,7 @@ def test_managed_jobs_queue_workspace_column(generic_cloud: str):
 
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
-@pytest.mark.no_shadeform  # Shadeform does not support host controllers        
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_managed_jobs_num_jobs_without_pool(generic_cloud: str):
     """`sky jobs launch --num-jobs N` works without a pool.
 

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -120,6 +120,102 @@ def test_managed_jobs_basic(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
+# Defining workspaces requires loading a server config, which means restarting
+# the API server -- not possible against a remote server or in the dependency
+# test (see test_workspaces.py for the same constraints).
+@pytest.mark.no_remote_server
+@pytest.mark.no_dependency
+def test_managed_jobs_queue_workspace_column(generic_cloud: str):
+    """Regression test for the `sky jobs queue` WORKSPACE column.
+
+    `sky jobs queue` renders a WORKSPACE column whenever the listed jobs span
+    more than one workspace (see `format_job_table` in sky/jobs/utils.py). That
+    extra column shifts the position of the NAME column, which used to break the
+    status-wait helper's awk parsing (it matched the name in a fixed column).
+
+    Launch two managed jobs in two different workspaces to force the WORKSPACE
+    column to appear, assert it is actually present, and confirm the helper can
+    still find each job's status despite the shifted NAME column.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    ws1 = f'{name}-wsa'
+    ws2 = f'{name}-wsb'
+    # A server config that defines the two workspaces the jobs run in. The
+    # client-side `workspaces:` key is ignored, so this must be loaded on the
+    # API server -- hence the restart below (and the no_remote_server marker).
+    server_config_content = textwrap.dedent(f"""\
+        workspaces:
+            {ws1}: {{}}
+            {ws2}: {{}}
+    """)
+    with tempfile.NamedTemporaryFile(prefix='jobs_ws_column_',
+                                     delete=False,
+                                     mode='w') as f:
+        f.write(server_config_content)
+        server_config_path = f.name
+
+    # Broad status set: the job may already be RUNNING/SUCCEEDED by the time we
+    # poll. We only care that the helper *finds* the status, not which one.
+    job_statuses = [
+        sky.ManagedJobStatus.PENDING,
+        sky.ManagedJobStatus.DEPRECATED_SUBMITTED,
+        sky.ManagedJobStatus.STARTING,
+        sky.ManagedJobStatus.RUNNING,
+        sky.ManagedJobStatus.SUCCEEDED,
+    ]
+    wait_timeout = 360 if generic_cloud in [
+        'azure', 'gcp', 'kubernetes', 'nebius'
+    ] else 120
+
+    def _launch(job_name: str, workspace: str) -> str:
+        return (f'sky jobs launch -n {job_name} --workspace {workspace} '
+                f'--infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} '
+                f'examples/managed_job.yaml -y -d')
+
+    test = smoke_tests_utils.Test(
+        'managed-jobs-queue-workspace-column',
+        [
+            # Load the two-workspace config onto the API server.
+            f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}={server_config_path} && '
+            f'{smoke_tests_utils.SKY_API_RESTART}',
+            _launch(f'{name}-1', ws1),
+            _launch(f'{name}-2', ws2),
+            # With jobs in two workspaces, `sky jobs queue` must render the
+            # WORKSPACE column -- otherwise this test would not exercise the
+            # column-shift scenario, so fail loudly if it is missing.
+            's=$(sky jobs queue); echo "$s"; echo "$s" | grep -q WORKSPACE',
+            # The actual regression guard: the helper must find each job's
+            # status even though the WORKSPACE column shifted the NAME column.
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}-1',
+                job_status=job_statuses,
+                timeout=wait_timeout),
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}-2',
+                job_status=job_statuses,
+                timeout=wait_timeout),
+        ],
+        # Cancel each job in its own workspace (cancel is workspace-scoped),
+        # then restore the server to its default (no-workspace) config.
+        teardown=
+        (f'sky jobs cancel -y -n {name}-1 --config active_workspace={ws1} || true; '
+         f'sky jobs cancel -y -n {name}-2 --config active_workspace={ws2} || true; '
+         f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}= && '
+         f'{smoke_tests_utils.SKY_API_RESTART}'),
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=20 * 60,
+    )
+    try:
+        smoke_tests_utils.run_one_test(test)
+    finally:
+        os.unlink(server_config_path)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
     """Test that logs are accessible after a managed job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -204,7 +204,12 @@ def test_managed_jobs_queue_workspace_column(generic_cloud: str):
          f'sky jobs cancel -y -n {name}-2 --config active_workspace={ws2} || true; '
          f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}= && '
          f'{smoke_tests_utils.SKY_API_RESTART}'),
-        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        # Use the dict form (config_dict) rather than LOW_CONTROLLER_RESOURCE_ENV
+        # (which points SKYPILOT_GLOBAL_CONFIG at a file): the env form would
+        # collide with the SKYPILOT_GLOBAL_CONFIG export used above to load the
+        # workspaces onto the server. config_dict is merged into the client
+        # config, so the controller still launches with low resources.
+        config_dict=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_OVERRIDE_CONFIG,
         timeout=20 * 60,
     )
     try:


### PR DESCRIPTION
## Summary

The smoke-test helper `get_cmd_wait_until_managed_job_status_contains_matching_job_name` polls `sky jobs queue` and parses the output with `awk "$2 == <name> || $3 == <name>"`, assuming the job NAME lives in a fixed column.

However, `sky jobs queue` renders a **variable number of leading columns**:
- the `TASK` column can be empty for a non-pipeline job, and
- a `WORKSPACE` column is added whenever the displayed jobs span more than one workspace (`show_workspace = len(workspaces) > 1 or show_all` in `format_job_table`, `sky/jobs/utils.py`).

Either of these shifts the `NAME` column out of `$2`/`$3`, so the `awk` match never fires. The wait loop then spins until timeout with an empty current status, and any test using this helper fails — even though the job actually reached the target status.

This is easy to hit on a shared API server where jobs from more than one workspace are listed at once, which makes the `WORKSPACE` column appear.

## Fix

Match the job name in *any* column via an `awk` loop instead of a fixed column index, so the wait is robust to however many leading columns `sky jobs queue` renders.

## Regression test

Adds `test_managed_jobs_queue_workspace_column`: it launches two managed jobs in two different workspaces to force the `WORKSPACE` column to appear, asserts the column is present, and then uses the status-wait helper on each job — exercising the shifted-`NAME`-column path. It follows the existing `test_workspaces.py` convention (load a two-workspace server config via an API restart), so it carries the `no_remote_server` / `no_dependency` markers.

## Test plan

- Rendered the generated command and ran its `awk` against real `sky jobs queue` output **with** and **without** the `WORKSPACE` column:
  - new `awk`: matches the status correctly in both cases
  - old `awk` (`$2`/`$3`): returns empty when the `WORKSPACE` column is present (reproduces the failure)
- `python -m py_compile` passes; `yapf --style google` reports no diff in the changed regions.
- Existing managed-job smoke tests (`test_managed_jobs_basic`, `test_managed_jobs_api_access`, `test_concurrent_file_mounts_jobs_launch`, etc.) exercise the fixed helper; a smoke run will confirm end-to-end.

-Claude