### PR TITLE
[Core] Rewrite ssh_proxy_command cluster aliases to explicit targets

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1774,6 +1774,141 @@ def ssh_credential_from_yaml(
     return credentials
 
 
+def _find_cluster_alias_in_tokens(
+        tokens: List[str],
+        cluster_names: Set[str]) -> Optional[Tuple[int, str]]:
+    """Returns (index, cluster_name) of the first token that references a known
+    SkyPilot cluster by its SSH host alias, or None. Handles ``user@host`` and
+    ``user@host:port`` forms by matching the host component."""
+    for idx, token in enumerate(tokens):
+        host = token.split('@')[-1].split(':')[0]
+        for candidate in (token, host):
+            if candidate in cluster_names:
+                return idx, candidate
+    return None
+
+
+def _restore_cluster_ssh_materials(
+        cluster_name: str) -> Optional[Tuple[str, int, str, str]]:
+    """Restores a cluster's local SSH key + config stanza from the global user
+    state and returns ``(ip, port, ssh_user, key_path)``, or None if the cluster
+    is unavailable (not found / not SSH-reachable / missing cached IPs or yaml).
+
+    Best-effort: the on-disk key and per-cluster stanza are (re)created so a
+    subsequent SSH can use them. This is the same "restore from DB + fix
+    permissions" path used elsewhere before establishing an SSH connection.
+    """
+    handle = global_user_state.get_handle_from_cluster_name(cluster_name)
+    if not isinstance(handle, backends.CloudVmRayResourceHandle):
+        return None
+    if handle.cluster_yaml is None:
+        return None
+    ips = handle.cached_external_ips
+    ports = handle.cached_external_ssh_ports
+    if not ips or not ports:
+        return None
+    auth_config = ssh_credential_from_yaml(handle.cluster_yaml,
+                                           ssh_user=handle.ssh_user,
+                                           docker_user=handle.docker_user)
+    key_path = auth_config.get('ssh_private_key')
+    ssh_user = auth_config.get('ssh_user')
+    if not key_path or not ssh_user:
+        return None
+    try:
+        auth_utils.create_ssh_key_files_from_db(key_path)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not restore SSH key for {cluster_name!r}: {e}')
+    try:
+        cluster_utils.SSHConfigHelper.add_cluster(handle.cluster_name,
+                                                  handle.cluster_name_on_cloud,
+                                                  ips, auth_config, ports,
+                                                  handle.docker_user,
+                                                  handle.ssh_user)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not restore SSH stanza for {cluster_name!r}: {e}')
+    return ips[0], ports[0], ssh_user, key_path
+
+
+def expand_proxy_cluster_aliases(
+    ssh_proxy_command: Optional[str],
+    ssh_proxy_jump: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Restores SSH materials and rewrites SkyPilot-cluster aliases in a proxy.
+
+    A user-provided ``ssh_proxy_command`` may reach its destination *through
+    another SkyPilot cluster* referenced by that cluster's SSH host alias (e.g.
+    a bastion started with ``sky launch``: ``ssh -W '[%h]:%p' jump-name``). The
+    inner ``ssh jump-name`` relies on a per-cluster stanza under
+    ``~/.sky/generated/ssh/`` (Included from ``~/.ssh/config``), which is local
+    state present only on the machine that launched the cluster.
+
+    On a machine that did not launch it (e.g. a remote API server that
+    provisioned it in a different session, or was restarted), the stanza is
+    absent and the alias fails to resolve. For each referenced cluster that
+    exists, this:
+
+      1. Restores its SSH key and per-cluster stanza on demand from the DB.
+      2. Rewrites the alias in ``ssh_proxy_command`` to a self-contained
+         explicit target (``-F /dev/null -i <key> -o Port=<port> <user>@<ip>``)
+         so the inner ssh does not depend on ``~/.ssh/config`` at all.
+
+    ``ssh_proxy_jump`` is a jump *spec* that cannot carry ``-i``/``-F``; only its
+    stanza is restored, so its resolution still relies on a readable config.
+
+    Best-effort: on any miss or error the proxy strings are returned unchanged
+    so a connection is never broken by this shim.
+    """
+    if not ssh_proxy_command and not ssh_proxy_jump:
+        return ssh_proxy_command, ssh_proxy_jump
+    try:
+        cluster_names = set(global_user_state.get_cluster_names())
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Skip proxy alias expansion; cannot list clusters: {e}')
+        return ssh_proxy_command, ssh_proxy_jump
+    if not cluster_names:
+        return ssh_proxy_command, ssh_proxy_jump
+
+    new_command = ssh_proxy_command
+    if ssh_proxy_command:
+        try:
+            tokens = shlex.split(ssh_proxy_command)
+        except ValueError:
+            tokens = ssh_proxy_command.split()
+        match = _find_cluster_alias_in_tokens(tokens, cluster_names)
+        if match is not None:
+            idx, name = match
+            try:
+                conn = _restore_cluster_ssh_materials(name)
+                if conn is not None:
+                    ip, port, ssh_user, key_path = conn
+                    explicit = (['-F', '/dev/null'] +
+                                command_runner.ssh_options_list(
+                                    key_path,
+                                    ssh_control_name=None,
+                                    port=port,
+                                    disable_control_master=True) +
+                                [f'{ssh_user}@{ip}'])
+                    tokens[idx:idx + 1] = explicit
+                    new_command = shlex.join(tokens)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Failed to rewrite SSH proxy alias {name!r}: {e}')
+
+    if ssh_proxy_jump:
+        try:
+            jump_tokens = shlex.split(ssh_proxy_jump)
+        except ValueError:
+            jump_tokens = ssh_proxy_jump.split()
+        jump_match = _find_cluster_alias_in_tokens(jump_tokens, cluster_names)
+        if jump_match is not None:
+            try:
+                _restore_cluster_ssh_materials(jump_match[1])
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug('Failed to restore SSH proxy jump '
+                             f'{jump_match[1]!r}: {e}')
+
+    return new_command, ssh_proxy_jump
+
+
 def ssh_credentials_from_handles(
     handles: List['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
 ) -> List[Dict[str, Any]]:

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1011,6 +1011,23 @@ class SSHCommandRunner(CommandRunner):
             if not os.path.exists(expanded_key_path):
                 raise FileNotFoundError(
                     f'SSH private key not found: {expanded_key_path}')
+        if ssh_proxy_command or ssh_proxy_jump:
+            # A user-provided proxy may reach the destination through another
+            # SkyPilot cluster referenced by its SSH host alias (e.g. a bastion
+            # started with `sky launch`). That alias is resolved from a
+            # per-cluster SSH config stanza which is local state, present only
+            # on the machine that launched the cluster. Restore it on demand
+            # from the global user state and rewrite the alias to an explicit,
+            # config-independent target.
+            # Lazy import: sky.backends.backend_utils imports this module, so a
+            # top-level import would be circular.
+            # pylint: disable-next=import-outside-toplevel
+            from sky.backends import backend_utils
+            ssh_proxy_command, ssh_proxy_jump = (
+                backend_utils.expand_proxy_cluster_aliases(
+                    ssh_proxy_command, ssh_proxy_jump))
+            self._ssh_proxy_command = ssh_proxy_command
+            self._ssh_proxy_jump = ssh_proxy_jump
         if docker_user is not None:
             assert port is None or port == 22, (
                 f'port must be None or 22 for docker_user, got {port}.')

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -647,3 +647,107 @@ def test_make_safe_symlink_command_leaves_target_unquoted():
         source='/etc/config', target='~/.sky/file_mounts/etc/config')
     assert 'ln -s ~/.sky/file_mounts/etc/config /etc/config' in cmd
     assert "'~/.sky/file_mounts/etc/config'" not in cmd
+
+
+def _fake_ssh_handle():
+    handle = mock.MagicMock(spec=backends.CloudVmRayResourceHandle)
+    handle.cluster_name = 'jump-abcd'
+    handle.cluster_name_on_cloud = 'jump-abcd-01'
+    handle.cached_external_ips = ['1.2.3.4']
+    handle.cached_external_ssh_ports = [22]
+    handle.cluster_yaml = '/fake/yaml'
+    handle.ssh_user = 'ubuntu'
+    handle.docker_user = None
+    return handle
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils.auth_utils, 'create_ssh_key_files_from_db')
+@mock.patch.object(backend_utils,
+                   'ssh_credential_from_yaml',
+                   return_value={
+                       'ssh_user': 'ubuntu',
+                       'ssh_private_key': '/fake/key'
+                   })
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_handle_from_cluster_name')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['jump-abcd'])
+def test_expand_proxy_rewrites_alias(mock_names, mock_get_handle, mock_cred,
+                                     mock_restore_key, mock_add):
+    mock_get_handle.return_value = _fake_ssh_handle()
+    proxy = "ssh -W '[%h]:%p' -o StrictHostKeyChecking=no jump-abcd"
+    command, jump = backend_utils.expand_proxy_cluster_aliases(proxy, None)
+    # Alias is replaced by an explicit, config-independent target.
+    assert 'jump-abcd' not in command
+    assert 'ubuntu@1.2.3.4' in command
+    assert '-i /fake/key' in command
+    assert '-F /dev/null' in command
+    assert 'Port=22' in command
+    # The user's own flags are preserved.
+    assert "-W '[%h]:%p'" in command
+    assert jump is None
+    # Restore side effects ran.
+    mock_restore_key.assert_called_once_with('/fake/key')
+    mock_add.assert_called_once()
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['other-cluster'])
+def test_expand_proxy_noop_when_not_a_cluster(mock_names, mock_add):
+    proxy = "ssh -W '[%h]:%p' jump-abcd"
+    command, jump = backend_utils.expand_proxy_cluster_aliases(proxy, None)
+    assert command == proxy
+    assert jump is None
+    mock_add.assert_not_called()
+
+
+@mock.patch.object(backend_utils.global_user_state, 'get_cluster_names')
+def test_expand_proxy_noop_without_proxy(mock_names):
+    command, jump = backend_utils.expand_proxy_cluster_aliases(None, None)
+    assert command is None and jump is None
+    mock_names.assert_not_called()
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_handle_from_cluster_name')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['jump-abcd'])
+def test_expand_proxy_best_effort_missing_ips(mock_names, mock_get_handle,
+                                              mock_add):
+    handle = _fake_ssh_handle()
+    handle.cached_external_ips = None  # not ssh-reachable yet
+    mock_get_handle.return_value = handle
+    proxy = "ssh -W '[%h]:%p' jump-abcd"
+    command, _ = backend_utils.expand_proxy_cluster_aliases(proxy, None)
+    assert command == proxy  # unchanged, no raise
+    mock_add.assert_not_called()
+
+
+@mock.patch.object(backend_utils.cluster_utils.SSHConfigHelper, 'add_cluster')
+@mock.patch.object(backend_utils.auth_utils, 'create_ssh_key_files_from_db')
+@mock.patch.object(backend_utils,
+                   'ssh_credential_from_yaml',
+                   return_value={
+                       'ssh_user': 'ubuntu',
+                       'ssh_private_key': '/fake/key'
+                   })
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_handle_from_cluster_name')
+@mock.patch.object(backend_utils.global_user_state,
+                   'get_cluster_names',
+                   return_value=['jump-abcd'])
+def test_expand_proxy_matches_user_at_host(mock_names, mock_get_handle,
+                                           mock_cred, mock_restore_key,
+                                           mock_add):
+    mock_get_handle.return_value = _fake_ssh_handle()
+    # user@alias form: the cluster's own user is used, alias dropped.
+    command, _ = backend_utils.expand_proxy_cluster_aliases(
+        'ssh -W [%h]:%p me@jump-abcd', None)
+    assert 'jump-abcd' not in command
+    assert 'ubuntu@1.2.3.4' in command


### PR DESCRIPTION
When a user's `ssh_proxy_command` reaches its destination *through another SkyPilot cluster* referenced by that cluster's SSH host alias — e.g. a bastion started with `sky launch` and used as `ssh -W '[%h]:%p' jump-name` — the inner `ssh jump-name` relies on a per-cluster stanza under `~/.sky/generated/ssh/` (Included from `~/.ssh/config`). That stanza is local state, present only on the machine that launched the cluster.

On a machine that did not launch it — e.g. a remote API server that provisioned the cluster in a different session, or was restarted, or otherwise starts from a fresh `~/.sky/generated` — the stanza is absent and the proxy fails with `Could not resolve hostname jump-name`.

This adds a best-effort shim: when constructing an SSH connection with a proxy configured, for each referenced cluster that exists in the global user state, it (1) restores that cluster's SSH key and per-cluster stanza on demand from the DB, and (2) rewrites the alias in the `ssh_proxy_command` into a self-contained, config-independent explicit target (`-F /dev/null -i <key> -o Port=<port> <user>@<ip>`) so the inner ssh no longer depends on `~/.ssh/config`. The user's other proxy flags (e.g. `-W '[%h]:%p'`) are preserved. On any miss or error the proxy string is returned unchanged, so a connection is never broken by this shim.

Reuses existing primitives: `auth_utils.create_ssh_key_files_from_db` (restore key + fix perms), `cluster_utils.SSHConfigHelper.add_cluster` (regenerate stanza), `backend_utils.ssh_credential_from_yaml`, and `command_runner.ssh_options_list` (the explicit `-i`/`-o` builder).

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` (pre-commit isort/mypy/yapf/pylint all pass on changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_aws_with_ssh_proxy_command` — the relevant end-to-end case (not yet run)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_backend_utils.py` (`test_expand_proxy_*`):

- rewrite output: `ssh -W '[%h]:%p' -o StrictHostKeyChecking=no jump-abcd` → explicit `-F /dev/null -i <key> -o Port=<port> ubuntu@1.2.3.4`, alias removed, `-W '[%h]:%p'` preserved; restore side-effects invoked.
- no-op when the host is not a cluster; no-op (no DB access) when no proxy is set.
- best-effort: cluster with no cached IPs → proxy unchanged, no restore, no raise.
- `user@jump-abcd` token form resolves the alias (uses the cluster's own user).
