### PR TITLE
[Jobs] Surface PENDING job reason in job details

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1575,7 +1575,11 @@ function JobDetailsContent({
         </div>
       </div>
 
-      {/* Queue Details section - right column */}
+      {/* Details section - surfaces the reason behind the current status
+          (e.g. why a job is still PENDING). A plugin may take over this slot
+          to render richer queue-specific details (e.g. Kueue); otherwise the
+          OSS fallback shows the plain details string so the reason is visible
+          here in the job details view, not just in the event table. */}
       {jobData.details && (
         <PluginSlot
           name="jobs.detail.queue_details"
@@ -1586,6 +1590,14 @@ function JobDetailsContent({
             jobData: jobData,
             title: 'Queue Details',
           }}
+          fallback={
+            <div>
+              <div className="text-gray-600 font-medium text-base">Details</div>
+              <div className="text-base mt-1 whitespace-pre-wrap break-words">
+                {jobData.details}
+              </div>
+            </div>
+          }
         />
       )}
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3622,33 +3622,63 @@ def get_job_events(job_id: int,
     } for row in rows]
 
 
-def get_latest_recovery_reasons(job_ids: List[int]) -> Dict[int, str]:
-    """Return {job_id: reason} for the most recent RECOVERING event per job.
+def _get_latest_event_reasons(
+    job_ids_by_status: Dict['ManagedJobStatus', List[int]]
+) -> Dict['ManagedJobStatus', Dict[int, str]]:
+    """Return {status: {job_id: reason}} for the latest event of each status.
 
-    Only jobs with a non-empty RECOVERING reason are included. Used to surface
-    why a job is currently recovering (e.g. an OOMKilled pod) in the
-    `details` column. A single batched query keeps this off the per-job path.
+    Fetches the most recent non-empty event reason per (status, job_id) in a
+    single batched query, to stay off the per-job path and avoid extra DB
+    round trips when several statuses are needed at once. Each job_id is
+    matched only against the status it was requested under, so a job's
+    historical events of other statuses are ignored.
     """
-    if not job_ids:
-        return {}
+    result: Dict['ManagedJobStatus',
+                 Dict[int, str]] = {status: {} for status in job_ids_by_status}
+    conditions = [
+        sqlalchemy.and_(
+            job_events_table.c.new_status == status.value,
+            job_events_table.c.spot_job_id.in_(job_ids),
+        ) for status, job_ids in job_ids_by_status.items() if job_ids
+    ]
+    if not conditions:
+        return result
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
         rows = session.execute(
             sqlalchemy.select(
                 job_events_table.c.spot_job_id,
+                job_events_table.c.new_status,
                 job_events_table.c.reason,
-            ).where(
-                sqlalchemy.and_(
-                    job_events_table.c.spot_job_id.in_(job_ids),
-                    job_events_table.c.new_status ==
-                    ManagedJobStatus.RECOVERING.value,
-                )).order_by(job_events_table.c.timestamp.desc())).fetchall()
-    # rows are newest-first; keep the first (latest) non-empty reason per job.
-    reasons: Dict[int, str] = {}
-    for spot_job_id, reason in rows:
+            ).where(sqlalchemy.or_(*conditions)).order_by(
+                job_events_table.c.timestamp.desc())).fetchall()
+    # rows are newest-first; keep the first (latest) non-empty reason per
+    # (status, job_id).
+    for spot_job_id, new_status, reason in rows:
+        reasons = result[ManagedJobStatus(new_status)]
         if spot_job_id not in reasons and reason:
             reasons[spot_job_id] = reason
-    return reasons
+    return result
+
+
+def get_latest_recovery_and_pending_reasons(
+        recovering_job_ids: List[int],
+        pending_job_ids: List[int]) -> Tuple[Dict[int, str], Dict[int, str]]:
+    """Return (recovery_reasons, pending_reasons) in a single DB query.
+
+    Each dict maps job_id -> the most recent non-empty event reason for that
+    status. Used to surface why a job is currently recovering (e.g. an
+    OOMKilled pod) or still pending (e.g. it was just submitted to the queue
+    or is in launch backoff) in the `details` column; both were previously
+    only visible in the event table. Fetches both in one round trip to stay
+    off the per-job path.
+    """
+    reasons = _get_latest_event_reasons({
+        ManagedJobStatus.RECOVERING: recovering_job_ids,
+        ManagedJobStatus.PENDING: pending_job_ids,
+    })
+    return (reasons[ManagedJobStatus.RECOVERING],
+            reasons[ManagedJobStatus.PENDING])
 
 
 async def cleanup_job_events_with_retention_async(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2409,8 +2409,9 @@ def _cluster_handle_not_required(fields: List[str]) -> bool:
 def _format_job_details(*,
                         job: Dict[str, Any],
                         highest_blocking_priority: int,
-                        recovery_reason: Optional[str] = None) -> None:
-    """Add details about schedule state / backoff / recovery."""
+                        recovery_reason: Optional[str] = None,
+                        pending_reason: Optional[str] = None) -> None:
+    """Add details about schedule state / backoff / recovery / pending."""
     state_details = None
     if job['schedule_state'] == 'ALIVE_BACKOFF':
         state_details = 'In backoff, waiting for resources'
@@ -2447,6 +2448,13 @@ def _format_job_details(*,
             if hint is not None:
                 detail += f' ({hint})'
         job['details'] = detail
+    elif pending_reason:
+        # Surface why a job is still PENDING (e.g. it was submitted to the
+        # controller queue or is in launch backoff) so the reason is visible
+        # in the job details view, not just the event table. Collapse
+        # whitespace so a multi-line reason renders on a single line in the
+        # details column.
+        job['details'] = ' '.join(pending_reason.split())
     else:
         job['details'] = None
 
@@ -2671,25 +2679,35 @@ def get_managed_job_queue(
 
     _populate_job_records_from_handles(jobs_with_handle)
 
-    # Batch-fetch the reason a recovering job is recovering (e.g. an OOMKilled
-    # pod), so it can be surfaced in `details`. Scoped to RECOVERING jobs (a
-    # small, transient subset) and done in one query to stay off the per-job
-    # path. `job['status']` is already stringified above.
+    # Batch-fetch the reason a job is recovering (e.g. an OOMKilled pod) or
+    # still pending (e.g. submitted to the queue or in launch backoff), so it
+    # can be surfaced in `details`. Both were previously only visible in the
+    # event table. Scoped to the (small, transient) RECOVERING/PENDING subsets
+    # and fetched together in one query to stay off the per-job path and avoid
+    # an extra DB round trip. `job['status']` is already stringified above.
     recovery_reasons: Dict[int, str] = {}
+    pending_reasons: Dict[int, str] = {}
     if not fields or 'details' in fields:
         recovering_job_ids = [
             job['job_id'] for job in jobs if job['status'] ==
             managed_job_state.ManagedJobStatus.RECOVERING.value
         ]
-        recovery_reasons = managed_job_state.get_latest_recovery_reasons(
-            recovering_job_ids)
+        pending_job_ids = [
+            job['job_id']
+            for job in jobs
+            if job['status'] == managed_job_state.ManagedJobStatus.PENDING.value
+        ]
+        recovery_reasons, pending_reasons = (
+            managed_job_state.get_latest_recovery_and_pending_reasons(
+                recovering_job_ids, pending_job_ids))
 
     for job in jobs:
         if not fields or 'details' in fields:
             _format_job_details(
                 job=job,
                 highest_blocking_priority=highest_blocking_priority,
-                recovery_reason=recovery_reasons.get(job['job_id']))
+                recovery_reason=recovery_reasons.get(job['job_id']),
+                pending_reason=pending_reasons.get(job['job_id']))
 
         # Derive is_job_group from execution column
         job['is_job_group'] = (

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -803,10 +803,10 @@ class TestGetManagedJobsWithFilters:
 
 
 class TestGetLatestRecoveryReasons:
-    """Tests for get_latest_recovery_reasons."""
+    """Recovery-reason coverage via get_latest_recovery_and_pending_reasons."""
 
     def test_empty_job_ids(self, _mock_managed_jobs_db_conn):
-        assert state.get_latest_recovery_reasons([]) == {}
+        assert state.get_latest_recovery_and_pending_reasons([], [])[0] == {}
 
     def test_latest_reason_wins_and_filters(self, _mock_managed_jobs_db_conn):
         early = datetime.datetime(2026, 1, 1, 0, 0, 0)
@@ -839,7 +839,7 @@ class TestGetLatestRecoveryReasons:
                             state.ManagedJobStatus.RECOVERING,
                             'unrelated',
                             timestamp=late)
-        result = state.get_latest_recovery_reasons([1, 2])
+        result = state.get_latest_recovery_and_pending_reasons([1, 2], [])[0]
         assert result == {
             1: 'OOMKilled (exit code 137)',
             2: 'preempted',
@@ -860,12 +860,14 @@ class TestGetLatestRecoveryReasons:
                             state.ManagedJobStatus.RECOVERING,
                             '',
                             timestamp=late)
-        assert state.get_latest_recovery_reasons([1]) == {1: 'real reason'}
+        assert state.get_latest_recovery_and_pending_reasons([1], [])[0] == {
+            1: 'real reason'
+        }
 
     def test_no_recovering_events_returns_empty(self,
                                                 _mock_managed_jobs_db_conn):
         state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running')
-        assert state.get_latest_recovery_reasons([1]) == {}
+        assert state.get_latest_recovery_and_pending_reasons([1], [])[0] == {}
 
 
 # Fixed epoch timestamps (seconds) for the time-range fixture. submitted_at is
@@ -1250,3 +1252,111 @@ class TestStatusExprSeam:
             fields=['job_id', 'status', 'task_id'])
         seq_d = [refined[j['job_id']] for j in desc]
         assert seq_d == sorted(seq_d, reverse=True), seq_d
+
+
+class TestGetLatestPendingReasons:
+    """Pending-reason coverage via get_latest_recovery_and_pending_reasons."""
+
+    def test_empty_job_ids(self, _mock_managed_jobs_db_conn):
+        assert state.get_latest_recovery_and_pending_reasons([], [])[1] == {}
+
+    def test_latest_reason_wins_and_filters(self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        # Job 1: two PENDING events -> the latest reason wins.
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'Job submitted to queue',
+                            timestamp=early)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'Job is in backoff',
+                            timestamp=late)
+        # Job 2: a RUNNING event is ignored; only the PENDING reason returns.
+        state.add_job_event(2,
+                            0,
+                            state.ManagedJobStatus.RUNNING,
+                            'Job started',
+                            timestamp=late)
+        state.add_job_event(2,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'Job submitted to queue',
+                            timestamp=early)
+        # Job 3 has a PENDING event but is not requested.
+        state.add_job_event(3,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'unrelated',
+                            timestamp=late)
+        result = state.get_latest_recovery_and_pending_reasons([], [1, 2])[1]
+        assert result == {
+            1: 'Job is in backoff',
+            2: 'Job submitted to queue',
+        }
+
+    def test_empty_reason_skipped(self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        # The most recent PENDING event has an empty reason -> fall back to
+        # the most recent non-empty one.
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'Job submitted to queue',
+                            timestamp=early)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            '',
+                            timestamp=late)
+        assert state.get_latest_recovery_and_pending_reasons([], [1])[1] == {
+            1: 'Job submitted to queue'
+        }
+
+    def test_no_pending_events_returns_empty(self, _mock_managed_jobs_db_conn):
+        state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running')
+        assert state.get_latest_recovery_and_pending_reasons([], [1])[1] == {}
+
+
+class TestGetLatestRecoveryAndPendingReasons:
+    """Tests for the single-query get_latest_recovery_and_pending_reasons."""
+
+    def test_both_empty(self, _mock_managed_jobs_db_conn):
+        assert state.get_latest_recovery_and_pending_reasons([], []) == ({}, {})
+
+    def test_returns_reasons_per_status(self, _mock_managed_jobs_db_conn):
+        # Job 1 is recovering; job 2 is pending. Each reason must land in its
+        # own bucket, matched to the status it was requested under.
+        state.add_job_event(1, 0, state.ManagedJobStatus.RECOVERING,
+                            'OOMKilled')
+        state.add_job_event(2, 0, state.ManagedJobStatus.PENDING,
+                            'Job submitted to queue')
+        recovery, pending = state.get_latest_recovery_and_pending_reasons([1],
+                                                                          [2])
+        assert recovery == {1: 'OOMKilled'}
+        assert pending == {2: 'Job submitted to queue'}
+
+    def test_status_scoped_per_job(self, _mock_managed_jobs_db_conn):
+        # Job 1 has both a RECOVERING and a (later) PENDING event -- e.g. it
+        # went back to PENDING during launch backoff. When requested only under
+        # PENDING, its RECOVERING reason must not leak into the recovery bucket,
+        # and its PENDING reason must not appear in the recovery bucket either.
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'stale recovering',
+                            timestamp=early)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.PENDING,
+                            'Job is in backoff',
+                            timestamp=late)
+        recovery, pending = state.get_latest_recovery_and_pending_reasons([],
+                                                                          [1])
+        assert recovery == {}
+        assert pending == {1: 'Job is in backoff'}

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1096,6 +1096,7 @@ class TestFormatJobDetails:
                  failure_reason=None,
                  status='RECOVERING',
                  recovery_reason=None,
+                 pending_reason=None,
                  cloud=None):
         job = {
             'schedule_state': schedule_state,
@@ -1105,7 +1106,8 @@ class TestFormatJobDetails:
         }
         jobs_utils._format_job_details(job=job,
                                        highest_blocking_priority=0,
-                                       recovery_reason=recovery_reason)
+                                       recovery_reason=recovery_reason,
+                                       pending_reason=pending_reason)
         return job['details']
 
     def test_recovery_reason_surfaced(self):
@@ -1162,6 +1164,38 @@ class TestFormatJobDetails:
         # No cloud info -> surface the reason without a (possibly wrong) hint.
         result = self._details(recovery_reason='podX OOMKilled (exit code 137)')
         assert result == 'Recovering: podX OOMKilled (exit code 137)'
+
+    def test_pending_reason_surfaced(self):
+        # A PENDING reason is surfaced in details when nothing else applies.
+        assert self._details(
+            schedule_state='INACTIVE',
+            status='PENDING',
+            pending_reason='Job submitted to queue') == 'Job submitted to queue'
+
+    def test_pending_reason_multiline_collapsed(self):
+        result = self._details(schedule_state='INACTIVE',
+                               status='PENDING',
+                               pending_reason='Rate limited.\nRetrying soon.')
+        assert '\n' not in result
+        assert result == 'Rate limited. Retrying soon.'
+
+    def test_no_pending_reason_is_none(self):
+        assert self._details(schedule_state='INACTIVE',
+                             status='PENDING',
+                             pending_reason=None) is None
+
+    def test_failure_reason_takes_precedence_over_pending(self):
+        assert self._details(status='PENDING',
+                             failure_reason='boom',
+                             pending_reason='ignored') == 'Failure: boom'
+
+    def test_backoff_state_takes_precedence_over_pending(self):
+        # The schedule-state-derived message is more informative than the raw
+        # PENDING event reason, so it wins.
+        assert self._details(
+            schedule_state='ALIVE_BACKOFF',
+            status='PENDING',
+            pending_reason='ignored') == 'In backoff, waiting for resources'
 
 
 class TestReadProvisionStatusFromLog:

--- a/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
+++ b/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
@@ -340,7 +340,10 @@ class TestGetJobTable:
         assert target_job.recovery_count == 0
         assert target_job.metadata == {}
         assert target_job.workspace == 'ws1'
-        assert not target_job.HasField('details')
+        # job_id1 is PENDING with schedule_state INACTIVE, so there is no
+        # schedule-state message; _format_job_details surfaces the latest
+        # PENDING event reason (from set_pending) in details instead.
+        assert target_job.details == 'Job submitted to queue'
         assert not target_job.HasField('failure_reason')
         assert not target_job.HasField('user_name')
         assert target_job.user_hash == 'abcd1234'
@@ -404,7 +407,10 @@ class TestGetJobTable:
         assert target_job.recovery_count == 0
         assert target_job.metadata == {}
         assert target_job.workspace == 'ws1'
-        assert not target_job.HasField('details')
+        # job_id1 is PENDING with schedule_state INACTIVE, so there is no
+        # schedule-state message; _format_job_details surfaces the latest
+        # PENDING event reason (from set_pending) in details instead.
+        assert target_job.details == 'Job submitted to queue'
         assert not target_job.HasField('failure_reason')
         assert not target_job.HasField('user_name')
         assert target_job.user_hash == 'abcd1234'


### PR DESCRIPTION
Previously the reason a managed job was still PENDING (e.g. submitted to the controller queue or in launch backoff) was only recorded in the job_events table and shown in the dashboard event table, not in the job details view. Users investigating a stuck PENDING job had to dig into the event table to find the reason.

Mirror the existing recovery-reason mechanism: batch-fetch the latest PENDING event reason per job and surface it in the `details` field via _format_job_details (lowest precedence, so the more informative schedule-state messages still win). The CLI table and the jobs list page already render `details`, so they pick this up for free; the OSS job detail page did not render `details` at all, so add a Details field (with a plugin fallback so a queue-details plugin can still take over).

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
