### PR TITLE
[API] Add retention-based cleanup for skypilot logs

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -329,7 +329,7 @@ Example:
 
 Retention period in hours for the per-operation provision log directories under ``~/sky_logs/sky-*`` on the API server (optional). Set to a negative value to disable this GC.
 
-Each launch/exec/provision creates a ``~/sky_logs/sky-<timestamp>`` directory holding server-side copies of ``provision.log``, ``setup-*.log``, ``run.log``, etc. (and each upload a ``~/sky_logs/file_uploads/*.log`` file). The GC daemon removes entries older than this period; the launched resources (clusters/jobs) are unaffected.
+Each launch/exec/provision creates a ``~/sky_logs/sky-<timestamp>`` directory holding server-side copies of ``provision.log``, ``setup-*.log``, ``run.log``, etc. (and each upload a ``~/sky_logs/file_uploads/*.log`` file). The GC daemon removes entries older than this period, except directories holding the provision log of an existing cluster, which are kept for as long as the cluster exists. The launched resources (clusters/jobs) are unaffected.
 
 Default: ``720`` (30 days).
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -29,6 +29,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`endpoint <config-yaml-api-server-endpoint>`: \http://xx.xx.xx.xx:8000
     :ref:`service_account_token <config-yaml-api-server-service-account-token>`: sky_xxx
     :ref:`requests_retention_hours <config-yaml-api-server-requests-gc-retention-hours>`: 24
+    :ref:`logs_retention_hours <config-yaml-api-server-logs-retention-hours>`: 720
     :ref:`cluster_event_retention_hours <config-yaml-api-server-cluster-event-retention-hours>`: 720
     :ref:`cluster_debug_event_retention_hours <config-yaml-api-server-cluster-debug-event-retention-hours>`: 720
     :ref:`daemon_log_max_bytes <config-yaml-api-server-daemon-log-max-bytes>`: 134217728
@@ -320,6 +321,24 @@ Example:
 
   api_server:
     requests_retention_hours: -1 # Disable requests GC
+
+.. _config-yaml-api-server-logs-retention-hours:
+
+``api_server.logs_retention_hours``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retention period in hours for the per-operation provision log directories under ``~/sky_logs/sky-*`` on the API server (optional). Set to a negative value to disable this GC.
+
+Each launch/exec/provision creates a ``~/sky_logs/sky-<timestamp>`` directory holding server-side copies of ``provision.log``, ``setup-*.log``, ``run.log``, etc. (and each upload a ``~/sky_logs/file_uploads/*.log`` file). The GC daemon removes entries older than this period; the launched resources (clusters/jobs) are unaffected.
+
+Default: ``720`` (30 days).
+
+Example:
+
+.. code-block:: yaml
+
+  api_server:
+    logs_retention_hours: -1 # Disable sky_logs provision dir GC
 
 .. _config-yaml-api-server-cluster-event-retention-hours:
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1689,6 +1689,15 @@ def get_cluster_provision_log_path(cluster_name: str) -> Optional[str]:
 
 
 @metrics_lib.time_me
+def get_all_cluster_provision_log_paths() -> List[str]:
+    """Returns the recorded provision_log_path of every existing cluster."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.query(cluster_table.c.provision_log_path).all()
+    return [row.provision_log_path for row in rows if row.provision_log_path]
+
+
+@metrics_lib.time_me
 def get_cluster_history_provision_log_path(cluster_name: str) -> Optional[str]:
     """Returns provision_log_path from cluster_history for this name.
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -158,6 +158,12 @@ REQUEST_LOG_PATH_PREFIX = '~/.sky/api_server/request_logs'
 # Configurable via api_server.daemon_log_max_bytes in ~/.sky/config.yaml.
 DEFAULT_DAEMON_LOG_MAX_BYTES = 128 * 1024 * 1024  # 128 MB
 
+# Default retention (hours) for per-operation artifacts under ~/sky_logs on
+# the API server. Nothing else cleans them up, so without a GC they grow
+# unbounded on a busy server. Configurable via api_server.logs_retention_hours;
+# a negative value disables the GC.
+DEFAULT_LOGS_RETENTION_HOURS = 720  # 30 days
+
 # Interval for the server-side heartbeat daemon that sends plugin metrics
 # to Loki (e.g., GPU inventory from billing plugin).
 SERVER_HEARTBEAT_INTERVAL_SECONDS = 600  # 10 minutes

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -158,10 +158,8 @@ REQUEST_LOG_PATH_PREFIX = '~/.sky/api_server/request_logs'
 # Configurable via api_server.daemon_log_max_bytes in ~/.sky/config.yaml.
 DEFAULT_DAEMON_LOG_MAX_BYTES = 128 * 1024 * 1024  # 128 MB
 
-# Default retention (hours) for per-operation artifacts under ~/sky_logs on
-# the API server. Nothing else cleans them up, so without a GC they grow
-# unbounded on a busy server. Configurable via api_server.logs_retention_hours;
-# a negative value disables the GC.
+# Default retention for per-operation artifacts under ~/sky_logs on the API
+# server. Configurable via api_server.logs_retention_hours; negative disables.
 DEFAULT_LOGS_RETENTION_HOURS = 720  # 30 days
 
 # Interval for the server-side heartbeat daemon that sends plugin metrics

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -691,11 +691,10 @@ async def cleanup_download_tmp():
 
 
 def _prune_sky_logs(cutoff: float) -> int:
-    """Remove expired ~/sky_logs artifacts by mtime; returns count removed.
+    """Remove ~/sky_logs artifacts older than cutoff; returns count removed.
 
-    Restricting the top-level sweep to ``sky-*`` directories spares the
-    job/request log trees that share ~/sky_logs (api_server/, jobs_controller/,
-    managed_jobs/, numbered job dirs like '1-my-job').
+    Only sky-* dirs are swept, sparing the job/request log trees that share
+    ~/sky_logs (api_server/, jobs_controller/, managed_jobs/, <job_id>-*).
     """
     sky_logs_dir = os.path.expanduser(constants.SKY_LOGS_DIRECTORY)
     if not os.path.isdir(sky_logs_dir):
@@ -711,10 +710,9 @@ def _prune_sky_logs(cutoff: float) -> int:
                 removed += 1
         except OSError:
             pass
-    # Literal rather than importing sky.client.common.FILE_UPLOAD_LOGS_DIR:
-    # the dependency direction is client -> server, not the reverse.
-    file_uploads_dir = os.path.join(
-        os.path.expanduser(constants.SKY_LOGS_DIRECTORY), 'file_uploads')
+    # sky.client.common.FILE_UPLOAD_LOGS_DIR; not imported since the server
+    # should not depend on the client.
+    file_uploads_dir = os.path.join(sky_logs_dir, 'file_uploads')
     if os.path.isdir(file_uploads_dir):
         for entry in os.scandir(file_uploads_dir):
             if not entry.is_file(follow_symlinks=False):
@@ -729,24 +727,21 @@ def _prune_sky_logs(cutoff: float) -> int:
 
 
 async def cleanup_sky_logs():
-    """Delete expired per-operation artifacts under ~/sky_logs.
+    """Hourly GC of expired per-operation ~/sky_logs artifacts.
 
-    Each launch/exec/provision leaves a ~/sky_logs/sky-<timestamp> directory
-    and each upload a ~/sky_logs/file_uploads/*.log file; nothing else GCs
-    them, so they grow unbounded. Prune anything older than
-    api_server.logs_retention_hours (negative disables the GC).
+    Nothing else cleans up the per-operation sky-<timestamp> dirs and
+    file_uploads/*.log files, so they grow unbounded on a busy server.
     """
     while True:
-        # Reread config each iteration so operators can retune (or disable)
-        # the GC without restarting the API server.
-        skypilot_config.reload_config()
-        retention_hours = skypilot_config.get_nested(
-            ('api_server', 'logs_retention_hours'),
-            server_constants.DEFAULT_LOGS_RETENTION_HOURS)
-        retention_seconds = retention_hours * 3600
         try:
-            if retention_seconds >= 0:
-                cutoff = time.time() - retention_seconds
+            # Use the latest config.
+            skypilot_config.reload_config()
+            retention_hours = skypilot_config.get_nested(
+                ('api_server', 'logs_retention_hours'),
+                server_constants.DEFAULT_LOGS_RETENTION_HOURS)
+            # Negative value disables the GC.
+            if retention_hours >= 0:
+                cutoff = time.time() - retention_hours * 3600
                 removed = await asyncio.to_thread(_prune_sky_logs, cutoff)
                 if removed:
                     logger.info(f'Cleaned up {removed} ~/sky_logs artifact(s) '
@@ -754,7 +749,7 @@ async def cleanup_sky_logs():
         except Exception as e:  # pylint: disable=broad-except
             logger.error('Error in cleanup_sky_logs: '
                          f'{common_utils.format_exception(e)}')
-        await asyncio.sleep(max(retention_seconds, 3600))
+        await asyncio.sleep(3600)
 
 
 async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -727,19 +727,13 @@ def _prune_sky_logs(cutoff: float) -> int:
 
 
 async def cleanup_sky_logs():
-    """Hourly GC of expired per-operation ~/sky_logs artifacts.
-
-    Nothing else cleans up the per-operation sky-<timestamp> dirs and
-    file_uploads/*.log files, so they grow unbounded on a busy server.
-    """
+    """Hourly GC of expired per-operation ~/sky_logs artifacts."""
     while True:
         try:
-            # Use the latest config.
             skypilot_config.reload_config()
             retention_hours = skypilot_config.get_nested(
                 ('api_server', 'logs_retention_hours'),
                 server_constants.DEFAULT_LOGS_RETENTION_HOURS)
-            # Negative value disables the GC.
             if retention_hours >= 0:
                 cutoff = time.time() - retention_hours * 3600
                 removed = await asyncio.to_thread(_prune_sky_logs, cutoff)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -695,13 +695,20 @@ def _prune_sky_logs(cutoff: float) -> int:
 
     Only sky-* dirs are swept, sparing the job/request log trees that share
     ~/sky_logs (api_server/, jobs_controller/, managed_jobs/, <job_id>-*).
+    Dirs holding the provision log of an existing cluster are kept regardless
+    of age so /provision_logs keeps serving live clusters; once the cluster
+    is terminated its logs fall back to the age-based retention.
     """
     sky_logs_dir = os.path.expanduser(constants.SKY_LOGS_DIRECTORY)
     if not os.path.isdir(sky_logs_dir):
         return 0
+    protected_dirs = {
+        os.path.basename(os.path.dirname(path))
+        for path in global_user_state.get_all_cluster_provision_log_paths()
+    }
     removed = 0
     for entry in os.scandir(sky_logs_dir):
-        if not entry.name.startswith('sky-'):
+        if not entry.name.startswith('sky-') or entry.name in protected_dirs:
             continue
         try:
             if (entry.is_dir(follow_symlinks=False) and

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -701,11 +701,11 @@ def _prune_sky_logs(cutoff: float) -> int:
         return 0
     removed = 0
     for entry in os.scandir(sky_logs_dir):
-        if not entry.name.startswith('sky-') or not entry.is_dir(
-                follow_symlinks=False):
+        if not entry.name.startswith('sky-'):
             continue
         try:
-            if entry.stat().st_mtime < cutoff:
+            if (entry.is_dir(follow_symlinks=False) and
+                    entry.stat().st_mtime < cutoff):
                 shutil.rmtree(entry.path, ignore_errors=True)
                 removed += 1
         except OSError:
@@ -715,10 +715,9 @@ def _prune_sky_logs(cutoff: float) -> int:
     file_uploads_dir = os.path.join(sky_logs_dir, 'file_uploads')
     if os.path.isdir(file_uploads_dir):
         for entry in os.scandir(file_uploads_dir):
-            if not entry.is_file(follow_symlinks=False):
-                continue
             try:
-                if entry.stat().st_mtime < cutoff:
+                if (entry.is_file(follow_symlinks=False) and
+                        entry.stat().st_mtime < cutoff):
                     os.remove(entry.path)
                     removed += 1
             except OSError:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -690,6 +690,73 @@ async def cleanup_download_tmp():
                          f'{common_utils.format_exception(e)}')
 
 
+def _prune_sky_logs(cutoff: float) -> int:
+    """Remove expired ~/sky_logs artifacts by mtime; returns count removed.
+
+    Restricting the top-level sweep to ``sky-*`` directories spares the
+    job/request log trees that share ~/sky_logs (api_server/, jobs_controller/,
+    managed_jobs/, numbered job dirs like '1-my-job').
+    """
+    sky_logs_dir = os.path.expanduser(constants.SKY_LOGS_DIRECTORY)
+    if not os.path.isdir(sky_logs_dir):
+        return 0
+    removed = 0
+    for entry in os.scandir(sky_logs_dir):
+        if not entry.name.startswith('sky-') or not entry.is_dir(
+                follow_symlinks=False):
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                shutil.rmtree(entry.path, ignore_errors=True)
+                removed += 1
+        except OSError:
+            pass
+    # Literal rather than importing sky.client.common.FILE_UPLOAD_LOGS_DIR:
+    # the dependency direction is client -> server, not the reverse.
+    file_uploads_dir = os.path.join(
+        os.path.expanduser(constants.SKY_LOGS_DIRECTORY), 'file_uploads')
+    if os.path.isdir(file_uploads_dir):
+        for entry in os.scandir(file_uploads_dir):
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    os.remove(entry.path)
+                    removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+async def cleanup_sky_logs():
+    """Delete expired per-operation artifacts under ~/sky_logs.
+
+    Each launch/exec/provision leaves a ~/sky_logs/sky-<timestamp> directory
+    and each upload a ~/sky_logs/file_uploads/*.log file; nothing else GCs
+    them, so they grow unbounded. Prune anything older than
+    api_server.logs_retention_hours (negative disables the GC).
+    """
+    while True:
+        # Reread config each iteration so operators can retune (or disable)
+        # the GC without restarting the API server.
+        skypilot_config.reload_config()
+        retention_hours = skypilot_config.get_nested(
+            ('api_server', 'logs_retention_hours'),
+            server_constants.DEFAULT_LOGS_RETENTION_HOURS)
+        retention_seconds = retention_hours * 3600
+        try:
+            if retention_seconds >= 0:
+                cutoff = time.time() - retention_seconds
+                removed = await asyncio.to_thread(_prune_sky_logs, cutoff)
+                if removed:
+                    logger.info(f'Cleaned up {removed} ~/sky_logs artifact(s) '
+                                f'older than {retention_hours} hours')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error('Error in cleanup_sky_logs: '
+                         f'{common_utils.format_exception(e)}')
+        await asyncio.sleep(max(retention_seconds, 3600))
+
+
 async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
                            interval: float = 0.1) -> None:
     target = loop.time() + interval
@@ -3557,6 +3624,7 @@ if __name__ == '__main__':
         global_tasks.append(
             background.create_task(cleanup_unreferenced_file_mounts()))
         global_tasks.append(background.create_task(cleanup_download_tmp()))
+        global_tasks.append(background.create_task(cleanup_sky_logs()))
         threading.Thread(target=background.run_forever, daemon=True).start()
 
         # managed-job-status-refresh runs as a thread inside this

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2315,6 +2315,9 @@ def get_config_schema():
             'requests_retention_hours': {
                 'type': 'integer',
             },
+            'logs_retention_hours': {
+                'type': 'integer',
+            },
             'cluster_event_retention_hours': {
                 'type': 'number',
             },

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -899,7 +899,6 @@ def test_prune_sky_logs_removes_only_expired_provision_dirs(
     now = 1_000_000.0
     old = _touch_dir(tmp_path / 'sky-2020-01-01-00-00-00-000000', now - 10_000)
     fresh = _touch_dir(tmp_path / 'sky-2020-01-02-00-00-00-000000', now - 100)
-    # Directories that must never be touched by the GC.
     job_dir = _touch_dir(tmp_path / '1-my-job', now - 10_000)
     api_dir = _touch_dir(tmp_path / 'api_server', now - 10_000)
 

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -892,8 +892,14 @@ def _touch_file(path: pathlib.Path, mtime: float) -> pathlib.Path:
     return path
 
 
+@pytest.fixture
+def _no_provision_log_paths(monkeypatch):
+    monkeypatch.setattr(server.global_user_state,
+                        'get_all_cluster_provision_log_paths', lambda: [])
+
+
 def test_prune_sky_logs_removes_only_expired_provision_dirs(
-        tmp_path, monkeypatch):
+        tmp_path, monkeypatch, _no_provision_log_paths):
     """Old sky-* dirs are pruned; fresh ones and non sky-* dirs are kept."""
     monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
     now = 1_000_000.0
@@ -911,7 +917,27 @@ def test_prune_sky_logs_removes_only_expired_provision_dirs(
     assert api_dir.exists()
 
 
-def test_prune_sky_logs_removes_expired_file_upload_logs(tmp_path, monkeypatch):
+def test_prune_sky_logs_keeps_live_cluster_provision_dirs(
+        tmp_path, monkeypatch):
+    """Expired dirs referenced by an existing cluster survive the sweep."""
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
+    now = 1_000_000.0
+    live = _touch_dir(tmp_path / 'sky-2020-01-01-00-00-00-000000', now - 10_000)
+    orphan = _touch_dir(tmp_path / 'sky-2020-01-01-11-11-11-111111',
+                        now - 10_000)
+    monkeypatch.setattr(server.global_user_state,
+                        'get_all_cluster_provision_log_paths',
+                        lambda: [str(live / 'provision.log')])
+
+    removed = server._prune_sky_logs(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert live.exists()
+    assert not orphan.exists()
+
+
+def test_prune_sky_logs_removes_expired_file_upload_logs(
+        tmp_path, monkeypatch, _no_provision_log_paths):
     """Old ~/sky_logs/file_uploads/*.log files are pruned by mtime."""
     monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
     now = 1_000_000.0

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -873,3 +873,62 @@ def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
             'regex': 'https://grafana.example.com/.*'
         }]
     }
+
+
+# --- Tests for _prune_sky_logs (~/sky_logs GC) ---
+
+
+def _touch_dir(path: pathlib.Path, mtime: float) -> pathlib.Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / 'provision.log').write_text('log')
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def _touch_file(path: pathlib.Path, mtime: float) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('log')
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_prune_sky_logs_removes_only_expired_provision_dirs(
+        tmp_path, monkeypatch):
+    """Old sky-* dirs are pruned; fresh ones and non sky-* dirs are kept."""
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
+    now = 1_000_000.0
+    old = _touch_dir(tmp_path / 'sky-2020-01-01-00-00-00-000000', now - 10_000)
+    fresh = _touch_dir(tmp_path / 'sky-2020-01-02-00-00-00-000000', now - 100)
+    # Directories that must never be touched by the GC.
+    job_dir = _touch_dir(tmp_path / '1-my-job', now - 10_000)
+    api_dir = _touch_dir(tmp_path / 'api_server', now - 10_000)
+
+    removed = server._prune_sky_logs(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert not old.exists()
+    assert fresh.exists()
+    assert job_dir.exists()
+    assert api_dir.exists()
+
+
+def test_prune_sky_logs_removes_expired_file_upload_logs(tmp_path, monkeypatch):
+    """Old ~/sky_logs/file_uploads/*.log files are pruned by mtime."""
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
+    now = 1_000_000.0
+    old_log = _touch_file(tmp_path / 'file_uploads' / 'sky-old.log',
+                          now - 10_000)
+    fresh_log = _touch_file(tmp_path / 'file_uploads' / 'sky-fresh.log',
+                            now - 100)
+
+    removed = server._prune_sky_logs(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert not old_log.exists()
+    assert fresh_log.exists()
+
+
+def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY',
+                        str(tmp_path / 'does-not-exist'))
+    assert server._prune_sky_logs(cutoff=1_000_000.0) == 0


### PR DESCRIPTION
## Context

The API server writes a `~/sky_logs/sky-<timestamp>` directory for every `CloudVmRayBackend` operation (`sky launch`/`exec`/provision, `sky local up`), holding that run's server-side `provision.log`, `setup-*.log`, and `run.log` (created via `sky_logging.get_run_timestamp()`). Each file upload also appends a `~/sky_logs/file_uploads/*.log`.

The server already garbage-collects request logs, file-mount blobs, download tmp dirs, and cluster/job events, but nothing ever removed these `sky-*` dirs or upload logs. On a busy server they grow without bound: one deployment hit "no space left on device" with ~69 GB across ~40k `sky-*` dirs, and operators worked around it with a `preDeployHook` that prunes old dirs by hand. This adds a native GC daemon for those artifacts.

Provision logs follow their cluster's lifecycle (per review feedback): a directory referenced by an existing cluster's `provision_log_path` is never pruned, so `/provision_logs` keeps serving live clusters no matter how old they are. Once the cluster is terminated, its logs become subject to the age-based retention, which also bounds how long `/provision_logs` can serve cluster-history entries.

> [!WARNING]
> **BREAKING:** These logs were previously kept forever. After upgrading, the server deletes any `~/sky_logs/sky-*` dir or `file_uploads/*.log` older than 30 days (including pre-existing ones, on the first sweep), unless the dir holds the provision log of a cluster that still exists. To keep the old behavior, set `api_server.logs_retention_hours: -1` before upgrading.

## Manual test

Runs against an isolated `$HOME`, so a dev machine's real `~/.sky` and `~/sky_logs` are untouched (requires no other local API server running, since the internal queue port is fixed):

```bash
# Isolated HOME with a 1-hour retention config
export TEST_HOME=$(mktemp -d)
mkdir -p $TEST_HOME/.sky $TEST_HOME/sky_logs/file_uploads
printf 'api_server:\n  logs_retention_hours: 1\n' > $TEST_HOME/.sky/config.yaml

# Expired artifacts (must be removed)
mkdir -p $TEST_HOME/sky_logs/sky-orphan
echo log > $TEST_HOME/sky_logs/sky-orphan/provision.log
touch -t 202501010000 $TEST_HOME/sky_logs/sky-orphan
echo log > $TEST_HOME/sky_logs/file_uploads/old-upload.log
touch -t 202501010000 $TEST_HOME/sky_logs/file_uploads/old-upload.log

# Must survive: fresh sky-* dir, fresh upload log, expired-but-protected job dir
mkdir -p $TEST_HOME/sky_logs/sky-fresh $TEST_HOME/sky_logs/1-my-job
echo log > $TEST_HOME/sky_logs/file_uploads/new-upload.log
touch -t 202501010000 $TEST_HOME/sky_logs/1-my-job

# Must survive: expired dir registered as a live cluster's provision log
mkdir -p $TEST_HOME/sky_logs/sky-live-cluster
echo log > $TEST_HOME/sky_logs/sky-live-cluster/provision.log
touch -t 202501010000 $TEST_HOME/sky_logs/sky-live-cluster
HOME=$TEST_HOME python - <<EOF
from sqlalchemy import orm
from sky import global_user_state as gus
with orm.Session(gus._db_manager.get_engine()) as session:
    session.execute(gus.cluster_table.insert().values(
        name='live-cluster',
        provision_log_path='$TEST_HOME/sky_logs/sky-live-cluster/provision.log'))
    session.commit()
EOF

# Start the API server; the first sweep runs at startup (then hourly)
HOME=$TEST_HOME sky api start

# Verify
ls $TEST_HOME/sky_logs $TEST_HOME/sky_logs/file_uploads

# Teardown
HOME=$TEST_HOME sky api stop && rm -rf $TEST_HOME
```

Observed:

```
$ ls $TEST_HOME/sky_logs $TEST_HOME/sky_logs/file_uploads
sky_logs/:            1-my-job  file_uploads  sky-fresh  sky-live-cluster
sky_logs/file_uploads: new-upload.log
```

`sky-orphan` and `old-upload.log` were removed. `sky-live-cluster` survived despite its expired mtime because a cluster row references it, as did the fresh entries and the non-`sky-*` `1-my-job/` dir.

Automated: `pytest tests/unit_tests/test_sky/server/test_server.py -k prune_sky_logs` (4 tests). `bash format.sh` is clean on the changed files.

## Changes

<details>
<summary>Click here to expand</summary>

- **`cleanup_sky_logs` daemon** (`sky/server/server.py`) prunes `~/sky_logs/sky-*` dirs and `file_uploads/*.log` files by mtime on an hourly sweep, following the existing `cleanup_download_tmp` pattern. The top-level sweep matches only `sky-*` dirs, so the `api_server/`, `jobs_controller/`, `managed_jobs/`, and numbered job dirs are left alone.
- **Live-cluster exemption** — dirs referenced by an existing cluster's `provision_log_path` are skipped regardless of age (via a new `global_user_state.get_all_cluster_provision_log_paths()`), keeping `/provision_logs` working for live clusters. Terminated clusters' logs age out normally.
- **`api_server.logs_retention_hours` config** (default 30 days; negative disables), reloaded each sweep so operators can retune without a restart. Added to the schema and `docs/source/reference/config.rst`.
- **Unit tests** covering expiry, protected sibling dirs, the live-cluster exemption, and the missing-dir no-op.

</details>
