### PR TITLE
[Jobs] Support cross-cluster Kubernetes JobGroups via DNS mirroring

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -508,6 +508,12 @@ rbac:
     - apiGroups: [ "" ]
       resources: [ "services" ]
       verbs: [ "*" ]
+    # Required for cross-cluster Job Group service discovery: the jobs
+    # controller manages selectorless mirror Services with manual Endpoints
+    # so tasks in one cluster can resolve tasks in another.
+    - apiGroups: [ "" ]
+      resources: [ "endpoints" ]
+      verbs: [ "get", "list", "create", "patch", "update", "delete" ]
     # Required for managing SSH keys
     - apiGroups: [ "" ]
       resources: [ "secrets" ]

--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -77,6 +77,13 @@ SkyPilot requires permissions equivalent to the following roles to be able to ma
       - apiGroups: [ "" ]
         resources: [ "services" ]
         verbs: [ "*" ]
+      # Required for cross-cluster Job Group service discovery: SkyPilot
+      # manages selectorless mirror Services with manually-managed Endpoints
+      # so tasks in one Kubernetes cluster can resolve tasks running in
+      # another.
+      - apiGroups: [ "" ]
+        resources: [ "endpoints" ]
+        verbs: [ "get", "list", "create", "patch", "update", "delete" ]
       # Required for managing SSH keys
       - apiGroups: [ "" ]
         resources: [ "secrets" ]
@@ -305,6 +312,13 @@ To create a service account that has all necessary permissions for SkyPilot (inc
       - apiGroups: [ "" ]
         resources: [ "services" ]
         verbs: [ "*" ]
+      # Required for cross-cluster Job Group service discovery: SkyPilot
+      # manages selectorless mirror Services with manually-managed Endpoints
+      # so tasks in one Kubernetes cluster can resolve tasks running in
+      # another.
+      - apiGroups: [ "" ]
+        resources: [ "endpoints" ]
+        verbs: [ "get", "list", "create", "patch", "update", "delete" ]
       # Required for managing SSH keys
       - apiGroups: [ "" ]
         resources: [ "secrets" ]

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -213,8 +213,13 @@ case above.
 Prerequisites
 ~~~~~~~~~~~~~
 
-Cross-cluster job groups require pod-to-pod network routability between the member
-clusters:
+These prerequisites only matter if the tasks need to **communicate with each
+other**. A job group whose tasks are independent can span clusters without any
+of the setup below — the tasks simply launch and run in their respective
+clusters (cross-cluster hostnames will not be reachable).
+
+For tasks to reach each other, pod-to-pod network routability is required
+between the member clusters:
 
 - The clusters' pod networks must be routable to each other (e.g., a shared or
   peered VPC, a flat network, or a cluster mesh) with non-overlapping pod CIDRs.

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -193,6 +193,14 @@ clusters. SkyPilot supports this by letting each task pin its own Kubernetes con
 Tasks reach each other using the same ``{task_name}-{node_index}.{job_group_name}``
 hostnames described above, regardless of which cluster they land on.
 
+.. note::
+
+    Explicitly pinning each task's cluster is the current mechanism for
+    spanning clusters. Automatic placement — a plain ``infra: k8s`` Job Group
+    spreading across clusters only when no single cluster can satisfy all
+    tasks — is planned; the networking described here already supports tasks
+    landing on different clusters however they got there.
+
 How it works
 ~~~~~~~~~~~~
 

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -164,6 +164,67 @@ Example usage in a task:
     curl http://trainer-0.${SKYPILOT_JOBGROUP_NAME}:8000/status
 
 
+Cross-cluster job groups
+------------------------
+
+Some workloads need to split tasks across different Kubernetes clusters, for example
+when heterogeneous accelerators (e.g., an RL actor/learner split) live in separate
+clusters. SkyPilot supports this by letting each task pin its own Kubernetes context:
+
+.. code-block:: yaml
+
+    name: rl-cross-cluster
+    execution: parallel
+    ---
+    name: actor
+    resources:
+      infra: k8s/context-a
+      accelerators: L4:1
+    run: |
+      curl http://learner-0.${SKYPILOT_JOBGROUP_NAME}:8000/status
+    ---
+    name: learner
+    resources:
+      infra: k8s/context-b
+      accelerators: H100:1
+    run: |
+      curl http://actor-0.${SKYPILOT_JOBGROUP_NAME}:8000/status
+
+Tasks reach each other using the same ``{task_name}-{node_index}.{job_group_name}``
+hostnames described above, regardless of which cluster they land on.
+
+How it works
+~~~~~~~~~~~~
+
+When a Job Group's tasks span more than one Kubernetes context, the jobs controller
+mirrors each task's service DNS records into every other member cluster and keeps
+those records pointed at the task's live pod IPs as pods are recreated or recovered.
+From a task's perspective, hostname resolution is identical to the single-cluster
+case above.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+Cross-cluster job groups require pod-to-pod network routability between the member
+clusters:
+
+- The clusters' pod networks must be routable to each other (e.g., a shared or
+  peered VPC, a flat network, or a cluster mesh) with non-overlapping pod CIDRs.
+- **GKE**: add a VPC firewall rule that allows traffic from the peer cluster's pod
+  IP range.
+- **EKS with the VPC CNI**: by default, cross-VPC pod traffic is SNATed to the
+  source node's IP, so security groups must allow the peer cluster's pod and node
+  CIDRs.
+- The SkyPilot API server's Kubernetes service account needs ``create``, ``patch``,
+  and ``delete`` permissions on ``services`` and ``endpoints`` in the SkyPilot
+  namespace of every member cluster (see :ref:`k8s-permissions`). Write access to
+  ``endpoints`` is a security-sensitive permission (it lets the holder redirect
+  traffic for any selectorless Service in the namespace) and should be scoped
+  accordingly.
+- All member clusters must use the same cluster DNS domain (``cluster.local``) and
+  IPv4 pod IPs.
+
+
 Viewing logs
 ------------
 
@@ -357,8 +418,10 @@ Here is a minimal example:
 Current limitations
 -------------------
 
-- **Co-location**: All tasks in a Job Group run on the same infrastructure
-  (same Kubernetes cluster or cloud zone).
+- **Infrastructure**: By default, all tasks in a Job Group run on the same
+  infrastructure (same Kubernetes cluster or cloud zone). Kubernetes tasks may
+  pin different clusters via ``infra: k8s/<context>`` — see
+  `Cross-cluster job groups`_.
 
 - **Networking**: Service discovery (hostname-based communication between tasks)
   currently only works on Kubernetes. On other clouds, tasks can run in parallel

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1356,12 +1356,27 @@ class JobController:
         own cluster DNS follows automatically, but mirrors in other member
         clusters must be re-pointed by the controller.
         """
+        tasks = [task for task, _ in all_tasks_handles]
         while True:
             await asyncio.sleep(
                 job_group_networking.MIRROR_RECONCILE_INTERVAL_SECONDS)
             try:
+                # Re-fetch handles every tick rather than using the ones
+                # captured at Phase 3: a recovered task has a fresh handle,
+                # and this keeps the loop correct if a recovery ever places
+                # a task on different infra.
+                tasks_handles = []
+                for task in tasks:
+                    assert task.name is not None
+                    cluster_name = (
+                        managed_job_utils.generate_managed_job_cluster_name(
+                            task.name, self._job_id))
+                    handle = await asyncio.to_thread(
+                        global_user_state.get_handle_from_cluster_name,
+                        cluster_name)
+                    tasks_handles.append((task, handle))
                 await job_group_networking.setup_cross_context_mirrors(
-                    job_group_name, self._job_id, all_tasks_handles, quiet=True)
+                    job_group_name, self._job_id, tasks_handles, quiet=True)
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception as e:  # pylint: disable=broad-except

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1,6 +1,7 @@
 """Controller: handles scheduling and the life cycle of a managed job.
 """
 import asyncio
+import contextlib
 import io
 import json
 import os
@@ -1314,6 +1315,8 @@ class JobController:
                     global_user_state.get_handle_from_cluster_name, t_cluster)
                 updated_handles.append((t, t_handle))
 
+            await job_group_networking.setup_cross_context_mirrors(
+                job_group_name, self._job_id, updated_handles)
             await job_group_networking.setup_job_group_networking(
                 job_group_name, updated_handles)
 
@@ -1342,6 +1345,28 @@ class JobController:
             force_transit_to_recovering=force_transit_to_recovering,
             on_recovery=on_recovery,
         )
+
+    async def _reconcile_job_group_mirrors(
+            self, job_group_name: str,
+            all_tasks_handles: List[Tuple['sky.Task', typing.Any]]) -> None:
+        """Keep cross-context DNS mirrors pointed at live pod IPs.
+
+        Covers pod IP churn that never surfaces as a SkyPilot-level recovery
+        (e.g. a runtime replacing an individual pod in place): the peer's
+        own cluster DNS follows automatically, but mirrors in other member
+        clusters must be re-pointed by the controller.
+        """
+        while True:
+            await asyncio.sleep(
+                job_group_networking.MIRROR_RECONCILE_INTERVAL_SECONDS)
+            try:
+                await job_group_networking.setup_cross_context_mirrors(
+                    job_group_name, self._job_id, all_tasks_handles, quiet=True)
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(
+                    f'JobGroup mirror reconcile failed (will retry): {e}')
 
     async def _run_job_group(self) -> bool:
         """Run a JobGroup with parallel execution.
@@ -1554,6 +1579,16 @@ class JobController:
 
         # Phase 3: Set up networking
         logger.info('Phase 3: Setting up JobGroup networking...')
+        # Set up cross-context DNS mirrors first (no-op unless the group's
+        # Kubernetes tasks span more than one context) so the per-node
+        # updater scripts started below have somewhere to resolve their
+        # peers' hostnames as soon as they come up.
+        all_tasks_handles = [(task, handles[tid])
+                             for tid, task in enumerate(tasks)
+                             if handles[tid] is not None]
+        await job_group_networking.setup_cross_context_mirrors(
+            job_group_name, self._job_id, all_tasks_handles)
+
         # Build list of (task, handle) for non-terminal tasks with valid
         # handles. Skip tasks that inline the DNS mapping — they already
         # start the DNS updater from task.run.
@@ -1578,157 +1613,180 @@ class JobController:
 
         logger.info('JobGroup setup complete, all jobs are running')
 
