### PR TITLE
[Test] Pin pod_config_sidecar cloud-cmd helper to landed context

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3456,11 +3456,14 @@ def test_kubernetes_pod_config_sidecar():
         test = smoke_tests_utils.Test(
             'kubernetes_pod_config_sidecar',
             [
-                smoke_tests_utils.launch_cluster_for_cloud_cmd(
-                    'kubernetes', name),
-                # Launch SkyPilot cluster with sidecar
+                # Launch SkyPilot cluster with sidecar first; it may land on
+                # any context on a multi-context API server.
                 f'sky launch -y -c {name} --infra kubernetes '
                 f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_yaml_path}',
+                # Pin the cloud-cmd helper to the context the target landed on
+                # so its in-cluster kubectl can see the target's resources.
+                smoke_tests_utils.resolve_k8s_context_cmd(name),
+                smoke_tests_utils.launch_cloud_cmd_on_landed_context(name),
                 # Verify pod has 2 containers (ray-node and sidecar)
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name,


### PR DESCRIPTION
## Summary

`test_kubernetes_pod_config_sidecar` launches its `cloud-cmd` helper cluster with the un-pinned `launch_cluster_for_cloud_cmd('kubernetes', name)`. On a multi-context API server the helper can land on a **different** Kubernetes context than the sidecar cluster under test.

The `cloud-cmd` helper is a regular (non-controller) cluster, so its `kubectl` runs with the helper pod's own in-cluster service-account credentials and can only reach the helper's own cluster (the API server's multi-context kubeconfig is uploaded only to controller clusters). When the two clusters land on different contexts, the pod-inspection step

```
kubectl get pod -l skypilot-cluster-name=<name> -o jsonpath='{.items[0].spec.containers[*].name}'
```

matches zero pods and returns an empty list, so `kubectl`'s client-side `jsonpath` fails with `array index out of bounds: index 0, length 0` (exit 1). That propagates up as a failed `sky exec` and the test fails — even though the sidecar pod is healthy and has both the `ray-node` and `sidecar` containers.

## Fix

Migrate the test to the context-pinned pattern already used by the other Kubernetes smoke tests (`resolve_k8s_context_cmd` + `launch_cloud_cmd_on_landed_context`, introduced in #9967):

1. launch the target cluster first (it may land on any context),
2. resolve the context it landed on, then
3. pin the `cloud-cmd` helper to that context,

so the helper's in-cluster `kubectl` shares the target's cluster and can see its pod. No product code changes; this is a test-only fix.

## Follow-up

A few other Kubernetes smoke tests still use the un-pinned helper and carry the same latent multi-context flakiness (`test_volumes_on_kubernetes`, `test_launching_with_pending_pods`, `test_managed_jobs_recovery_kubernetes_multinode`, and the SkyServe HA-kill tests). They can be migrated the same way in a follow-up.

## Test plan

- `python -m py_compile` passes; `yapf --style google` reports no diff in the changed region.
- The change swaps to the identical helper pair exercised by ~20 other passing Kubernetes smoke tests, placed in the same order (target launch → resolve context → pinned helper → checks).
- A `--kubernetes` smoke run on a multi-context API server confirms end-to-end (the failure only reproduces when the helper and target land on different contexts).

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSUqwJtnCvbx4b8nTpmVfE