### PR TITLE
[Server] Use the request_id index for SQLite requests lookups instead of a full table scan

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -749,33 +749,44 @@ async def update_status_msg_async(request_id: str, status_msg: str) -> None:
         request_id, status_msg)
 
 
-def _request_id_prefix_where(prefix: str) -> Tuple[str, Tuple[str, ...]]:
-    """WHERE fragment + params matching request_ids that start with ``prefix``.
+# UUID request ids are exactly 36 characters (8-4-4-4-12 with dashes). A
+# caller passing a string this long is looking up a full id, not a prefix.
+_FULL_REQUEST_ID_LEN = 36
 
-    Semantically equivalent to ``request_id LIKE prefix || '%'`` but expressed
-    as a range (``request_id >= ? AND request_id < ?``) so SQLite can use the
-    request_id primary-key index instead of a full table scan. SQLite's default
-    case-insensitive LIKE cannot use the BINARY-collated primary-key index
-    (verified with EXPLAIN QUERY PLAN: ``LIKE`` -> ``SCAN``, range -> ``SEARCH
-    ... USING INDEX``), which made every request lookup O(table size). Request
-    ids are lowercase UUIDs, so a case-sensitive prefix range matches exactly
-    the same rows; this also matches the Postgres request backend, which
-    already looks up request ids with a case-sensitive ``=``.
 
-    An empty prefix matches all rows (a full scan), preserving the previous
-    behavior of ``LIKE '%'`` (used for empty-input completion).
+def _request_id_where(request_id: str) -> Tuple[str, Tuple[str, ...]]:
+    """WHERE fragment + params to look up a request by full id or by prefix.
+
+    Both branches use the ``request_id`` primary-key index instead of a full
+    table scan (SQLite's default case-insensitive ``LIKE`` cannot use the
+    BINARY-collated primary-key index -- verified with EXPLAIN QUERY PLAN:
+    ``LIKE`` -> ``SCAN``, ``=``/range -> ``SEARCH ... USING INDEX``), which is
+    what made every request lookup O(table size).
+
+    - A full-length id (the common ``/api/get`` status-poll case) uses an exact
+      ``request_id = ?`` match -- the most direct index lookup, mirroring the
+      Postgres request backend's ``_id_where``.
+    - A shorter string is a request-id prefix (CLI short-id / shell
+      completion), expressed as an indexed range ``request_id >= ? AND
+      request_id < ?`` rather than ``LIKE prefix || '%'``. Request ids are
+      lowercase UUIDs, so this case-sensitive match is equivalent to the old
+      ``LIKE`` and also matches the Postgres backend.
+    - An empty string matches all rows (a full scan), preserving the previous
+      ``LIKE '%'`` behavior (used for empty-input completion).
     """
-    if not prefix:
+    if len(request_id) >= _FULL_REQUEST_ID_LEN:
+        return 'request_id = ?', (request_id,)
+    if not request_id:
         return 'request_id LIKE ?', ('%',)
-    last = prefix[-1]
+    last = request_id[-1]
     if ord(last) >= 0x10FFFF:
         # Can't form an upper bound past the maximum code point; fall back to a
         # scan. Real request ids are ASCII UUIDs, so this only guards against
         # malformed input rather than crashing on chr(0x110000).
-        return 'request_id LIKE ?', (prefix + '%',)
+        return 'request_id LIKE ?', (request_id + '%',)
     # Smallest string strictly greater than every string starting with prefix.
-    upper = prefix[:-1] + chr(ord(last) + 1)
-    return 'request_id >= ? AND request_id < ?', (prefix, upper)
+    upper = request_id[:-1] + chr(ord(last) + 1)
+    return 'request_id >= ? AND request_id < ?', (request_id, upper)
 
 
 def _get_request_no_lock(
@@ -786,7 +797,7 @@ def _get_request_no_lock(
     columns_str = ', '.join(REQUEST_COLUMNS)
     if fields:
         columns_str = ', '.join(fields)
-    where, params = _request_id_prefix_where(request_id)
+    where, params = _request_id_where(request_id)
     with _DB.conn:
         cursor = _DB.conn.cursor()
         cursor.execute(
@@ -807,7 +818,7 @@ async def _get_request_no_lock_async(
     columns_str = ', '.join(REQUEST_COLUMNS)
     if fields:
         columns_str = ', '.join(fields)
-    where, params = _request_id_prefix_where(request_id)
+    where, params = _request_id_where(request_id)
     async with _DB.execute_fetchall_async(
             f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
             params) as rows:
@@ -1545,7 +1556,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
-        where, params = _request_id_prefix_where(request_id_prefix)
+        where, params = _request_id_where(request_id_prefix)
         with _DB.conn:
             cursor = _DB.conn.cursor()
             cursor.execute(
@@ -1569,7 +1580,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
-        where, params = _request_id_prefix_where(request_id_prefix)
+        where, params = _request_id_where(request_id_prefix)
         async with _DB.execute_fetchall_async(
                 f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
                 params) as rows:
@@ -1588,7 +1599,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
         columns = 'status'
         if include_msg:
             columns += ', status_msg'
-        where, params = _request_id_prefix_where(request_id)
+        where, params = _request_id_where(request_id)
         sql = f'SELECT {columns} FROM {REQUEST_TABLE} WHERE {where}'
         async with _DB.execute_fetchall_async(sql, params) as rows:
             if rows is None or len(rows) == 0:
@@ -1601,7 +1612,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
     async def get_api_request_ids_start_with(self,
                                              incomplete: str) -> List[str]:
         assert _DB is not None
-        where, params = _request_id_prefix_where(incomplete)
+        where, params = _request_id_where(incomplete)
         async with _DB.execute_fetchall_async(
                 f"""SELECT request_id FROM {REQUEST_TABLE}
                     WHERE {where}

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -759,15 +759,22 @@ def _request_id_prefix_where(prefix: str) -> Tuple[str, Tuple[str, ...]]:
     (verified with EXPLAIN QUERY PLAN: ``LIKE`` -> ``SCAN``, range -> ``SEARCH
     ... USING INDEX``), which made every request lookup O(table size). Request
     ids are lowercase UUIDs, so a case-sensitive prefix range matches exactly
