### PR TITLE
[Test] Pin set_pod_resource_limits cloud-cmd helper to landed context

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3521,11 +3521,14 @@ def test_kubernetes_set_pod_resource_limits():
         test = smoke_tests_utils.Test(
             'kubernetes_set_pod_resource_limits',
             [
-                smoke_tests_utils.launch_cluster_for_cloud_cmd(
-                    'kubernetes', name),
-                # Launch a cluster with set_pod_resource_limits=2.0
-                # Using --cpus 2 --memory 2 so limits should be 4 CPU, 4G memory
+                # Launch the cluster under test first; it may land on any
+                # context. Using --cpus 2 --memory 2 so limits should be
+                # 4 CPU, 4G memory with the 2x multiplier.
                 f'sky launch -y -c {name} --infra kubernetes --cpus 2 --memory 2',
+                # Resolve its context and pin the cloud-cmd cluster to the same
+                # context so the cloud-cmd pod's in-cluster kubectl can see it.
+                smoke_tests_utils.resolve_k8s_context_cmd(name),
+                smoke_tests_utils.launch_cloud_cmd_on_landed_context(name),
                 # Verify CPU limit is set (should be 4 with 2x multiplier)
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name,


### PR DESCRIPTION
## Summary

`test_kubernetes_set_pod_resource_limits` launches a cloud-cmd helper cluster and then inspects the pod of the cluster under test via the helper's in-cluster `kubectl`. It launched the helper with a plain `--infra kubernetes` (and *before* the target cluster existed), so on a **multi-context Kubernetes API server** the helper and the target can land on **different contexts**. The helper's in-cluster kubectl only reaches its own cluster, so:

```
kubectl get pod -l ray-cluster-name=<target> -o jsonpath='{.items[0]...}'
→ error: array index out of bounds: index 0, length 0   # zero pods matched
```

The test passes only when both clusters happen to land on the same context, making it flaky on multi-context servers (single-context servers are unaffected).

This mirrors the failure mode already fixed for the other Kubernetes cloud-cmd smoke tests (`test_kubernetes_recovery`, `test_launching_with_pending_pods`, `test_kubernetes_pod_config_sidecar`, ...), which pin the helper to the target's landed context. This test was simply never migrated.

## Fix

Reorder to the established pattern: launch the cluster under test first, resolve its landed context, then pin the cloud-cmd helper to that same context via `resolve_k8s_context_cmd` / `launch_cloud_cmd_on_landed_context`, so the helper's kubectl is co-located with the target. On a single-context server this is a no-op (`--infra kubernetes`).

## Test plan

- Reproduced the empty-pod-query failure on a multi-context Kubernetes API server: two independent unpinned `--infra kubernetes` launches reliably land on different contexts when more than one has capacity, so the helper's kubectl sees zero target pods.
- With the pinning, the helper and target are always co-located and the CPU/memory limit assertions (`4` CPU, `4G` memory with the 2x multiplier) pass regardless of placement.
- No behavior change on single-context servers.