### PR TITLE
[Core] Add SKYPILOT_DISABLE_LOCAL_API_SERVER to block local API server autostart

### DIFF
--- a/docs/source/reference/api-server/api-server.rst
+++ b/docs/source/reference/api-server/api-server.rst
@@ -117,6 +117,12 @@ To verify that the API server is working, run ``sky api info``:
         ├── Status: healthy, commit: xxxxx, version: 1.0.0-dev0
         └── User: skypilot-user (xxxxxx)
 
+.. note::
+
+    Set ``SKYPILOT_DISABLE_LOCAL_API_SERVER=1`` to prevent starting a local
+    API server — both the automatic background start and ``sky api start``.
+    Blocked commands error and point to ``sky api login -e <endpoint>``.
+
 
 .. toctree::
    :hidden:

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -42,6 +42,7 @@ from sky.skylet import constants
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import env_options
 from sky.utils import rich_utils
 from sky.utils import ux_utils
 from sky.utils import yaml_utils
@@ -644,6 +645,27 @@ def get_stream_request_id(
     return None
 
 
+def check_local_api_server_enabled_or_raise() -> None:
+    """Raises if starting a local API server is disabled via env var.
+
+    Guards every code path that would start a local API server (both the
+    implicit auto-start when no healthy server is found at a local endpoint,
+    and the explicit `sky api start`) when
+    SKYPILOT_DISABLE_LOCAL_API_SERVER=1 is set.
+
+    Raises:
+        RuntimeError: if the local API server is disabled.
+    """
+    if env_options.Options.DISABLE_LOCAL_API_SERVER.get():
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                'No SkyPilot API server endpoint is configured, and starting '
+                'a local API server on this machine is disabled '
+                f'({env_options.Options.DISABLE_LOCAL_API_SERVER.env_var}=1).'
+                ' To connect to a SkyPilot API server, run: '
+                'sky api login -e <endpoint>')
+
+
 def _start_api_server(deploy: bool = False,
                       host: str = '127.0.0.1',
                       foreground: bool = False,
@@ -651,6 +673,7 @@ def _start_api_server(deploy: bool = False,
                       metrics_port: Optional[int] = None,
                       enable_basic_auth: bool = False):
     """Starts a SkyPilot API server locally."""
+    check_local_api_server_enabled_or_raise()
     server_url = get_server_url(host)
     assert server_url in AVAILABLE_LOCAL_API_SERVER_URLS, (
         f'server url {server_url} is not a local url')
@@ -909,6 +932,9 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
         if not is_api_server_local():
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ApiServerConnectionError(endpoint) from exc
+        # Fail early (before taking the creation lock) if silently starting
+        # a local API server is disabled on this machine.
+        check_local_api_server_enabled_or_raise()
         # Lock to prevent multiple processes from starting the server at the
         # same time, causing issues with database initialization.
         with filelock.FileLock(

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -31,6 +31,14 @@ class Options(enum.Enum):
     # config.
     ALLOW_ALL_KUBERNETES_CONTEXTS = ('SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS',
                                      False)
+    # Disable starting a local API server on this machine, including the
+    # silent auto-start that happens when a client command finds no API
+    # server endpoint configured. When set, any code path that would start
+    # a local API server fails with an actionable error instead. Useful in
+    # managed environments (CI runners, dev containers, in-cluster pods)
+    # where an implicitly started local API server could schedule real
+    # workloads using ambient credentials (e.g. a pod ServiceAccount).
+    DISABLE_LOCAL_API_SERVER = ('SKYPILOT_DISABLE_LOCAL_API_SERVER', False)
     # Whether `allowed_contexts: 'all'` (or the env-var-triggered allow-all
     # path) should include the API server's own in-cluster context. Default
     # `True` (backward compatible). Set to `false` on the API server pod to

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -136,6 +136,52 @@ def test_check_server_healthy_or_start_rechecks_status(
         versions.set_remote_version('unknown')
 
 
+@mock.patch('sky.server.common._start_api_server')
+@mock.patch('sky.server.common.filelock.FileLock')
+@mock.patch('sky.server.common.make_authenticated_request')
+@mock.patch('sky.server.common.is_api_server_local', return_value=True)
+@mock.patch('sky.server.common.get_server_url',
+            return_value='http://127.0.0.1:1111')
+def test_check_server_healthy_or_start_disabled_local_api_server(
+        unused_mock_server_url, unused_mock_is_local, mock_make_request,
+        mock_filelock, mock_start_server):
+    """SKYPILOT_DISABLE_LOCAL_API_SERVER=1 blocks the silent auto-start.
+
+    When no healthy API server is reachable at a local endpoint, the client
+    normally starts one in the background. With the env var set, it must
+    fail with an actionable error instead, and never attempt the start.
+    """
+    mock_make_request.side_effect = requests.exceptions.ConnectionError()
+
+    with mock.patch.dict(os.environ,
+                         {'SKYPILOT_DISABLE_LOCAL_API_SERVER': '1'}):
+        with pytest.raises(RuntimeError) as exc_info:
+            common.check_server_healthy_or_start_fn()
+
+    assert 'sky api login' in str(exc_info.value)
+    assert 'SKYPILOT_DISABLE_LOCAL_API_SERVER' in str(exc_info.value)
+    mock_start_server.assert_not_called()
+    # The guard fires before the server-creation lock is taken.
+    mock_filelock.assert_not_called()
+
+
+def test_start_api_server_disabled_by_env_var():
+    """_start_api_server itself is guarded (covers `sky api start` too)."""
+    with mock.patch.dict(os.environ,
+                         {'SKYPILOT_DISABLE_LOCAL_API_SERVER': '1'}):
+        with pytest.raises(RuntimeError) as exc_info:
+            common._start_api_server()
+    assert 'SKYPILOT_DISABLE_LOCAL_API_SERVER' in str(exc_info.value)
+
+
+def test_local_api_server_not_disabled_by_default():
+    """Without the env var, the guard is a no-op."""
+    env = os.environ.copy()
+    env.pop('SKYPILOT_DISABLE_LOCAL_API_SERVER', None)
+    with mock.patch.dict(os.environ, env, clear=True):
+        common.check_local_api_server_enabled_or_raise()
+
+
 @mock.patch('sky.server.common.get_api_server_status')
 @mock.patch('sky.server.common.is_api_server_local')
 def test_local_client_server_mismatch(mock_is_local, mock_get_status):


### PR DESCRIPTION
## Problem

When no healthy API server is found at a local endpoint, the SkyPilot client silently starts a local API server in the background (`check_server_healthy_or_start_fn` -> `_start_api_server`). In managed or shared environments — CI runners, dev containers, in-cluster pods — this implicit fallback can be dangerous: the auto-started server picks up ambient credentials (e.g. an in-cluster Kubernetes ServiceAccount) and can schedule real workloads (jobs controller, job pods) that the user never intended to run from that machine, outside of any centrally-managed API server.

## Change

Add a `SKYPILOT_DISABLE_LOCAL_API_SERVER` env var, following the existing `env_options.Options` convention. When set to `1`/`true`:

- The silent autostart path in `check_server_healthy_or_start_fn` fails with an actionable error instead of spawning a server:

  ```
  No SkyPilot API server endpoint is configured, and starting a local API server
  on this machine is disabled (SKYPILOT_DISABLE_LOCAL_API_SERVER=1). To connect
  to a SkyPilot API server, run: sky api login -e <endpoint>
  ```

- `_start_api_server` itself is guarded as a single choke point, which also covers the explicit `sky api start` (via `sdk.api_start` -> `check_server_healthy_or_start_fn`).

Default behavior is completely unchanged: without the env var, autostart works exactly as before.

## Changes

- `sky/utils/env_options.py`: new `DISABLE_LOCAL_API_SERVER` option.
- `sky/server/common.py`: `check_local_api_server_enabled_or_raise()` guard, called from the autostart path (before taking the server-creation lock) and from `_start_api_server`.
- `tests/unit_tests/test_sky/server/test_common.py`: unit tests — env var set blocks autostart with the actionable error and never takes the creation lock; `_start_api_server` is guarded directly; guard is a no-op by default.
- `docs/source/reference/api-server/api-server.rst`: note documenting the env var.

## Tests

```
$ pytest tests/unit_tests/test_sky/server/test_common.py
18 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)