### PR TITLE
Update the config doc and default value for rbac.restrict_config_to_admins

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -256,7 +256,6 @@ Below is the configuration syntax and some example values. See detailed explanat
 
   :ref:`rbac <config-yaml-rbac>`:
     :ref:`default_role <config-yaml-rbac-default-role>`: admin
-    :ref:`restrict_config_to_admins <config-yaml-rbac-restrict-config-to-admins>`: false
 
   :ref:`db <config-yaml-db>`: postgresql://postgres@localhost/skypilot
 
@@ -2750,26 +2749,6 @@ If not specified, the default role is ``admin``.
 .. TODO(aylei): Refine this after unified authentication.
 
 Note: RBAC is only functional when :ref:`OAuth <api-server-oauth>` is configured.
-
-.. _config-yaml-rbac-restrict-config-to-admins:
-
-``rbac.restrict_config_to_admins``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Restrict reading the API server config to admins (optional, default ``false``).
-
-The API server config (returned by ``GET /workspaces/config``) includes
-admin-only secrets such as cloud provider tokens. When this is set to ``true``,
-the ``user`` role is blocked from reading it (returns ``403``) and the dashboard
-hides the configuration page for non-admin users. Writing the config
-(``POST /workspaces/config``) is admin-only regardless of this setting.
-
-Defaults to ``false`` to preserve backward-compatible behavior.
-
-.. code-block:: yaml
-
-  rbac:
-    restrict_config_to_admins: true
 
 .. _config-yaml-db:
 

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -56,14 +56,16 @@ export function Config() {
 
   useEffect(() => {
     // If the caller can't read the config, it would 403, so skip the request
-    // entirely and show the access-denied card instead.
-    if (!canViewConfig) {
+    // entirely and show the access-denied card instead. The header (metrics
+    // button, version) is still rendered for everyone below.
+    if (canViewConfig) {
+      loadConfig();
+    } else {
       setLoading(false);
-      return;
     }
-    loadConfig();
 
-    // Check Grafana availability
+    // Check Grafana availability for everyone: the metrics button and version
+    // info in the header are shown regardless of config read access.
     const checkGrafana = async () => {
       const available = await checkGrafanaAvailability();
       setIsGrafanaAvailable(available);
@@ -175,85 +177,92 @@ export function Config() {
     );
   }
 
+  // Top header bar (title + metrics button + version) shown to everyone,
+  // regardless of whether they can read the config below.
+  const header = (
+    <div className="flex items-center justify-between mb-4 h-8">
+      <div className="text-base flex items-center">
+        <span className="text-sky-blue leading-none">SkyPilot API Server</span>
+      </div>
+
+      <div className="flex items-center">
+        <div className="text-sm flex items-center">
+          {(loading || saving) && (
+            <div className="flex items-center mr-4">
+              <CircularProgress size={15} className="mt-0" />
+              <span className="ml-2 text-gray-500">
+                {saving ? 'Applying...' : 'Loading...'}
+              </span>
+            </div>
+          )}
+        </div>
+        {isGrafanaAvailable && (
+          <button
+            onClick={() => {
+              const grafanaUrl = getGrafanaUrl();
+              // Get app name from environment variable
+              const releaseName =
+                process.env.SKYPILOT_RELEASE_NAME || 'skypilot';
+              const appName = `${releaseName}-api`;
+              window.open(
+                `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${appName}`,
+                '_blank'
+              );
+            }}
+            className="inline-flex items-center h-8 px-3 text-sm font-medium text-white bg-sky-blue-bright border border-transparent rounded-md shadow-sm hover:bg-sky-blue focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-blue mr-4"
+          >
+            <svg
+              className="w-4 h-4 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+              />
+            </svg>
+            View API Server Metrics
+          </button>
+        )}
+        <NewVersionAvailable />
+        <PluginSlot
+          name="settings.version-display"
+          fallback={<VersionDisplay />}
+        />
+      </div>
+    </div>
+  );
+
   // The API server configuration exposes admin-only secrets. Anyone who can't
   // read it (restricted non-admins, or viewers) gets an access-denied card
-  // instead of a 403.
+  // instead of a 403 -- but the header above is still shown.
   if (!canViewConfig) {
     return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="text-base font-normal">
-            API Server Configuration
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-gray-600">
-            You must be an admin to view the API server configuration.
-          </p>
-        </CardContent>
-      </Card>
+      <>
+        {header}
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-base font-normal">
+              API Server Configuration
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-600">
+              You must be an admin to view the API server configuration.
+            </p>
+          </CardContent>
+        </Card>
+      </>
     );
   }
 
   return (
     <>
-      <div className="flex items-center justify-between mb-4 h-8">
-        <div className="text-base flex items-center">
-          <span className="text-sky-blue leading-none">
-            SkyPilot API Server
-          </span>
-        </div>
-
-        <div className="flex items-center">
-          <div className="text-sm flex items-center">
-            {(loading || saving) && (
-              <div className="flex items-center mr-4">
-                <CircularProgress size={15} className="mt-0" />
-                <span className="ml-2 text-gray-500">
-                  {saving ? 'Applying...' : 'Loading...'}
-                </span>
-              </div>
-            )}
-          </div>
-          {isGrafanaAvailable && (
-            <button
-              onClick={() => {
-                const grafanaUrl = getGrafanaUrl();
-                // Get app name from environment variable
-                const releaseName =
-                  process.env.SKYPILOT_RELEASE_NAME || 'skypilot';
-                const appName = `${releaseName}-api`;
-                window.open(
-                  `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${appName}`,
-                  '_blank'
-                );
-              }}
-              className="inline-flex items-center h-8 px-3 text-sm font-medium text-white bg-sky-blue-bright border border-transparent rounded-md shadow-sm hover:bg-sky-blue focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-blue mr-4"
-            >
-              <svg
-                className="w-4 h-4 mr-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-                />
-              </svg>
-              View API Server Metrics
-            </button>
-          )}
-          <NewVersionAvailable />
-          <PluginSlot
-            name="settings.version-display"
-            fallback={<VersionDisplay />}
-          />
-        </div>
-      </div>
+      {header}
 
       {/* Main Content */}
       <Card className="w-full">

--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -59,9 +59,10 @@ export function SidebarProvider({ children }) {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [userEmail, setUserEmail] = useState(null);
   const [userRole, setUserRole] = useState(null);
-  // Server-side opt-in (rbac.restrict_config_to_admins) surfaced via
-  // /api/health, so the config UI can be hidden for non-admins.
-  const [restrictConfigToAdmins, setRestrictConfigToAdmins] = useState(false);
+  // Server-side flag (rbac.restrict_config_to_admins, default true) surfaced
+  // via /api/health, so the config UI can be hidden for non-admins. Default to
+  // restricted before /api/health resolves.
+  const [restrictConfigToAdmins, setRestrictConfigToAdmins] = useState(true);
 
   const toggleSidebar = () => {
     setIsSidebarOpen((prev) => !prev);

--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -84,37 +84,33 @@ export function SidebarProvider({ children }) {
         setRestrictConfigToAdmins(!!data.restrict_config_to_admins);
         if (data.user && data.user.name) {
           setUserEmail(data.user.name);
+        }
 
-          // Get role from direct API endpoint to avoid cache interference
-          // Using cache would cause race condition, which leads to unexpected
-          // behavior in workspaces and users page.
-          const getUserRole = async () => {
-            try {
-              const response = await fetch(`${fullEndpoint}/users/role`);
-              if (response.ok) {
-                const roleData = await response.json();
-                // Fall back to the least-privileged role if the payload has no
-                // role, so admin-gated views (e.g. the Config page) never hang
-                // waiting on a null role.
-                setUserRole(roleData.role || 'user');
-              } else {
-                setUserRole('user');
-              }
-            } catch (error) {
-              // On any failure, resolve to the least-privileged role rather
-              // than leaving it null (which would hang admin-gated views).
-              console.log('Could not fetch user role:', error);
+        // Always resolve the role from /users/role rather than inferring it
+        // from the presence of a user in /api/health.
+        // Fetch directly (no cache) to avoid a race that misbehaves on
+        // the workspaces and users pages.
+        const getUserRole = async () => {
+          try {
+            const response = await fetch(`${fullEndpoint}/users/role`);
+            if (response.ok) {
+              const roleData = await response.json();
+              // Fall back to the least-privileged role if the payload has no
+              // role, so admin-gated views (e.g. the Config page) never hang
+              // waiting on a null role.
+              setUserRole(roleData.role || 'user');
+            } else {
               setUserRole('user');
             }
-          };
+          } catch (error) {
+            // On any failure, resolve to the least-privileged role rather
+            // than leaving it null (which would hang admin-gated views).
+            console.log('Could not fetch user role:', error);
+            setUserRole('user');
+          }
+        };
 
-          getUserRole();
-        } else {
-          // No user info (e.g. auth disabled or anonymous): resolve the role
-          // to the least-privileged value instead of leaving it null, which
-          // would hang admin-gated views (e.g. the Config page) forever.
-          setUserRole('user');
-        }
+        getUserRole();
       })
       .catch((error) => {
         console.error('Error fetching user data:', error);

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -93,7 +93,7 @@ class APIHealthResponse(ResponseBaseModel):
     # Whether GET /workspaces/config is restricted to admins (config payload
     # includes admin-only secrets). Lets the dashboard hide the config UI for
     # non-admins when enabled.
-    restrict_config_to_admins: bool = False
+    restrict_config_to_admins: bool = True
 
 
 class StatusResponse(ResponseBaseModel):

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -393,13 +393,13 @@ def restrict_config_to_admins() -> bool:
     """Whether GET /workspaces/config is restricted to admins.
 
     The config payload includes admin-only secrets (e.g. cloud provider
-    tokens), so admins can opt into blocking non-admin reads by setting
-    ``rbac.restrict_config_to_admins: true``. Defaults to False to preserve
-    backward-compatible behavior (POST is always admin-only regardless).
+    tokens), so non-admin reads are blocked by default. Admins can opt out by
+    setting ``rbac.restrict_config_to_admins: false`` (POST is always
+    admin-only regardless).
     """
     return bool(
         skypilot_config.get_nested(('rbac', 'restrict_config_to_admins'),
-                                   default_value=False))
+                                   default_value=True))
 
 
 def get_role_permissions(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2344,7 +2344,7 @@ def get_config_schema():
                 'case_insensitive_enum': ['admin', 'user', 'viewer']
             },
             # When true, GET /workspaces/config is restricted to admins (the
-            # config payload includes admin-only secrets). Defaults to false.
+            # config payload includes admin-only secrets). Defaults to true.
             'restrict_config_to_admins': {
                 'type': 'boolean',
             },

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -20,8 +20,8 @@ class TestRoleEnum:
 
 
 class TestGetRolePermissions:
-    """GET /workspaces/config is admin-only only when opted in via
-    rbac.restrict_config_to_admins; POST is always admin-only."""
+    """GET /workspaces/config is admin-only unless opted out via
+    rbac.restrict_config_to_admins: false; POST is always admin-only."""
 
     @staticmethod
     def _user_blocklist(restrict):
@@ -43,8 +43,9 @@ class TestGetRolePermissions:
             'method': 'POST'
         } in self._user_blocklist(False)
 
-    def test_config_get_not_blocked_by_default(self):
-        # Default (flag off): reads are allowed for the user role.
+    def test_config_get_not_blocked_when_opted_out(self):
+        # rbac.restrict_config_to_admins=false: reads are allowed for the user
+        # role.
         assert {
             'path': '/workspaces/config',
             'method': 'GET'
@@ -56,6 +57,15 @@ class TestGetRolePermissions:
             'path': '/workspaces/config',
             'method': 'GET'
         } in self._user_blocklist(True)
+
+    def test_restrict_config_to_admins_defaults_to_true(self):
+        # With nothing set in config, reads default to admin-only.
+        def fake_get_nested(keys, default_value=None, *args, **kwargs):
+            return default_value
+
+        with mock.patch('sky.skypilot_config.get_nested',
+                        side_effect=fake_get_nested):
+            assert rbac.restrict_config_to_admins() is True
 
     def test_config_get_blocked_even_when_user_role_customized(self):
         # Security: a custom user role in config must not bypass the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
- Update the config doc and default value for `rbac.restrict_config_to_admins`.
- Show the metrics button and the version info in the config page with `rbac.restrict_config_to_admins: false`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Users with `User` role cannot see the SkyPilot config page by default or with `rbac.restrict_config_to_admins: true`
  - [x] Users with `User` role can see the SkyPilot config page with `rbac.restrict_config_to_admins: false`
  - [x] Users can see the SkyPilot config page by default with ingress auth
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