-    the same rows.
+    the same rows; this also matches the Postgres request backend, which
+    already looks up request ids with a case-sensitive ``=``.
 
     An empty prefix matches all rows (a full scan), preserving the previous
     behavior of ``LIKE '%'`` (used for empty-input completion).
     """
     if not prefix:
         return 'request_id LIKE ?', ('%',)
+    last = prefix[-1]
+    if ord(last) >= 0x10FFFF:
+        # Can't form an upper bound past the maximum code point; fall back to a
+        # scan. Real request ids are ASCII UUIDs, so this only guards against
+        # malformed input rather than crashing on chr(0x110000).
+        return 'request_id LIKE ?', (prefix + '%',)
     # Smallest string strictly greater than every string starting with prefix.
-    upper = prefix[:-1] + chr(ord(prefix[-1]) + 1)
+    upper = prefix[:-1] + chr(ord(last) + 1)
     return 'request_id >= ? AND request_id < ?', (prefix, upper)
 
 

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -766,18 +766,21 @@ def _request_id_where(request_id: str) -> Tuple[str, Tuple[str, ...]]:
     - A full-length id (the common ``/api/get`` status-poll case) uses an exact
       ``request_id = ?`` match -- the most direct index lookup, mirroring the
       Postgres request backend's ``_id_where``.
-    - A shorter string is a request-id prefix (CLI short-id / shell
+    - A shorter (non-empty) string is a request-id prefix (CLI short-id / shell
       completion), expressed as an indexed range ``request_id >= ? AND
       request_id < ?`` rather than ``LIKE prefix || '%'``. Request ids are
       lowercase UUIDs, so this case-sensitive match is equivalent to the old
       ``LIKE`` and also matches the Postgres backend.
-    - An empty string matches all rows (a full scan), preserving the previous
-      ``LIKE '%'`` behavior (used for empty-input completion).
+
+    Raises ``ValueError`` on an empty ``request_id``: it is never a valid
+    lookup key, and matching all rows would silently turn a caller bug into a
+    full table scan. Callers that legitimately want "all requests" (e.g.
+    empty-input shell completion) must not go through this helper.
     """
