### PR TITLE
[AWS] Skip unreachable me-south-1 region in catalog fetcher

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -49,7 +49,8 @@ ALL_REGIONS = [
     'eu-south-2',
     'eu-west-3',
     'eu-north-1',
-    'me-south-1',
+    # 'me-south-1', # currently unreachable, so skip it to avoid
+    # failing the whole fetch. Re-enable once connectivity is restored.
     'me-central-1',
     'af-south-1',
     'ap-east-1',


### PR DESCRIPTION
## Summary

- The scheduled `update-aws-catalog` GitHub Action is failing because the `me-south-1` EC2 endpoint is currently unreachable from the fetcher's network environment (`Failed to connect to the AWS EC2 endpoint`).
- Since `me-south-1` remained in the requested region set, `_check_regions_integrity` (and `--check-all-regions-enabled-for-account`) then failed the entire fetch with `Diff: {'me-south-1'}`.
- This comments out `me-south-1` from `ALL_REGIONS` so it is excluded from the requested set and both integrity checks — consistent with how other unavailable regions (`eu-central-2`, `ap-south-2`) are already handled. Re-enable once connectivity is restored.

Failing run: https://github.com/skypilot-org/skypilot-catalog/actions/runs/29210520764/job/86697377985

## Test plan

- `get_enabled_regions()` intersects account-enabled regions with `ALL_REGIONS`, so dropping `me-south-1` from the list removes it from `user_regions`, from `get_all_regions_instance_types_df` / `get_all_regions_images_df`, and from `_check_regions_integrity` — no other references to `me-south-1` remain in the fetcher.
- Verified the diff is a comment-only change to the region list; pre-commit (isort/mypy/yapf/pylint) passes.
- The scheduled catalog fetcher action will confirm end-to-end on the next run (it installs the released `sky` package, so this lands after a version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)