### PR TITLE
[Core] Use a shared lock for config reloads to avoid serializing reads

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -158,8 +158,9 @@ def get_skypilot_config_lock_path() -> str:
 
 # Distributed lock id guarding config-file reads/writes.
 # A Postgres advisory lock if PG is available, falling back to a file
-# lock locally). All config-file writers/readers MUST use this same id
-#  so they stay mutually exclusive.
+# lock locally). All config-file writers/readers MUST use this same id.
+# Writers take it exclusively; pure reads (reloads) take it shared, so reads
+# don't serialize against each other but still block against a mid-write writer.
 SKYPILOT_CONFIG_LOCK_ID = 'skypilot-config-file'
 
 # Bounded wait for `safe_reload_config` (a read): long enough to ride out a
@@ -178,12 +179,21 @@ _CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS = 20
 _CONFIG_LOCK_POLL_INTERVAL_SECONDS = 0.1
 
 
-def get_skypilot_config_lock(timeout: Optional[float] = None):
+def get_skypilot_config_lock(timeout: Optional[float] = None,
+                             shared_lock: bool = False):
     """Return the distributed lock guarding the config file.
 
     ``timeout=None`` waits indefinitely (matches the historical file-lock
     behavior); callers that must not block forever pass a timeout and handle
     ``locks.LockTimeout``.
+
+    ``shared_lock=True`` acquires a *shared* (read) advisory lock instead of the
+    default *exclusive* (write) lock. Concurrent shared holders don't block each
+    other, but a shared holder still blocks against an exclusive writer (and
+    vice versa) for torn-read safety. Use it for pure config *reads* (reloads);
+    read-modify-write callers MUST keep the exclusive lock. Only the Postgres
+    backend distinguishes the two modes — the filelock fallback is always
+    exclusive (acceptable at local/low concurrency).
     """
     # Lazy import: sky.utils.locks -> global_user_state -> skypilot_config, so a
     # top-level import here would be circular. Imported at call time (after all
@@ -191,7 +201,8 @@ def get_skypilot_config_lock(timeout: Optional[float] = None):
     from sky.utils import locks  # pylint: disable=import-outside-toplevel
     return locks.get_lock(SKYPILOT_CONFIG_LOCK_ID,
                           timeout,
-                          poll_interval=_CONFIG_LOCK_POLL_INTERVAL_SECONDS)
+                          poll_interval=_CONFIG_LOCK_POLL_INTERVAL_SECONDS,
+                          shared_lock=shared_lock)
 
 
 def _get_config_context() -> ConfigContext:
@@ -638,12 +649,20 @@ def safe_reload_config() -> None:
     lock timeout we log and proceed with the currently loaded config rather than
     block the caller indefinitely behind a wedged lock holder (the historical
     ``timeout=None`` could hang every reloader across replicas forever).
