### PR TITLE
[Jobs] Start consolidation-mode controllers only from the leader daemon

### DIFF
--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -235,21 +235,46 @@ def maybe_start_controllers(from_scheduler: bool = False) -> None:
     Will also add the job_id, dag_yaml_path, and env_file_path to the
     controllers list of processes.
     """
-    # In consolidation mode, during rolling update, two API servers may be
-    # running. If we are on the new API server, and we haven't finished the
-    # recovery process, we should avoid starting new controllers. The old API
-    # server/consolidated jobs controller could run update_managed_jobs_statuses
-    # and if there are jobs running on the new API server, the old one will not
-    # see the corresponding processes and may mark them as FAILED_CONTROLLER.
-    if from_scheduler and managed_job_utils.is_consolidation_mode(
-    ) and os.path.exists(
-            os.path.expanduser(
-                constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE)):
-        # This could happen during an API server rolling update, or during
-        # normal running while managed-job-status-refresh-daemon is running. In
-        # either case, the controllers should be already started or will be
-        # started by the recovery process.
-        logger.info('Recovery is still in progress, skipping controller start.')
+    if from_scheduler and managed_job_utils.is_consolidation_mode():
+        # In consolidation mode the controller pool is owned exclusively by the
+        # leader-elected managed-job refresh daemon (see
+        # sky/jobs/managed_job_refresh_thread.py). Never start controllers from
+        # a request: the request path runs on whichever replica handled the
+        # request, whose controller PIDs the leader cannot see (its liveness
+        # check is a local psutil lookup), and controller startup would inherit
+        # per-request state into a long-lived process tree.
+        #
+        # This is safe for launch latency: submit_jobs has already moved the job
+        # to WAITING, and a controller from the leader's warm pool claims it
+        # within ~10s (controller.py::monitor_loop). The pool itself is started
+        # by ha_recovery_for_consolidation_mode at leader election.
+        #
+        # Caveat: a controller that dies mid-life is now only replaced on the
+        # daemon's ManagedJobEvent tick (~300s), where previously the next
+        # in-request start would have replaced it immediately. This only delays
+        # a job when the pool is fully drained -- with a typical pool size the
+        # surviving controllers keep claiming WAITING jobs on their ~10s poll.
+        #
+        # NOTE: `from_scheduler` is only ever True from submit_jobs(), which is
+        # only reached from this module's __main__, which is only spawned by
+        # sky/templates/jobs-controller.yaml.j2. In particular it is never
+        # reached from the controller process itself -- where
+        # is_consolidation_mode() returns True unconditionally because
+        # start_controller() exports OVERRIDE_CONSOLIDATION_MODE. See
+        # tests/unit_tests/test_sky/jobs/test_consolidation_mode_gate.py.
+        #
+        # Corollary: in the transitional misconfiguration where
+        # jobs.controller.consolidation_mode is flipped to true but the API
+        # server has not been restarted (already warned about, see
+        # controller_utils.is_jobs_consolidation_mode), a jobs-controller VM may
+        # read itself as consolidated and skip the in-request start. Jobs still
+        # run -- the VM's skylet ManagedJobEvent tops the pool up -- just with
+        # that event's cadence of added latency.
+        #
+        # Logged at info (not debug) so that a misdetection is greppable in
+        # ~/sky_logs/managed_jobs/submit-job-*.log rather than a silent stall.
+        logger.info('Consolidation mode: controller startup is owned by the '
+                    'managed-job refresh daemon; skipping in-request start.')
         return
     try:
         with filelock.FileLock(JOB_CONTROLLER_PID_LOCK, blocking=False):

--- a/tests/unit_tests/test_sky/jobs/test_consolidation_mode_detection.py
+++ b/tests/unit_tests/test_sky/jobs/test_consolidation_mode_detection.py
@@ -1,0 +1,208 @@
+"""Unit tests for consolidation mode detection and invariants.
+
+Pins the detector behavior and critical invariants that make the
+consolidation mode controller startup gate (CHANGE 1) safe.
+"""
+import ast
+import pathlib
+from unittest import mock
+
+import pytest
+
+from sky.jobs import utils as managed_job_utils
+import sky.jobs.controller as _jobs_controller_module
+from sky.skylet import constants
+from sky.utils import controller_utils
+
+
+def _collect_identifiers(tree: ast.AST) -> set:
+    """Collect every identifier referenced in an AST, by name or attribute.
+
+    This must look at BOTH ast.Name.id (bare names, e.g. `foo`) AND
+    ast.Attribute.attr (attribute accesses, e.g. the `bar` in `foo.bar`).
+    Call sites in this codebase use the `module.function(...)` shape (e.g.
+    `scheduler.maybe_start_controllers()`), where the function name only
+    shows up as an Attribute.attr, never as a Name.id. A collector that only
+    looks at Name.id can never detect such calls.
+    """
+    identifiers = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            identifiers.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            identifiers.add(node.attr)
+    return identifiers
+
+
+@pytest.fixture
+def _clear_consolidation_caches():  # pylint: disable=invalid-name
+    """Clear consolidation mode detection caches before/after tests."""
+    # Clear before test
+    if hasattr(managed_job_utils.is_consolidation_mode, 'cache_clear'):
+        managed_job_utils.is_consolidation_mode.cache_clear()
+    # pylint: disable=protected-access
+    if hasattr(controller_utils._effective_jobs_consolidation_with_warnings,
+               'cache_clear'):
+        controller_utils._effective_jobs_consolidation_with_warnings.cache_clear(
+        )
+
+    yield
+
+    # Clear after test
+    if hasattr(managed_job_utils.is_consolidation_mode, 'cache_clear'):
+        managed_job_utils.is_consolidation_mode.cache_clear()
+    # pylint: disable=protected-access
+    if hasattr(controller_utils._effective_jobs_consolidation_with_warnings,
+               'cache_clear'):
+        controller_utils._effective_jobs_consolidation_with_warnings.cache_clear(
+        )
+
+
+class TestConsolidationModeDetector:
+    """Tests for consolidation mode detection."""
+
+    @pytest.mark.parametrize(
+        'override_set,signal_present,expected',
+        [
+            (False, False,
+             False),  # controller-VM scheduler subprocess, non-consolidation
+            (False, True,
+             True),  # API-server scheduler subprocess, consolidation
+            (True, False,
+             True),  # remote controller process (OVERRIDE forces True)
+            (True, True, True),  # all env vars set
+        ])
+    def test_detector_matrix(self, override_set: bool, signal_present: bool,
+                             expected: bool, tmp_path, monkeypatch,
+                             _clear_consolidation_caches):  # pylint: disable=invalid-name
+        """Test consolidation mode detection across all configurations."""
+        # Set up environment
+        if override_set:
+            monkeypatch.setenv(constants.OVERRIDE_CONSOLIDATION_MODE, 'true')
+        else:
+            monkeypatch.delenv(constants.OVERRIDE_CONSOLIDATION_MODE,
+                               raising=False)
+
+        # Set up signal file
+        signal_file = tmp_path / '.jobs_controller_consolidation_reloaded_signal'
+        if signal_present:
+            signal_file.touch()
+        monkeypatch.setenv('HOME', str(tmp_path))
+
+        # Also ensure IS_SKYPILOT_SERVER is not set for this test
+        monkeypatch.delenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, raising=False)
+
+        # Patch the constant to point to our temp signal file
+        monkeypatch.setattr(
+            'sky.jobs.constants.JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE',
+            str(signal_file))
+
+        # Test the detector
+        result = managed_job_utils.is_consolidation_mode()
+        assert result == expected, (
+            f'override_set={override_set}, signal_present={signal_present}, '
+            f'expected={expected}, got={result}')
+
+    def test_override_consolidation_mode_not_in_controller_envs(
+            self, _clear_consolidation_caches):  # pylint: disable=invalid-name
+        """OVERRIDE_CONSOLIDATION_MODE must NOT be in controller_envs.
+
+        If this var entered controller_envs, jobs-controller VM startup would
+        see is_consolidation_mode()==True and gate would break all startup.
+
+        NOTE: controller_only_vars_to_fill() returns an outer dict (with keys
+        like 'sky_activate_python_env', 'controller_envs', etc). The env vars
+        that actually get exported to the controller process live in the
+        NESTED `controller_envs` dict, so the assertion must target that, not
+        the outer dict (see sky/utils/controller_utils.py:679).
+        """
+        with mock.patch.object(
+            controller_utils,
+            '_get_cloud_dependencies_installation_commands',
+            return_value=''), \
+            mock.patch.object(
+                controller_utils.plugin_utils,
+                'get_plugin_mounts_and_commands',
+                return_value=(None, None)):
+            result = controller_utils.controller_only_vars_to_fill(
+                controller_utils.Controllers.JOBS_CONTROLLER)
+
+        controller_envs = result['controller_envs']
+        assert controller_envs, 'controller_envs must not be empty'
+        # Positive control: confirms we are looking at the right dict (this
+        # key is set unconditionally in controller_only_vars_to_fill's
+        # env_vars.update({...})), which is what makes the negative
+        # assertion below meaningful rather than vacuous.
+        assert constants.IS_SKYPILOT_SERVE_CONTROLLER in controller_envs, (
+            f'{constants.IS_SKYPILOT_SERVE_CONTROLLER} should be a key of '
+            'controller_envs; if not, this test is asserting against the '
+            'wrong dict')
+
+        # The override should NOT be in the nested controller_envs dict.
+        assert constants.OVERRIDE_CONSOLIDATION_MODE not in controller_envs, (
+            f'{constants.OVERRIDE_CONSOLIDATION_MODE} must not be in '
+            'controller_envs to avoid breaking the jobs-controller VM path')
+
+    def test_controller_module_never_reaches_from_scheduler_path(self):
+        """Tripwire: controller.py has no DIRECT reference to
+        maybe_start_controllers or submit_jobs.
+
+        This proves only that -- a direct reference is absent from
+        controller.py's source -- not that the from_scheduler=True path is
+        unreachable from the controller process by some indirect route.
+        controller.py does import managed_job_utils, and managed_job_utils
+        itself calls scheduler.maybe_start_controllers(), but always with
+        from_scheduler=False (see ha_recovery_for_consolidation_mode and
+        similar), so that indirect path is fine.
+
+        The invariant this is guarding: is_consolidation_mode() returns True
+        unconditionally inside the controller process (start_controller()
+        exports OVERRIDE_CONSOLIDATION_MODE there), so if controller.py ever
+        gained a direct call to maybe_start_controllers or submit_jobs, the
+        from_scheduler=True gate in maybe_start_controllers() -- meant only
+        to protect the in-request submission path (submit_jobs() ->
+        maybe_start_controllers(from_scheduler=True)), reached from this
+        module's __main__ as spawned by
+        sky/templates/jobs-controller.yaml.j2, never from the controller
+        process itself -- would become reachable from a context where
+        is_consolidation_mode() is forced True, defeating the gate
+        documented in test_consolidation_mode_gate.py. This test is a cheap
+        tripwire for that direct-call case, not a proof that the indirect
+        route is safe; that's established by reading managed_job_utils
+        (and pinned by test_daemon_event_path_starts_controller_uncgated in
+        test_consolidation_mode_gate.py, which asserts the daemon path
+        calls with from_scheduler falsy).
+        """
+        # Self-check: prove the detector actually finds the call shape used
+        # in this codebase (`module.function(...)`, an Attribute access, not
+        # a bare Name) before trusting it against the real file. This makes
+        # it impossible for a future refactor of _collect_identifiers to
+        # silently re-vacuum this test.
+        probe = ast.parse('scheduler.maybe_start_controllers()')
+        assert 'maybe_start_controllers' in _collect_identifiers(probe), (
+            '_collect_identifiers must detect attribute-style calls like '
+            'scheduler.maybe_start_controllers(); if this fails the '
+            'reachability check below is vacuous')
+
+        # Resolve the path from the imported module rather than hardcoding
+        # an absolute path, so this works in CI (and anywhere else the repo
+        # is checked out) and not just on one machine.
+        controller_path = pathlib.Path(_jobs_controller_module.__file__)
+        source_code = controller_path.read_text(encoding='utf-8')
+
+        try:
+            tree = ast.parse(source_code)
+        except SyntaxError as e:
+            pytest.skip(f'Could not parse controller.py: {e}')
+
+        identifiers = _collect_identifiers(tree)
+
+        # These two functions must not appear anywhere in controller.py,
+        # whether as bare names or as `module.function` attribute accesses.
+        forbidden = {'maybe_start_controllers', 'submit_jobs'}
+        found = forbidden & identifiers
+
+        assert not found, (
+            f'controller.py must not reference {found}. These are in-request '
+            'submission paths that would split-brain the pool in consolidation mode'
+        )

--- a/tests/unit_tests/test_sky/jobs/test_consolidation_mode_gate.py
+++ b/tests/unit_tests/test_sky/jobs/test_consolidation_mode_gate.py
@@ -1,0 +1,247 @@
+"""Unit tests for consolidation mode controller startup gate.
+
+Tests the mechanism that prevents in-request controller startup in consolidation
+mode (sky/jobs/scheduler.py::maybe_start_controllers with from_scheduler=True).
+The gate is critical: it ensures only the leader-elected refresh daemon owns
+the controller pool, preventing split-brain during rolling updates and safely
+delegating pool maintenance to a single source.
+"""
+from unittest import mock
+
+import pytest
+
+from sky.jobs import scheduler
+from sky.jobs import utils as managed_job_utils
+from sky.skylet import constants as skylet_constants
+from sky.skylet import events
+from sky.utils import controller_utils
+
+
+@pytest.fixture
+def _gate_env(tmp_path):
+    """Helper fixture for hermetic consolidation-mode test environment.
+
+    Returns a context manager (use in a 'with' statement) that patches all the
+    necessary mocks for testing maybe_start_controllers in both consolidation
+    and non-consolidation modes.
+    """
+
+    class _GateEnv:  # pylint: disable=missing-class-docstring
+
+        def __init__(self, consolidation: bool):
+            self.consolidation = consolidation
+            self.tmp_path = tmp_path
+            self._patchers: list = []
+
+        def _start(self, *args, **kwargs):
+            """Start a mock.patch.object(...) and track it for teardown."""
+            patcher = mock.patch.object(*args, **kwargs)
+            # Append before start() so a failed start still lets any prior
+            # patchers get stopped by __exit__.
+            self._patchers.append(patcher)
+            return patcher.start()
+
+        def __enter__(self):
+            # Patch start_controller to prevent real spawning
+            self.start_controller_mock = self._start(scheduler,
+                                                     'start_controller')
+
+            # Patch get_alive_controllers to return 0 (deterministic)
+            self.get_alive_mock = self._start(scheduler,
+                                              'get_alive_controllers',
+                                              return_value=0)
+
+            # Patch controller_utils.get_number_of_jobs_controllers to return 1
+            self.get_number_mock = self._start(controller_utils,
+                                               'get_number_of_jobs_controllers',
+                                               return_value=1)
+
+            # Redirect PID lock and path to tmp_path
+            lock_path = self.tmp_path / 'controller.lock'
+            pid_path = self.tmp_path / 'controller.pid'
+            self.lock_patch = self._start(scheduler, 'JOB_CONTROLLER_PID_LOCK',
+                                          str(lock_path))
+            self.pid_patch = self._start(scheduler, 'JOB_CONTROLLER_PID_PATH',
+                                         str(pid_path))
+
+            # Patch consolidation mode
+            self.consolidation_patch = self._start(
+                managed_job_utils,
+                'is_consolidation_mode',
+                return_value=self.consolidation)
+
+            # The recovery signal file must always be absent so that tests
+            # exercising the gate never depend on real `~/.sky` state: the
+            # gate is `from_scheduler AND is_consolidation_mode()` and must
+            # not lean on this file at all (see
+            # test_gate_holds_without_recovery_signal_file). Point the
+            # constant at a path inside a directory we deliberately do NOT
+            # create, so os.path.exists() is guaranteed False unless a test
+            # opts in via self.signal_file_path.
+            signal_dir = self.tmp_path / 'nosignal'
+            self.signal_file_path = signal_dir / 'signal'
+            # sky/jobs/scheduler.py does `from sky.skylet import constants`,
+            # so the attribute must be patched on the `sky.skylet.constants`
+            # module object for the patch to be visible there.
+            self.signal_file_patch = self._start(
+                skylet_constants, 'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                str(self.signal_file_path))
+
+            # For non-consolidation mode, we need to patch the wheel hash logic
+            if not self.consolidation:
+                current_hash = self.tmp_path / 'current_sky_wheel_hash'
+                current_hash.write_text('hash123')
+                self.hash_patch = self._start(scheduler, 'CURRENT_HASH',
+                                              str(current_hash))
+                self.api_stop_mock = self._start(scheduler.sdk, 'api_stop')
+                self.reset_jobs_mock = self._start(scheduler.state,
+                                                   'reset_jobs_for_recovery')
+
+            return self
+
+        def __exit__(self, *args):
+            # Stop in reverse order, and keep going even if one raises so a
+            # single bad patcher can't leak the rest into later tests.
+            errors = []
+            for patcher in reversed(self._patchers):
+                try:
+                    patcher.stop()
+                except Exception as e:  # pylint: disable=broad-except
+                    errors.append(e)
+            if errors:
+                raise errors[0]
+
+    return _GateEnv
+
+
+class TestConsolidationModeGate:
+    """Tests for the consolidation mode controller startup gate."""
+
+    def test_consolidation_from_scheduler_does_not_start_controller(
+            self, _gate_env):  # pylint: disable=invalid-name
+        """In consolidation mode with from_scheduler=True, skip startup."""
+        with _gate_env(consolidation=True) as env:
+            scheduler.maybe_start_controllers(from_scheduler=True)
+
+            # Verify start_controller was NOT called
+            env.start_controller_mock.assert_not_called()
+            # Verify we never checked pool sizing
+            env.get_alive_mock.assert_not_called()
+            env.get_number_mock.assert_not_called()
+
+    def test_non_consolidation_from_scheduler_starts_controller(
+            self, _gate_env):  # pylint: disable=invalid-name
+        """Non-consolidation mode with from_scheduler=True starts controller.
+
+        This guards the jobs-controller-VM path where startup is not delegated.
+        """
+        with _gate_env(consolidation=False) as env:
+            scheduler.maybe_start_controllers(from_scheduler=True)
+
+            # Verify start_controller WAS called
+            env.start_controller_mock.assert_called_once()
+
+    def test_consolidation_daemon_path_starts_controller(self, _gate_env):  # pylint: disable=invalid-name
+        """With from_scheduler=False, must start controller in consolidation mode.
+
+        CRITICAL: The gate checks from_scheduler, not just consolidation mode.
+        """
+        with _gate_env(consolidation=True) as env:
+            scheduler.maybe_start_controllers(from_scheduler=False)
+
+            # Verify start_controller WAS called (daemon path must work)
+            env.start_controller_mock.assert_called_once()
+
+    def test_gate_holds_without_recovery_signal_file(self, _gate_env):  # pylint: disable=invalid-name
+        """Gate checks consolidation_mode(), not signal file.
+
+        The `_gate_env` fixture always points
+        PERSISTENT_RUN_RESTARTING_SIGNAL_FILE at a path that does not exist
+        (see fixture docstring/comments), so simply relying on it here proves
+        the gate does not lean on the signal file: the old gate was
+        `from_scheduler AND is_consolidation_mode() AND
+        os.path.exists(signal_file)`, which would have let this call fall
+        through to start_controller() once the file is absent. The new gate
+        must still short-circuit.
+        """
+        with _gate_env(consolidation=True) as env:
+            scheduler.maybe_start_controllers(from_scheduler=True)
+
+            # Must not start controller even though signal file doesn't exist
+            env.start_controller_mock.assert_not_called()
+
+    def test_gate_short_circuits_before_pool_sizing(self, _gate_env):  # pylint: disable=invalid-name
+        """Gate short-circuits before calling pool-sizing functions."""
+        with _gate_env(consolidation=True) as env:
+            scheduler.maybe_start_controllers(from_scheduler=True)
+
+            # Verify these were never called (would mean we got past the gate)
+            env.get_alive_mock.assert_not_called()
+            env.get_number_mock.assert_not_called()
+
+    def test_submit_jobs_still_marks_waiting_but_starts_no_controller(
+            self, _gate_env, tmp_path, monkeypatch):  # pylint: disable=invalid-name
+        """submit_jobs calls scheduler_set_waiting but skips start."""
+        # Create temp files for submit_jobs
+        dag_path = tmp_path / 'dag.yaml'
+        user_path = tmp_path / 'user.yaml'
+        env_path = tmp_path / 'env.sh'
+        dag_path.touch()
+        user_path.touch()
+        env_path.touch()
+
+        # Ensure SKYPILOT_CONFIG is unset
+        monkeypatch.delenv('SKYPILOT_CONFIG', raising=False)
+
+        with _gate_env(consolidation=True) as env:
+            with mock.patch.object(scheduler.state,
+                                   'get_job_controller_process',
+                                   return_value=None), \
+                 mock.patch.object(scheduler.state,
+                                   'scheduler_set_waiting') as set_waiting_mock:
+                scheduler.submit_jobs([1],
+                                      str(dag_path),
+                                      str(user_path),
+                                      str(env_path),
+                                      priority=0)
+
+                # Verify scheduler_set_waiting WAS called (state moved to WAITING)
+                assert set_waiting_mock.called
+                # Verify start_controller was NOT called
+                env.start_controller_mock.assert_not_called()
+
+
+class TestManagedJobEventDaemonPath:
+    """Cheap tripwire for the daemon-side caller of maybe_start_controllers.
+
+    ``ManagedJobEvent._run`` is one of the callers that must remain
+    ungated in consolidation mode -- unlike ``submit_jobs``'s
+    ``from_scheduler=True`` in-request path, this is the periodic skylet
+    tick that self-heals the controller pool. Guards against someone later
+    adding a gate to this path, or flipping ``from_scheduler``'s default.
+    """
+
+    def test_daemon_event_path_starts_controller_uncgated(self):  # pylint: disable=invalid-name
+        event = events.ManagedJobEvent()
+        with mock.patch.object(
+                events.managed_job_utils,
+                'update_managed_jobs_statuses') as update_mock, \
+                mock.patch.object(
+                    events.scheduler,
+                    'maybe_start_controllers') as start_mock, \
+                mock.patch.object(
+                    events.managed_job_utils,
+                    'is_consolidation_mode',
+                    return_value=True):
+            event._run()  # pylint: disable=protected-access
+
+        update_mock.assert_called_once()
+        start_mock.assert_called_once()
+        # from_scheduler must be absent (defaults to False) or explicitly
+        # falsy -- the daemon path must never claim to be the in-request
+        # scheduler path.
+        assert not start_mock.call_args.kwargs.get('from_scheduler', False), (
+            'ManagedJobEvent._run must call maybe_start_controllers without '
+            'from_scheduler=True; that flag is reserved for the in-request '
+            'submission path and gates controller startup in consolidation '
+            'mode')


### PR DESCRIPTION
## Summary

In consolidation mode, managed-job controllers can currently be started from **two** places:

1. **From a request** — `submit_jobs()` (reached via `sky jobs launch` → `_consolidated_launch` →
   the scheduler subprocess) calls `maybe_start_controllers(from_scheduler=True)`.
2. **From the leader** — the leader-elected managed-job refresh daemon
   (`managed_job_refresh_thread.py`), via `ha_recovery_for_consolidation_mode()` at leader election and
   `ManagedJobEvent` on its tick.

This PR removes (1). In consolidation mode the controller pool becomes **owned exclusively by the
leader daemon**.

Today the "only the leader starts controllers" property is *emergent* rather than explicit: it falls
out of a `PERSISTENT_RUN_RESTARTING_SIGNAL_FILE` dance spread across the refresh thread (which touches
the file before acquiring the lock and unlinks it after recovery) and the scheduler's gate. A follower
keeps the file because it blocks in `acquire()`. That is subtle, easy to break by reordering, and it
leaves controller startup running in request context on the leader — where it inherits whatever env and
failure modes the request path has, and where an exception from `maybe_start_controllers` propagates
into the user's launch request (the only `except` there is `filelock.Timeout`).

Making the invariant explicit also means `start_controller()` is no longer reachable from a request on
*any* replica, rather than only on replicas that happen to still hold the signal file.

## Change

`sky/jobs/scheduler.py` — the existing early-return in `maybe_start_controllers` was
`from_scheduler AND is_consolidation_mode() AND signal_file_exists`. The new one drops the last
conjunct: `from_scheduler AND is_consolidation_mode()`. The old condition is a strict subset of the new
one, so this is a net removal.

`submit_jobs()` still calls `state.scheduler_set_waiting()` — the job reaches `WAITING` in-request
exactly as before, and a controller from the leader's warm pool claims it on its next poll (~10s,
`controller.py::monitor_loop`). **Launch latency is unchanged**, verified end-to-end.

Non-consolidation is untouched: on the jobs-controller VM `is_consolidation_mode()` is `False`, so the
wheel-hash / `api_stop` / `reset_jobs_for_recovery` block and the controller start both still run.

### Known consequence

A controller that dies mid-life is now replaced only on the daemon's `ManagedJobEvent` tick
(`EVENT_INTERVAL_SECONDS=300`, throttled through `SkyletEvent.run()`), where previously the next
`sky jobs launch` would have replaced it immediately. Measured on a real consolidation server:
`kill -9` the only controller → the pool is restored after **277s**, and the caller stack confirms the
restore comes from `ManagedJobEvent._run`.

This only delays a job when the pool is **fully drained**. `get_number_of_jobs_controllers()` is a
fixed-size, memory-derived pool (up to `MAX_CONTROLLERS=64`), so with a typical pool size the surviving
controllers keep claiming `WAITING` jobs on their ~10s poll and nothing stalls. The full-drain case is
accepted here; surfacing it via alerting on a below-target controller count is tracked as a follow-up,
which is a better fit than adding a self-healing loop to the leader.

## Tests

Existing coverage of this linkage was zero. New
`tests/unit_tests/test_sky/jobs/test_consolidation_mode_gate.py`:
- consolidation + `from_scheduler=True` → no controller started
- **non-consolidation + `from_scheduler=True` → controller still started** (guards the on-VM path)
- **consolidation + `from_scheduler=False` (daemon) → controller still started** (a gate that ignored
  `from_scheduler` would break *all* controller startup)
- `ManagedJobEvent._run()` still calls `maybe_start_controllers` un-gated (tripwire against someone
  later gating the daemon path or flipping the parameter default)
- the gate holds with the recovery signal file absent, and short-circuits *before* pool sizing is
  consulted, so a request can never influence the controller count
- `submit_jobs` still marks the job `WAITING`

New `tests/unit_tests/test_sky/jobs/test_consolidation_mode_detection.py` pins the invariants the gate
depends on, because `is_consolidation_mode()` is context-dependent:

| context | `IS_SKYPILOT_JOB_CONTROLLER` | signal file | result |
|---|---|---|---|
| scheduler subprocess on the jobs-controller VM | unset | absent | `False` |
| scheduler subprocess on the API server | unset | present | `True` |
| **inside the controller process** | **set** | – | **`True`** |

The third row is why the gate keys on `from_scheduler`: `is_consolidation_mode()` is `True` inside every
controller process (because `start_controller()` exports `OVERRIDE_CONSOLIDATION_MODE`), even on
non-consolidation deployments. It is safe only because `from_scheduler=True` is unreachable from there.
The tests pin that reachability, pin `OVERRIDE_CONSOLIDATION_MODE ∉ controller_envs` (if it ever leaked
in, the VM's scheduler subprocess would silently stop starting controllers), and pin the detector matrix.

Every gate test was mutation-checked: restoring the old signal-file condition makes them fail, while the
two "must still start a controller" guards keep passing. They are guards, not tautologies.

## Tested

- `pytest tests/unit_tests/test_sky/jobs/` passes, except `test_details_is_none_when_no_state_or_failure`,
  which fails identically on pristine master with a clean `HOME` (pre-existing, unrelated).
- Mutation check: restoring the old signal-file gate fails 4 of the new tests; the 2 guards keep passing.
- End-to-end on a real consolidation-mode API server against a Kubernetes cluster:
  - the pool bootstraps at leader election (`Started 1 controllers`; caller stack
    `ha_recovery_for_consolidation_mode → maybe_start_controllers → start_controller`)
  - with the pool drained, `sky jobs launch` — **before**: the request spawns a controller
    (`Started 1 controllers` in `~/sky_logs/managed_jobs/submit-job-N.log`);
    **after**: that log instead reads *"controller startup is owned by the managed-job refresh daemon"*
    and nothing is spawned. The job is claimed and runs to `SUCCEEDED` either way.
- End-to-end in **non-consolidation** on Kubernetes: the jobs-controller cluster launches, exactly one
  `sky.jobs.controller` process starts on the VM (the new gate logs zero hits there), and the job
  succeeds. This is the surface where a wrong `is_consolidation_mode()` would silently hang every job in
  `WAITING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUfjEnVetV14pRRWiJbVNc
