### PR TITLE
[Jobs] Stream managed job logs on demand when a logging agent is configured

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -277,17 +277,22 @@ class JobController:
         download and stream should be faster, and more robust against
         preemptions or ssh disconnection during the streaming.
 
-        When a logging agent is configured, the job's logs are forwarded to an
-        external store, which becomes the durable copy. In that case we skip
-        pulling the logs back to the controller entirely; ``sky jobs logs``
-        streams them on demand (from the cluster while it is alive, then from
-        the external store once it is gone).
+        When a logging agent forwards the job's logs to an external store AND a
+        log reader is registered to stream them back, that external store is the
+        durable copy, so we skip pulling the logs back to the controller
+        entirely; ``sky jobs logs`` streams them on demand (from the cluster
+        while it is alive, then from the external store once it is gone). If the
+        logs are forwarded but there is no reader to read them back (e.g. a
+        write-only logging store), we still keep the local copy so ``sky jobs
+        logs`` can serve a finished job's logs.
         """
-        if logs.is_logging_agent_configured():
+        if (logs.is_logging_agent_configured() and
+                logs.get_log_reader() is not None):
             logger.info(
-                f'Logging agent is configured for job {self._job_id}; logs are '
-                'forwarded to the external store. Skipping downloading and '
-                'streaming the logs to the controller.')
+                f'Logging agent and log reader are configured for job '
+                f'{self._job_id}; logs are forwarded to the external store and '
+                'read back on demand. Skipping downloading and streaming the '
+                'logs to the controller.')
             return
         if handle is None:
             logger.info(f'Cluster for job {self._job_id} is not found. '

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -21,6 +21,7 @@ import sky
 from sky import core
 from sky import exceptions
 from sky import global_user_state
+from sky import logs
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
@@ -275,7 +276,19 @@ class JobController:
         We do not stream the logs from the cluster directly, as the
         download and stream should be faster, and more robust against
         preemptions or ssh disconnection during the streaming.
+
+        When a logging agent is configured, the job's logs are forwarded to an
+        external store, which becomes the durable copy. In that case we skip
+        pulling the logs back to the controller entirely; ``sky jobs logs``
+        streams them on demand (from the cluster while it is alive, then from
+        the external store once it is gone).
         """
+        if logs.is_logging_agent_configured():
+            logger.info(
+                f'Logging agent is configured for job {self._job_id}; logs are '
+                'forwarded to the external store. Skipping downloading and '
+                'streaming the logs to the controller.')
+            return
         if handle is None:
             logger.info(f'Cluster for job {self._job_id} is not found. '
                         'Skipping downloading and streaming the logs.')

--- a/sky/jobs/log_gc.py
+++ b/sky/jobs/log_gc.py
@@ -67,7 +67,14 @@ def gc_controller_logs_for_job():
 
 
 def gc_task_logs_for_job():
