### PR TITLE
[Dashboard] Truncate long managed job names in the jobs table

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -493,6 +493,19 @@ function BatchProgressBar({ completed, total }) {
   );
 }
 
+function JobNameLink({ href, name }) {
+  return (
+    <NonCapitalizedTooltip content={name}>
+      <Link
+        href={href}
+        className="text-blue-600 block min-w-[200px] max-w-[240px] truncate"
+      >
+        {name}
+      </Link>
+    </NonCapitalizedTooltip>
+  );
+}
+
 export function ManagedJobsTable({
   refreshInterval,
   setLoading,
@@ -1493,9 +1506,7 @@ export function ManagedJobsTable({
             return (
               <TableCell className="whitespace-nowrap">
                 <div className="flex items-center">
-                  <Link href={`/jobs/${jobId}`} className="text-blue-600">
-                    {item.name}
-                  </Link>
+                  <JobNameLink href={`/jobs/${jobId}`} name={item.name} />
                   {isBatch && <BatchBadge className="ml-2" />}
                   <button
                     onClick={() => toggleJobGroup(jobId)}
@@ -1534,9 +1545,7 @@ export function ManagedJobsTable({
           return (
             <TableCell className="whitespace-nowrap">
               <div className="flex items-center">
-                <Link href={`/jobs/${item.id}`} className="text-blue-600">
-                  {item.name}
-                </Link>
+                <JobNameLink href={`/jobs/${item.id}`} name={item.name} />
                 {isBatch && <BatchBadge className="ml-2" />}
               </div>
             </TableCell>


### PR DESCRIPTION
## Summary

Long managed job names expanded the Name column until the jobs table exceeded the viewport and the whole page scrolled horizontally. This caps the job-name link with a min/max width and truncates it with an ellipsis, revealing the full name on hover — so the table stays within its width regardless of name length.

## Changes

- Add a small `JobNameLink` component that wraps the name in a tooltip and caps the link at `min-w-[200px] max-w-[240px]` with `truncate`.
- Use it at the two job-name render sites (single task + job-group parent) in the Managed Jobs table.

## Test plan

Verified manually in the running dashboard across viewport widths (375–1920px) with long job names:

- Long names truncate with an ellipsis; the full name shows on hover.
- The page no longer scrolls horizontally because of the Name column.
- Short names render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
