### PR TITLE
[Core] debug-dump: fast-fail unreachable kube contexts, parallelize per-cluster collection

### DIFF
--- a/sky/provision/kubernetes/debug.py
+++ b/sky/provision/kubernetes/debug.py
@@ -221,6 +221,51 @@ def dump_context_resources(context: Optional[str],
     return errors
 
 
+def context_reachable(context: Optional[str]) -> bool:
+    """Return whether a kube context's API server answers a bounded probe.
+
+    One no-retry, ``API_TIMEOUT``-bounded ``list_namespaced_pod`` against the
+    ``default`` namespace (``limit=1`` -- we only care whether the API server
+    answers, not what it returns). This is the same fast-fail signal the
+    per-cluster/per-context resource collection computes internally (see
+    ``_dump_pods`` / ``_dump_gpu_metrics_pods``), exposed standalone so other
+    debug-dump collectors can gate themselves on context reachability without
+    racking up their own timeouts.
+
+    Why this matters for the skylet log: ``_resolve_remote_skylet_log_path``
+    runs a remote command via a ``KubernetesCommandRunner``, whose
+    ``connect_timeout`` maps to ``kubectl --pod-running-timeout`` -- which only
+    bounds waiting for the pod to reach Running, a phase *after* kubectl reaches
+    the API server. Against a defunct API server kubectl never gets that far and
+    falls back to client-go defaults (~2min before giving up). A reachability
+    probe via the Python client (which honours ``_request_timeout`` + the
+    ``_fail_fast`` no-retry pool) lets the caller skip skylet collection on a
+    dead context in ~``API_TIMEOUT`` seconds instead.
+
+    Best-effort and fail-safe: returns ``False`` only on a connection/timeout
+    error (``MaxRetryError``), which is the unreachable signal we act on. Any
+    other error (e.g. RBAC 403, or unexpected client internals) returns ``True``
+    -- the context is reachable, just restricted -- so we never wrongly skip
+    collection for a live cluster on a transient hiccup.
+    """
+    try:
+        core = _fail_fast(kubernetes.core_api(context))
+        core.list_namespaced_pod('default',
+                                 limit=1,
+                                 _request_timeout=kubernetes.API_TIMEOUT)
+        return True
+    except kubernetes.max_retry_error():
+        logger.debug(f'Kubernetes context {context!r} is unreachable; '
+                     f'callers gating on reachability will skip it.')
+        return False
+    except Exception as e:  # pylint: disable=broad-except
+        # Reachable but the probe failed for another reason (RBAC, etc.). Treat
+        # as reachable so we don't wrongly skip a live cluster.
+        logger.debug(f'Reachability probe for context {context!r} failed with '
+                     f'a non-connection error; treating as reachable: {e}')
+        return True
+
+
 def _record_error(errors: List[Dict[str, str]], resource: str,
                   e: Exception) -> None:
     logger.debug(f'Failed to collect {resource}: {e}')

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1,5 +1,6 @@
 """Debug dump utilities for troubleshooting SkyPilot issues."""
 import collections
+import concurrent.futures
 import datetime
 import hashlib
 import json
@@ -690,6 +691,15 @@ def _populate_recent_context(debug_dump_context: DebugDumpContext,
                  f'from recent activity')
 
 
+# Wall-clock deadline for the sky_check.check() enabled-clouds probe in the
+# dump. check() probes every enabled context and a defunct one costs ~20s
+# (urllib3 retries); per dead context that stacks. check() is general-purpose
+# with no timeout knob, so we bound it here (dump-only) rather than altering
+# global check behavior. Generous enough for a healthy multi-cloud check, tight
+# enough that a couple of dead contexts can't dominate the dump.
+_SKY_CHECK_TIMEOUT = 30
+
+
 def _dump_server_info(dump_dir: str,
                       errors: Optional[List[Dict[str, str]]] = None) -> None:
     """Collect server metadata."""
@@ -748,9 +758,42 @@ def _dump_server_info(dump_dir: str,
 
     # Add cloud status (keyed by workspace name, each mapping cloud names
     # to a list of capability strings — already JSON-serializable).
+    #
+    # sky_check.check() probes every enabled context's credentials
+    # (list_namespaced_pod), and a defunct context costs ~20s there (urllib3
+    # retries). check() is general-purpose and has no timeout param, and we
+    # must NOT change its global behavior, so we bound it for the dump only:
+    # run it in a worker thread with a wall-clock deadline. On timeout we
+    # record a partial-result error and move on rather than hang the dump.
+    # (The worker may keep running briefly; check() is a read-only probe, so a
+    # lingering thread is harmless for this one-shot dump.)
+    #
+    # NOTE: we deliberately do NOT use the executor as a context manager -- its
+    # __exit__ calls shutdown(wait=True), which would re-block on the
+    # still-running worker and defeat the timeout. On timeout we shut it down
+    # with wait=False and let the orphaned worker finish in the background.
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     try:
-        server_info['enabled_clouds'] = sky_check.check(quiet=True)
+        future = executor.submit(sky_check.check, quiet=True)
+        server_info['enabled_clouds'] = future.result(
+            timeout=_SKY_CHECK_TIMEOUT)
+        executor.shutdown(wait=False)
+    except concurrent.futures.TimeoutError:
+        executor.shutdown(wait=False)
+        msg = (f'sky check timed out after {_SKY_CHECK_TIMEOUT}s (likely a '
+               f'defunct/unreachable cloud or kube context); skipping '
+               f'enabled_clouds in the dump.')
+        logger.warning(msg)
+        server_info['cloud_status_error'] = msg
+        if errors is not None:
+            errors.append({
+                'component': 'server_info',
+                'resource': 'cloud_status',
+                'error': msg,
+                'traceback': _full_traceback()
+            })
     except Exception as e:  # pylint: disable=broad-except
+        executor.shutdown(wait=False)
         server_info['cloud_status_error'] = str(e)
         if errors is not None:
             errors.append({

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -605,9 +605,11 @@ def _get_clusters_from_managed_jobs(
     debug_dump_context['cluster_names'].add(common.JOB_CONTROLLER_NAME)
 
 
-def _populate_recent_context(debug_dump_context: DebugDumpContext,
-                             minutes: float,
-                             reachability: '_KubeContextReachabilityChecker') -> None:
+def _populate_recent_context(
+    debug_dump_context: DebugDumpContext,
+    minutes: float,
+    reachability: '_KubeContextReachabilityChecker',
+) -> None:
     """Populate context with resources active within the given time window."""
     logger.debug(
         f'Populating context with resources from last {minutes} minutes')

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -10,6 +10,7 @@ import platform
 import posixpath
 import re
 import shutil
+import threading
 import time
 import traceback
 from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict
@@ -1262,10 +1263,209 @@ def _dump_kube_contexts_info(dump_dir: str,
                 })
 
 
+class _ContextReachabilityCache:
+    """Thread-safe, memoized per-context kube reachability probes.
+
+    Multiple SkyPilot clusters can share one kube context, and the per-cluster
+    dump runs in parallel (see _dump_cluster_info), so without memoization N
+    clusters on one defunct context would each pay the ~API_TIMEOUT probe. We
+    cache the first probe's result per context under a lock so each context is
+    probed at most once per dump. ``None`` (in-cluster auth) is a valid key.
+
+    The probe itself is the bounded, no-retry signal #9937 added
+    (kubernetes_debug.context_reachable); see that function and
+    _resolve_remote_skylet_log_path for why kubectl's connect_timeout can't be
+    used here.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cache: Dict[Optional[str], bool] = {}
+
+    def is_reachable(self, context: Optional[str]) -> bool:
+        with self._lock:
+            if context in self._cache:
+                return self._cache[context]
+        # Probe outside the lock so a slow (timing-out) probe on one context
+        # doesn't block reachability lookups for other contexts. A duplicate
+        # concurrent probe of the same context is harmless and rare.
+        reachable = kubernetes_debug.context_reachable(context)
+        with self._lock:
+            self._cache.setdefault(context, reachable)
+            return self._cache[context]
+
+
+def _dump_one_cluster(
+        cluster_name: str, clusters_dir: str,
+        reachability: _ContextReachabilityCache) -> List[Dict[str, str]]:
+    """Dump one cluster's state, events, requests, skylet log and k8s objects.
+
+    Returns this cluster's error records. Runs as a worker under
+    run_in_parallel, so it owns a private ``errors`` list (no shared mutable
+    state across threads); the caller merges them after all workers finish.
+    Best-effort throughout: any failure is recorded, never raised, so one bad
+    cluster can't abort the others.
+    """
+    errors: List[Dict[str, str]] = []
+    cluster_dir = os.path.join(clusters_dir, cluster_name)
+    os.makedirs(cluster_dir, exist_ok=True)
+
+    # Get cluster info, history, and events. Cluster history and
+    # events outlive the cluster row, so terminated clusters still
+    # produce data here.
+    try:
+        dump_data = debug_dump_helpers.get_cluster_dump_data(cluster_name)
+        for filename, content in dump_data:
+            file_path = os.path.join(cluster_dir, filename)
+            with open(file_path, 'w', encoding='utf-8') as f:
+                json.dump(content, f, indent=2, default=str)
+        if dump_data:
+            logger.debug(f'Dumped cluster {cluster_name!r} '
+                         f'({len(dump_data)} files)')
+        else:
+            logger.debug(f'Cluster {cluster_name!r} not found in DB or '
+                         f'cluster history')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to get info for cluster {cluster_name}: {e}')
+        errors.append({
+            'component': 'clusters',
+            'resource': cluster_name,
+            'error': str(e),
+            'traceback': _full_traceback()
+        })
+
+    # Copy the provision log if available. The path is recorded in
+    # cluster history, so this also works for terminated clusters.
+    try:
+        provision_log_path = (
+            global_user_state.get_cluster_history_provision_log_path(
+                cluster_name))
+        if provision_log_path:
+            provision_log = pathlib.Path(provision_log_path).expanduser()
+            if provision_log.is_file():
+                shutil.copy2(provision_log,
+                             os.path.join(cluster_dir, 'provision.log'))
+                logger.debug(
+                    f'Copied provision log for cluster {cluster_name!r}')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to copy provision log for cluster '
+                       f'{cluster_name}: {e}')
+        errors.append({
+            'component': 'clusters',
+            'resource': f'{cluster_name}/provision_log',
+            'error': str(e),
+            'traceback': _full_traceback()
+        })
+
+    # Get associated requests
+    try:
+        requests = requests_lib.get_request_tasks(
+            requests_lib.RequestTaskFilter(
+                cluster_names=[cluster_name],
+                fields=['request_id', 'name', 'status', 'created_at']))
+        associated_requests = [{
+            'request_id': r.request_id,
+            'name': r.name,
+            'status': r.status.value if r.status else None,
+            'created_at': r.created_at,
+            'created_at_human': debug_dump_helpers.epoch_to_human(r.created_at),
+        } for r in requests]
+
+        assoc_path = os.path.join(cluster_dir, 'associated_requests.json')
+        with open(assoc_path, 'w', encoding='utf-8') as f:
+            json.dump(associated_requests, f, indent=2, default=str)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to get associated requests for cluster '
+                       f'{cluster_name}: {e}')
+        errors.append({
+            'component': 'clusters',
+            'resource': f'{cluster_name}/associated_requests',
+            'error': str(e),
+            'traceback': _full_traceback()
+        })
+
+    # Live cluster record for the skylet-log and Kubernetes sections
+    # below. None for terminated clusters, which have no reachable
+    # node or handle (their history/events were dumped above).
+    cluster_record = None
+    try:
+        cluster_record = global_user_state.get_cluster_from_name(cluster_name)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to get cluster record for '
+                       f'{cluster_name}: {e}')
+        errors.append({
+            'component': 'clusters',
+            'resource': f'{cluster_name}/cluster_record',
+            'error': str(e),
+            'traceback': _full_traceback()
+        })
+
+    # Pull the skylet log from the head node. We attempt this for both UP
+    # and INIT clusters: an INIT cluster may be degraded (failed setup,
+    # partial provisioning) but still have a reachable node with a skylet
+    # log, which is exactly when the log is most useful. The only status we
+    # skip is STOPPED, which has no reachable node. A not-yet-provisioned
+    # cluster simply fails the rsync, which is handled best-effort.
+    status = cluster_record.get('status') if cluster_record else None
+    handle = cluster_record.get('handle') if cluster_record else None
+
+    if status != status_lib.ClusterStatus.STOPPED and handle is not None:
+        # For a Kubernetes cluster, skylet collection runs `kubectl exec`,
+        # whose connect_timeout maps to `--pod-running-timeout` and does NOT
+        # bound the API connect/TLS/discovery phase -- so against a defunct
+        # context it falls back to client-go defaults and hangs ~2min (see
+        # _resolve_remote_skylet_log_path). Gate it on a bounded, no-retry
+        # reachability probe (the same fast-fail signal #9937 added) so a dead
+        # context costs ~API_TIMEOUT instead of ~2min. Non-k8s clusters have no
+        # kube coordinates and skip the probe -- their SSH connect_timeout is a
+        # real TCP deadline, so they already fail fast.
+        skip_skylet = False
+        try:
+            coords = _kube_coordinates_for_handle(handle)
+        except Exception as e:  # pylint: disable=broad-except
+            # Couldn't resolve coordinates; fall through and let skylet
+            # collection record its own best-effort failure.
+            logger.debug(f'Could not resolve kube coordinates for cluster '
+                         f'{cluster_name!r}; skipping reachability gate: {e}')
+            coords = None
+        if coords is not None:
+            context, _ = coords
+            if not reachability.is_reachable(context):
+                logger.debug(f'Skipping skylet log for cluster '
+                             f'{cluster_name!r}: kube context {context!r} is '
+                             f'unreachable (fast-fail).')
+                skip_skylet = True
+        if not skip_skylet:
+            _collect_cluster_skylet_log(cluster_name, cluster_dir, handle,
+                                        errors, status)
+    else:
+        logger.debug(f'Skipping skylet log for cluster {cluster_name!r} '
+                     f'(status={status})')
+
+    # For Kubernetes clusters, also snapshot the related k8s objects (pods,
+    # events, Services, Kueue Workload, ...). Gated only on having a handle,
+    # not on status: these come from the kube API server, so they're
+    # reachable -- and most useful -- even when the cluster isn't UP. This path
+    # already fast-fails on a defunct context (the first list call is a
+    # no-retry, bounded probe; see kubernetes_debug._dump_pods).
+    if handle is not None:
+        _collect_cluster_kubernetes_resources(cluster_name, cluster_dir, handle,
+                                              errors)
+
+    return errors
+
+
 def _dump_cluster_info(cluster_names: Set[str],
                        dump_dir: str,
                        errors: Optional[List[Dict[str, str]]] = None) -> None:
-    """Collect cluster state and events."""
+    """Collect cluster state and events.
+
+    Clusters are dumped in parallel: each cluster's collection can make slow
+    network calls (skylet-log rsync, kube API reads), so a sequential loop let
+    a single unreachable cluster stack its timeout in front of every other
+    cluster. run_in_parallel keeps per-cluster best-effort isolation -- each
+    worker returns its own error records, merged here after all finish.
+    """
     if not cluster_names:
         logger.debug('No clusters to dump')
         return
@@ -1275,130 +1475,17 @@ def _dump_cluster_info(cluster_names: Set[str],
     clusters_dir = os.path.join(dump_dir, 'clusters')
     os.makedirs(clusters_dir, exist_ok=True)
 
-    for cluster_name in cluster_names:
-        cluster_dir = os.path.join(clusters_dir, cluster_name)
-        os.makedirs(cluster_dir, exist_ok=True)
+    reachability = _ContextReachabilityCache()
+    cluster_list = list(cluster_names)
+    num_threads = min(len(cluster_list),
+                      subprocess_utils.get_parallel_threads())
+    results = subprocess_utils.run_in_parallel(
+        lambda name: _dump_one_cluster(name, clusters_dir, reachability),
+        cluster_list, num_threads)
 
-        # Get cluster info, history, and events. Cluster history and
-        # events outlive the cluster row, so terminated clusters still
-        # produce data here.
-        try:
-            dump_data = debug_dump_helpers.get_cluster_dump_data(cluster_name)
-            for filename, content in dump_data:
-                file_path = os.path.join(cluster_dir, filename)
-                with open(file_path, 'w', encoding='utf-8') as f:
-                    json.dump(content, f, indent=2, default=str)
-            if dump_data:
-                logger.debug(f'Dumped cluster {cluster_name!r} '
-                             f'({len(dump_data)} files)')
-            else:
-                logger.debug(f'Cluster {cluster_name!r} not found in DB or '
-                             f'cluster history')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get info for cluster '
-                           f'{cluster_name}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'clusters',
-                    'resource': cluster_name,
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
-
-        # Copy the provision log if available. The path is recorded in
-        # cluster history, so this also works for terminated clusters.
-        try:
-            provision_log_path = (
-                global_user_state.get_cluster_history_provision_log_path(
-                    cluster_name))
-            if provision_log_path:
-                provision_log = pathlib.Path(provision_log_path).expanduser()
-                if provision_log.is_file():
-                    shutil.copy2(provision_log,
-                                 os.path.join(cluster_dir, 'provision.log'))
-                    logger.debug(
-                        f'Copied provision log for cluster {cluster_name!r}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to copy provision log for cluster '
-                           f'{cluster_name}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'clusters',
-                    'resource': f'{cluster_name}/provision_log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
-
-        # Get associated requests
-        try:
-            requests = requests_lib.get_request_tasks(
-                requests_lib.RequestTaskFilter(
-                    cluster_names=[cluster_name],
-                    fields=['request_id', 'name', 'status', 'created_at']))
-            associated_requests = [{
-                'request_id': r.request_id,
-                'name': r.name,
-                'status': r.status.value if r.status else None,
-                'created_at': r.created_at,
-                'created_at_human': debug_dump_helpers.epoch_to_human(
-                    r.created_at),
-            } for r in requests]
-
-            assoc_path = os.path.join(cluster_dir, 'associated_requests.json')
-            with open(assoc_path, 'w', encoding='utf-8') as f:
-                json.dump(associated_requests, f, indent=2, default=str)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get associated requests for cluster '
-                           f'{cluster_name}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'clusters',
-                    'resource': f'{cluster_name}/associated_requests',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
-
-        # Live cluster record for the skylet-log and Kubernetes sections
-        # below. None for terminated clusters, which have no reachable
-        # node or handle (their history/events were dumped above).
-        cluster_record = None
-        try:
-            cluster_record = global_user_state.get_cluster_from_name(
-                cluster_name)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get cluster record for '
-                           f'{cluster_name}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'clusters',
-                    'resource': f'{cluster_name}/cluster_record',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
-
-        # Pull the skylet log from the head node. We attempt this for both UP
-        # and INIT clusters: an INIT cluster may be degraded (failed setup,
-        # partial provisioning) but still have a reachable node with a skylet
-        # log, which is exactly when the log is most useful. The only status we
-        # skip is STOPPED, which has no reachable node. A not-yet-provisioned
-        # cluster simply fails the rsync, which is handled best-effort.
-        status = cluster_record.get('status') if cluster_record else None
-        handle = cluster_record.get('handle') if cluster_record else None
-
-        if status != status_lib.ClusterStatus.STOPPED and handle is not None:
-            _collect_cluster_skylet_log(cluster_name, cluster_dir, handle,
-                                        errors, status)
-        else:
-            logger.debug(f'Skipping skylet log for cluster {cluster_name!r} '
-                         f'(status={status})')
-
-        # For Kubernetes clusters, also snapshot the related k8s objects (pods,
-        # events, Services, Kueue Workload, ...). Gated only on having a handle,
-        # not on status: these come from the kube API server, so they're
-        # reachable -- and most useful -- even when the cluster isn't UP.
-        if handle is not None:
-            _collect_cluster_kubernetes_resources(cluster_name, cluster_dir,
-                                                  handle, errors)
+    if errors is not None:
+        for cluster_errors in results:
+            errors.extend(cluster_errors)
 
     logger.debug('Exiting _dump_cluster_info')
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -2,6 +2,7 @@
 import collections
 import concurrent.futures
 import datetime
+import functools
 import hashlib
 import json
 import logging
@@ -11,10 +12,9 @@ import platform
 import posixpath
 import re
 import shutil
-import threading
 import time
 import traceback
-from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict
 import zipfile
 
 import sky
@@ -229,7 +229,8 @@ def _get_requests_from_clusters(debug_dump_context: DebugDumpContext) -> None:
 
 
 def _get_requests_from_managed_jobs(
-        debug_dump_context: DebugDumpContext) -> None:
+        debug_dump_context: DebugDumpContext,
+        reachability: '_KubeContextReachabilityChecker') -> None:
     """Parse request database to find requests related to managed jobs."""
     if not debug_dump_context['managed_job_ids']:
         return
@@ -237,29 +238,40 @@ def _get_requests_from_managed_jobs(
         f'Getting requests for {len(debug_dump_context["managed_job_ids"])} '
         f'managed jobs')
 
-    # Fetch job details to enable matching by name and user
+    # Fetch job details to enable matching by name and user. Skipped on an
+    # unreachable controller context: only the name/user matching below
+    # degrades; the request-body matching (job_id/job_ids) is local and
+    # still runs.
     job_names: Set[str] = set()
     job_user_hashes: Set[str] = set()
-    try:
-        jobs, _, _, _ = managed_jobs_core.queue_v2(
-            refresh=False,
-            job_ids=list(debug_dump_context['managed_job_ids']),
-            all_users=True)
-        for job in jobs:
-            name = job.get('job_name')
-            if name:
-                job_names.add(name)
-            user_hash = job.get('user_hash')
-            if user_hash:
-                job_user_hashes.add(user_hash)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to fetch managed job details: {e}')
-        debug_dump_context['errors'].append({
-            'component': 'cross_link',
-            'resource': 'managed_job_details',
-            'error': str(e),
-            'traceback': _full_traceback()
-        })
+    dead_context = _jobs_controller_unreachable_context(reachability)
+    if dead_context is not None:
+        logger.debug('Skipping managed job details fetch: controller '
+                     f'context {dead_context!r} unreachable (fast-fail).')
+        debug_dump_context['errors'].append(
+            _controller_skip_error('cross_link', 'managed_job_details',
+                                   dead_context))
+    else:
+        try:
+            jobs, _, _, _ = managed_jobs_core.queue_v2(
+                refresh=False,
+                job_ids=list(debug_dump_context['managed_job_ids']),
+                all_users=True)
+            for job in jobs:
+                name = job.get('job_name')
+                if name:
+                    job_names.add(name)
+                user_hash = job.get('user_hash')
+                if user_hash:
+                    job_user_hashes.add(user_hash)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to fetch managed job details: {e}')
+            debug_dump_context['errors'].append({
+                'component': 'cross_link',
+                'resource': 'managed_job_details',
+                'error': str(e),
+                'traceback': _full_traceback()
+            })
 
     try:
         # Get all requests with managed job-related names
@@ -482,7 +494,8 @@ def _managed_job_cluster_names_from_records(
 
 
 def _get_managed_jobs_from_clusters(
-        debug_dump_context: DebugDumpContext) -> None:
+        debug_dump_context: DebugDumpContext,
+        reachability: '_KubeContextReachabilityChecker') -> None:
     """Get managed job IDs whose underlying cluster is in the context.
 
     This must run FIRST in _build_debug_dump — before the recent-activity
@@ -499,6 +512,14 @@ def _get_managed_jobs_from_clusters(
     logger.debug(
         f'Getting managed jobs for '
         f'{len(debug_dump_context["cluster_names"])} requested clusters')
+    dead_context = _jobs_controller_unreachable_context(reachability)
+    if dead_context is not None:
+        logger.debug('Skipping cluster -> job expansion: controller '
+                     f'context {dead_context!r} unreachable (fast-fail).')
+        debug_dump_context['errors'].append(
+            _controller_skip_error('cross_link', 'managed_jobs_from_clusters',
+                                   dead_context))
+        return
     try:
         jobs, _, _, _ = managed_jobs_core.queue_v2(refresh=False,
                                                    all_users=True)
@@ -585,7 +606,8 @@ def _get_clusters_from_managed_jobs(
 
 
 def _populate_recent_context(debug_dump_context: DebugDumpContext,
-                             minutes: float) -> None:
+                             minutes: float,
+                             reachability: '_KubeContextReachabilityChecker') -> None:
     """Populate context with resources active within the given time window."""
     logger.debug(
         f'Populating context with resources from last {minutes} minutes')
@@ -657,33 +679,43 @@ def _populate_recent_context(debug_dump_context: DebugDumpContext,
 
     # Get recent managed jobs via queue_v2 (handles remote controllers
     # via gRPC/SSH, unlike direct DB access which only works in
-    # consolidation mode).
-    try:
-        jobs, _, _, _ = managed_jobs_core.queue_v2(refresh=False,
-                                                   all_users=True)
-        for job in jobs:
-            submitted_at = job.get('submitted_at') or 0
-            end_at = job.get('end_at') or time.time()
-            if submitted_at >= cutoff_time or end_at >= cutoff_time:
-                job_id = job.get('job_id')
-                if job_id is not None:
-                    reasons = []
-                    if submitted_at >= cutoff_time:
-                        reasons.append(f'submitted_at={submitted_at:.0f}')
-                    if end_at >= cutoff_time:
-                        reasons.append(f'end_at={end_at:.0f}')
-                    logger.debug(f'Recent: including managed job {job_id} '
-                                 f'({", ".join(reasons)} >= '
-                                 f'cutoff {cutoff_time:.0f})')
-                    debug_dump_context['managed_job_ids'].add(job_id)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to get recent managed jobs: {e}')
-        debug_dump_context['errors'].append({
-            'component': 'recent_context',
-            'resource': 'managed_jobs',
-            'error': str(e),
-            'traceback': _full_traceback()
-        })
+    # consolidation mode). Skipped when the controller's kube context is
+    # unreachable -- the exec into the controller would just eat a kubectl
+    # connect timeout.
+    dead_context = _jobs_controller_unreachable_context(reachability)
+    if dead_context is not None:
+        logger.debug('Skipping recent managed jobs scan: controller '
+                     f'context {dead_context!r} unreachable (fast-fail).')
+        debug_dump_context['errors'].append(
+            _controller_skip_error('recent_context', 'managed_jobs',
+                                   dead_context))
+    else:
+        try:
+            jobs, _, _, _ = managed_jobs_core.queue_v2(refresh=False,
+                                                       all_users=True)
+            for job in jobs:
+                submitted_at = job.get('submitted_at') or 0
+                end_at = job.get('end_at') or time.time()
+                if submitted_at >= cutoff_time or end_at >= cutoff_time:
+                    job_id = job.get('job_id')
+                    if job_id is not None:
+                        reasons = []
+                        if submitted_at >= cutoff_time:
+                            reasons.append(f'submitted_at={submitted_at:.0f}')
+                        if end_at >= cutoff_time:
+                            reasons.append(f'end_at={end_at:.0f}')
+                        logger.debug(f'Recent: including managed job {job_id} '
+                                     f'({", ".join(reasons)} >= '
+                                     f'cutoff {cutoff_time:.0f})')
+                        debug_dump_context['managed_job_ids'].add(job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to get recent managed jobs: {e}')
+            debug_dump_context['errors'].append({
+                'component': 'recent_context',
+                'resource': 'managed_jobs',
+                'error': str(e),
+                'traceback': _full_traceback()
+            })
 
     logger.debug(f'Found {len(debug_dump_context["request_ids"])} requests, '
                  f'{len(debug_dump_context["cluster_names"])} clusters, '
@@ -1306,41 +1338,90 @@ def _dump_kube_contexts_info(dump_dir: str,
                 })
 
 
-class _ContextReachabilityCache:
-    """Thread-safe, memoized per-context kube reachability probes.
+_KubeContextReachabilityChecker = Callable[[Optional[str]], bool]
+
+
+@functools.lru_cache(maxsize=128)
+def _kube_context_reachable(context: Optional[str]) -> bool:
+    """Bounded, memoized kube context reachability probe.
 
     Multiple SkyPilot clusters can share one kube context, and the per-cluster
     dump runs in parallel (see _dump_cluster_info), so without memoization N
-    clusters on one defunct context would each pay the ~API_TIMEOUT probe. We
-    cache the first probe's result per context under a lock so each context is
-    probed at most once per dump. ``None`` (in-cluster auth) is a valid key.
+    clusters on one defunct context would each pay the ~API_TIMEOUT probe.
+    ``lru_cache`` memoizes per context for the lifetime of one dump; the caller
+    clears the cache at dump start so results do not carry over. ``None``
+    (in-cluster auth) is a valid key.
 
     The probe itself is the bounded, no-retry signal #9937 added
     (kubernetes_debug.context_reachable); see that function and
     _resolve_remote_skylet_log_path for why kubectl's connect_timeout can't be
     used here.
     """
+    return kubernetes_debug.context_reachable(context)
 
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._cache: Dict[Optional[str], bool] = {}
 
-    def is_reachable(self, context: Optional[str]) -> bool:
-        with self._lock:
-            if context in self._cache:
-                return self._cache[context]
-        # Probe outside the lock so a slow (timing-out) probe on one context
-        # doesn't block reachability lookups for other contexts. A duplicate
-        # concurrent probe of the same context is harmless and rare.
-        reachable = kubernetes_debug.context_reachable(context)
-        with self._lock:
-            self._cache.setdefault(context, reachable)
-            return self._cache[context]
+def _jobs_controller_unreachable_context(
+        reachability: _KubeContextReachabilityChecker) -> Optional[str]:
+    """Return the jobs controller's kube context iff it is unreachable.
+
+    Every managed-jobs read outside consolidation mode (queue_v2, the
+    controller debug manifest, log rsync) execs into the controller
+    cluster, and for a Kubernetes controller on a defunct context each
+    such call eats a full kubectl connect timeout -- ungated, they stack
+    on top of the per-cluster fast-fail this module already does. Callers
+    use this as a skip signal: a non-None return means "the controller
+    lives on kube context X and X is unreachable, don't try".
+
+    None means "don't skip", i.e. the one failure mode this gate exists
+    for (Kubernetes controller behind a dead context) is absent, and the
+    call either can't hang or is already bounded:
+      - consolidation mode: reads are local, no network at all;
+      - no controller cluster record, or a record without a handle: the
+        callers detect this from the DB and fail fast locally;
+      - a non-Kubernetes controller: its SSH connect_timeout is a real
+        TCP deadline, so an unreachable VM already fails fast;
+      - a reachable context.
+    Resolution errors also return None -- the gate fails open so the real
+    call runs and its own best-effort handler records the true failure,
+    rather than suppressing work based on a broken gate.
+    """
+    try:
+        if managed_job_utils.is_consolidation_mode():
+            return None
+        controller_name = (
+            controller_utils.Controllers.JOBS_CONTROLLER.value.cluster_name)
+        record = global_user_state.get_cluster_from_name(controller_name)
+        if record is None:
+            return None
+        handle = record.get('handle')
+        if handle is None:
+            return None
+        coords = _kube_coordinates_for_handle(handle)
+        if coords is None:
+            return None
+        context, _ = coords
+        if reachability(context):
+            return None
+        return context
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not determine jobs controller reachability: {e}')
+        return None
+
+
+def _controller_skip_error(component: str, resource: str,
+                           context: str) -> Dict[str, str]:
+    """Error record for a managed-jobs read skipped by the fast-fail gate."""
+    return {
+        'component': component,
+        'resource': resource,
+        'error': (f'Skipped: jobs controller kube context {context!r} is '
+                  'unreachable (fast-fail).'),
+    }
 
 
 def _dump_one_cluster(
         cluster_name: str, clusters_dir: str,
-        reachability: _ContextReachabilityCache) -> List[Dict[str, str]]:
+        reachability: _KubeContextReachabilityChecker) -> List[Dict[str, str]]:
     """Dump one cluster's state, events, requests, skylet log and k8s objects.
 
     Returns this cluster's error records. Runs as a worker under
@@ -1473,7 +1554,7 @@ def _dump_one_cluster(
             coords = None
         if coords is not None:
             context, _ = coords
-            if not reachability.is_reachable(context):
+            if not reachability(context):
                 logger.debug(f'Skipping skylet log for cluster '
                              f'{cluster_name!r}: kube context {context!r} is '
                              f'unreachable (fast-fail).')
@@ -1500,6 +1581,7 @@ def _dump_one_cluster(
 
 def _dump_cluster_info(cluster_names: Set[str],
                        dump_dir: str,
+                       reachability: '_KubeContextReachabilityChecker',
                        errors: Optional[List[Dict[str, str]]] = None) -> None:
     """Collect cluster state and events.
 
@@ -1518,7 +1600,6 @@ def _dump_cluster_info(cluster_names: Set[str],
     clusters_dir = os.path.join(dump_dir, 'clusters')
     os.makedirs(clusters_dir, exist_ok=True)
 
-    reachability = _ContextReachabilityCache()
     cluster_list = list(cluster_names)
     num_threads = min(len(cluster_list),
                       subprocess_utils.get_parallel_threads())
@@ -1536,8 +1617,15 @@ def _dump_cluster_info(cluster_names: Set[str],
 def _dump_managed_job_info(
         managed_job_ids: Set[int],
         dump_dir: str,
+        reachability: '_KubeContextReachabilityChecker',
         errors: Optional[List[Dict[str, str]]] = None) -> None:
-    """Collect managed job state and logs."""
+    """Collect managed job state and logs.
+
+    Both phases exec into the jobs controller outside consolidation mode,
+    so both are gated on the controller context's reachability -- one
+    memoized probe covers the whole section (and, via the shared cache,
+    reuses the clusters section's probe of the same context).
+    """
     if not managed_job_ids:
         logger.debug('No managed jobs to dump')
         return
@@ -1546,6 +1634,17 @@ def _dump_managed_job_info(
 
     jobs_dir = os.path.join(dump_dir, 'managed_jobs')
     os.makedirs(jobs_dir, exist_ok=True)
+
+    dead_context = _jobs_controller_unreachable_context(reachability)
+    if dead_context is not None:
+        logger.debug('Skipping managed jobs collection: controller '
+                     f'context {dead_context!r} unreachable (fast-fail).')
+        if errors is not None:
+            errors.append(
+                _controller_skip_error('managed_jobs', 'controller_access',
+                                       dead_context))
+        logger.debug('Exiting _dump_managed_job_info')
+        return
 
     # Phase 1: Queue info from queue_v2 (works in both consolidation and
     # non-consolidation modes via existing gRPC/SSH plumbing)
@@ -1799,14 +1898,21 @@ def _build_debug_dump(
     # _get_requests_from_clusters. Combined with the via_cluster skip in
     # _get_clusters_from_requests, a cluster shared by many requests
     # (e.g. the controller) cannot drag unrelated jobs or clusters in.
+    # One reachability cache for the whole dump: the cross-link scans, the
+    # clusters section, and the managed-jobs section share per-context
+    # probe results, so a defunct context is probed exactly once per dump.
+    _kube_context_reachable.cache_clear()
+    reachability = _kube_context_reachable
+
     logger.debug('Cross-linking related resources')
-    _get_managed_jobs_from_clusters(debug_dump_context)
+    _get_managed_jobs_from_clusters(debug_dump_context, reachability)
     if recent_minutes is not None:
-        _populate_recent_context(debug_dump_context, recent_minutes)
+        _populate_recent_context(debug_dump_context, recent_minutes,
+                                 reachability)
     _get_managed_jobs_from_requests(debug_dump_context)
     _get_job_clusters_from_managed_jobs(debug_dump_context)
     _get_requests_from_clusters(debug_dump_context)
-    _get_requests_from_managed_jobs(debug_dump_context)
+    _get_requests_from_managed_jobs(debug_dump_context, reachability)
     _get_clusters_from_requests(debug_dump_context)
     _get_clusters_from_managed_jobs(debug_dump_context)
 
@@ -1830,9 +1936,11 @@ def _build_debug_dump(
                           errors=errors)
     _dump_cluster_info(debug_dump_context['cluster_names'],
                        dump_dir,
+                       reachability,
                        errors=errors)
     _dump_managed_job_info(debug_dump_context['managed_job_ids'],
                            dump_dir,
+                           reachability,
                            errors=errors)
 
     # Write client info if provided

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1831,6 +1831,75 @@ def test_kubernetes_context_failover(unreachable_context):
 
 
 @pytest.mark.kubernetes
+def test_debug_dump_unreachable_context_fast_fail(unreachable_context):
+    """Debug dump must fast-fail on a dead kube context.
+
+    With an unreachable context in allowed_contexts, the dump must (a)
+    complete within a hard wall-clock ceiling -- without fast-fail each dead
+    context stacked unbounded probe/exec timeouts -- and (b) still contain
+    the live cluster's data plus an explicit reachable:false marker for
+    the dead context, so fast-failing never silently drops resources.
+
+    The cluster-on-a-dead-context path (skylet-log and managed-jobs
+    gating) can't be built in CI -- a launch on a dead context fails -- and
+    is pinned by unit tests instead (test_debug_utils.py).
+    """
+    if smoke_tests_utils.is_non_docker_remote_api_server():
+        pytest.skip('Kubernetes configs and credentials are located on the '
+                    'remote API server, not the machine running the test')
+    if unreachable_context is None:
+        pytest.skip('No kubeconfig available to inject the dead context into')
+
+    live_context = subprocess.check_output('kubectl config current-context',
+                                           shell=True).decode('utf-8').strip()
+    config = textwrap.dedent(f"""\
+    kubernetes:
+      allowed_contexts:
+        - {live_context}
+        - {unreachable_context}
+    """)
+    name = smoke_tests_utils.get_cluster_name()
+    dump_prefix = f'/tmp/{name}-dump'
+    with tempfile.NamedTemporaryFile(delete=True) as f:
+        f.write(config.encode('utf-8'))
+        f.flush()
+        test = smoke_tests_utils.Test(
+            'debug_dump_unreachable_context_fast_fail',
+            [
+                f'sky launch -y -c {name} --cpus 1 '
+                f'--infra kubernetes/{live_context} echo hi',
+                # The ceiling. Generous for a healthy dump (typically well
+                # under a minute here); far below what unbounded kubectl /
+                # credential-probe timeouts against the dead context stack
+                # up to. Asserted via $SECONDS rather than GNU timeout so
+                # the step also runs on macOS dev machines; a fully hung
+                # dump is still bounded by the Test-level timeout.
+                f'start=$SECONDS && sky debug-dump --recent-minutes 5 '
+                f'--output {dump_prefix}.zip && '
+                'elapsed=$((SECONDS - start)) && '
+                'echo "dump took ${elapsed}s" && [ "$elapsed" -lt 300 ]',
+                f'test -f {dump_prefix}.zip',
+                f'unzip -o {dump_prefix}.zip -d {dump_prefix}',
+                # Live cluster data is intact.
+                f'test -f {dump_prefix}/debug_dump_*/clusters/{name}/'
+                'cluster_info.json',
+                # The dead context is present and explicitly marked
+                # unreachable rather than silently missing.
+                f'grep -r \'"reachable": false\' '
+                f'{dump_prefix}/debug_dump_*/kubernetes_contexts/',
+            ],
+            f'sky down -y {name}; rm -rf {dump_prefix} {dump_prefix}.zip',
+            env={
+                skypilot_config.ENV_VAR_GLOBAL_CONFIG: f.name,
+                constants.SKY_API_SERVER_URL_ENV_VAR:
+                    sky.server.common.get_server_url()
+            },
+            timeout=15 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
 def test_launch_image_pull_back_off():
     """The launch error message for an unresolvable image must contain the
     Kubernetes failure reason (ImagePullBackOff or ErrImagePull), not the

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -721,3 +721,33 @@ def test_defunct_context_fast_fails_per_cluster(tmp_path, k8s_apis):
     k8s_apis.custom.list_namespaced_custom_object.assert_not_called()
     assert not (tmp_path / 'services.yaml').exists()
     assert not (tmp_path / 'kueue').exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests for context_reachable (standalone bounded, no-retry probe)
+# ---------------------------------------------------------------------------
+def test_context_reachable_true_on_success(k8s_apis):
+    """A context whose API server answers the probe is reachable."""
+    k8s_apis.core.list_namespaced_pod.return_value = _pods()
+
+    assert debug.context_reachable('ctx') is True
+    # Bounded, namespace-scoped probe (default ns, limit=1).
+    _, kwargs = k8s_apis.core.list_namespaced_pod.call_args
+    assert kwargs['limit'] == 1
+    assert '_request_timeout' in kwargs
+
+
+def test_context_reachable_false_on_connection_error(k8s_apis):
+    """A connection/timeout failure means the context is defunct."""
+    k8s_apis.core.list_namespaced_pod.side_effect = _FakeMaxRetryError(
+        'connection timed out')
+
+    assert debug.context_reachable('ctx') is False
+
+
+def test_context_reachable_true_on_non_connection_error(k8s_apis):
+    """A non-connection error (e.g. RBAC 403) is reachable-but-restricted, so
+    we must NOT wrongly skip collection for it."""
+    k8s_apis.core.list_namespaced_pod.side_effect = _FakeApiException(403)
+
+    assert debug.context_reachable('ctx') is True

--- a/tests/unit_tests/kubernetes/test_debug.py
+++ b/tests/unit_tests/kubernetes/test_debug.py
@@ -356,7 +356,7 @@ def test_context_prometheus_log_failure_is_recorded(tmp_path, k8s_apis):
     errors = _run_context(tmp_path)
 
     resources = {e['resource'] for e in errors}
-    assert ('gpu_metrics/skypilot-prometheus-server-abc123.log' in resources)
+    assert 'gpu_metrics/skypilot-prometheus-server-abc123.log' in resources
 
 
 def test_context_prometheus_logs_dedupes_identical_previous(tmp_path, k8s_apis):

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -3150,6 +3150,114 @@ class TestDumpClusterInfo:
         runner.rsync.assert_called_once()
         assert not errors
 
+    @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable',
+                return_value=False)
+    @mock.patch('sky.utils.debug_utils._kube_coordinates_for_handle',
+                return_value=('defunct-ctx', 'ns'))
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.debug_dump_helpers'
+                '.get_cluster_events_data',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.global_user_state'
+                '.get_cluster_from_name')
+    def test_unreachable_kube_context_skips_skylet_log(
+            self, mock_get_cluster, mock_events, mock_requests, mock_coords,
+            mock_reachable, tmp_path):
+        """A k8s cluster on a defunct context must NOT attempt the (would-hang)
+        skylet collection -- it's gated on the bounded reachability probe."""
+        del mock_events, mock_requests, mock_coords  # required by mock.patch
+        handle = mock.Mock()
+        runner = mock.Mock()
+        handle.get_command_runners.return_value = [runner]
+        mock_get_cluster.return_value = {
+            'name': 'k8s-dead',
+            'cluster_hash': 'abc',
+            'status': status_lib.ClusterStatus.UP,
+            'handle': handle,
+        }
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
+                        '_resources'):
+            debug_utils._dump_cluster_info({'k8s-dead'}, str(tmp_path), errors)
+
+        mock_reachable.assert_called_once_with('defunct-ctx')
+        # Skylet collection was skipped: the head runner's remote command (the
+        # ~2min-hang path) was never invoked.
+        runner.run.assert_not_called()
+        runner.rsync.assert_not_called()
+
+    @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable',
+                return_value=True)
+    @mock.patch('sky.utils.debug_utils._kube_coordinates_for_handle',
+                return_value=('live-ctx', 'ns'))
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.debug_dump_helpers'
+                '.get_cluster_events_data',
+                return_value=[])
+    @mock.patch('sky.utils.debug_utils.global_user_state'
+                '.get_cluster_from_name')
+    def test_reachable_kube_context_collects_skylet_log(
+            self, mock_get_cluster, mock_events, mock_requests, mock_coords,
+            mock_reachable, tmp_path):
+        """A k8s cluster on a reachable context still collects the skylet log."""
+        del mock_events, mock_requests, mock_coords  # required by mock.patch
+        handle = mock.Mock()
+        runner = mock.Mock()
+        runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
+        handle.get_command_runners.return_value = [runner]
+        mock_get_cluster.return_value = {
+            'name': 'k8s-live',
+            'cluster_hash': 'abc',
+            'status': status_lib.ClusterStatus.UP,
+            'handle': handle,
+        }
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
+                        '_resources'):
+            debug_utils._dump_cluster_info({'k8s-live'}, str(tmp_path), errors)
+
+        mock_reachable.assert_called_once_with('live-ctx')
+        runner.rsync.assert_called_once()
+
+
+class TestContextReachabilityCache:
+    """Tests for _ContextReachabilityCache (per-dump memoized kube probes)."""
+
+    @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable')
+    def test_probes_each_context_once(self, mock_reachable):
+        """Repeated lookups of the same context probe only once."""
+        mock_reachable.return_value = True
+        cache = debug_utils._ContextReachabilityCache()
+
+        assert cache.is_reachable('ctx-a') is True
+        assert cache.is_reachable('ctx-a') is True
+        assert cache.is_reachable('ctx-a') is True
+        mock_reachable.assert_called_once_with('ctx-a')
+
+    @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable')
+    def test_distinct_contexts_probed_separately(self, mock_reachable):
+        mock_reachable.side_effect = lambda ctx: ctx == 'live'
+        cache = debug_utils._ContextReachabilityCache()
+
+        assert cache.is_reachable('live') is True
+        assert cache.is_reachable('dead') is False
+        assert cache.is_reachable('live') is True
+        assert mock_reachable.call_count == 2
+
+    @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable',
+                return_value=True)
+    def test_none_in_cluster_context_is_cached(self, mock_reachable):
+        """None (in-cluster auth) is a valid, cacheable key."""
+        cache = debug_utils._ContextReachabilityCache()
+
+        assert cache.is_reachable(None) is True
+        assert cache.is_reachable(None) is True
+        mock_reachable.assert_called_once_with(None)
+
 
 class TestDumpRequestIdInfoLogCollection:
     """_dump_request_id_info collects logs via the LogProvider."""

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import posixpath
+import threading
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set
@@ -2161,6 +2162,60 @@ class TestSensitiveEnvVarRedaction:
         assert env['SKY_NORMAL_VAR'] == 'visible'
         # Sensitive var should be redacted to bool
         assert env['SKYPILOT_DB_CONNECTION_URI'] is True
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                return_value=None)
+    def test_dump_server_info_check_timeout_does_not_hang(
+            self, mock_req, tmp_path, monkeypatch):
+        """A slow sky_check.check() is bounded; the dump records a timeout error
+        and moves on instead of hanging (the ~20s-per-dead-context probe)."""
+        del mock_req  # required by mock.patch
+        # Tighten the deadline so the test is fast.
+        monkeypatch.setattr(debug_utils, '_SKY_CHECK_TIMEOUT', 0.2)
+        started = threading.Event()
+
+        def _slow_check(*_args, **_kwargs):
+            started.set()
+            time.sleep(5)  # Longer than the (patched) deadline.
+            return {}
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils.sky_check.check',
+                        side_effect=_slow_check):
+            start = time.time()
+            debug_utils._dump_server_info(str(tmp_path), errors=errors)
+            elapsed = time.time() - start
+
+        assert started.is_set()
+        # Returned well before the slow check would have finished.
+        assert elapsed < 3
+        with open(os.path.join(str(tmp_path), 'server_info.json')) as f:
+            info = json.load(f)
+        assert 'enabled_clouds' not in info
+        assert 'cloud_status_error' in info
+        assert any(e['resource'] == 'cloud_status' for e in errors)
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                return_value=None)
+    @mock.patch('sky.utils.debug_utils.sky_check.check',
+                return_value={'default': {
+                    'kubernetes': ['compute']
+                }})
+    def test_dump_server_info_check_result_recorded(self, mock_check, mock_req,
+                                                    tmp_path):
+        """A fast check result is recorded as enabled_clouds (no timeout)."""
+        del mock_check, mock_req  # required by mock.patch
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_server_info(str(tmp_path), errors=errors)
+
+        with open(os.path.join(str(tmp_path), 'server_info.json')) as f:
+            info = json.load(f)
+        assert info['enabled_clouds'] == {
+            'default': {
+                'kubernetes': ['compute']
+            }
+        }
+        assert 'cloud_status_error' not in info
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -3277,9 +3277,9 @@ class TestDumpClusterInfo:
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
                         '_resources'):
