### PR TITLE
[Test] Make staging smoke robust on shared multi-context servers

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -1038,6 +1038,38 @@ def launch_cloud_cmd_on_landed_context(name: str) -> str:
         f'kubernetes/$(cat {k8s_landed_context_file(name)})', name)
 
 
+def resolve_cloud_cmd_k8s_context_cmd(test_cluster_name: str) -> str:
+    """Resolve+persist the context the cloud-cmd helper landed on, so a later
+    ``sky launch`` can be pinned to the same context (the inverse of
+    :func:`launch_cloud_cmd_on_landed_context`, which pins the helper to an
+    existing target). Use when a test mutates cluster state *via the helper*
+    (e.g. ``kubectl create`` a pod) and then launches a real cluster that must
+    land on that same context to interact with it.
+
+    No-op when the API server is local: there is no cloud-cmd helper
+    (see :func:`launch_cluster_for_cloud_cmd`) and only one context exists, so
+    the subsequent launch is already co-located.
+    """
+    if server_common.is_api_server_local() and not is_remote_server_test():
+        return 'true'
+    return resolve_k8s_context_cmd(test_cluster_name +
+                                   _CLOUD_CMD_CLUSTER_NAME_SUFFIX)
+
+
+def cloud_cmd_landed_k8s_infra(test_cluster_name: str) -> str:
+    """``--infra`` value that pins a ``sky launch`` to the cloud-cmd helper's
+    landed context on a remote/multi-context server (paired with
+    :func:`resolve_cloud_cmd_k8s_context_cmd`), or plain ``kubernetes`` locally
+    (single context, no helper).
+    """
+    if server_common.is_api_server_local() and not is_remote_server_test():
+        return 'kubernetes'
+    return (
+        'kubernetes/$(cat '
+        f'{k8s_landed_context_file(test_cluster_name + _CLOUD_CMD_CLUSTER_NAME_SUFFIX)})'
+    )
+
+
 def run_cloud_cmd_on_cluster(test_cluster_name: str,
                              cmd: str,
                              envs: Set[str] = None,

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3326,7 +3326,15 @@ def test_launching_with_pending_pods():
             # Check Pod pending
             smoke_tests_utils.run_cloud_cmd_on_cluster(
                 name, f'kubectl get pod {head} | grep "Pending"'),
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra kubernetes --cpus 0.1+ \'echo hi\'); echo "$s"; echo; echo; echo "$s" | grep "Timed out while waiting for nodes to start"',
+            # The pending head pod above was created via the cloud-cmd helper,
+            # i.e. on the helper's kubectl context. On a multi-context API
+            # server the launch below could otherwise land on a *different*
+            # context and never contend with that pod (it would then succeed
+            # instead of timing out, failing this test). Pin the launch to the
+            # helper's context so the two are co-located; on a local
+            # single-context server this is a no-op (`--infra kubernetes`).
+            smoke_tests_utils.resolve_cloud_cmd_k8s_context_cmd(name),
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra {smoke_tests_utils.cloud_cmd_landed_k8s_infra(name)} --cpus 0.1+ \'echo hi\'); echo "$s"; echo; echo; echo "$s" | grep "Timed out while waiting for nodes to start"',
             # Check Pods have been deleted
             smoke_tests_utils.run_cloud_cmd_on_cluster(
                 name,

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -252,8 +252,11 @@ def test_managed_jobs_num_jobs_without_pool(generic_cloud: str):
             '! echo "$s" | grep "value=None"; '
             '! echo "$s" | grep "in the pool"')
         # Resolve the num_jobs job IDs by name (col 2 or 3 of `sky jobs queue`).
+        # Use --all: on a shared server the default queue is truncated to the
+        # latest 50 jobs, so the just-launched jobs can fall outside the window
+        # and the name lookup finds 0.
         capture_ids_cmd = (
-            's=$(sky jobs queue); echo "$s"; echo "$s" | '
+            's=$(sky jobs queue --all); echo "$s"; echo "$s" | '
             'awk -v n=' + name + ' \'($2==n)||($3==n){print $1}\' | '
             f'sort -un > {ids_file}; cat {ids_file}; '
             f'cnt=$(wc -l < {ids_file}); '


### PR DESCRIPTION
Two independent smoke-test flakes on a **shared / multi-context** API server. Both pass reliably on single-context local/CI clusters, so they only bite the shared-server lane.

## 1. `test_launching_with_pending_pods` — pin the launch to the helper's context

The test plants a `Pending` head pod via the cloud-cmd helper (which runs `kubectl` with its **in-cluster** ServiceAccount, i.e. scoped to its own kubectl context/namespace), then runs `sky launch --infra kubernetes` expecting the launch to contend with that pod and print `Timed out while waiting for nodes to start`.

On a **multi-context** server the unpinned launch can land on a *different* context than the helper, so it never sees the pending pod → it succeeds instead of timing out → the `grep "Timed out …"` fails (flaky).

**Fix:** pin the launch to the helper's landed context via two new `smoke_tests_utils` helpers — `resolve_cloud_cmd_k8s_context_cmd()` / `cloud_cmd_landed_k8s_infra()` — the inverse of the existing `launch_cloud_cmd_on_landed_context()`. Both **no-op on a local single-context server** (there is no cloud-cmd helper there), so local runs are unchanged (`--infra kubernetes`); the pin only engages on a remote/multi-context server.

## 2. `test_managed_jobs_num_jobs_without_pool` — use `sky jobs queue --all`

The `--num-jobs N` launch works; the test then resolves the launched job IDs **by name** from `sky jobs queue`. That output is truncated to the **latest 50** managed jobs, so on a busy shared server the just-launched jobs fall outside the window and the name lookup finds 0 → `Expected N jobs …, found 0`.

**Fix:** query `sky jobs queue --all` so the freshly-launched jobs are always found regardless of queue depth.

## Test
- Local single-context smoke run: unchanged (helpers no-op; `--all` is a superset).
- Multi-context server: (1) the launch co-locates with the pending pod and reliably times out; (2) the job-ID lookup is no longer truncated.