### PR TITLE
[k8s] Support storage.existingClaim to attach a pre-provisioned PVC

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   {{- if and (not .Values.apiService.dbConnectionSecretName) (not .Values.apiService.dbConnectionString) }}
   {{- fail "External database must be configured via .apiService.dbConnectionSecretName or .apiService.dbConnectionString when using RollingUpdate strategy" }}
   {{- end }}
-  {{- if and .Values.storage.enabled (ne .Values.storage.accessMode "ReadWriteMany") }}
+  {{- if and .Values.storage.enabled (not .Values.storage.existingClaim) (ne .Values.storage.accessMode "ReadWriteMany") }}
   {{- fail "Local storage with ReadWriteOnce access mode is not supported when using RollingUpdate strategy. Either use Recreate upgrade strategy, set storage.enabled to false, or use ReadWriteMany access mode with a compatible storage class (e.g., NFS-backed storage like Google Filestore)." }}
   {{- end }}
   {{- $rollingUpdate := .Values.apiService.rollingUpdate | default (dict) }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -775,7 +775,21 @@ spec:
       {{- end }}
 
       volumes:
-      {{- if .Values.storage.enabled }}
+      {{- if .Values.storage.existingClaim }}
+      # Attach a pre-existing, out-of-band PVC as the state volume. Takes
+      # precedence over the chart-provisioned PVC (pvc.yaml skips provisioning
+      # when existingClaim is set).
+      - name: state-volume
+        persistentVolumeClaim:
+          claimName: {{ .Values.storage.existingClaim }}
+      {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
+      # RollingUpdate with persistent storage: use a separate emptyDir for
+      # ~/.sky to avoid running SQLite on NFS. Only specific subdirectories
+      # like api_server/clients are persisted to the claim.
+      - name: sky-ephemeral
+        emptyDir: {}
+      {{- end }}
+      {{- else if .Values.storage.enabled }}
       - name: state-volume
         persistentVolumeClaim:
           claimName: {{ $fullName }}-state

--- a/charts/skypilot/templates/pvc.yaml
+++ b/charts/skypilot/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storage.enabled }}
+{{- if and .Values.storage.enabled (not .Values.storage.existingClaim) }}
 {{- $fullName := include "skypilot.fullname" . -}}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -842,6 +842,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "existingClaim": {
+                    "type": "string"
+                },
                 "selector": {
                     "type": "object"
                 },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -357,6 +357,14 @@ storage:
   # - storage.enabled=false: Supported - but file mounts and logs will be lost on pod restart. Consider configuring
   #   'jobs.bucket' in the SkyPilot config to use cloud storage for file mounts.
   enabled: true
+  # Use a pre-existing PersistentVolumeClaim as the state volume instead of
+  # letting the chart provision one. When set, the chart mounts this claim as
+  # the state volume and does NOT create its own PVC (the storageClassName /
+  # size / accessMode / selector fields below are ignored — the claim is
+  # provisioned out-of-band). Useful for attaching storage created separately
+  # (e.g. a pre-provisioned RWX PVC). Takes precedence over the provisioned PVC;
+  # leave empty to have the chart provision one from the fields below.
+  existingClaim: ""
   # Storage class name - leave empty to use cluster default
   # For RWX storage with RollingUpdate, use a storage class that supports ReadWriteMany access mode:
   # - GKE: Create a Filestore-backed storage class (https://cloud.google.com/filestore/docs/accessing-fileshares)


### PR DESCRIPTION
## Summary

Add a `storage.existingClaim` value to the Helm chart so the API server state volume can be backed by a PersistentVolumeClaim provisioned out-of-band, instead of the chart always creating its own PVC.

When `storage.existingClaim` is set:
- the api-server Deployment mounts that claim as the single `state-volume` (taking precedence over the chart-provisioned PVC), and
- `templates/pvc.yaml` skips provisioning the chart-managed `<fullname>-state` PVC.

This is useful when the state volume's PVC is managed separately — e.g. a pre-provisioned RWX PVC shared across replicas. Leaving `existingClaim` empty preserves today's behavior.

## Test

`helm template` / `helm lint` across the storage permutations:
- `storage.enabled=false` (default): `state-volume` is an emptyDir, no PVC — unchanged.
- `storage.enabled=true`, no existingClaim: chart provisions `<fullname>-state`, `state-volume` binds to it — unchanged.
- `storage.existingClaim=<claim>`: exactly one `state-volume` bound to `<claim>`, no chart PVC provisioned (with either `enabled=true` or `enabled=false`).