### PR TITLE
[Test] Skip test_batch_diffusion on Azure (no L4 GPU in catalog)

### DIFF
--- a/tests/smoke_tests/test_batch.py
+++ b/tests/smoke_tests/test_batch.py
@@ -141,6 +141,7 @@ def test_batch_simple(generic_cloud: str):
 @pytest.mark.batch
 @pytest.mark.resource_heavy
 @pytest.mark.no_kubernetes  # pool.yaml hardcodes L4 GPU; K8s CI clusters may not have it
+@pytest.mark.no_azure  # pool.yaml hardcodes L4 GPU; Azure has no L4 instance
 @pytest.mark.no_remote_server  # see note 1 above
 def test_batch_diffusion(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
## Summary
- `test_batch_diffusion` (in `tests/smoke_tests/test_batch.py`) fails on the Azure leg because `examples/batch/diffusion/pool.yaml` hardcodes `accelerators: L4:1`, and SkyPilot's Azure catalog has no instance offering an L4 GPU.
- This adds `@pytest.mark.no_azure`, directly mirroring the `@pytest.mark.no_kubernetes` marker already on the same test (both skip because the example requires an L4 GPU the target infra cannot provide).

## Root Cause
On the Azure leg (`generic_cloud=azure`), the test runs `sky jobs pool apply --infra azure examples/batch/diffusion/pool.yaml`. Because `pool.yaml` requests `L4:1` and no Azure instance offers an L4, optimization fails deterministically at optimize time with `ResourcesUnavailableError: Catalog does not contain any instances satisfying the request: 1x Azure({'L4': 1})`, before any provisioning. This is not transient: it fails on every Azure run. AWS (g6) and GCP (g2) offer L4, so those legs pass.

## Fix
Skip the test on Azure via `@pytest.mark.no_azure`. The conftest generic-cloud skip logic (`tests/conftest.py`) skips a generic test when `no_<generic_cloud_keyword>` is present in its keywords, so this leaves the AWS and GCP legs running while skipping only Azure. The example `pool.yaml` is intentionally left unchanged (it is what users see) rather than making its GPU cloud-aware.

## Release blocker
This is a release blocker for **0.13.0rc1**. The failing job is on the release build (branch `test_releases/0.13.0rc1`). This PR targets `master`; it will need to be **cherry-picked onto the release branch `test_releases/0.13.0rc1`** by the release owner.

## Tested
- Verified the failure mechanism against the repo:
  - `examples/batch/diffusion/pool.yaml` hardcodes `accelerators: L4:1`.
  - `test_batch_diffusion` is a generic test (no cloud-specific keyword) and already carries `@pytest.mark.no_kubernetes` for the same L4 reason.
  - `tests/conftest.py` skips a generic test when `no_<generic_cloud_keyword>` is in its keywords; `azure` maps to keyword `azure`, so `no_azure` is the correct marker. `no_azure` is an established marker already used in several smoke test files.
- `yapf` and `isort` report no changes on `tests/smoke_tests/test_batch.py`; the diff is a single added decorator line. (pylint in `format.sh` runs only on `sky/` and `examples/`, not `tests/`.)
- Smoke test triggered for the batch test on aws/azure/gcp to confirm the Azure leg is now skipped while AWS and GCP still run.