-    """Garbage collect task logs for job."""
+    """Garbage collect task logs for job.
+
+    Only local task logs are garbage collected here: the cleanup query
+    requires ``local_log_file IS NOT NULL``. When a logging agent forwards a
+    job's logs to an external store the controller does not persist a local
+    copy, so those logs are not subject to this retention -- their lifetime is
+    governed by the external store's own retention policy.
+    """
     while True:
         skypilot_config.reload_config()
         task_logs_retention = skypilot_config.get_nested(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1867,6 +1867,8 @@ def stream_logs_by_id(
                     # configured). Stream the logs back from the external store
                     # for this task's ephemeral cluster. The cluster ran exactly
                     # one job, so read the latest indexed one (job_id=None).
+                    # external_logging is only True when a reader is registered.
+                    assert log_reader is not None
                     pool = managed_job_state.get_pool_from_job_id(job_id)
                     if pool is not None:
                         cluster_name, _ = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1776,6 +1776,16 @@ def stream_logs_by_id(
             # logs back from the external store via the registered log reader,
             # mirroring core.tail_logs' fallback.
             external_logging = logs.is_logging_agent_configured()
+            log_reader = logs.get_log_reader() if external_logging else None
+            if external_logging and log_reader is None:
+                # A logging agent forwards logs to an external store but no
+                # reader is registered to stream them back. Warn instead of
+                # silently reporting the job as unreadable.
+                print(f'{colorama.Fore.YELLOW}Warning: a logging agent is '
+                      f'configured but no external log reader is registered; '
+                      f'cannot stream logs for job {job_id} from the external '
+                      f'store.{colorama.Style.RESET_ALL}')
+                external_logging = False
             task_info = managed_job_state.get_all_task_ids_names_statuses_logs(
                 job_id)
             total_tasks = len(task_info)
@@ -1857,23 +1867,24 @@ def stream_logs_by_id(
                     # configured). Stream the logs back from the external store
                     # for this task's ephemeral cluster. The cluster ran exactly
                     # one job, so read the latest indexed one (job_id=None).
-                    reader = logs.get_log_reader()
-                    if reader is None:
-                        continue
                     pool = managed_job_state.get_pool_from_job_id(job_id)
                     if pool is not None:
                         cluster_name, _ = (
                             managed_job_state.get_pool_submit_info(job_id))
-                    else:
+                    elif task_name:
                         cluster_name = generate_managed_job_cluster_name(
                             task_name, job_id)
+                    else:
+                        # Without a task name we cannot derive the ephemeral
+                        # cluster name; fall through to the terminal message.
+                        cluster_name = None
                     if cluster_name is None:
                         continue
                     task_str = (f'Task {task_name}({task_id})'
                                 if task_name else f'Task {task_id}')
                     if num_tasks > 1 or task is not None:
                         print(f'=== {task_str} ===')
-                    returncode = reader.read_cluster_job_logs(
+                    returncode = log_reader.read_cluster_job_logs(
                         cluster_name,
                         None,
                         follow=False,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -32,6 +32,7 @@ import filelock
 from sky import backends
 from sky import exceptions
 from sky import global_user_state
+from sky import logs
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
@@ -1769,6 +1770,12 @@ def stream_logs_by_id(
                 job_msg = ('\nFailure reason: '
                            f'{managed_job_state.get_failure_reason(job_id)}')
             log_file_ever_existed = False
+            # When a logging agent is configured, managed-job logs are not
+            # pulled back to the controller (see download_log_and_stream). The
+            # cluster is gone by the time the job is terminal, so stream the
+            # logs back from the external store via the registered log reader,
+            # mirroring core.tail_logs' fallback.
+            external_logging = logs.is_logging_agent_configured()
             task_info = managed_job_state.get_all_task_ids_names_statuses_logs(
                 job_id)
             total_tasks = len(task_info)
@@ -1840,6 +1847,43 @@ def stream_logs_by_id(
                     # Show task finished message for multi-task or filtering
                     if num_tasks > 1 or task is not None:
                         # Add the "Task finished" message for terminal states
+                        if task_status.is_terminal():
+                            print(ux_utils.finishing_message(
+                                f'{task_str} finished '
+                                f'(status: {task_status.value}).'),
+                                  flush=True)
+                elif external_logging:
+                    # No local log was persisted (a logging agent is
+                    # configured). Stream the logs back from the external store
+                    # for this task's ephemeral cluster. The cluster ran exactly
+                    # one job, so read the latest indexed one (job_id=None).
+                    reader = logs.get_log_reader()
+                    if reader is None:
+                        continue
+                    pool = managed_job_state.get_pool_from_job_id(job_id)
+                    if pool is not None:
+                        cluster_name, _ = (
+                            managed_job_state.get_pool_submit_info(job_id))
+                    else:
+                        cluster_name = generate_managed_job_cluster_name(
+                            task_name, job_id)
+                    if cluster_name is None:
+                        continue
+                    task_str = (f'Task {task_name}({task_id})'
+                                if task_name else f'Task {task_id}')
+                    if num_tasks > 1 or task is not None:
+                        print(f'=== {task_str} ===')
+                    returncode = reader.read_cluster_job_logs(
+                        cluster_name,
+                        None,
+                        follow=False,
+                        tail=tail if tail is not None else 0)
+                    if returncode is None:
+                        # No logs in the external store for this task; fall
+                        # through to the terminal-state message below.
+                        continue
+                    log_file_ever_existed = True
+                    if num_tasks > 1 or task is not None:
                         if task_status.is_terminal():
                             print(ux_utils.finishing_message(
                                 f'{task_str} finished '

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1770,22 +1770,16 @@ def stream_logs_by_id(
                 job_msg = ('\nFailure reason: '
                            f'{managed_job_state.get_failure_reason(job_id)}')
             log_file_ever_existed = False
-            # When a logging agent is configured, managed-job logs are not
-            # pulled back to the controller (see download_log_and_stream). The
-            # cluster is gone by the time the job is terminal, so stream the
-            # logs back from the external store via the registered log reader,
-            # mirroring core.tail_logs' fallback.
-            external_logging = logs.is_logging_agent_configured()
-            log_reader = logs.get_log_reader() if external_logging else None
-            if external_logging and log_reader is None:
-                # A logging agent forwards logs to an external store but no
-                # reader is registered to stream them back. Warn instead of
-                # silently reporting the job as unreadable.
-                print(f'{colorama.Fore.YELLOW}Warning: a logging agent is '
-                      f'configured but no external log reader is registered; '
-                      f'cannot stream logs for job {job_id} from the external '
-                      f'store.{colorama.Style.RESET_ALL}')
-                external_logging = False
+            # Whether a task's logs went to an external store is a per-task,
+            # write-time fact: the controller only skips persisting a local
+            # copy (leaving local_log_file NULL) when a logging agent forwarded
+            # the logs elsewhere (see download_log_and_stream). So we decide the
+            # read source per task by the presence of a local file, NOT by the
+            # current global logging-agent config -- this keeps read-back
+            # working after the agent is disconnected or when serving from a
+            # replica whose config view differs. When there is no local copy we
+            # stream from the registered log reader, mirroring core.tail_logs.
+            log_reader = logs.get_log_reader()
             task_info = managed_job_state.get_all_task_ids_names_statuses_logs(
                 job_id)
             total_tasks = len(task_info)
@@ -1862,35 +1856,41 @@ def stream_logs_by_id(
                                 f'{task_str} finished '
                                 f'(status: {task_status.value}).'),
                                   flush=True)
-                elif external_logging:
-                    # No local log was persisted (a logging agent is
-                    # configured). Stream the logs back from the external store
-                    # for this task's ephemeral cluster. The cluster ran exactly
-                    # one job, so read the latest indexed one (job_id=None).
-                    # external_logging is only True when a reader is registered.
-                    assert log_reader is not None
-                    pool = managed_job_state.get_pool_from_job_id(job_id)
-                    if pool is not None:
-                        cluster_name, _ = (
-                            managed_job_state.get_pool_submit_info(job_id))
-                    elif task_name:
-                        cluster_name = generate_managed_job_cluster_name(
-                            task_name, job_id)
-                    else:
-                        # Without a task name we cannot derive the ephemeral
-                        # cluster name; fall through to the terminal message.
-                        cluster_name = None
-                    if cluster_name is None:
+                elif log_reader is not None:
+                    # No local copy was persisted for this task, so its logs
+                    # were forwarded to an external store. Stream them back for
+                    # this task's ephemeral cluster; the cluster ran exactly one
+                    # job, so read the latest indexed one (job_id=None).
+                    returncode = None
+                    try:
+                        pool = managed_job_state.get_pool_from_job_id(job_id)
+                        if pool is not None:
+                            cluster_name, _ = (
+                                managed_job_state.get_pool_submit_info(job_id))
+                        else:
+                            cluster_name = generate_managed_job_cluster_name(
+                                task_name, job_id)
+                        if cluster_name is None:
+                            # A pool job that was never assigned a cluster has
+                            # no logs to read back; fall through to the message.
+                            continue
+                        task_str = (f'Task {task_name}({task_id})'
+                                    if task_name else f'Task {task_id}')
+                        if num_tasks > 1 or task is not None:
+                            print(f'=== {task_str} ===')
+                        returncode = log_reader.read_cluster_job_logs(
+                            cluster_name,
+                            None,
+                            follow=False,
+                            tail=tail if tail is not None else 0)
+                    except Exception as e:  # pylint: disable=broad-except
+                        # Surface the failure (streamed to the user via the
+                        # request's stdout redirection) and fall through to the
+                        # terminal-state message instead of crashing.
+                        logger.warning(
+                            'Failed to read logs for job %s task %s from the '
+                            'external log store: %s', job_id, task_id, e)
                         continue
-                    task_str = (f'Task {task_name}({task_id})'
-                                if task_name else f'Task {task_id}')
-                    if num_tasks > 1 or task is not None:
-                        print(f'=== {task_str} ===')
-                    returncode = log_reader.read_cluster_job_logs(
-                        cluster_name,
-                        None,
-                        follow=False,
-                        tail=tail if tail is not None else 0)
                     if returncode is None:
                         # No logs in the external store for this task; fall
                         # through to the terminal-state message below.
@@ -1910,6 +1910,23 @@ def stream_logs_by_id(
                           flush=True)
                 return '', exceptions.JobExitCode.from_managed_job_status(
                     managed_job_status)
+            if log_reader is not None:
+                # An external log reader is registered but returned nothing for
+                # this job: its logs were not persisted locally and are not (or
+                # no longer) in the external store -- e.g. outside the store's
+                # retention window, or never captured. When a logging agent is
+                # in use, task-log retention is governed by the external store,
+                # not by jobs.controller.task_logs_gc_retention_hours.
+                return (
+                    f'{colorama.Fore.YELLOW}'
+                    f'No logs found for job {job_id} in the external log '
+                    f'store. The logs may be outside the store\'s retention '
+                    f'window or were never captured. For controller logs, '
+                    f'run: sky jobs logs --controller {job_id}'
+                    f'{colorama.Style.RESET_ALL}'
+                    f'{job_msg}',
+                    exceptions.JobExitCode.from_managed_job_status(
+                        managed_job_status))
             return (f'{colorama.Fore.YELLOW}'
                     f'Job {job_id} is already in terminal state '
                     f'{managed_job_status.value}. For more details, run: '

--- a/sky/logs/__init__.py
+++ b/sky/logs/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     'get_log_reader',
     'register_log_reader',
     'get_logging_agent',
+    'is_logging_agent_configured',
     'register_logging_agent_provider',
 ]
 
@@ -56,3 +57,13 @@ def get_logging_agent() -> Optional[LoggingAgent]:
             skypilot_config.get_nested(('logs', 'aws'), {}))
     raise exceptions.InvalidSkyPilotConfigError(
         f'Invalid logging store: {store}')
+
+
+def is_logging_agent_configured() -> bool:
+    """Returns whether a logging agent is configured.
+
+    When True, job logs are forwarded to an external store, so callers can
+    stream them on demand and fall back to the registered ``LogReader`` instead
+    of persisting a local copy.
+    """
+    return get_logging_agent() is not None

--- a/tests/smoke_tests/test_logs.py
+++ b/tests/smoke_tests/test_logs.py
@@ -9,6 +9,8 @@ import textwrap
 import pytest
 from smoke_tests import smoke_tests_utils
 
+import sky
+
 
 @pytest.mark.no_vast  # Requires GCP
 @pytest.mark.no_shadeform  # Requires GCP
@@ -70,6 +72,72 @@ def test_log_collection_to_gcp(generic_cloud: str):
                  f'{validate_logs_cmd}'),
             ],
             f'sky down -y {name}',
+            timeout=20 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.no_vast  # Requires GCP
+@pytest.mark.no_shadeform  # Requires GCP
+@pytest.mark.no_fluidstack  # Requires GCP to be enabled
+@pytest.mark.no_nebius  # Requires GCP to be enabled
+@pytest.mark.no_kubernetes  # Requires GCP to be enabled
+@pytest.mark.no_seeweb  # Requires GCP to be enabled
+def test_managed_job_logs_with_log_store(generic_cloud: str):
+    """`sky jobs logs` works for running and terminal jobs with a log store.
+
+    When a log store is configured, job logs are forwarded to it. `sky jobs
+    logs` must keep working in both states: streaming from the cluster while the
+    job is running, and returning a finished job's logs afterwards (served from
+    the controller's local copy when the store has no read-back path).
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    job_name = f'{name}-job'
+    marker = 'SKY_JOBS_LOG_STORE_LINE'
+    # Print a marker every 2s for ~90s so the job has a running window.
+    run_cmd = f'for i in $(seq 1 45); do echo "{marker}_$i"; sleep 2; done'
+    # Resolve the job id by name from any column of `sky jobs queue --all`.
+    get_job_id_cmd = (
+        's=$(sky jobs queue --all); echo "$s" | '
+        'awk -v n=' + job_name +
+        ' \'{for (i=1; i<=NF; i++) if ($i==n) {print $1; break}}\' | '
+        'sort -un | head -1')
+    with tempfile.NamedTemporaryFile(mode='w') as base:
+        base.write(
+            textwrap.dedent("""\
+            logs:
+              store: gcp
+            """))
+        base.flush()
+        test = smoke_tests_utils.Test(
+            'managed_job_logs_with_log_store',
+            [
+                smoke_tests_utils.with_config(
+                    f'sky jobs launch -y -d -n {job_name} '
+                    f'--infra {generic_cloud} '
+                    f'{smoke_tests_utils.LOW_RESOURCE_ARG} \'{run_cmd}\'',
+                    base.name),
+                # Running state: logs stream from the cluster.
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=job_name,
+                    job_status=[sky.ManagedJobStatus.RUNNING],
+                    timeout=360),
+                'sleep 10',
+                f's=$(sky jobs logs -n {job_name} --no-follow); echo "$s"; '
+                f'echo "$s" | grep "{marker}_1"',
+                # Terminal state: logs are still retrievable (served from the
+                # controller-local copy when the store has no read-back path).
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=job_name,
+                    job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                    timeout=360),
+                f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
+                f'echo "$s"; echo "$s" | grep "{marker}_1"',
+            ],
+            f'sky jobs cancel -y -n {job_name}',
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
             timeout=20 * 60,
         )
         smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -361,6 +361,54 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_terminal_logs_no_logging_agent(generic_cloud: str):
+    """`sky jobs logs` serves a finished job's logs from the controller-local
+    copy when no logging agent is configured (the default).
+
+    Regression guard for the on-demand log path: when a logging agent is
+    configured the controller stops persisting logs locally and `sky jobs logs`
+    falls back to the registered external log reader. With NO logging agent
+    (the open-source default, and no external reader), that fallback must not
+    engage -- the controller must still download the logs and `sky jobs logs`
+    must read them back from the local file, unchanged from before.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    marker = 'MANAGED_JOB_LOG_READBACK_OK'
+    # Resolve the job id by name from any column of `sky jobs queue --all`.
+    get_job_id_cmd = (
+        's=$(sky jobs queue --all); echo "$s" | '
+        'awk -v n=' + name +
+        ' \'{for (i=1; i<=NF; i++) if ($i==n) {print $1; break}}\' | '
+        'sort -un | head -1')
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(f'run: |\n  echo {marker}\n')
+        f.flush()
+        file_path = f.name
+        test = smoke_tests_utils.Test(
+            'managed_jobs_terminal_logs_no_logging_agent',
+            [
+                f'sky jobs launch -n {name} --infra {generic_cloud} '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {file_path} -y -d',
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=name,
+                    job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                    timeout=360),
+                # No logging agent -> the controller downloaded the logs, so
+                # `sky jobs logs` must read them back from the local file.
+                f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
+                f'echo "$s"; echo "$s" | grep {marker}',
+            ],
+            f'sky jobs cancel -y -n {name}',
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            timeout=20 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_pipeline_cancelled_logs(generic_cloud: str):
     """Test that logs are accessible after a pipeline job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -361,54 +361,6 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
-def test_managed_jobs_terminal_logs_no_logging_agent(generic_cloud: str):
-    """`sky jobs logs` serves a finished job's logs from the controller-local
-    copy when no logging agent is configured (the default).
-
-    Regression guard for the on-demand log path: when a logging agent is
-    configured the controller stops persisting logs locally and `sky jobs logs`
-    falls back to the registered external log reader. With NO logging agent
-    (the open-source default, and no external reader), that fallback must not
-    engage -- the controller must still download the logs and `sky jobs logs`
-    must read them back from the local file, unchanged from before.
-    """
-    name = smoke_tests_utils.get_cluster_name()
-    marker = 'MANAGED_JOB_LOG_READBACK_OK'
-    # Resolve the job id by name from any column of `sky jobs queue --all`.
-    get_job_id_cmd = (
-        's=$(sky jobs queue --all); echo "$s" | '
-        'awk -v n=' + name +
-        ' \'{for (i=1; i<=NF; i++) if ($i==n) {print $1; break}}\' | '
-        'sort -un | head -1')
-    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        f.write(f'run: |\n  echo {marker}\n')
-        f.flush()
-        file_path = f.name
-        test = smoke_tests_utils.Test(
-            'managed_jobs_terminal_logs_no_logging_agent',
-            [
-                f'sky jobs launch -n {name} --infra {generic_cloud} '
-                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {file_path} -y -d',
-                smoke_tests_utils.
-                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                    job_name=name,
-                    job_status=[sky.ManagedJobStatus.SUCCEEDED],
-                    timeout=360),
-                # No logging agent -> the controller downloaded the logs, so
-                # `sky jobs logs` must read them back from the local file.
-                f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
-                f'echo "$s"; echo "$s" | grep {marker}',
-            ],
-            f'sky jobs cancel -y -n {name}',
-            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
-            timeout=20 * 60,
-        )
-        smoke_tests_utils.run_one_test(test)
-
-
-@pytest.mark.managed_jobs
-@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
-@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_pipeline_cancelled_logs(generic_cloud: str):
     """Test that logs are accessible after a pipeline job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1082,6 +1082,59 @@ class TestDownloadLogsForCancelledJob:
                 1, mock_handle_1, None)
 
 
+class TestDownloadLogAndStreamLoggingAgentGate:
+    """download_log_and_stream skips pulling logs when a logging agent is set.
+
+    When a logging agent is configured, job logs are forwarded to an external
+    store, so the controller must not download/persist a local copy.
+    """
+
+    def _make_controller(self):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._backend = MagicMock()
+        controller.download_log_and_stream = (
+            JobController.download_log_and_stream.__get__(
+                controller, JobController))
+        return controller
+
+    def test_skips_download_when_logging_agent_configured(self):
+        controller = self._make_controller()
+        handle = MagicMock()
+
+        with patch('sky.jobs.controller.logs.is_logging_agent_configured',
+                   return_value=True), \
+             patch('sky.jobs.controller.managed_job_state') as mock_state, \
+             patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
+             patch('sky.jobs.controller.controller_utils') as mock_cutils:
+
+            controller.download_log_and_stream(0, handle, None)
+
+            # No local copy persisted and no download performed.
+            mock_state.set_local_log_file.assert_not_called()
+            mock_runtime.download_logs.assert_not_called()
+            mock_cutils.download_and_stream_job_log.assert_not_called()
+
+    def test_downloads_when_no_logging_agent(self):
+        controller = self._make_controller()
+        handle = MagicMock()
+
+        with patch('sky.jobs.controller.logs.is_logging_agent_configured',
+                   return_value=False), \
+             patch('sky.jobs.controller.managed_job_state') as mock_state, \
+             patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
+             patch('sky.jobs.controller.controller_utils') as mock_cutils:
+
+            mock_runtime.is_registered.return_value = False
+            mock_cutils.download_and_stream_job_log.return_value = (
+                '/tmp/run.log')
+
+            controller.download_log_and_stream(0, handle, None)
+
+            # Falls back to the normal controller download path.
+            mock_cutils.download_and_stream_job_log.assert_called_once()
+
+
 class TestJobGroupResumeDoesNotReissueStarting:
     """Regression: a resumed JobGroup task must not be re-issued STARTING.
 

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1083,10 +1083,13 @@ class TestDownloadLogsForCancelledJob:
 
 
 class TestDownloadLogAndStreamLoggingAgentGate:
-    """download_log_and_stream skips pulling logs when a logging agent is set.
+    """download_log_and_stream skips the local copy only when logs are both
+    forwarded externally AND readable back.
 
-    When a logging agent is configured, job logs are forwarded to an external
-    store, so the controller must not download/persist a local copy.
+    The controller skips downloading a local copy only when a logging agent
+    forwards the logs AND a log reader is registered to stream them back. If the
+    store has no read-back path (no reader), it must keep the local copy so
+    sky jobs logs can still serve a finished job.
     """
 
     def _make_controller(self):
@@ -1098,41 +1101,39 @@ class TestDownloadLogAndStreamLoggingAgentGate:
                 controller, JobController))
         return controller
 
-    def test_skips_download_when_logging_agent_configured(self):
+    def _run(self, agent_configured, reader):
         controller = self._make_controller()
         handle = MagicMock()
-
         with patch('sky.jobs.controller.logs.is_logging_agent_configured',
-                   return_value=True), \
+                   return_value=agent_configured), \
+             patch('sky.jobs.controller.logs.get_log_reader',
+                   return_value=reader), \
              patch('sky.jobs.controller.managed_job_state') as mock_state, \
              patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
              patch('sky.jobs.controller.controller_utils') as mock_cutils:
-
-            controller.download_log_and_stream(0, handle, None)
-
-            # No local copy persisted and no download performed.
-            mock_state.set_local_log_file.assert_not_called()
-            mock_runtime.download_logs.assert_not_called()
-            mock_cutils.download_and_stream_job_log.assert_not_called()
-
-    def test_downloads_when_no_logging_agent(self):
-        controller = self._make_controller()
-        handle = MagicMock()
-
-        with patch('sky.jobs.controller.logs.is_logging_agent_configured',
-                   return_value=False), \
-             patch('sky.jobs.controller.managed_job_state') as mock_state, \
-             patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
-             patch('sky.jobs.controller.controller_utils') as mock_cutils:
-
             mock_runtime.is_registered.return_value = False
             mock_cutils.download_and_stream_job_log.return_value = (
                 '/tmp/run.log')
-
             controller.download_log_and_stream(0, handle, None)
+            return mock_state, mock_runtime, mock_cutils
 
-            # Falls back to the normal controller download path.
-            mock_cutils.download_and_stream_job_log.assert_called_once()
+    def test_skips_download_when_agent_and_reader_configured(self):
+        # Logs are forwarded and readable back -> skip the local copy.
+        mock_state, mock_runtime, mock_cutils = self._run(agent_configured=True,
+                                                          reader=MagicMock())
+        mock_state.set_local_log_file.assert_not_called()
+        mock_runtime.download_logs.assert_not_called()
+        mock_cutils.download_and_stream_job_log.assert_not_called()
+
+    def test_downloads_when_agent_but_no_reader(self):
+        # Forwarded to a write-only store (no reader) -> keep the local copy so
+        # sky jobs logs still works for a finished job.
+        _, _, mock_cutils = self._run(agent_configured=True, reader=None)
+        mock_cutils.download_and_stream_job_log.assert_called_once()
+
+    def test_downloads_when_no_logging_agent(self):
+        _, _, mock_cutils = self._run(agent_configured=False, reader=None)
+        mock_cutils.download_and_stream_job_log.assert_called_once()
 
 
 class TestJobGroupResumeDoesNotReissueStarting:

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1435,3 +1435,20 @@ class TestStreamLogsByIdExternalStoreFallback:
 
         fake_reader.read_cluster_job_logs.assert_called_once()
         assert 'already in terminal state' in msg
+
+    def test_warns_when_agent_configured_but_no_reader(self, monkeypatch,
+                                                       capsys):
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        mock_logs = MagicMock()
+        mock_logs.is_logging_agent_configured.return_value = True
+        mock_logs.get_log_reader.return_value = None
+        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+
+        msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        # A warning is printed and we fall back to the terminal-state message.
+        assert 'no external log reader is registered' in capsys.readouterr().out
+        assert 'already in terminal state' in msg

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for sky.jobs.utils functions."""
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -1355,3 +1356,82 @@ class TestIsRelayedStatusPayloadLine:
     def test_plain_log_line_not_detected(self):
         assert jobs_utils._is_relayed_status_payload_line(
             'Preparing SkyPilot runtime (1/3)\n') is False
+
+
+class TestStreamLogsByIdExternalStoreFallback:
+    """stream_logs_by_id falls back to the external log reader for terminal jobs.
+
+    When a logging agent is configured, terminal managed-job logs are streamed
+    back from the external store (the controller no longer persists a local
+    copy). When no logging agent is configured, the reader is not consulted.
+    """
+
+    def _patch_terminal_job(self, monkeypatch, task_info):
+        """Stub managed_job_state so stream_logs_by_id hits the terminal branch.
+
+        task_info: list of (task_id, task_name, task_status, log_file,
+            logs_cleaned_at) tuples.
+        """
+        status = managed_job_state.ManagedJobStatus.SUCCEEDED
+        mock_state = MagicMock(wraps=managed_job_state)
+        mock_state.ManagedJobStatus = managed_job_state.ManagedJobStatus
+        mock_state.get_num_tasks.return_value = len(task_info)
+        mock_state.get_status.return_value = status
+        mock_state.get_all_task_ids_names_statuses_logs.return_value = task_info
+        mock_state.get_pool_from_job_id.return_value = None
+        monkeypatch.setattr(jobs_utils, 'managed_job_state', mock_state)
+        return mock_state
+
+    def test_reads_from_external_store_when_agent_configured(self, monkeypatch):
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        fake_reader.read_cluster_job_logs.return_value = 0
+        mock_logs = MagicMock()
+        mock_logs.is_logging_agent_configured.return_value = True
+        mock_logs.get_log_reader.return_value = fake_reader
+        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            lambda name, jid: f'sky-managed-{jid}-{name}')
+
+        msg, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        fake_reader.read_cluster_job_logs.assert_called_once_with(
+            'sky-managed-5-mytask', None, follow=False, tail=0)
+        assert code == exceptions.JobExitCode.from_managed_job_status(
+            managed_job_state.ManagedJobStatus.SUCCEEDED)
+
+    def test_reader_not_consulted_when_no_agent(self, monkeypatch):
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        mock_logs = MagicMock()
+        mock_logs.is_logging_agent_configured.return_value = False
+        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+
+        msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        mock_logs.get_log_reader.assert_not_called()
+        assert 'already in terminal state' in msg
+
+    def test_falls_through_when_reader_returns_none(self, monkeypatch):
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        fake_reader.read_cluster_job_logs.return_value = None
+        mock_logs = MagicMock()
+        mock_logs.is_logging_agent_configured.return_value = True
+        mock_logs.get_log_reader.return_value = fake_reader
+        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            lambda name, jid: f'sky-managed-{jid}-{name}')
+
+        msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        fake_reader.read_cluster_job_logs.assert_called_once()
+        assert 'already in terminal state' in msg

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1361,9 +1361,12 @@ class TestIsRelayedStatusPayloadLine:
 class TestStreamLogsByIdExternalStoreFallback:
     """stream_logs_by_id falls back to the external log reader for terminal jobs.
 
-    When a logging agent is configured, terminal managed-job logs are streamed
-    back from the external store (the controller no longer persists a local
-    copy). When no logging agent is configured, the reader is not consulted.
+    The read source is decided per task by the presence of a local log file
+    (local_log_file), not by the current logging-agent config: a task with no
+    local copy had its logs forwarded to an external store, so we stream them
+    back via the registered log reader. A registered reader is the only read-
+    side gate -- read-back keeps working even after the logging agent is
+    disconnected.
     """
 
     def _patch_terminal_job(self, monkeypatch, task_info):
@@ -1382,73 +1385,116 @@ class TestStreamLogsByIdExternalStoreFallback:
         monkeypatch.setattr(jobs_utils, 'managed_job_state', mock_state)
         return mock_state
 
-    def test_reads_from_external_store_when_agent_configured(self, monkeypatch):
+    def _patch_logs(self, monkeypatch, reader):
+        mock_logs = MagicMock()
+        mock_logs.get_log_reader.return_value = reader
+        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        return mock_logs
+
+    def test_reads_from_external_store_when_local_file_absent(
+            self, monkeypatch):
+        # local_log_file is None -> logs went to the external store.
         task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
                       None, None)]
         self._patch_terminal_job(monkeypatch, task_info)
 
         fake_reader = MagicMock()
         fake_reader.read_cluster_job_logs.return_value = 0
-        mock_logs = MagicMock()
-        mock_logs.is_logging_agent_configured.return_value = True
-        mock_logs.get_log_reader.return_value = fake_reader
-        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        self._patch_logs(monkeypatch, fake_reader)
         monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
                             lambda name, jid: f'sky-managed-{jid}-{name}')
 
-        msg, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+        _, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
 
         fake_reader.read_cluster_job_logs.assert_called_once_with(
             'sky-managed-5-mytask', None, follow=False, tail=0)
         assert code == exceptions.JobExitCode.from_managed_job_status(
             managed_job_state.ManagedJobStatus.SUCCEEDED)
 
-    def test_reader_not_consulted_when_no_agent(self, monkeypatch):
+    def test_local_file_takes_precedence_over_reader(self, monkeypatch,
+                                                     tmp_path):
+        # A local log file exists -> read it, never consult the reader (even
+        # when one is registered).
+        log_file = tmp_path / 'run.log'
+        log_file.write_text('hello\n', encoding='utf-8')
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      str(log_file), None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        self._patch_logs(monkeypatch, fake_reader)
+
+        _, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        fake_reader.read_cluster_job_logs.assert_not_called()
+        assert code == exceptions.JobExitCode.from_managed_job_status(
+            managed_job_state.ManagedJobStatus.SUCCEEDED)
+
+    def test_no_reader_falls_to_terminal_message(self, monkeypatch):
+        # No external logging integration (no reader registered) and no local
+        # file -> the original terminal-state message, reader never consulted.
         task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
                       None, None)]
         self._patch_terminal_job(monkeypatch, task_info)
-
-        mock_logs = MagicMock()
-        mock_logs.is_logging_agent_configured.return_value = False
-        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        self._patch_logs(monkeypatch, None)
 
         msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
 
-        mock_logs.get_log_reader.assert_not_called()
         assert 'already in terminal state' in msg
 
     def test_falls_through_when_reader_returns_none(self, monkeypatch):
+        # Reader registered but returns None (logs not in the store, e.g. aged
+        # out) -> the external-store fall-through message.
         task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
                       None, None)]
         self._patch_terminal_job(monkeypatch, task_info)
 
         fake_reader = MagicMock()
         fake_reader.read_cluster_job_logs.return_value = None
-        mock_logs = MagicMock()
-        mock_logs.is_logging_agent_configured.return_value = True
-        mock_logs.get_log_reader.return_value = fake_reader
-        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        self._patch_logs(monkeypatch, fake_reader)
         monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
                             lambda name, jid: f'sky-managed-{jid}-{name}')
 
         msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
 
         fake_reader.read_cluster_job_logs.assert_called_once()
-        assert 'already in terminal state' in msg
+        assert 'external log store' in msg
 
-    def test_warns_when_agent_configured_but_no_reader(self, monkeypatch,
-                                                       capsys):
+    def test_reader_exception_is_logged_and_falls_through(self, monkeypatch):
+        # A reader error must not crash sky jobs logs; it falls through to the
+        # external-store message.
         task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
                       None, None)]
         self._patch_terminal_job(monkeypatch, task_info)
 
-        mock_logs = MagicMock()
-        mock_logs.is_logging_agent_configured.return_value = True
-        mock_logs.get_log_reader.return_value = None
-        monkeypatch.setattr(jobs_utils, 'logs', mock_logs)
+        fake_reader = MagicMock()
+        fake_reader.read_cluster_job_logs.side_effect = RuntimeError('boom')
+        self._patch_logs(monkeypatch, fake_reader)
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            lambda name, jid: f'sky-managed-{jid}-{name}')
 
         msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
 
-        # A warning is printed and we fall back to the terminal-state message.
-        assert 'no external log reader is registered' in capsys.readouterr().out
-        assert 'already in terminal state' in msg
+        assert 'external log store' in msg
+
+    def test_none_task_name_does_not_crash(self, monkeypatch):
+        # Guard removed: a null task name that breaks cluster-name derivation is
+        # caught and logged, not raised.
+        task_info = [(0, None, managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        self._patch_logs(monkeypatch, fake_reader)
+
+        def _raise_on_none(name, jid):
+            if not name:
+                raise TypeError('task name is None')
+            return f'sky-managed-{jid}-{name}'
+
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            _raise_on_none)
+
+        # Should not raise.
+        msg, _ = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+        assert 'external log store' in msg


### PR DESCRIPTION
When a logging agent is configured, job logs are forwarded to an external store. Today `sky jobs logs` still relies on the controller pre-downloading each task's log to the API-server disk during the run and reads only that local copy — there is no fallback to the external store, so once the local copy is missing or cleaned the logs are unreachable even though they still exist in the store. This mirrors the `LogReader` fallback that `sky.core.tail_logs` (i.e. `sky logs <cluster> <job>`) already uses for regular clusters into the managed-jobs path.

- Controller: when a logging agent is configured, `download_log_and_stream` returns early instead of pulling logs back to the API server. The external store is the durable copy, so the local copy is redundant.
- `sky jobs logs`: for a terminal job, `stream_logs_by_id` falls back to the registered `LogReader`, streaming from the external store by the task's cluster name, when no local log is present.
- Adds `sky.logs.is_logging_agent_configured()` to gate both sides. When no logging agent is configured, behavior is unchanged (download to controller, read the local file).

## Tested

- [x] Code formatting: `bash format.sh`
- [x] New unit tests: `pytest tests/unit_tests/test_sky/jobs/test_utils.py::TestStreamLogsByIdExternalStoreFallback tests/unit_tests/test_sky/jobs/test_controller.py::TestDownloadLogAndStreamLoggingAgentGate`
- [ ] Manual end-to-end with a logging agent configured (pending)
