### PR TITLE
[Jobs] Default managed jobs queue to a lightweight field set

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -69,6 +69,7 @@ from sky.client.cli import deprecation_utils
 from sky.client.cli import flags
 from sky.client.cli import table_utils
 from sky.client.cli import utils as cli_utils
+from sky.jobs import constants as managed_job_constants
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.state import ManagedJobStatus
 from sky.provision.kubernetes import constants as kubernetes_constants
@@ -134,12 +135,8 @@ _DEFAULT_REQUEST_FIELDS_TO_SHOW = [
 _VERBOSE_REQUEST_FIELDS_TO_SHOW = _DEFAULT_REQUEST_FIELDS_TO_SHOW + [
     'cluster_name'
 ]
-_DEFAULT_MANAGED_JOB_FIELDS_TO_GET = [
-    'job_id', 'task_id', 'workspace', 'job_name', 'task_name', 'resources',
-    'submitted_at', 'end_at', 'job_duration', 'recovery_count', 'status',
-    'pool', 'is_primary_in_job_group', 'batch_total_batches',
-    'batch_completed_batches'
-]
+_DEFAULT_MANAGED_JOB_FIELDS_TO_GET = (
+    managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
 _VERBOSE_MANAGED_JOB_FIELDS_TO_GET = _DEFAULT_MANAGED_JOB_FIELDS_TO_GET + [
     'current_cluster_name', 'job_id_on_pool_cluster', 'start_at', 'infra',
     'cloud', 'region', 'zone', 'cluster_resources', 'schedule_state', 'details',

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -135,7 +135,7 @@ _DEFAULT_REQUEST_FIELDS_TO_SHOW = [
 _VERBOSE_REQUEST_FIELDS_TO_SHOW = _DEFAULT_REQUEST_FIELDS_TO_SHOW + [
     'cluster_name'
 ]
-_DEFAULT_MANAGED_JOB_FIELDS_TO_GET = (
+_DEFAULT_MANAGED_JOB_FIELDS_TO_GET = list(
     managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
 _VERBOSE_MANAGED_JOB_FIELDS_TO_GET = _DEFAULT_MANAGED_JOB_FIELDS_TO_GET + [
     'current_cluster_name', 'job_id_on_pool_cluster', 'start_at', 'infra',

--- a/sky/client/cli/utils.py
+++ b/sky/client/cli/utils.py
@@ -3,7 +3,6 @@ import enum
 import typing
 from typing import Dict, List, Optional, Tuple, Union
 
-from sky import exceptions
 from sky import jobs as managed_jobs
 from sky import sky_logging
 from sky.schemas.api import responses
@@ -72,37 +71,17 @@ def get_managed_job_queue(
           does not exist.
         RuntimeError: if failed to get the managed jobs with ssh.
     """
-    try:
-        return typing.cast(
-            server_common.RequestId[
-                Union[List[responses.ManagedJobRecord],
-                      Tuple[List[responses.ManagedJobRecord], int,
-                            Dict[str, int], int]]],
-            managed_jobs.queue_v2(
-                refresh,
-                skip_finished,
-                all_users,
-                job_ids,
-                limit,
-                fields,
-                statuses=statuses,
-                submitted_after=submitted_after,
-                submitted_before=submitted_before)), QueueResultVersion.V2
-    except exceptions.APINotSupportedError:
-        if statuses is not None:
-            logger.warning(
-                'Filtering by status is not supported in your API server. '
-                'Please upgrade to a newer API server to use --status. '
-                'Showing all jobs.')
-        if submitted_after is not None or submitted_before is not None:
-            logger.warning(
-                'Filtering by submission time is not supported in your API '
-                'server. Please upgrade to a newer API server to use '
-                '--since/--after/--before. Showing all jobs.')
-        return typing.cast(
-            server_common.RequestId[
-                Union[List[responses.ManagedJobRecord],
-                      Tuple[List[responses.ManagedJobRecord], int,
-                            Dict[str, int], int]]],
-            managed_jobs.queue(refresh, skip_finished, all_users,
-                               job_ids)), QueueResultVersion.V1
+    return typing.cast(
+        server_common.RequestId[Union[List[responses.ManagedJobRecord],
+                                      Tuple[List[responses.ManagedJobRecord],
+                                            int, Dict[str, int], int]]],
+        managed_jobs.queue_v2(
+            refresh,
+            skip_finished,
+            all_users,
+            job_ids,
+            limit,
+            fields,
+            statuses=statuses,
+            submitted_after=submitted_after,
+            submitted_before=submitted_before)), QueueResultVersion.V2

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -13,6 +13,7 @@ from sky import sky_logging
 from sky.backends import backend_utils
 from sky.client import common as client_common
 from sky.client import sdk
+from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
@@ -165,13 +166,15 @@ def launch(
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @versions.minimal_api_version(18)
-def queue_v2(
+# DEFAULT_MANAGED_JOB_FIELDS is a module-level, read-only constant and is
+# never mutated here, so the mutable-default warning is a false positive.
+def queue_v2(  # pylint: disable=dangerous-default-value
     refresh: bool,
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[List[str]] = None,
+    fields: Optional[List[str]] = DEFAULT_MANAGED_JOB_FIELDS,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
     statuses: Optional[List[str]] = None,
@@ -189,7 +192,11 @@ def queue_v2(
         all_users: Whether to show all users' jobs.
         job_ids: IDs of the managed jobs to show.
         limit: Number of jobs to show.
-        fields: Fields to get for the managed jobs.
+        fields: Fields to get for the managed jobs. Defaults to a lightweight
+            set of fields (see
+            ``sky.jobs.constants.DEFAULT_MANAGED_JOB_FIELDS``) that excludes
+            heavy fields such as the task YAML. Pass ``fields=None`` to fetch
+            every field (larger payload).
         sort_by: Field to sort by (e.g., 'job_id', 'name', 'submitted_at').
         sort_order: Sort direction ('asc' or 'desc').
         statuses: Only return jobs whose status is in this list.

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -13,7 +13,7 @@ from sky import sky_logging
 from sky.backends import backend_utils
 from sky.client import common as client_common
 from sky.client import sdk
-from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
+from sky.jobs import constants as managed_job_constants
 from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
@@ -172,7 +172,8 @@ def queue_v2(
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[Sequence[str]] = DEFAULT_MANAGED_JOB_FIELDS,
+    fields: Optional[
+        Sequence[str]] = managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
     statuses: Optional[List[str]] = None,

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -166,15 +166,13 @@ def launch(
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @versions.minimal_api_version(18)
-# DEFAULT_MANAGED_JOB_FIELDS is a module-level, read-only constant and is
-# never mutated here, so the mutable-default warning is a false positive.
-def queue_v2(  # pylint: disable=dangerous-default-value
+def queue_v2(
     refresh: bool,
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[List[str]] = DEFAULT_MANAGED_JOB_FIELDS,
+    fields: Optional[Sequence[str]] = DEFAULT_MANAGED_JOB_FIELDS,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
     statuses: Optional[List[str]] = None,
@@ -268,7 +266,7 @@ def queue_v2(  # pylint: disable=dangerous-default-value
         all_users=all_users,
         job_ids=job_ids,
         limit=limit,
-        fields=fields,
+        fields=list(fields) if fields is not None else None,
         sort_by=sort_by,
         sort_order=sort_order,
         statuses=statuses,

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -8,6 +8,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.client import sdk_async
 from sky.jobs.client import sdk
+from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.usage import usage_lib
@@ -47,13 +48,13 @@ async def launch(
 
 
 @usage_lib.entrypoint
-async def queue_v2(
+async def queue_v2(  # pylint: disable=dangerous-default-value
     refresh: bool,
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[List[str]] = None,
+    fields: Optional[List[str]] = DEFAULT_MANAGED_JOB_FIELDS,
     stream_logs: Optional[
         sdk_async.StreamConfig] = sdk_async.DEFAULT_STREAM_CONFIG
 ) -> Tuple[List[responses.ManagedJobRecord], int, Dict[str, int], int]:

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -7,8 +7,8 @@ from sky import backends
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.client import sdk_async
+from sky.jobs import constants as managed_job_constants
 from sky.jobs.client import sdk
-from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.usage import usage_lib
@@ -54,7 +54,8 @@ async def queue_v2(
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[Sequence[str]] = DEFAULT_MANAGED_JOB_FIELDS,
+    fields: Optional[
+        Sequence[str]] = managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS,
     stream_logs: Optional[
         sdk_async.StreamConfig] = sdk_async.DEFAULT_STREAM_CONFIG
 ) -> Tuple[List[responses.ManagedJobRecord], int, Dict[str, int], int]:

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -1,7 +1,7 @@
 """Async SDK functions for managed jobs."""
 import asyncio
 import typing
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from sky import backends
 from sky import sky_logging
@@ -48,13 +48,13 @@ async def launch(
 
 
 @usage_lib.entrypoint
-async def queue_v2(  # pylint: disable=dangerous-default-value
+async def queue_v2(
     refresh: bool,
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
-    fields: Optional[List[str]] = DEFAULT_MANAGED_JOB_FIELDS,
+    fields: Optional[Sequence[str]] = DEFAULT_MANAGED_JOB_FIELDS,
     stream_logs: Optional[
         sdk_async.StreamConfig] = sdk_async.DEFAULT_STREAM_CONFIG
 ) -> Tuple[List[responses.ManagedJobRecord], int, Dict[str, int], int]:

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -12,6 +12,17 @@ JOBS_CONTROLLER_LOGS_DIR = '~/sky_logs/jobs_controller'
 
 JOBS_TASK_YAML_PREFIX = '~/.sky/managed_jobs'
 
+# Default fields returned by the managed jobs queue when the caller does not
+# specify `fields`. This intentionally excludes heavy fields (e.g. the task
+# YAML) so the default queue payload stays small even with many jobs. Callers
+# that need every field must pass `fields=None` explicitly.
+DEFAULT_MANAGED_JOB_FIELDS = [
+    'job_id', 'task_id', 'workspace', 'job_name', 'task_name', 'resources',
+    'submitted_at', 'end_at', 'job_duration', 'recovery_count', 'status',
+    'pool', 'is_primary_in_job_group', 'batch_total_batches',
+    'batch_completed_batches'
+]
+
 JOB_CONTROLLER_INDICATOR_FILE = '~/.sky/is_jobs_controller'
 
 CONSOLIDATED_SIGNAL_PATH = os.path.expanduser('~/.sky/signals/')

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -16,12 +16,12 @@ JOBS_TASK_YAML_PREFIX = '~/.sky/managed_jobs'
 # specify `fields`. This intentionally excludes heavy fields (e.g. the task
 # YAML) so the default queue payload stays small even with many jobs. Callers
 # that need every field must pass `fields=None` explicitly.
-DEFAULT_MANAGED_JOB_FIELDS = [
-    'job_id', 'task_id', 'workspace', 'job_name', 'task_name', 'resources',
-    'submitted_at', 'end_at', 'job_duration', 'recovery_count', 'status',
-    'pool', 'is_primary_in_job_group', 'batch_total_batches',
-    'batch_completed_batches'
-]
+# Defined as a tuple so it is immutable and safe to use as a default argument.
+DEFAULT_MANAGED_JOB_FIELDS = ('job_id', 'task_id', 'workspace', 'job_name',
+                              'task_name', 'resources', 'submitted_at',
+                              'end_at', 'job_duration', 'recovery_count',
+                              'status', 'pool', 'is_primary_in_job_group',
+                              'batch_total_batches', 'batch_completed_batches')
 
 JOB_CONTROLLER_INDICATOR_FILE = '~/.sky/is_jobs_controller'
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1224,7 +1224,7 @@ def queue(refresh: bool,
         skip_finished,
         all_users,
         job_ids,
-        fields=managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
+        fields=list(managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS))
 
     return jobs
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1216,7 +1216,15 @@ def queue(refresh: bool,
             does not exist.
         RuntimeError: if failed to get the managed jobs with ssh.
     """
-    jobs, _, _, _ = queue_v2(refresh, skip_finished, all_users, job_ids)
+    # The deprecated v1 queue body cannot request specific fields, so default
+    # to the lightweight field set to avoid returning heavy fields (e.g. the
+    # task YAML) for every job, which is expensive with many jobs.
+    jobs, _, _, _ = queue_v2(
+        refresh,
+        skip_finished,
+        all_users,
+        job_ids,
+        fields=managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
 
     return jobs
 

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2449,7 +2449,9 @@ def test_managed_job_labels_in_queue(generic_cloud: str):
     def check_labels_in_queue():
         """Check that labels are present in the job queue."""
         # Get the job queue using SDK
-        queue_request_id = jobs_sdk.queue_v2(refresh=False, all_users=True)
+        queue_request_id = jobs_sdk.queue_v2(refresh=False,
+                                             all_users=True,
+                                             fields=['job_name', 'labels'])
         queue_records = sdk.stream_and_get(queue_request_id)
 
         # Parse the queue response
@@ -2541,7 +2543,9 @@ def test_managed_job_git_commit_in_queue(generic_cloud: str):
 
     def check_git_commit_in_queue():
         """Check that git_commit is present in the job queue metadata."""
-        queue_request_id = jobs_sdk.queue_v2(refresh=False, all_users=True)
+        queue_request_id = jobs_sdk.queue_v2(refresh=False,
+                                             all_users=True,
+                                             fields=['job_name', 'metadata'])
         queue_records = sdk.stream_and_get(queue_request_id)
 
         if isinstance(queue_records, tuple):

--- a/tests/unit_tests/test_sky/jobs/test_client_sdk.py
+++ b/tests/unit_tests/test_sky/jobs/test_client_sdk.py
@@ -36,7 +36,7 @@ def test_queue_v2_defaults_to_lightweight_fields():
     # A high remote API version avoids the version-based field stripping so we
     # can assert the full default field set is sent.
     body = _call_raw_queue_v2(refresh=False)
-    assert body['fields'] == DEFAULT_MANAGED_JOB_FIELDS
+    assert body['fields'] == list(DEFAULT_MANAGED_JOB_FIELDS)
     # The lightweight default must not pull heavy fields.
     assert 'node_names' not in body['fields']
     assert 'metadata' not in body['fields']

--- a/tests/unit_tests/test_sky/jobs/test_client_sdk.py
+++ b/tests/unit_tests/test_sky/jobs/test_client_sdk.py
@@ -3,9 +3,9 @@ from unittest import mock
 
 import pytest
 
+from sky.jobs import constants as managed_job_constants
 from sky.jobs.client import sdk as jobs_sdk
 from sky.jobs.client import sdk_async as jobs_sdk_async
-from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 
 
 def _unwrap(fn):
@@ -36,7 +36,8 @@ def test_queue_v2_defaults_to_lightweight_fields():
     # A high remote API version avoids the version-based field stripping so we
     # can assert the full default field set is sent.
     body = _call_raw_queue_v2(refresh=False)
-    assert body['fields'] == list(DEFAULT_MANAGED_JOB_FIELDS)
+    assert body['fields'] == list(
+        managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
     # The lightweight default must not pull heavy fields.
     assert 'node_names' not in body['fields']
     assert 'metadata' not in body['fields']

--- a/tests/unit_tests/test_sky/jobs/test_client_sdk.py
+++ b/tests/unit_tests/test_sky/jobs/test_client_sdk.py
@@ -5,6 +5,47 @@ import pytest
 
 from sky.jobs.client import sdk as jobs_sdk
 from sky.jobs.client import sdk_async as jobs_sdk_async
+from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
+
+
+def _unwrap(fn):
+    """Strip all functools.wraps-based decorators."""
+    while hasattr(fn, '__wrapped__'):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _call_raw_queue_v2(**kwargs):
+    """Call queue_v2 (decorators stripped) and return the request JSON body."""
+    raw_queue_v2 = _unwrap(jobs_sdk.queue_v2)
+    with mock.patch.object(jobs_sdk.versions,
+                           'get_remote_api_version',
+                           return_value=999), \
+         mock.patch.object(jobs_sdk.server_common,
+                           'make_authenticated_request',
+                           return_value='response') as mock_request, \
+         mock.patch.object(jobs_sdk.server_common,
+                           'get_request_id',
+                           return_value='request-id'):
+        raw_queue_v2(**kwargs)
+    _, request_kwargs = mock_request.call_args
+    return request_kwargs['json']
+
+
+def test_queue_v2_defaults_to_lightweight_fields():
+    # A high remote API version avoids the version-based field stripping so we
+    # can assert the full default field set is sent.
+    body = _call_raw_queue_v2(refresh=False)
+    assert body['fields'] == DEFAULT_MANAGED_JOB_FIELDS
+    # The lightweight default must not pull heavy fields.
+    assert 'node_names' not in body['fields']
+    assert 'metadata' not in body['fields']
+
+
+def test_queue_v2_fields_none_requests_all_fields():
+    # fields=None is the explicit "give me everything" escape hatch.
+    body = _call_raw_queue_v2(refresh=False, fields=None)
+    assert body['fields'] is None
 
 
 def test_queue_version_2_dispatches_to_queue_v2():

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -30,7 +30,7 @@ def test_v1_queue_handler_defaults_to_lightweight_fields():
                   all_users=False,
                   job_ids=None)
     _, kwargs = mock_queue_v2.call_args
-    assert kwargs['fields'] == DEFAULT_MANAGED_JOB_FIELDS
+    assert kwargs['fields'] == list(DEFAULT_MANAGED_JOB_FIELDS)
 
 
 def _make_job(job_id: int,

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -5,9 +5,9 @@ from unittest import mock
 
 import pytest
 
+from sky.jobs import constants as managed_job_constants
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as jobs_utils
-from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 # Target under test
 from sky.jobs.server import core as jobs_core
 from sky.skylet import constants as skylet_constants
@@ -30,7 +30,8 @@ def test_v1_queue_handler_defaults_to_lightweight_fields():
                   all_users=False,
                   job_ids=None)
     _, kwargs = mock_queue_v2.call_args
-    assert kwargs['fields'] == list(DEFAULT_MANAGED_JOB_FIELDS)
+    assert kwargs['fields'] == list(
+        managed_job_constants.DEFAULT_MANAGED_JOB_FIELDS)
 
 
 def _make_job(job_id: int,

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -1,14 +1,36 @@
 """Unit tests for the jobs server queue."""
 import time
 from typing import Any, Dict, List, Optional
+from unittest import mock
 
 import pytest
 
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as jobs_utils
+from sky.jobs.constants import DEFAULT_MANAGED_JOB_FIELDS
 # Target under test
 from sky.jobs.server import core as jobs_core
 from sky.skylet import constants as skylet_constants
+
+
+def _unwrap(fn):
+    while hasattr(fn, '__wrapped__'):
+        fn = fn.__wrapped__
+    return fn
+
+
+def test_v1_queue_handler_defaults_to_lightweight_fields():
+    """The deprecated v1 queue path (core.queue) must narrow fields so old
+    clients hitting /jobs/queue don't trigger a full-payload pull."""
+    raw_queue = _unwrap(jobs_core.queue)
+    with mock.patch.object(jobs_core, 'queue_v2',
+                           return_value=([], 0, {}, 0)) as mock_queue_v2:
+        raw_queue(refresh=False,
+                  skip_finished=False,
+                  all_users=False,
+                  job_ids=None)
+    _, kwargs = mock_queue_v2.call_args
+    assert kwargs['fields'] == DEFAULT_MANAGED_JOB_FIELDS
 
 
 def _make_job(job_id: int,


### PR DESCRIPTION
## Summary

- The managed jobs queue returned **every** field (including the task YAML) whenever the caller didn't request specific `fields`. With many jobs this makes the payload large and slow to serialize/transfer, and pressures the API server.
- Introduce `sky.jobs.constants.DEFAULT_MANAGED_JOB_FIELDS` (a lightweight set excluding heavy fields) and use it as the default `fields` for `queue_v2()` (SDK + async). Pass `fields=None` to fetch every field.
- Apply the same default in the deprecated v1 queue handler (`core.queue`), which cannot request specific fields, so old clients hitting `/jobs/queue` no longer trigger a full-payload pull.
- Reuse the shared constant in the CLI (`_DEFAULT_MANAGED_JOB_FIELDS_TO_GET`) instead of a local copy.
- Drop the dead `APINotSupportedError -> v1 queue` fallback in the CLI: the server is always at least `MIN_COMPATIBLE_API_VERSION` (24), well above the `queue_v2` minimum (18), so the fallback never triggers.

The v1 `/jobs/queue` endpoint and `queue()` SDK function are intentionally **kept** for backward compatibility — released clients still POST to `/jobs/queue` for `sky.jobs.queue()`. Removing them is deferred until `MIN_COMPATIBLE_API_VERSION` advances past this release.

## Behavior change

Direct SDK callers of `queue_v2()`/`queue()` that omit `fields` now receive the lightweight set instead of all fields. Callers needing heavy fields (e.g. `node_names`, task YAML, `metadata`) must request them explicitly (or pass `fields=None`). The `sky jobs queue` / `sky status` CLI output is unchanged (they already request explicit field sets).

## Test plan

- Added unit tests:
  - `queue_v2()` with no `fields` sends `DEFAULT_MANAGED_JOB_FIELDS` (and excludes `node_names`/`metadata`).
  - `queue_v2(fields=None)` sends `fields=None` (full payload).
  - v1 handler `core.queue` calls `core.queue_v2` with `DEFAULT_MANAGED_JOB_FIELDS`.
  - Revert-check: reverting the defaults to `None` makes the new tests fail.
- `pytest tests/unit_tests/test_sky/jobs/ tests/unit_tests/test_sky/server/ ...` — all related tests pass (one pre-existing, unrelated `test_local_dir_mounts_cleaned_up` failure, confirmed present without this change).
- Manual: `sky jobs queue` / `-v` / `--all-users` render correctly with no YAML in the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)