### PR TITLE
[k8s] Wait for terminated workers before resize scale-down re-provision

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -159,6 +159,15 @@ _FETCH_IP_MAX_ATTEMPTS = 3
 _TEARDOWN_WAIT_MAX_ATTEMPTS = 10
 _TEARDOWN_WAIT_BETWEEN_ATTEMPS_SECONDS = 1
 
+# During a resize scale-down we terminate the worker instances and then
+# re-provision to the target count. terminate_instances() can return before
+# the terminated instances have fully disappeared from the provider's view
+# (e.g. on Kubernetes a force-deleted pod lingers in the Running phase until
+# the kubelet finalizes it), so we poll until only the head remains before
+# re-provisioning. How many times to poll, and how long to wait between polls.
+_RESIZE_SCALE_DOWN_WAIT_MAX_ATTEMPTS = 60
+_RESIZE_SCALE_DOWN_WAIT_BETWEEN_ATTEMPTS_SECONDS = 1
+
 _TEARDOWN_FAILURE_MESSAGE = (
     f'\n{colorama.Fore.RED}Failed to terminate '
     '{cluster_name}. {extra_reason}'
@@ -6058,6 +6067,49 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                           handle.cluster_name_on_cloud,
                                           provider_config,
                                           worker_only=True)
+
+        # terminate_instances() may return before the workers have actually
+        # disappeared from the provider's view. On Kubernetes, for example,
+        # pods are force-deleted asynchronously and linger in the Running
+        # phase until the kubelet finalizes them. The bulk_provision that
+        # follows counts the instances still present to decide how many
+        # workers to (re)create, and aborts if it sees more instances than
+        # requested -- mistaking the not-yet-removed workers for a resource
+        # leak. Wait until only the head node remains so the recount is
+        # accurate. This is a no-op for clouds whose terminate is already
+        # synchronous (the first query returns immediately).
+        for attempt in range(_RESIZE_SCALE_DOWN_WAIT_MAX_ATTEMPTS):
+            remaining = provision_lib.query_instances(
+                cloud_name,
+                handle.cluster_name,
+                handle.cluster_name_on_cloud,
+                provider_config,
+                non_terminated_only=True)
+            if len(remaining) <= 1:
+                # Only the head node remains; the workers are gone.
+                break
+            logger.debug(
+                f'Waiting for {len(remaining) - 1} terminated worker(s) of '
+                f'cluster {cluster_name!r} to be removed before '
+                f're-provisioning (attempt '
+                f'{attempt + 1}/{_RESIZE_SCALE_DOWN_WAIT_MAX_ATTEMPTS}).')
+            time.sleep(_RESIZE_SCALE_DOWN_WAIT_BETWEEN_ATTEMPTS_SECONDS)
+        else:
+            # The workers were terminated but have not disappeared from the
+            # provider within the timeout (e.g. pods stuck terminating). We
+            # already tore the workers down, so the cluster cannot stay at its
+            # original size; rather than let bulk_provision misread the stale
+            # instances as a resource leak, fail with an actionable message.
+            timeout_seconds = (_RESIZE_SCALE_DOWN_WAIT_MAX_ATTEMPTS *
+                               _RESIZE_SCALE_DOWN_WAIT_BETWEEN_ATTEMPTS_SECONDS)
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(
+                    f'Timed out after {timeout_seconds}s waiting for the '
+                    f'terminated worker(s) of cluster {cluster_name!r} to be '
+                    f'removed during scale-down. The cluster may now have '
+                    f'fewer nodes than before; run "sky down {cluster_name}" '
+                    f'and relaunch at the desired size, or retry the resize '
+                    f'once the cluster settles.')
 
     @timeline.event
     def _check_existing_cluster(

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -273,10 +273,11 @@ def test_resize_scale_down_ssh_failure_aborts():
         backend._handle_resize_pre_provision(handle, task, 'test-cluster')
 
 
+@mock.patch('sky.provision.query_instances', return_value={})
 @mock.patch('sky.provision.terminate_instances')
 @mock.patch('sky.global_user_state.get_cluster_yaml_dict')
 def test_resize_scale_down_on_stopped_cluster_skips_ssh_and_terminates(
-        mock_get_yaml, mock_terminate):
+        mock_get_yaml, mock_terminate, mock_query):
     """Scale-down on a STOPPED cluster must skip the SSH job-queue check (a
     stopped cluster has no running jobs and its head node is unreachable) and
     proceed to terminate the excess workers; bulk provisioning later restarts
@@ -323,12 +324,14 @@ def test_resize_scale_down_on_init_cluster_rejected():
             cluster_status=status_lib.ClusterStatus.INIT)
 
 
+@mock.patch('sky.provision.query_instances', return_value={})
 @mock.patch('sky.provision.terminate_instances')
 @mock.patch('sky.global_user_state.get_cluster_yaml_dict')
 @mock.patch('sky.skylet.job_lib.load_job_queue')
 def test_resize_scale_down_handles_missing_cluster_yaml(mock_load_queue,
                                                         mock_get_yaml,
-                                                        mock_terminate):
+                                                        mock_terminate,
+                                                        mock_query):
     """If get_cluster_yaml_dict returns None (e.g. yaml file missing), the
     resize path must not crash with AttributeError."""
     backend = CloudVmRayBackend()
@@ -353,11 +356,12 @@ def test_resize_scale_down_handles_missing_cluster_yaml(mock_load_queue,
 # --- Scale-down: success cases (the happy path) ---
 
 
+@mock.patch('sky.provision.query_instances', return_value={})
 @mock.patch('sky.provision.terminate_instances')
 @mock.patch('sky.global_user_state.get_cluster_yaml_dict')
 @mock.patch('sky.skylet.job_lib.load_job_queue')
 def test_resize_scale_down_idle_cluster_terminates_workers(
-        mock_load_queue, mock_get_yaml, mock_terminate):
+        mock_load_queue, mock_get_yaml, mock_terminate, mock_query):
     """Scale-down on an idle cluster should terminate excess workers."""
     backend = CloudVmRayBackend()
     handle = _make_mock_handle(launched_nodes=4)
@@ -378,12 +382,13 @@ def test_resize_scale_down_idle_cluster_terminates_workers(
     )
 
 
+@mock.patch('sky.provision.query_instances', return_value={})
 @mock.patch('sky.provision.terminate_instances')
 @mock.patch('sky.global_user_state.get_cluster_yaml_dict')
 @mock.patch('sky.skylet.job_lib.load_job_queue')
 def test_resize_scale_down_completed_jobs_allowed(mock_load_queue,
-                                                  mock_get_yaml,
-                                                  mock_terminate):
+                                                  mock_get_yaml, mock_terminate,
+                                                  mock_query):
     """Completed/failed jobs should not block scale-down."""
     backend = CloudVmRayBackend()
     handle = _make_mock_handle(launched_nodes=3)
@@ -411,11 +416,12 @@ def test_resize_scale_down_completed_jobs_allowed(mock_load_queue,
     mock_terminate.assert_called_once()
 
 
+@mock.patch('sky.provision.query_instances', return_value={})
 @mock.patch('sky.provision.terminate_instances')
 @mock.patch('sky.global_user_state.get_cluster_yaml_dict')
 @mock.patch('sky.skylet.job_lib.load_job_queue')
 def test_resize_scale_down_to_one_node(mock_load_queue, mock_get_yaml,
-                                       mock_terminate):
+                                       mock_terminate, mock_query):
     """Scale-down to 1 node (head-only) should work."""
     backend = CloudVmRayBackend()
     handle = _make_mock_handle(launched_nodes=3)
@@ -426,6 +432,88 @@ def test_resize_scale_down_to_one_node(mock_load_queue, mock_get_yaml,
     mock_get_yaml.return_value = {'provider': {'type': 'kubernetes'}}
 
     backend._handle_resize_pre_provision(handle, task, 'test-cluster')
+    mock_terminate.assert_called_once()
+
+
+@mock.patch('sky.provision.terminate_instances')
+@mock.patch('sky.global_user_state.get_cluster_yaml_dict')
+@mock.patch('sky.skylet.job_lib.load_job_queue')
+@mock.patch('sky.provision.query_instances')
+def test_resize_scale_down_waits_for_terminated_workers(mock_query,
+                                                        mock_load_queue,
+                                                        mock_get_yaml,
+                                                        mock_terminate):
+    """After terminating the workers, the resize path must poll the provider
+    and only return once the workers are actually gone (only the head
+    remains). Otherwise the subsequent bulk_provision can miscount
+    not-yet-removed instances as a resource leak and abort the scale-down."""
+    backend = CloudVmRayBackend()
+    handle = _make_mock_handle(launched_nodes=3)
+    task = _make_mock_task(num_nodes=2)
+
+    backend.run_on_head = mock.MagicMock(return_value=(0, 'payload', ''))
+    mock_load_queue.return_value = []
+    mock_get_yaml.return_value = {'provider': {'type': 'kubernetes'}}
+
+    up = status_lib.ClusterStatus.UP
+    # First two polls still see terminating workers (3 then 2 instances); the
+    # third sees only the head. The loop must keep polling until then.
+    mock_query.side_effect = [
+        {
+            'head': (up, None),
+            'w1': (up, None),
+            'w2': (up, None)
+        },
+        {
+            'head': (up, None),
+            'w1': (up, None)
+        },
+        {
+            'head': (up, None)
+        },
+    ]
+
+    with mock.patch('sky.backends.cloud_vm_ray_backend.time.sleep') as m_sleep:
+        backend._handle_resize_pre_provision(handle, task, 'test-cluster')
+
+    mock_terminate.assert_called_once()
+    # Polled until only the head remained.
+    assert mock_query.call_count == 3
+    # Waited between the two polls that still saw workers.
+    assert m_sleep.call_count == 2
+    # query_instances must run only after the workers were terminated.
+    assert mock_query.call_args.kwargs['non_terminated_only'] is True
+
+
+@mock.patch('sky.provision.terminate_instances')
+@mock.patch('sky.global_user_state.get_cluster_yaml_dict')
+@mock.patch('sky.skylet.job_lib.load_job_queue')
+@mock.patch('sky.provision.query_instances')
+def test_resize_scale_down_raises_if_workers_never_terminate(
+        mock_query, mock_load_queue, mock_get_yaml, mock_terminate):
+    """If the terminated workers never disappear (e.g. pods stuck
+    terminating), the resize must fail with a clear error instead of letting
+    bulk_provision misread the stale instances as a resource leak."""
+    backend = CloudVmRayBackend()
+    handle = _make_mock_handle(launched_nodes=3)
+    task = _make_mock_task(num_nodes=2)
+
+    backend.run_on_head = mock.MagicMock(return_value=(0, 'payload', ''))
+    mock_load_queue.return_value = []
+    mock_get_yaml.return_value = {'provider': {'type': 'kubernetes'}}
+
+    up = status_lib.ClusterStatus.UP
+    # Workers never go away: every poll still reports more than the head.
+    mock_query.return_value = {
+        'head': (up, None),
+        'w1': (up, None),
+        'w2': (up, None)
+    }
+
+    with mock.patch('sky.backends.cloud_vm_ray_backend.time.sleep'):
+        with pytest.raises(RuntimeError, match=r'Timed out.*scale-down'):
+            backend._handle_resize_pre_provision(handle, task, 'test-cluster')
+
     mock_terminate.assert_called_once()
 
 


### PR DESCRIPTION
## Why

Cluster resize scale-down terminates the worker nodes and then re-provisions to the target count via `bulk_provision`. On Kubernetes this can fail intermittently with a spurious resource-leak error, surfaced as `StopFailoverError` and aborting the resize:

```
RuntimeError: The number of running+pending pods (3) in cluster "<name>" is
greater than the number requested by the user (2). This is likely a resource
leak. Use "sky down" to terminate the cluster.
```

**Root cause.** `_handle_resize_pre_provision` calls `provision.terminate_instances(..., worker_only=True)`, which on Kubernetes force-deletes the worker pods (`grace_period_seconds=0`) and returns **before** those pods leave the `Pending/Running` phase set. The `bulk_provision` that immediately follows counts the instances still present (`run_instances`) and treats "more instances than requested" as a resource leak. If the just-deleted workers are still finalizing, the recount is wrong and the scale-down fails.

It's timing-sensitive: it passes when the pods finalize before the recount and fails when they don't, so the same scale-down can be green on one run and red on another.

## What

- After `terminate_instances(worker_only=True)`, poll `provision.query_instances(non_terminated_only=True)` until only the head node remains, then let `bulk_provision` recount. This uses the same "instance present" view the leak check relies on, so the recount is always accurate.
- No-op for clouds whose terminate is already synchronous (the first query returns immediately and the loop exits).
- If the terminated workers never disappear within the timeout (e.g. pods stuck terminating), raise a clear, actionable error (relaunch / retry) instead of the confusing resource-leak message.

## Test

- `tests/unit_tests/test_core.py`:
  - `test_resize_scale_down_waits_for_terminated_workers` — asserts the path polls until only the head remains before returning.
  - `test_resize_scale_down_raises_if_workers_never_terminate` — asserts a clear error on timeout.
  - Updated the existing scale-down tests that now reach the poll.
- All resize unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)