-        # Phase 4: Monitor all jobs in parallel with primary/auxiliary support
-        logger.info('Phase 4: Monitoring all jobs...')
-
-        # Determine primary vs auxiliary jobs
-        primary_job_names = self._dag.primary_tasks
-        if not primary_job_names:
-            # All jobs are primary (traditional behavior)
-            primary_task_ids: Set[int] = set(range(len(tasks)))
-            auxiliary_task_ids: Set[int] = set()
-        else:
-            primary_task_ids = {
-                tid for tid, t in enumerate(tasks)
-                if t.name in primary_job_names
-            }
-            auxiliary_task_ids = set(range(len(tasks))) - primary_task_ids
-
-        if auxiliary_task_ids:
-            logger.info(
-                f'Primary jobs: {[tasks[tid].name for tid in primary_task_ids]}'
-            )
-            logger.info(f'Auxiliary jobs: '
-                        f'{[tasks[tid].name for tid in auxiliary_task_ids]}')
-
-        # Create asyncio.Task objects for all non-terminal tasks
-        # Maps task_id -> asyncio.Task
-        monitor_async_tasks: Dict[int, asyncio.Task] = {}
-        for task_id, task in enumerate(tasks):
-            if is_terminal(task_id):
-                continue
-
-            _, force_recovery = task_resume_info[task_id]
-            task_handle = handles[task_id]
-            executor = strategy_executors[task_id]
-            cluster_name = cluster_names[task_id]
-            assert cluster_name is not None
-            assert executor is not None
-            coro = self._monitor_job_group_task(task_id, task, cluster_name,
-                                                executor, job_group_name,
-                                                tasks_handles, force_recovery)
-            monitor_async_tasks[task_id] = asyncio.create_task(
-                coro, name=f'monitor_{task.name}')
-
-        # Track results: task_id -> success (True/False/Exception)
-        task_results: Dict[int, typing.Union[bool, Exception]] = {}
-        # Track remaining primary task IDs (non-terminal ones)
-        remaining_primary = primary_task_ids - {
-            tid for tid in range(len(tasks)) if is_terminal(tid)
-        }
-        # Reverse mapping: asyncio.Task -> task_id for efficient lookup
-        async_task_to_id: Dict[asyncio.Task, int] = {
-            at: tid for tid, at in monitor_async_tasks.items()
-        }
+        # Periodically re-point cross-context DNS mirrors at live pod IPs
+        # (no-op unless the group's Kubernetes tasks span more than one
+        # context). Started here so it covers the whole monitoring phase;
+        # cancelled in the `finally` below on every exit path.
+        mirror_reconcile_task: Optional[asyncio.Task] = None
+        if job_group_networking.group_spans_multiple_contexts(
+                all_tasks_handles, self._job_id):
+            mirror_reconcile_task = asyncio.create_task(
+                self._reconcile_job_group_mirrors(job_group_name,
+                                                  all_tasks_handles),
+                name=f'mirror_reconcile_{job_group_name}')
 
         try:
-            # Monitor with primary/auxiliary termination logic
-            while monitor_async_tasks:
-                # Wait for any task to complete
-                done, _ = await asyncio.wait(
-                    monitor_async_tasks.values(),
-                    return_when=asyncio.FIRST_COMPLETED)
+            # Phase 4: Monitor all jobs in parallel with primary/auxiliary
+            # support
+            logger.info('Phase 4: Monitoring all jobs...')
 
-                for completed_task in done:
-                    completed_task_id = async_task_to_id[completed_task]
+            # Determine primary vs auxiliary jobs
+            primary_job_names = self._dag.primary_tasks
+            if not primary_job_names:
+                # All jobs are primary (traditional behavior)
+                primary_task_ids: Set[int] = set(range(len(tasks)))
+                auxiliary_task_ids: Set[int] = set()
+            else:
+                primary_task_ids = {
+                    tid for tid, t in enumerate(tasks)
+                    if t.name in primary_job_names
+                }
+                auxiliary_task_ids = set(range(len(tasks))) - primary_task_ids
 
-                    # Remove from monitoring
-                    del monitor_async_tasks[completed_task_id]
-                    del async_task_to_id[completed_task]
+            if auxiliary_task_ids:
+                logger.info(f'Primary jobs: '
+                            f'{[tasks[tid].name for tid in primary_task_ids]}')
+                logger.info(
+                    f'Auxiliary jobs: '
+                    f'{[tasks[tid].name for tid in auxiliary_task_ids]}')
 
-                    # Get result
-                    try:
-                        task_result: typing.Union[bool, Exception] = (
-                            completed_task.result())
-                        task_results[completed_task_id] = task_result
-                        if task_result:
-                            logger.info(
-                                f'Job {tasks[completed_task_id].name} succeeded'
-                            )
-                        else:
-                            logger.info(
-                                f'Job {tasks[completed_task_id].name} failed')
-                    except asyncio.CancelledError:
-                        # Task was cancelled (auxiliary job termination)
-                        task_results[completed_task_id] = False
-                        task_name = tasks[completed_task_id].name
-                        logger.info(f'Job {task_name} was terminated')
-                    except Exception as e:  # pylint: disable=broad-except
-                        # TODO: avoid broad except
-                        task_results[completed_task_id] = e
-                        logger.error(
-                            f'Job {tasks[completed_task_id].name} failed with '
-                            f'exception: {e}')
+            # Create asyncio.Task objects for all non-terminal tasks
+            # Maps task_id -> asyncio.Task
+            monitor_async_tasks: Dict[int, asyncio.Task] = {}
+            for task_id, task in enumerate(tasks):
+                if is_terminal(task_id):
+                    continue
 
-                    # If this was a primary task, check if all primary done
-                    if completed_task_id in remaining_primary:
-                        remaining_primary.discard(completed_task_id)
+                _, force_recovery = task_resume_info[task_id]
+                task_handle = handles[task_id]
+                executor = strategy_executors[task_id]
+                cluster_name = cluster_names[task_id]
+                assert cluster_name is not None
+                assert executor is not None
+                coro = self._monitor_job_group_task(task_id, task, cluster_name,
+                                                    executor, job_group_name,
+                                                    tasks_handles,
+                                                    force_recovery)
+                monitor_async_tasks[task_id] = asyncio.create_task(
+                    coro, name=f'monitor_{task.name}')
 
-                        if not remaining_primary:
-                            # All primary jobs are done
-                            logger.info('All primary jobs completed')
+            # Track results: task_id -> success (True/False/Exception)
+            task_results: Dict[int, typing.Union[bool, Exception]] = {}
+            # Track remaining primary task IDs (non-terminal ones)
+            remaining_primary = primary_task_ids - {
+                tid for tid in range(len(tasks)) if is_terminal(tid)
+            }
+            # Reverse mapping: asyncio.Task -> task_id for efficient lookup
+            async_task_to_id: Dict[asyncio.Task, int] = {
+                at: tid for tid, at in monitor_async_tasks.items()
+            }
 
-                            # Check if all primary jobs succeeded. For terminal
-                            # tasks, check their status; for others, check
-                            # result.
-                            def primary_task_succeeded(tid: int) -> bool:
-                                if is_terminal(tid):
-                                    return (task_resume_info[tid][0] ==
-                                            managed_job_state.ManagedJobStatus.
-                                            SUCCEEDED)
-                                return task_results.get(tid, True) is True
+            try:
+                # Monitor with primary/auxiliary termination logic
+                while monitor_async_tasks:
+                    # Wait for any task to complete
+                    done, _ = await asyncio.wait(
+                        monitor_async_tasks.values(),
+                        return_when=asyncio.FIRST_COMPLETED)
 
-                            all_primary_succeeded = all(
-                                primary_task_succeeded(tid)
-                                for tid in primary_task_ids)
+                    for completed_task in done:
+                        completed_task_id = async_task_to_id[completed_task]
 
-                            # Terminate remaining auxiliary jobs
-                            if monitor_async_tasks:
-                                await self._terminate_auxiliary_jobs(
-                                    tasks, monitor_async_tasks, cluster_names,
-                                    all_primary_succeeded)
-                                # All auxiliary jobs terminated, exit loop
-                                break
+                        # Remove from monitoring
+                        del monitor_async_tasks[completed_task_id]
+                        del async_task_to_id[completed_task]
 
-        except Exception as e:
-            logger.error(f'Monitoring failed: {e}')
-            # Cancel all remaining tasks
-            for task_id, async_task in monitor_async_tasks.items():
-                async_task.cancel()
-            await self._cleanup_job_group_clusters(cluster_names)
-            raise
+                        # Get result
+                        try:
+                            task_result: typing.Union[bool, Exception] = (
+                                completed_task.result())
+                            task_results[completed_task_id] = task_result
+                            if task_result:
+                                logger.info(f'Job '
+                                            f'{tasks[completed_task_id].name} '
+                                            'succeeded')
+                            else:
+                                logger.info(
+                                    f'Job {tasks[completed_task_id].name} '
+                                    'failed')
+                        except asyncio.CancelledError:
+                            # Task was cancelled (auxiliary job termination)
+                            task_results[completed_task_id] = False
+                            task_name = tasks[completed_task_id].name
+                            logger.info(f'Job {task_name} was terminated')
+                        except Exception as e:  # pylint: disable=broad-except
+                            # TODO: avoid broad except
+                            task_results[completed_task_id] = e
+                            logger.error(
+                                f'Job {tasks[completed_task_id].name} failed '
+                                f'with exception: {e}')
 
-        # Check results (include terminal tasks)
-        all_succeeded = True
-        for task_id, task in enumerate(tasks):
-            if is_terminal(task_id):
-                # Terminal task - check if it succeeded
-                task_status = task_resume_info[task_id][0]
-                if task_status != managed_job_state.ManagedJobStatus.SUCCEEDED:
+                        # If this was a primary task, check if all primary
+                        # done
+                        if completed_task_id in remaining_primary:
+                            remaining_primary.discard(completed_task_id)
+
+                            if not remaining_primary:
+                                # All primary jobs are done
+                                logger.info('All primary jobs completed')
+
+                                # Check if all primary jobs succeeded. For
+                                # terminal tasks, check their status; for
+                                # others, check result.
+                                def primary_task_succeeded(tid: int) -> bool:
+                                    if is_terminal(tid):
+                                        return (task_resume_info[tid][0] ==
+                                                managed_job_state.
+                                                ManagedJobStatus.SUCCEEDED)
+                                    return task_results.get(tid, True) is True
+
+                                all_primary_succeeded = all(
+                                    primary_task_succeeded(tid)
+                                    for tid in primary_task_ids)
+
+                                # Terminate remaining auxiliary jobs
+                                if monitor_async_tasks:
+                                    await self._terminate_auxiliary_jobs(
+                                        tasks, monitor_async_tasks,
+                                        cluster_names, all_primary_succeeded)
+                                    # All auxiliary jobs terminated, exit loop
+                                    break
+
+            except Exception as e:
+                logger.error(f'Monitoring failed: {e}')
+                # Cancel all remaining tasks
+                for task_id, async_task in monitor_async_tasks.items():
+                    async_task.cancel()
+                await self._cleanup_job_group_clusters(cluster_names)
+                raise
+
+            # Check results (include terminal tasks)
+            all_succeeded = True
+            for task_id, task in enumerate(tasks):
+                if is_terminal(task_id):
+                    # Terminal task - check if it succeeded
+                    task_status = task_resume_info[task_id][0]
+                    if (task_status !=
+                            managed_job_state.ManagedJobStatus.SUCCEEDED):
+                        all_succeeded = False
+                    continue
+
+                # Check the result for this task
+                check_result = task_results.get(task_id)
+                if isinstance(check_result, Exception):
+                    logger.error(
+                        f'Job {task.name} monitoring failed: {check_result}')
                     all_succeeded = False
-                continue
+                elif check_result is not True:
+                    all_succeeded = False
 
