### PR TITLE
[Debug Dump] Resolve k8s coordinates from cluster YAML so INIT clusters still get their k8s/Kueue state dumped

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -34,8 +34,8 @@ from sky.server import daemons
 from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants as skylet_constants
-from sky.utils import command_runner
 from sky.utils import common
+from sky.utils import common_utils
 from sky.utils import controller_utils
 from sky.utils import debug_dump_helpers
 from sky.utils import message_utils
@@ -43,6 +43,7 @@ from sky.utils import status_lib
 from sky.utils import subprocess_utils
 from sky.utils import tempstore
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -1048,29 +1049,27 @@ def _kube_coordinates_for_handle(
         handle: Any) -> Optional[Tuple[Optional[str], str]]:
     """Resolve a cluster handle's (kube context, namespace), or None.
 
-    Returns None for clusters that aren't on Kubernetes (or whose runners can't
-    be resolved). For a Kubernetes cluster every command runner is a
-    KubernetesCommandRunner carrying its pod's (context, namespace); they're
-    cluster-wide identical, so runners[0] suffices. get_command_runners()
-    rebuilds from the cached cluster_info (no live API call), so this is cheap
-    and safe even when the context is defunct.
+    Returns None for clusters that aren't on Kubernetes. The coordinates come
+    from the cluster YAML's provider config -- static launch-time facts that
+    exist from the moment provisioning starts. Resolving them through
+    handle.get_command_runners() would not work here: for a cluster that never
+    finished provisioning, cached_cluster_info is unset, so the runner path
+    makes a live get_cluster_info() call that requires a Running head pod --
+    failing on exactly the stuck-in-INIT launches (e.g. pods Pending in a
+    Kueue queue) whose k8s state the dump most needs to capture.
     """
     launched_resources = getattr(handle, 'launched_resources', None)
     cloud = getattr(launched_resources, 'cloud', None)
     if not isinstance(cloud, clouds.Kubernetes):
         return None
 
-    runners = handle.get_command_runners()
-    k8s_runners: List[Any] = [
-        r for r in runners
-        if isinstance(r, command_runner.KubernetesCommandRunner)
-    ]
-    if not k8s_runners:
-        return None
-    runner = k8s_runners[0]
-    assert isinstance(runner, command_runner.KubernetesCommandRunner), runner
-    # .context/.namespace are set via tuple-unpacking mypy can't track.
-    return runner.context, runner.namespace  # type: ignore[attr-defined]
+    # Raises on a missing/unreadable YAML; the caller records that as a dump
+    # error for this cluster rather than silently skipping it.
+    provider_config = yaml_utils.read_yaml(handle.cluster_yaml).get(
+        'provider', {})
+    context = kubernetes_utils.get_context_from_config(provider_config)
+    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    return context, namespace
 
 
 def _sanitize_context_name(context: Optional[str]) -> str:
@@ -1116,21 +1115,24 @@ def _collect_cluster_kubernetes_resources(
     try:
         coords = _kube_coordinates_for_handle(handle)
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to get command runners for cluster '
-                       f'{cluster_name}: {e}')
+        # format_exception, not str(e): some exceptions (e.g.
+        # FetchClusterInfoError) stringify to '', which left the error record
+        # blank with only the traceback to go on.
+        error_str = common_utils.format_exception(e)
+        logger.warning(f'Failed to resolve kube coordinates for cluster '
+                       f'{cluster_name}: {error_str}')
         if errors is not None:
             errors.append({
                 'component': 'clusters',
                 'resource': f'{cluster_name}/kubernetes',
-                'error': str(e),
+                'error': error_str,
                 'traceback': _full_traceback()
             })
         return
 
     if coords is None:
-        logger.debug(
-            f'Cluster {cluster_name!r} is not on Kubernetes (or has no '
-            f'k8s runners); skipping k8s resource dump')
+        logger.debug(f'Cluster {cluster_name!r} is not on Kubernetes; '
+                     f'skipping k8s resource dump')
         return
 
     context, namespace = coords

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -14,11 +14,11 @@ import pytest
 
 from sky import clouds
 from sky import exceptions
