### PR TITLE
[Core] Reload config atomically and honor runtime rbac.default_role without restart

### DIFF
--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -15,7 +15,6 @@ import starlette.middleware.base
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
-from sky import skypilot_config
 from sky.server import constants as server_constants
 from sky.server import middleware_utils
 from sky.server.auth import loopback
@@ -162,13 +161,12 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                         })
                 newly_added = global_user_state.add_or_update_user(auth_user)
                 if newly_added:
-                    # This middleware runs in the main API-server process,
-                    # which does not reload config per request; refresh so a
-                    # runtime `rbac.default_role` change is honored when
-                    # seeding this new user's role without a server restart.
-                    skypilot_config.safe_reload_config()
-                    permission.permission_service.add_user_if_not_exists(
-                        auth_user.id)
+                    # Offload the blocking config reload + role seed to a
+                    # worker thread so this async middleware doesn't block the
+                    # event loop. The reload lets a runtime `rbac.default_role`
+                    # change take effect for this new user without a restart.
+                    await asyncio.to_thread(permission.seed_new_user_role,
+                                            auth_user.id)
                 request.state.auth_user = auth_user
                 return await call_next(request)
             elif auth_response.status == http.HTTPStatus.UNAUTHORIZED:

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -15,6 +15,7 @@ import starlette.middleware.base
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
+from sky import skypilot_config
 from sky.server import constants as server_constants
 from sky.server import middleware_utils
 from sky.server.auth import loopback
@@ -161,6 +162,11 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                         })
                 newly_added = global_user_state.add_or_update_user(auth_user)
                 if newly_added:
+                    # This middleware runs in the main API-server process,
+                    # which does not reload config per request; refresh so a
+                    # runtime `rbac.default_role` change is honored when
+                    # seeding this new user's role without a server restart.
+                    skypilot_config.safe_reload_config()
                     permission.permission_service.add_user_if_not_exists(
                         auth_user.id)
                 request.state.auth_user = auth_user

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -576,14 +576,13 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         if auth_user is not None:
             newly_added = global_user_state.add_or_update_user(auth_user)
             if newly_added:
-                # This middleware runs in the main API-server process, which —
-                # unlike executor-queued requests — does not reload config per
-                # request. Refresh it so a runtime change to `rbac.default_role`
-                # (or any other config) is honored when seeding this new user's
-                # role, instead of only taking effect after a server restart.
-                skypilot_config.safe_reload_config()
-                permission.permission_service.add_user_if_not_exists(
-                    auth_user.id)
+                # Offload the blocking config reload + role seed to a worker
+                # thread so this async middleware doesn't block the event loop.
+                # The reload lets a runtime `rbac.default_role` change take
+                # effect for this new user without a restart (the main
+                # API-server process does not reload config per request).
+                await asyncio.to_thread(permission.seed_new_user_role,
+                                        auth_user.id)
 
         # Store user info in request.state for access by GET endpoints
         if auth_user is not None:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -576,6 +576,12 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         if auth_user is not None:
             newly_added = global_user_state.add_or_update_user(auth_user)
             if newly_added:
+                # This middleware runs in the main API-server process, which —
+                # unlike executor-queued requests — does not reload config per
+                # request. Refresh it so a runtime change to `rbac.default_role`
+                # (or any other config) is honored when seeding this new user's
+                # role, instead of only taking effect after a server restart.
+                skypilot_config.safe_reload_config()
                 permission.permission_service.add_user_if_not_exists(
                     auth_user.id)
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -717,10 +717,9 @@ def _parse_dotlist(dotlist: List[str]) -> config_utils.Config:
 
 
 def _reload_config_from_internal_file(internal_config_path: str) -> None:
-    # Reset the global variables, to avoid using stale values.
-    _set_loaded_config(config_utils.Config())
-    _set_loaded_config_path(None)
-
+    # Build the new config fully, then swap it in at the end (see
+    # `_reload_config_as_server` for why we don't blank up front). A missing
+    # file raises with the previously-loaded config left intact.
     config_path = os.path.expanduser(internal_config_path)
     if not os.path.exists(config_path):
         with ux_utils.print_exception_no_traceback():