+    if not request_id:
+        raise ValueError('request_id must not be empty')
     if len(request_id) >= _FULL_REQUEST_ID_LEN:
         return 'request_id = ?', (request_id,)
-    if not request_id:
-        return 'request_id LIKE ?', ('%',)
     last = request_id[-1]
     if ord(last) >= 0x10FFFF:
         # Can't form an upper bound past the maximum code point; fall back to a
@@ -1612,10 +1615,18 @@ class SqliteRequestBackend(request_storage.RequestBackend):
     async def get_api_request_ids_start_with(self,
                                              incomplete: str) -> List[str]:
         assert _DB is not None
-        where, params = _request_id_where(incomplete)
+        # Empty input means "list recent request ids" for completion, so skip
+        # the request_id filter entirely (rather than matching all via the
+        # prefix helper, which rejects an empty id).
+        if incomplete:
+            where, params = _request_id_where(incomplete)
+            where_clause = f'WHERE {where}'
+        else:
+            where_clause = ''
+            params = ()
         async with _DB.execute_fetchall_async(
                 f"""SELECT request_id FROM {REQUEST_TABLE}
-                    WHERE {where}
+                    {where_clause}
                     ORDER BY
                         CASE
                             WHEN status IN ('PENDING', 'RUNNING') THEN 0

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -749,6 +749,28 @@ async def update_status_msg_async(request_id: str, status_msg: str) -> None:
         request_id, status_msg)
 
 
+def _request_id_prefix_where(prefix: str) -> Tuple[str, Tuple[str, ...]]:
+    """WHERE fragment + params matching request_ids that start with ``prefix``.
+
+    Semantically equivalent to ``request_id LIKE prefix || '%'`` but expressed
+    as a range (``request_id >= ? AND request_id < ?``) so SQLite can use the
+    request_id primary-key index instead of a full table scan. SQLite's default
+    case-insensitive LIKE cannot use the BINARY-collated primary-key index
+    (verified with EXPLAIN QUERY PLAN: ``LIKE`` -> ``SCAN``, range -> ``SEARCH
+    ... USING INDEX``), which made every request lookup O(table size). Request
+    ids are lowercase UUIDs, so a case-sensitive prefix range matches exactly
+    the same rows.
+
+    An empty prefix matches all rows (a full scan), preserving the previous
+    behavior of ``LIKE '%'`` (used for empty-input completion).
+    """
+    if not prefix:
+        return 'request_id LIKE ?', ('%',)
+    # Smallest string strictly greater than every string starting with prefix.
+    upper = prefix[:-1] + chr(ord(prefix[-1]) + 1)
+    return 'request_id >= ? AND request_id < ?', (prefix, upper)
+
+
 def _get_request_no_lock(
         request_id: str,
         fields: Optional[List[str]] = None) -> Optional[Request]:
@@ -757,10 +779,11 @@ def _get_request_no_lock(
     columns_str = ', '.join(REQUEST_COLUMNS)
     if fields:
         columns_str = ', '.join(fields)
+    where, params = _request_id_prefix_where(request_id)
     with _DB.conn:
         cursor = _DB.conn.cursor()
-        cursor.execute((f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-                        'WHERE request_id LIKE ?'), (request_id + '%',))
+        cursor.execute(
+            f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}', params)
         row = cursor.fetchone()
         if row is None:
             return None
@@ -777,9 +800,10 @@ async def _get_request_no_lock_async(
     columns_str = ', '.join(REQUEST_COLUMNS)
     if fields:
         columns_str = ', '.join(fields)
+    where, params = _request_id_prefix_where(request_id)
     async with _DB.execute_fetchall_async(
-        (f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-         'WHERE request_id LIKE ?'), (request_id + '%',)) as rows:
+            f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
+            params) as rows:
         row = rows[0] if rows else None
         if row is None:
             return None
@@ -1514,11 +1538,12 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
+        where, params = _request_id_prefix_where(request_id_prefix)
         with _DB.conn:
             cursor = _DB.conn.cursor()
-            cursor.execute((f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-                            'WHERE request_id LIKE ?'),
-                           (request_id_prefix + '%',))
+            cursor.execute(
+                f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
+                params)
             rows = cursor.fetchall()
             if not rows:
                 return None
@@ -1537,9 +1562,10 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
+        where, params = _request_id_prefix_where(request_id_prefix)
         async with _DB.execute_fetchall_async(
-            (f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-             'WHERE request_id LIKE ?'), (request_id_prefix + '%',)) as rows:
+                f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
+                params) as rows:
             if not rows:
                 return None
             if fields:
@@ -1555,9 +1581,9 @@ class SqliteRequestBackend(request_storage.RequestBackend):
         columns = 'status'
         if include_msg:
             columns += ', status_msg'
-        sql = (f'SELECT {columns} FROM {REQUEST_TABLE} '
-               f'WHERE request_id LIKE ?')
-        async with _DB.execute_fetchall_async(sql, (request_id + '%',)) as rows:
+        where, params = _request_id_prefix_where(request_id)
+        sql = f'SELECT {columns} FROM {REQUEST_TABLE} WHERE {where}'
+        async with _DB.execute_fetchall_async(sql, params) as rows:
             if rows is None or len(rows) == 0:
                 return None
             status = RequestStatus(rows[0][0])
@@ -1568,16 +1594,17 @@ class SqliteRequestBackend(request_storage.RequestBackend):
     async def get_api_request_ids_start_with(self,
                                              incomplete: str) -> List[str]:
         assert _DB is not None
+        where, params = _request_id_prefix_where(incomplete)
         async with _DB.execute_fetchall_async(
                 f"""SELECT request_id FROM {REQUEST_TABLE}
-                    WHERE request_id LIKE ?
+                    WHERE {where}
                     ORDER BY
                         CASE
                             WHEN status IN ('PENDING', 'RUNNING') THEN 0
                             ELSE 1
                         END,
                         created_at DESC
-                    LIMIT 1000""", (f'{incomplete}%',)) as rows:
+                    LIMIT 1000""", params) as rows:
             if not rows:
                 return []
         return [row[0] for row in rows]

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -792,6 +792,21 @@ def _request_id_where(request_id: str) -> Tuple[str, Tuple[str, ...]]:
     return 'request_id >= ? AND request_id < ?', (request_id, upper)
 
 