+from sky.adaptors import kubernetes as adaptors_kubernetes
 from sky.jobs import utils as managed_job_utils
 from sky.server import constants as server_constants
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
-from sky.utils import command_runner
 from sky.utils import common
 from sky.utils import debug_dump_helpers
 from sky.utils import debug_utils
@@ -3376,19 +3376,16 @@ class TestResolveRemoteSkyletLogPath:
 class TestCollectClusterKubernetesResources:
     """Tests for the _collect_cluster_kubernetes_resources helper."""
 
-    def _k8s_handle(self, runners):
+    def _k8s_handle(self, tmp_path, context='ctx', namespace='ns'):
         handle = mock.Mock()
         handle.launched_resources.cloud = clouds.Kubernetes()
         handle.cluster_name_on_cloud = 'cluster-abc'
-        handle.get_command_runners.return_value = runners
+        yaml_path = tmp_path / 'cluster.yaml'
+        yaml_path.write_text(f'provider:\n'
+                             f'  context: {context}\n'
+                             f'  namespace: {namespace}\n')
+        handle.cluster_yaml = str(yaml_path)
         return handle
-
-    def _k8s_runner(self, context, namespace, pod_name):
-        runner = mock.MagicMock(spec=command_runner.KubernetesCommandRunner)
-        runner.context = context
-        runner.namespace = namespace
-        runner.pod_name = pod_name
-        return runner
 
     def test_non_kubernetes_cluster_is_noop(self, tmp_path):
         """A cluster on another cloud must not touch the k8s code path."""
@@ -3402,17 +3399,15 @@ class TestCollectClusterKubernetesResources:
                 'c', str(tmp_path), handle, errors)
 
         dump.assert_not_called()
-        handle.get_command_runners.assert_not_called()
         assert not errors
 
-    def test_delegates_with_coordinates_from_runners(self, tmp_path):
-        """Context/namespace are pulled off the k8s runners and passed through;
-        the dump finds the cluster's objects by label, so no pod names needed."""
-        runners = [
-            self._k8s_runner('ctx', 'ns', 'pod-head'),
-            self._k8s_runner('ctx', 'ns', 'pod-worker'),
-        ]
-        handle = self._k8s_handle(runners)
+    def test_delegates_with_coordinates_from_cluster_yaml(self, tmp_path):
+        """Context/namespace come from the cluster YAML's provider config;
+        the dump finds the cluster's objects by label, so no pod names needed.
+        Crucially, command runners are never built: they require a Running
+        head pod, which an INIT cluster (e.g. pods Pending in a Kueue queue)
+        doesn't have -- exactly the launches this dump must still cover."""
+        handle = self._k8s_handle(tmp_path)
 
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources',
@@ -3425,6 +3420,7 @@ class TestCollectClusterKubernetesResources:
                                      cluster_name_on_cloud='cluster-abc',
                                      output_dir=os.path.join(
                                          str(tmp_path), 'kubernetes'))
+        handle.get_command_runners.assert_not_called()
         assert not errors
         # A context.json mapping is dropped pointing at the per-context dump.
         with open(os.path.join(str(tmp_path), 'kubernetes', 'context.json'),
@@ -3435,9 +3431,24 @@ class TestCollectClusterKubernetesResources:
         assert mapping['cluster_name_on_cloud'] == 'cluster-abc'
         assert mapping['context_dir'].startswith('kubernetes_contexts/')
 
+    def test_in_cluster_context_maps_to_none(self, tmp_path):
+        """The in-cluster context name resolves to context=None (in-cluster
+        auth), matching how the provisioner reads the same provider config."""
+        handle = self._k8s_handle(
+            tmp_path, context=adaptors_kubernetes.in_cluster_context_name())
+
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources',
+                        return_value=[]) as dump:
+            debug_utils._collect_cluster_kubernetes_resources(
+                'mycluster', str(tmp_path), handle, errors)
+
+        assert dump.call_args.kwargs['context'] is None
+        assert not errors
+
     def test_provider_errors_are_prefixed_with_cluster(self, tmp_path):
         """Errors from the provider are re-tagged with component + cluster."""
