### PR TITLE
[Azure] Fix NIC provisioning broken by azure-mgmt-network 31.0.0

### DIFF
--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -200,13 +200,12 @@ def _create_network_interface(
         provider_config: Dict[str,
                               Any]) -> 'azure_network_models.NetworkInterface':
     network = azure.azure_mgmt_models('network')
-    compute = azure.azure_mgmt_models('compute')
     logger.info(f'Start creating network interface for {vm_name}...')
     if provider_config.get('use_internal_ips', False):
         name = f'{vm_name}-nic-private'
         ip_config = network.IPConfiguration(
             name=f'ip-config-private-{vm_name}',
-            subnet=compute.SubResource(id=provider_config['subnet']),
+            subnet=network.Subnet(id=provider_config['subnet']),
             private_ip_allocation_method=network.IPAllocationMethod.DYNAMIC)
     else:
         name = f'{vm_name}-nic-public'
@@ -223,7 +222,7 @@ def _create_network_interface(
                     f'with address {ip_poller.result().ip_address}.')
         ip_config = network.IPConfiguration(
             name=f'ip-config-public-{vm_name}',
-            subnet=compute.SubResource(id=provider_config['subnet']),
+            subnet=network.Subnet(id=provider_config['subnet']),
             private_ip_allocation_method=network.IPAllocationMethod.DYNAMIC,
             public_ip_address=network.PublicIPAddress(id=ip_poller.result().id))
 


### PR DESCRIPTION
## Summary

- Fixes every Azure launch failing at NIC creation with `TypeError: Object of type SubResource is not JSON serializable`, which was wiping out the entire Azure smoke-test suite (e.g. release build `full-smoke-tests-run` #121).
- Root cause: `_create_network_interface` built the subnet reference with `compute.SubResource` (an `azure.mgmt.compute.models` type) but embedded it in a `network.IPConfiguration` sent to the network client.
- `azure-mgmt-network` **31.0.0** (published 2026-07-01) regenerated its models with the TypeSpec toolchain and a strict `SdkJSONEncoder` (`_utils/model_base.py`) that only serializes network-SDK models, so the foreign compute model now raises. Versions `<=30.2.0` used a lenient serializer that accepted any object exposing `.id`, which had masked this latent bug since the SDK refactor in #4139.
- Our pin is `azure-mgmt-network>=27.0.0` with no upper bound, so fresh release/nightly installs pick up 31.0.x automatically.

## Fix

Use `network.Subnet(id=...)` (the declared type of `IPConfiguration.subnet`) instead of `compute.SubResource(id=...)`, and drop the now-unused compute-models alias in that function. This serializes to the same `{"id": ...}` ARM reference and is correct on both `azure-mgmt-network` 30.x and 31.x.

```python
-    subnet=compute.SubResource(id=provider_config['subnet']),
+    subnet=network.Subnet(id=provider_config['subnet']),
```

## Test plan

- `bash format.sh --files sky/provision/azure/instance.py` → mypy clean, pylint 10.00/10.
- CI: triggering `/smoke-test --azure` on this PR to validate Azure provisioning end-to-end (NIC creation + VM launch).
- Manual: `sky launch --cloud azure --cpus 2+` should provision successfully against `azure-mgmt-network>=31.0.0`.

## Notes

- This is a release blocker for 0.13.0rc1; it should be cherry-picked onto `staging/0.13.0rc1` (and any other active release branch) after landing on master.
- Optional hardening (not included): add an `azure-mgmt-network` upper cap in `dependencies.py` mirroring the existing `azure-cli<2.87.0` TypeSpec cap. The code fix alone resolves the issue on both SDK generations, so this PR leads with the code fix and avoids pinning away from the CVE-required `azure-core`.
