### PR TITLE
[Helm] Add apiService.persistSSHConfig to control ~/.ssh persistence

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -358,7 +358,7 @@ spec:
           subPath: .sky
         {{- end }}
         {{- if .Values.storage.enabled }}
-        {{- if .Values.apiService.persistSSHConfig }}
+        {{- if ne .Values.apiService.persistSSHConfig false }}
         - name: state-volume
           mountPath: /root/.ssh # To preserve the SSH keys for the user when using the API server
           subPath: .ssh

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -358,9 +358,11 @@ spec:
           subPath: .sky
         {{- end }}
         {{- if .Values.storage.enabled }}
+        {{- if .Values.apiService.persistSSHConfig }}
         - name: state-volume
           mountPath: /root/.ssh # To preserve the SSH keys for the user when using the API server
           subPath: .ssh
+        {{- end }}
         # Mount the entire sky_logs folder because the request
         # logs have been moved out of this directory
         - name: state-volume

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -152,6 +152,9 @@
                 "nodeSelector": {
                     "type": "object"
                 },
+                "persistSSHConfig": {
+                    "type": "boolean"
+                },
                 "preDeployHook": {
                     "type": "string"
                 },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -157,6 +157,12 @@ apiService:
   # Optional secret that contains SSH keys for the API server to use, all the entries in the secret will be mounted to ~/.ssh/ directory in the API server.
   # @schema type: [string, null]
   sshKeySecret: null
+  # Whether to persist the API server's ~/.ssh directory on the storage volume.
+  # Only takes effect when storage.enabled is true. When set to false, ~/.ssh is
+  # kept on ephemeral pod storage even if storage is enabled, so SSH keys are
+  # not preserved across pod restarts.
+  # @schema type: [boolean]
+  persistSSHConfig: true
   # Metrics configuration for the API server.
   # Refer to https://docs.skypilot.co/en/latest/reference/api-server/examples/api-server-metrics-setup.html for more details.
   metrics:


### PR DESCRIPTION
Add a new `apiService.persistSSHConfig` value (default `true`) that controls whether the API server's `~/.ssh` directory is persisted on the state storage volume. When set to `false`, `~/.ssh` is kept on ephemeral pod storage even if `storage.enabled` is true, while other persisted paths (e.g. `sky_logs`) are unaffected.

This lets deployments that provision SSH keys through another mechanism (e.g. `apiService.sshKeySecret`) opt out of persisting them on the shared volume.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual test: `helm template` with `storage.enabled=true`:
- default (`persistSSHConfig` unset → true): `/root/.ssh` mount present.
- `apiService.persistSSHConfig=false`: `/root/.ssh` mount removed, `/root/sky_logs` mount still present.