@@ -748,10 +747,12 @@ _db_manager = db_utils.DatabaseManager(db_name='config',
 
 
 def _reload_config_as_server() -> None:
-    # Reset the global variables, to avoid using stale values.
-    _set_loaded_config(config_utils.Config())
-    _set_loaded_config_path(None)
-
+    # Build the new config fully, then swap it in with a single
+    # `_set_loaded_config` at the end. Do NOT blank the loaded config up front:
+    # `get_nested` reads without the config lock (hot path), so a transient
+    # empty config would be observable by a concurrent reader and e.g. make
+    # `rbac.get_default_role()` fall back to admin. On any exception below the
+    # previously-loaded config is left in place (stale is safer than empty).
     server_config_path = _resolve_server_config_path()
     server_config = _get_config_from_path(server_config_path)
     # Get the db url from the env var. _get_config_from_path should have moved
@@ -785,10 +786,8 @@ def _reload_config_as_server() -> None:
 
 
 def _reload_config_as_client() -> None:
-    # Reset the global variables, to avoid using stale values.
-    _set_loaded_config(config_utils.Config())
-    _set_loaded_config_path(None)
-
+    # Build the new config fully, then swap it in at the end (see
+    # `_reload_config_as_server` for why we don't blank up front).
     overrides: List[config_utils.Config] = []
     user_config_path = resolve_user_config_path()
     user_config = _get_config_from_path(user_config_path)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -158,8 +158,9 @@ def get_skypilot_config_lock_path() -> str:
 
 # Distributed lock id guarding config-file reads/writes.
 # A Postgres advisory lock if PG is available, falling back to a file
-# lock locally). All config-file writers/readers MUST use this same id
-#  so they stay mutually exclusive.
+# lock locally). All config-file writers/readers MUST use this same id.
+# Writers take it exclusively; pure reads (reloads) take it shared, so reads
+# don't serialize against each other but still block against a mid-write writer.
 SKYPILOT_CONFIG_LOCK_ID = 'skypilot-config-file'
 
 # Bounded wait for `safe_reload_config` (a read): long enough to ride out a
@@ -178,12 +179,21 @@ _CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS = 20
 _CONFIG_LOCK_POLL_INTERVAL_SECONDS = 0.1
 
 
-def get_skypilot_config_lock(timeout: Optional[float] = None):
+def get_skypilot_config_lock(timeout: Optional[float] = None,
+                             shared_lock: bool = False):
     """Return the distributed lock guarding the config file.
 
     ``timeout=None`` waits indefinitely (matches the historical file-lock
     behavior); callers that must not block forever pass a timeout and handle
     ``locks.LockTimeout``.
+
+    ``shared_lock=True`` acquires a *shared* (read) advisory lock instead of the
+    default *exclusive* (write) lock. Concurrent shared holders don't block each
+    other, but a shared holder still blocks against an exclusive writer (and
+    vice versa) for torn-read safety. Use it for pure config *reads* (reloads);
+    read-modify-write callers MUST keep the exclusive lock. Only the Postgres
+    backend distinguishes the two modes — the filelock fallback is always
+    exclusive (acceptable at local/low concurrency).
     """
     # Lazy import: sky.utils.locks -> global_user_state -> skypilot_config, so a
     # top-level import here would be circular. Imported at call time (after all
@@ -191,7 +201,8 @@ def get_skypilot_config_lock(timeout: Optional[float] = None):
     from sky.utils import locks  # pylint: disable=import-outside-toplevel
     return locks.get_lock(SKYPILOT_CONFIG_LOCK_ID,
                           timeout,
-                          poll_interval=_CONFIG_LOCK_POLL_INTERVAL_SECONDS)
+                          poll_interval=_CONFIG_LOCK_POLL_INTERVAL_SECONDS,
+                          shared_lock=shared_lock)
 
 
 def _get_config_context() -> ConfigContext:
