### PR TITLE
[Logs] Add a programmatic logging-agent provider hook

### DIFF
--- a/sky/logs/__init__.py
+++ b/sky/logs/__init__.py
@@ -1,5 +1,5 @@
 """Sky logging agents."""
-from typing import Optional
+from typing import Callable, Optional
 
 from sky import exceptions
 from sky import skypilot_config
@@ -18,10 +18,31 @@ __all__ = [
     'get_log_reader',
     'register_log_reader',
     'get_logging_agent',
+    'register_logging_agent_provider',
 ]
+
+# An optional programmatic override for the logging agent, mirroring the
+# read-side ``LogReader`` registry (``register_log_reader``). When registered,
+# it is consulted before the ``logs.store`` config selection, so a caller can
+# supply a logging agent whose destination/credentials are resolved at runtime
+# rather than from static config. Returning ``None`` falls back to the
+# config-based selection, so the override never has to reimplement it.
+LoggingAgentProvider = Callable[[], Optional[LoggingAgent]]
+_logging_agent_provider: Optional[LoggingAgentProvider] = None
+
+
+def register_logging_agent_provider(
+        provider: Optional[LoggingAgentProvider]) -> None:
+    """Registers the process-global logging agent provider (None to clear)."""
+    global _logging_agent_provider
+    _logging_agent_provider = provider
 
 
 def get_logging_agent() -> Optional[LoggingAgent]:
+    if _logging_agent_provider is not None:
+        agent = _logging_agent_provider()
+        if agent is not None:
+            return agent
     store = skypilot_config.get_nested(('logs', 'store'), None)
     if store is None:
         return None

--- a/sky/logs/__init__.py
+++ b/sky/logs/__init__.py
@@ -39,8 +39,11 @@ def register_logging_agent_provider(
 
 
 def get_logging_agent() -> Optional[LoggingAgent]:
-    if _logging_agent_provider is not None:
-        agent = _logging_agent_provider()
+    # Capture into a local so a concurrent register_logging_agent_provider(None)
+    # cannot clear the global between the check and the call.
+    provider = _logging_agent_provider
+    if provider is not None:
+        agent = provider()
         if agent is not None:
             return agent
     store = skypilot_config.get_nested(('logs', 'store'), None)

--- a/tests/unit_tests/test_sky/logs/test_logging_agent_provider.py
+++ b/tests/unit_tests/test_sky/logs/test_logging_agent_provider.py
@@ -1,0 +1,55 @@
+"""Unit tests for the logging-agent provider hook in sky.logs."""
+
+import unittest
+from unittest import mock
+
+import sky.logs as logs
+from sky.logs.agent import LoggingAgent
+
+
+class _FakeAgent(LoggingAgent):
+    """Minimal LoggingAgent stand-in for the provider tests."""
+
+    def get_setup_command(self, cluster_name):
+        return 'true'
+
+    def get_credential_file_mounts(self):
+        return {}
+
+
+class TestLoggingAgentProvider(unittest.TestCase):
+
+    def tearDown(self):
+        # Always clear the process-global provider between tests.
+        logs.register_logging_agent_provider(None)
+
+    def test_no_provider_no_config_returns_none(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value=None):
+            self.assertIsNone(logs.get_logging_agent())
+
+    def test_provider_takes_precedence_over_config(self):
+        agent = _FakeAgent()
+        logs.register_logging_agent_provider(lambda: agent)
+        # Even with no logs.store configured, the provider's agent is returned.
+        with mock.patch('sky.skypilot_config.get_nested',
+                        return_value=None) as m:
+            self.assertIs(logs.get_logging_agent(), agent)
+            # Config selection is skipped entirely when the provider returns one.
+            m.assert_not_called()
+
+    def test_provider_returning_none_falls_back_to_config(self):
+        logs.register_logging_agent_provider(lambda: None)
+
+        def fake_get_nested(keys, default=None):
+            return 'gcp' if keys == ('logs', 'store') else {}
+
+        with mock.patch('sky.skypilot_config.get_nested',
+                        side_effect=fake_get_nested):
+            agent = logs.get_logging_agent()
+        self.assertIsInstance(agent, logs.GCPLoggingAgent)
+
+    def test_clearing_provider_restores_config_path(self):
+        logs.register_logging_agent_provider(lambda: _FakeAgent())
+        logs.register_logging_agent_provider(None)
+        with mock.patch('sky.skypilot_config.get_nested', return_value=None):
+            self.assertIsNone(logs.get_logging_agent())


### PR DESCRIPTION
## Summary

`get_logging_agent()` selects the external logging agent from the `logs.store` config. This adds an optional programmatic override, `register_logging_agent_provider()`, that is consulted **before** the config-based selection — mirroring the read-side `LogReader` registry (`register_log_reader`) already present in `sky/logs`.

This lets a caller supply a logging agent whose destination/credentials are resolved at runtime rather than from static config (e.g. when the logging destination is managed dynamically). The provider returning `None` falls back to the existing config-based selection, and the registry is empty by default, so behavior is unchanged when the hook is unused.

```python
import sky.logs as logs

logs.register_logging_agent_provider(lambda: my_agent_or_none)
```

## Test plan

New unit tests in `tests/unit_tests/test_sky/logs/test_logging_agent_provider.py`:
- no provider + no config → `None`
- provider takes precedence over config (config selection skipped)
- provider returning `None` → config fallback (yields `GCPLoggingAgent`)
- clearing the provider restores the config path

```
pytest tests/unit_tests/test_sky/logs/test_logging_agent_provider.py
# 4 passed
```