### PR TITLE
Strip None-valued leaves from client config override before merge

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -873,6 +873,12 @@ def override_skypilot_config(
     original_config = _get_loaded_config()
     original_config_path = loaded_config_path_serialized()
     override_configs = config_utils.Config(override_configs)
+    # Drop leaves whose value is explicitly None before merging over the
+    # server config. YAML loads an unset nested field as None, and the
+    # recursive merge would otherwise let such a None clobber a valid server
+    # value and fail schema re-validation (e.g. None is not of type 'string').
+    override_configs = config_utils.Config(
+        config_utils.remove_none_values(override_configs))
     if override_config_path_serialized is None:
         override_config_path = []
     else:

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -186,6 +186,27 @@ def _recursive_update(
     return base_config
 
 
+def remove_none_values(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively drops keys whose value is literally None.
+
+    Empty dicts (``{}``) and empty lists (``[]``) are preserved; only leaves
+    whose value is ``None`` are removed. This is used to sanitize a client
+    config override before it is merged over the server config: YAML loads an
+    unset nested field as ``None``, and without this the recursive merge would
+    clobber a valid server value with ``None`` and then fail schema
+    re-validation (e.g. ``None is not of type 'string'``).
+    """
+    result: Dict[str, Any] = {}
+    for key, value in config.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            result[key] = remove_none_values(value)
+        else:
+            result[key] = value
+    return result
+
+
 def _get_nested(configs: Optional[Dict[str, Any]],
                 keys: Tuple[str, ...],
                 default_value: Any,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1960,3 +1960,75 @@ class TestRemoveQueueNameFromConfig:
                 ]:
                     assert current.get_nested(
                         keys, 'NOT_SET') is None, (f'Expected None at {keys}')
+
+
+def test_override_skypilot_config_strips_none_leaves(monkeypatch, tmp_path):
+    """A None-valued override leaf must not clobber a valid server value.
+
+    Regression test: a client config override may carry an explicitly unset
+    (None) nested leaf (YAML loads an empty field as None). Such a leaf must be
+    dropped before the merge, otherwise it overwrites a valid server value and
+    the request fails schema re-validation with e.g.
+    "None is not of type 'string'".
+    """
+    os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
+    config_path = tmp_path / 'config.yaml'
+    config_path.write_text(
+        textwrap.dedent("""\
+            kubernetes:
+                context_configs:
+                    contextA:
+                        quota:
+                            queue: server-queue
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    skypilot_config.reload_config()
+
+    queue_keys = ('kubernetes', 'context_configs', 'contextA', 'quota', 'queue')
+    assert skypilot_config.get_nested(queue_keys, None) == 'server-queue'
+
+    # A None override leaf must not raise and must not clobber the server value.
+    none_override = {
+        'kubernetes': {
+            'context_configs': {
+                'contextA': {
+                    'quota': {
+                        'queue': None
+                    }
+                }
+            }
+        }
+    }
+    with skypilot_config.override_skypilot_config(none_override):
+        assert skypilot_config.get_nested(queue_keys, None) == 'server-queue'
+    # The server value is restored after the context exits.
+    assert skypilot_config.get_nested(queue_keys, None) == 'server-queue'
+
+    # A legit non-null override value still wins.
+    value_override = copy.deepcopy(none_override)
+    value_override['kubernetes']['context_configs']['contextA']['quota'][
+        'queue'] = 'override-queue'
+    with skypilot_config.override_skypilot_config(value_override):
+        assert skypilot_config.get_nested(queue_keys, None) == 'override-queue'
+
+
+def test_remove_none_values_preserves_empty_containers():
+    """remove_none_values drops only None leaves; {} and [] are preserved."""
+    override = {
+        'a': None,
+        'b': 'value',
+        'c': {},
+        'd': [],
+        'e': {
+            'f': None,
+            'g': 'nested',
+        },
+    }
+    assert config_utils.remove_none_values(override) == {
+        'b': 'value',
+        'c': {},
+        'd': [],
+        'e': {
+            'g': 'nested',
+        },
+    }


### PR DESCRIPTION
## Description

**Before:** When a client sends a config override that carries an explicit `null` for a nested field, the recursive merge writes that `None` on top of a valid server-side value. Because YAML loads an unset nested field as `None`, an override that merely leaves a field blank ends up erasing the server's real setting. The request then fails schema re-validation with errors like `None is not of type 'string'`, so a request that should have simply used the server default is rejected outright.

**After:** Null-valued leaves are dropped from the override before it is merged. Unset fields in the override no longer clobber valid server config: a blank/`None` leaf is ignored and the server value is preserved, while any real (non-null) override value still takes precedence as before. No more spurious `None is not of type 'string'` schema failures.

## How

`override_skypilot_config` in `sky/skypilot_config.py` now sanitizes the incoming override by running it through a new recursive `remove_none_values` helper in `sky/utils/config_utils.py` before merging it over the server config. `remove_none_values` walks the config dict and drops only keys whose value is literally `None`, recursing into nested dicts. Empty containers (`{}` and `[]`) are deliberately preserved — only `None` leaves are removed — so intentional empty values are not lost.

## Tests

Added two regression tests in `tests/test_config.py`:
- `test_override_skypilot_config_strips_none_leaves` — a `None` override leaf does not raise and does not clobber a valid server value; a legitimate non-null override still wins.
- `test_remove_none_values_preserves_empty_containers` — the helper drops only `None` leaves and preserves empty dicts and lists.