-            debug_utils._dump_cluster_info(
-                {'k8s-dead'}, str(tmp_path),
-                debug_utils._kube_context_reachable, errors)
+            debug_utils._dump_cluster_info({'k8s-dead'}, str(tmp_path),
+                                           debug_utils._kube_context_reachable,
+                                           errors)
 
         mock_reachable.assert_called_once_with('defunct-ctx')
         # Skylet collection was skipped: the head runner's remote command (the
@@ -3301,7 +3301,7 @@ class TestDumpClusterInfo:
     def test_reachable_kube_context_collects_skylet_log(
             self, mock_get_cluster, mock_events, mock_requests, mock_coords,
             mock_reachable, tmp_path):
-        """A k8s cluster on a reachable context still collects the skylet log."""
+        """Reachable k8s context still collects the skylet log."""
         del mock_events, mock_requests, mock_coords  # required by mock.patch
         handle = mock.Mock()
         runner = mock.Mock()
@@ -3317,9 +3317,9 @@ class TestDumpClusterInfo:
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
                         '_resources'):
-            debug_utils._dump_cluster_info(
-                {'k8s-live'}, str(tmp_path),
-                debug_utils._kube_context_reachable, errors)
+            debug_utils._dump_cluster_info({'k8s-live'}, str(tmp_path),
+                                           debug_utils._kube_context_reachable,
+                                           errors)
 
         mock_reachable.assert_called_once_with('live-ctx')
         runner.rsync.assert_called_once()
