### PR TITLE
[Test] Expand ssh_proxy_command alias in test_aws_with_ssh_proxy_command

### DIFF
--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -22,7 +22,6 @@
 import pathlib
 import shlex
 import tempfile
-import textwrap
 import time
 
 import jinja2
@@ -35,6 +34,7 @@ from sky import clouds
 from sky import skypilot_config
 from sky.data import storage as storage_lib
 from sky.skylet import constants
+from sky.utils import common_utils
 from sky.utils import controller_utils
 
 
@@ -64,17 +64,37 @@ def test_aws_region():
 def test_aws_with_ssh_proxy_command():
     name = smoke_tests_utils.get_cluster_name()
     with tempfile.NamedTemporaryFile(mode='w') as f:
-        f.write(
-            textwrap.dedent(f"""\
-        aws:
-            ssh_proxy_command: ssh -W '[%h]:%p' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jump-{name}
-        """))
-        f.write(
-            textwrap.dedent(f"""\
-            api_server:
-                endpoint: {smoke_tests_utils.get_api_server_url()}
-            """))
-        f.flush()
+        # We used to point ssh_proxy_command at the SSH alias `jump-{name}`,
+        # which relies on the machine executing the proxy command (the API
+        # server, and for managed jobs the jobs controller) having the local
+        # ~/.ssh/config that includes SkyPilot's generated per-cluster
+        # configs. That does not hold for a remote API server, so instead we
+        # expand the proxy command into the jump cluster's actual SSH command.
+        # The jump cluster's IP/user/port become available locally in
+        # ~/.sky/generated/ssh/jump-{name} after `sky launch jump-{name}`, and
+        # the private key is the user's shared SkyPilot key, which lives at the
+        # same path (~/.sky/clients/<user_hash>/ssh/sky-key) on the client, the
+        # API server and the jobs controller. The generated config's own
+        # IdentityFile points to a client-only key copy, so we cannot use it.
+        jump_ssh_config = f'~/.sky/generated/ssh/jump-{name}'
+        jump_key_path = (
+            f'~/.sky/clients/{common_utils.get_user_hash()}/ssh/sky-key')
+        # Built at runtime (after the jump cluster is launched) since the jump
+        # cluster's IP is not known when the test is defined.
+        build_jump_config_cmd = (
+            f'JUMP_CFG=$(eval echo {jump_ssh_config}); '
+            'JUMP_IP=$(awk \'$1=="HostName"{print $2; exit}\' "$JUMP_CFG"); '
+            'JUMP_USER=$(awk \'$1=="User"{print $2; exit}\' "$JUMP_CFG"); '
+            'JUMP_PORT=$(awk \'$1=="Port"{print $2; exit}\' "$JUMP_CFG"); '
+            f'cat > {f.name} <<EOF\n'
+            'aws:\n'
+            '    ssh_proxy_command: ssh -W \'[%h]:%p\' '
+            '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
+            f'-o IdentitiesOnly=yes -i {jump_key_path} '
+            '-p $JUMP_PORT $JUMP_USER@$JUMP_IP\n'
+            'api_server:\n'
+            f'    endpoint: {smoke_tests_utils.get_api_server_url()}\n'
+            'EOF')
 
         jobs_controller_proxy_test_cmds = []
         jobs_controller_proxy_test_cmds_down = ''
@@ -108,6 +128,9 @@ def test_aws_with_ssh_proxy_command():
             'aws_with_ssh_proxy_command',
             [
                 f'sky launch -y -c jump-{name} --infra aws/us-east-1 {smoke_tests_utils.LOW_RESOURCE_ARG}',
+                # Expand the proxy command into the jump cluster's actual SSH
+                # command now that the jump cluster's SSH config is available.
+                build_jump_config_cmd,
                 # Use jump config
                 f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}={f.name}; '
                 f'sky launch -y -c {name} --infra aws/us-east-1 {smoke_tests_utils.LOW_RESOURCE_ARG} echo hi',


### PR DESCRIPTION
## Summary

`test_aws_with_ssh_proxy_command` set `ssh_proxy_command` to the SSH alias
`jump-{name}`. Resolving that alias requires the machine that actually runs the
proxy command (the API server, and for managed jobs the jobs controller) to have
the client's `~/.ssh/config` with SkyPilot's per-cluster `Include`. This does not
hold for a remote API server, making the test unreliable.

This PR expands the proxy command into the jump cluster's actual SSH command,
built at runtime after `sky launch jump-{name}`:
- IP / user / port are parsed from the locally-generated
  `~/.sky/generated/ssh/jump-{name}` config.
- The identity file uses the user's shared SkyPilot key at
  `~/.sky/clients/<user_hash>/ssh/sky-key`, which lives at the same path on the
  client, the API server, and the jobs controller. (The generated config's own
  `IdentityFile` points to a client-only key copy, so it cannot be used.)

## Test

- `bash format.sh --files tests/smoke_tests/test_region_and_zone.py` — clean
  (no new pylint violations vs. master).
- Validated the runtime config generation against a realistic mock
  `~/.sky/generated/ssh/jump-*` file: awk extracts the correct IP/user/port and
  the emitted YAML parses to the expected `ssh_proxy_command`.
- `/smoke-test --aws` for `test_aws_with_ssh_proxy_command` (pending).
