### PR TITLE
[Test] chaos_proxy: jitter the kill interval to avoid phase-locked races

### DIFF
--- a/tests/chaos/chaos_proxy.py
+++ b/tests/chaos/chaos_proxy.py
@@ -1,6 +1,7 @@
 """TCP proxy that brings chaos."""
 import argparse
 import asyncio
+import random
 from typing import Optional
 from urllib import parse
 
@@ -185,8 +186,8 @@ async def handle_client(local_reader, local_writer, target_host, target_port,
 
     # Check if connection is still active (tasks haven't completed)
     if pending:
-        print(
-            f'Connection {connection_id}: Closing connection after {interval}s')
+        print(f'Connection {connection_id}: Closing connection after '
+              f'{interval:.1f}s')
         # Cancel remaining tasks
         for task in pending:
             task.cancel()
@@ -214,7 +215,7 @@ async def handle_client(local_reader, local_writer, target_host, target_port,
         pass
 
 
-async def main(local_port, interval):
+async def main(local_port, interval, jitter=0.0):
     global connection_counter
 
     server_url = common.get_server_url()
@@ -225,14 +226,22 @@ async def main(local_port, interval):
     async def client_handler(reader, writer):
         global connection_counter
         connection_counter += 1
-        await handle_client(reader, writer, target_host, target_port, interval,
-                            connection_counter)
+        # Randomize each connection's lifetime. With a fixed interval the
+        # kill schedule phase-locks to the client's reconnect cadence, so a
+        # timing-sensitive race (e.g. the kill landing right as a stream
+        # finishes) either never fires or fires on every attempt. Jitter
+        # de-correlates the kills so no single unlucky alignment repeats
+        # deterministically.
+        effective_interval = max(1.0,
+                                 interval + random.uniform(-jitter, jitter))
+        await handle_client(reader, writer, target_host, target_port,
+                            effective_interval, connection_counter)
 
     server = await asyncio.start_server(client_handler, '127.0.0.1', local_port)
     addrs = ', '.join(str(sock.getsockname()) for sock in server.sockets)
     print(
         f'Serving proxy on {addrs}, forwarding to {target_host}:{target_port}, '
-        f'disconnect interval={interval}s')
+        f'disconnect interval={interval}s, jitter={jitter}s')
 
     async with server:
         await server.serve_forever()
@@ -248,6 +257,11 @@ if __name__ == '__main__':
                         type=int,
                         required=True,
                         help='Seconds before disconnect')
+    parser.add_argument('--jitter',
+                        type=float,
+                        default=0.0,
+                        help='Randomize each connection\'s disconnect time by '
+                        'up to +/- this many seconds')
     args = parser.parse_args()
 
-    asyncio.run(main(args.port, args.interval))
+    asyncio.run(main(args.port, args.interval, args.jitter))

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -170,8 +170,14 @@ def test_cli_auto_retry(generic_cloud: str):
     test = smoke_tests_utils.Test(
         'cli_auto_retry',
         [
-            # Chaos proxy will kill TCP connections every 30 seconds.
-            f'python tests/chaos/chaos_proxy.py --port {port} --interval 30 & echo $! > /tmp/{name}-chaos.pid',
+            # Chaos proxy kills TCP connections roughly every 30 seconds.
+            # The +/-10s jitter keeps the kill schedule from phase-locking
+            # to the client's reconnect cadence: without it, a kill landing
+            # in the small window between the job finishing and the log
+            # stream closing repeats on every attempt (the job runtime and
+            # reconnect timing are ~deterministic), turning a rare race into
+            # a deterministic failure. See #9246.
+            f'python tests/chaos/chaos_proxy.py --port {port} --interval 30 --jitter 10 & echo $! > /tmp/{name}-chaos.pid',
             # Wait until the proxy is actually listening on the port. The
             # background `&` returns control immediately and on slower CI
             # workers the first sky-launch would otherwise race the proxy


### PR DESCRIPTION
## Summary

`test_cli_auto_retry` fails when the chaos proxy's connection kill lands in the small window between the managed job finishing and the log stream closing: the CLI's transparent retry then re-POSTs `/jobs/logs -n NAME`, the server's name resolution only considers non-terminal jobs (`get_nonterminal_job_ids_by_name`), and the command exits 102 (`JobExitCode.NOT_FOUND`) even though the job SUCCEEDED and its logs streamed fully.

Because the proxy kills every connection exactly 30s after creation and the client reconnects ~1s after each kill, the kill schedule phase-locks to the reconnect cadence. With a fixed 60s job, the position of the job's terminal transition inside a kill window is nearly deterministic per environment — so the race either never fires, or fires on **every** attempt. In a recent nightly it failed 6/6 attempts with byte-identical timing signatures (`POST /jobs/logs` gaps of 34.0s/31.0s/31.0s two days in a row). Tracking issue: #9246.

- Add `--jitter` to `tests/chaos/chaos_proxy.py`: each connection's kill interval becomes `interval ± uniform(0, jitter)`, floored at 1s.
- Use `--interval 30 --jitter 10` in `test_cli_auto_retry` so no single unlucky alignment can repeat across attempts.

This is a mitigation for the test flakiness; the underlying client behavior (retried log streams re-resolving the job name after the job reaches a terminal state) is being addressed separately by resolving the name to a job ID up front.

## Test plan

- Local functional check: ran the proxy with `--interval 5 --jitter 3` against a held-open upstream with 5 concurrent connections; observed varied close times (2.7s, 3.2s, 6.9s, 7.3s, 7.4s) vs. a fixed 5s before.
- `python tests/chaos/chaos_proxy.py --help` parses; default `--jitter 0` preserves existing behavior.
- Will run `/smoke-test --kubernetes -k test_cli_auto_retry` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PKc6HKVWgC1AB9eqk3szv