@@ -3617,11 +3617,12 @@ class TestJobsControllerUnreachableGate:
             e['resource'] == 'managed_job_details' and 'fast-fail' in e['error']
             for e in ctx['errors'])
 
+
 class TestCollectClusterSkyletLog:
     """Tests for the _collect_cluster_skylet_log helper."""
 
     def test_rsyncs_skylet_log_from_head(self, tmp_path):
-        """Pulls the remotely-resolved skylet log off the first (head) runner."""
+        """Pulls the remotely-resolved skylet log off the head runner."""
         runner = mock.Mock()
         runner.run.return_value = (0, '/home/sky/.sky/skylet.log\n', '')
         handle = mock.Mock()

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -27,6 +27,17 @@ from sky.utils import debug_utils
 from sky.utils import status_lib
 
 
+class _StubReachability:
+    """Reachability checker stubbed to a fixed answer -- no network probe."""
+
+    def __init__(self, reachable: bool = True) -> None:
+        self._reachable = reachable
+
+    def __call__(self, context: Optional[str]) -> bool:
+        del context  # unused
+        return self._reachable
+
+
 def _make_context(
     request_ids: Optional[Set[str]] = None,
     cluster_names: Optional[Set[str]] = None,
@@ -201,7 +212,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-j1' in ctx['request_ids']
 
@@ -217,7 +228,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={20})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-j2' in ctx['request_ids']
 