-        handle = self._k8s_handle([self._k8s_runner('ctx', 'ns', 'pod-head')])
+        handle = self._k8s_handle(tmp_path)
         provider_errors = [{
             'resource': 'kubernetes/pods/pod-head',
             'error': 'boom',
@@ -3457,10 +3468,11 @@ class TestCollectClusterKubernetesResources:
             'traceback': 'tb',
         }]
 
-    def test_get_command_runners_failure_is_recorded(self, tmp_path):
-        """A k8s cluster whose runners can't be built records one error."""
-        handle = self._k8s_handle([])
-        handle.get_command_runners.side_effect = RuntimeError('unreachable')
+    def test_coordinate_failure_is_recorded(self, tmp_path):
+        """A k8s cluster whose YAML is missing records one error."""
+        handle = mock.Mock()
+        handle.launched_resources.cloud = clouds.Kubernetes()
+        handle.cluster_yaml = None
 
         errors: List[Dict[str, str]] = []
         with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources'
@@ -3473,19 +3485,22 @@ class TestCollectClusterKubernetesResources:
         assert errors[0]['resource'] == 'mycluster/kubernetes'
         assert errors[0]['component'] == 'clusters'
 
-    def test_no_kubernetes_runners_is_noop(self, tmp_path):
-        """A k8s-cloud handle whose runners aren't KubernetesCommandRunners
-        (e.g. cluster info unavailable) is skipped without error."""
-        handle = self._k8s_handle([mock.Mock()])  # plain runner, wrong type
+    def test_empty_str_exception_still_yields_error_message(self, tmp_path):
+        """Exceptions that stringify to '' (e.g. FetchClusterInfoError) must
+        still leave a readable error record, not a blank one."""
+        handle = self._k8s_handle(tmp_path)
 
         errors: List[Dict[str, str]] = []
-        with mock.patch('sky.provision.kubernetes.debug.dump_cluster_resources'
-                       ) as dump:
+        with mock.patch.object(
+                debug_utils,
+                '_kube_coordinates_for_handle',
+                side_effect=exceptions.FetchClusterInfoError(
+                    exceptions.FetchClusterInfoError.Reason.HEAD)):
             debug_utils._collect_cluster_kubernetes_resources(
                 'mycluster', str(tmp_path), handle, errors)
 
-        dump.assert_not_called()
-        assert not errors
+        assert len(errors) == 1
+        assert 'FetchClusterInfoError' in errors[0]['error']
 
 
 class TestSanitizeContextName:


### PR DESCRIPTION
Follow-up to #9937.

## Problem

The per-cluster Kubernetes collection in the debug dump resolved a cluster's (kube context, namespace) via `handle.get_command_runners()`. For a cluster that has never finished provisioning, `cached_cluster_info` is unset, so that path makes a **live** `get_cluster_info()` call that requires a Running head pod and raises `FetchClusterInfoError` otherwise. The exception aborted the whole per-cluster k8s dump — pods, pod events, labeled resources, and the Kueue Workload — before any of it ran.

That failure mode fires precisely in the case the Kueue collection was built for: a launch sitting Pending in a Kueue queue is by definition a cluster whose head pod isn't Running. Observed in the field on a tenant dump: a managed job's cluster stuck in INIT (16 pods Pending in a Kueue queue) produced a cluster folder with no `kubernetes/` subtree at all, and an `errors.json` entry whose `error` field was empty (`str(FetchClusterInfoError())` is `''`), leaving only the traceback to explain it.

## Fix

- `_kube_coordinates_for_handle` now reads context/namespace from the cluster YAML's provider config — static launch-time facts available from the moment provisioning starts — using the same `kubernetes_utils.get_context_from_config` / `get_namespace_from_config` helpers the provisioner itself uses. No command runners, no live head-pod requirement.
- Error records for coordinate-resolution failures use `common_utils.format_exception(e)` instead of `str(e)`, so exceptions that stringify to `''` still leave a readable record.

## Tested

- Updated `TestCollectClusterKubernetesResources`: coordinates come from the cluster YAML; `get_command_runners` is asserted **never called** (the regression); in-cluster context maps to `None`; missing YAML records one error; `''`-stringifying exceptions still produce a readable error record.
- `pytest tests/unit_tests/test_sky/utils/test_debug_utils.py tests/unit_tests/kubernetes/test_debug.py` — all pass.
- `bash format.sh --files ...` + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)