### PR TITLE
[Kubernetes] enable_docker: fix BuildKit cache_volume on unsupported storage

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3665,6 +3665,33 @@ _BUILDKITD_CONTAINER_NAME = 'buildkitd'
 _DIND_CACHE_SUBPATH_PREFIX = 'var_lib_docker'
 _BUILDKIT_CACHE_SUBPATH_PREFIX = 'buildkit_cache'
 
+# Rootless BuildKit reproduces image-layer ownership by chowning files to the
+# daemon's user-namespace ids while materializing each layer. Network
+# filesystems (NFS/CIFS/SMB) do not honor that chown, so every build step past
+# the base image fails deep into the build with an opaque
+# "lchown ... operation not permitted". A block-backed volume (ext4/xfs) is
+# required for the cache_volume. This init container detects the backing
+# filesystem before the daemon starts and fails fast with an actionable message
+# instead of the cryptic error mid-build.
+_BUILDKIT_CACHE_FS_CHECK_CONTAINER = 'buildkit-cache-fs-check'
+_BUILDKIT_CACHE_FS_CHECK_MOUNT = '/cache'
+_BUILDKIT_CACHE_FS_CHECK_SCRIPT = (
+    'set -eu\n'
+    'fstype=$(stat -f -c %T ' + _BUILDKIT_CACHE_FS_CHECK_MOUNT +
+    ' 2>/dev/null || echo unknown)\n'
+    'case "$fstype" in\n'
+    'nfs|nfs4|cifs|smb2|smb3|smbfs|fuseblk|fuse|fuse.*)\n'
+    'echo "enable_docker: the BuildKit cache_volume is backed by a network '
+    'filesystem ($fstype), but rootless BuildKit requires block/local storage '
+    'to host its layer store; image builds fail with lchown '
+    'operation-not-permitted. Use a block-backed StorageClass (ext4/xfs) for '
+    'the cache_volume, or omit cache_volume to use an ephemeral local cache." '
+    '1>&2\n'
+    'exit 1\n'
+    ';;\n'
+    'esac\n'
+    'echo "BuildKit cache_volume filesystem ($fstype) is supported"\n')
+
 
 class DockerMode(str, enum.Enum):
     """Modes for the ``enable_docker`` config."""
@@ -3818,6 +3845,44 @@ def inject_docker_cache_volume(
                     'name': vol_name,
                     'mountPath': cache_mount,
                     'subPath': sub_path,
+                })
+                if mode == DockerMode.BUILD:
+                    # Pin the snapshotter to overlayfs so buildkitd always takes
+                    # the fast kernel-overlay path on a supported (block/local)
+                    # cache volume and never silently degrades to the slower
+                    # `native` full-copy snapshotter (which buildkit auto-selects
+                    # whenever its overlay-support probe fails, e.g. on a volume
+                    # mounted nosuid/nodev). Unsupported network-filesystem
+                    # cache volumes are rejected up front by the fs-check init
+                    # container below.
+                    args = ctr.setdefault('args', [])
+                    if not any(
+                            str(a).startswith('--oci-worker-snapshotter')
+                            for a in args):
+                        args.append('--oci-worker-snapshotter=overlayfs')
+
+        if mode == DockerMode.BUILD:
+            # Fail fast if the cache_volume is on a network filesystem that
+            # rootless BuildKit cannot use as a layer store (see
+            # _BUILDKIT_CACHE_FS_CHECK_SCRIPT).
+            init_ctrs = pod_spec['spec'].setdefault('initContainers', [])
+            if not any(
+                    c.get('name') == _BUILDKIT_CACHE_FS_CHECK_CONTAINER
+                    for c in init_ctrs):
+                init_ctrs.append({
+                    'name': _BUILDKIT_CACHE_FS_CHECK_CONTAINER,
+                    'image': defaults.image,
+                    'command': ['/bin/sh', '-c'],
+                    'args': [_BUILDKIT_CACHE_FS_CHECK_SCRIPT],
+                    'securityContext': {
+                        'runAsUser': 1000,
+                        'runAsGroup': 1000,
+                    },
+                    'volumeMounts': [{
+                        'name': vol_name,
+                        'mountPath': _BUILDKIT_CACHE_FS_CHECK_MOUNT,
+                        'subPath': sub_path,
+                    }],
                 })
     else:
         # No PVC: add an emptyDir so the builder doesn't write to the

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -3980,6 +3980,84 @@ class TestInjectDockerCacheVolume(unittest.TestCase):
 
         assert pod['spec']['securityContext']['fsGroup'] == 2000
 