@@ -233,7 +244,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert ctx['request_ids'] == set()
 
@@ -242,7 +253,7 @@ class TestGetRequestsFromManagedJobs:
         """Empty managed_job_ids should not trigger any DB call."""
         ctx = _make_context(managed_job_ids=set())
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         mock_get_tasks.assert_not_called()
         assert ctx['request_ids'] == set()
@@ -258,7 +269,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert ctx['request_ids'] == set()
 
@@ -270,7 +281,7 @@ class TestGetRequestsFromManagedJobs:
         ctx = _make_context(managed_job_ids={42})
 
         # Should not raise
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert ctx['request_ids'] == set()
 
@@ -282,7 +293,7 @@ class TestGetRequestsFromManagedJobs:
         mock_get_tasks.return_value = []
         ctx = _make_context(managed_job_ids={1})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         call_args = mock_get_tasks.call_args
         task_filter = call_args[0][0]
@@ -314,7 +325,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-cancel-name' in ctx['request_ids']
 
@@ -339,7 +350,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-cancel-all-users' in ctx['request_ids']
 
@@ -365,7 +376,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-cancel-all' in ctx['request_ids']
 
@@ -391,7 +402,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-cancel-other' not in ctx['request_ids']
 
@@ -408,7 +419,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={42})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-rv' in ctx['request_ids']
 
