### PR TITLE
[Test] Fix positional NAME match in managed-jobs num-jobs test

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -251,13 +251,19 @@ def test_managed_jobs_num_jobs_without_pool(generic_cloud: str):
             '! echo "$s" | grep -- "--pool None"; '
             '! echo "$s" | grep "value=None"; '
             '! echo "$s" | grep "in the pool"')
-        # Resolve the num_jobs job IDs by name (col 2 or 3 of `sky jobs queue`).
+        # Resolve the num_jobs job IDs by name. `sky jobs queue` renders a
+        # variable number of leading columns before NAME: the TASK column can be
+        # empty and a WORKSPACE column is added whenever the listed jobs span
+        # more than one workspace (always the case with --all), so NAME is not at
+        # a fixed column index. Match the name in any column and print the ID
+        # (always the first column).
         # Use --all: on a shared server the default queue is truncated to the
         # latest 50 jobs, so the just-launched jobs can fall outside the window
         # and the name lookup finds 0.
         capture_ids_cmd = (
             's=$(sky jobs queue --all); echo "$s"; echo "$s" | '
-            'awk -v n=' + name + ' \'($2==n)||($3==n){print $1}\' | '
+            'awk -v n=' + name +
+            ' \'{for (i=1; i<=NF; i++) if ($i==n) {print $1; break}}\' | '
             f'sort -un > {ids_file}; cat {ids_file}; '
             f'cnt=$(wc -l < {ids_file}); '
             f'if [ "$cnt" -ne {num_jobs} ]; then '


### PR DESCRIPTION
## Summary

`test_managed_jobs_num_jobs_without_pool` resolves the launched job IDs by parsing `sky jobs queue --all` with `awk '$2 == <name> || $3 == <name>'`, assuming the job NAME sits in a fixed column. It doesn't — the queue renders a **variable number of leading columns** before NAME:

- the `TASK` column can be empty, and
- a `WORKSPACE` column is added whenever the listed jobs span more than one workspace, which is **always the case with `--all`** (`--all` forces `show_all`, and `show_workspace = len(workspaces) > 1 or show_all`).

Either of these shifts NAME past column 3, so the awk matches nothing and the test fails with `Expected N jobs named <name>, found 0` even though the jobs launched correctly and appear in the queue.

This is the same class of bug fixed for the shared status-wait helper in #10007 (commit e31cc715d2d3ae373d8d315aba0757fb45f6c407); that change did not cover this inline command in `test_managed_jobs_num_jobs_without_pool`.

The fix matches the name in **any** column and prints the ID (always the first column), so the lookup works regardless of which leading columns the queue renders.

## Tested

Test-only change; the awk is exercised via a shell command string. I reproduced the column shift locally by piping a `sky jobs queue` table through both awk forms:

- **With a `WORKSPACE` column present** (NAME in column 4, the `--all` layout): old `awk '($2==n)||($3==n){print $1}'` → **0** matches (the bug); new `awk '{for (i=1;i<=NF;i++) if ($i==n) {print $1; break}}'` → **2** matches (correct IDs).
- **Without a `WORKSPACE` column** (NAME in column 3, single-workspace layout): new awk → **2** matches (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)