### PR TITLE
Avoid Kubernetes rsync hangs over kubectl exec

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -68,6 +68,8 @@ RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 
 _HASH_MAX_LENGTH = 10
 _DEFAULT_CONNECT_TIMEOUT = 30
+_K8S_CAPTURED_EXEC_TIMEOUT = int(
+    os.environ.get('SKYPILOT_K8S_CAPTURED_EXEC_TIMEOUT', '20'))
 
 DEFAULT_SSH_CONTROL_NAME = '__default__'
 
@@ -1688,14 +1690,26 @@ class KubernetesCommandRunner(CommandRunner):
             # immediately at EOF, making it impossible to detect
             # disconnection.
             kwargs.setdefault('stdin', subprocess.PIPE)
-        result = log_lib.run_with_log(' '.join(command),
-                                      log_path,
-                                      require_outputs=require_outputs,
-                                      stream_logs=stream_logs,
-                                      process_stream=process_stream,
-                                      shell=True,
-                                      executable=executable,
-                                      **kwargs)
+        timeout = kwargs.pop('timeout', None)
+        if timeout is None and require_outputs and not stream_logs:
+            timeout = _K8S_CAPTURED_EXEC_TIMEOUT
+
+        try:
+            result = log_lib.run_with_log(' '.join(command),
+                                          log_path,
+                                          require_outputs=require_outputs,
+                                          stream_logs=stream_logs,
+                                          process_stream=process_stream,
+                                          shell=True,
+                                          executable=executable,
+                                          timeout=timeout,
+                                          **kwargs)
+        except subprocess.TimeoutExpired:
+            if require_outputs:
+                stderr = (
+                    f'kubectl exec timed out after {timeout} seconds')
+                return 124, '', stderr
+            raise
         # When `kubectl exec` fails because the target pod is already gone
         # (e.g. it was OOMKilled), the bare kubectl error ("cannot exec into a
         # container in a completed pod") hides the real cause. Enrich stderr

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1706,8 +1706,7 @@ class KubernetesCommandRunner(CommandRunner):
                                           **kwargs)
         except subprocess.TimeoutExpired:
             if require_outputs:
-                stderr = (
-                    f'kubectl exec timed out after {timeout} seconds')
+                stderr = (f'kubectl exec timed out after {timeout} seconds')
                 return 124, '', stderr
             raise
         # When `kubectl exec` fails because the target pod is already gone

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -68,8 +68,6 @@ RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 
 _HASH_MAX_LENGTH = 10
 _DEFAULT_CONNECT_TIMEOUT = 30
-_K8S_CAPTURED_EXEC_TIMEOUT = int(
-    os.environ.get('SKYPILOT_K8S_CAPTURED_EXEC_TIMEOUT', '20'))
 
 DEFAULT_SSH_CONTROL_NAME = '__default__'
 
@@ -1690,25 +1688,14 @@ class KubernetesCommandRunner(CommandRunner):
             # immediately at EOF, making it impossible to detect
             # disconnection.
             kwargs.setdefault('stdin', subprocess.PIPE)
-        timeout = kwargs.pop('timeout', None)
-        if timeout is None and require_outputs and not stream_logs:
-            timeout = _K8S_CAPTURED_EXEC_TIMEOUT
-
-        try:
-            result = log_lib.run_with_log(' '.join(command),
-                                          log_path,
-                                          require_outputs=require_outputs,
-                                          stream_logs=stream_logs,
-                                          process_stream=process_stream,
-                                          shell=True,
-                                          executable=executable,
-                                          timeout=timeout,
-                                          **kwargs)
-        except subprocess.TimeoutExpired:
-            if require_outputs:
-                stderr = (f'kubectl exec timed out after {timeout} seconds')
-                return 124, '', stderr
-            raise
+        result = log_lib.run_with_log(' '.join(command),
+                                      log_path,
+                                      require_outputs=require_outputs,
+                                      stream_logs=stream_logs,
+                                      process_stream=process_stream,
+                                      shell=True,
+                                      executable=executable,
+                                      **kwargs)
         # When `kubectl exec` fails because the target pod is already gone
         # (e.g. it was OOMKilled), the bare kubectl error ("cannot exec into a
         # container in a completed pod") hides the real cause. Enrich stderr

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -1,69 +1,134 @@
 #!/bin/bash
