### PR TITLE
[Test] Fix pools --num-jobs ID parsing for collapsed ID ranges

### DIFF
--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1259,6 +1259,26 @@ def test_pools_job_cancel_no_jobs(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
+def _parse_job_ids_snippet(source_var: str, ids_file: str) -> str:
+    """Shell snippet: extract launched job IDs into a comma list at ids_file.
+
+    ``sky jobs launch --num-jobs`` collapses contiguous IDs into ranges in its
+    "Jobs submitted with IDs:" line (e.g. ``2-11``), so widen the capture to
+    include ``-`` and expand any ``N-M`` range back into individual
+    comma-separated IDs (plain comma lists pass through unchanged). Downstream
+    ``awk -F,`` field access then works regardless of format. ``source_var`` is
+    the shell var holding the launch output (e.g. ``s`` for ``$s``).
+    """
+    # awk expands each field: an 'N-M' range becomes N,N+1,...,M; a bare id is
+    # kept as-is. Braces/`$i` are literal awk, not str formatting.
+    expand = (
+        r"""awk -F, '{o=""; for (i=1; i<=NF; i++) {n=split($i, a, "-"); """
+        r"""if (n==2) {for (j=a[1]; j<=a[2]; j++) o=o (o == "" ? "" : ",") j} """
+        r"""else o=o (o == "" ? "" : ",") $i} print o}'""")
+    return (f'echo "${source_var}" | grep "Jobs submitted with IDs:" | '
+            f'sed "s/.*IDs: \\([0-9,-]*\\).*/\\1/" | {expand} > {ids_file}')
+
+
 @pytest.mark.no_remote_server  # see note 1 above
 def test_pools_num_jobs_basic(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
@@ -1281,8 +1301,7 @@ def test_pools_num_jobs_basic(generic_cloud: str):
             launch_cmd = (
                 f's=$(sky jobs launch --pool {pool_name} {job_yaml.name} '
                 f'--num-jobs {num_jobs} -d -y); echo "$s"; '
-                f'echo "$s" | grep "Jobs submitted with IDs:" | '
-                f'sed "s/.*IDs: \\([0-9,]*\\).*/\\1/" > {ids_file}; '
+                f'{_parse_job_ids_snippet("s", ids_file)}; '
                 f'cat {ids_file}')
             id_expr = (lambda i: f"$(awk -F, '{{print ${i + 1}}}' {ids_file})")
             test = smoke_tests_utils.Test(
@@ -1364,12 +1383,20 @@ def test_pools_num_jobs_option(generic_cloud: str):
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
-                    # Test parallel job launching with --num-jobs 3
-                    ('s=$(sky jobs launch --pool {pool_name} {job_yaml} --num-jobs 10 -d -y); '
-                     'echo "$s"; '
-                     'echo; echo; echo "$s" | grep "Jobs submitted with IDs: 2,3,4,5,6,7,8,9,10,11"; '
-                     'sleep 5').format(pool_name=pool_name,
-                                       job_yaml=job_yaml.name)
+                    # Test parallel job launching with --num-jobs 10. The IDs
+                    # are collapsed into a single N-M range (see
+                    # _parse_job_ids_snippet); assert the range spans exactly 10
+                    # jobs rather than hard-coding the start ID, which is not 2
+                    # on a shared/long-lived server DB.
+                    (
+                        's=$(sky jobs launch --pool {pool_name} {job_yaml} --num-jobs 10 -d -y); '
+                        'echo "$s"; '
+                        'echo; echo; echo "$s" | grep "Jobs submitted with IDs:" | '
+                        'sed "s/.*IDs: \\([0-9,-]*\\).*/\\1/" | '
+                        # Braces doubled: this string goes through str.format().
+                        'awk -F- \'{{c = $2 - $1 + 1}} END {{exit !(c == 10)}}\'; '
+                        'sleep 5').format(pool_name=pool_name,
+                                          job_yaml=job_yaml.name)
                 ],
                 timeout=smoke_tests_utils.get_timeout(generic_cloud),
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
@@ -2434,10 +2461,12 @@ def test_pools_num_jobs_rank(generic_cloud: str):
             launch_cmd = (
                 's=$(sky jobs launch --pool {pool_name} {job_yaml} --num-jobs {NUM_JOBS} -d -y); '
                 'echo "$s"; '
-                'echo "$s" | grep "Jobs submitted with IDs:" | sed "s/.*IDs: \\([0-9,]*\\).*/\\1/" > {ids_file}; '
+                '{parse}; '
                 'cat {ids_file}').format(pool_name=pool_name,
                                          job_yaml=job_yaml.name,
                                          NUM_JOBS=NUM_JOBS,
+                                         parse=_parse_job_ids_snippet(
+                                             's', ids_file),
                                          ids_file=ids_file)
             test_commands.append(launch_cmd)
 


### PR DESCRIPTION
## Problem

`test_pools_num_jobs_basic` and `test_pools_num_jobs_rank` fail in the nightly `--aws` smoke suite (e.g. [smoke-tests build 11538](https://buildkite.com/skypilot-1/smoke-tests/builds/11538)). They passed the previous night and failed the next with no test change.

### Root cause: #9997

**#9997 ([Jobs] Support `--num-jobs` without a pool)** changed the `sky jobs launch` summary line to collapse contiguous job IDs into ranges:

```diff
- job_ids_str = ','.join(map(str, sorted(job_ids)))          # "1,2"
+ job_ids_str = managed_job_utils.format_job_ids_as_ranges(job_ids)   # "1-2"
```

But these tests parse that line with a **comma-only** extractor and index the result with `awk -F,`:

```bash
... | grep "Jobs submitted with IDs:" | sed "s/.*IDs: \([0-9,]*\).*/\1/"
```

For 2 jobs, the output is now `Jobs submitted with IDs: 1-2.`. The `[0-9,]*` class stops at the hyphen and captures only `1`. The second job's ID (`awk '{print $2}'`) then resolves to an **empty string**, so:

```
sky jobs logs --controller ""
Error: Invalid value for '[JOB_ID]': '' is not a valid integer.
```

The wait-for-`SUCCEEDED` loop never matches and spins until the 900s (`DEFAULT_CMD_TIMEOUT`) timeout — **even though both managed jobs actually succeed**. Verified live on the running test VM: the pool worker reached `READY` in ~3 min and `sky jobs queue` showed both jobs `SUCCEEDED`; the test still failed purely on the empty-ID parse.

`test_pools_num_jobs_option` is broken the same way — it greps for a hard-coded comma list `IDs: 2,3,4,...,11` which is now `2-11`.

## Fix

Add a small `_parse_job_ids_snippet()` helper that widens the capture to include `-` and expands any `N-M` range back into an individual comma list (plain comma lists pass through unchanged), so downstream `awk -F,` works regardless of format. `test_pools_num_jobs_option` is updated to expect the collapsed range form.

Verified end-to-end against both real output formats:

| Launch output | parsed ids file | fields |
|---|---|---|
| `Jobs submitted with IDs: 1-2.` | `1,2` | 2 |
| `Jobs submitted with IDs: 2-11.` | `2,3,4,5,6,7,8,9,10,11` | 10 |

## Test plan

- [ ] `/smoke-test -k test_pools_num_jobs_basic --aws`
- [ ] `/smoke-test -k test_pools_num_jobs_rank --aws`
- [ ] `/smoke-test -k test_pools_num_jobs_option`

🤖 Generated with [Claude Code](https://claude.com/claude-code)