@@ -426,7 +437,7 @@ class TestGetRequestsFromManagedJobs:
         ]
         ctx = _make_context(managed_job_ids={43})
 
-        debug_utils._get_requests_from_managed_jobs(ctx)
+        debug_utils._get_requests_from_managed_jobs(ctx, _StubReachability())
 
         assert 'req-rv-list' in ctx['request_ids']
 
@@ -610,7 +621,7 @@ class TestGetManagedJobsFromClusters:
         name = managed_job_utils.generate_managed_job_cluster_name('train', 7)
         ctx = _make_context(cluster_names={name})
 
-        debug_utils._get_managed_jobs_from_clusters(ctx)
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
 
         assert ctx['managed_job_ids'] == {7}
 
@@ -640,7 +651,7 @@ class TestGetManagedJobsFromClusters:
         ], 0, {}, 0)
         ctx = _make_context(cluster_names={'worker-1'})
 
-        debug_utils._get_managed_jobs_from_clusters(ctx)
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
 
         assert ctx['managed_job_ids'] == {1, 2}
 
@@ -656,7 +667,7 @@ class TestGetManagedJobsFromClusters:
         """
         ctx = _make_context()
 
-        debug_utils._get_managed_jobs_from_clusters(ctx)
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
 
         assert ctx['managed_job_ids'] == set()
         mock_queue.assert_not_called()
@@ -667,7 +678,7 @@ class TestGetManagedJobsFromClusters:
         errors: List[Dict[str, str]] = []
         ctx = _make_context(cluster_names={'c1'}, errors=errors)
 
-        debug_utils._get_managed_jobs_from_clusters(ctx)
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
 
         assert ctx['managed_job_ids'] == set()
         assert len(errors) == 1
@@ -938,7 +949,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert 'req-recent' in ctx['request_ids']
 
@@ -953,7 +966,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=120.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=120.0,
+                                             reachability=_StubReachability())
 
         call_args = mock_get_tasks.call_args
         task_filter = call_args[0][0]
@@ -985,7 +1000,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert 'active-cluster' in ctx['cluster_names']
         assert 'old-cluster' not in ctx['cluster_names']
@@ -1022,7 +1039,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert ctx['cluster_names'] == {'active-cluster'}
 
@@ -1049,7 +1068,9 @@ class TestPopulateRecentContext:
         ], 2, {}, 2)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert 1 in ctx['managed_job_ids']
         assert 2 not in ctx['managed_job_ids']
@@ -1068,7 +1089,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert 'req-running' in ctx['request_ids']
 
@@ -1084,7 +1107,9 @@ class TestPopulateRecentContext:
 
         ctx = _make_context()
         # Should not raise
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert ctx['request_ids'] == set()
         assert ctx['cluster_names'] == set()
@@ -1108,7 +1133,9 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0)
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx, minutes=60.0)
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
 
         assert 'newly-launched' in ctx['cluster_names']
 
@@ -1213,7 +1240,8 @@ class TestCrossLinkCycleBreak:
         with mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
                         return_value=([], 0, {}, 0)):
             ctx = _make_context(managed_job_ids={42})
-            debug_utils._get_requests_from_managed_jobs(ctx)
+            debug_utils._get_requests_from_managed_jobs(ctx,
+                                                        _StubReachability())
 
         assert 'req-1' in ctx['request_ids']
         assert 'req-1' in ctx['request_ids_via_job']
@@ -1273,7 +1301,8 @@ class TestCrossLinkCycleBreak:
             # 'user-seeded' was already in request_ids before the helper ran.
             ctx = _make_context(managed_job_ids={42},
                                 request_ids={'user-seeded'})
-            debug_utils._get_requests_from_managed_jobs(ctx)
+            debug_utils._get_requests_from_managed_jobs(ctx,
+                                                        _StubReachability())
 
         assert 'user-seeded' in ctx['request_ids']
         # Pre-existing request was not tagged → still expandable downstream.
@@ -1306,7 +1335,8 @@ class TestCrossLinkCycleBreak:
         with mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
                         return_value=([], 0, {}, 0)):
             ctx = _make_context(managed_job_ids={1})
-            debug_utils._get_requests_from_managed_jobs(ctx)
+            debug_utils._get_requests_from_managed_jobs(ctx,
+                                                        _StubReachability())
 
         assert 'cancel-req' in ctx['request_ids']
         assert 'cancel-req' in ctx['request_ids_via_job']
@@ -2613,6 +2643,7 @@ class TestDumpClusterInfo:
         errors: List[Dict[str, str]] = []
         debug_utils._dump_cluster_info({'gone-cluster'},
                                        str(tmp_path),
+                                       _StubReachability(),
                                        errors=errors)
 
         cluster_dir = tmp_path / 'clusters' / 'gone-cluster'
@@ -2636,7 +2667,10 @@ class TestDumpClusterInfo:
         mock_get_tasks.return_value = []
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'c1'}, str(tmp_path), errors=errors)
+        debug_utils._dump_cluster_info({'c1'},
+                                       str(tmp_path),
+                                       _StubReachability(),
+                                       errors=errors)
 
         assert len(errors) == 1
         assert errors[0]['component'] == 'clusters'
@@ -3006,7 +3040,8 @@ class TestDumpClusterInfo:
         }
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'my-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'my-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         info_path = (tmp_path / 'clusters' / 'my-cluster' / 'cluster_info.json')
         assert info_path.exists()
@@ -3026,7 +3061,8 @@ class TestDumpClusterInfo:
         mock_get_cluster.return_value = None
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'gone-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'gone-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         assert not errors
         info_path = (tmp_path / 'clusters' / 'gone-cluster' /
@@ -3040,7 +3076,8 @@ class TestDumpClusterInfo:
         mock_get_cluster.side_effect = RuntimeError('DB error')
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'fail-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'fail-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         assert len(errors) >= 1
         assert any(e['component'] == 'clusters' for e in errors)
@@ -3048,7 +3085,8 @@ class TestDumpClusterInfo:
     def test_empty_cluster_names_is_noop(self, tmp_path):
         """Empty cluster_names should not create any files."""
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info(set(), str(tmp_path), errors)
+        debug_utils._dump_cluster_info(set(), str(tmp_path),
+                                       _StubReachability(), errors)
 
         assert not errors
         assert not (tmp_path / 'clusters').exists()
@@ -3077,7 +3115,8 @@ class TestDumpClusterInfo:
         }]
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'ev-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'ev-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         event_path = (tmp_path / 'clusters' / 'ev-cluster' /
                       'events_provision.json')
@@ -3103,7 +3142,8 @@ class TestDumpClusterInfo:
         ]
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'assoc-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'assoc-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         assoc_path = (tmp_path / 'clusters' / 'assoc-cluster' /
                       'associated_requests.json')
@@ -3137,7 +3177,8 @@ class TestDumpClusterInfo:
         }
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'live-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'live-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         # Pulled the skylet log off the head node (runners[0]) into the
         # cluster dump dir, using the remotely-resolved source path.
@@ -3171,7 +3212,7 @@ class TestDumpClusterInfo:
 
         errors: List[Dict[str, str]] = []
         debug_utils._dump_cluster_info({'stopped-cluster'}, str(tmp_path),
-                                       errors)
+                                       _StubReachability(), errors)
 
         handle.get_command_runners.assert_not_called()
         assert not errors
@@ -3200,7 +3241,8 @@ class TestDumpClusterInfo:
         }
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_cluster_info({'init-cluster'}, str(tmp_path), errors)
+        debug_utils._dump_cluster_info({'init-cluster'}, str(tmp_path),
+                                       _StubReachability(), errors)
 
         runner.rsync.assert_called_once()
         assert not errors
@@ -3235,7 +3277,9 @@ class TestDumpClusterInfo:
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
                         '_resources'):
-            debug_utils._dump_cluster_info({'k8s-dead'}, str(tmp_path), errors)
+            debug_utils._dump_cluster_info(
+                {'k8s-dead'}, str(tmp_path),
+                debug_utils._kube_context_reachable, errors)
 
         mock_reachable.assert_called_once_with('defunct-ctx')
         # Skylet collection was skipped: the head runner's remote command (the
@@ -3273,44 +3317,48 @@ class TestDumpClusterInfo:
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.utils.debug_utils._collect_cluster_kubernetes'
                         '_resources'):
-            debug_utils._dump_cluster_info({'k8s-live'}, str(tmp_path), errors)
+            debug_utils._dump_cluster_info(
+                {'k8s-live'}, str(tmp_path),
+                debug_utils._kube_context_reachable, errors)
 
         mock_reachable.assert_called_once_with('live-ctx')
         runner.rsync.assert_called_once()
 
 
-class TestContextReachabilityCache:
-    """Tests for _ContextReachabilityCache (per-dump memoized kube probes)."""
+class TestKubeContextReachability:
+    """Tests for _kube_context_reachable (per-dump memoized kube probes)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_reachability_cache(self):
+        debug_utils._kube_context_reachable.cache_clear()
+        yield
+        debug_utils._kube_context_reachable.cache_clear()
 
     @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable')
     def test_probes_each_context_once(self, mock_reachable):
         """Repeated lookups of the same context probe only once."""
         mock_reachable.return_value = True