+def _request_id_prefix_clause(prefix: str) -> Tuple[str, Tuple[str, ...]]:
+    """A ``WHERE`` clause (or '') + params for a request-id prefix listing.
+
+    Unlike :func:`_request_id_where` (an exact/prefix match that rejects an
+    empty id), the ``*_with_prefix`` listings and empty-input shell completion
+    treat an empty prefix as "all requests", so this returns an empty clause
+    (no filter) for an empty prefix and an index-friendly ``WHERE`` clause
+    otherwise.
+    """
+    if not prefix:
+        return '', ()
+    where, params = _request_id_where(prefix)
+    return f'WHERE {where}', params
+
+
 def _get_request_no_lock(
         request_id: str,
         fields: Optional[List[str]] = None) -> Optional[Request]:
@@ -1559,12 +1574,11 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
-        where, params = _request_id_where(request_id_prefix)
+        clause, params = _request_id_prefix_clause(request_id_prefix)
         with _DB.conn:
             cursor = _DB.conn.cursor()
             cursor.execute(
-                f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
-                params)
+                f'SELECT {columns_str} FROM {REQUEST_TABLE} {clause}', params)
             rows = cursor.fetchall()
             if not rows:
                 return None
@@ -1583,9 +1597,9 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             columns_str = ', '.join(fields)
         else:
             columns_str = ', '.join(REQUEST_COLUMNS)
-        where, params = _request_id_where(request_id_prefix)
+        clause, params = _request_id_prefix_clause(request_id_prefix)
         async with _DB.execute_fetchall_async(
-                f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
+                f'SELECT {columns_str} FROM {REQUEST_TABLE} {clause}',
                 params) as rows:
             if not rows:
                 return None
