### PR TITLE
[Jobs] Pin log streaming to a job ID resolved before the stream starts

### DIFF
--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -9,11 +9,13 @@ import zlib
 
 import click
 
+from sky import exceptions
 from sky import sky_logging
 from sky.backends import backend_utils
 from sky.client import common as client_common
 from sky.client import sdk
 from sky.jobs import constants as managed_job_constants
+from sky.jobs import state as managed_job_state
 from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
@@ -435,6 +437,96 @@ def cancel(
     return server_common.get_request_id(response=response)
 
 
+@rest.retry_transient_errors()
+def _resolve_managed_job_id_by_name(
+        name: str, refresh: bool,
+        controller: bool) -> Union[int, Tuple[str, int]]:
+    """Resolves a managed job name to its job ID.
+
+    The name is resolved once, before log streaming starts, so that the
+    (transparently retried) streaming requests carry a stable job ID. If the
+    server re-resolved the name on every retried request, a retry could fail
+    with NOT_FOUND after the job reached a terminal state mid-stream
+    (non-controller name resolution only considers non-terminal jobs), or
+    attach to a different job submitted with the same name in between.
+
+    Mirrors the server-side resolution semantics in
+    ``sky.jobs.utils.stream_logs``:
+    - ``controller=False`` resolves against non-terminal jobs only;
+    - ``controller=True`` resolves against all jobs, terminal included;
+    - multiple matches raise ValueError.
+
+    Returns:
+        The resolved job ID, or a ``(message, exit_code)`` tuple when no
+        matching job exists.
+    """
+    body = payloads.JobsQueueV2Body(
+        refresh=refresh,
+        skip_finished=False,
+        all_users=True,
+        name_match=name,
+        fields=['job_id', 'job_name', 'status'],
+    )
+    response = server_common.make_authenticated_request(
+        'POST',
+        '/jobs/queue/v2',
+        json=json.loads(body.model_dump_json()),
+        timeout=(5, None))
+    request_id: server_common.RequestId[
+        Tuple[List[responses.ManagedJobRecord], int, Dict[str, int],
+              int]] = server_common.get_request_id(response)
+    result = sdk.get(request_id)
+    records = result[0] if isinstance(result, tuple) else result
+
+    def _field(record: Any, key: str) -> Any:
+        if isinstance(record, dict):
+            return record.get(key)
+        return getattr(record, key, None)
+
+    # ``name_match`` is a substring match (and servers predating the field
+    # ignore it and return the full queue), so keep exact matches only. A
+    # multi-task job has one record per task; a job counts as non-terminal
+    # if any of its tasks is.
+    job_has_nonterminal_task: Dict[int, bool] = {}
+    for record in records:
+        if _field(record, 'job_name') != name:
+            continue
+        record_job_id = _field(record, 'job_id')
+        if record_job_id is None:
+            continue
+        status = _field(record, 'status')
+        if isinstance(status, str):
+            status = managed_job_state.ManagedJobStatus(status)
+        nonterminal = status is not None and not status.is_terminal()
+        job_has_nonterminal_task[record_job_id] = (job_has_nonterminal_task.get(
+            record_job_id, False) or nonterminal)
+
+    if controller:
+        candidate_ids = list(job_has_nonterminal_task.keys())
+    else:
+        candidate_ids = [
+            record_job_id
+            for record_job_id, nonterminal in job_has_nonterminal_task.items()
+            if nonterminal
+        ]
+    if not candidate_ids:
+        if controller:
+            return (f'No managed job found with name {name!r}.',
+                    int(exceptions.JobExitCode.NOT_FOUND))
+        return (f'No running managed job found with name {name!r}.',
+                int(exceptions.JobExitCode.NOT_FOUND))
+    if len(candidate_ids) > 1:
+        if controller:
+            job_ids_str = ', '.join(
+                str(record_job_id) for record_job_id in candidate_ids)
+            raise ValueError(
+                f'Multiple managed jobs found with name {name!r} '
+                f'(Job IDs: {job_ids_str}). Please specify the job_id '
+                'instead.')
+        raise ValueError(f'Multiple running jobs found with name {name!r}.')
+    return candidate_ids[0]
+
+
 @typing.overload
 def tail_logs(
     name: Optional[str] = None,
@@ -469,7 +561,6 @@ def tail_logs(name: Optional[str] = None,
 
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
-@rest.retry_transient_errors()
 def tail_logs(
     name: Optional[str] = None,
     job_id: Optional[int] = None,
@@ -530,6 +621,45 @@ def tail_logs(
     if output_stream is not None and not preload_content:
         raise ValueError(
             'output_stream cannot be specified when preload_content is False')
+
+    if job_id is None and name is not None:
+        # Resolve the name to a job ID up-front so the streaming requests
+        # below (including transparent retries, which re-issue the request)
+        # are pinned to one job. See _resolve_managed_job_id_by_name.
+        resolved = _resolve_managed_job_id_by_name(name, refresh, controller)
+        if isinstance(resolved, tuple):
+            message, returncode = resolved
+            if not preload_content:
+                return iter([message + '\n'])
+            print(message, file=output_stream, flush=True)
+            return returncode if follow else None
+        job_id = resolved
+        name = None
+    return _tail_logs(name=name,
+                      job_id=job_id,
+                      follow=follow,
+                      controller=controller,
+                      refresh=refresh,
+                      tail=tail,
+                      tail_offset=tail_offset,
+                      output_stream=output_stream,
+                      task=task,
+                      preload_content=preload_content)
+
+
+@rest.retry_transient_errors()
+def _tail_logs(
+    name: Optional[str],
+    job_id: Optional[int],
+    follow: bool,
+    controller: bool,
+    refresh: bool,
+    tail: Optional[int],
+    tail_offset: Optional[int],
+    output_stream: Optional['io.TextIOBase'],
+    task: Optional[Union[str, int]],
+    preload_content: bool,
+) -> Union[Optional[int], Iterator[Optional[str]]]:
     body = payloads.JobsLogsBody(
         name=name,
         job_id=job_id,

--- a/tests/unit_tests/test_sky/jobs/test_client_sdk_tail_logs.py
+++ b/tests/unit_tests/test_sky/jobs/test_client_sdk_tail_logs.py
@@ -1,0 +1,162 @@
+"""Tests for job-name resolution in ``sky.jobs.client.sdk.tail_logs``.
+
+``tail_logs`` resolves a job name to a job ID once, before streaming
+starts, so that transparently retried streaming requests stay pinned to
+the same job (a retried request carrying only the name would fail with
+NOT_FOUND once the job reaches a terminal state, or could attach to a
+newer job submitted with the same name).
+"""
+from unittest import mock
+
+import pytest
+
+from sky import exceptions
+from sky.jobs.client import sdk as jobs_sdk
+
+
+def _queue_result(records):
+    """Builds a /jobs/queue/v2 result tuple around the given records."""
+    return (records, len(records), {}, len(records))
+
+
+def _resolve(records, name='foo', refresh=False, controller=False):
+    with mock.patch.object(jobs_sdk.server_common,
+                           'make_authenticated_request') as request_mock, \
+         mock.patch.object(jobs_sdk.server_common, 'get_request_id',
+                           return_value='req-id'), \
+         mock.patch.object(jobs_sdk.sdk, 'get',
+                           return_value=_queue_result(records)):
+        result = jobs_sdk._resolve_managed_job_id_by_name(  # pylint: disable=protected-access
+            name, refresh, controller)
+        return result, request_mock
+
+
+class TestResolveManagedJobIdByName:
+
+    def test_single_running_job_resolves(self):
+        result, request_mock = _resolve([{
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'RUNNING'
+        }])
+        assert result == 7
+        # The resolution must go through the queue endpoint.
+        assert request_mock.call_args[0][1] == '/jobs/queue/v2'
+
+    def test_only_terminal_job_is_not_found_without_controller(self):
+        result, _ = _resolve([{
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'SUCCEEDED'
+        }])
+        message, returncode = result
+        assert 'No running managed job found' in message
+        assert returncode == int(exceptions.JobExitCode.NOT_FOUND)
+
+    def test_only_terminal_job_resolves_with_controller(self):
+        result, _ = _resolve([{
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'SUCCEEDED'
+        }],
+                             controller=True)
+        assert result == 7
+
+    def test_no_match_is_not_found(self):
+        message, returncode = _resolve([])[0]
+        assert 'No running managed job found' in message
+        assert returncode == int(exceptions.JobExitCode.NOT_FOUND)
+
+    def test_multiple_running_jobs_raise(self):
+        with pytest.raises(ValueError, match='Multiple running jobs'):
+            _resolve([{
+                'job_id': 7,
+                'job_name': 'foo',
+                'status': 'RUNNING'
+            }, {
+                'job_id': 8,
+                'job_name': 'foo',
+                'status': 'RUNNING'
+            }])
+
+    def test_multiple_jobs_raise_with_controller(self):
+        with pytest.raises(ValueError, match='Multiple managed jobs'):
+            _resolve([{
+                'job_id': 7,
+                'job_name': 'foo',
+                'status': 'SUCCEEDED'
+            }, {
+                'job_id': 8,
+                'job_name': 'foo',
+                'status': 'RUNNING'
+            }],
+                     controller=True)
+
+    def test_name_match_superset_is_filtered_to_exact_matches(self):
+        # ``name_match`` is a substring filter server-side (and old servers
+        # ignore it entirely), so near-matches must be dropped client-side.
+        result, _ = _resolve([{
+            'job_id': 6,
+            'job_name': 'foobar',
+            'status': 'RUNNING'
+        }, {
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'RUNNING'
+        }])
+        assert result == 7
+
+    def test_multitask_job_counts_once(self):
+        # A multi-task job has one record per task; the job is running if
+        # any task is, and it must not be double-counted as two matches.
+        result, _ = _resolve([{
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'SUCCEEDED'
+        }, {
+            'job_id': 7,
+            'job_name': 'foo',
+            'status': 'RUNNING'
+        }])
+        assert result == 7
+
+
+class TestTailLogsNameResolution:
+
+    def _tail_logs(self, resolved, **kwargs):
+        with mock.patch.object(jobs_sdk.server_common,
+                               'check_server_healthy_or_start_fn'), \
+             mock.patch.object(jobs_sdk, '_resolve_managed_job_id_by_name',
+                               return_value=resolved) as resolve_mock, \
+             mock.patch.object(jobs_sdk, '_tail_logs',
+                               return_value=0) as tail_mock:
+            returncode = jobs_sdk.tail_logs(**kwargs)
+            return returncode, resolve_mock, tail_mock
+
+    def test_name_is_replaced_with_resolved_job_id(self):
+        _, resolve_mock, tail_mock = self._tail_logs(resolved=7, name='foo')
+        resolve_mock.assert_called_once_with('foo', False, False)
+        _, kwargs = tail_mock.call_args
+        assert kwargs['job_id'] == 7
+        assert kwargs['name'] is None
+
+    def test_explicit_job_id_skips_resolution(self):
+        _, resolve_mock, tail_mock = self._tail_logs(resolved=7, job_id=3)
+        resolve_mock.assert_not_called()
+        _, kwargs = tail_mock.call_args
+        assert kwargs['job_id'] == 3
+
+    def test_not_found_returns_exit_code_when_following(self, capsys):
+        returncode, _, tail_mock = self._tail_logs(resolved=('no job', 102),
+                                                   name='foo',
+                                                   follow=True)
+        assert returncode == 102
+        tail_mock.assert_not_called()
+        assert 'no job' in capsys.readouterr().out
+
+    def test_not_found_returns_none_when_not_following(self):
+        returncode, _, tail_mock = self._tail_logs(resolved=('no job', 102),
+                                                   name='foo',
+                                                   follow=False)
+        assert returncode is None
+        tail_mock.assert_not_called()


### PR DESCRIPTION
## Summary

`sky jobs logs -n NAME` sends the name on every `/jobs/logs` request, and the SDK's transparent retry (`rest.retry_transient_errors`) re-issues the whole request on transient connection failures. The server resolves a name against **non-terminal jobs only**, so a retry that lands after the job reached a terminal state mid-stream exits **102 (`JobExitCode.NOT_FOUND`)** even though the job succeeded and its logs streamed fully. This is the root cause of the recurring `test_cli_auto_retry` failure (#9246): the chaos proxy kills the connection right after the final "Job finished" line, the client retries, and the retried name lookup finds nothing. A retried name lookup could also attach to a *different* job if a new job with the same name was submitted in between.

Two alternatives were considered and rejected:
- Resolving names against terminal jobs server-side was proposed in #9670 and closed as unwanted (ambiguity when multiple finished jobs share a name).
- Re-attaching to the original server-side request on retry doesn't survive an API server rollout (requests are not persisted across rollouts), which is exactly when HA retries matter.

Instead, resolve the name to a job ID **once, before streaming starts**, and carry only the ID on the (retried) streaming requests — tailing by ID works fine for terminal jobs:

- New `_resolve_managed_job_id_by_name` resolves via `/jobs/queue/v2` with a `name_match` filter (exact-match enforced client-side, since `name_match` is a substring filter and older servers ignore it), mirroring the server-side semantics of `sky.jobs.utils.stream_logs` exactly: non-controller resolution considers non-terminal jobs only; `--controller` resolution includes terminal jobs; multiple matches raise `ValueError` with the same messages; no match prints the same message and exits with the same code.
- `tail_logs` keeps its public signature and behavior; the `retry_transient_errors` boundary moves to the inner `_tail_logs` so resolution happens exactly once per user call.
- A multi-task job (one queue record per task) counts as one candidate, non-terminal if any task is.

Behavior notes:
- One extra lightweight queue request per `sky jobs logs -n NAME` invocation (fields limited to `job_id`/`job_name`/`status`). `refresh` is passed through so a stopped controller is still restarted when requested.
- Name resolution now goes through the queue path, which applies workspace visibility filtering; a job in a workspace the user cannot access is no longer resolvable by name (it previously was, via the unfiltered controller-side lookup).

## Test plan

- New unit tests: `tests/unit_tests/test_sky/jobs/test_client_sdk_tail_logs.py` (12 tests: resolution semantics for controller/non-controller, exact-name filtering, multi-task jobs, multiple-match errors, NOT_FOUND exit codes, and `tail_logs` pinning the resolved ID / skipping resolution when an explicit ID is given).
- Existing `tests/unit_tests/test_sky/test_cli_jobs_logs_tail.py` still passes (12 tests).
- Local API server sanity check: `sky jobs logs -n nonexistent` surfaces the same `ClusterNotUpError` as before when no controller exists.
- Will run `/smoke-test --kubernetes -k "test_cli_auto_retry or test_managed_jobs_cli_exit_codes"` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PKc6HKVWgC1AB9eqk3szv