### PR TITLE
[Dashboard] Default Clusters to My Clusters, add scope hint, unify toggle styling

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -182,12 +182,30 @@ const OWNER_SCOPE_STORAGE_KEY = 'skypilot-dashboard-clusters-owner-scope';
 const isOwnerScope = (value) =>
   value === OWNER_SCOPE_MINE || value === OWNER_SCOPE_ALL;
 
+// localStorage access is wrapped in try-catch: it can throw when storage
+// is restricted (blocked site data, sandboxed iframes), and scope
+// persistence is not worth crashing the page over.
 const readStoredOwnerScope = () => {
   if (typeof window === 'undefined') {
     return null;
   }
-  const stored = window.localStorage.getItem(OWNER_SCOPE_STORAGE_KEY);
-  return isOwnerScope(stored) ? stored : null;
+  try {
+    const stored = window.localStorage.getItem(OWNER_SCOPE_STORAGE_KEY);
+    return isOwnerScope(stored) ? stored : null;
+  } catch (e) {
+    return null;
+  }
+};
+
+const writeStoredOwnerScope = (scope) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(OWNER_SCOPE_STORAGE_KEY, scope);
+  } catch (e) {
+    // Ignore: the scope still applies for this session via state/URL.
+  }
 };
 
 export function Clusters() {
@@ -321,7 +339,7 @@ export function Clusters() {
           // On a fresh load the initial state is already seeded from the URL,
           // so the branch above never runs; still persist the deep-linked
           // choice like a manual toggle.
-          window.localStorage.setItem(OWNER_SCOPE_STORAGE_KEY, owner);
+          writeStoredOwnerScope(owner);
         }
       }
     }
