### PR TITLE
[Core] Restore per-cluster SSH config from DB for proxy commands

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1774,6 +1774,96 @@ def ssh_credential_from_yaml(
     return credentials
 
 
+def _cluster_names_referenced_in_proxy(proxy_strs: List[str],
+                                       cluster_names: List[str]) -> List[str]:
+    """Returns cluster names that appear as SSH host tokens in proxy strings.
+
+    A proxy command / jump may reach the destination through a SkyPilot
+    cluster referenced by its SSH host alias (which equals the cluster name),
+    e.g. ``ssh -W '[%h]:%p' jump-host`` or a ``user@jump-host:port`` jump spec.
+    This tokenizes the proxy strings and returns the subset of tokens (or their
+    host component) that match a known cluster name.
+    """
+    names = set(cluster_names)
+    matched: List[str] = []
+    for proxy in proxy_strs:
+        try:
+            tokens = shlex.split(proxy)
+        except ValueError:
+            tokens = proxy.split()
+        for token in tokens:
+            # A jump host may be given as user@host:port or a comma-separated
+            # chain; expand the token into its host components before matching.
+            candidates = [token]
+            for sep in ('@', ':', ','):
+                candidates = [
+                    part for cand in candidates for part in cand.split(sep)
+                ]
+            for cand in candidates:
+                if cand in names and cand not in matched:
+                    matched.append(cand)
+    return matched
+
+
+def restore_ssh_config_from_db_for_proxy(ssh_proxy_command: Optional[str],
+                                         ssh_proxy_jump: Optional[str]) -> None:
+    """Restores local SSH config stanzas for clusters referenced by a proxy.
+
+    When a cluster is launched, SkyPilot writes a per-cluster SSH config stanza
+    under ``~/.sky/generated/ssh/<name>`` (Included from ``~/.ssh/config``).
+    This stanza is local state, present only on the machine that ran the
+    launch. A user-provided ``ssh_proxy_command`` / ``ssh_proxy_jump`` may reach
+    its destination *through another SkyPilot cluster* by that cluster's SSH
+    host alias (e.g. a bastion started with ``sky launch``); the inner
+    ``ssh <alias>`` then needs the alias' stanza to be present locally to
+    resolve it.
+
+    On a machine that did not launch the referenced cluster (e.g. a remote API
+    server that provisioned it in a different session, or was restarted), the
+    stanza is absent and the proxy cannot resolve the alias. This rebuilds the
+    stanza on demand from the authoritative cluster state in the global user
+    state.
+
+    Best-effort: failures are logged at debug level and ignored (the proxy may
+    legitimately reference a non-SkyPilot host that is not in the database).
+    """
+    proxy_strs = [s for s in (ssh_proxy_command, ssh_proxy_jump) if s]
+    if not proxy_strs:
+        return
+    try:
+        cluster_names = global_user_state.get_cluster_names()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Skip SSH config restore; cannot list clusters: {e}')
+        return
+    for name in _cluster_names_referenced_in_proxy(proxy_strs, cluster_names):
+        try:
+            stanza_path = os.path.expanduser(
+                cluster_utils.SSHConfigHelper.ssh_cluster_path.format(name))
+            if os.path.exists(stanza_path):
+                continue
+            handle = global_user_state.get_handle_from_cluster_name(name)
+            if not isinstance(handle, backends.CloudVmRayResourceHandle):
+                continue
+            if (not handle.cached_external_ips or
+                    not handle.cached_external_ssh_ports):
+                continue
+            auth_config = ssh_credential_from_yaml(
+                handle.cluster_yaml,
+                ssh_user=handle.ssh_user,
+                docker_user=handle.docker_user)
+            cluster_utils.SSHConfigHelper.add_cluster(
+                handle.cluster_name, handle.cluster_name_on_cloud,
+                handle.cached_external_ips, auth_config,
+                handle.cached_external_ssh_ports, handle.docker_user,
+                handle.ssh_user)
+            logger.debug(
+                f'Restored local SSH config stanza for cluster {name!r} '
+                'referenced by an SSH proxy.')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(
+                f'Failed to restore SSH config for cluster {name!r}: {e}')
+
+
 def ssh_credentials_from_handles(
     handles: List['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
 ) -> List[Dict[str, Any]]:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1805,6 +1805,14 @@ def _cluster_names_referenced_in_proxy(proxy_strs: List[str],
     return matched
 
 
+# Proxy (command, jump) pairs whose referenced SkyPilot clusters already have
+# their local SSH config stanzas present, so the DB-querying restore below can
+# be skipped. restore_ssh_config_from_db_for_proxy() runs on every
+# SSHCommandRunner instantiation with a proxy configured; this memoizes the
+# pairs already satisfied on this machine.
+_checked_proxies: Set[Tuple[Optional[str], Optional[str]]] = set()
+
+
 def restore_ssh_config_from_db_for_proxy(ssh_proxy_command: Optional[str],
                                          ssh_proxy_jump: Optional[str]) -> None:
     """Restores local SSH config stanzas for clusters referenced by a proxy.
@@ -1830,19 +1838,28 @@ def restore_ssh_config_from_db_for_proxy(ssh_proxy_command: Optional[str],
     proxy_strs = [s for s in (ssh_proxy_command, ssh_proxy_jump) if s]
     if not proxy_strs:
         return
+    cache_key = (ssh_proxy_command, ssh_proxy_jump)
+    if cache_key in _checked_proxies:
+        return
     try:
         cluster_names = global_user_state.get_cluster_names()
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Skip SSH config restore; cannot list clusters: {e}')
         return
-    for name in _cluster_names_referenced_in_proxy(proxy_strs, cluster_names):
+    referenced = _cluster_names_referenced_in_proxy(proxy_strs, cluster_names)
+
+    def _stanza_path(name: str) -> str:
+        return os.path.expanduser(
+            cluster_utils.SSHConfigHelper.ssh_cluster_path.format(name))
+
+    for name in referenced:
+        if os.path.exists(_stanza_path(name)):
+            continue
         try:
-            stanza_path = os.path.expanduser(
-                cluster_utils.SSHConfigHelper.ssh_cluster_path.format(name))
-            if os.path.exists(stanza_path):
-                continue
             handle = global_user_state.get_handle_from_cluster_name(name)
             if not isinstance(handle, backends.CloudVmRayResourceHandle):
+                continue
+            if handle.cluster_yaml is None:
                 continue
             if (not handle.cached_external_ips or
                     not handle.cached_external_ssh_ports):
@@ -1862,6 +1879,11 @@ def restore_ssh_config_from_db_for_proxy(ssh_proxy_command: Optional[str],
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(
                 f'Failed to restore SSH config for cluster {name!r}: {e}')
+    # Memoize only when every referenced cluster's stanza is present, so a
+    # not-yet-ready cluster (e.g. one without cached IPs yet) is retried on a
+    # later call rather than being permanently skipped.
+    if all(os.path.exists(_stanza_path(name)) for name in referenced):
+        _checked_proxies.add(cache_key)
 
 
 def ssh_credentials_from_handles(

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1011,6 +1011,20 @@ class SSHCommandRunner(CommandRunner):
             if not os.path.exists(expanded_key_path):
                 raise FileNotFoundError(
                     f'SSH private key not found: {expanded_key_path}')
+        # A user-provided proxy command/jump may reach the destination through
+        # another SkyPilot cluster referenced by its SSH host alias (e.g. a
+        # bastion started with `sky launch`). That alias is resolved from a
+        # per-cluster SSH config stanza which is local state, present only on
+        # the machine that launched the cluster. Restore it from the global
+        # user state if this machine (e.g. a different API server) lacks it.
+        if ssh_proxy_command is not None or ssh_proxy_jump is not None:
+            # Lazy import: sky.backends.backend_utils imports this module, so a
+            # top-level import would be circular. This branch is only reached
+            # for proxied connections, which are uncommon.
+            # pylint: disable-next=import-outside-toplevel
+            from sky.backends import backend_utils
+            backend_utils.restore_ssh_config_from_db_for_proxy(
+                ssh_proxy_command, ssh_proxy_jump)
         if docker_user is not None:
             assert port is None or port == 22, (
                 f'port must be None or 22 for docker_user, got {port}.')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1017,7 +1017,7 @@ class SSHCommandRunner(CommandRunner):
         # per-cluster SSH config stanza which is local state, present only on
         # the machine that launched the cluster. Restore it from the global
         # user state if this machine (e.g. a different API server) lacks it.
-        if ssh_proxy_command is not None or ssh_proxy_jump is not None:
+        if ssh_proxy_command or ssh_proxy_jump:
             # Lazy import: sky.backends.backend_utils imports this module, so a
             # top-level import would be circular. This branch is only reached
             # for proxied connections, which are uncommon.

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -692,6 +692,7 @@ def _fake_handle():
                    return_value=['jump-abcd'])
 def test_restore_ssh_config_rebuilds_missing_stanza(mock_names, mock_get_handle,
                                                     mock_cred, mock_add):
+    backend_utils._checked_proxies.clear()
     mock_get_handle.return_value = _fake_handle()
     proxy = "ssh -W '[%h]:%p' jump-abcd"
     with mock.patch.object(backend_utils.os.path, 'exists', return_value=False):
@@ -708,6 +709,7 @@ def test_restore_ssh_config_rebuilds_missing_stanza(mock_names, mock_get_handle,
                    'get_cluster_names',
                    return_value=['jump-abcd'])
 def test_restore_ssh_config_skips_when_stanza_present(mock_names, mock_add):
+    backend_utils._checked_proxies.clear()
     proxy = "ssh -W '[%h]:%p' jump-abcd"
     with mock.patch.object(backend_utils.os.path, 'exists', return_value=True):
         backend_utils.restore_ssh_config_from_db_for_proxy(proxy, None)

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -647,3 +647,74 @@ def test_make_safe_symlink_command_leaves_target_unquoted():
         source='/etc/config', target='~/.sky/file_mounts/etc/config')
     assert 'ln -s ~/.sky/file_mounts/etc/config /etc/config' in cmd
     assert "'~/.sky/file_mounts/etc/config'" not in cmd
+
+
+def test_cluster_names_referenced_in_proxy():
+    names = ['jump-abcd', 'sky-1234-me', 'target']
+    f = backend_utils._cluster_names_referenced_in_proxy
+    # ProxyCommand referencing a bastion by its SSH alias (the shape used by
+    # the aws ssh_proxy_command smoke test).
+    p = ("ssh -W '[%h]:%p' -o StrictHostKeyChecking=no "
+         "-o UserKnownHostsFile=/dev/null jump-abcd")
+    assert f([p], names) == ['jump-abcd']
+    # ProxyJump user@host:port form.
+    assert f(['me@jump-abcd:22'], names) == ['jump-abcd']
+    # Comma-separated jump chain.
+    assert f(['jump-abcd,sky-1234-me'], names) == ['jump-abcd', 'sky-1234-me']
+    # A non-SkyPilot host is not matched.
+    assert not f(['ssh bastion.corp.example'], names)
+    # Malformed quoting falls back to a whitespace split.
+    assert f(["ssh 'unterminated jump-abcd"], names) == ['jump-abcd']
+    # No duplicates even if referenced more than once.
+    assert f(['jump-abcd jump-abcd'], names) == ['jump-abcd']
+
+
+def _fake_handle():
+    handle = mock.MagicMock(spec=backends.CloudVmRayResourceHandle)
+    handle.cluster_name = 'jump-abcd'
+    handle.cluster_name_on_cloud = 'jump-abcd-01'
+    handle.cached_external_ips = ['1.2.3.4']
+    handle.cached_external_ssh_ports = [22]
+    handle.cluster_yaml = '/fake/yaml'
+    handle.ssh_user = 'ubuntu'
+    handle.docker_user = None
+    return handle
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils,
+                   'ssh_credential_from_yaml',
+                   return_value={'ssh_user': 'ubuntu'})
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_handle_from_cluster_name')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['jump-abcd'])
+def test_restore_ssh_config_rebuilds_missing_stanza(mock_names, mock_get_handle,
+                                                    mock_cred, mock_add):
+    mock_get_handle.return_value = _fake_handle()
+    proxy = "ssh -W '[%h]:%p' jump-abcd"
+    with mock.patch.object(backend_utils.os.path, 'exists', return_value=False):
+        backend_utils.restore_ssh_config_from_db_for_proxy(proxy, None)
+    mock_add.assert_called_once()
+    args = mock_add.call_args[0]
+    assert args[0] == 'jump-abcd'  # cluster_name
+    assert args[2] == ['1.2.3.4']  # ips
+    assert args[4] == [22]  # ports
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['jump-abcd'])
+def test_restore_ssh_config_skips_when_stanza_present(mock_names, mock_add):
+    proxy = "ssh -W '[%h]:%p' jump-abcd"
+    with mock.patch.object(backend_utils.os.path, 'exists', return_value=True):
+        backend_utils.restore_ssh_config_from_db_for_proxy(proxy, None)
+    mock_add.assert_not_called()
+
+
+@mock.patch.object(backend_utils.global_user_state, 'get_cluster_names')
+def test_restore_ssh_config_noop_without_proxy(mock_names):
+    backend_utils.restore_ssh_config_from_db_for_proxy(None, None)
+    mock_names.assert_not_called()


### PR DESCRIPTION
Per-cluster SSH config stanzas are written under `~/.sky/generated/ssh/<name>` (Included from `~/.ssh/config`) when a cluster is launched. This is local state: it only exists on the machine that ran the launch.

A user-provided `ssh_proxy_command` / `ssh_proxy_jump` can reach its destination *through another SkyPilot cluster* by that cluster's SSH host alias — for example a bastion started with `sky launch` and referenced as `ssh -W '[%h]:%p' <bastion>`. The inner `ssh <bastion>` relies on the bastion's local SSH config stanza to resolve the alias.

On a machine that did not launch the referenced cluster — e.g. a remote API server that provisioned it in a different session, was restarted, or otherwise starts from a fresh `~/.sky/generated` — the stanza is absent and the proxy fails with `Could not resolve hostname <bastion>`.

This restores the referenced cluster's stanza on demand from the authoritative cluster state in the global user state, gated on a proxy command/jump being configured. It matches only SkyPilot cluster aliases; non-SkyPilot proxy hosts are left untouched, and the whole path is best-effort (failures are logged at debug level).

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` (pre-commit isort/mypy/yapf/pylint all pass on changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_aws_with_ssh_proxy_command` — the relevant end-to-end case (not yet run)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_backend_utils.py`:

- `test_cluster_names_referenced_in_proxy` — proxy host matching for `ssh -W '[%h]:%p' <alias>`, `user@host:port`, and comma-separated jump chains; ignores non-cluster tokens and falls back to whitespace split on malformed quoting.
- `test_restore_ssh_config_rebuilds_missing_stanza` — rebuilds the stanza via `SSHConfigHelper.add_cluster` when it is missing locally.
- `test_restore_ssh_config_skips_when_stanza_present` — no-op when the stanza already exists.
- `test_restore_ssh_config_noop_without_proxy` — no DB access when no proxy is configured.
