### PR TITLE
[Test] Fix flaky test_burstable_executor_pool_recovery under load

### DIFF
--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -185,7 +185,13 @@ def test_burstable_executor_pool_recovery():
             # This should trigger the pool recovery logic in
             # _submit_to_guaranteed_pool
             future = executor.submit_until_success(dummy_task)
-            result = future.result(timeout=5.0)
+            # Recovery replaces the guaranteed pool with a brand-new
+            # ProcessPoolExecutor, so this future's task runs on a worker
+            # that must be spawned from scratch (fork/spawn + ``import sky``
+            # in the child). That cold start can take several seconds under
+            # CI load, so use a generous timeout to keep the test
+            # deterministic while still catching genuine hangs.
+            result = future.result(timeout=60.0)
 
             # Verify the task completed successfully despite initial failure
             assert result is True


### PR DESCRIPTION
## Summary

`tests/unit_tests/test_sky/server/requests/test_process.py::test_burstable_executor_pool_recovery` is flaky under CPU contention and intermittently fails with `concurrent.futures.TimeoutError`.

The test exercises `BurstableExecutor`'s `BrokenProcessPool` recovery path, which replaces the guaranteed pool with a **brand-new** `ProcessPoolExecutor`. The submitted task therefore runs on a worker that must be spawned from scratch (fork/spawn + `import sky` in the child process). That cold start can take several seconds when the test host is loaded (e.g. many parallel xdist workers), so the previous `future.result(timeout=5.0)` was too tight and could time out even though recovery succeeded.

This raises the timeout to `60.0s` to keep the test deterministic while still catching genuine hangs, matching the generous timeouts already used elsewhere in this file (e.g. `wait_for_futures` defaults to 20s). No production code changes.

## Test plan

- `pytest tests/unit_tests/test_sky/server/requests/test_process.py::test_burstable_executor_pool_recovery` passes.
- `pytest tests/unit_tests/test_sky/server/requests/test_process.py` — all 6 tests pass.