-            # Check the result for this task
-            check_result = task_results.get(task_id)
-            if isinstance(check_result, Exception):
-                logger.error(
-                    f'Job {task.name} monitoring failed: {check_result}')
-                all_succeeded = False
-            elif check_result is not True:
-                all_succeeded = False
-
-        await self._cleanup_job_group_clusters(cluster_names)
-        return all_succeeded
+            await self._cleanup_job_group_clusters(cluster_names)
+            return all_succeeded
+        finally:
+            if mirror_reconcile_task is not None:
+                mirror_reconcile_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await mirror_reconcile_task
 
     async def _terminate_auxiliary_jobs(self, tasks: List['task_lib.Task'],
                                         monitor_async_tasks: Dict[int,
@@ -1972,6 +2030,28 @@ class ControllerManager:
         # sky.exceptions.ResourcesUnavailableError).
         await managed_job_state.remove_ha_recovery_script_async(job_id)
 
+        dag = _get_dag(job_id)
+
+        # Clean up cross-context DNS mirrors before tearing down clusters
+        # below, while handles are still readable from global_user_state
+        # (this is a no-op, no-API-call for single-context/non-JobGroup
+        # jobs — see `cleanup_cross_context_mirrors`).
+        if dag.is_job_group():
+            mirror_tasks_handles: List[Tuple['sky.Task', typing.Any]] = []
+            for task in dag.tasks:
+                assert task.name is not None
+                cluster_name = (
+                    managed_job_utils.generate_managed_job_cluster_name(
+                        task.name, job_id))
+                handle = global_user_state.get_handle_from_cluster_name(
+                    cluster_name)
+                mirror_tasks_handles.append((task, handle))
+            try:
+                await job_group_networking.cleanup_cross_context_mirrors(
+                    dag.name or '', job_id, mirror_tasks_handles)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f'Failed to clean up JobGroup DNS mirrors: {e}')
+
         def task_cleanup(task: 'sky.Task', job_id: int):
             assert task.name is not None, task
             error = None
@@ -2057,7 +2137,6 @@ class ControllerManager:
             if error is not None:
                 raise error
 
-        dag = _get_dag(job_id)
         error = None
         for task in dag.tasks:
             # most things in this function are blocking

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -20,15 +20,18 @@ Design Goals:
 """
 import asyncio
 import base64
+import dataclasses
 import os
+import re
 import tempfile
 import textwrap
 import traceback
 import typing
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from sky import clouds as sky_clouds
 from sky import sky_logging
+from sky.adaptors import kubernetes
 from sky.utils import command_runner
 
 if typing.TYPE_CHECKING:
@@ -134,6 +137,35 @@ def _get_job_address(job_name: str,
     return f'{job_name}-{node_idx}.{job_group_name}'
 
 
+# Labels stamped on mirror Services/Endpoints created for cross-context
+# JobGroups (see the "Cross-context DNS mirrors" section below). The job-id
+# label is the cleanup key; the group label is used to garbage-collect stale
+# mirrors from a previous run of a group with the same name (a relaunch gets
+# a new job id, so names never collide).
+_MIRROR_LABEL_GROUP = 'skypilot-jobgroup-mirror'
+_MIRROR_LABEL_JOB_ID = 'skypilot-managed-job-id'
+# Exported (no leading underscore) so the jobs controller can reference it
+# without triggering a protected-access lint across modules.
+MIRROR_RECONCILE_INTERVAL_SECONDS = 15
+
+
+def _get_context_from_handle(
+        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle'
+) -> Optional[str]:
+    """Return the kubeconfig context name for a Kubernetes handle.
+
+    For Kubernetes, ``Resources.region`` holds the kubeconfig context name.
+    """
+    if not _is_kubernetes(handle):
+        return None
+    return handle.launched_resources.region
+
+
+def _label_value(value: str) -> str:
+    """Truncate to the Kubernetes label value length limit (63 chars)."""
+    return value[:63]
+
+
 # ============================================================================
 # Layer 3: NetworkConfigurator - Platform-specific network configuration
 # ============================================================================
@@ -142,13 +174,27 @@ def _get_job_address(job_name: str,
 def _generate_k8s_dns_mappings(
     job_group_name: str,
     tasks_handles: List[Tuple['task_lib.Task',
-                              'cloud_vm_ray_backend.CloudVmRayResourceHandle']]
+                              'cloud_vm_ray_backend.CloudVmRayResourceHandle']],
+    consumer_context: Optional[str] = None,
+    consumer_namespace: Optional[str] = None,
 ) -> List[Tuple[str, str]]:
     """Generate K8s DNS to hostname mappings for background updater.
 
     Args:
         job_group_name: Name of the JobGroup.
         tasks_handles: List of (Task, ResourceHandle) tuples.
+        consumer_context: Kubeconfig context of the consumer these mappings
+            are being generated for (i.e. the cluster whose /etc/hosts will
+            be updated). When set and a peer's own context differs from
+            this one, the peer's constructed-name entry is pointed at the
+            consumer's own namespace instead of the peer's — that is where
+            the cross-context DNS mirror Service for this peer lives.
+            Same-context callers (or callers that don't care, e.g.
+            single-context groups) should leave this unset, which preserves
+            today's behavior exactly.
+        consumer_namespace: Namespace to use for cross-context peers when
+            ``consumer_context`` is set. Required (and only meaningful) in
+            that case.
 
     Returns:
         List of (k8s_dns, simple_hostname) tuples.
@@ -165,7 +211,14 @@ def _generate_k8s_dns_mappings(
             addresses = managed_job_runtime.k8s_dns_addresses_for_handle(handle)
         if addresses is None:
             cluster_name_on_cloud = handle.cluster_name_on_cloud
+            peer_context = _get_context_from_handle(handle)
             namespace = _get_k8s_namespace_from_handle(handle)
+            if (consumer_context is not None and
+                    peer_context != consumer_context):
+                assert consumer_namespace is not None, (
+                    'consumer_namespace is required when consumer_context '
+                    'is set')
+                namespace = consumer_namespace
             num_nodes = (len(handle.stable_internal_external_ips)
                          if handle.stable_internal_external_ips else 1)
             addresses = [
@@ -365,8 +418,13 @@ def generate_k8s_dns_updater_script(dns_mappings: List[Tuple[str, str]],
           for mapping in $MAPPINGS; do
             k8s_dns="${{mapping%%:*}}"
             simple_name="${{mapping##*:}}"
-            # Resolve K8s DNS to IP
-            ip=$(getent hosts "$k8s_dns" 2>/dev/null | awk '{{print $1}}')
+            # Resolve K8s DNS to IP. Query the absolute name (trailing dot)
+            # so resolv.conf search-path expansion (ndots:5) can't append a
+            # search domain and let a wildcard DNS record silently answer
+            # this lookup instead of NXDOMAIN. $simple_name below must NOT
+            # get a trailing dot: it needs to keep resolving via the
+            # 'files' backend against /etc/hosts itself.
+            ip=$(getent hosts "$k8s_dns." 2>/dev/null | awk '{{print $1}}')
             if [ -n "$ip" ]; then
               new_entries="${{new_entries}}$ip $simple_name  $MARKER
         "
@@ -536,8 +594,24 @@ class NetworkConfigurator:
 
         ssh_hosts_content = _generate_hosts_entries(job_group_name,
                                                     tasks_handles)
-        k8s_dns_mappings = _generate_k8s_dns_mappings(job_group_name,
-                                                      tasks_handles)
+
+        # Cross-context classic mappings must embed the CONSUMING cluster's
+        # namespace (where the controller creates that peer's DNS mirror
+        # Service), not the peer's own namespace — see
+        # `_generate_k8s_dns_mappings`. Only pay for per-consumer mapping
+        # generation when the group actually spans multiple K8s contexts;
+        # single-context groups keep today's single global mapping list
+        # (byte-identical behavior, no per-task recomputation).
+        k8s_contexts = {
+            _get_context_from_handle(handle)
+            for _, handle in tasks_handles
+            if handle is not None and _is_kubernetes(handle)
+        }
+        spans_multiple_contexts = len(k8s_contexts) > 1
+        global_k8s_dns_mappings: List[Tuple[str, str]] = []
+        if not spans_multiple_contexts:
+            global_k8s_dns_mappings = _generate_k8s_dns_mappings(
+                job_group_name, tasks_handles)
 
         # Each entry: (coroutine, task_name, node_idx, is_k8s)
         setup_tasks: List[Tuple] = []
@@ -552,6 +626,19 @@ class NetworkConfigurator:
                 logger.warning(
                     f'Failed to get command runners for {task.name}: {e}')
                 continue
+
+            if is_k8s:
+                # Computed once per task, not per node.
+                if spans_multiple_contexts:
+                    consumer_context = _get_context_from_handle(handle)
+                    consumer_namespace = _get_k8s_namespace_from_handle(handle)
+                    k8s_dns_mappings = _generate_k8s_dns_mappings(
+                        job_group_name,
+                        tasks_handles,
+                        consumer_context=consumer_context,
+                        consumer_namespace=consumer_namespace)
+                else:
+                    k8s_dns_mappings = global_k8s_dns_mappings
 
             for node_idx, runner in enumerate(runners):
                 if is_k8s:
@@ -604,6 +691,493 @@ class NetworkConfigurator:
         logger.info(
             f'Hosts injection: {success_count}/{len(results)} succeeded')
         return success_count == len(results)
+
+
+# ============================================================================
+# Cross-context DNS mirrors
+#
+# When a JobGroup's Kubernetes tasks span more than one kubeconfig context,
+# each task's real headless Service only resolves inside its own cluster.
+# The functions below let the controller create selectorless "mirror"
+# Services + manually-managed core/v1 Endpoints for each peer task in every
+# OTHER member (context, namespace), so the on-pod DNS updater's mapping
+# strings resolve verbatim regardless of which cluster the consumer is in.
+#
+# Single-context groups never call any Kubernetes API here: everything below
+# gates on there being more than one distinct context among the group's
+# tasks.
+# ============================================================================
+
+# (task, handle) pairs as the controller tracks them: a handle may be None
+# for tasks that are terminal, never launched, or already torn down.
+_TasksHandles = List[Tuple[
+    'task_lib.Task', Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle']]]
+
+
+@dataclasses.dataclass
+class _TaskNetworkInfo:
+    """Per-task Kubernetes network info used for cross-context mirroring."""
+    task_name: str
+    cluster_name_on_cloud: str
+    context: Optional[str]
+    namespace: str
+    num_nodes: int
+    # Whether the task's DNS addresses are runtime-supplied (single headless
+    # Service, per-pod hostname records) rather than the classic per-node
+    # Services SkyPilot creates itself.
+    is_v1: bool
+
+
+def _fallback_task_network_info(
+        task: 'task_lib.Task') -> Optional[_TaskNetworkInfo]:
+    """Best-effort network info for a task whose handle is already gone.
+
+    Used only by `cleanup_cross_context_mirrors`: derives (context,
+    namespace) from the task's pinned resources so stale mirrors can still
+    be found and deleted after the cluster itself has been torn down (and
+    thus has no handle in `global_user_state` any more). `cluster_name_on_
+    cloud`/`num_nodes`/`is_v1` are irrelevant for cleanup (which only keys
+    off (context, namespace) and the job-id label) and are filled in
+    best-effort.
+    """
+    if task.name is None:
+        return None
+    context = None
+    for resource in task.resources:
+        if (isinstance(resource.cloud, sky_clouds.Kubernetes) and
+                resource.region is not None):
+            context = resource.region
+            break
+    if context is None:
+        return None
+    # pylint: disable-next=import-outside-toplevel
+    from sky.provision.kubernetes import utils as k8s_utils
+    try:
+        namespace = k8s_utils.get_kube_config_context_namespace(context)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to resolve namespace for context {context} '
+                     f'during JobGroup mirror cleanup, falling back to '
+                     f'default: {e}')
+        namespace = 'default'
+    return _TaskNetworkInfo(task_name=task.name,
+                            cluster_name_on_cloud=task.name,
+                            context=context,
+                            namespace=namespace,
+                            num_nodes=1,
+                            is_v1=False)
+
+
+def _task_network_infos(
+    tasks_handles: _TasksHandles,
+    job_id: int,
+    include_fallback: bool = False,
+) -> List[_TaskNetworkInfo]:
+    """Collect per-task Kubernetes network info for cross-context mirroring.
+
+    Args:
+        tasks_handles: (Task, ResourceHandle) tuples for each task.
+        job_id: Managed job ID (used to detect runtime-supplied addresses).
+        include_fallback: If True, also emit a best-effort info entry (see
+            `_fallback_task_network_info`) for tasks whose handle is None.
+            Only meaningful for cleanup — `setup_cross_context_mirrors`
+            needs live handles and leaves this False.
+
+    Returns:
+        List of `_TaskNetworkInfo`, one per Kubernetes task with usable
+        info. Non-Kubernetes tasks and (unless `include_fallback`) tasks
+        with no handle are omitted.
+    """
+    infos: List[_TaskNetworkInfo] = []
+    for task, handle in tasks_handles:
+        if handle is not None and _is_kubernetes(handle):
+            assert task.name is not None, task
+            infos.append(
+                _TaskNetworkInfo(
+                    task_name=task.name,
+                    cluster_name_on_cloud=handle.cluster_name_on_cloud,
+                    context=_get_context_from_handle(handle),
+                    namespace=_get_k8s_namespace_from_handle(handle),
+                    num_nodes=(len(handle.stable_internal_external_ips)
+                               if handle.stable_internal_external_ips else 1),
+                    is_v1=dns_addresses_for_task(task, job_id) is not None))
+        elif include_fallback and handle is None:
+            fallback = _fallback_task_network_info(task)
+            if fallback is not None:
+                infos.append(fallback)
+    return infos
+
+
+def group_spans_multiple_contexts(
+    tasks_handles: _TasksHandles,
+    job_id: int,
+) -> bool:
+    """True iff the group's Kubernetes tasks span more than one context."""
+    infos = _task_network_infos(tasks_handles, job_id)
+    return len({info.context for info in infos}) > 1
+
+
+def _list_peer_pod_ips(context: Optional[str], namespace: str,
+                       cluster_name_on_cloud: str) -> Dict[int, str]:
+    """List a peer task's pod IPs, keyed by node index.
+
+    Synchronous (intended to be run via `asyncio.to_thread`). Exceptions
+    propagate to the caller.
+    """
+    core_api = kubernetes.core_api(context)
+    # Classic clusters label pods with the SkyPilot cluster name; fall back
+    # to the (runtime-managed) job name label if that selector comes up
+    # empty.
+    selectors = [
+        f'skypilot-cluster-name={cluster_name_on_cloud}',
+        f'skypilot-managed-job-name={cluster_name_on_cloud}',
+    ]
+    pods: List[Any] = []
+    for selector in selectors:
+        pods = core_api.list_namespaced_pod(namespace,
+                                            label_selector=selector,
+                                            _request_timeout=10).items
+        if pods:
+            break
+
+    worker_prefix = f'{cluster_name_on_cloud}-worker'
+    pod_ips: Dict[int, str] = {}
+    for pod in pods:
+        if pod.metadata.deletion_timestamp is not None:
+            continue
+        if not pod.status.pod_ip:
+            continue
+        name = pod.metadata.name
+        node_idx: Optional[int] = None
+        if name == f'{cluster_name_on_cloud}-head':
+            node_idx = 0
+        elif name.startswith(worker_prefix):
+            suffix = name[len(worker_prefix):]
+            if suffix.isdigit():
+                node_idx = int(suffix)
+        elif pod.spec.hostname is not None:
+            match = re.match(r'node-(\d+)', pod.spec.hostname)
+            if match is not None:
+                node_idx = int(match.group(1))
+        if node_idx is None:
+            logger.debug(f'Could not determine node index for pod {name} '
+                         f'(peer cluster {cluster_name_on_cloud}); '
+                         'skipping.')
+            continue
+        pod_ips[node_idx] = pod.status.pod_ip
+    return pod_ips
+
+
+def _mirror_specs(
+        peer: _TaskNetworkInfo,
+        pod_ips: Dict[int, str]) -> List[Tuple[str, List[Dict[str, str]]]]:
+    """Build (service_name, endpoint_addresses) pairs to mirror a peer task.
+
+    `endpoint_addresses` is the `addresses` list for a single Endpoints
+    subset (empty when the corresponding pod IP is not yet known).
+    """
+    if peer.is_v1:
+        # V1-runtime mirrors expose node 0 only — this matches the
+        # in-cluster contract, where the runtime's own headless Service +
+        # pod hostname/subdomain only ever resolves node 0 for inter-task
+        # discovery; intra-task workers use their own discovery mechanism.
+        addresses = []
+        if 0 in pod_ips:
+            addresses = [{'ip': pod_ips[0], 'hostname': 'node-0'}]
+        return [(peer.cluster_name_on_cloud, addresses)]
+
+    # Classic peer: one headless Service per node, name-identical to the
+    # real per-node Services the peer's own cluster creates. No 'hostname'
+    # field needed — the lookup name is the mirror Service's own A record.
+    specs: List[Tuple[str, List[Dict[str, str]]]] = []
+    for node_idx in range(peer.num_nodes):
+        name = (f'{peer.cluster_name_on_cloud}-head' if node_idx == 0 else
+                f'{peer.cluster_name_on_cloud}-worker{node_idx}')
+        addresses = [{'ip': pod_ips[node_idx]}] if node_idx in pod_ips else []
+        specs.append((name, addresses))
+    return specs
+
+
+def _mirror_service_manifest(name: str, job_group_name: str,
+                             job_id: int) -> Dict[str, Any]:
+    """Selectorless headless Service manifest for a JobGroup DNS mirror.
+
+    Deliberately no selector and no ports: DNS A records come from the
+    manually-managed Endpoints (`_mirror_endpoints_manifest`) below, and
+    ports are irrelevant for A-record resolution (the real Services being
+    mirrored are portless too).
+    """
+    return {
+        'apiVersion': 'v1',
+        'kind': 'Service',
+        'metadata': {
+            'name': name,
+            'labels': {
+                'parent': 'skypilot',
+                _MIRROR_LABEL_GROUP: _label_value(job_group_name),
+                _MIRROR_LABEL_JOB_ID: str(job_id),
+            },
+        },
+        'spec': {
+            'clusterIP': 'None',
+        },
+    }
+
+
+def _mirror_endpoints_manifest(name: str, addresses: List[Dict[str, str]],
+                               job_group_name: str,
+                               job_id: int) -> Dict[str, Any]:
+    """Endpoints manifest for a JobGroup DNS mirror Service.
+
+    Uses legacy core/v1 Endpoints rather than discovery.k8s.io EndpointSlice
+    deliberately: kube-dns (GKE Standard's default) only reads Endpoints,
+    while the endpointslice-mirroring controller (GA, default-on since k8s
+    1.19) mirrors selectorless-Service Endpoints into EndpointSlices for
+    clusters running CoreDNS / Cloud DNS. Writing legacy Endpoints therefore
+    serves both without needing to know which the member cluster runs.
+    """
+    return {
+        'apiVersion': 'v1',
+        'kind': 'Endpoints',
+        'metadata': {
+            'name': name,
+            'labels': {
+                'parent': 'skypilot',
+                _MIRROR_LABEL_GROUP: _label_value(job_group_name),
+                _MIRROR_LABEL_JOB_ID: str(job_id),
+            },
+        },
+        'subsets': [{
+            'addresses': addresses
+        }] if addresses else [],
+    }
+
+
+def _apply_mirrors_in_cluster(context: Optional[str], namespace: str,
+                              job_group_name: str, job_id: int,
+                              desired: Dict[str, List[Dict[str, str]]],
+                              quiet: bool) -> None:
+    """Create/update JobGroup DNS mirrors in one member cluster.
+
+    Synchronous (intended to be run via `asyncio.to_thread`). Raises on
+    hard API errors so the caller can aggregate per-member failures; does
+    not catch anything itself.
+    """
+    core_api = kubernetes.core_api(context)
+
+    # GC mirrors left behind by a previous run of a group with the same
+    # name. A relaunch gets a new job id, so the current run's mirror names
+    # never collide with stale ones — safe to delete unconditionally.
+    group_label = _label_value(job_group_name)
+    stale = core_api.list_namespaced_service(
+        namespace,
+        label_selector=f'{_MIRROR_LABEL_GROUP}={group_label}',
+        _request_timeout=10)
+    for svc in stale.items:
+        if svc.metadata.labels.get(_MIRROR_LABEL_JOB_ID) == str(job_id):
+            continue
+        name = svc.metadata.name
+        for delete_fn in (core_api.delete_namespaced_service,
+                          core_api.delete_namespaced_endpoints):
+            try:
+                delete_fn(name, namespace, _request_timeout=10)
+            except kubernetes.api_exception() as e:
+                if e.status != 404:
+                    raise
+
+    for name, addresses in desired.items():
+        service_manifest = _mirror_service_manifest(name, job_group_name,
+                                                    job_id)
+        try:
+            core_api.create_namespaced_service(namespace,
+                                               service_manifest,
+                                               _request_timeout=10)
+        except kubernetes.api_exception() as e:
+            # The mirror Service spec is static (no selector/ports), so an
+            # already-existing Service needs no update.
+            if e.status != 409:
+                raise
+
+        try:
+            existing = core_api.read_namespaced_endpoints(name,
+                                                          namespace,
+                                                          _request_timeout=10)
+        except kubernetes.api_exception() as e:
+            if e.status != 404:
+                raise
+            existing = None
+
+        desired_key = sorted((address.get('ip'), address.get('hostname'))
+                             for address in addresses)
+        if existing is None:
+            endpoints_manifest = _mirror_endpoints_manifest(
+                name, addresses, job_group_name, job_id)
+            core_api.create_namespaced_endpoints(namespace,
+                                                 endpoints_manifest,
+                                                 _request_timeout=10)
+            continue
+
+        existing_key = sorted((address.ip, address.hostname)
+                              for subset in (existing.subsets or [])
+                              for address in (subset.addresses or []))
+        if desired_key != existing_key:
+            endpoints_manifest = _mirror_endpoints_manifest(
+                name, addresses, job_group_name, job_id)
+            core_api.replace_namespaced_endpoints(name,
+                                                  namespace,
+                                                  endpoints_manifest,
+                                                  _request_timeout=10)
+
+    level = logger.debug if quiet else logger.info
+    level(f'Mirrored {len(desired)} JobGroup peer service(s) into '
+          f'{context}/{namespace}')
+
+
+def _delete_mirrors_in_cluster(context: Optional[str], namespace: str,
+                               job_id: int) -> None:
+    """Delete this job's DNS mirrors from one member cluster.
+
+    Synchronous (intended to be run via `asyncio.to_thread`). Best-effort:
+    404s are tolerated and other errors are logged, never raised.
+    """
+    core_api = kubernetes.core_api(context)
+    try:
+        services = core_api.list_namespaced_service(
+            namespace,
+            label_selector=f'{_MIRROR_LABEL_JOB_ID}={job_id}',
+            _request_timeout=10)
+    except kubernetes.api_exception() as e:
+        logger.warning(f'Failed to list JobGroup mirrors in '
+                       f'{context}/{namespace}: {e}')
+        return
+
+    for svc in services.items:
+        name = svc.metadata.name
+        for delete_fn in (core_api.delete_namespaced_service,
+                          core_api.delete_namespaced_endpoints):
+            try:
+                delete_fn(name, namespace, _request_timeout=10)
+            except kubernetes.api_exception() as e:
+                if e.status != 404:
+                    logger.warning(
+                        f'Failed to delete JobGroup mirror {name} in '
+                        f'{context}/{namespace}: {e}')
+
+
+# Per-group lock so Phase 3 setup, on-recovery re-setup, and the periodic
+# reconcile loop (see controller.py) never interleave mirror writes for the
+# same job. Created lazily; entries are small and outlive their job for the
+# life of the controller process, which is acceptable.
+_mirror_locks: Dict[int, asyncio.Lock] = {}
+
+
+def _get_mirror_lock(job_id: int) -> asyncio.Lock:
+    return _mirror_locks.setdefault(job_id, asyncio.Lock())
+
+
+async def setup_cross_context_mirrors(
+    job_group_name: str,
+    job_id: int,
+    tasks_handles: _TasksHandles,
+    quiet: bool = False,
+) -> bool:
+    """Mirror each K8s task's peer DNS into every other member cluster.
+
+    No-op (returns True immediately, no Kubernetes API calls) unless the
+    group's tasks span more than one Kubernetes context — single-context
+    groups are completely unaffected.
+
+    Never raises: per-member failures are logged and reflected in the
+    return value so the caller can proceed (mirrors are best-effort, same
+    as the rest of JobGroup networking setup).
+
+    Args:
+        job_group_name: Name of the JobGroup.
+        job_id: Managed job ID.
+        tasks_handles: (Task, ResourceHandle) tuples for tasks with a live
+            handle (a None handle is simply skipped by `_task_network_infos`
+            since there is nothing to mirror for it yet).
+        quiet: If True, log at debug instead of info/warning (used by the
+            periodic reconcile loop to avoid spamming the log every
+            interval).
+
+    Returns:
+        True if every member cluster was reconciled successfully.
+    """
+    infos = _task_network_infos(tasks_handles, job_id)
+    contexts = {info.context for info in infos}
+    if len(contexts) <= 1:
+        return True
+
+    members = sorted({(info.context, info.namespace) for info in infos})
+    if not quiet:
+        logger.info(f'Setting up cross-cluster DNS mirrors for JobGroup '
+                    f'{job_group_name!r} across contexts: '
+                    f'{sorted(str(c) for c in contexts)}')
+
+    async with _get_mirror_lock(job_id):
+        ok = True
+        for ctx, ns in members:
+            desired: Dict[str, List[Dict[str, str]]] = {}
+            for peer in infos:
+                if peer.context == ctx:
+                    continue
+                try:
+                    pod_ips = await asyncio.to_thread(
+                        _list_peer_pod_ips, peer.context, peer.namespace,
+                        peer.cluster_name_on_cloud)
+                except Exception as e:  # pylint: disable=broad-except
+                    if not quiet:
+                        logger.warning(f'Failed to list pods for JobGroup peer '
+                                       f'{peer.task_name!r} in {peer.context}/'
+                                       f'{peer.namespace}: {e}')
+                    pod_ips = {}
+                desired.update(dict(_mirror_specs(peer, pod_ips)))
+
+            try:
+                await asyncio.to_thread(_apply_mirrors_in_cluster, ctx, ns,
+                                        job_group_name, job_id, desired, quiet)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error(
+                    f'Failed to set up JobGroup DNS mirrors in {ctx}/{ns}: '
+                    f'{e}. The SkyPilot service account needs get/list/'
+                    'create/patch/update/delete on services and endpoints '
+                    f'in that namespace.')
+                ok = False
+        return ok
+
+
+async def cleanup_cross_context_mirrors(
+    job_group_name: str,
+    job_id: int,
+    tasks_handles: _TasksHandles,
+) -> None:
+    """Delete this job's DNS mirrors from every member cluster.
+
+    No-op (no Kubernetes API calls) unless the group's tasks span more than
+    one Kubernetes context. Best-effort and never raises: handles in
+    `tasks_handles` may be None (cluster already gone), in which case a
+    fallback (context, namespace) is derived from the task's pinned
+    resources so mirrors can still be found and swept.
+
+    Args:
+        job_group_name: Name of the JobGroup (used only for logging — the
+            job-id label alone identifies this run's mirrors).
+        job_id: Managed job ID.
+        tasks_handles: (Task, ResourceHandle) tuples for all tasks.
+    """
+    infos = _task_network_infos(tasks_handles, job_id, include_fallback=True)
+    contexts = {info.context for info in infos}
+    if len(contexts) <= 1:
+        return
+
+    members = sorted({(info.context, info.namespace) for info in infos})
+    for ctx, ns in members:
+        try:
+            await asyncio.to_thread(_delete_mirrors_in_cluster, ctx, ns, job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to clean up JobGroup {job_group_name!r} DNS '
+                f'mirrors in {ctx}/{ns}: {e}')
 
 
 # ============================================================================

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -1006,7 +1006,9 @@ def _apply_mirrors_in_cluster(context: Optional[str], namespace: str,
                 raise
             existing = None
 
-        desired_key = sorted((address.get('ip'), address.get('hostname'))
+        # Normalize a missing hostname to '' so the sort key never mixes
+        # None and str (tuple comparison would raise TypeError on equal IPs).
+        desired_key = sorted((address.get('ip'), address.get('hostname') or '')
                              for address in addresses)
         if existing is None:
             endpoints_manifest = _mirror_endpoints_manifest(
@@ -1016,7 +1018,7 @@ def _apply_mirrors_in_cluster(context: Optional[str], namespace: str,
                                                  _request_timeout=10)
             continue
 
-        existing_key = sorted((address.ip, address.hostname)
+        existing_key = sorted((address.ip, address.hostname or '')
                               for subset in (existing.subsets or [])
                               for address in (subset.addresses or []))
         if desired_key != existing_key:

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -743,6 +743,26 @@ def launch(
                     f'communicate with each other using hostnames.'
                     f'{colorama.Style.RESET_ALL}')
 
+        # Warn if the job group's tasks span multiple Kubernetes contexts:
+        # cross-cluster service discovery requires pod-to-pod network
+        # routability between the member clusters.
+        contexts = set()
+        for task_ in dag.tasks:
+            if task_.best_resources is None:
+                continue
+            best_cloud = task_.best_resources.cloud
+            if (best_cloud is not None and
+                    str(best_cloud).lower() == 'kubernetes' and
+                    task_.best_resources.region is not None):
+                contexts.add(task_.best_resources.region)
+        if len(contexts) > 1:
+            logger.info(
+                f'{colorama.Fore.CYAN}Job group "{dag.name}" spans multiple '
+                f'Kubernetes clusters: {sorted(contexts)}. Cross-cluster '
+                'service discovery requires pod-to-pod network routability '
+                'between the clusters (e.g. shared/peered VPC with '
+                f'non-overlapping pod CIDRs).{colorama.Style.RESET_ALL}')
+
     # If there is a local postgres db, when the api server tries launching on
     # the remote jobs controller it will fail. therefore, we should remove this
     # before sending the config to the jobs controller.

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1068,6 +1068,32 @@ class Optimizer:
             logger.info(
                 f'Optimizing JobGroup "{dag.name}" with {len(tasks)} jobs')
 
+        # When every job pins an explicit infra, respect the pins. If they
+        # differ, skip the common-infra search entirely: heterogeneous
+        # groups (e.g. tasks on different Kubernetes clusters) are
+        # intentional, not a failed optimization.
+        pinned_infras = set()
+        all_pinned = True
+        for task in tasks:
+            task_resources = getattr(task, 'resources', None)
+            if not task_resources:
+                all_pinned = False
+                break
+            for resource in task_resources:
+                if resource.cloud is None or resource.region is None:
+                    all_pinned = False
+                    break
+                pinned_infras.add((str(resource.cloud), resource.region))
+            if not all_pinned:
+                break
+        if all_pinned and len(pinned_infras) > 1:
+            if not quiet:
+                logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
+                            'infrastructures; optimizing each job '
+                            'independently.')
+            return Optimizer._optimize_independent(dag, minimize,
+                                                   blocked_resources, quiet)
+
         # Find common infrastructure for all tasks in the JobGroup
         return Optimizer._optimize_same_infra(dag, minimize, blocked_resources,
                                               quiet)

--- a/tests/test_job_groups/test_job_group.py
+++ b/tests/test_job_groups/test_job_group.py
@@ -639,6 +639,520 @@ class TestJobGroupNetworking:
             'Script should still use sudo commands (to be aliased when root)')
 
 
+def _make_k8s_handle(context: str,
+                     cluster_name_on_cloud: str = 'cluster',
+                     num_nodes: int = 1):
+    """Build a fake handle that `_is_kubernetes`/`_get_context_from_handle`
+    accept: a real `clouds.Kubernetes()` cloud plus `region` as the
+    kubeconfig context (matching the real Resources contract)."""
+    handle = mock.MagicMock()
+    handle.launched_resources = mock.MagicMock()
+    handle.launched_resources.cloud = clouds.Kubernetes()
+    handle.launched_resources.region = context
+    # cluster_yaml=None routes namespace resolution through the kubeconfig
+    # fallback (get_kube_config_context_namespace), which tests patch.
+    handle.cluster_yaml = None
+    handle.cluster_name_on_cloud = cluster_name_on_cloud
+    handle.stable_internal_external_ips = [
+        (f'10.0.0.{i}', f'1.2.3.{i}') for i in range(num_nodes)
+    ]
+    return handle
+
+
+def _make_non_k8s_handle():
+    handle = mock.MagicMock()
+    handle.launched_resources = mock.MagicMock()
+    handle.launched_resources.cloud = clouds.AWS()
+    handle.launched_resources.region = 'us-east-1'
+    return handle
+
+
+def _make_task(name: str):
+    task = mock.MagicMock(spec=task_lib.Task)
+    task.name = name
+    return task
+
+
+def _make_pod(name: str,
+              pod_ip: Optional[str] = '10.0.0.1',
+              hostname: Optional[str] = None,
+              deletion_timestamp: Optional[str] = None):
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod.metadata.deletion_timestamp = deletion_timestamp
+    pod.status.pod_ip = pod_ip
+    pod.spec.hostname = hostname
+    return pod
+
+
+class TestCrossContextMirrors:
+    """Tests for cross-context JobGroup DNS mirror machinery."""
+
+    # -- Multi-context detection -----------------------------------------
+
+    def test_group_spans_multiple_contexts_true_for_distinct_contexts(self):
+        from sky.jobs import job_group_networking
+
+        handle_a = _make_k8s_handle('ctx-a')
+        handle_b = _make_k8s_handle('ctx-b')
+
+        with mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace',
+                return_value='default'):
+            result = job_group_networking.group_spans_multiple_contexts(
+                [(_make_task('task-a'), handle_a),
+                 (_make_task('task-b'), handle_b)],
+                job_id=1)
+
+        assert result is True
+
+    def test_group_spans_multiple_contexts_false_for_same_context(self):
+        from sky.jobs import job_group_networking
+
+        handle_a = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-a')
+        handle_b = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-b')
+
+        with mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace',
+                return_value='default'):
+            result = job_group_networking.group_spans_multiple_contexts(
+                [(_make_task('task-a'), handle_a),
+                 (_make_task('task-b'), handle_b)],
+                job_id=1)
+
+        assert result is False
+
+    def test_group_spans_multiple_contexts_false_for_non_kubernetes(self):
+        from sky.jobs import job_group_networking
+
+        result = job_group_networking.group_spans_multiple_contexts(
+            [(_make_task('task-a'), _make_non_k8s_handle()),
+             (_make_task('task-b'), _make_non_k8s_handle())],
+            job_id=1)
+
+        assert result is False
+
+    # -- _mirror_specs ------------------------------------------------------
+
+    def test_mirror_specs_v1_peer_single_head_only_entry(self):
+        from sky.jobs import job_group_networking
+
+        peer = job_group_networking._TaskNetworkInfo(
+            task_name='trainer',
+            cluster_name_on_cloud='trainer-cluster',
+            context='ctx-b',
+            namespace='ns-b',
+            num_nodes=2,
+            is_v1=True)
+
+        specs = job_group_networking._mirror_specs(peer, {
+            0: '10.0.0.1',
+            1: '10.0.0.2',
+        })
+
+        # V1 mirrors expose node 0 only, with the 'hostname' field the
+        # runtime-supplied mapping string expects.
+        assert specs == [('trainer-cluster', [{
+            'ip': '10.0.0.1',
+            'hostname': 'node-0',
+        }])]
+
+    def test_mirror_specs_v1_peer_missing_pod_ip_yields_empty_addresses(self):
+        from sky.jobs import job_group_networking
+
+        peer = job_group_networking._TaskNetworkInfo(
+            task_name='trainer',
+            cluster_name_on_cloud='trainer-cluster',
+            context='ctx-b',
+            namespace='ns-b',
+            num_nodes=1,
+            is_v1=True)
+
+        specs = job_group_networking._mirror_specs(peer, {})
+
+        assert specs == [('trainer-cluster', [])]
+
+    def test_mirror_specs_classic_peer_multi_node_names(self):
+        from sky.jobs import job_group_networking
+
+        peer = job_group_networking._TaskNetworkInfo(
+            task_name='trainer',
+            cluster_name_on_cloud='trainer-cluster',
+            context='ctx-b',
+            namespace='ns-b',
+            num_nodes=3,
+            is_v1=False)
+
+        specs = job_group_networking._mirror_specs(peer, {
+            0: '10.0.0.1',
+            1: '10.0.0.2',
+            2: '10.0.0.3',
+        })
+
+        names = [name for name, _ in specs]
+        assert names == [
+            'trainer-cluster-head',
+            'trainer-cluster-worker1',
+            'trainer-cluster-worker2',
+        ]
+        # Classic mirrors don't need the 'hostname' field.
+        for _, addresses in specs:
+            for address in addresses:
+                assert 'hostname' not in address
+
+    def test_mirror_specs_classic_peer_missing_pod_ip_yields_empty_addresses(
+            self):
+        from sky.jobs import job_group_networking
+
+        peer = job_group_networking._TaskNetworkInfo(
+            task_name='trainer',
+            cluster_name_on_cloud='trainer-cluster',
+            context='ctx-b',
+            namespace='ns-b',
+            num_nodes=2,
+            is_v1=False)
+
+        specs = job_group_networking._mirror_specs(peer, {0: '10.0.0.1'})
+
+        assert specs == [
+            ('trainer-cluster-head', [{
+                'ip': '10.0.0.1'
+            }]),
+            ('trainer-cluster-worker1', []),
+        ]
+
+    # -- _list_peer_pod_ips ---------------------------------------------
+
+    def test_list_peer_pod_ips_uses_first_selector_when_it_matches(self):
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_pod.return_value.items = [
+                _make_pod('cluster-a-head', '10.0.0.1'),
+                _make_pod('cluster-a-worker1', '10.0.0.2'),
+            ]
+
+            result = job_group_networking._list_peer_pod_ips(
+                'ctx-a', 'ns-a', 'cluster-a')
+
+        assert result == {0: '10.0.0.1', 1: '10.0.0.2'}
+        core_api.list_namespaced_pod.assert_called_once()
+        _, kwargs = core_api.list_namespaced_pod.call_args
+        assert kwargs['label_selector'] == 'skypilot-cluster-name=cluster-a'
+
+    def test_list_peer_pod_ips_falls_back_to_job_name_selector(self):
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            core_api = mock_k8s.core_api.return_value
+            empty = mock.MagicMock()
+            empty.items = []
+            matched = mock.MagicMock()
+            matched.items = [_make_pod('cluster-a-head', '10.0.0.1')]
+            core_api.list_namespaced_pod.side_effect = [empty, matched]
+
+            result = job_group_networking._list_peer_pod_ips(
+                'ctx-a', 'ns-a', 'cluster-a')
+
+        assert result == {0: '10.0.0.1'}
+        assert core_api.list_namespaced_pod.call_count == 2
+        _, second_kwargs = core_api.list_namespaced_pod.call_args_list[1]
+        assert (second_kwargs['label_selector'] ==
+                'skypilot-managed-job-name=cluster-a')
+
+    def test_list_peer_pod_ips_parses_node_index_from_hostname(self):
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_pod.return_value.items = [
+                _make_pod('some-runtime-managed-pod-name',
+                          '10.0.0.5',
+                          hostname='node-0'),
+            ]
+
+            result = job_group_networking._list_peer_pod_ips(
+                'ctx-a', 'ns-a', 'trainer')
+
+        assert result == {0: '10.0.0.5'}
+
+    def test_list_peer_pod_ips_skips_terminating_and_ipless_pods(self):
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_pod.return_value.items = [
+                _make_pod('cluster-a-head',
+                          '10.0.0.1',
+                          deletion_timestamp='2024-01-01T00:00:00Z'),
+                _make_pod('cluster-a-worker1', pod_ip=None),
+                _make_pod('cluster-a-worker2', '10.0.0.3'),
+            ]
+
+            result = job_group_networking._list_peer_pod_ips(
+                'ctx-a', 'ns-a', 'cluster-a')
+
+        assert result == {2: '10.0.0.3'}
+
+    # -- _apply_mirrors_in_cluster ----------------------------------------
+
+    def test_apply_mirrors_creates_service_and_endpoints(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = []
+            core_api.read_namespaced_endpoints.side_effect = ApiException(
+                status=404)
+
+            job_group_networking._apply_mirrors_in_cluster(
+                'ctx-a', 'ns-a', 'my-group', 42,
+                {'peer-head': [{
+                    'ip': '10.0.0.1'
+                }]}, True)
+
+        core_api.create_namespaced_service.assert_called_once()
+        args, _ = core_api.create_namespaced_service.call_args
+        assert args[0] == 'ns-a'
+        assert args[1]['metadata']['name'] == 'peer-head'
+        core_api.create_namespaced_endpoints.assert_called_once()
+        endpoints_args, _ = core_api.create_namespaced_endpoints.call_args
+        assert endpoints_args[1]['subsets'] == [{
+            'addresses': [{
+                'ip': '10.0.0.1'
+            }]
+        }]
+
+    def test_apply_mirrors_tolerates_409_on_create_service(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = []
+            core_api.create_namespaced_service.side_effect = ApiException(
+                status=409)
+            core_api.read_namespaced_endpoints.side_effect = ApiException(
+                status=404)
+
+            # Should not raise despite the service already existing.
+            job_group_networking._apply_mirrors_in_cluster(
+                'ctx-a', 'ns-a', 'my-group', 42,
+                {'peer-head': [{
+                    'ip': '10.0.0.1'
+                }]}, True)
+
+        core_api.create_namespaced_endpoints.assert_called_once()
+
+    def test_apply_mirrors_raises_on_non_409_service_error(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = []
+            core_api.create_namespaced_service.side_effect = ApiException(
+                status=403)
+
+            with pytest.raises(ApiException):
+                job_group_networking._apply_mirrors_in_cluster(
+                    'ctx-a', 'ns-a', 'my-group', 42,
+                    {'peer-head': [{
+                        'ip': '10.0.0.1'
+                    }]}, True)
+
+    def test_apply_mirrors_endpoints_not_replaced_when_unchanged(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        existing = mock.MagicMock()
+        subset = mock.MagicMock()
+        address = mock.MagicMock()
+        address.ip = '10.0.0.1'
+        address.hostname = None
+        subset.addresses = [address]
+        existing.subsets = [subset]
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = []
+            core_api.create_namespaced_service.side_effect = ApiException(
+                status=409)
+            core_api.read_namespaced_endpoints.return_value = existing
+
+            job_group_networking._apply_mirrors_in_cluster(
+                'ctx-a', 'ns-a', 'my-group', 42,
+                {'peer-head': [{
+                    'ip': '10.0.0.1'
+                }]}, True)
+
+        core_api.replace_namespaced_endpoints.assert_not_called()
+        core_api.create_namespaced_endpoints.assert_not_called()
+
+    def test_apply_mirrors_endpoints_replaced_when_ip_changes(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        existing = mock.MagicMock()
+        subset = mock.MagicMock()
+        address = mock.MagicMock()
+        address.ip = '10.0.0.1'
+        address.hostname = None
+        subset.addresses = [address]
+        existing.subsets = [subset]
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = []
+            core_api.create_namespaced_service.side_effect = ApiException(
+                status=409)
+            core_api.read_namespaced_endpoints.return_value = existing
+
+            job_group_networking._apply_mirrors_in_cluster(
+                'ctx-a', 'ns-a', 'my-group', 42,
+                {'peer-head': [{
+                    'ip': '10.0.0.2'
+                }]}, True)
+
+        core_api.replace_namespaced_endpoints.assert_called_once()
+
+    def test_apply_mirrors_gc_deletes_stale_job_id_mirrors_only(self):
+        from kubernetes.client.rest import ApiException
+
+        from sky.jobs import job_group_networking
+
+        def make_svc(name, job_id):
+            svc = mock.MagicMock()
+            svc.metadata.name = name
+            svc.metadata.labels = {
+                job_group_networking._MIRROR_LABEL_JOB_ID: job_id
+            }
+            return svc
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            mock_k8s.api_exception.return_value = ApiException
+            core_api = mock_k8s.core_api.return_value
+            core_api.list_namespaced_service.return_value.items = [
+                make_svc('stale-head', '99'),  # different job -> GC'd
+                make_svc('current-head', '42'),  # same job -> left alone
+            ]
+            core_api.read_namespaced_endpoints.side_effect = ApiException(
+                status=404)
+
+            job_group_networking._apply_mirrors_in_cluster(
+                'ctx-a', 'ns-a', 'my-group', 42, {}, True)
+
+        core_api.delete_namespaced_service.assert_called_once_with(
+            'stale-head', 'ns-a', _request_timeout=10)
+        core_api.delete_namespaced_endpoints.assert_called_once_with(
+            'stale-head', 'ns-a', _request_timeout=10)
+
+    # -- Consumer-aware classic mappings ----------------------------------
+
+    def test_consumer_aware_mappings_cross_context_peer_uses_consumer_ns(self):
+        from sky.jobs import job_group_networking
+
+        handle_a = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-a-c')
+        handle_b = _make_k8s_handle('ctx-b', cluster_name_on_cloud='task-b-c')
+        task_a = _make_task('task-a')
+        task_b = _make_task('task-b')
+
+        namespaces = {'ctx-a': 'ns-a-real', 'ctx-b': 'ns-b-real'}
+        with mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace',
+                side_effect=lambda ctx: namespaces[ctx]):
+            mappings = job_group_networking._generate_k8s_dns_mappings(
+                'my-group', [(task_a, handle_a), (task_b, handle_b)],
+                consumer_context='ctx-b',
+                consumer_namespace='ns-b-consumer')
+
+        peer_a_dns = [
+            dns for dns, hostname in mappings if hostname.startswith('task-a')
+        ]
+        peer_b_dns = [
+            dns for dns, hostname in mappings if hostname.startswith('task-b')
+        ]
+        # task-a is in a DIFFERENT context than the consumer (ctx-b): its
+        # mirror lives in the consumer's own namespace.
+        assert peer_a_dns == ['task-a-c-head.ns-b-consumer.svc.cluster.local']
+        # task-b is in the SAME context as the consumer: keeps its own
+        # (real, looked-up) namespace, unaffected by consumer_namespace.
+        assert peer_b_dns == ['task-b-c-head.ns-b-real.svc.cluster.local']
+
+    def test_consumer_aware_mappings_no_kwargs_uses_peer_namespace(self):
+        """Regression guard: omitting the kwargs preserves today's behavior."""
+        from sky.jobs import job_group_networking
+
+        handle_a = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-a-c')
+        handle_b = _make_k8s_handle('ctx-b', cluster_name_on_cloud='task-b-c')
+        task_a = _make_task('task-a')
+        task_b = _make_task('task-b')
+
+        namespaces = {'ctx-a': 'ns-a-real', 'ctx-b': 'ns-b-real'}
+        with mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace',
+                side_effect=lambda ctx: namespaces[ctx]):
+            mappings = job_group_networking._generate_k8s_dns_mappings(
+                'my-group', [(task_a, handle_a), (task_b, handle_b)])
+
+        dns_names = sorted(dns for dns, _ in mappings)
+        assert dns_names == [
+            'task-a-c-head.ns-a-real.svc.cluster.local',
+            'task-b-c-head.ns-b-real.svc.cluster.local',
+        ]
+
+    # -- Updater-script trailing-dot hardening -----------------------------
+
+    def test_updater_script_dns_lookup_uses_trailing_dot(self):
+        from sky.jobs import job_group_networking
+
+        dns_mappings = [('trainer-head.ns.svc.cluster.local',
+                         'trainer-0.my-group')]
+        script = job_group_networking.generate_k8s_dns_updater_script(
+            dns_mappings, 'my-group')
+
+        # The K8s-DNS lookup queries the absolute name (trailing dot) so
+        # search-path/ndots expansion can't hand back a wildcard match.
+        assert 'getent hosts "$k8s_dns."' in script
+        # The simple-name /etc/hosts lookup must NOT get a trailing dot: it
+        # needs to keep resolving via the 'files' backend.
+        assert 'getent hosts "$simple_name"' in script
+        assert 'getent hosts "$simple_name."' not in script
+
+    # -- setup_cross_context_mirrors single-context gate --------------------
+
+    @pytest.mark.asyncio
+    async def test_setup_cross_context_mirrors_single_context_is_noop(self):
+        from sky.jobs import job_group_networking
+
+        handle_a = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-a')
+        handle_b = _make_k8s_handle('ctx-a', cluster_name_on_cloud='task-b')
+
+        with mock.patch.object(job_group_networking, 'kubernetes') as mock_k8s:
+            result = await job_group_networking.setup_cross_context_mirrors(
+                'my-group', 1, [(_make_task('task-a'), handle_a),
+                                (_make_task('task-b'), handle_b)])
+
+        assert result is True
+        mock_k8s.core_api.assert_not_called()
+
+
 class TestOptimizerSelectBestInfra:
     """Tests for Optimizer._select_best_infra logic.
 

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -304,6 +304,117 @@ class TestOptimizeJobGroup:
             mock_same_infra.assert_called_once()
 
 
+class TestOptimizeJobGroupExplicitPins:
+    """Tests for optimize_job_group's explicit-pins fast path.
+
+    When every task in a JobGroup pins an explicit (cloud, region) and the
+    pins are not all identical, optimize_job_group should skip the
+    common-infra search entirely and route straight to
+    `_optimize_independent` (with an informational, not a "no common
+    infrastructure", log message).
+    """
+
+    def _make_pinned_task(self, name: str, cloud_str: str, region: str):
+        cloud = MagicMock(spec=clouds.Cloud)
+        cloud.__str__ = MagicMock(return_value=cloud_str)
+        resource = MagicMock(spec=resources_lib.Resources)
+        resource.cloud = cloud
+        resource.region = region
+        task = MagicMock(spec=task_lib.Task)
+        task.name = name
+        task.resources = [resource]
+        return task
+
+    def _make_unpinned_task(self, name: str):
+        resource = MagicMock(spec=resources_lib.Resources)
+        resource.cloud = None
+        resource.region = None
+        task = MagicMock(spec=task_lib.Task)
+        task.name = name
+        task.resources = [resource]
+        return task
+
+    def _make_dag(self, tasks, name='test-job-group'):
+        dag = MagicMock(spec=dag_lib.Dag)
+        dag.is_job_group = MagicMock(return_value=True)
+        dag.name = name
+        dag.tasks = tasks
+        return dag
+
+    def test_different_pins_routes_to_optimize_independent(self):
+        """All tasks pinned to different (cloud, region) -> independent."""
+        task1 = self._make_pinned_task('task-1', 'Kubernetes', 'ctx-a')
+        task2 = self._make_pinned_task('task-2', 'Kubernetes', 'ctx-b')
+        dag = self._make_dag([task1, task2])
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent, \
+             patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_independent.return_value = dag
+
+            result = optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+
+            mock_independent.assert_called_once()
+            mock_same_infra.assert_not_called()
+            assert result == dag
+
+    def test_different_pins_logs_info_not_common_infra_warning(self):
+        """The differing-pins fast path logs an INFO note, not a warning."""
+        task1 = self._make_pinned_task('task-1', 'AWS', 'us-east-1')
+        task2 = self._make_pinned_task('task-2', 'GCP', 'us-central1')
+        dag = self._make_dag([task1, task2])
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent, \
+             patch.object(optimizer, 'logger') as mock_logger:
+            mock_independent.return_value = dag
+
+            optimizer.Optimizer.optimize_job_group(dag, quiet=False)
+
+            info_messages = ' '.join(
+                call.args[0] for call in mock_logger.info.call_args_list)
+            assert 'pin different' in info_messages
+            assert 'No common infrastructure' not in info_messages
+            mock_logger.warning.assert_not_called()
+
+    def test_same_pins_uses_same_infra_path(self):
+        """All tasks pinned to the SAME (cloud, region) -> same-infra path."""
+        task1 = self._make_pinned_task('task-1', 'AWS', 'us-east-1')
+        task2 = self._make_pinned_task('task-2', 'AWS', 'us-east-1')
+        dag = self._make_dag([task1, task2])
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra, \
+             patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent:
+            mock_same_infra.return_value = dag
+
+            result = optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+
+            mock_same_infra.assert_called_once()
+            mock_independent.assert_not_called()
+            assert result == dag
+
+    def test_partially_pinned_uses_same_infra_path(self):
+        """A partially-pinned group falls back to the same-infra search."""
+        task1 = self._make_pinned_task('task-1', 'AWS', 'us-east-1')
+        task2 = self._make_unpinned_task('task-2')
+        dag = self._make_dag([task1, task2])
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra, \
+             patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent:
+            mock_same_infra.return_value = dag
+
+            result = optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+
+            mock_same_infra.assert_called_once()
+            mock_independent.assert_not_called()
+            assert result == dag
+
+
 class TestOptimizeIndependent:
     """Tests for _optimize_independent method."""
 

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -9,7 +9,7 @@ Also tests the cancelled job log download feature in ControllerManager
 and file mount cleanup in task_cleanup().
 """
 import asyncio
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -1241,3 +1241,285 @@ class TestUserJobStatusClassification:
 
         failure_type = mock_set_failed.call_args.kwargs['failure_type']
         assert failure_type == managed_job_state.ManagedJobStatus.FAILED
+
+
+class TestJobGroupCrossContextMirrorWiring:
+    """Tests for cross-context DNS mirror wiring in the JobGroup controller.
+
+    These extend the mocking style used by `TestJobGroupResumeDoesNotReissue
+    Starting` (patch `sky.jobs.controller.job_group_networking` and drive the
+    real controller methods) to cover the plumbing added for cross-context
+    JobGroups: mirrors are set up in Phase 3 and from `on_recovery`, the
+    periodic reconcile task is started/cancelled around Phase 4, and mirrors
+    are cleaned up from `ControllerManager._cleanup`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_recovery_sets_up_mirrors_before_networking(self):
+        """`on_recovery` must mirror cross-context DNS before the normal
+        JobGroup networking re-setup, so a recovered peer's new IP is
+        visible to every other member cluster as soon as /etc/hosts is
+        refreshed."""
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 7
+        controller._monitor_one_task = AsyncMock(return_value=True)
+
+        task = MagicMock()
+        task.name = 'task-a'
+        all_tasks_handles = [(task, MagicMock())]
+
+        call_order: List[str] = []
+        captured: Dict[str, Any] = {}
+
+        async def fake_monitor_task(**kwargs):
+            # Capture the on_recovery closure instead of driving the full
+            # recovery-strategy machinery; it's exercised directly below.
+            captured['on_recovery'] = kwargs['on_recovery']
+            return None  # Falls through to _monitor_one_task.
+
+        executor = MagicMock()
+        executor.monitor_task = fake_monitor_task
+
+        with patch('sky.jobs.controller.job_group_networking') as net, \
+             patch('sky.jobs.controller.global_user_state') as gus, \
+             patch('sky.jobs.controller.managed_job_utils') as utils:
+            net.setup_cross_context_mirrors = AsyncMock(
+                side_effect=lambda *a, **k: call_order.append('mirrors'))
+            net.setup_job_group_networking = AsyncMock(
+                side_effect=lambda *a, **k: call_order.append('networking'))
+            utils.generate_managed_job_cluster_name.return_value = 'task-a-7'
+            gus.get_handle_from_cluster_name = MagicMock(
+                return_value=MagicMock())
+
+            await JobController._monitor_job_group_task(
+                controller,
+                task_id=0,
+                task=task,
+                cluster_name='task-a-7',
+                executor=executor,
+                job_group_name='my-group',
+                all_tasks_handles=all_tasks_handles,
+            )
+
+            await captured['on_recovery']()
+
+        assert call_order == ['mirrors', 'networking']
+        net.setup_cross_context_mirrors.assert_awaited_once()
+        net.setup_job_group_networking.assert_awaited_once()
+        mirrors_args = net.setup_cross_context_mirrors.call_args.args
+        assert mirrors_args[0] == 'my-group'
+        assert mirrors_args[1] == 7
+
+    def _make_run_job_group_controller(self, job_id: int = 1):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = job_id
+        controller._pool = None
+        return controller
+
+    async def _run_job_group_with_mocks(self, controller, dag, net):
+        """Drive `_run_job_group` for a single fresh-launch task, with every
+        collaborator mocked away except the cross-context mirror wiring
+        under test."""
+        executor = MagicMock()
+        executor.launch = AsyncMock()
+        controller._prepare_job_group_task_for_launch = AsyncMock(
+            return_value=('cluster-a', executor))
+        controller._cleanup_job_group_clusters = AsyncMock()
+        controller._monitor_job_group_task = AsyncMock(return_value=True)
+
+        handle = MagicMock()
+
+        with patch('sky.jobs.controller.job_group_networking', net), \
+             patch('sky.jobs.controller.managed_job_runtime') as runtime, \
+             patch('sky.jobs.controller.managed_job_state') as state, \
+             patch('sky.jobs.controller.managed_job_utils') as utils, \
+             patch('sky.jobs.controller.global_user_state') as gus:
+            runtime.is_registered.return_value = False
+            state.get_job_status_with_task_id_async = AsyncMock(
+                return_value=None)  # None -> fresh launch for every task.
+            state.set_started_async = AsyncMock()
+            utils.event_callback_func = MagicMock(return_value=None)
+            gus.get_handle_from_cluster_name = MagicMock(return_value=handle)
+
+            return await JobController._run_job_group(controller)
+
+    @pytest.mark.asyncio
+    async def test_phase3_sets_up_cross_context_mirrors(self):
+        controller = self._make_run_job_group_controller(job_id=3)
+        task = MagicMock()
+        task.name = 'task-a'
+        task.envs = {}
+        dag = MagicMock()
+        dag.name = 'my-group'
+        dag.tasks = [task]
+        dag.primary_tasks = []
+        controller._dag = dag
+
+        with patch('sky.jobs.controller.job_group_networking') as net:
+            net.dns_addresses_for_task = MagicMock(return_value=None)
+            net.setup_cross_context_mirrors = AsyncMock(return_value=True)
+            net.setup_job_group_networking = AsyncMock(return_value=True)
+            net.group_spans_multiple_contexts = MagicMock(return_value=False)
+
+            result = await self._run_job_group_with_mocks(controller, dag, net)
+
+        assert result is True
+        net.setup_cross_context_mirrors.assert_awaited_once()
+        call_args = net.setup_cross_context_mirrors.call_args.args
+        assert call_args[0] == 'my-group'
+        assert call_args[1] == 3
+
+    @pytest.mark.asyncio
+    async def test_reconcile_task_started_and_cancelled_when_multi_context(
+            self):
+        """When `group_spans_multiple_contexts` is True, the periodic mirror
+        reconcile task must be created at Phase 3 and cancelled once
+        monitoring completes (via the try/finally around Phase 4)."""
+        controller = self._make_run_job_group_controller(job_id=5)
+        task = MagicMock()
+        task.name = 'task-a'
+        task.envs = {}
+        dag = MagicMock()
+        dag.name = 'my-group'
+        dag.tasks = [task]
+        dag.primary_tasks = []
+        controller._dag = dag
+
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def fake_reconcile(job_group_name, all_tasks_handles):
+            started.set()
+            try:
+                # Block until the controller cancels us in its `finally`.
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        controller._reconcile_job_group_mirrors = fake_reconcile
+
+        with patch('sky.jobs.controller.job_group_networking') as net:
+            net.dns_addresses_for_task = MagicMock(return_value=None)
+            net.setup_cross_context_mirrors = AsyncMock(return_value=True)
+            net.setup_job_group_networking = AsyncMock(return_value=True)
+            net.group_spans_multiple_contexts = MagicMock(return_value=True)
+
+            result = await self._run_job_group_with_mocks(controller, dag, net)
+
+        assert result is True
+        assert started.is_set(), 'reconcile task should have been started'
+        assert cancelled.is_set(), (
+            'reconcile task should have been cancelled once Phase 4 '
+            'monitoring completed')
+
+    @pytest.mark.asyncio
+    async def test_reconcile_task_not_started_for_single_context(self):
+        controller = self._make_run_job_group_controller(job_id=6)
+        task = MagicMock()
+        task.name = 'task-a'
+        task.envs = {}
+        dag = MagicMock()
+        dag.name = 'my-group'
+        dag.tasks = [task]
+        dag.primary_tasks = []
+        controller._dag = dag
+
+        reconcile_called = False
+
+        async def fake_reconcile(job_group_name, all_tasks_handles):
+            nonlocal reconcile_called
+            reconcile_called = True
+
+        controller._reconcile_job_group_mirrors = fake_reconcile
+
+        with patch('sky.jobs.controller.job_group_networking') as net:
+            net.dns_addresses_for_task = MagicMock(return_value=None)
+            net.setup_cross_context_mirrors = AsyncMock(return_value=True)
+            net.setup_job_group_networking = AsyncMock(return_value=True)
+            net.group_spans_multiple_contexts = MagicMock(return_value=False)
+
+            await self._run_job_group_with_mocks(controller, dag, net)
+
+        assert not reconcile_called
+
+
+class TestJobGroupMirrorCleanup:
+    """Tests for cross-context DNS mirror cleanup in
+    `ControllerManager._cleanup`."""
+
+    @pytest.fixture
+    def cleanup_patches(self):
+        """Patch all `_cleanup()` dependencies other than the JobGroup
+        mirror-cleanup block under test (mirrors `TestTaskCleanup.
+        cleanup_patches`)."""
+        patches = {
+            'ha_recovery': patch(
+                'sky.jobs.state.remove_ha_recovery_script_async',
+                new_callable=AsyncMock),
+            'terminate': patch('sky.jobs.utils.terminate_cluster'),
+            'gen_name': patch(
+                'sky.jobs.utils.generate_managed_job_cluster_name',
+                return_value='test-cluster'),
+            'status': patch('sky.core.status', return_value=[]),
+            'backend': patch('sky.backends.cloud_vm_ray_backend.'
+                             'CloudVmRayBackend'),
+            'get_handle': patch(
+                'sky.jobs.controller.global_user_state.'
+                'get_handle_from_cluster_name',
+                return_value=None),
+            'cleanup_mirrors': patch(
+                'sky.jobs.controller.job_group_networking.'
+                'cleanup_cross_context_mirrors',
+                new_callable=AsyncMock),
+        }
+        mocks = {}
+        for name, p in patches.items():
+            mocks[name] = p.start()
+        yield mocks
+        for p in patches.values():
+            p.stop()
+
+    def _make_task(self, name='test-task'):
+        task = MagicMock()
+        task.name = name
+        task.file_mounts = None
+        task.storage_mounts = {}
+        return task
+
+    @pytest.mark.asyncio
+    async def test_cleanup_awaits_cleanup_cross_context_mirrors_for_job_group(
+            self, cleanup_patches):
+        task1 = self._make_task('trainer')
+        task2 = self._make_task('evaluator')
+        dag = MagicMock()
+        dag.is_job_group.return_value = True
+        dag.name = 'my-group'
+        dag.tasks = [task1, task2]
+
+        from sky.jobs.controller import ControllerManager
+        manager = ControllerManager('test-uuid')
+        with patch('sky.jobs.controller._get_dag', return_value=dag):
+            await manager._cleanup(job_id=1)
+
+        cleanup_patches['cleanup_mirrors'].assert_awaited_once()
+        call_args = cleanup_patches['cleanup_mirrors'].call_args.args
+        assert call_args[0] == 'my-group'
+        assert call_args[1] == 1
+        tasks_handles = call_args[2]
+        assert [t.name for t, _ in tasks_handles] == ['trainer', 'evaluator']
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skips_mirror_cleanup_for_non_job_group(
+            self, cleanup_patches):
+        task = self._make_task('solo-task')
+        dag = MagicMock()
+        dag.is_job_group.return_value = False
+        dag.tasks = [task]
+
+        from sky.jobs.controller import ControllerManager
+        manager = ControllerManager('test-uuid')
+        with patch('sky.jobs.controller._get_dag', return_value=dag):
+            await manager._cleanup(job_id=2)
+
+        cleanup_patches['cleanup_mirrors'].assert_not_awaited()


### PR DESCRIPTION
Closes the gap where a Job Group whose tasks pin different Kubernetes contexts launches fine, but in-group hostname networking silently fails.

## Problem

Job Group tasks can already land on different Kubernetes clusters: per-task `infra: k8s/<context>` pins are accepted, and when no common infra exists the optimizer falls back to per-task optimization. But in-group service discovery breaks: each pod's DNS updater resolves peers via their `*.svc.cluster.local` service names, which only resolve *inside the peer's own cluster*. Cross-cluster, the networking wait script times out after 300s and tasks can never reach each other by their `{task}-{i}.{group}` hostnames.

This blocks heterogeneous workloads — e.g. RL actor/learner or disaggregated-inference splits where different accelerator types live in different Kubernetes clusters.

## Approach: cross-cluster DNS mirroring

When a Job Group's Kubernetes tasks span more than one context, the jobs controller creates **name-identical, selectorless headless mirror Services with manually-managed core/v1 Endpoints** in every member cluster, for each peer task that lives in a *different* context. The peer's existing service DNS names then resolve in the consumer's cluster exactly as they do in the peer's own cluster, and the existing on-pod `/etc/hosts` updater works unchanged.

- Runtime-supplied addresses of the form `node-0.<cluster>.$POD_NAMESPACE.svc.cluster.local` resolve verbatim: the mirror Endpoints carry a per-address `hostname` so the `node-0.<svc>` record exists in the consumer's cluster.
- Classic per-node services (`<cluster>-head`, `<cluster>-worker<i>`) get one single-address mirror each. Mapping generation becomes consumer-aware: for cross-context peers the mapping name embeds the consumer's namespace (where the mirror lives) instead of the peer's.
- Legacy `Endpoints` (not `EndpointSlice`) is deliberate: kube-dns (GKE Standard's default) only reads Endpoints, while the GA endpointslice-mirroring controller converts selectorless-Service Endpoints for CoreDNS/Cloud DNS clusters — one object kind serves both.

Reconciliation / lifecycle:
- Mirrors are created in networking Phase 3 (after all clusters are up), re-pointed by the existing on-recovery networking re-setup, and additionally refreshed by a lightweight per-group reconcile loop (15s) that lists the group's pods per member cluster — covering pod IP churn that never surfaces as a SkyPilot-level recovery.
- Mirrors are labeled with the managed job id and swept in the controller's cleanup path, which runs on success, failure, and cancellation. Stale mirrors from a previous run of a same-named group are garbage-collected at setup time.
- Single-context groups are completely unaffected: the mirror machinery is fully gated on the group spanning >1 context, and generated mappings are unchanged.

Prerequisites (documented in `docs/source/examples/job-groups.rst`): pod-to-pod routability between member clusters (shared/peered VPC or flat network) with non-overlapping pod CIDRs, and `services`/`endpoints` write permission for the SkyPilot service account in each member cluster. The docs call out GKE firewall and EKS VPC-CNI SNAT specifics.

Also included:
- Optimizer: a Job Group whose tasks all pin explicit, differing infra now goes straight to per-task optimization with an INFO log, instead of the misleading `No common infrastructure found` warning.
- `sky jobs launch` logs an info when a group spans multiple Kubernetes contexts, pointing at the routability prerequisite.
- DNS-updater hardening: `getent` lookups now query the absolute name (trailing dot) so resolv.conf search-path expansion (`ndots:5`) can't let a wildcard DNS record shadow an in-cluster name.
- Helm chart + minimal-permissions docs: `endpoints` verbs for the API server role.

## Tested

- **Unit tests** (new): mirror manifest/spec generation (runtime-style vs classic peers), pod-IP discovery incl. label-selector fallback and node-index parsing, apply/GC idempotency against a mocked k8s API, consumer-aware mapping generation (incl. regression guard that single-context behavior is byte-identical), multi-context gating, optimizer explicit-pins fast path.
- **Manual e2e** on two `kind` clusters with routable pod networks (non-overlapping pod CIDRs + static routes), local API server in jobs consolidation mode, and a 2-task Job Group (`server` pinned to `k8s/kind-jga`, `client` pinned to `k8s/kind-jgb`, `primary_tasks: [client]`):
  - Launch: optimizer took the per-task path (no `No common infrastructure` warning); mirrors appeared in both clusters (`client-…-head` mirror + Endpoints in cluster A, `server-…-head` in cluster B); client resolved `server-0.<group>` via `/etc/hosts` and fetched an HTTP payload cross-cluster.
  - Recovery: deleted the server head pod mid-run → task recovered on a new pod with a new IP (`10.244.0.7` → `10.244.0.8`) → mirror Endpoints in the client's cluster re-pointed to the new IP → client's `/etc/hosts` followed → client's post-recovery connectivity check passed. `#RECOVERIES=1`, group `SUCCEEDED`.
  - Lifecycle: client (primary) success auto-terminated the auxiliary server; all mirror Services/Endpoints were swept from both clusters on completion (verified empty by label selector after both runs).
- Pre-existing failure (unrelated, fails identically on `master`): `tests/test_job_groups/test_job_group.py::TestControllerAsyncPatterns::test_download_log_uses_to_thread_in_monitor_job_group_task` asserts on a `_download_log_and_stream` symbol that no longer exists in `sky/jobs/controller.py`.

Follow-ups (not in this PR): **automatic cross-cluster placement** — a plain `infra: k8s` Job Group should spread across clusters only when no single cluster can satisfy all tasks (explicit per-task pins are the current mechanism; this PR provides the networking substrate either way); a two-context smoke test (the smoke-test yaml renderer currently substitutes a single `{{cloud}}` into every task), and a validation/e2e pass on a kube-dns (GKE Standard) member cluster.

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8XJpppS1KjGfgskWkoY4v
