### PR TITLE
[Buildkite] Allow running a single exclusive smoke test by name on an isolated lane

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -315,14 +315,23 @@ def _extract_marked_tests(
         if param:
             function_name_param_map[clean_function_name].append(param)
 
+    # A run shares one API server across all its tests only when it targets a
+    # remote/env-file server; the local lane starts a fresh server per test
+    # step, so exclusivity doesn't apply there.
+    shared_server = remote_server or '--env-file' in extra_args
+
     function_cloud_map = {}
     for function_name, marks in function_name_marks_map.items():
-        # Partition exclusive vs normal tests. Exclusive-marked tests run only
-        # in an --exclusive run (serialized) and are excluded from normal
-        # parallel runs; non-exclusive tests are excluded from --exclusive runs.
-        # The two never share a pipeline, so server-mutating tests never run
-        # alongside others.
-        if ('exclusive' in marks) != exclusive_run:
+        # Partition exclusive vs normal tests. In an --exclusive run, only
+        # exclusive tests are selected (and serialized). Otherwise, exclusive
+        # tests are excluded only when the run shares one server across
+        # tests; on the local lane (its own server per test) they behave like
+        # any other test.
+        is_exclusive = 'exclusive' in marks
+        if exclusive_run:
+            if not is_exclusive:
+                continue
+        elif is_exclusive and shared_server:
             continue
         clouds_to_include = []
         run_on_cloud_kube_backend = ('resource_heavy' in marks and

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -315,18 +315,19 @@ def _extract_marked_tests(
         if param:
             function_name_param_map[clean_function_name].append(param)
 
-    # A run shares one API server across all its tests only when it targets a
-    # remote/env-file server; the local lane starts a fresh server per test
-    # step, so exclusivity doesn't apply there.
-    shared_server = remote_server or '--env-file' in extra_args
+    # Exclusivity only matters when tests share one API server. Only the
+    # --env-file lane does that -- it points every test at a single external
+    # endpoint. --remote-server launches a fresh Docker-container server per
+    # test, and the local lane restarts a fresh server per test step; both
+    # isolate each test, so exclusive tests need no serializing there.
+    shared_server = '--env-file' in extra_args
 
     function_cloud_map = {}
     for function_name, marks in function_name_marks_map.items():
         # Partition exclusive vs normal tests. In an --exclusive run, only
         # exclusive tests are selected (and serialized). Otherwise, exclusive
-        # tests are excluded only when the run shares one server across
-        # tests; on the local lane (its own server per test) they behave like
-        # any other test.
+        # tests are excluded only on a shared-server run; when each test gets
+        # its own server they behave like any other test.
         is_exclusive = 'exclusive' in marks
         if exclusive_run:
             if not is_exclusive:

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -315,24 +315,24 @@ def _extract_marked_tests(
         if param:
             function_name_param_map[clean_function_name].append(param)
 
-    # Exclusivity only matters when tests share one API server. Only the
-    # --env-file lane does that -- it points every test at a single external
-    # endpoint. --remote-server launches a fresh Docker-container server per
-    # test, and the local lane restarts a fresh server per test step; both
-    # isolate each test, so exclusive tests need no serializing there.
+    # A run shares one API server across its tests only on the --env-file lane
+    # (one external endpoint); --remote-server gives each test its own Docker
+    # container and the local lane its own restarted server.
     shared_server = '--env-file' in extra_args
 
     function_cloud_map = {}
     for function_name, marks in function_name_marks_map.items():
         # Partition exclusive vs normal tests. In an --exclusive run, only
-        # exclusive tests are selected (and serialized). Otherwise, exclusive
-        # tests are excluded only on a shared-server run; when each test gets
-        # its own server they behave like any other test.
+        # exclusive (server-mutating) tests are selected (and serialized).
+        # Otherwise exclusive tests are excluded, so a bare run never pulls
+        # them in -- except when one is named explicitly with -k on an
+        # isolated lane (not the shared --env-file server), which lets a single
+        # exclusive test be run individually without an --exclusive pipeline.
         is_exclusive = 'exclusive' in marks
         if exclusive_run:
             if not is_exclusive:
                 continue
-        elif is_exclusive and shared_server:
+        elif is_exclusive and (shared_server or k_value is None):
             continue
         clouds_to_include = []
         run_on_cloud_kube_backend = ('resource_heavy' in marks and


### PR DESCRIPTION
## Summary

`exclusive`-marked tests (server-mutating) are excluded from normal pipeline runs and only run under `--exclusive` (serialized), because they can't safely share an API server with other tests running concurrently. That is the right default and this PR keeps it: **a bare run still excludes exclusive tests on every lane.**

The gap this closes: you currently cannot run *one* exclusive test on its own without spinning up a full `--exclusive` pipeline. `-k test_x` without `--exclusive` filters the test out (0 tests collected → pipeline generation fails), and `--exclusive` pulls in *every* exclusive test rather than the one named.

This adds a single, narrow exception: when an exclusive test is selected **by name with `-k`** on an **isolated lane** (not the shared `--env-file` server), it is included so it can be run individually. Isolated lanes give each test its own server, so there's nothing to serialize against:
- `--remote-server` launches a fresh Docker-container API server per test.
- the local lane restarts a fresh API server per test step (`SKY_API_RESTART`).

The shared lane is `--env-file` (every test points at one external endpoint, hence its concurrency limit); exclusive tests stay excluded there in normal runs and serialized under `--exclusive` (unchanged — the `concurrency_group` keying from #9949 is untouched).

## Behavior matrix

| run | `-k` a specific exclusive test? | exclusive test |
| --- | --- | --- |
| `--exclusive` | — | runs, serialized (unchanged) |
| normal, `--env-file` | either | excluded (unchanged) |
| normal, isolated lane, no `-k` | no | excluded (unchanged — bare runs never pull them in) |
| normal, isolated lane | yes, by name | **included** (new) |

## Test plan
- [x] `python3 -m py_compile .buildkite/generate_pipeline.py` — passes.
- [x] Traced the partition across all lanes (see matrix); a bare run's collected set is unchanged.
- [ ] CI pipeline generation on this PR.