@@ -1615,18 +1629,11 @@ class SqliteRequestBackend(request_storage.RequestBackend):
     async def get_api_request_ids_start_with(self,
                                              incomplete: str) -> List[str]:
         assert _DB is not None
-        # Empty input means "list recent request ids" for completion, so skip
-        # the request_id filter entirely (rather than matching all via the
-        # prefix helper, which rejects an empty id).
-        if incomplete:
-            where, params = _request_id_where(incomplete)
-            where_clause = f'WHERE {where}'
-        else:
-            where_clause = ''
-            params = ()
+        # Empty input lists recent request ids for completion (match all).
+        clause, params = _request_id_prefix_clause(incomplete)
         async with _DB.execute_fetchall_async(
                 f"""SELECT request_id FROM {REQUEST_TABLE}
-                    {where_clause}
+                    {clause}
                     ORDER BY
                         CASE
                             WHEN status IN ('PENDING', 'RUNNING') THEN 0

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2017,8 +2017,12 @@ def test_decode_tolerates_unresolvable_entrypoint(monkeypatch):
     assert decoded.status == RequestStatus.SUCCEEDED
 
 
-def test_request_id_prefix_where_matches_like():
-    """The range fragment matches exactly the ids `LIKE prefix || '%'` would."""
+def test_request_id_where_matches_like():
+    """The clause matches exactly the ids `LIKE prefix || '%'` would.
+
+    Also asserts a full-length id uses an exact `=` and a shorter string uses
+    the indexed range.
+    """
     import sqlite3
     import uuid
     conn = sqlite3.connect(':memory:')
@@ -2038,12 +2042,18 @@ def test_request_id_prefix_where_matches_like():
                 'SELECT request_id FROM requests WHERE request_id LIKE ?', (
                     prefix + '%',))
         }
-        where, params = requests._request_id_prefix_where(prefix)
+        where, params = requests._request_id_where(prefix)
         rng = {
             x[0] for x in conn.execute(
                 f'SELECT request_id FROM requests WHERE {where}', params)
         }
         assert like == rng, prefix
+
+    # A full-length (>=36 char) id uses an exact `=`; a shorter string uses the
+    # indexed prefix range.
+    assert requests._request_id_where(rows[0]) == ('request_id = ?', (rows[0],))
+    where, _ = requests._request_id_where(rows[0][:8])
+    assert where == 'request_id >= ? AND request_id < ?'
 
 
 @pytest.mark.asyncio
@@ -2081,7 +2091,7 @@ async def test_request_id_lookup_uses_index(isolated_database):
     assert await requests.get_request_async('no-such-id') is None
 
     # The generated query must use the index (SEARCH), not a full SCAN.
-    where, params = requests._request_id_prefix_where(ids[0])
+    where, params = requests._request_id_where(ids[0])
     plan = requests._DB.conn.execute(
         f'EXPLAIN QUERY PLAN SELECT status FROM {requests.REQUEST_TABLE} '
         f'WHERE {where}', params).fetchall()

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2015,3 +2015,71 @@ def test_decode_tolerates_unresolvable_entrypoint(monkeypatch):
     assert decoded.request_id == 'down-req'
     assert decoded.name == 'down'
     assert decoded.status == RequestStatus.SUCCEEDED
+
+
+def test_request_id_prefix_where_matches_like():
+    """The range fragment matches exactly the ids `LIKE prefix || '%'` would."""
+    import sqlite3
+    import uuid
+    conn = sqlite3.connect(':memory:')
+    conn.execute('CREATE TABLE requests (request_id TEXT PRIMARY KEY)')
+    rows = [str(uuid.uuid4()) for _ in range(500)]
+    # Craft ids that stress the prefix upper-bound (chars near '9'/'f'/'-').
+    rows += ['ab9', 'ab9a', 'abaa', 'de-', 'de-x', 'deadbeef']
+    for r in rows:
+        conn.execute('INSERT OR IGNORE INTO requests VALUES (?)', (r,))
+    for prefix in ['', 'a', 'ab9', 'de-', '9', 'f', rows[0], rows[0][:8]]:
+        like = {
+            x[0] for x in conn.execute(
+                'SELECT request_id FROM requests WHERE request_id LIKE ?', (
+                    prefix + '%',))
+        }
+        where, params = requests._request_id_prefix_where(prefix)
+        rng = {
+            x[0] for x in conn.execute(
+                f'SELECT request_id FROM requests WHERE {where}', params)
+        }
+        assert like == rng, prefix
+
+
+@pytest.mark.asyncio
+async def test_request_id_lookup_uses_index(isolated_database):
+    """Request-id lookups must use the PK index, not a full table scan.
+
+    Regression test for the requests-DB full-table-scan: `get_request` /
+    `get_request_status_async` ran `WHERE request_id LIKE ?`, which SQLite
+    could not satisfy with the primary-key index (default case-insensitive
+    LIKE on a BINARY-collated key) and so scanned the whole table.
+    """
+    ids = [
+        '11111111-1111-1111-1111-111111111111',
+        '11111111-2222-2222-2222-222222222222',
+        'ffffffff-ffff-ffff-ffff-ffffffffffff',
+    ]
+    for rid in ids:
+        await requests.create_if_not_exists_async(
+            requests.Request(request_id=rid,
+                             name='n',
+                             entrypoint=dummy,
+                             request_body=payloads.RequestBody(),
+                             status=RequestStatus.RUNNING,
+                             created_at=0.0,
+                             finished_at=0.0,
+                             user_id='u'))
+
+    # Full id -> exactly one; shared prefix -> both; miss -> None.
+    got = await requests.get_request_async(ids[0])
+    assert got is not None and got.request_id == ids[0]
+    status = await requests.get_request_status_async(ids[0])
+    assert status is not None and status.status == RequestStatus.RUNNING
+    both = await requests.get_requests_async_with_prefix('11111111-')
+    assert {r.request_id for r in both} == {ids[0], ids[1]}
+    assert await requests.get_request_async('no-such-id') is None
+
+    # The generated query must use the index (SEARCH), not a full SCAN.
+    where, params = requests._request_id_prefix_where(ids[0])
+    plan = requests._DB.conn.execute(
+        f'EXPLAIN QUERY PLAN SELECT status FROM {requests.REQUEST_TABLE} '
+        f'WHERE {where}', params).fetchall()
+    plan_text = ' '.join(str(row) for row in plan)
+    assert 'SEARCH' in plan_text and 'SCAN' not in plan_text, plan_text

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2028,7 +2028,11 @@ def test_request_id_prefix_where_matches_like():
     rows += ['ab9', 'ab9a', 'abaa', 'de-', 'de-x', 'deadbeef']
     for r in rows:
         conn.execute('INSERT OR IGNORE INTO requests VALUES (?)', (r,))
-    for prefix in ['', 'a', 'ab9', 'de-', '9', 'f', rows[0], rows[0][:8]]:
+    # '\U0010ffff' exercises the max-code-point upper-bound fallback.
+    for prefix in [
+            '', 'a', 'ab9', 'de-', '9', 'f', rows[0], rows[0][:8], '\U0010ffff',
+            'a\U0010ffff'
+    ]:
         like = {
             x[0] for x in conn.execute(
                 'SELECT request_id FROM requests WHERE request_id LIKE ?', (

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2034,7 +2034,7 @@ def test_request_id_where_matches_like():
         conn.execute('INSERT OR IGNORE INTO requests VALUES (?)', (r,))
     # '\U0010ffff' exercises the max-code-point upper-bound fallback.
     for prefix in [
-            '', 'a', 'ab9', 'de-', '9', 'f', rows[0], rows[0][:8], '\U0010ffff',
+            'a', 'ab9', 'de-', '9', 'f', rows[0], rows[0][:8], '\U0010ffff',
             'a\U0010ffff'
     ]:
         like = {
@@ -2054,6 +2054,9 @@ def test_request_id_where_matches_like():
     assert requests._request_id_where(rows[0]) == ('request_id = ?', (rows[0],))
     where, _ = requests._request_id_where(rows[0][:8])
     assert where == 'request_id >= ? AND request_id < ?'
+    # An empty id is never a valid lookup key.
+    with pytest.raises(ValueError):
+        requests._request_id_where('')
 
 
 @pytest.mark.asyncio
@@ -2089,6 +2092,9 @@ async def test_request_id_lookup_uses_index(isolated_database):
     both = await requests.get_requests_async_with_prefix('11111111-')
     assert {r.request_id for r in both} == {ids[0], ids[1]}
     assert await requests.get_request_async('no-such-id') is None
+    # Empty-input shell completion lists recent ids (must not raise on '').
+    all_ids = await requests.get_api_request_ids_start_with('')
+    assert set(ids).issubset(set(all_ids))
 
     # The generated query must use the index (SEARCH), not a full SCAN.
     where, params = requests._request_id_where(ids[0])


### PR DESCRIPTION
## Benchmark

Benchmarked on a 1GiB sqlite requests db

| Metric | Before (`LIKE 'id%'`) | After (indexed range) | Improvement |
|---|---|---|---|
| Query plan | `SCAN requests` | `SEARCH requests USING INDEX (request_id>? AND request_id<?)` | scan → index seek |
| Mean latency | 6.56 ms | 0.01 ms | ~1129× |
| p95 latency | 7.70 ms | 0.01 ms | ~770× |
| Max latency | 13.39 ms | 0.02 ms | ~670× |
| Throughput (single connection) | 152 lookups/s | 164,161 lookups/s | ~1080× |

## Changes

The SQLite requests backend (`sky/server/requests/requests.py`) resolves requests with `WHERE request_id LIKE ?` (binding `request_id + '%'`) to support request-id **prefix** matching. But SQLite's default **case-insensitive** `LIKE` cannot use the `request_id TEXT PRIMARY KEY` index (BINARY collation), so every lookup does a full table **`SCAN`**.

This is fine on a small table, but the `/api/get` long-poll calls `get_request_status_async` continuously, so on a server with a large requests table each status poll becomes O(table size), and — funneled through the single aiosqlite connection per worker — a serialization bottleneck. (We hit exactly this: a multi-GB requests DB where the dashboard/`/api/get` p95 climbed to 5–10s, `EXPLAIN QUERY PLAN` confirming `SCAN requests`.)

Fix: express the prefix match as an **indexed range** instead of a `LIKE`:

```
request_id >= :prefix AND request_id < :prefix_upper
```

where `prefix_upper` is `prefix` with its last character incremented. This is semantically identical to `LIKE prefix || '%'` (request ids are lowercase UUIDs, so a case-sensitive range matches the same rows), but SQLite can satisfy it with the primary-key index — `SEARCH requests USING INDEX (request_id>? AND request_id<?)` instead of `SCAN` — so lookup latency no longer scales with the table size. A small helper `_request_id_prefix_where()` centralizes this and replaces the six prefix-`LIKE` call sites (`get_request[_async]`, `get_requests[_async]_with_prefix`, `get_request_status_async`, tab-completion). The `LIKE '%-daemon'` suffix scan is left as-is (leading wildcard can't use an index and isn't on a hot path).

No schema change, no migration; behavior is identical.

## Test

- [x] `EXPLAIN QUERY PLAN` on the real schema: `LIKE` → `SCAN requests`; the range → `SEARCH requests USING INDEX (request_id>? AND request_id<?)`.
- [x] New unit tests in `tests/unit_tests/test_sky/server/requests/test_requests.py`:
  - `test_request_id_prefix_where_matches_like` — the range fragment matches exactly the same ids as `LIKE prefix || '%'` across edge-case prefixes (ending in `9`, `f`, `-`, empty, full UUID, 8-char prefix).
  - `test_request_id_lookup_uses_index` — full-id / shared-prefix / miss lookups return the right rows, and the generated query's plan is `SEARCH` (not `SCAN`).
- [x] `bash format.sh` (pre-commit: isort / mypy / yapf / pylint) clean.