### PR TITLE
[Jobs] Give the controller process a single class identity

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2584,4 +2584,17 @@ async def main(controller_uuid: str):
 
 
 if __name__ == '__main__':
-    asyncio.run(main(sys.argv[1]))
+    # This file is launched as `python -u -m sky.jobs.controller <uuid>`, so
+    # runpy executes this module a second time under the name `__main__`,
+    # in addition to the normal import as `sky.jobs.controller`. That means
+    # every class and module-level function defined above (JobController,
+    # etc.) exists as two distinct objects in this process: the `__main__`
+    # copy and the imported-module copy. If we called the local `main()`
+    # here, everything it constructs would resolve against the `__main__`
+    # copy, so `mock.patch('sky.jobs.controller.JobController...')`,
+    # `isinstance`, and `pickle` would silently operate on the wrong class.
+    # Delegate to the imported module instead, so the process has a single
+    # identity for these classes. The import must stay local to this
+    # block -- at module scope it would be a self-import of this very file.
+    from sky.jobs import controller as _controller
+    asyncio.run(_controller.main(sys.argv[1]))

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -9,13 +9,17 @@ Also tests the cancelled job log download feature in ControllerManager
 and file mount cleanup in task_cleanup().
 """
 import asyncio
+import runpy
+import sys
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import warnings
 
 import pytest
 
+from sky.jobs import controller as controller_module
 from sky.jobs import state as managed_job_state
 from sky.jobs.controller import ControllerManager
 from sky.jobs.controller import JobController
@@ -1241,3 +1245,64 @@ class TestUserJobStatusClassification:
 
         failure_type = mock_set_failed.call_args.kwargs['failure_type']
         assert failure_type == managed_job_state.ManagedJobStatus.FAILED
+
+
+class TestDunderMainDispatchesToImportedModule:
+    """Regression: running this file as `__main__` must dispatch into the
+    IMPORTED `sky.jobs.controller` module, not into a second copy of it.
+
+    The controller process is launched as
+    `python -u -m sky.jobs.controller <uuid>`. Under `python -m pkg.mod`,
+    Python's `runpy` executes the module's source a SECOND time into a
+    fresh `__main__` namespace, in addition to the normal import of
+    `sky.jobs.controller`. That leaves the process with two distinct copies
+    of every class and module-level function defined in this file -- the
+    imported `sky.jobs.controller.JobController` and a separate
+    `__main__.JobController` -- and whichever `main()` actually runs
+    determines which copy every subsequently constructed object belongs to.
+    If the `__main__` guard called the LOCAL `main` (the `__main__` copy),
+    `mock.patch('sky.jobs.controller.JobController...')`, `isinstance`
+    checks, and `pickle` would all silently operate on the wrong class.
+
+    This test exercises the real `__main__` guard via `runpy` (it does not
+    reimplement the dispatch logic) and asserts that the imported module's
+    `main` -- addressed as `sky.jobs.controller.main` -- is the one that
+    gets called.
+    """
+
+    def test_run_as_main_calls_imported_module_main(self):
+        started = []
+
+        def _close_without_running(coro, *args, **kwargs):
+            # The `__main__` guard builds a coroutine and hands it to
+            # `asyncio.run`. Close it rather than run it: a coroutine does
+            # not execute any of its body until it is awaited, so this keeps
+            # a REGRESSION cheap and loud. Without this, a regression makes
+            # the `__main__` copy's own (unmocked) `main` coroutine run the
+            # real controller loop forever, and the test would hang CI
+            # instead of failing it. `asyncio.run` is resolved on the shared
+            # `asyncio` module at call time, so patching it here reaches the
+            # `__main__` copy too.
+            coro.close()
+            started.append(coro)
+
+        with warnings.catch_warnings():
+            # runpy warns that 'sky.jobs.controller' is already present in
+            # sys.modules (it was imported normally when this test module
+            # was collected). That is expected and is exactly the scenario
+            # under test, so it is suppressed rather than worked around.
+            warnings.filterwarnings('ignore',
+                                    message=r'.*found in sys\.modules.*',
+                                    category=RuntimeWarning)
+            with patch.object(controller_module, 'main',
+                              new_callable=AsyncMock) as mock_main, \
+                 patch.object(asyncio, 'run',
+                              side_effect=_close_without_running), \
+                 patch.object(sys, 'argv',
+                              ['sky.jobs.controller', 'test-uuid']):
+                runpy.run_module('sky.jobs.controller', run_name='__main__')
+
+        assert started, 'the __main__ guard never called asyncio.run'
+        # The imported module's `main` -- not the `__main__` copy's -- must be
+        # the one that was called.
+        mock_main.assert_called_once_with('test-uuid')


### PR DESCRIPTION
## Summary

The jobs controller is started with `python -u -m sky.jobs.controller <uuid>` (`sky/jobs/scheduler.py::start_controller`). Under `python -m pkg.mod`, runpy executes the module's source a **second** time into a fresh `__main__` namespace, in addition to the ordinary import of `sky.jobs.controller`. So the process holds two distinct copies of every class and module-level function defined in `controller.py`, and `main()` — hence every object it constructs — runs against the `__main__` copy.

Every consequence is silent:

- `mock.patch('sky.jobs.controller.JobController.<method>')` patches a class the running controller never calls.
- `isinstance(obj, sky.jobs.controller.JobController)` can be `False` for an object the controller just created.
- `pickle` round-trips can resolve to the wrong class.

## Fix

Have the `__main__` guard delegate to the imported module:

```python
if __name__ == '__main__':
    from sky.jobs import controller as _controller
    asyncio.run(_controller.main(sys.argv[1]))
```

`main.__globals__` is then the imported module's dict, so `ControllerManager`, `JobController` and friends resolve there and the process has a single identity for each.

- The launch command is unchanged, so `sky/jobs/utils.py`'s check that `-m sky.jobs.controller` appears in the controller's cmdline still matches.
- `main()` depends on nothing defined only in `__main__` — the sole `__name__` reference in the file is the guard itself.
- The only cost is that `controller.py`'s module body executes twice (definitions only; its imports are already cached), which was already true before this change.
- The import must stay local to the guard; at module scope it would be a self-import.

## Test plan

```
pytest tests/unit_tests/test_sky/jobs/      # all green
bash format.sh --files sky/jobs/controller.py tests/unit_tests/test_sky/jobs/test_controller.py
```

New regression test drives the **real** `__main__` guard via `runpy.run_module(..., run_name='__main__')` and asserts that the *imported* module's `main` is the one called.

It also patches `asyncio.run` to `close()` the coroutine rather than run it. A coroutine executes none of its body until awaited, so on a regression the test fails in ~7s:

```
E   AssertionError: Expected 'main' to be called once. Called 0 times.
```

Without that, a regression would hand the `__main__` copy's own unmocked `main` coroutine to `asyncio.run`, start the real controller loop, and **hang CI** instead of failing it.

Verified non-vacuous: reverting only the `__main__` guard produces exactly the assertion above (exit 1, 7s); restoring it makes the test pass.

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QZdqWwq2MP4mgq2EHFvvp