-        cache = debug_utils._ContextReachabilityCache()
 
-        assert cache.is_reachable('ctx-a') is True
-        assert cache.is_reachable('ctx-a') is True
-        assert cache.is_reachable('ctx-a') is True
+        assert debug_utils._kube_context_reachable('ctx-a') is True
+        assert debug_utils._kube_context_reachable('ctx-a') is True
+        assert debug_utils._kube_context_reachable('ctx-a') is True
         mock_reachable.assert_called_once_with('ctx-a')
 
     @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable')
     def test_distinct_contexts_probed_separately(self, mock_reachable):
         mock_reachable.side_effect = lambda ctx: ctx == 'live'
-        cache = debug_utils._ContextReachabilityCache()
 
-        assert cache.is_reachable('live') is True
-        assert cache.is_reachable('dead') is False
-        assert cache.is_reachable('live') is True
+        assert debug_utils._kube_context_reachable('live') is True
+        assert debug_utils._kube_context_reachable('dead') is False
+        assert debug_utils._kube_context_reachable('live') is True
         assert mock_reachable.call_count == 2
 
     @mock.patch('sky.utils.debug_utils.kubernetes_debug.context_reachable',
                 return_value=True)
     def test_none_in_cluster_context_is_cached(self, mock_reachable):
         """None (in-cluster auth) is a valid, cacheable key."""
