### PR TITLE
[Kubernetes] Support use_spot on Karpenter clusters

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -833,7 +833,12 @@ class Kubernetes(clouds.Cloud):
         # Configure spot labels, if requested and supported
         spot_label_key, spot_label_value = None, None
         if resources.use_spot:
-            spot_label_key, spot_label_value = kubernetes_utils.get_spot_label()
+            # Pass the provisioning context so get_spot_label() can resolve the
+            # autoscaler type per-context. Without it, only a global
+            # kubernetes.autoscaler setting is honored, and per-context configs
+            # (context_configs.<ctx>.autoscaler) never inject the spot label.
+            spot_label_key, spot_label_value = kubernetes_utils.get_spot_label(
+                context)
 
         network_type, metadata = self._detect_network_type(
             context, resources.network_tier, k8s_acc_label_key,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -4116,7 +4116,12 @@ def get_custom_config_k8s_contexts() -> List[str]:
 # corresponding spot label key and value.
 SPOT_LABEL_MAP = {
     kubernetes_enums.KubernetesAutoscalerType.GKE.value:
-        ('cloud.google.com/gke-spot', 'true')
+        ('cloud.google.com/gke-spot', 'true'),
+    # Karpenter satisfies a pod's capacity-type node requirement by choosing the
+    # capacity type, so a `karpenter.sh/capacity-type: spot` node selector routes
+    # the pod to a spot NodePool.
+    kubernetes_enums.KubernetesAutoscalerType.KARPENTER.value:
+        ('karpenter.sh/capacity-type', 'spot'),
 }
 
 
@@ -4157,10 +4162,11 @@ def get_spot_label(
                     key] == value:
                 return key, value
 
-    # Check if autoscaler is configured. Allow spot instances if autoscaler type
-    # is known to support spot instances.
+    # Check if autoscaler is configured. Allow spot instances if the autoscaler
+    # type is known to support them (i.e. has an entry in SPOT_LABEL_MAP).
     autoscaler_type = get_autoscaler_type(context=context)
-    if autoscaler_type == kubernetes_enums.KubernetesAutoscalerType.GKE:
+    if (autoscaler_type is not None and
+            autoscaler_type.value in SPOT_LABEL_MAP):
         return SPOT_LABEL_MAP[autoscaler_type.value]
 
     return None, None

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5269,3 +5269,30 @@ def test_diagnose_terminated_pod_substitutes_dashboard_url_token(monkeypatch):
     assert msg is not None
     assert '{dashboard_url}' not in msg
     assert 'the SkyPilot dashboard infra page' in msg
+
+
+def test_get_spot_label_karpenter():
+    """use_spot on a Karpenter context maps to karpenter.sh/capacity-type."""
+    kat = utils.kubernetes_enums.KubernetesAutoscalerType
+    with mock.patch.object(utils, 'get_kubernetes_nodes', return_value=[]), \
+         mock.patch.object(utils, 'get_autoscaler_type',
+                           return_value=kat.KARPENTER):
+        assert utils.get_spot_label('ctx') == ('karpenter.sh/capacity-type',
+                                               'spot')
+
+
+def test_get_spot_label_gke_unchanged():
+    """GKE spot label is unchanged by the Karpenter addition."""
+    kat = utils.kubernetes_enums.KubernetesAutoscalerType
+    with mock.patch.object(utils, 'get_kubernetes_nodes', return_value=[]), \
+         mock.patch.object(utils, 'get_autoscaler_type',
+                           return_value=kat.GKE):
+        assert utils.get_spot_label('ctx') == ('cloud.google.com/gke-spot',
+                                               'true')
+
+
+def test_get_spot_label_none_without_known_autoscaler():
+    """No autoscaler (or one without a known spot label) -> no spot label."""
+    with mock.patch.object(utils, 'get_kubernetes_nodes', return_value=[]), \
+         mock.patch.object(utils, 'get_autoscaler_type', return_value=None):
+        assert utils.get_spot_label('ctx') == (None, None)

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4194,5 +4194,103 @@ class TestKubernetesRemoteIdentityFnmatch(unittest.TestCase):
         self.assertEqual(result, 'numeric-sa')
 
 
+class TestKubernetesSpotLabelContext(unittest.TestCase):
+    """Regression test for TICKET-034.
+
+    make_deploy_resources_variables must pass the provisioning context to
+    get_spot_label(). get_spot_label resolves the autoscaler type per-context
+    (get_effective_region_config keyed on the context name), so without the
+    context argument only a *global* kubernetes.autoscaler is honored and a
+    per-context setting (context_configs.<ctx>.autoscaler: karpenter) never
+    injects the spot node label. This test fails if the call site drops the
+    context (the original bug: get_spot_label() with no args).
+    """
+
+    def setUp(self):
+        self.resources = mock.MagicMock()
+        self.resources.instance_type = "2CPU--4GB"
+        self.resources.accelerators = None
+        self.resources.use_spot = True
+        self.resources.region = "test-context"
+        self.resources.zone = None
+        self.resources.cluster_config_overrides = {}
+        self.resources.image_id = None
+        setattr(self.resources, 'assert_launchable', lambda: self.resources)
+        self.resources.network_tier = resources_utils.NetworkTier.BEST
+        self.cluster_name = "test-cluster"
+        self.region = mock.MagicMock()
+        self.region.name = "test-context"
+
+    @patch('sky.provision.kubernetes.utils.get_spot_label')
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_spot_label_uses_provisioning_context(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_cloud_config_value,
+            mock_is_exec_auth, mock_get_accelerator_label_keys,
+            mock_get_namespace, mock_get_current_context, mock_get_k8s_nodes,
+            mock_get_spot_label):
+        mock_cluster_type = mock.MagicMock()
+        mock_cluster_type.supports_high_performance_networking.return_value = (
+            False)
+        mock_cluster_type.requires_ipc_lock_capability.return_value = False
+        mock_detect_network_type.return_value = (mock_cluster_type, None)
+
+        mock_get_current_context.return_value = "test-context"
+        mock_get_namespace.return_value = "default"
+        mock_get_accelerator_label_keys.return_value = []
+        mock_get_workspace_cloud.return_value.get.return_value = None
+        mock_is_exec_auth.return_value = (False, None)
+        mock_get_cloud_config_value.side_effect = (
+            lambda cloud, keys, region, default_value=None, override_configs=
+            None: {
+                ('kubernetes', 'remote_identity'): 'SERVICE_ACCOUNT',
+                ('kubernetes', 'provision_timeout'): 10,
+                ('kubernetes', 'high_availability', 'storage_class_name'): None,
+            }.get((cloud,) + keys, default_value))
+        mock_port_mode = mock.MagicMock()
+        mock_port_mode.value = "portforward"
+        mock_get_port_mode.return_value = mock_port_mode
+        mock_get_image.return_value = "test-image:latest"
+        # Simulate a Karpenter context: get_spot_label returns the label only
+        # when it can resolve the (per-context) autoscaler.
+        mock_get_spot_label.return_value = ('karpenter.sh/capacity-type',
+                                            'spot')
+
+        k8s_cloud = kubernetes.Kubernetes()
+        deploy_vars = k8s_cloud.make_deploy_resources_variables(
+            resources=self.resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name=self.cluster_name,
+                name_on_cloud=self.cluster_name),
+            region=self.region,
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        # The heart of the regression: NO call to get_spot_label may drop the
+        # provisioning context. get_spot_label runs at more than one site during
+        # deploy-var construction; every one must forward the context, or the
+        # per-context autoscaler config is silently ignored. A bare call()
+        # (the original bug) must never appear.
+        self.assertGreaterEqual(mock_get_spot_label.call_count, 1)
+        self.assertNotIn(mock.call(), mock_get_spot_label.call_args_list)
+        for call_args in mock_get_spot_label.call_args_list:
+            self.assertEqual(call_args, mock.call('test-context'))
+        # ...and the resolved label must flow into the pod template vars.
+        self.assertEqual(deploy_vars['k8s_spot_label_key'],
+                         'karpenter.sh/capacity-type')
+        self.assertEqual(deploy_vars['k8s_spot_label_value'], 'spot')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
get_spot_label only knew about GKE, so `use_spot: true` on a Karpenter autoscaler context was silently unsupported: no spot node selector was added and the feasibility check marked SPOT_INSTANCE unsupported, so a spot NodePool never received a pod.

Add karpenter.sh/capacity-type=spot to SPOT_LABEL_MAP and generalize the autoscaler branch to return the label for any autoscaler with a known entry (GKE + Karpenter). Karpenter satisfies a pod's capacity-type node requirement by provisioning a spot node from a NodePool that allows capacity-type: spot; no custom taint or per-job YAML is needed.

Adds unit tests for get_spot_label (karpenter / gke / none).

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

Fixes: #10038 10038
