### PR TITLE
[Core] Retry transient SSH transport failures in the ray status health check

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -122,6 +122,14 @@ SSH_CONNECTION_ERROR_PATTERN = re.compile(
     r'^ssh:.*(timed out|connection refused)$', re.IGNORECASE)
 _SSH_CONNECTION_TIMED_OUT_PATTERN = re.compile(r'^ssh:.*timed out$',
                                                re.IGNORECASE)
+# Transient transport failures (e.g. an SSM ProxyCommand dropping for a
+# moment) that do not indicate an unhealthy ray cluster; retried by the ray
+# health check. Excludes 'timed out', which signals a changed IP on manually
+# restarted clusters (_SSH_CONNECTION_TIMED_OUT_PATTERN).
+_TRANSIENT_SSH_FAILURE_PATTERN = re.compile(
+    r'(TargetNotConnected|kex_exchange_identification|'
+    r'Connection reset by peer|Connection closed by remote host|Broken pipe)',
+    re.IGNORECASE)
 K8S_PODS_NOT_FOUND_PATTERN = re.compile(r'.*(NotFound|pods .* not found).*',
                                         re.IGNORECASE)
 _RAY_CLUSTER_NOT_FOUND_MESSAGE = 'Ray cluster is not found'
@@ -2669,7 +2677,16 @@ def _update_cluster_status(
                                 f'{reset}{bright}sky start {cluster_name}{reset} '
                                 f'{yellow}to recover from INIT status.{reset}')
                             return False
-                        raise e
+                        # Proxied transports (e.g. SSH over SSM) can drop
+                        # momentarily while the instance and ray are fine;
+                        # retry instead of flagging the cluster abnormal.
+                        transient_ssh_failure = (
+                            e.returncode == 255 and
+                            _TRANSIENT_SSH_FAILURE_PATTERN.search(
+                                f'{e.error_msg or ""} '
+                                f'{e.detailed_reason or ""}') is not None)
+                        if not transient_ssh_failure:
+                            raise e
                     # We retry for kubernetes because coreweave can have a
                     # transient network issue.
                     time.sleep(1)

--- a/tests/unit_tests/test_backend_utils_transient_ssh.py
+++ b/tests/unit_tests/test_backend_utils_transient_ssh.py
@@ -1,0 +1,49 @@
+"""Tests for _TRANSIENT_SSH_FAILURE_PATTERN in backend_utils.
+
+The pattern must catch momentary proxy drops (e.g. SSH over SSM) while NOT
+catching 'timed out', which maps to the changed-IP recovery hint on manually
+restarted clusters (_SSH_CONNECTION_TIMED_OUT_PATTERN).
+"""
+from sky.backends.backend_utils import _SSH_CONNECTION_TIMED_OUT_PATTERN
+from sky.backends.backend_utils import _TRANSIENT_SSH_FAILURE_PATTERN
+
+
+class TestTransientSshFailurePattern:
+    """Retryable transport failures vs. genuine failures."""
+
+    def test_ssm_target_not_connected_is_transient(self):
+        # Observed via an SSM ProxyCommand: the agent dropped for a moment
+        # while the instance and ray stayed healthy.
+        stderr = ('An error occurred (TargetNotConnected) when calling the '
+                  'StartSession operation: i-03ec6e6553dd78951 is not '
+                  'connected.')
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is not None
+
+    def test_kex_exchange_is_transient(self):
+        stderr = ('kex_exchange_identification: Connection closed by remote '
+                  'host')
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is not None
+
+    def test_connection_reset_is_transient(self):
+        stderr = 'client_loop: send disconnect: Connection reset by peer'
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is not None
+
+    def test_broken_pipe_is_transient(self):
+        stderr = 'client_loop: send disconnect: Broken pipe'
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is not None
+
+    def test_timed_out_is_not_transient(self):
+        # "timed out" must keep flowing to the changed-IP recovery hint,
+        # not the retry loop.
+        stderr = 'ssh: connect to host 1.2.3.4 port 22: Connection timed out'
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is None
+        assert _SSH_CONNECTION_TIMED_OUT_PATTERN.search(stderr) is not None
+
+    def test_ray_failure_is_not_transient(self):
+        # A real ray-side failure must not be swallowed by the retry loop.
+        output = 'Failed to check ray cluster\'s healthiness.'
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(output) is None
+
+    def test_permission_denied_is_not_transient(self):
+        stderr = 'user@1.2.3.4: Permission denied (publickey).'
+        assert _TRANSIENT_SSH_FAILURE_PATTERN.search(stderr) is None


### PR DESCRIPTION
A single transport-level SSH failure (rc 255) during the ray status health check raises immediately on non-Kubernetes clouds, flagging the cluster `abnormal because ray cluster is unhealthy` even though the instance and ray are fine. With an SSM ProxyCommand this happens in practice: a momentary agent drop surfaces as `An error occurred (TargetNotConnected) when calling the StartSession operation` and the cluster flaps INIT→UP within seconds. Only Kubernetes currently gets retries (added for CoreWeave's transient network issues) — the same class of failure exists on other transports.

Retry rc-255 failures matching known transient transport patterns (`TargetNotConnected`, `kex_exchange_identification`, connection reset/closed, broken pipe) on all clouds, reusing the existing retry loop. `timed out` is deliberately excluded so it keeps signalling a changed IP on manually restarted clusters (the `sky start` recovery hint path); the runtime-not-setup early return is unchanged, and other failures (e.g. `Permission denied`) still raise immediately.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - New `tests/unit_tests/test_backend_utils_transient_ssh.py` pins the pattern contract, including non-match guarantees for `timed out` and `Permission denied`. Observed the INIT flap in a production deployment (2 EC2 clusters in one afternoon; both self-recovered on the next refresh).
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)