+
+    Uses a *shared* lock so concurrent reloads (this is a hot path: every
+    sync-handler config refresh, login-time role seed, per-replica reconcile)
+    don't serialize against each other; a writer's exclusive lock still blocks
+    reloads mid-write for torn-read safety. Safe against concurrent reloads
+    within a single process because `reload_config` swaps the new config in
+    atomically (no transient empty-config window).
     """
     # Lazy import to avoid the sky.utils.locks -> global_user_state ->
     # skypilot_config import cycle (see get_skypilot_config_lock).
     from sky.utils import locks  # pylint: disable=import-outside-toplevel
     try:
-        with get_skypilot_config_lock(_CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS):
+        with get_skypilot_config_lock(_CONFIG_RELOAD_LOCK_TIMEOUT_SECONDS,
+                                      shared_lock=True):
             reload_config()
     except locks.LockTimeout:
         logger.warning(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,6 +226,7 @@ def test_safe_reload_config_uses_shared_lock(monkeypatch) -> None:
 
     def fake_get_lock(lock_id,
                       timeout=None,
+                      lock_type=None,
                       poll_interval=None,
                       shared_lock=False):
         captured['shared_lock'] = shared_lock
@@ -246,6 +247,7 @@ def test_get_skypilot_config_lock_defaults_to_exclusive(monkeypatch) -> None:
 
     def fake_get_lock(lock_id,
                       timeout=None,
+                      lock_type=None,
                       poll_interval=None,
                       shared_lock=False):
         captured['shared_lock'] = shared_lock

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,6 +208,56 @@ def test_reload_config_no_empty_window(monkeypatch, tmp_path) -> None:
         f'config was empty mid-reload (would fall back to admin): {observed}')
 
 
+class _DummyLock:
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_safe_reload_config_uses_shared_lock(monkeypatch) -> None:
+    """`safe_reload_config` (a pure read) must take the lock in SHARED mode so
+    concurrent reloads don't serialize. Reverting `shared_lock=True` fails this.
+    """
+    from sky.utils import locks
+    captured = {}
+
+    def fake_get_lock(lock_id,
+                      timeout=None,
+                      poll_interval=None,
+                      shared_lock=False):
+        captured['shared_lock'] = shared_lock
+        return _DummyLock()
+
+    monkeypatch.setattr(locks, 'get_lock', fake_get_lock)
+    monkeypatch.setattr(skypilot_config, 'reload_config', lambda: None)
+
+    skypilot_config.safe_reload_config()
+
+    assert captured.get('shared_lock') is True
+
+
+def test_get_skypilot_config_lock_defaults_to_exclusive(monkeypatch) -> None:
+    """Writers (the default) must take the lock EXCLUSIVELY."""
+    from sky.utils import locks
+    captured = {}
+
+    def fake_get_lock(lock_id,
+                      timeout=None,
+                      poll_interval=None,
+                      shared_lock=False):
+        captured['shared_lock'] = shared_lock
+        return _DummyLock()
+
+    monkeypatch.setattr(locks, 'get_lock', fake_get_lock)
+
+    skypilot_config.get_skypilot_config_lock()
+
+    assert captured.get('shared_lock') is False
+
+
 def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'valid.yaml', 'w', encoding='utf-8') as f:


### PR DESCRIPTION
> **Stacked on #10046** (base is `sky-4678-config-reload`, not `master`). This depends on that PR's atomic config swap — with a shared lock, two same-process threads can reload concurrently, and the atomic swap is what guarantees neither observes a transient empty config. Merge #10046 first, then this retargets to `master`.

## Summary

`safe_reload_config()` is a pure *read*, but it took the distributed config lock **exclusively**, so concurrent reloads serialized against each other. This is a hot path — every sync-handler config refresh (`refresh_workspace_state_for_sync_handler`), login-time role seed, and per-replica reconcile reloads — and contended acquires are quantized to the ~100 ms lock poll interval, so tail latency balloons under concurrency.

This switches reloads to a **shared** advisory lock:
- `get_skypilot_config_lock()` grows a `shared_lock=False` param, threaded to `locks.get_lock` (already supports it — `PostgresLock` uses `pg_try_advisory_lock_shared`).
- `safe_reload_config()` passes `shared_lock=True`.
- Writers (the `workspaces/core.py` read-modify-write and the config-file write) keep the **exclusive** lock, so a reload still blocks against a mid-write writer for torn-read safety.
- Only the Postgres backend distinguishes the modes; the filelock fallback stays exclusive (acceptable at local/low concurrency).

## Test plan

Unit (wiring, backend-agnostic):
- `tests/test_config.py::test_safe_reload_config_uses_shared_lock` — reload acquires the lock shared (fails if `shared_lock=True` is dropped).
- `tests/test_config.py::test_get_skypilot_config_lock_defaults_to_exclusive` — writers stay exclusive.
- Full `tests/test_config.py` passes.

Benchmark (Postgres-backed server, 16 concurrent clients × 20 `GET /users/me/workspace` requests each — that handler calls `safe_reload_config` per request):

| metric | exclusive (before) | shared (this PR) |
|---|---|---|
| throughput | 104.7 req/s | **180.7 req/s** (+73%) |
| wall | 3.06s | **1.77s** |
| p95 latency | 543.8 ms | **197.1 ms** (−64%) |
| p99 latency | 841.4 ms | 698.0 ms |

Tail latency drops sharply (the eliminated ~100 ms poll waits); residual tail is the reload's own per-call DB read, not the lock (a version/mtime short-circuit is a possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)