### PR TITLE
[Kubernetes] Co-locate multi-node EFA jobs in one AZ

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -848,6 +848,19 @@ class Kubernetes(clouds.Cloud):
                     f'No EFA interfaces detected on AWS nodes with '
                     f'accelerator {k8s_acc_label_key}, skipping enabling EFA.')
 
+        # Multi-node EFA jobs must co-locate every replica in a single AZ: an
+        # AWS EFA placement group is single-AZ, so pods that scatter across AZs
+        # cannot form the fabric (NCCL degrades or fails to init). SkyPilot
+        # schedules each pod independently with no cross-pod topology
+        # constraint, so on a multi-AZ cluster they can scatter. For a
+        # multi-node network_tier: best job on AWS EFA, tell the template to
+        # inject a required same-zone podAffinity keyed on the per-job label so
+        # every replica follows the first into whatever AZ it lands in (the user
+        # names no zone). network_type is only AWS_EFA when network_tier is
+        # BEST, so this stays off for every other tier and cloud.
+        k8s_efa_same_az = (num_nodes > 1 and network_type
+                           == KubernetesHighPerformanceNetworkType.AWS_EFA)
+
         # Check if this cluster supports high performance networking and
         # configure appropriate settings for different cluster types
         if (resources.network_tier is not None and
@@ -973,6 +986,7 @@ class Kubernetes(clouds.Cloud):
             'timeout': str(timeout),
             'k8s_efa_count': str(k8s_efa_count)
                              if k8s_efa_count is not None else None,
+            'k8s_efa_same_az': k8s_efa_same_az,
             'k8s_port_mode': port_mode.value,
             'k8s_acc_label_key': k8s_acc_label_key,
             'k8s_acc_label_values': k8s_acc_label_values,

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -474,6 +474,21 @@ available_node_types:
                         values:
                           - "gpu"
                   topologyKey: kubernetes.io/hostname
+            {% if k8s_efa_same_az %}
+            # Multi-node EFA co-location: an AWS EFA placement group is
+            # single-AZ, so every replica of this job must schedule into one
+            # zone or the fabric cannot form. Attract each pod to the zone of
+            # the other pods of the same SkyPilot cluster -- the first pod fixes
+            # the AZ (Karpenter provisions an EFA node wherever it has
+            # capacity) and the rest follow; the user names no zone. required
+            # (not preferred): cross-AZ EFA is broken, so pend loudly rather
+            # than silently fall back to TCP.
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    skypilot-cluster: {{cluster_name_on_cloud}}
+                topologyKey: topology.kubernetes.io/zone
+            {% endif %}
           {% endif %}
           {% endif %}
           {% if k8s_host_network %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -486,7 +486,7 @@ available_node_types:
             requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
                   matchLabels:
-                    skypilot-cluster: {{cluster_name_on_cloud}}
+                    skypilot-cluster-name: {{cluster_name_on_cloud}}
                 topologyKey: topology.kubernetes.io/zone
             {% endif %}
           {% endif %}

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4278,6 +4278,42 @@ class TestKubernetesEfaSameAzAffinity(unittest.TestCase):
             KubernetesHighPerformanceNetworkType as N)
         self.assertFalse(self._deploy_vars(2, N.NONE)['k8s_efa_same_az'])
 
+    def _render_same_az_affinity(self, same_az):
+        """Render just the k8s_efa_same_az podAffinity block from the live
+        template, so a wrong label or topologyKey is caught -- not only the
+        deploy var. Keeps the assertion coupled to the real template file."""
+        import jinja2
+
+        import sky
+        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
+                                     'kubernetes-ray.yml.j2')
+        with open(template_path, 'r', encoding='utf-8') as fin:
+            full = fin.read()
+        begin_marker = '{% if k8s_efa_same_az %}'
+        end_marker = '{% endif %}'
+        begin = full.index(begin_marker)
+        end = full.index(end_marker, begin) + len(end_marker)
+        snippet = full[begin:end]
+        return jinja2.Template(snippet).render(
+            k8s_efa_same_az=same_az, cluster_name_on_cloud='my-cluster')
+
+    def test_same_az_affinity_renders_cluster_name_label_and_zone(self):
+        # When the flag is set the rendered podAffinity must carry the
+        # (non-deprecated) cluster-name label and the single-AZ topology key.
+        rendered = self._render_same_az_affinity(same_az=True)
+        self.assertIn('requiredDuringSchedulingIgnoredDuringExecution',
+                      rendered)
+        self.assertIn('skypilot-cluster-name: my-cluster', rendered)
+        self.assertIn('topologyKey: topology.kubernetes.io/zone', rendered)
+        # Must not use the deprecated skypilot-cluster label.
+        self.assertNotIn('skypilot-cluster:', rendered)
+
+    def test_same_az_affinity_absent_when_flag_unset(self):
+        # When the flag is unset the same-AZ affinity must not be rendered.
+        rendered = self._render_same_az_affinity(same_az=False)
+        self.assertNotIn('topology.kubernetes.io/zone', rendered)
+        self.assertNotIn('skypilot-cluster-name', rendered)
+
 
 class TestKubernetesSpotLabelContext(unittest.TestCase):
     """Regression test for TICKET-034.

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4194,5 +4194,90 @@ class TestKubernetesRemoteIdentityFnmatch(unittest.TestCase):
         self.assertEqual(result, 'numeric-sa')
 
 
+class TestKubernetesEfaSameAzAffinity(unittest.TestCase):
+    """Multi-node network_tier: best on AWS EFA sets k8s_efa_same_az so the pod
+    template injects a required same-zone podAffinity (EFA is single-AZ).
+    Single-node and non-EFA network types must not set it. Fails without the
+    fix (the deploy var does not exist).
+    """
+
+    def _deploy_vars(self, num_nodes, network_type):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType)
+        gpu_resources = mock.MagicMock()
+        gpu_resources.instance_type = '8CPU--32GB--H100:8'
+        gpu_resources.accelerators = {'H100': 8}
+        gpu_resources.use_spot = False
+        gpu_resources.region = 'eks-context'
+        gpu_resources.zone = None
+        gpu_resources.cluster_config_overrides = {}
+        gpu_resources.image_id = None
+        setattr(gpu_resources, 'assert_launchable', lambda: gpu_resources)
+        gpu_resources.network_tier = resources_utils.NetworkTier.BEST
+
+        meta = ({
+            'efa_count': 32
+        } if network_type == KubernetesHighPerformanceNetworkType.AWS_EFA else
+                None)
+
+        with patch('sky.provision.kubernetes.utils.get_kubernetes_nodes'), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_current_kube_config_context_name',
+                   return_value='eks-context'), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_kube_config_context_namespace',
+                   return_value='default'), \
+             patch('sky.provision.kubernetes.utils.get_accelerator_label_keys',
+                   return_value=[]), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_accelerator_label_key_values',
+                   return_value=('accelerator', ['H100'], None, None)), \
+             patch('sky.provision.kubernetes.utils.get_gpu_resource_key',
+                   return_value='nvidia.com/gpu'), \
+             patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth',
+                   return_value=(False, None)), \
+             patch('sky.skypilot_config.get_workspace_cloud') as mock_ws, \
+             patch('sky.skypilot_config.get_effective_region_config',
+                   side_effect=lambda cloud, keys, region, default_value=None,
+                   override_configs=None: {
+                       ('kubernetes', 'remote_identity'): 'SERVICE_ACCOUNT',
+                       ('kubernetes', 'provision_timeout'): 10,
+                       ('kubernetes', 'high_availability',
+                        'storage_class_name'): None,
+                   }.get((cloud,) + keys, default_value)), \
+             patch('sky.provision.kubernetes.network_utils.get_port_mode'
+                  ) as mock_pm, \
+             patch('sky.catalog.get_image_id_from_tag',
+                   return_value='img:latest'), \
+             patch('sky.clouds.kubernetes.Kubernetes._detect_network_type',
+                   return_value=(network_type, meta)):
+            mock_ws.return_value.get.return_value = None
+            mock_pm.return_value.value = 'portforward'
+            k8s_cloud = kubernetes.Kubernetes()
+            return k8s_cloud.make_deploy_resources_variables(
+                resources=gpu_resources,
+                cluster_name=resources_utils.ClusterName(display_name='c',
+                                                         name_on_cloud='c'),
+                region=mock.MagicMock(name='eks-context'),
+                zones=None,
+                num_nodes=num_nodes,
+                dryrun=False)
+
+    def test_multinode_aws_efa_best_sets_same_az(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        self.assertTrue(self._deploy_vars(2, N.AWS_EFA)['k8s_efa_same_az'])
+
+    def test_single_node_aws_efa_does_not_set_same_az(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        self.assertFalse(self._deploy_vars(1, N.AWS_EFA)['k8s_efa_same_az'])
+
+    def test_multinode_non_efa_does_not_set_same_az(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        self.assertFalse(self._deploy_vars(2, N.NONE)['k8s_efa_same_az'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #10056

An AWS EFA placement group is single-AZ, so every replica of a multi-node network_tier: best job must schedule into one Availability Zone or the fabric cannot form (NCCL degrades to TCP or fails to init). SkyPilot schedules each pod independently and injects no cross-pod topology constraint, so on a multi-AZ cluster (e.g. Karpenter with per-AZ EFA node pools) the replicas can scatter.

For num_nodes>1 + network_tier: best on an AWS EFA context, inject a required same-zone podAffinity keyed on the per-job skypilot-cluster label: the first pod fixes the AZ (wherever the autoscaler has capacity) and the rest follow -- the user names no zone. Gated on AWS EFA detection (network_type is only AWS_EFA when tier is BEST), so single-node, non-best, and non-AWS paths are unchanged. required (not preferred) so a capacity shortfall pends loudly rather than silently degrading to TCP.

Adds unit tests asserting the flag is set only for multi-node AWS-EFA best and unset otherwise.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
