### PR TITLE
[Dashboard] Support admin-configured URL template external links

### DIFF
--- a/docs/source/running-jobs/external-links.rst
+++ b/docs/source/running-jobs/external-links.rst
@@ -5,11 +5,12 @@ External Links
 
 External links are URLs associated with managed jobs and clusters that are displayed in the SkyPilot dashboard. This is useful for linking to external dashboards, experiment trackers, or any other relevant resources.
 
-SkyPilot automatically detects and displays three types of links:
+SkyPilot automatically detects and displays four types of links:
 
 1. **Instance links**: For jobs running on AWS, GCP, or Azure, SkyPilot automatically adds links to the cloud console for the underlying instance.
 2. **Log-detected links (built-in)**: The dashboard automatically parses job logs to detect URLs from supported services (currently Weights & Biases) and displays them as external links.
 3. **Admin-configured custom URLs**: Administrators can register a list of labeled regex patterns in the SkyPilot config. Matching URLs that appear in job logs (job detail page) or cluster provision logs (cluster detail page) are rendered as clickable, labeled links.
+4. **Admin-configured URL templates**: Administrators can register labeled URL templates that are built from cluster/job metadata (e.g., ``https://ray.internal.example.com/dashboard/${cluster_name}``) and rendered on every cluster and job detail page, without needing the URL to appear in logs.
 
 .. image:: ../images/examples/external-links/job-page-wandb.png
   :width: 800
@@ -113,3 +114,61 @@ Custom URL matches appear on:
 
 Regexes that fail to compile are rejected at config load time with a clear
 error, so a malformed entry does not silently disable other entries.
+
+
+Admin-configured URL templates
+------------------------------
+
+For services with stable, predictable URLs (a Ray dashboard behind a reverse
+proxy, Grafana dashboards keyed by cluster name, an internal experiment
+platform keyed by job ID, etc.), scanning logs is unnecessary: the link can
+be constructed directly from cluster or job metadata. Configure these as
+``{label, url}`` entries in the same ``dashboard.external_links`` list:
+
+.. code-block:: yaml
+
+  dashboard:
+    external_links:
+      - label: "Ray Dashboard"
+        url: 'https://ray.internal.example.com/dashboard/${cluster_name}'
+      - label: "Grafana"
+        url: 'https://grafana.internal.example.com/d/gpu?var-cluster=${cluster_name}'
+      - label: "Experiment Platform"
+        url: 'https://exp.internal.example.com/jobs/${job_id}'
+
+Each entry takes:
+
+- ``label``: The text shown to users in the External Links section.
+- ``url``: A URL template. ``${variable}`` placeholders are substituted
+  with URI-encoded values from the page being viewed. An entry must have
+  either ``url`` or ``regex``, never both.
+
+Supported template variables:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Variable
+     - Cluster page
+     - Job pages
+   * - ``${cluster_name}``
+     - The cluster's name
+     - The job's backing cluster
+   * - ``${job_id}``
+     - Not available
+     - The job's ID
+   * - ``${job_name}``
+     - Not available
+     - The job's name
+   * - ``${user}``
+     - The cluster's owner
+     - The job's owner
+   * - ``${workspace}``
+     - The cluster's workspace
+     - The job's workspace
+
+A link is only rendered on pages where all of its variables resolve: an
+entry referencing ``${job_id}`` appears on job detail pages but not on
+cluster detail pages, while an entry referencing only ``${cluster_name}``
+appears on both. Templates referencing unknown variables are rejected at
+config load time.

--- a/sky/dashboard/src/data/connectors/dashboard_config.jsx
+++ b/sky/dashboard/src/data/connectors/dashboard_config.jsx
@@ -13,9 +13,12 @@ const EMPTY_CONFIG = { externalLinks: [] };
 /**
  * Fetch the admin-configured dashboard settings from the server.
  *
- * Returns an object of the shape { externalLinks: [{ label, regex }] }. On
- * network or parse failure, returns an empty config rather than throwing so
- * the dashboard stays usable when the endpoint is unavailable.
+ * Returns an object of the shape
+ * { externalLinks: [{ label, regex } | { label, url }] }, where `regex`
+ * entries are matched against logs and `url` entries are templates resolved
+ * against cluster/job metadata. On network or parse failure, returns an
+ * empty config rather than throwing so the dashboard stays usable when the
+ * endpoint is unavailable.
  */
 export const getDashboardConfig = async () => {
   if (dashboardConfigCache !== null) {
@@ -41,11 +44,15 @@ export const getDashboardConfig = async () => {
           (entry) =>
             entry &&
             typeof entry.label === 'string' &&
-            typeof entry.regex === 'string' &&
             entry.label.length > 0 &&
-            entry.regex.length > 0
+            ((typeof entry.regex === 'string' && entry.regex.length > 0) ||
+              (typeof entry.url === 'string' && entry.url.length > 0))
         )
-        .map((entry) => ({ label: entry.label, regex: entry.regex }));
+        .map((entry) =>
+          typeof entry.regex === 'string' && entry.regex.length > 0
+            ? { label: entry.label, regex: entry.regex }
+            : { label: entry.label, url: entry.url }
+        );
       dashboardConfigCache = { externalLinks };
       return dashboardConfigCache;
     } catch (error) {

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -40,6 +40,7 @@ import {
   extractLinksFromLogs,
   normalizeUrl,
   useCustomUrlPatterns,
+  useTemplateLinks,
 } from '@/utils/externalLinks';
 import {
   SSHInstructionsModal,
@@ -320,19 +321,32 @@ function ActiveTab({
     });
   }, []);
 
-  // Persisted DB-backed links take priority over the live-scanned ones, same
-  // merge semantics the managed-job page uses (sky/dashboard/src/pages/jobs/
-  // [job].js: combinedLinks). DB links currently come from
+  // Admin-configured url templates (dashboard.external_links entries with a
+  // `url` field) resolved against this cluster's metadata.
+  const templateLinkContext = useMemo(
+    () => ({
+      cluster_name: clusterData?.cluster,
+      user: clusterData?.user,
+      workspace: clusterData?.workspace,
+    }),
+    [clusterData?.cluster, clusterData?.user, clusterData?.workspace]
+  );
+  const templateLinks = useTemplateLinks(templateLinkContext);
+
+  // Merge order on label collision: template links are the base, persisted
+  // DB-backed links override them, and live-scanned links only fill gaps,
+  // same merge semantics the managed-job page uses (sky/dashboard/src/pages/
+  // jobs/[job].js: combinedLinks). DB links currently come from
   // instance_links.generate_instance_links() at launch time.
   const combinedClusterLinks = useMemo(() => {
-    const combined = { ...(clusterData?.links || {}) };
+    const combined = { ...templateLinks, ...(clusterData?.links || {}) };
     for (const [label, url] of Object.entries(clusterExtractedLinks)) {
       if (!(label in combined)) {
         combined[label] = url;
       }
     }
     return combined;
-  }, [clusterData?.links, clusterExtractedLinks]);
+  }, [templateLinks, clusterData?.links, clusterExtractedLinks]);
 
   const toggleYamlExpanded = () => {
     setIsYamlExpanded(!isYamlExpanded);
@@ -576,8 +590,9 @@ function ActiveTab({
                 </div>
               )}
 
-              {/* External Links section: persisted DB links (e.g., cloud
-                  instance console URLs from
+              {/* External Links section: admin-configured url templates
+                  resolved against cluster metadata, persisted DB links
+                  (e.g., cloud instance console URLs from
                   instance_links.generate_instance_links() at launch time)
                   plus live regex matches against the admin-configured
                   `dashboard.external_links` allowlist and built-in patterns

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -22,7 +22,11 @@ import { CheckIcon, CopyIcon } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { useCallback } from 'react';
-import { normalizeUrl, useLogLinkExtractor } from '@/utils/externalLinks';
+import {
+  normalizeUrl,
+  useLogLinkExtractor,
+  useTemplateLinks,
+} from '@/utils/externalLinks';
 
 // Custom header component with buttons inline
 function JobHeader({
@@ -137,19 +141,37 @@ export function JobDetailPage() {
     scanLines(displayLines);
   }, [displayLines, scanLines]);
 
-  // Merge server-computed links (extracted from the full log, authoritative)
-  // with client-extracted links (DB first), so a link surfaces even if the
-  // user never streamed the line it appeared on.
+  // Admin-configured url templates (dashboard.external_links entries with a
+  // `url` field) resolved against this job's metadata.
+  const jobRecord = useMemo(
+    () => clusterJobData?.find((j) => j.id == job),
+    [clusterJobData, job]
+  );
+  const templateLinkContext = useMemo(
+    () => ({
+      cluster_name: cluster,
+      job_id: job,
+      job_name: jobRecord?.job,
+      user: jobRecord?.user,
+      workspace: jobRecord?.workspace,
+    }),
+    [cluster, job, jobRecord?.job, jobRecord?.user, jobRecord?.workspace]
+  );
+  const templateLinks = useTemplateLinks(templateLinkContext);
+
+  // Merge order on label collision: template links are the base,
+  // server-computed links (extracted from the full log, authoritative)
+  // override them, and client-extracted links only fill gaps, so a link
+  // surfaces even if the user never streamed the line it appeared on.
   const combinedExternalLinks = useMemo(() => {
-    const jobRecord = clusterJobData?.find((j) => j.id == job);
-    const combined = { ...(jobRecord?.links || {}) };
+    const combined = { ...templateLinks, ...(jobRecord?.links || {}) };
     for (const [label, url] of Object.entries(extractedLinks)) {
       if (!(label in combined)) {
         combined[label] = url;
       }
     }
     return combined;
-  }, [clusterJobData, job, extractedLinks]);
+  }, [templateLinks, jobRecord, extractedLinks]);
 
   const handleRefreshLogs = () => {
     setLogsRefreshToken((token) => token + 1);

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -62,7 +62,11 @@ import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents } from '@/plugins/PluginProvider';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import { normalizeUrl, useLogLinkExtractor } from '@/utils/externalLinks';
+import {
+  normalizeUrl,
+  useLogLinkExtractor,
+  useTemplateLinks,
+} from '@/utils/externalLinks';
 import { TelemetrySection } from '@/components/TelemetrySection';
 import { hasAccelerator } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
@@ -1179,11 +1183,34 @@ function JobDetailsContent({
     }
   }, [logExtractedLinks, onLinksExtracted]);
 
-  // Combine database links with log-extracted links
+  // Admin-configured url templates (dashboard.external_links entries with a
+  // `url` field) resolved against this managed job's metadata. The backing
+  // cluster name is the job's current cluster (present while running or
+  // after the last recovery).
+  const templateLinkContext = useMemo(
+    () => ({
+      cluster_name: jobData?.current_cluster_name,
+      job_id: jobData?.id,
+      job_name: jobData?.name,
+      user: jobData?.user,
+      workspace: jobData?.workspace,
+    }),
+    [
+      jobData?.current_cluster_name,
+      jobData?.id,
+      jobData?.name,
+      jobData?.user,
+      jobData?.workspace,
+    ]
+  );
+  const templateLinks = useTemplateLinks(templateLinkContext);
+
+  // Combine template links, database links, and log-extracted links.
   // Use logExtractedLinksFromParent if provided (for info tab), otherwise use local extraction
   const combinedLinks = useMemo(() => {
-    // Start with database links (they take priority if there's a conflict)
-    const combined = { ...(links || {}) };
+    // Template links are the base; database links take priority if there's
+    // a conflict.
+    const combined = { ...templateLinks, ...(links || {}) };
     // Use parent-provided links (for info tab) or locally extracted links (for logs tab)
     const extractedToUse = logExtractedLinksFromParent || logExtractedLinks;
     // Add log-extracted links (only if not already present)
@@ -1193,7 +1220,7 @@ function JobDetailsContent({
       }
     }
     return combined;
-  }, [links, logExtractedLinks, logExtractedLinksFromParent]);
+  }, [templateLinks, links, logExtractedLinks, logExtractedLinksFromParent]);
 
   // Auto-scroll to bottom when logs change or tab changes
   useEffect(() => {

--- a/sky/dashboard/src/utils/externalLinks.js
+++ b/sky/dashboard/src/utils/externalLinks.js
@@ -226,6 +226,14 @@ export const resolveTemplateLinks = (externalLinks, context) => {
     const url = entry.url.replace(
       TEMPLATE_VARIABLE_PATTERN,
       (_match, variable) => {
+        // Only allowlisted variables may be read from the context.
+        // Without this, a variable like ${toString} would resolve to an
+        // Object.prototype method instead of undefined and serialize
+        // function source into the URL.
+        if (!TEMPLATE_LINK_VARIABLES.includes(variable)) {
+          allResolved = false;
+          return '';
+        }
         const value = ctx[variable];
         if (value === undefined || value === null || value === '') {
           allResolved = false;

--- a/sky/dashboard/src/utils/externalLinks.js
+++ b/sky/dashboard/src/utils/externalLinks.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { stripAnsiCodes } from '@/components/utils';
 import { getDashboardConfig } from '@/data/connectors/dashboard_config';
@@ -182,6 +182,97 @@ export const useLogLinkExtractor = () => {
   }, [urlPatterns, scanLines]);
 
   return { extractedLinks, scanLines };
+};
+
+// Variables that may appear as ${var} inside an admin-configured
+// `dashboard.external_links` url template. Must stay in sync with
+// DASHBOARD_LINK_TEMPLATE_VARIABLES in sky/skypilot_config.py, which
+// rejects unknown variables at config load time.
+export const TEMPLATE_LINK_VARIABLES = [
+  'cluster_name',
+  'job_id',
+  'job_name',
+  'user',
+  'workspace',
+];
+
+const TEMPLATE_VARIABLE_PATTERN = /\$\{([^}]*)\}/g;
+
+/**
+ * Resolve admin-configured url-template entries against a page's metadata.
+ *
+ * Each `{label, url}` entry has its ${var} placeholders substituted with
+ * URI-encoded values from `context`. An entry is skipped (not rendered
+ * broken) when any of its variables is missing or empty in the context, so
+ * e.g. a ${job_id} link only appears on job pages.
+ *
+ * @param {Array<{label: string, url: string}>} externalLinks
+ * @param {Object<string, string|number>} context e.g. {cluster_name, job_id}
+ * @returns {Object<string, string>} label -> resolved url map
+ */
+export const resolveTemplateLinks = (externalLinks, context) => {
+  const resolved = {};
+  if (!Array.isArray(externalLinks)) return resolved;
+  const ctx = context || {};
+  for (const entry of externalLinks) {
+    if (
+      !entry ||
+      typeof entry.label !== 'string' ||
+      typeof entry.url !== 'string'
+    ) {
+      continue;
+    }
+    let allResolved = true;
+    const url = entry.url.replace(
+      TEMPLATE_VARIABLE_PATTERN,
+      (_match, variable) => {
+        const value = ctx[variable];
+        if (value === undefined || value === null || value === '') {
+          allResolved = false;
+          return '';
+        }
+        return encodeURIComponent(String(value));
+      }
+    );
+    if (allResolved) {
+      resolved[entry.label] = url;
+    }
+  }
+  return resolved;
+};
+
+/**
+ * React hook that resolves admin-configured url-template links against the
+ * supplied page context. The admin config is fetched once on mount and
+ * cached at the connector layer. Re-resolves when the context values change
+ * (e.g. cluster data finishes loading).
+ *
+ * @param {Object<string, string|number>} context e.g. {cluster_name, job_id}
+ * @returns {Object<string, string>} label -> resolved url map
+ */
+export const useTemplateLinks = (context) => {
+  const [entries, setEntries] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDashboardConfig()
+      .then((config) => {
+        if (cancelled) return;
+        setEntries(config?.externalLinks || []);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.debug('useTemplateLinks failed:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return useMemo(
+    () => resolveTemplateLinks(entries, context),
+    [entries, context]
+  );
 };
 
 /**

--- a/sky/dashboard/src/utils/externalLinks.test.js
+++ b/sky/dashboard/src/utils/externalLinks.test.js
@@ -178,6 +178,21 @@ describe('resolveTemplateLinks', () => {
     );
     expect(links).toEqual({ 'Job page': 'https://exp.internal/jobs/7' });
   });
+
+  it('skips non-allowlisted variables, including Object.prototype names', () => {
+    // ${toString} must not resolve to Object.prototype.toString; the entry
+    // is skipped like any other unresolvable variable. Server-side config
+    // validation rejects these, but the client must not trust the config.
+    const links = resolveTemplateLinks(
+      [
+        { label: 'Proto', url: 'https://x.internal/${toString}' },
+        { label: 'Ctor', url: 'https://x.internal/${constructor}' },
+        { label: 'Ok', url: 'https://x.internal/${cluster_name}' },
+      ],
+      { cluster_name: 'my-cluster' }
+    );
+    expect(links).toEqual({ Ok: 'https://x.internal/my-cluster' });
+  });
 });
 
 describe('useTemplateLinks', () => {

--- a/sky/dashboard/src/utils/externalLinks.test.js
+++ b/sky/dashboard/src/utils/externalLinks.test.js
@@ -3,8 +3,11 @@ import { act, renderHook } from '@testing-library/react';
 import {
   BUILTIN_URL_PATTERNS,
   extractLinksFromLogs,
+  resolveTemplateLinks,
   useLogLinkExtractor,
+  useTemplateLinks,
 } from '@/utils/externalLinks';
+import { getDashboardConfig } from '@/data/connectors/dashboard_config';
 
 jest.mock('@/data/connectors/dashboard_config', () => ({
   getDashboardConfig: jest.fn().mockResolvedValue({ externalLinks: [] }),
@@ -104,5 +107,98 @@ describe('useLogLinkExtractor', () => {
     const first = result.current.scanLines;
     rerender();
     expect(result.current.scanLines).toBe(first);
+  });
+});
+
+describe('resolveTemplateLinks', () => {
+  const RAY_ENTRY = {
+    label: 'Ray Dashboard',
+    url: 'https://ray.internal.example.com/dashboard/${cluster_name}',
+  };
+
+  it('substitutes context values into ${var} placeholders', () => {
+    const links = resolveTemplateLinks([RAY_ENTRY], {
+      cluster_name: 'my-cluster',
+    });
+    expect(links).toEqual({
+      'Ray Dashboard': 'https://ray.internal.example.com/dashboard/my-cluster',
+    });
+  });
+
+  it('URI-encodes substituted values', () => {
+    const links = resolveTemplateLinks(
+      [{ label: 'Jobs', url: 'https://exp.internal/jobs?name=${job_name}' }],
+      { job_name: 'train run/v2' }
+    );
+    expect(links).toEqual({
+      Jobs: 'https://exp.internal/jobs?name=train%20run%2Fv2',
+    });
+  });
+
+  it('skips entries whose variables are missing or empty in the context', () => {
+    const entries = [
+      RAY_ENTRY,
+      { label: 'Job page', url: 'https://exp.internal/jobs/${job_id}' },
+    ];
+    // Cluster page context: no job_id, so only the Ray link resolves.
+    const links = resolveTemplateLinks(entries, {
+      cluster_name: 'my-cluster',
+      job_id: undefined,
+    });
+    expect(links).toEqual({
+      'Ray Dashboard': 'https://ray.internal.example.com/dashboard/my-cluster',
+    });
+  });
+
+  it('passes through static urls with no variables', () => {
+    const links = resolveTemplateLinks(
+      [{ label: 'Wiki', url: 'https://wiki.internal/skypilot' }],
+      {}
+    );
+    expect(links).toEqual({ Wiki: 'https://wiki.internal/skypilot' });
+  });
+
+  it('ignores regex entries and malformed input', () => {
+    const links = resolveTemplateLinks(
+      [
+        { label: 'Grafana', regex: 'https://grafana\\.internal/.*' },
+        null,
+        { label: 42, url: 'https://example.com' },
+      ],
+      { cluster_name: 'my-cluster' }
+    );
+    expect(links).toEqual({});
+    expect(resolveTemplateLinks(null, {})).toEqual({});
+  });
+
+  it('substitutes numeric context values (job ids)', () => {
+    const links = resolveTemplateLinks(
+      [{ label: 'Job page', url: 'https://exp.internal/jobs/${job_id}' }],
+      { job_id: 7 }
+    );
+    expect(links).toEqual({ 'Job page': 'https://exp.internal/jobs/7' });
+  });
+});
+
+describe('useTemplateLinks', () => {
+  const flushConfigFetch = () => act(async () => {});
+
+  it('resolves admin-configured url templates against the context', async () => {
+    getDashboardConfig.mockResolvedValueOnce({
+      externalLinks: [
+        {
+          label: 'Ray Dashboard',
+          url: 'https://ray.internal.example.com/dashboard/${cluster_name}',
+        },
+        { label: 'Grafana', regex: 'https://grafana\\.internal/.*' },
+      ],
+    });
+    const { result } = renderHook(() =>
+      useTemplateLinks({ cluster_name: 'my-cluster' })
+    );
+    await flushConfigFetch();
+    expect(result.current).toEqual({
+      'Ray Dashboard': 'https://ray.internal.example.com/dashboard/my-cluster',
+    });
   });
 });

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2681,9 +2681,10 @@ async def api_status(
 async def dashboard_config() -> Dict[str, Any]:
     """Returns admin-configured dashboard settings consumed by the UI.
 
-    Currently exposes the optional `external_links` allowlist that the dashboard
-    matches against streamed logs to render labeled external links on cluster
-    and job detail pages.
+    Currently exposes the optional `external_links` entries: `regex` entries
+    that the dashboard matches against streamed logs, and `url` template
+    entries that the dashboard resolves against cluster/job metadata to render
+    labeled external links on cluster and job detail pages.
     """
     external_links = skypilot_config.get_nested(('dashboard', 'external_links'),
                                                 [])
@@ -2693,9 +2694,15 @@ async def dashboard_config() -> Dict[str, Any]:
             if not isinstance(entry, dict):
                 continue
             label = entry.get('label')
+            if not isinstance(label, str):
+                continue
             regex = entry.get('regex')
-            if isinstance(label, str) and isinstance(regex, str):
+            if isinstance(regex, str):
                 sanitized.append({'label': label, 'regex': regex})
+                continue
+            url = entry.get('url')
+            if isinstance(url, str):
+                sanitized.append({'label': label, 'url': url})
     return {'external_links': sanitized}
 
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -604,9 +604,27 @@ def _validate_config(config: Dict[str, Any], config_source: str) -> None:
     _validate_dashboard_external_links(config, config_source)
 
 
+# Variables that may appear as ${var} inside a dashboard.external_links url
+# template. Substitution happens client-side in the dashboard; keep in sync
+# with TEMPLATE_LINK_VARIABLES in
+# sky/dashboard/src/utils/externalLinks.js.
+DASHBOARD_LINK_TEMPLATE_VARIABLES = frozenset({
+    'cluster_name',
+    'job_id',
+    'job_name',
+    'user',
+    'workspace',
+})
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r'\$\{([^}]*)\}')
+
+
 def _validate_dashboard_external_links(config: Dict[str, Any],
                                        config_source: str) -> None:
-    """Ensures every dashboard.external_links regex is compilable."""
+    """Ensures every dashboard.external_links entry is well-formed.
+
+    `regex` entries must compile; `url` entries may only reference known
+    template variables.
+    """
     dashboard = config.get('dashboard') if isinstance(config, dict) else None
     if not isinstance(dashboard, dict):
         return
@@ -617,15 +635,26 @@ def _validate_dashboard_external_links(config: Dict[str, Any],
         if not isinstance(entry, dict):
             continue
         regex = entry.get('regex')
-        if not isinstance(regex, str):
-            continue
-        try:
-            re.compile(regex)
-        except re.error as e:
-            raise ValueError(
-                f'Invalid config YAML from ({config_source}). '
-                f'dashboard.external_links[{idx}].regex is not a valid regex: '
-                f'{regex!r} ({e}).') from e
+        if isinstance(regex, str):
+            try:
+                re.compile(regex)
+            except re.error as e:
+                raise ValueError(
+                    f'Invalid config YAML from ({config_source}). '
+                    f'dashboard.external_links[{idx}].regex is not a valid '
+                    f'regex: {regex!r} ({e}).') from e
+        url = entry.get('url')
+        if isinstance(url, str):
+            for match in _TEMPLATE_VARIABLE_PATTERN.finditer(url):
+                variable = match.group(1)
+                if variable not in DASHBOARD_LINK_TEMPLATE_VARIABLES:
+                    allowed = ', '.join(
+                        sorted(DASHBOARD_LINK_TEMPLATE_VARIABLES))
+                    raise ValueError(
+                        f'Invalid config YAML from ({config_source}). '
+                        f'dashboard.external_links[{idx}].url references an '
+                        f'unknown template variable '
+                        f'${{{variable}}}. Allowed variables: {allowed}.')
 
 
 def overlay_skypilot_config(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2689,7 +2689,7 @@ def get_config_schema():
                 'type': 'array',
                 'items': {
                     'type': 'object',
-                    'required': ['label', 'regex'],
+                    'required': ['label'],
                     'additionalProperties': False,
                     'properties': {
                         'label': {
@@ -2700,7 +2700,21 @@ def get_config_schema():
                             'type': 'string',
                             'minLength': 1,
                         },
+                        'url': {
+                            'type': 'string',
+                            'minLength': 1,
+                        },
                     },
+                    # Each entry is either a log-scanning pattern (regex) or
+                    # a templated link (url), never both.
+                    'oneOf': [
+                        {
+                            'required': ['regex']
+                        },
+                        {
+                            'required': ['url']
+                        },
+                    ],
                 },
             },
         },

--- a/tests/unit_tests/test_log_links.py
+++ b/tests/unit_tests/test_log_links.py
@@ -141,6 +141,18 @@ class TestCompileAdminPatterns:
             }, 'str'])
         assert not log_links.compile_admin_patterns(None)
 
+    def test_skips_url_template_entries(self):
+        # `url` entries are resolved by the dashboard from cluster/job
+        # metadata; the log scanner must ignore them.
+        compiled = log_links.compile_admin_patterns([{
+            'label': 'Ray Dashboard',
+            'url': 'https://ray.internal.example.com/dashboard/${cluster_name}'
+        }, {
+            'label': 'Good',
+            'regex': r'^https://good\.com/.+$'
+        }])
+        assert set(compiled) == {'Good'}
+
 
 class TestGetPatterns:
     """Combining built-in and admin patterns from config."""

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -860,6 +860,11 @@ def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
         skypilot_config, 'get_nested', lambda keys, default: [{
             'label': 'Grafana',
             'regex': 'https://grafana.example.com/.*'
+        }, {
+            'label': 'Ray Dashboard',
+            'url': 'https://ray.internal.example.com/dashboard/${cluster_name}'
+        }, {
+            'label': 'Malformed entry without regex or url',
         }])
 
     client = TestClient(server.app)
@@ -871,6 +876,9 @@ def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
         'external_links': [{
             'label': 'Grafana',
             'regex': 'https://grafana.example.com/.*'
+        }, {
+            'label': 'Ray Dashboard',
+            'url': 'https://ray.internal.example.com/dashboard/${cluster_name}'
         }]
     }
 

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -1376,6 +1376,59 @@ class TestDashboardSchema(unittest.TestCase):
         with self.assertRaises(jsonschema.ValidationError):
             jsonschema.validate(instance=config, schema=self._get_schema())
 
+    def test_accepts_url_template_entry(self):
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'Ray Dashboard',
+                    'url': 'https://ray.internal.example.com/dashboard/${cluster_name}',
+                }],
+            },
+        }
+        jsonschema.validate(instance=config, schema=self._get_schema())
+
+    def test_accepts_mixed_regex_and_url_entries(self):
+        config = {
+            'dashboard': {
+                'external_links': [
+                    {
+                        'label': 'Grafana',
+                        'regex': r'https://grafana\.internal\.example\.com/.*',
+                    },
+                    {
+                        'label': 'Ray Dashboard',
+                        'url': 'https://ray.internal.example.com/dashboard/${cluster_name}',
+                    },
+                ],
+            },
+        }
+        jsonschema.validate(instance=config, schema=self._get_schema())
+
+    def test_rejects_entry_with_both_regex_and_url(self):
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'Ray Dashboard',
+                    'regex': r'https://example\.com/.*',
+                    'url': 'https://ray.internal.example.com/dashboard/${cluster_name}',
+                }],
+            },
+        }
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=config, schema=self._get_schema())
+
+    def test_rejects_empty_url(self):
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'Ray Dashboard',
+                    'url': '',
+                }],
+            },
+        }
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=config, schema=self._get_schema())
+
 
 class TestDashboardConfigRegexValidation(unittest.TestCase):
     """Tests for the runtime regex-compile validation in skypilot_config."""
@@ -1404,6 +1457,61 @@ class TestDashboardConfigRegexValidation(unittest.TestCase):
                 'external_links': [{
                     'label': 'Good',
                     'regex': r'https://example\.com/.*',
+                }],
+            },
+        }
+        # Should not raise.
+        skypilot_config._validate_dashboard_external_links(  # pylint: disable=protected-access
+            config, 'test_config')
+
+
+class TestDashboardConfigUrlTemplateValidation(unittest.TestCase):
+    """Tests for the url-template validation in skypilot_config."""
+
+    def test_unknown_template_variable_raises_value_error(self):
+        # pylint: disable-next=import-outside-toplevel
+        from sky import skypilot_config
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'Ray Dashboard',
+                    'url': 'https://ray.internal.example.com/dashboard/${clustername}',
+                }],
+            },
+        }
+        with self.assertRaises(ValueError) as ctx:
+            skypilot_config._validate_dashboard_external_links(  # pylint: disable=protected-access
+                config, 'test_config')
+        self.assertIn('dashboard.external_links[0].url', str(ctx.exception))
+        self.assertIn('clustername', str(ctx.exception))
+        self.assertIn('cluster_name', str(ctx.exception))
+
+    def test_known_template_variables_pass(self):
+        # pylint: disable-next=import-outside-toplevel
+        from sky import skypilot_config
+        variables = '/'.join(
+            f'${{{v}}}'
+            for v in sorted(skypilot_config.DASHBOARD_LINK_TEMPLATE_VARIABLES))
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'All variables',
+                    'url': f'https://example.com/{variables}',
+                }],
+            },
+        }
+        # Should not raise.
+        skypilot_config._validate_dashboard_external_links(  # pylint: disable=protected-access
+            config, 'test_config')
+
+    def test_static_url_without_variables_passes(self):
+        # pylint: disable-next=import-outside-toplevel
+        from sky import skypilot_config
+        config = {
+            'dashboard': {
+                'external_links': [{
+                    'label': 'Static',
+                    'url': 'https://example.com/dashboard',
                 }],
             },
         }


### PR DESCRIPTION
## Summary

Stacked on #9934.

* Adds a second kind of entry to `dashboard.external_links`: `{label, url}` templates alongside the existing `{label, regex}` log-scanning entries. Motivated by users whose links never appear in logs but are constructible from metadata, e.g. a Ray dashboard behind a reverse proxy at `https://ray.internal.example.com/dashboard/${cluster_name}`.
* `${variable}` placeholders are substituted client-side by the dashboard with URI-encoded values from the page being viewed. Supported variables: `cluster_name`, `job_id`, `job_name`, `user`, `workspace`. A link only renders on pages where all of its variables resolve, so `${job_id}` entries appear on job pages only, while `${cluster_name}` entries appear on both cluster and job pages (managed jobs use the job's backing cluster via `current_cluster_name`).
* Config-load-time validation: an entry must have exactly one of `regex` / `url` (JSON schema `oneOf`), and `url` templates referencing unknown variables fail fast with an error listing the allowed variables.
* No DB changes and no new endpoints: `GET /dashboard_config` now passes `url` entries through, and the server-side log scanner from #9934 ignores them.

## Config example

```yaml
dashboard:
  external_links:
    # Existing: scan logs for URLs matching a regex.
    - label: "Grafana (from logs)"
      regex: 'https://grafana\.internal\.example\.com/d/[a-z0-9]+.*'
    # New: templated URL, always rendered, no log scanning.
    - label: "Ray Dashboard"
      url: 'https://ray.internal.example.com/dashboard/${cluster_name}'
    - label: "Experiment Platform"
      url: 'https://exp.internal.example.com/jobs/${job_id}'
```

## Test plan

* [x] `bash format.sh`: pylint 10.00/10, mypy clean, ESLint and Prettier clean.
* [x] Unit tests:
  * `tests/unit_tests/test_sky/utils/test_schemas.py`: url entries accepted, mixed lists accepted, both-regex-and-url rejected, empty url rejected, unknown template variable rejected with allowed-variable list, all known variables and static urls accepted (18 passed).
  * `tests/unit_tests/test_sky/server/test_server.py`: `/dashboard_config` serializes url entries and drops malformed ones.
  * `tests/unit_tests/test_log_links.py`: server-side scanner skips url entries (22 passed).
  * `sky/dashboard/src/utils/externalLinks.test.js`: substitution, URI-encoding, skip-on-missing-variable, static urls, malformed input, numeric job ids, and the `useTemplateLinks` hook (15 passed).
* Manual verification on a local API server:
  1. Add the config example above to `~/.sky/config.yaml` and restart the API server.
  2. `curl http://127.0.0.1:46580/dashboard_config` returns both regex and url entries.
  3. Launch a cluster; `/dashboard/clusters/<name>` shows a Ray Dashboard link pointing at `.../dashboard/<name>` (no Experiment Platform link, since `${job_id}` does not resolve on cluster pages).
  4. Open `/dashboard/clusters/<name>/<job>` and a managed job page `/dashboard/jobs/<id>`; both show Ray Dashboard and Experiment Platform links with the cluster name / job id substituted.
  5. Set `url: 'https://x/${clustername}'` (typo) and restart; config load fails with an error naming the entry and listing allowed variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)