@@ -510,9 +528,7 @@ export function Clusters() {
 
   const selectScope = (scope) => {
     setUserScope(scope);
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(OWNER_SCOPE_STORAGE_KEY, scope);
-    }
+    writeStoredOwnerScope(scope);
     const query = { ...router.query };
     query.owner = scope;
     router.replace(

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -607,7 +607,7 @@ export function Clusters() {
       {/* Toggles live on their own row (mirrors the Managed Jobs layout) so
           they read consistently across pages and stay clear of the search
           box. Refresh/last-updated sit on the right of the same row. */}
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex items-center justify-between mb-3">
         <div className="flex flex-wrap items-center gap-2">
           <SegmentedToggle
             ariaLabel="Filter clusters by activity"
@@ -631,8 +631,6 @@ export function Clusters() {
               onChange={selectScope}
             />
           )}
-        </div>
-        <div className="flex items-center gap-2 shrink-0 ml-2">
           {/* Scope hint: when the table is filtered to the current user's
               clusters, remind them and offer a one-click path to All
               Clusters (mirrors the Managed Jobs page). Suppressed in the
@@ -660,6 +658,8 @@ export function Clusters() {
                 </button>
               </div>
             )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-2">
           {showHistory && (
             <Select
               value={historyDays.toString()}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -68,10 +68,11 @@ import {
 } from '@/components/ui/select';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
+import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { evaluateCondition } from '@/components/shared/FilterSystem';
+import { SegmentedToggle } from '@/components/elements/SegmentedToggle';
 import { getCurrentUserInfo } from '@/data/connectors/client';
 import { trackClusterAction, trackFilterUsed } from '@/lib/analytics';
 
@@ -172,7 +173,8 @@ const formatDuration = (durationSeconds) => {
   return result.trim() || '0s';
 };
 
-// Clusters are shared infra: default to All Clusters and remember the user's last My/All choice in localStorage.
+// Default to the signed-in user's own clusters (matching the jobs page) and
+// remember the user's last My/All choice in localStorage.
 const OWNER_SCOPE_MINE = 'mine';
 const OWNER_SCOPE_ALL = 'all';
 const OWNER_SCOPE_STORAGE_KEY = 'skypilot-dashboard-clusters-owner-scope';
@@ -229,8 +231,8 @@ export function Clusters() {
     ) {
       return owner;
     }
-    // Fall back to the user's last choice, then to All Clusters.
-    return readStoredOwnerScope() ?? OWNER_SCOPE_ALL;
+    // Fall back to the user's last choice, then to My Clusters.
+    return readStoredOwnerScope() ?? OWNER_SCOPE_MINE;
   };
 
   const [showHistory, setShowHistory] = useState(getInitialShowHistory);
@@ -238,6 +240,9 @@ export function Clusters() {
   const [userScope, setUserScope] = useState(getInitialUserScope);
   const [currentUser, setCurrentUser] = useState(null);
   const [authResolved, setAuthResolved] = useState(false);
+  // Whether the current scope has any rows; gates the "Showing your
+  // clusters only" hint so it never overlaps the empty-state CTA.
+  const [scopedHasRows, setScopedHasRows] = useState(false);
   const isMobile = useMobile();
 
   useEffect(() => {
@@ -604,68 +609,57 @@ export function Clusters() {
           box. Refresh/last-updated sit on the right of the same row. */}
       <div className="flex items-center justify-between mb-1">
         <div className="flex flex-wrap items-center gap-2">
-          <div
-            role="tablist"
-            aria-label="Filter clusters by activity"
-            className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-          >
-            <button
-              role="tab"
-              aria-selected={!showHistory}
-              onClick={() => selectHistoryTab(false)}
-              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                !showHistory
-                  ? 'bg-white text-gray-900 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              Active
-            </button>
-            <button
-              role="tab"
-              aria-selected={showHistory}
-              onClick={() => selectHistoryTab(true)}
-              className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                showHistory
-                  ? 'bg-white text-gray-900 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              All
-            </button>
-          </div>
+          <SegmentedToggle
+            ariaLabel="Filter clusters by activity"
+            options={[
+              { value: 'active', label: 'Active' },
+              { value: 'all', label: 'All' },
+            ]}
+            value={showHistory ? 'all' : 'active'}
+            onChange={(value) => selectHistoryTab(value === 'all')}
+          />
           {currentUser && (
-            <div
-              role="tablist"
-              aria-label="Filter clusters by owner"
-              className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-            >
-              <button
-                role="tab"
-                aria-selected={isMine}
-                onClick={() => selectScope(OWNER_SCOPE_MINE)}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  isMine
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                My Clusters
-              </button>
-              <button
-                role="tab"
-                aria-selected={isEveryone}
-                onClick={() => selectScope(OWNER_SCOPE_ALL)}
-                className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                  isEveryone
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                All Clusters
-              </button>
-            </div>
+            <SegmentedToggle
+              ariaLabel="Filter clusters by owner"
+              options={[
+                { value: OWNER_SCOPE_MINE, label: 'My Clusters' },
+                { value: OWNER_SCOPE_ALL, label: 'All Clusters' },
+              ]}
+              value={
+                isMine ? OWNER_SCOPE_MINE : isEveryone ? OWNER_SCOPE_ALL : null
+              }
+              onChange={selectScope}
+            />
           )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-2">
+          {/* Scope hint: when the table is filtered to the current user's
+              clusters, remind them and offer a one-click path to All
+              Clusters (mirrors the Managed Jobs page). Suppressed in the
+              empty state (the empty-state CTA already says this) and when
+              an explicit User filter has overridden the toggle. */}
+          {userScope === OWNER_SCOPE_MINE &&
+            currentUser &&
+            !explicitUserFilter &&
+            scopedHasRows && (
+              <div
+                className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-sky-50 pl-2 pr-2.5 py-0.5 text-xs shrink-0"
+                role="status"
+                aria-live="polite"
+              >
+                <InfoIcon className="h-3 w-3 text-sky-600 shrink-0" />
+                <span className="text-gray-700">
+                  Showing your clusters only.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => selectScope(OWNER_SCOPE_ALL)}
+                  className="font-medium text-sky-700 transition-colors hover:text-sky-800 hover:underline"
+                >
+                  View all clusters
+                </button>
+              </div>
+            )}
           {showHistory && (
             <Select
               value={historyDays.toString()}
@@ -686,8 +680,6 @@ export function Clusters() {
               </SelectContent>
             </Select>
           )}
-        </div>
-        <div className="flex items-center gap-2 shrink-0 ml-2">
           {loading && (
             <div className="flex items-center">
               <CircularProgress size={15} className="mt-0" />
@@ -716,6 +708,7 @@ export function Clusters() {
         userScope={userScope}
         currentUser={currentUser}
         onViewAllClusters={() => selectScope(OWNER_SCOPE_ALL)}
+        onRowsPresenceChange={setScopedHasRows}
         showHistory={showHistory}
         historyDays={historyDays}
         onOpenSSHModal={(cluster) => {
@@ -754,6 +747,7 @@ export function ClusterTable({
   userScope,
   currentUser,
   onViewAllClusters,
+  onRowsPresenceChange,
   showHistory,
   historyDays,
   onOpenSSHModal,
@@ -986,6 +980,11 @@ export function ClusterTable({
   const scopedEmpty = isServerPagination
     ? total === 0
     : sortedData.length === 0;
+  // Report whether the current scope has rows so the parent can gate the
+  // "Showing your clusters only" hint (hidden while loading or empty).
+  useEffect(() => {
+    onRowsPresenceChange?.(!scopedEmpty && !hookLoading);
+  }, [scopedEmpty, hookLoading, onRowsPresenceChange]);
   useEffect(() => {
     let cancelled = false;
     const scopedToMine =

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -607,7 +607,7 @@ export function Clusters() {
       {/* Toggles live on their own row (mirrors the Managed Jobs layout) so
           they read consistently across pages and stay clear of the search
           box. Refresh/last-updated sit on the right of the same row. */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center justify-between mb-4">
         <div className="flex flex-wrap items-center gap-2">
           <SegmentedToggle
             ariaLabel="Filter clusters by activity"

--- a/sky/dashboard/src/components/elements/SegmentedToggle.jsx
+++ b/sky/dashboard/src/components/elements/SegmentedToggle.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+/**
+ * Segmented control for switching the scope of a table view
+ * (e.g. Active/All activity, My/All ownership). Sized to sit inline
+ * with the dashboard's compact filter-row controls (status chips,
+ * Refresh link) — text-sm labels on a gray track with a white
+ * selected segment.
+ *
+ * The selected segment is the single source of truth for the current
+ * scope — pair it with a scope-aware empty state rather than a separate
+ * "showing X only" hint.
+ *
+ * @param {string} ariaLabel - Accessible label for the tablist.
+ * @param {Array<{value: string, label: string}>} options - Segments.
+ * @param {string|null} value - Currently selected segment value. May match
+ *   no option (e.g. an explicit filter has overridden the toggle), in which
+ *   case no segment is highlighted.
+ * @param {Function} onChange - Called with the clicked segment's value.
+ */
+export function SegmentedToggle({ ariaLabel, options, value, onChange }) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="inline-flex items-center bg-gray-100 rounded-lg p-0.5 shrink-0"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onChange(option.value)}
+            className={`px-3 py-1 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
+              selected
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2034,7 +2034,7 @@ export function ManagedJobsTable({
     <div className="relative">
       <div className="flex flex-col space-y-1 mb-1">
         {/* Combined Status Filter */}
-        <div className="flex items-center justify-between text-sm mb-1">
+        <div className="flex items-center justify-between text-sm mb-4">
           <div className="flex flex-wrap items-center min-w-0">
             <span className="mr-2 text-sm font-medium">Statuses:</span>
             <div className="flex flex-wrap gap-2 items-center">

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { PaginationControls } from '@/components/elements/PaginationControls';
+import { SegmentedToggle } from '@/components/elements/SegmentedToggle';
 import { CircularProgress } from '@mui/material';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -2188,39 +2189,19 @@ export function ManagedJobsTable({
                     setCurrentPage(1);
                   });
                 };
-                const isActive = activeTab === 'active' && showAllMode;
-                const isAll = activeTab === 'all' && showAllMode;
+                // Neither segment is highlighted while a status chip
+                // narrows the view (showAllMode=false).
+                const activityValue = showAllMode ? activeTab : null;
                 return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by activity"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => selectTab('active')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isActive
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Active
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isAll}
-                      onClick={() => selectTab('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isAll
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      All
-                    </button>
-                  </div>
+                  <SegmentedToggle
+                    ariaLabel="Filter jobs by activity"
+                    options={[
+                      { value: 'active', label: 'Active' },
+                      { value: 'all', label: 'All' },
+                    ]}
+                    value={activityValue}
+                    onChange={selectTab}
+                  />
                 );
               })()}
               {(() => {
@@ -2234,36 +2215,15 @@ export function ManagedJobsTable({
                   : userScope === 'mine';
                 const isEveryone = !explicitUserFilter && userScope === 'all';
                 return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by owner"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isMine}
-                      onClick={() => selectScope('mine')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isMine
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      My Jobs
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isEveryone}
-                      onClick={() => selectScope('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isEveryone
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      All Jobs
-                    </button>
-                  </div>
+                  <SegmentedToggle
+                    ariaLabel="Filter jobs by owner"
+                    options={[
+                      { value: 'mine', label: 'My Jobs' },
+                      { value: 'all', label: 'All Jobs' },
+                    ]}
+                    value={isMine ? 'mine' : isEveryone ? 'all' : null}
+                    onChange={selectScope}
+                  />
                 );
               })()}
               {/* Scope hint: when filtered to the current user's jobs,


### PR DESCRIPTION
## Summary

Follow-up to #9884:

- Default the Clusters ownership scope to **My Clusters**, matching the Jobs page. Last choice still persists; anonymous deployments still fall back to All. Also avoids the expensive all-users fetch on first load.
- Add the jobs-style scope hint next to the toggles ("Showing your clusters only — View all clusters"). Hidden while loading, when the scoped view is empty, or when a `User` filter overrides the toggle.
- Move the history-days selector to the right control group and widen the gap between the controls row and the table on both pages.
- Extract a shared `SegmentedToggle` element used by both pages (jobs change is styling-only).

## Test plan

- `next lint` / `prettier --check` pass; the 6 connector tests from #9884 pass after rebase.
- Manual with a signed-in identity (live deployment): fresh visit lands on My Clusters with the hint next to the toggles; "View all clusters" flips and persists; `?owner=`/`?history=` deep links restore; empty My Clusters shows the existing CTA instead of the hint; Jobs renders identically with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)