-        cache = debug_utils._ContextReachabilityCache()
-
-        assert cache.is_reachable(None) is True
-        assert cache.is_reachable(None) is True
+        assert debug_utils._kube_context_reachable(None) is True
+        assert debug_utils._kube_context_reachable(None) is True
         mock_reachable.assert_called_once_with(None)
 
 
@@ -3379,6 +3427,195 @@ class TestDumpRequestIdInfoLogCollection:
         assert (request_dir / 'request.log').read_text() == 'local content'
         assert not errors
 
+
+class TestJobsControllerUnreachableGate:
+    """Tests for _jobs_controller_unreachable_context and its call sites.
+
+    The gate must only skip on positive evidence of the one hang mode
+    (k8s controller behind a dead context) and fail open otherwise.
+    """
+
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=True)
+    def test_consolidation_mode_never_skips(self, _):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name',
+                return_value=None)
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_no_controller_record_never_skips(self, _, __):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name',
+                return_value={'handle': None})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_no_handle_never_skips(self, _, __):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name')
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_non_k8s_controller_never_skips(self, _, mock_get_cluster):
+        resources = SimpleNamespace(cloud=clouds.AWS(),
+                                    region='us-east-1',
+                                    zone=None)
+        handle = SimpleNamespace(launched_resources=resources,
+                                 cluster_name_on_cloud='ctrl-on-cloud')
+        mock_get_cluster.return_value = {'handle': handle}
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils._kube_coordinates_for_handle',
+                return_value=('ctrl-ctx', 'ns'))
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name',
+                return_value={'handle': mock.Mock()})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_reachable_k8s_context_never_skips(self, _, __, ___):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=True))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils._kube_coordinates_for_handle',
+                return_value=('ctrl-ctx', 'ns'))
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name',
+                return_value={'handle': mock.Mock()})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_unreachable_k8s_context_skips(self, _, __, ___):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result == 'ctrl-ctx'
+
+    @mock.patch('sky.utils.debug_utils.global_user_state.'
+                'get_cluster_from_name',
+                side_effect=RuntimeError('db exploded'))
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'is_consolidation_mode',
+                return_value=False)
+    def test_resolution_error_fails_open(self, _, __):
+        result = debug_utils._jobs_controller_unreachable_context(
+            _StubReachability(reachable=False))
+        assert result is None
+
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context',
+                return_value='dead-ctx')
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_recent_context_skips_jobs_scan_on_dead_controller(
+            self, mock_queue, mock_gate):
+        """queue_v2 must not run; a skip record lands in errors."""
+        ctx = _make_context()
+        with mock.patch('sky.utils.debug_utils.requests_lib.'
+                        'get_request_tasks',
+                        return_value=[]), \
+             mock.patch('sky.utils.debug_utils.global_user_state.'
+                        'get_clusters',
+                        return_value=[]):
+            debug_utils._populate_recent_context(
+                ctx, minutes=60.0, reachability=_StubReachability())
+
+        mock_queue.assert_not_called()
+        assert any(e['component'] == 'recent_context' and
+                   e['resource'] == 'managed_jobs' and 'fast-fail' in e['error']
+                   for e in ctx['errors'])
+
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context',
+                return_value='dead-ctx')
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_dump_managed_job_info_skips_on_dead_controller(
+            self, mock_queue, mock_gate, tmp_path):
+        """Neither queue_v2 nor controller collection runs; skip recorded."""
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils.'
+                        '_collect_controller_debug_data') as mock_collect:
+            debug_utils._dump_managed_job_info({1, 2},
+                                               str(tmp_path),
+                                               _StubReachability(),
+                                               errors=errors)
+
+        mock_queue.assert_not_called()
+        mock_collect.assert_not_called()
+        assert any(
+            e['component'] == 'managed_jobs' and
+            e['resource'] == 'controller_access' and 'fast-fail' in e['error']
+            for e in errors)
+
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context',
+                return_value=None)
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
+                return_value=([], None, None, None))
+    def test_dump_managed_job_info_proceeds_on_reachable_controller(
+            self, mock_queue, mock_gate, tmp_path):
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils.'
+                        '_collect_controller_debug_data') as mock_collect:
+            debug_utils._dump_managed_job_info({1},
+                                               str(tmp_path),
+                                               _StubReachability(),
+                                               errors=errors)
+
+        mock_queue.assert_called_once()
+        mock_collect.assert_called_once()
+
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context',
+                return_value='dead-ctx')
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_cluster_to_job_expansion_skips_on_dead_controller(
+            self, mock_queue, mock_gate):
+        ctx = _make_context(cluster_names={'c1'})
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
+
+        mock_queue.assert_not_called()
+        assert not ctx['managed_job_ids']
+        assert any(e['resource'] == 'managed_jobs_from_clusters' and
+                   'fast-fail' in e['error'] for e in ctx['errors'])
+
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context',
+                return_value='dead-ctx')
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_request_matching_degrades_but_still_runs_on_dead_controller(
+            self, mock_queue, mock_gate):
+        """Name/user matching is skipped, body matching still runs."""
+        request = _make_request(
+            request_id='req-1',
+            name=(server_constants.REQUEST_NAME_PREFIX +
+                  request_names.RequestName.JOBS_CANCEL.value),
+            request_body=SimpleNamespace(job_id=42),
+        )
+        ctx = _make_context(managed_job_ids={42})
+        with mock.patch(
+                'sky.utils.debug_utils.requests_lib.'
+                'get_request_tasks',
+                return_value=[request]):
+            debug_utils._get_requests_from_managed_jobs(ctx,
+                                                        _StubReachability())
+
+        mock_queue.assert_not_called()
+        # Body matching (local) still linked the request.
+        assert 'req-1' in ctx['request_ids']
+        assert any(
+            e['resource'] == 'managed_job_details' and 'fast-fail' in e['error']
+            for e in ctx['errors'])
 
 class TestCollectClusterSkyletLog:
     """Tests for the _collect_cluster_skylet_log helper."""