@@ -638,12 +649,20 @@ def safe_reload_config() -> None:
     lock timeout we log and proceed with the currently loaded config rather than
     block the caller indefinitely behind a wedged lock holder (the historical
     ``timeout=None`` could hang every reloader across replicas forever).
+
+    Uses a *shared* lock so concurrent reloads (this is a hot path: every
+    sync-handler config refresh, login-time role seed, per-replica reconcile)
+    don't serialize against each other; a writer's exclusive lock still blocks
+    reloads mid-write for torn-read safety. Safe against concurrent reloads
+    within a single process because `reload_config` swaps the new config in
+    atomically (no transient empty-config window).
     """
     # Lazy import to avoid the sky.utils.locks -> global_user_state ->
     # skypilot_config import cycle (see get_skypilot_config_lock).
     from sky.utils import locks  # pylint: disable=import-outside-toplevel
     try:
-        with get_skypilot_config_lock(_CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS):
+        with get_skypilot_config_lock(_CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS,
+                                      shared_lock=True):
             reload_config()
     except locks.LockTimeout:
         logger.warning(

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -14,6 +14,7 @@ import sqlalchemy_adapter
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
+from sky import skypilot_config
 from sky.skylet import constants
 from sky.users import rbac
 from sky.utils import common
@@ -659,3 +660,19 @@ def _policy_lock() -> Generator[None, None, None]:
 
 # Singleton instance of PermissionService for other modules to use.
 permission_service = PermissionService()
+
+
+def seed_new_user_role(user_id: str) -> None:
+    """Reload config, then assign the default role to a new user.
+
+    Refreshes the in-memory config first so a runtime change to
+    `rbac.default_role` is honored without a server restart: the main API-server
+    process (auth middlewares, sync handlers) bypasses the executor's
+    per-request config reload. `add_user_if_not_exists` is a no-op if the user
+    already has a role.
+
+    Blocking (config file/DB read + policy lock). Async callers MUST offload it
+    via `asyncio.to_thread` so it does not block the event loop.
+    """
+    skypilot_config.safe_reload_config()
+    permission_service.add_user_if_not_exists(user_id)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -832,16 +832,12 @@ def create_service_account_token(
                 f'already exists ({service_account_user_id}). '
                 'Please use a different name.')
 
-        # Add service account to permission system with default role
-        # Import here to avoid circular imports
-        # pylint: disable=import-outside-toplevel
-        from sky.users.permission import permission_service
-
-        # This handler runs in the main API-server process and does not reload
-        # config per request; refresh so a runtime `rbac.default_role` change is
-        # honored for the SA's seeded role without a server restart.
-        skypilot_config.safe_reload_config()
-        permission_service.add_user_if_not_exists(service_account_user_id)
+        # Add the service account to the permission system with the default
+        # role. This handler runs in the main API-server process (no per-request
+        # config reload), so seed via the helper that refreshes config first —
+        # an admin's runtime `rbac.default_role` change then applies without a
+        # server restart.
+        permission.seed_new_user_role(service_account_user_id)
 
         # Handle expiration: 0 means "never expire"
         expires_in_days = token_body.expires_in_days

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -283,6 +283,10 @@ def user_create(user_create_body: payloads.UserCreateBody) -> None:
                                     detail=f'Invalid role: {role}')
 
     if not role:
+        # Main-process handler: refresh config so a runtime `rbac.default_role`
+        # change is honored without a server restart (executor requests reload
+        # per request, sync handlers like this one do not).
+        skypilot_config.safe_reload_config()
         role = rbac.get_default_role()
 
     # Create user
@@ -568,6 +572,10 @@ def user_import(user_import_body: payloads.UserImportBody) -> Dict[str, Any]:
             status_code=400,
             detail=f'Missing required columns: {", ".join(missing_headers)}')
 
+    # Main-process handler: refresh config once (not per row) so rows that fall
+    # back to `rbac.default_role` honor a runtime change without a restart.
+    skypilot_config.safe_reload_config()
+
     # Parse user data
     users_to_create = []
     parse_errors = []
@@ -666,6 +674,9 @@ def user_import(user_import_body: payloads.UserImportBody) -> Dict[str, Any]:
 def user_export() -> Dict[str, Any]:
     """Export all users as CSV content."""
     try:
+        # Main-process handler: refresh config once so the roleless-user display
+        # fallback below reflects a runtime `rbac.default_role` change.
+        skypilot_config.safe_reload_config()
         # Get all users
         user_list = global_user_state.get_all_users()
 
@@ -825,6 +836,11 @@ def create_service_account_token(
         # Import here to avoid circular imports
         # pylint: disable=import-outside-toplevel
         from sky.users.permission import permission_service
+
+        # This handler runs in the main API-server process and does not reload
+        # config per request; refresh so a runtime `rbac.default_role` change is
+        # honored for the SA's seeded role without a server restart.
+        skypilot_config.safe_reload_config()
         permission_service.add_user_if_not_exists(service_account_user_id)
 
         # Handle expiration: 0 means "never expire"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,6 +166,48 @@ def test_empty_config(monkeypatch, tmp_path) -> None:
     _check_empty_config()
 
 
+def test_reload_config_no_empty_window(monkeypatch, tmp_path) -> None:
+    """A reload must never expose a transient empty config.
+
+    `reload_config` builds the new config fully and swaps it in with a single
+    assignment. A concurrent reader that hits `get_nested` while a reload is in
+    flight must observe the previously-loaded value, never the fallback. This
+    guards against the old blank-then-repopulate behavior, which let a reader
+    (e.g. `rbac.get_default_role()`) fall back to admin mid-reload.
+    """
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text('rbac:\n  default_role: user\n')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_file)
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
+                        tmp_path / 'does_not_exist')
+    _reload_config()
+    assert skypilot_config.get_nested(('rbac', 'default_role'),
+                                      'admin') == 'user'
+
+    # Spy on the file read that happens in the middle of a reload; while it runs,
+    # the not-yet-swapped config must still return the old value. With the old
+    # pre-blanking this observed 'admin' (the fallback); with the atomic swap it
+    # stays 'user'.
+    observed = []
+    real_get_config_from_path = skypilot_config._get_config_from_path
+
+    def spy_get_config_from_path(path):
+        observed.append(
+            skypilot_config.get_nested(('rbac', 'default_role'), 'admin'))
+        return real_get_config_from_path(path)
+
+    monkeypatch.setattr(skypilot_config, '_get_config_from_path',
+                        spy_get_config_from_path)
+    # Call reload_config directly (not `_reload_config`, which resets the loaded
+    # config first) so the previously-loaded config is what a mid-reload reader
+    # would see.
+    skypilot_config.reload_config()
+
+    assert observed, 'reload did not read the config file'
+    assert all(value == 'user' for value in observed), (
+        f'config was empty mid-reload (would fall back to admin): {observed}')
+
+
 def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'valid.yaml', 'w', encoding='utf-8') as f:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,6 +208,58 @@ def test_reload_config_no_empty_window(monkeypatch, tmp_path) -> None:
         f'config was empty mid-reload (would fall back to admin): {observed}')
 
 
+class _DummyLock:
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_safe_reload_config_uses_shared_lock(monkeypatch) -> None:
+    """`safe_reload_config` (a pure read) must take the lock in SHARED mode so
+    concurrent reloads don't serialize. Reverting `shared_lock=True` fails this.
+    """
+    from sky.utils import locks
+    captured = {}
+
+    def fake_get_lock(lock_id,
+                      timeout=None,
+                      lock_type=None,
+                      poll_interval=None,
+                      shared_lock=False):
+        captured['shared_lock'] = shared_lock
+        return _DummyLock()
+
+    monkeypatch.setattr(locks, 'get_lock', fake_get_lock)
+    monkeypatch.setattr(skypilot_config, 'reload_config', lambda: None)
+
+    skypilot_config.safe_reload_config()
+
+    assert captured.get('shared_lock') is True
+
+
+def test_get_skypilot_config_lock_defaults_to_exclusive(monkeypatch) -> None:
+    """Writers (the default) must take the lock EXCLUSIVELY."""
+    from sky.utils import locks
+    captured = {}
+
+    def fake_get_lock(lock_id,
+                      timeout=None,
+                      lock_type=None,
+                      poll_interval=None,
+                      shared_lock=False):
+        captured['shared_lock'] = shared_lock
+        return _DummyLock()
+
+    monkeypatch.setattr(locks, 'get_lock', fake_get_lock)
+
+    skypilot_config.get_skypilot_config_lock()
+
+    assert captured.get('shared_lock') is False
+
+
 def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'valid.yaml', 'w', encoding='utf-8') as f:

--- a/tests/unit_tests/test_sky/test_reconcile_distributed_locks.py
+++ b/tests/unit_tests/test_sky/test_reconcile_distributed_locks.py
@@ -28,7 +28,8 @@ def test_get_skypilot_config_lock_uses_distributed_lock():
     get_lock.assert_called_once_with(
         skypilot_config.SKYPILOT_CONFIG_LOCK_ID,
         42,
-        poll_interval=skypilot_config._CONFIG_LOCK_POLL_INTERVAL_SECONDS)  # pylint: disable=protected-access
+        poll_interval=skypilot_config._CONFIG_LOCK_POLL_INTERVAL_SECONDS,  # pylint: disable=protected-access
+        shared_lock=False)
     assert skypilot_config.SKYPILOT_CONFIG_LOCK_ID == 'skypilot-config-file'
 
 
@@ -38,9 +39,11 @@ def test_safe_reload_config_holds_the_config_lock():
             mock.patch.object(skypilot_config, 'reload_config') as reload_config:
         skypilot_config.safe_reload_config()
     # The reload must happen inside the (distributed) config lock, with a
-    # bounded wait (not the historical infinite timeout).
+    # bounded wait (not the historical infinite timeout), and as a SHARED read
+    # so concurrent reloads don't serialize.
     get_lock.assert_called_once_with(
-        skypilot_config._CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS)  # pylint: disable=protected-access
+        skypilot_config._CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS,  # pylint: disable=protected-access
+        shared_lock=True)
     reload_config.assert_called_once()
 
 

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -1564,3 +1564,22 @@ class TestPermissionServiceMultiProcess:
         mock_add_tables.assert_called()
         mock_init_policies.assert_called()
         mock_init_basic_auth.assert_called()
+
+
+class TestSeedNewUserRole:
+    """`seed_new_user_role` reloads config before seeding the default role."""
+
+    def test_reloads_config_before_add(self, monkeypatch):
+        # Order matters: the reload must happen before `add_user_if_not_exists`
+        # resolves `rbac.default_role`, so a runtime default-role change is
+        # honored. Reordering or dropping the reload makes this fail.
+        calls = []
+        monkeypatch.setattr(permission.skypilot_config, 'safe_reload_config',
+                            lambda: calls.append('reload'))
+        monkeypatch.setattr(permission.permission_service,
+                            'add_user_if_not_exists',
+                            lambda user_id: calls.append(f'add:{user_id}'))
+
+        permission.seed_new_user_role('u1')
+
+        assert calls == ['reload', 'add:u1']

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -1,5 +1,6 @@
 """Unit tests for the users server endpoints."""
 
+import contextlib
 import hashlib
 from unittest import mock
 
@@ -122,6 +123,67 @@ def mock_request():
     request = mock.MagicMock(spec=fastapi.Request)
     request.state = mock.MagicMock()
     return request
+
+
+class TestDefaultRoleFreshness:
+    """Main-process sync handlers must reload config before resolving
+    `rbac.default_role`, so an admin's runtime change to the default role takes
+    effect without an API-server restart.
+
+    Each test seeds a stale in-memory default ('user') and makes a reload pick up
+    the fresh value ('viewer'). Reverting the handler's `safe_reload_config()`
+    call makes the assertion see the stale 'user' and fail.
+    """
+
+    def _patch_common(self, monkeypatch, state):
+
+        def fake_reload():
+            state['role'] = 'viewer'
+
+        monkeypatch.setattr(server.skypilot_config, 'safe_reload_config',
+                            fake_reload)
+        monkeypatch.setattr(server.rbac, 'get_default_role',
+                            lambda: state['role'])
+        monkeypatch.setattr(server.rbac, 'get_supported_roles',
+                            lambda: ['admin', 'user', 'viewer'])
+        monkeypatch.setattr(server.global_user_state, 'get_user_by_name',
+                            lambda name: None)
+        monkeypatch.setattr(server.global_user_state, 'add_or_update_user',
+                            lambda user, **kwargs: True)
+        monkeypatch.setattr(server.server_common.crypt_ctx, 'hash',
+                            lambda pw: 'hashed')
+        monkeypatch.setattr(server, '_user_lock',
+                            lambda user_id: contextlib.nullcontext())
+
+    def test_user_create_reloads_before_resolving_default_role(
+            self, monkeypatch):
+        state = {'role': 'user'}
+        self._patch_common(monkeypatch, state)
+        captured = {}
+        monkeypatch.setattr(server.permission.permission_service, 'update_role',
+                            lambda user_id, role: captured.update(role=role))
+
+        server.user_create(
+            payloads.UserCreateBody(username='alice', password='pw'))
+
+        assert captured['role'] == 'viewer'
+
+    def test_user_import_reloads_before_resolving_default_role(
+            self, monkeypatch):
+        state = {'role': 'user'}
+        self._patch_common(monkeypatch, state)
+        # Password is plain text -> handler hashes it (identify returns None).
+        monkeypatch.setattr(server.server_common.crypt_ctx, 'identify',
+                            lambda pw: None)
+        captured = []
+        monkeypatch.setattr(server.permission.permission_service, 'update_role',
+                            lambda user_id, role: captured.append(role))
+
+        # CSV row leaves role empty -> falls back to the default role.
+        csv_content = 'username,password,role\nalice,pw,\n'
+        server.user_import(payloads.UserImportBody(csv_content=csv_content))
+
+        assert captured == ['viewer']
 
 
 class TestUsersEndpoints:


### PR DESCRIPTION
## Summary

Two related config-reload fixes:

1. **Atomic config swap.** `_reload_config_as_server` / `_reload_config_as_client` / `_reload_config_from_internal_file` previously blanked the loaded config and *then* repopulated it. Config reads are lock-free on the hot path (`get_nested`), so that transient empty-config window was observable by a concurrent reader — e.g. `rbac.get_default_role()` would fall back to `admin` mid-reload. They now build the new `Config` fully and swap it in with a single assignment; on error the previously-loaded config is left intact (stale is safer than empty).

2. **`rbac.default_role` takes effect without a restart.** After an admin changes `rbac.default_role` at runtime, new users kept getting the boot-time default until the server was restarted. The write lands in an executor worker (which reloads its own config), but the user-provisioning code runs in the **main API-server process** — the auth-proxy / oauth2-proxy middlewares and the sync `/users/create`, `/users/import`, `/users/export`, and service-account-token handlers — which bypass the executor's per-request reload. These now `safe_reload_config()` before resolving the default role (gated on new-user for the middlewares so only new logins pay it).

Fix #2 depends on fix #1: adding more reload sites without the atomic swap would widen the empty-config window.

## Test plan

- `pytest tests/test_config.py::test_reload_config_no_empty_window` — deterministic guard: a nested read taken *while a reload is in flight* never observes the empty-config fallback. Fails if the pre-blanking is restored.
- `pytest tests/unit_tests/test_sky/users/test_server.py::TestDefaultRoleFreshness` — `/users/create` and `/users/import` resolve the default role against freshly-reloaded config. Fails if the reload is removed.
- Manual E2E: with `rbac.default_role: user`, create a user (gets `user`); change `rbac.default_role` to `viewer` on the running server (dashboard config editor / config file); create another user — it gets `viewer` without a restart. On an unpatched server it stays `user` until restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)