### PR TITLE
[Jobs] Retry transient cluster-status errors in controller monitor loop

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1096,9 +1096,18 @@ class JobController:
                         force_refresh_statuses=set(status_lib.ClusterStatus)))
             except exceptions.ClusterStatusFetchingError as e:
                 # The refresh kept failing after retries. Treat it as a
-                # transient condition and back off, reusing the same window as
-                # a transient job-status check error so a sustained outage
-                # still surfaces cleanly once the total timeout is exceeded.
+                # transient condition and back off, reusing the transient
+                # job-status-check window. Sharing the window (rather than
+                # keeping a separate one for this handler) is deliberate: a
+                # successful get_job_status resets it, so while the job-status
+                # probe keeps returning a healthy status -- a direct positive
+                # liveness signal -- the loop keeps retrying instead of
+                # escalating. Restarting a demonstrably running job is exactly
+                # the false alarm this handler exists to prevent, and recovery
+                # could not relaunch anyway while the provider API is
+                # unreachable. Only when both get_job_status and this refresh
+                # keep failing for JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS is
+                # the error re-raised, escalating to emergency recovery.
                 if transient_job_check_error_start_time is None:
                     transient_job_check_error_start_time = time.time()
                     job_check_backoff = common_utils.Backoff(

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -44,6 +44,7 @@ from sky.server import plugins
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.usage import usage_lib
+from sky.utils import cloud_api_retries
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import context
@@ -1079,10 +1080,49 @@ class JobController:
             # depending on the cloud, which can also cause failure of the job.
             # Plugins can report such failures via ExternalFailureSource.
             # TODO(cooperc): do we need to add this to asyncio thread?
-            (cluster_status, handle) = await asyncio.to_thread(
-                backend_utils.refresh_cluster_status_handle,
-                cluster_name,
-                force_refresh_statuses=set(status_lib.ClusterStatus))
+            # A transient provider-API error (e.g. an HTTP 503 from the
+            # Kubernetes API server) during this refresh raises
+            # ClusterStatusFetchingError. Retry it a few times so a momentary
+            # blip is absorbed transparently; if it still fails, fall through
+            # to the transient-error handling below and retry on the next
+            # iteration rather than escalating to run()'s unexpected-error
+            # handling (emergency recovery), which would tear down and
+            # relaunch a healthy cluster.
+            try:
+                (cluster_status, handle) = await asyncio.to_thread(
+                    cloud_api_retries.with_cloud_api_retries,
+                    lambda: backend_utils.refresh_cluster_status_handle(
+                        cluster_name,
+                        force_refresh_statuses=set(status_lib.ClusterStatus)))
+            except exceptions.ClusterStatusFetchingError as e:
+                # The refresh kept failing after retries. Treat it as a
+                # transient condition and back off, reusing the same window as
+                # a transient job-status check error so a sustained outage
+                # still surfaces cleanly once the total timeout is exceeded.
+                if transient_job_check_error_start_time is None:
+                    transient_job_check_error_start_time = time.time()
+                    job_check_backoff = common_utils.Backoff(
+                        initial_backoff=1, max_backoff_factor=5)
+                elapsed = time.time() - transient_job_check_error_start_time
+                timeout = (
+                    managed_job_utils.JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS)
+                if elapsed >= timeout:
+                    logger.error(
+                        'Failed to refresh cluster status after retrying for '
+                        f'{elapsed:.1f} seconds: '
+                        f'{common_utils.format_exception(e)}')
+                    raise
+                assert job_check_backoff is not None, (
+                    transient_job_check_error_start_time, job_check_backoff)
+                backoff_time = min(job_check_backoff.current_backoff(),
+                                   timeout - elapsed)
+                logger.info(
+                    'Failed to refresh cluster status, likely due to a '
+                    'transient provider API error. Retrying to avoid a false '
+                    f'alarm for job failure. Retrying in {backoff_time:.1f} '
+                    f'seconds: {common_utils.format_exception(e)}')
+                await asyncio.sleep(backoff_time)
+                continue
 
             external_failures: Optional[List[ExternalClusterFailure]] = None
             cluster_event_reason = None

--- a/sky/utils/cloud_api_retries.py
+++ b/sky/utils/cloud_api_retries.py
@@ -1,0 +1,84 @@
+"""Retry helpers for transient cloud-provider API errors.
+
+Long-running SkyPilot processes (notably the managed-jobs controller
+monitor loop) poll cloud-provider APIs on a routine schedule to refresh
+cluster status. A brief provider-side blip -- for example an HTTP 503
+``ServiceUnavailable`` from the Kubernetes API server, or a momentary
+network error -- surfaces as ``sky.exceptions.ClusterStatusFetchingError``.
+Without a retry, that transient error propagates to the controller
+catch-all, which tears down and relaunches a perfectly healthy job
+(emergency recovery).
+
+Wrap such a call site with ``with_cloud_api_retries``. It retries on
+``ClusterStatusFetchingError`` with exponential backoff so a momentary
+outage is absorbed transparently; a sustained outage still raises after
+the retry budget is exhausted, so the caller can decide how to surface it.
+
+This is deliberately separate from ``sky.utils.db.retries`` -- a provider
+API 503 is not a database error, and the two have different retryable
+exception sets.
+"""
+
+import logging
+import time
+from typing import Callable, Tuple, Type, TypeVar
+
+from sky import exceptions
+from sky.utils import common_utils
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+# ``ClusterStatusFetchingError`` is raised by
+# ``backend_utils.refresh_cluster_status_handle`` whenever the provider
+# status query fails -- it wraps the underlying transient provider error
+# (e.g. a Kubernetes ``ApiException`` with HTTP 503).
+RETRYABLE_EXCEPTIONS: Tuple[Type[BaseException],
+                            ...] = (exceptions.ClusterStatusFetchingError,)
+
+# 5 attempts x exp backoff capped at 5s ~= 10s of backoff sleeps -- covers
+# typical brief provider blips (a 503 spike, a short API-server rollout).
+# Sustained outages still raise after the budget is exhausted.
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_INITIAL_BACKOFF = 1.0
+_DEFAULT_MAX_BACKOFF_FACTOR = 5  # cap = 1.0 * 5 = 5s
+
+
+def summarize(e: BaseException) -> str:
+    """One-line exception summary."""
+    return f'{type(e).__name__}: {str(e).splitlines()[0] if str(e) else ""}'
+
+
+def with_cloud_api_retries(fn: Callable[[], T],
+                           max_retries: int = _DEFAULT_MAX_RETRIES) -> T:
+    """Run ``fn()`` with retry/backoff on transient cloud-provider API errors.
+
+    ``fn`` must be idempotent (a status read is). On a retryable error the
+    call is retried up to ``max_retries`` times with exponential backoff; if
+    the last attempt still fails, the exception is re-raised.
+    """
+    if max_retries < 1:
+        raise ValueError(
+            f'max_retries must be greater than 0, got {max_retries}')
+    backoff = common_utils.Backoff(
+        initial_backoff=_DEFAULT_INITIAL_BACKOFF,
+        max_backoff_factor=_DEFAULT_MAX_BACKOFF_FACTOR)
+    for attempt in range(max_retries):
+        try:
+            result = fn()
+            if attempt > 0:
+                logger.info('Transient cloud-provider API error recovered '
+                            f'after {attempt} retries.')
+            return result
+        except RETRYABLE_EXCEPTIONS as e:
+            if attempt == max_retries - 1:
+                logger.error('Transient cloud-provider API error: giving up '
+                             f'after {max_retries} attempts; {summarize(e)}')
+                raise
+            delay = backoff.current_backoff()
+            logger.warning('Transient cloud-provider API error (attempt '
+                           f'{attempt + 1}/{max_retries}), retrying in '
+                           f'{delay:.1f}s: {summarize(e)}')
+            time.sleep(delay)
+    raise AssertionError('with_cloud_api_retries: unreachable')

--- a/tests/unit_tests/test_sky/utils/test_cloud_api_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_cloud_api_retries.py
@@ -1,0 +1,81 @@
+"""Unit tests for sky.utils.cloud_api_retries."""
+# pylint: disable=missing-class-docstring,protected-access
+from unittest import mock
+
+import pytest
+
+from sky import exceptions
+from sky.utils import cloud_api_retries
+
+
+def _fetch_error(
+    msg: str = 'Failed to query kubernetes cluster status: '
+    '(503) Reason: Service Unavailable'
+) -> exceptions.ClusterStatusFetchingError:
+    return exceptions.ClusterStatusFetchingError(msg)
+
+
+class TestWithCloudApiRetries:
+
+    def test_returns_immediately_on_success(self):
+        fn = mock.Mock(return_value=('UP', 'handle'))
+        with mock.patch.object(cloud_api_retries.time, 'sleep') as sleep:
+            assert cloud_api_retries.with_cloud_api_retries(fn) == ('UP',
+                                                                    'handle')
+        fn.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_succeeds_after_transient_failures(self):
+        # Fail with a transient 503 four times, then succeed on the fifth
+        # attempt (the default budget). The healthy status must be returned
+        # and the transient error must NOT propagate -- i.e. it never reaches
+        # the controller catch-all that would emergency-recover the job.
+        fn = mock.Mock(side_effect=[
+            _fetch_error(),
+            _fetch_error(),
+            _fetch_error(),
+            _fetch_error(),
+            ('UP', 'handle'),
+        ])
+        with mock.patch.object(cloud_api_retries.time, 'sleep') as sleep:
+            assert cloud_api_retries.with_cloud_api_retries(fn) == ('UP',
+                                                                    'handle')
+        assert fn.call_count == 5
+        assert sleep.call_count == 4
+
+    def test_raises_after_exhausting_retries(self):
+        # A sustained outage still surfaces the error once the retry budget
+        # is exhausted, so the caller can decide how to handle it.
+        fn = mock.Mock(side_effect=_fetch_error())
+        with mock.patch.object(cloud_api_retries.time, 'sleep'):
+            with pytest.raises(exceptions.ClusterStatusFetchingError):
+                cloud_api_retries.with_cloud_api_retries(fn)
+        assert fn.call_count == cloud_api_retries._DEFAULT_MAX_RETRIES
+
+    def test_respects_custom_max_retries(self):
+        fn = mock.Mock(side_effect=[_fetch_error(), ('UP', 'handle')])
+        with mock.patch.object(cloud_api_retries.time, 'sleep'):
+            assert cloud_api_retries.with_cloud_api_retries(
+                fn, max_retries=2) == ('UP', 'handle')
+        assert fn.call_count == 2
+
+    def test_does_not_retry_non_retryable(self):
+        # A genuine bug (e.g. a ValueError) must not be retried or swallowed.
+        fn = mock.Mock(side_effect=ValueError('not retryable'))
+        with mock.patch.object(cloud_api_retries.time, 'sleep') as sleep:
+            with pytest.raises(ValueError, match='not retryable'):
+                cloud_api_retries.with_cloud_api_retries(fn)
+        fn.assert_called_once()
+        sleep.assert_not_called()
+
+    @pytest.mark.parametrize('bad_max_retries', [0, -1, -100])
+    def test_invalid_max_retries(self, bad_max_retries):
+        with pytest.raises(ValueError, match='max_retries must be'):
+            cloud_api_retries.with_cloud_api_retries(
+                mock.Mock(), max_retries=bad_max_retries)
+
+    def test_summarize_single_line(self):
+        e = _fetch_error('line one\nline two')
+        summary = cloud_api_retries.summarize(e)
+        assert summary == 'ClusterStatusFetchingError: line one'
+        assert '\n' not in summary


### PR DESCRIPTION
## Summary

The managed-jobs controller monitor loop (`_monitor_one_task` in `sky/jobs/controller.py`) refreshes cluster status on every poll iteration via `backend_utils.refresh_cluster_status_handle`. A brief cloud-provider API blip during that refresh — for example an HTTP 503 `ServiceUnavailable` from the Kubernetes API server, or a momentary network drop on the path to the provider API — surfaces as `exceptions.ClusterStatusFetchingError`. That call site was **not** wrapped in a `try/except`, so the error propagated to `run()`'s catch-all and triggered emergency recovery on a perfectly healthy job: the cluster is torn down and relaunched from scratch, and the job restarts. One failed 5s status poll should not cost a multi-node job a full restart.

This is the cloud-provider-API twin of the transient-DB-error handling added in #9748 ("[Jobs] Retry transient DB errors in controller monitor loop and cleanup"): the same "a momentary blip must not kill a healthy job" property, for the provider-API path instead of the DB path.

## Root cause

1. On each poll, `_monitor_one_task` calls `managed_job_utils.get_job_status()`. For multi-node jobs, even a healthy non-terminal job status falls through to check the actual cluster status (partial preemptions/node failures may not fail the user program immediately). A transient error in `get_job_status` itself is also recognized as a *potential transient error* and likewise falls through to the cluster-status check.
2. That check calls `backend_utils.refresh_cluster_status_handle(cluster_name, force_refresh_statuses=set(status_lib.ClusterStatus))`.
3. If the provider status query fails there — e.g. the underlying `list_namespaced_pod` hits a network error and urllib3 exhausts its socket-level retries inside the client timeout — `backend_utils` wraps it in `exceptions.ClusterStatusFetchingError`. Nothing in `_monitor_one_task` caught it, so it propagated to `run()`'s broad `except (Exception, SystemExit)` → "Unexpected controller error" → emergency recovery: best-effort teardown of the (healthy) cluster, backoff, relaunch. After the emergency-recovery budget is exhausted, the job is marked `FAILED_CONTROLLER`.
4. Contrast: when the refresh instead *returns* a non-`UP` status, the loop routes into the normal preemption-recovery path. So a transient *failure to fetch* the cluster status should be retried / treated as transient — not escalated as an unexpected controller error.

Note there is no application-level retry anywhere on this path: the Kubernetes client's own retries operate at the socket level and exhaust within seconds, so any blip longer than that (but far shorter than a real outage) escapes as `ClusterStatusFetchingError`.

## Change

- Add `sky/utils/cloud_api_retries.py`: a thin retry wrapper built on the existing `common_utils.Backoff` (no new deps), scoped to `ClusterStatusFetchingError`. It is deliberately separate from `sky/utils/db/retries.py` — a provider API 503 is not a DB error, and the two have different retryable exception sets.
- Wrap the `refresh_cluster_status_handle` call in `_monitor_one_task` with it (5 attempts, exponential backoff capped at 5s) so a momentary blip is absorbed transparently.
- If the refresh still fails after the retry budget, treat it as a transient condition and back off + `continue` on the next loop iteration, reusing the existing transient-job-status-check window (`JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS`). A **sustained** outage that also breaks the job-status probe still escalates once the total timeout is exceeded; as long as `get_job_status` keeps returning a healthy status (i.e. we have a direct positive signal the job is alive and only the provider status query is failing), the loop keeps retrying rather than restarting a demonstrably running job it could not relaunch anyway (recovery needs the same provider API).
- The non-transient path is unchanged: a returned non-`UP` status still routes into recovery exactly as before.

## Tested

Unit tests in `tests/unit_tests/test_sky/utils/test_cloud_api_retries.py` (9 tests, all pass):

```
$ pytest tests/unit_tests/test_sky/utils/test_cloud_api_retries.py -q
9 passed
```

Coverage: returns immediately on success; retries each transient `ClusterStatusFetchingError`; succeeds after N transient failures (proving the transient error does not propagate to the controller catch-all); raises after exhausting the retry budget (a sustained outage still surfaces); respects a custom `max_retries`; does not retry non-retryable errors; and rejects invalid `max_retries`.

`tests/unit_tests/test_sky/jobs/test_controller.py` also passes (including the post-recovery window-reset test from #10156, which shares the transient window this change reuses).

`bash format.sh --files <changed files>` is clean (yapf, isort, mypy, pylint 10.00/10).