### PR DESCRIPTION
## Summary

Debug dumps were unnecessarily slow, and pathologically slow whenever any kube context was unreachable — each dead context stacked unbounded kubectl / credential-probe timeouts serially in front of the rest of the dump. This PR makes the dump fast-fail on positive evidence of a dead context and parallelizes per-cluster collection, without dropping any data:

- **Fast-fail skylet collection + parallel per-cluster dump**: skylet log collection runs `kubectl exec`, whose `connect_timeout` maps to `--pod-running-timeout` and does not bound the API connect phase — against a dead context it falls back to client-go defaults (~2min). Gate it on a bounded, no-retry per-context reachability probe (reusing the fast-fail primitives from #9937), memoized per context. Cluster collection now runs in parallel via `subprocess_utils.run_in_parallel`, so one unreachable cluster no longer stacks its timeout in front of every other cluster.
- **Bound the `sky_check.check()` probe in server-info collection**: `check()` probes every enabled cloud's credentials with no timeout knob; a broken credential (e.g. expired gcloud reauth) can hang it indefinitely. Bound it to a 30s wall-clock deadline for the dump only — on timeout we record a `cloud_status` error and omit `enabled_clouds` instead of hanging the dump.
- **Gate managed-jobs controller reads on context reachability**: every managed-jobs read outside consolidation mode (`queue_v2` for the recent-activity scan and cross-links, the controller debug manifest, log rsync) execs into the jobs controller. Gate them on the same shared reachability cache. The gate skips only on the one mode that hangs (k8s controller behind a dead context) and fails open everywhere else; skips are recorded in `errors.json`.
- **Smoke test**: with a dead context in `allowed_contexts`, assert the dump completes under a hard wall-clock ceiling and still contains the live cluster's data plus an explicit `reachable: false` marker for the dead context.

Cross-link expansion ordering and dump section ordering are untouched; parallelism is strictly within the cluster-collection section after cross-linking completes.

## Benchmarks

Local API server, 3 clusters + 2 managed jobs on a kind cluster. "Degraded" = the kube API server accepts TCP but never answers (`docker pause` on the kind node) — the defunct-context failure mode seen in production dumps.

| scenario | before | after commit 1+2 | after commit 3 |
|---|---|---|---|
| healthy, warm | ~17.5s | ~17s | ~17s |
| healthy, cold server (stale cloud-check cache, broken gcloud creds) | **568.9s** | 26.5s | — |
| degraded context | **145.8s / 146.0s** | 47.4s / 47.5s | **26.7s / 28.8s (5.5x)** |

Dump contents were diffed old-vs-new in both scenarios: file trees are identical (modulo the `requests/` population, which changes across server restarts regardless of code). Terminated-cluster history collection and scoped `-c`/`-j` cross-links verified intact.

## Tested

- `pytest tests/unit_tests/test_sky/utils/test_debug_utils.py tests/unit_tests/kubernetes/test_debug.py` — all pass, including 13 new tests covering every branch of the controller-reachability gate and the partial degradation of request matching.
- New smoke test `test_debug_dump_unreachable_context_fast_fail` run locally against kind: launches a real cluster with an unreachable context injected into `allowed_contexts`; dump completed in 14s against the 300s ceiling with live-cluster data and the `reachable: false` marker asserted.
- Manual benchmark above (old vs new server on the same cluster/job fleet, dumps timed end-to-end via `sky debug-dump --recent-minutes 600`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)