### PR TITLE
[Kubernetes] enable Kueue priority-class label from {CLI, SDK, YAML}

### DIFF
--- a/docs/source/reference/kubernetes/examples/kueue-example.rst
+++ b/docs/source/reference/kubernetes/examples/kueue-example.rst
@@ -331,6 +331,30 @@ The config above allows the API server to submit jobs using the local queue.
    :width: 80%
    :align: center
 
+Set job priorities
+------------------
+
+Kueue orders and preempts workloads by their `WorkloadPriorityClass
+<https://kueue.sigs.k8s.io/docs/concepts/workload_priority_class/>`_. With a
+local queue configured, the ``--priority`` flag on ``sky launch`` and
+``sky jobs launch`` (or the ``priority_class`` field in a task's resources)
+sets the priority class for the pods:
+
+.. code-block:: bash
+
+    sky launch --priority high-priority task.yaml
+
+The pods are labeled with ``kueue.x-k8s.io/priority-class`` set to the given
+name. The priority class must already exist in the cluster, e.g.:
+
+.. code-block:: yaml
+
+    apiVersion: kueue.x-k8s.io/v1beta1
+    kind: WorkloadPriorityClass
+    metadata:
+      name: high-priority
+    value: 1000
+
 Further reading
 ---------------
 

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -301,7 +301,7 @@ available_node_types:
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
             kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
             {% if priority_class is not none %}
-            kueue.x-k8s.io/priority-class: {{priority_class}}
+            kueue.x-k8s.io/priority-class: {{priority_class|tojson}}
             {% endif %}
             {% endif %}
         annotations:

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -300,6 +300,9 @@ available_node_types:
             {% if k8s_kueue_local_queue_name %}
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
             kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
+            {% if priority_class is not none %}
+            kueue.x-k8s.io/priority-class: {{priority_class}}
+            {% endif %}
             {% endif %}
         annotations:
           # The skypilot-user *label* (above) sanitizes characters that are

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -235,8 +235,7 @@ def test_aws_template_applies_labels_to_volume_tags() -> None:
 def test_kubernetes_template_applies_kueue_priority_class_label() -> None:
     """Pods must carry the Kueue priority-class label when both a local queue
     and a priority class are set, so Kueue orders/preempts by the named
-    WorkloadPriorityClass (the skypilot-priority-class annotation alone is
-    not read by Kueue)."""
+    WorkloadPriorityClass."""
     template_path = pathlib.Path('sky/templates/kubernetes-ray.yml.j2')
     template = template_path.read_text(encoding='utf-8')
 

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -244,7 +244,7 @@ def test_kubernetes_template_applies_kueue_priority_class_label() -> None:
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
             kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
             {% if priority_class is not none %}
-            kueue.x-k8s.io/priority-class: {{priority_class}}
+            kueue.x-k8s.io/priority-class: {{priority_class|tojson}}
             {% endif %}
             {% endif %}"""
 

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -232,6 +232,25 @@ def test_aws_template_applies_labels_to_volume_tags() -> None:
     assert expected_block in template
 
 
+def test_kubernetes_template_applies_kueue_priority_class_label() -> None:
+    """Pods must carry the Kueue priority-class label when both a local queue
+    and a priority class are set, so Kueue orders/preempts by the named
+    WorkloadPriorityClass (the skypilot-priority-class annotation alone is
+    not read by Kueue)."""
+    template_path = pathlib.Path('sky/templates/kubernetes-ray.yml.j2')
+    template = template_path.read_text(encoding='utf-8')
+
+    expected_block = """            {% if k8s_kueue_local_queue_name %}
+            kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
+            kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
+            {% if priority_class is not none %}
+            kueue.x-k8s.io/priority-class: {{priority_class}}
+            {% endif %}
+            {% endif %}"""
+
+    assert expected_block in template
+
+
 def test_get_clusters_launch_refresh(monkeypatch):
     # verifies that `get_clusters` works when one cluster is launching
     # and other is not.


### PR DESCRIPTION
`resources.priority_class` (settable via `sky launch --priority <name>`, added in #9794) is currently only recorded as a `skypilot-priority-class` pod annotation, which Kueue does not read — so the flag has no scheduling effect on Kueue-managed clusters, this PR enables it for Kueue.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh` (yapf + isort clean on changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

**Manual test** — local API server from this branch + a k3d cluster (Kueue controller not required to verify labeling), with config:

```yaml
kubernetes:
  kueue:
    local_queue_name: smoke-queue
```

```console
$ sky launch -y -c pri-smoke --infra k8s/k3d-ac2 --cpus 0.5+ --priority high-priority -- 'echo hi'
$ kubectl get pod pri-smoke-f736945b-head -o jsonpath='{.metadata.labels}'
... "kueue.x-k8s.io/priority-class":"high-priority","kueue.x-k8s.io/queue-name":"smoke-queue" ...
```