### PR TITLE
Add a pre-write validator hook for API server config saves

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1249,12 +1249,15 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
             constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
         raise ValueError('This function can only be called by the API Server.')
 
-    # Run registered validators before persisting or mutating the config, so
-    # a validator can veto the save by raising. Exceptions propagate to abort
-    # the update.
-    current = to_dict()
-    for validator in list(_CONFIG_SAVE_VALIDATORS):
-        validator(current, config)
+    # Run registered validators before persisting the config, so a validator
+    # can veto the save by raising; exceptions propagate to abort the update.
+    # Validators must not mutate the config, so hand them a deep copy of the
+    # incoming config (to_dict() already returns a fresh copy for `current`).
+    if _CONFIG_SAVE_VALIDATORS:
+        current = to_dict()
+        incoming = copy.deepcopy(config)
+        for validator in list(_CONFIG_SAVE_VALIDATORS):
+            validator(current, incoming)
 
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1013,6 +1013,33 @@ def register_config_update_hook(fn: Callable[[], None]) -> None:
         _CONFIG_UPDATE_HOOKS.append(fn)
 
 
+# Validators invoked at the start of `update_api_server_config_no_lock`,
+# before the new config is persisted. Each validator receives the currently
+# persisted config and the incoming config, and may reject the save by
+# raising. Server-side integrations use this to enforce invariants and block
+# invalid or conflicting config changes before they take effect. Registered at
+# server startup during single-threaded plugin loading, so no lock is needed.
+_CONFIG_SAVE_VALIDATORS: List[Callable[
+    [config_utils.Config, config_utils.Config], None]] = []
+
+
+def register_config_save_validator(
+        fn: Callable[[config_utils.Config, config_utils.Config], None]) -> None:
+    """Register a validator invoked before the API server config is saved.
+
+    Called at server startup during plugin loading (single-threaded), so no
+    lock is needed. Each validator is called as ``fn(current, incoming)``
+    before the incoming config is persisted, where ``current`` is the
+    currently persisted config and ``incoming`` is the config about to be
+    saved. A validator vetoes the save by raising; unlike
+    `register_config_update_hook`, exceptions are NOT caught -- they propagate
+    to the caller so the save is aborted. Validators must not mutate the
+    config.
+    """
+    if fn not in _CONFIG_SAVE_VALIDATORS:
+        _CONFIG_SAVE_VALIDATORS.append(fn)
+
+
 def _get_effective_k8s_config_value(
         cloud: str,
         property_keys: List[Tuple[str, ...]],
@@ -1221,6 +1248,13 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
     if not is_running_pytest() and os.environ.get(
             constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
         raise ValueError('This function can only be called by the API Server.')
+
+    # Run registered validators before persisting or mutating the config, so
+    # a validator can veto the save by raising. Exceptions propagate to abort
+    # the update.
+    current = to_dict()
+    for validator in list(_CONFIG_SAVE_VALIDATORS):
+        validator(current, config)
 
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -996,6 +996,78 @@ def test_hierarchical_server_config(monkeypatch, tmp_path):
         ('gcp', 'labels', 'env-project-config'), None) is None
 
 
+def test_config_save_validator(monkeypatch, tmp_path):
+    """Validators run before persisting and can veto the config save."""
+    monkeypatch.delenv(skypilot_config.ENV_VAR_GLOBAL_CONFIG, raising=False)
+    monkeypatch.delenv(skypilot_config.ENV_VAR_PROJECT_CONFIG, raising=False)
+    # Isolate the validator registry so the test does not leak global state.
+    monkeypatch.setattr(skypilot_config, '_CONFIG_SAVE_VALIDATORS', [])
+
+    config_path = str(tmp_path / 'server_config.yaml')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    with open(config_path, 'w', encoding='utf-8') as f:
+        f.write(
+            textwrap.dedent("""\
+                aws:
+                    labels:
+                        original: present
+                """))
+    skypilot_config.reload_config()
+
+    new_config = skypilot_config.to_dict()
+    new_config.set_nested(('aws', 'labels', 'added'), 'yes')
+
+    # A validator that vetoes by raising blocks the save.
+    calls = []
+
+    def vetoing_validator(current, incoming):
+        calls.append((copy.deepcopy(current), copy.deepcopy(incoming)))
+        raise ValueError('rejected config change')
+
+    skypilot_config.register_config_save_validator(vetoing_validator)
+
+    with pytest.raises(ValueError, match='rejected config change'):
+        skypilot_config.update_api_server_config_no_lock(new_config)
+
+    # The validator saw the currently-persisted config and the incoming
+    # config, and the on-disk config is unchanged.
+    assert len(calls) == 1
+    seen_current, seen_incoming = calls[0]
+    assert seen_current.get_nested(('aws', 'labels', 'added'), None) is None
+    assert seen_incoming.get_nested(('aws', 'labels', 'added'), None) == 'yes'
+    assert yaml_utils.read_yaml(config_path) == {
+        'aws': {
+            'labels': {
+                'original': 'present'
+            }
+        }
+    }
+
+    # A validator that passes lets the save through.
+    monkeypatch.setattr(skypilot_config, '_CONFIG_SAVE_VALIDATORS', [])
+    passed = []
+
+    def passing_validator(current, incoming):
+        del current, incoming
+        passed.append(True)
+
+    skypilot_config.register_config_save_validator(passing_validator)
+    skypilot_config.update_api_server_config_no_lock(new_config)
+    assert passed == [True]
+    assert yaml_utils.read_yaml(config_path) == {
+        'aws': {
+            'labels': {
+                'original': 'present',
+                'added': 'yes'
+            }
+        }
+    }
+
+    # Registration is idempotent.
+    skypilot_config.register_config_save_validator(passing_validator)
+    assert skypilot_config._CONFIG_SAVE_VALIDATORS.count(passing_validator) == 1
+
+
 def test_kubernetes_context_configs(monkeypatch, tmp_path) -> None:
     """Test that the nested config works."""
     from sky.provision.kubernetes import utils as kubernetes_utils


### PR DESCRIPTION
## What

Adds `register_config_save_validator`, a registry of validators invoked at the
start of `update_api_server_config_no_lock`, before the incoming config is
persisted or mutated. Each validator is called as `fn(current, incoming)` —
the currently persisted config and the config about to be saved — and may
**veto the save by raising**.

## Why

`register_config_update_hook` already lets code react *after* a config update
lands, but there's no way to reject an invalid or conflicting change *before*
it's persisted. This adds the pre-write complement: server-side integrations
can enforce invariants and block bad config saves up front. Unlike the
post-update hook (whose exceptions are caught and logged so a hook can't fail
the update), validator exceptions intentionally propagate — that propagation
is the veto.

## Testing

New unit test `tests/test_config.py::test_config_save_validator`:
- a vetoing validator raises → the save is aborted and the on-disk config is unchanged;
- a passing validator → the config persists;
- registration is idempotent.

yapf clean; pylint 10.00/10 on `sky/skypilot_config.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)