### PR TITLE
[Dashboard] Hint when a K8s context's nodes are filtered by allowed_nodes

### DIFF
--- a/sky/dashboard/src/components/AllowedNodesHint.jsx
+++ b/sky/dashboard/src/components/AllowedNodesHint.jsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { InfoIcon } from 'lucide-react';
+import { getAllowedNodesConfig } from '@/data/connectors/infra';
+import { NonCapitalizedTooltip } from '@/components/utils';
+
+/**
+ * Resolve whether a K8s context's node list is filtered by an `allowed_nodes`
+ * config. Shared by the hint banner and the row badge. Fails closed: any error
+ * (or a skipped, non-K8s context) yields `false` so callers never render a
+ * misleading indicator.
+ */
+function useAllowedNodesConfigured(context, skip) {
+  const [configured, setConfigured] = useState(false);
+
+  useEffect(() => {
+    if (skip) {
+      setConfigured(false);
+      return undefined;
+    }
+    // Reset before the in-flight fetch so switching contexts fails closed
+    // rather than flashing the previous context's filtered/unfiltered state.
+    setConfigured(false);
+    let cancelled = false;
+    getAllowedNodesConfig(context)
+      .then((data) => {
+        if (!cancelled) setConfigured(!!data?.configured);
+      })
+      .catch(() => {
+        if (!cancelled) setConfigured(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [context, skip]);
+
+  return configured;
+}
+
+/**
+ * Hint banner shown on the infra context-detail page when the context's node
+ * list is filtered by an `allowed_nodes` config. Without this, an admin who
+ * expects to see more nodes than are listed may mistake the filtered view for
+ * a bug.
+ *
+ * `allowed_nodes` is a Kubernetes-only concept, so this renders nothing for
+ * Slurm contexts or SSH node pools (`ssh-<pool>`).
+ */
+export function AllowedNodesHint({ contextName, isSlurm = false }) {
+  const skip = isSlurm || !contextName || contextName.startsWith('ssh-');
+  const configured = useAllowedNodesConfigured(contextName, skip);
+
+  if (skip || !configured) {
+    return null;
+  }
+
+  return (
+    <div
+      role="note"
+      className="flex items-start gap-2 mb-4 px-3 py-2.5 rounded-md border border-blue-200 bg-blue-50 text-sm leading-normal text-blue-900"
+    >
+      <InfoIcon className="w-4 h-4 mt-0.5 flex-shrink-0" />
+      <span>
+        This context has{' '}
+        <code className="px-1 py-0.5 rounded bg-blue-100 text-xs font-mono">
+          allowed_nodes
+        </code>{' '}
+        configured, so only matching nodes are shown here — other nodes in this
+        context are hidden by configuration
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Compact badge shown next to a K8s context's name in the main infra-page
+ * Kubernetes table when that context's node list is filtered by an
+ * `allowed_nodes` config. Surfaces the same information as `AllowedNodesHint`
+ * without needing to click into the context, so the Nodes count isn't
+ * mistaken for the full cluster. `kind` is 'k8s' | 'ssh' | 'slurm' and `id` is
+ * the context name.
+ */
+export function AllowedNodesRowBadge({ id, kind }) {
+  const skip = kind !== 'k8s' || !id;
+  const configured = useAllowedNodesConfigured(id, skip);
+
+  if (skip || !configured) {
+    return null;
+  }
+
+  return (
+    <NonCapitalizedTooltip
+      content="Node list filtered by allowed_nodes — not all nodes in this context are shown"
+      placement="top"
+    >
+      <span
+        role="img"
+        aria-label="allowed_nodes filter active"
+        className="inline-flex items-center flex-shrink-0 text-blue-600"
+      >
+        <InfoIcon className="w-3.5 h-3.5" />
+      </span>
+    </NonCapitalizedTooltip>
+  );
+}
+
+export default AllowedNodesHint;

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -88,6 +88,10 @@ import {
   NonCapitalizedTooltip,
   LastUpdatedTimestamp,
 } from '@/components/utils';
+import {
+  AllowedNodesHint,
+  AllowedNodesRowBadge,
+} from '@/components/AllowedNodesHint';
 import { Card } from '@/components/ui/card';
 import {
   Select,
@@ -507,9 +511,15 @@ export function InfrastructureSection({
                             {!hasGpuData ? (
                               <SkeletonBadge />
                             ) : (
-                              <span className="px-2 py-0.5 bg-gray-100 text-gray-500 rounded text-xs font-medium">
-                                {totalGpus}
-                              </span>
+                              <div className="flex items-center gap-1.5">
+                                <span className="px-2 py-0.5 bg-gray-100 text-gray-500 rounded text-xs font-medium">
+                                  {totalGpus}
+                                </span>
+                                <AllowedNodesRowBadge
+                                  id={rowId}
+                                  kind={rowKind}
+                                />
+                              </div>
                             )}
                           </td>
                           <td className="p-3 text-right">
@@ -757,6 +767,7 @@ export function ContextDetails({
         name="infra.contextDetail.statusPanel"
         context={{ contextName, isSlurm }}
       />
+      <AllowedNodesHint contextName={contextName} isSlurm={isSlurm} />
       <div className="rounded-lg border bg-card text-card-foreground shadow-sm h-full">
         <div className="p-5">
           <div className="flex items-center justify-between mb-4">

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -207,6 +207,25 @@ export async function getGPUs() {
   return await getWorkspaceInfrastructure();
 }
 
+/**
+ * Whether a Kubernetes context's node list is filtered by an `allowed_nodes`
+ * config. Drives the infra-page hint/badge that warn not all nodes in the
+ * context are shown, so a missing node isn't mistaken for a bug. Falls back to
+ * `{ configured: false }` on any error so the hint fails closed (no banner)
+ * rather than showing a misleading one.
+ */
+export async function getAllowedNodesConfig(context) {
+  try {
+    const response = await apiClient.get(
+      `/kubernetes/allowed_nodes?k8s_context=${encodeURIComponent(context)}`
+    );
+    if (!response.ok) return { configured: false };
+    return await response.json();
+  } catch {
+    return { configured: false };
+  }
+}
+
 // New workspace-aware infrastructure fetching function
 export async function getWorkspaceInfrastructure() {
   try {

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2677,6 +2677,31 @@ async def api_status(
         return encoded_request_tasks
 
 
+@app.get('/kubernetes/allowed_nodes')
+async def kubernetes_allowed_nodes(k8s_context: str) -> Dict[str, Any]:
+    """Whether a K8s context's node list is filtered by ``allowed_nodes``.
+
+    Drives the infra-page hint that tells users the node list for this
+    context is filtered by an ``allowed_nodes`` config — so a node they
+    expect to see but is missing isn't mistaken for a bug. Reads the loaded
+    config directly (a cheap in-memory lookup with the same context-override
+    resolution the provisioner uses), so it runs in the event loop without
+    the request-id machinery.
+
+    Fails closed: any error resolving the config yields ``configured: False``
+    so the dashboard never shows a misleading banner.
+    """
+    try:
+        allowed_nodes = kubernetes_utils.get_allowed_nodes_config(
+            context=k8s_context)
+    except Exception:  # pylint: disable=broad-except
+        logger.debug('Failed to resolve allowed_nodes for context %r',
+                     k8s_context,
+                     exc_info=True)
+        return {'configured': False}
+    return {'configured': bool(allowed_nodes)}
+
+
 @app.get('/dashboard_config')
 async def dashboard_config() -> Dict[str, Any]:
     """Returns admin-configured dashboard settings consumed by the UI.

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -247,6 +247,10 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'method': 'GET'
     },
     {
+        'path': '/kubernetes/allowed_nodes',
+        'method': 'GET'
+    },
+    {
         'path': '/list_accelerators',
         'method': 'POST'
     },


### PR DESCRIPTION
## Summary

When a Kubernetes context has an `allowed_nodes` config, the infra page only lists the matching nodes. With no indication that a filter is in effect, an admin who expects to see more nodes can mistake the filtered view (and the reduced **Nodes** / **GPUs** counts) for a bug.

This PR surfaces the filter in two places, both fed by a new lightweight `GET /kubernetes/allowed_nodes` endpoint that reports whether a context's node list is restricted. The endpoint is a cheap in-memory config lookup (`kubernetes_utils.get_allowed_nodes_config`) that reuses the same context-override resolution the provisioner uses, so it runs directly in the event loop:

- **Context-detail banner** — a note on the context page explaining that only matching nodes are shown.
- **Infra-table badge** — a small info icon in the **GPUs** column, right after the count, so a reduced GPU count is legible without clicking in.

Both fail closed: any error resolving the config renders nothing rather than a misleading banner. `allowed_nodes` is Kubernetes-only, so Slurm contexts and SSH node pools are skipped.

## Test plan

- `npm run build` in `sky/dashboard` succeeds.
- `python -m yapf --diff sky/server/server.py` reports no changes.
- Manual (not yet run on a live server): set `kubernetes.allowed_nodes` for a context in `~/.sky/config.yaml`, start the API server, and confirm the banner shows on the context-detail page and the badge shows after the GPU count in the infra table; confirm neither renders for a context with no `allowed_nodes`, nor for a Slurm context or SSH node pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)