### PR TITLE
[k8s] storage.existingClaim activates the persistent-storage layout

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -1,4 +1,10 @@
 {{- $fullName := include "skypilot.fullname" . -}}
+{{- /* Persistent state storage is active either when the chart provisions a PVC
+       (storage.enabled) or when an out-of-band PVC is attached
+       (storage.existingClaim). Both back the same `state-volume`, so the
+       storage mounts / ephemeral ~/.sky / env below key off this rather than
+       storage.enabled alone. */ -}}
+{{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -162,7 +168,7 @@ spec:
         - name: SKYPILOT_ROLLING_UPDATE_ENABLED
           value: "true"
         {{- end }}
-        {{- if .Values.storage.enabled }}
+        {{- if $statePersist }}
         - name: SKYPILOT_API_SERVER_STORAGE_ENABLED
           value: "true"
         {{- end }}
@@ -342,7 +348,7 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
-        {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
+        {{- if and $statePersist (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         # For RollingUpdate with storage enabled, use emptyDir for ~/.sky to avoid
         # running SQLite on NFS. Only persist the clients directory for file mounts.
         # An ephemeral volume is still required since we have to share ~/.sky between
@@ -357,7 +363,7 @@ spec:
           mountPath: /root/.sky
           subPath: .sky
         {{- end }}
-        {{- if .Values.storage.enabled }}
+        {{- if $statePersist }}
         {{- if ne .Values.apiService.persistSSHConfig false }}
         - name: state-volume
           mountPath: /root/.ssh # To preserve the SSH keys for the user when using the API server
@@ -488,7 +494,7 @@ spec:
             sleep 60;
           done
         volumeMounts:
-        {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
+        {{- if and $statePersist (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         - name: sky-ephemeral
           mountPath: /root/.sky
         {{- else }}
@@ -775,28 +781,20 @@ spec:
       {{- end }}
 
       volumes:
-      {{- if .Values.storage.existingClaim }}
-      # Attach a pre-existing, out-of-band PVC as the state volume. Takes
-      # precedence over the chart-provisioned PVC (pvc.yaml skips provisioning
-      # when existingClaim is set).
+      {{- if $statePersist }}
       - name: state-volume
         persistentVolumeClaim:
+          {{- if .Values.storage.existingClaim }}
+          # Attach a pre-existing, out-of-band PVC (pvc.yaml skips provisioning
+          # the chart-managed PVC when existingClaim is set).
           claimName: {{ .Values.storage.existingClaim }}
-      {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
-      # RollingUpdate with persistent storage: use a separate emptyDir for
-      # ~/.sky to avoid running SQLite on NFS. Only specific subdirectories
-      # like api_server/clients are persisted to the claim.
-      - name: sky-ephemeral
-        emptyDir: {}
-      {{- end }}
-      {{- else if .Values.storage.enabled }}
-      - name: state-volume
-        persistentVolumeClaim:
+          {{- else }}
           claimName: {{ $fullName }}-state
+          {{- end }}
       {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
-      # When using RollingUpdate with storage enabled, use a separate emptyDir
+      # When using RollingUpdate with persistent storage, use a separate emptyDir
       # for ~/.sky to avoid running SQLite on NFS. Only specific subdirectories
-      # like api_server/clients are persisted to the PVC.
+      # like api_server/clients are persisted to the state volume.
       - name: sky-ephemeral
         emptyDir: {}
       {{- end }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -358,12 +358,16 @@ storage:
   #   'jobs.bucket' in the SkyPilot config to use cloud storage for file mounts.
   enabled: true
   # Use a pre-existing PersistentVolumeClaim as the state volume instead of
-  # letting the chart provision one. When set, the chart mounts this claim as
-  # the state volume and does NOT create its own PVC (the storageClassName /
-  # size / accessMode / selector fields below are ignored — the claim is
-  # provisioned out-of-band). Useful for attaching storage created separately
-  # (e.g. a pre-provisioned RWX PVC). Takes precedence over the provisioned PVC;
-  # leave empty to have the chart provision one from the fields below.
+  # letting the chart provision one. Setting this activates persistent storage
+  # exactly like storage.enabled=true (same mounts, same RollingUpdate handling)
+  # but backs the state volume with this claim and does NOT create the
+  # chart-managed PVC. The provisioning fields below (storageClassName / size /
+  # accessMode / selector / volumeName) are ignored — the claim is provisioned
+  # out-of-band, so its access mode is the PV's responsibility (the chart does
+  # not validate it). Useful for attaching storage created separately, e.g. a
+  # pre-provisioned RWX PVC. Takes precedence over the chart-provisioned PVC;
+  # leave empty to provision one from the fields below (subject to
+  # storage.enabled).
   existingClaim: ""
   # Storage class name - leave empty to use cluster default
   # For RWX storage with RollingUpdate, use a storage class that supports ReadWriteMany access mode:


### PR DESCRIPTION
## Summary

Follow-up to #10085. When `storage.existingClaim` is set with `storage.enabled=false`, the chart attached the claim as `state-volume` but skipped the blocks gated on `storage.enabled` — so under `RollingUpdate` there was no `sky-ephemeral` emptyDir for `~/.sky` (SQLite would run on the claim, which may be networked), and `~/.ssh` / `~/sky_logs` were not persisted. That diverges from `storage.enabled=true`.

Route the storage mounts, the ephemeral `~/.sky` (RollingUpdate), and `SKYPILOT_API_SERVER_STORAGE_ENABLED` through a shared `$statePersist = (storage.enabled OR storage.existingClaim)`, gated identically to `storage.enabled` before. Now `existingClaim` renders the same layout as `storage.enabled=true`, differing only in that the PVC is not provisioned and its access mode is not validated (out of the chart's control — kept the accessMode check gated on `storage.enabled` alone).

## Test

`helm template` / `helm lint` across permutations:
- `existingClaim` + `enabled=false` + RollingUpdate: exactly one `state-volume` bound to the claim, `sky-ephemeral` present, `~/.ssh` / `~/sky_logs` mounted, no chart PVC.
- `enabled=true` (no existingClaim): unchanged (provisions PVC).
- `enabled=false`, no existingClaim: unchanged (`state-volume` emptyDir, no ephemeral).