-# We need to determine the pod, namespace and context from the args
-# For backward compatibility, we use + as the separator between namespace and context and add handling when context is not provided
+# SkyPilot rsync remote shell for Kubernetes pods.
+#
+# This local patch avoids a kubectl exec -i EOF deadlock seen with SSH node
+# pools by forwarding pod port 22 and running rsync over real SSH.
+
+set -u
+
+url_decode() {
+    echo "$1" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g'
+}
+
 if [ "$1" = "-l" ]; then
-    # -l pod namespace+context ...
-    # used by normal rsync
     shift
     pod=$1
     shift
     encoded_namespace_context=$1
-    shift # Shift past the encoded namespace+context
+    shift
     echo "pod: $pod" >&2
-    # Revert the encoded namespace+context to the original string.
-    namespace_context=$(echo "$encoded_namespace_context" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
+    namespace_context=$(url_decode "$encoded_namespace_context")
     echo "namespace_context: $namespace_context" >&2
 else
-    # pod@namespace+context ...
-    # used by openrsync
     encoded_pod_namespace_context=$1
-    shift # Shift past the pod@namespace+context
-    pod_namespace_context=$(echo "$encoded_pod_namespace_context" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
+    shift
+    pod_namespace_context=$(url_decode "$encoded_pod_namespace_context")
     echo "pod_namespace_context: $pod_namespace_context" >&2
-    pod=$(echo $pod_namespace_context | cut -d@ -f1)
+    pod=$(echo "$pod_namespace_context" | cut -d@ -f1)
     echo "pod: $pod" >&2
-    namespace_context=$(echo $pod_namespace_context | cut -d@ -f2-)
+    namespace_context=$(echo "$pod_namespace_context" | cut -d@ -f2-)
     echo "namespace_context: $namespace_context" >&2
 fi
 
-namespace=$(echo $namespace_context | cut -d+ -f1)
+namespace=$(echo "$namespace_context" | cut -d+ -f1)
 echo "namespace: $namespace" >&2
-context=$(echo $namespace_context | grep '+' >/dev/null && echo $namespace_context | cut -d+ -f2- || echo "")
+context=$(echo "$namespace_context" | grep '+' >/dev/null && echo "$namespace_context" | cut -d+ -f2- || echo "")
 echo "context: $context" >&2
 context_lower=$(echo "$context" | tr '[:upper:]' '[:lower:]')
 container="${SKYPILOT_K8S_EXEC_CONTAINER:-ray-node}"
 echo "container: $container" >&2
 
-# Check if the resource is a pod or a deployment (or other type)
 if [[ "$pod" == *"/"* ]]; then
-    # Format is resource_type/resource_name
     echo "Resource contains type: $pod" >&2
-    resource_type=$(echo $pod | cut -d/ -f1)
-    resource_name=$(echo $pod | cut -d/ -f2)
+    resource_type=$(echo "$pod" | cut -d/ -f1)
+    resource_name=$(echo "$pod" | cut -d/ -f2)
     echo "Resource type: $resource_type, Resource name: $resource_name" >&2
 else
-    # For backward compatibility or simple pod name, assume it's a pod
     resource_type="pod"
     resource_name=$pod
     echo "Assuming resource is a pod: $resource_name" >&2
 fi
 
-if [ -z "$context" ] || [ "$context_lower" = "none" ]; then
-    # If context is none, it means we are using incluster auth. In this case,
-    # we need to set KUBECONFIG to /dev/null to avoid using kubeconfig file.
-    kubectl_cmd_base="kubectl exec \"$resource_type/$resource_name\" -n \"$namespace\" -c \"$container\" --kubeconfig=/dev/null --"
-else
-    kubectl_cmd_base="kubectl exec \"$resource_type/$resource_name\" -n \"$namespace\" -c \"$container\" --context=\"$context\" --"
+sky_key="${SKYPILOT_SSH_KEY:-}"
+if [ -z "$sky_key" ]; then
+    for candidate in "$HOME"/.sky/clients/*/ssh/sky-key; do
+        if [ -f "$candidate" ]; then
+            sky_key="$candidate"
+            break
+        fi
+    done
 fi
+if [ -z "$sky_key" ] || [ ! -f "$sky_key" ]; then
+    echo "Could not find SkyPilot SSH key. Set SKYPILOT_SSH_KEY to the pod SSH private key." >&2
+    exit 1
+fi
+chmod 600 "$sky_key" 2>/dev/null || true
+echo "ssh_key: $sky_key" >&2
 
-# Execute command on remote pod, waiting for rsync to be available first.
-# The waiting happens on the remote pod, not locally, which is more efficient
-# and reliable than polling from the local machine.
-# We wrap the command in a bash script that waits for rsync, then execs the original command.
-# Timeout after MAX_WAIT_TIME_SECONDS seconds.
+pick_port() {
+    base=$((20000 + ($$ % 20000)))
+    i=0
+    while [ "$i" -lt 200 ]; do
+        port=$((base + i))
+        if ! nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+            echo "$port"
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+local_port=$(pick_port) || {
+    echo "Could not find a free local port for kubectl port-forward." >&2
+    exit 1
+}
+
+pf_log="${TMPDIR:-/tmp}/skypilot-rsync-port-forward-${resource_name}-${local_port}.log"
+if [ -z "$context" ] || [ "$context_lower" = "none" ]; then
+    kubectl port-forward "$resource_type/$resource_name" -n "$namespace" --kubeconfig=/dev/null --address 127.0.0.1 "${local_port}:22" >"$pf_log" 2>&1 &
+else
+    kubectl port-forward "$resource_type/$resource_name" -n "$namespace" --context="$context" --address 127.0.0.1 "${local_port}:22" >"$pf_log" 2>&1 &
+fi
+pf_pid=$!
+
+cleanup() {
+    kill "$pf_pid" >/dev/null 2>&1 || true
+    wait "$pf_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+count=0
+max_count=600
+until nc -z 127.0.0.1 "$local_port" >/dev/null 2>&1; do
+    if ! kill -0 "$pf_pid" >/dev/null 2>&1; then
+        echo "kubectl port-forward exited before port ${local_port} became ready." >&2
+        cat "$pf_log" >&2 2>/dev/null || true
+        exit 1
+    fi
+    if [ "$count" -ge "$max_count" ]; then
+        echo "Timed out waiting for kubectl port-forward to pod SSH port 22." >&2
+        cat "$pf_log" >&2 2>/dev/null || true
+        exit 1
+    fi
+    sleep 0.5
+    count=$((count + 1))
+done
+
+ssh_opts=(
+    -p "$local_port"
+    -i "$sky_key"
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o IdentitiesOnly=yes
+    -o LogLevel=ERROR
+    -o ConnectTimeout=5
+)
+
 MAX_WAIT_TIME_SECONDS=300
 MAX_WAIT_COUNT=$((MAX_WAIT_TIME_SECONDS * 2))
-# Use --norc --noprofile to prevent bash from sourcing startup files that might
-# output to stdout and corrupt the rsync protocol. All debug output must go to
-# stderr (>&2) to keep stdout clean for rsync communication.
-eval "${kubectl_cmd_base% --} -i -- bash --norc --noprofile -c 'count=0; until which rsync >/dev/null 2>&1; do if [ \$count -ge $MAX_WAIT_COUNT ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); done; exec \"\$@\"' -- \"\$@\""
+
+exec ssh "${ssh_opts[@]}" sky@127.0.0.1 \
+    bash --norc --noprofile -c \
+    'count=0; until which rsync >/dev/null 2>&1; do if [ "$count" -ge '"$MAX_WAIT_COUNT"' ]; then echo "Error when trying to rsync files to kubernetes cluster. Package installation may have failed." >&2; exit 1; fi; sleep 0.5; count=$((count+1)); done; exec "$@"' \
+    -- "$@"

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -51,7 +51,7 @@ fi
 
 sky_key="${SKYPILOT_SSH_KEY:-}"
 if [ -z "$sky_key" ]; then
-    for candidate in "$HOME"/.sky/clients/*/ssh/sky-key; do
+    for candidate in "${HOME:-}"/.sky/clients/*/ssh/sky-key; do
         if [ -f "$candidate" ]; then
             sky_key="$candidate"
             break

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -130,5 +130,5 @@ MAX_WAIT_COUNT=$((MAX_WAIT_TIME_SECONDS * 2))
 
 exec ssh "${ssh_opts[@]}" sky@127.0.0.1 \
     bash --norc --noprofile -c \
-    'count=0; until which rsync >/dev/null 2>&1; do if [ "$count" -ge '"$MAX_WAIT_COUNT"' ]; then echo "Error when trying to rsync files to kubernetes cluster. Package installation may have failed." >&2; exit 1; fi; sleep 0.5; count=$((count+1)); done; exec "$@"' \
+    'count=0; until command -v rsync >/dev/null 2>&1; do if [ "$count" -ge '"$MAX_WAIT_COUNT"' ]; then echo "Error when trying to rsync files to kubernetes cluster. Package installation may have failed." >&2; exit 1; fi; sleep 0.5; count=$((count+1)); done; exec "$@"' \
     -- "$@"

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -6,6 +6,10 @@
 
 set -u
 
+if ! command -v nc >/dev/null 2>&1; then
+    echo "Error: netcat (nc) is required but not installed." >&2
+    exit 1
+fi
 url_decode() {
     echo "$1" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g'
 }

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -88,19 +88,24 @@ local_port=$(pick_port) || {
     exit 1
 }
 
+pf_pid=""
 pf_log="${TMPDIR:-/tmp}/skypilot-rsync-port-forward-${resource_name}-${local_port}.log"
+
+cleanup() {
+    if [ -n "$pf_pid" ]; then
+        kill "$pf_pid" >/dev/null 2>&1 || true
+        wait "$pf_pid" >/dev/null 2>&1 || true
+    fi
+    rm -f "$pf_log" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
 if [ -z "$context" ] || [ "$context_lower" = "none" ]; then
     kubectl port-forward "$resource_type/$resource_name" -n "$namespace" --kubeconfig=/dev/null --address 127.0.0.1 "${local_port}:22" >"$pf_log" 2>&1 &
 else
     kubectl port-forward "$resource_type/$resource_name" -n "$namespace" --context="$context" --address 127.0.0.1 "${local_port}:22" >"$pf_log" 2>&1 &
 fi
 pf_pid=$!
-
-cleanup() {
-    kill "$pf_pid" >/dev/null 2>&1 || true
-    wait "$pf_pid" >/dev/null 2>&1 || true
-}
-trap cleanup EXIT INT TERM
 
 count=0
 max_count=600

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -11,7 +11,7 @@ if ! command -v nc >/dev/null 2>&1; then
     exit 1
 fi
 url_decode() {
-    echo "$1" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g'
+    printf '%s\n' "$1" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g'
 }
 
 if [ "$1" = "-l" ]; then


### PR DESCRIPTION
## Summary

This changes Kubernetes file sync to avoid the `rsync -> kubectl exec -i -> remote rsync` transport path.

On a real SSH node pool backed by k3s, the file transfer can complete successfully, but the `kubectl exec -i` stream may not deliver EOF back to the local rsync process. That leaves `sky launch` stuck while preparing the runtime.

The helper now:

- preserves the existing pod / namespace / context parsing behavior
- opens a short-lived `kubectl port-forward` to the SkyPilot pod SSH port
- runs the rsync server over SSH to `sky@127.0.0.1`
- waits for remote `rsync` before executing the original rsync server argv
- cleans up the port-forward process and temporary log on exit
- reports port-forward startup failures with the captured kubectl log

## Validation

Tested locally on an SSH node pool backed by k3s:

- SkyPilot: `0.12.3.post1`
- infra: `ssh/my-pool`
- Kubernetes context: `ssh-my-pool`
- Kubernetes: `v1.36.2+k3s1`
- GPU: `NVIDIA GeForce RTX 5090`

Reproduced before the patch:

- standalone rsync copied files but hung after transfer completion
- `sky launch` got stuck during runtime preparation

Verified after patching the installed helper:

```bash
sky launch -c sky-test --infra ssh/my-pool --gpus RTX5090:1 -y -- 'hostname && nvidia-smi'
```

The launch completed and printed the RTX 5090 from `nvidia-smi`.

Local syntax check:

```bash
bash -n sky/utils/kubernetes/rsync_helper.sh
```

## Test plan

- [x] Manual SSH node pool launch on real k3s node
- [x] GPU launch/job: `hostname && nvidia-smi`
- [x] Shell syntax check for `rsync_helper.sh`
- [ ] Unit/smoke tests