### PR TITLE
[k8s] Guard against None pod.status.conditions in termination-reason lookup

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2354,7 +2354,7 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
 
     # Check pod status conditions for high level overview.
     # No need to sort, as each condition.type will only appear once.
-    for condition in pod.status.conditions:
+    for condition in (pod.status.conditions or []):
         reason = condition.reason or 'Unknown reason'
         message = condition.message or ''
 

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -420,6 +420,17 @@ class TestGetPodTerminationReason:
         result = k8s_instance._get_pod_termination_reason(pod, 'cluster')
         assert 'Terminated unexpectedly' in result
 
+    def test_none_conditions_does_not_raise(self, monkeypatch):
+        # status.conditions is nullable in the Kubernetes API and is often
+        # None for pods in Failed/Unknown phase (e.g. after a node becomes
+        # unreachable). It must not raise TypeError.
+        monkeypatch.setattr(k8s_instance.global_user_state, 'add_cluster_event',
+                            lambda *a, **k: None)
+        pod = self._make_terminated_pod(reason=None, message=None)
+        pod.status.conditions = None
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster')
+        assert 'Terminated unexpectedly' in result
+
 
 def _make_event(reason, message):
     """Create a mock kubelet pod event."""


### PR DESCRIPTION
## Summary

`_get_pod_termination_reason()` in `sky/provision/kubernetes/instance.py` iterates `pod.status.conditions` without a None guard. In the Kubernetes API `pod.status.conditions` is nullable, and it is commonly `None` for pods in the Failed/Unknown phase — for example when a node becomes unreachable and its pods transition to Failed/Unknown with no status conditions set.

In that case the loop raises `TypeError: 'NoneType' object is not iterable`, which propagates out of `query_instances()` as a cluster status-fetching error rather than the pod loss being detected and handled normally.

## Fix

Guard the iteration with `or []`, matching the existing None handling already applied to `pod.status.container_statuses` a few lines below in the same function. The change is minimal and does not restructure the function.

## Why `conditions` can be None

- In the Kubernetes API definition, `PodStatus.Conditions` is marked `+optional` with `json:"conditions,omitempty"`, so the API server omits the field entirely when there are no conditions. See [`kubernetes/api` `core/v1/types.go`](https://github.com/kubernetes/api/blob/master/core/v1/types.go) (`PodStatus.Conditions`).
- The Python client (`kubernetes==33.1.0`) maps an absent `conditions` key to `None`, not `[]` — its generated `V1PodStatus.conditions` setter stores the value as-is with no empty-list coercion. Deserializing a `PodStatus` payload without a `conditions` key yields `status.conditions is None`, which is exactly what reaches this code path.

## Test

Adds a unit test in `tests/unit_tests/test_sky/provision/test_k8s_pod_health.py` covering a pod whose `status.conditions` is `None`. Verified the test raises `TypeError` without the fix and passes with it; the full `test_k8s_pod_health.py` file (33 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)