+    # ---- BuildKit: cache-volume filesystem guard ----
+
+    def test_buildkit_pvc_adds_fs_check_init_container(self):
+        """BuildKit PVC path adds a guard init container that rejects a
+        network-filesystem cache_volume (rootless BuildKit can't chown its
+        layer store there)."""
+        pod = self._make_pod_spec(ctr_name='buildkitd')
+        utils.inject_docker_cache_volume(pod,
+                                         self._BUILDKIT_CFG,
+                                         pvc_name='my-pvc',
+                                         context='ctx',
+                                         namespace='ns')
+
+        init_ctrs = pod['spec']['initContainers']
+        guard = next(c for c in init_ctrs
+                     if c['name'] == utils._BUILDKIT_CACHE_FS_CHECK_CONTAINER)
+        # Guard inspects the same subPath the daemon will use.
+        guard_vm = guard['volumeMounts'][0]
+        bk_ctr = next(
+            c for c in pod['spec']['containers'] if c['name'] == 'buildkitd')
+        assert guard_vm['subPath'] == bk_ctr['volumeMounts'][0]['subPath']
+        assert guard_vm['mountPath'] == utils._BUILDKIT_CACHE_FS_CHECK_MOUNT
+        assert guard['securityContext']['runAsUser'] == 1000
+        # Script fails on network filesystems, passes otherwise.
+        script = guard['args'][0]
+        assert 'nfs' in script and 'cifs' in script
+        assert 'exit 1' in script
+
+    def test_buildkit_pvc_pins_overlayfs_snapshotter(self):
+        """BuildKit PVC path pins the overlayfs snapshotter so buildkitd never
+        silently degrades to the native snapshotter."""
+        pod = self._make_pod_spec(ctr_name='buildkitd')
+        utils.inject_docker_cache_volume(pod,
+                                         self._BUILDKIT_CFG,
+                                         pvc_name='my-pvc',
+                                         context='ctx',
+                                         namespace='ns')
+        bk_ctr = next(
+            c for c in pod['spec']['containers'] if c['name'] == 'buildkitd')
+        assert '--oci-worker-snapshotter=overlayfs' in bk_ctr['args']
+
+    def test_buildkit_pvc_preserves_existing_snapshotter(self):
+        """A user-provided snapshotter flag is not overridden."""
+        pod = self._make_pod_spec(ctr_name='buildkitd')
+        bk_ctr = next(
+            c for c in pod['spec']['containers'] if c['name'] == 'buildkitd')
+        bk_ctr['args'] = ['--oci-worker-snapshotter=fuse-overlayfs']
+        utils.inject_docker_cache_volume(pod,
+                                         self._BUILDKIT_CFG,
+                                         pvc_name='my-pvc',
+                                         context='ctx',
+                                         namespace='ns')
+        snapshotter_args = [
+            a for a in bk_ctr['args']
+            if a.startswith('--oci-worker-snapshotter')
+        ]
+        assert snapshotter_args == ['--oci-worker-snapshotter=fuse-overlayfs']
+
+    def test_buildkit_no_pvc_no_fs_check(self):
+        """emptyDir (no PVC) needs no guard — it is always local."""
+        pod = self._make_pod_spec(ctr_name='buildkitd')
+        utils.inject_docker_cache_volume(pod,
+                                         self._BUILDKIT_CFG,
+                                         pvc_name=None,
+                                         context='ctx',
+                                         namespace='ns')
+        assert 'initContainers' not in pod['spec']
+
+    def test_dind_pvc_no_fs_check(self):
+        """DinD does not use the rootless BuildKit layer store, so no guard."""
+        pod = self._make_pod_spec(ctr_name='dind')
+        utils.inject_docker_cache_volume(pod,
+                                         self._DIND_CFG,
+                                         pvc_name='my-pvc',
+                                         context='ctx',
+                                         namespace='ns')
+        assert 'initContainers' not in pod['spec']
+
     # ---- subPath hashing ----
 
     def test_subpath_varies_by_pod_name(self):


### PR DESCRIPTION
**Problem.** `enable_docker` in `build` mode with a `cache_volume` fails on the first build step after the base image with an opaque

```
failed to Lchown ".../etc/shadow" for UID 0, GID 42: operation not permitted
```

when the cache volume can't host the rootless-BuildKit layer store. Cluster **default** StorageClasses are commonly network filesystems (NFS/CIFS/SMB), so users hit this by default.

**Cause.** On a network filesystem, rootless BuildKit cannot chown image-layer files to its user-namespace ids while materializing each layer — this chown is in containerd's mount-callback layer apply, *above* the snapshotter, so no snapshotter choice (native, overlayfs, or fuse-overlayfs) avoids it. A block/local volume (ext4/xfs) is required, as the docs already state; nothing enforced it. A secondary issue makes this worse and costs performance even where builds work: when the volume can't host overlayfs, buildkitd silently degrades to the `native` full-copy snapshotter — builds still succeed on supported storage, but slower, and the degradation is invisible.

**Fix.**
- Add an init container that detects a network-filesystem cache volume before the daemon starts and fails fast with an actionable message (use a block-backed StorageClass, or omit `cache_volume` for an ephemeral local cache).
- Pin `--oci-worker-snapshotter=overlayfs` on the BuildKit sidecar when a `cache_volume` is set, so a supported block/local volume deterministically takes the fast kernel-overlay path instead of ever silently picking `native` (a user-provided snapshotter flag is preserved).

**Why not fuse-overlayfs for network-fs caches?** Tested directly: with `/dev/fuse` available and the snapshotter pinned to `fuse-overlayfs`, a build on an NFS-backed cache volume fails at snapshot preparation with `rename ... invalid cross-device link` (the snapshotter's prepare→commit rename crosses a FUSE mount boundary), while the identical setup succeeds on local storage. So no snapshotter — native, overlayfs, or fuse-overlayfs — makes a network-filesystem layer store work for rootless BuildKit: the requirement is block/local storage, which this change now enforces up front.

**Minimal repro.** `enable_docker: build` with a `cache_volume` on an NFS/SMB-backed StorageClass, then build:

```dockerfile
FROM alpine:3.20
RUN echo hi > /x
```

**Tested.**
- Unit: `tests/unit_tests/kubernetes/test_kubernetes_utils.py::TestInjectDockerCacheVolume` (17 passed) — asserts the pinned snapshotter arg (and that a user flag is preserved) and the guard init container (present for the BuildKit PVC path with the daemon's subPath; absent for emptyDir and DinD).
- Manual (Kubernetes): NFS-backed PVC → pod stops at `Init:Error` with the block-storage message, the daemon never starts; local volume → prints "filesystem (xfs) is supported" and proceeds; block PVC → overlayfs auto-selected, multi-layer builds pass.



