### PR TITLE
[Test] Pin fd-leak fusermount test to a single k8s context

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -696,7 +696,6 @@ def test_kubernetes_ensure_no_fd_leak_fusermount_server():
     """
     name = smoke_tests_utils.get_cluster_name()
     storage_name = f'sky-test-{int(time.time())}'
-    cloud = 'kubernetes'
     yaml_content = textwrap.dedent(f"""\
         resources:
           cloud: kubernetes
@@ -754,25 +753,41 @@ def test_kubernetes_ensure_no_fd_leak_fusermount_server():
                       ' | grep -q MOUNT_READY'
                       ' && break || sleep 5;'
                       ' done')
+        # The fuse fd check runs kubectl from the cloud-cmd helper, whose
+        # in-cluster credentials only reach its own cluster. On a
+        # multi-context API server each `sky launch` may land on a different
+        # context, so we pin everything to a single context: launch the first
+        # workload cluster, resolve the context it landed on, pin the cloud-cmd
+        # helper to it, and launch the second workload cluster on the same
+        # context. This keeps both workload pods (and their per-node
+        # fusermount-server pods) visible to the helper's kubectl.
+        landed_context = (
+            f'$(cat {smoke_tests_utils.k8s_landed_context_file(name1)})')
         test_commands = [
             *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
-            smoke_tests_utils.launch_cluster_for_cloud_cmd(cloud, name),
-            # Launch first cluster with MOUNT_CACHED
+            # Launch first cluster with MOUNT_CACHED; it may land on any
+            # context on a multi-context API server.
             f'sky launch -y -c {name1} -d {yaml_path}',
+            # Pin the cloud-cmd helper to the context the first cluster landed
+            # on so its in-cluster kubectl can see the workload's resources.
+            smoke_tests_utils.resolve_k8s_context_cmd(name1),
+            smoke_tests_utils.launch_cloud_cmd_on_landed_context(name1),
             wait_mount.format(cluster=name1),
             # After first mount: assert 0 leaked fuse fds
             smoke_tests_utils.run_cloud_cmd_on_cluster(
-                name, fuse_fd_check.format(cluster=name1)),
-            # Launch second cluster with MOUNT_CACHED
-            f'sky launch -y -c {name2} -d {yaml_path}',
+                name1, fuse_fd_check.format(cluster=name1)),
+            # Launch second cluster with MOUNT_CACHED, pinned to the same
+            # context so the same cloud-cmd helper can reach it too.
+            f'sky launch -y -c {name2} --infra kubernetes/{landed_context} '
+            f'-d {yaml_path}',
             wait_mount.format(cluster=name2),
             # After second mount: still 0 leaked fuse fds
             smoke_tests_utils.run_cloud_cmd_on_cluster(
-                name, fuse_fd_check.format(cluster=name2)),
+                name1, fuse_fd_check.format(cluster=name2)),
         ]
         clean_command = (
             f'sky down -y {name1} {name2}; '
-            f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
+            f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name1)}; '
             f'sky storage delete -y {storage_name}')
         test = smoke_tests_utils.Test(
             'kubernetes_ensure_no_fd_leak_fusermount_server',


### PR DESCRIPTION
`test_kubernetes_ensure_no_fd_leak_fusermount_server` runs its `kubectl` checks from the cloud-cmd helper cluster, whose in-cluster credentials only reach its own Kubernetes cluster. On a multi-context API server, the helper and the two workload clusters (`{name}-1`, `{name}-2`) can each land on a different context, so the helper's `kubectl get pods` returns an empty list — `node=` comes back empty, and the follow-up fuse-pod lookup fails with `error executing jsonpath "{.items[0].metadata.name}": array index out of bounds: index 0, length 0`, failing the test.

This test predates the context-pinning helpers added in #9967 and never adopted them.

This PR pins everything to a single context, following the #9967 pattern:
- Launch the first workload cluster (`{name}-1`), which may land on any context.
- `resolve_k8s_context_cmd` / `launch_cloud_cmd_on_landed_context`: pin the cloud-cmd helper to the context the first cluster landed on.
- Launch the second workload cluster (`{name}-2`) on that same context via `--infra kubernetes/<context>`.

Both workload pods and their per-node `fusermount-server` pods are then visible to the helper's `kubectl`. Single-context / local-API-server runs are unaffected (the helpers no-op or resolve to the sole context).

<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_kubernetes_ensure_no_fd_leak_fusermount_server`
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
