### PR TITLE
[Test] Replace retired p3.2xlarge with g4dn.xlarge in tests

### DIFF
--- a/tests/test_jobs_and_serve.py
+++ b/tests/test_jobs_and_serve.py
@@ -101,7 +101,7 @@ def _mock_cluster_state(_mock_db_conn, tmp_path):
         cluster_yaml=_generate_tmp_yaml(tmp_path, 'cluster1.yaml'),
         launched_nodes=2,
         launched_resources=sky.Resources(infra='aws/us-east-1',
-                                         instance_type='p3.2xlarge'),
+                                         instance_type='g4dn.xlarge'),
     )
     global_user_state.add_or_update_cluster(
         'test-cluster1',

--- a/tests/test_no_parellel.py
+++ b/tests/test_no_parellel.py
@@ -47,7 +47,7 @@ class TestAllCloudsEnabled:
         spec = textwrap.dedent("""\
             resources:
                 cloud: aws
-                instance_type: p3.2xlarge""")
+                instance_type: g4dn.xlarge""")
         cli_runner = cli_testing.CliRunner()
 
         def _capture_mismatch_gpus_spec(file_path, gpus: str):
@@ -66,15 +66,15 @@ class TestAllCloudsEnabled:
             f.write(spec)
             f.flush()
 
-            _capture_mismatch_gpus_spec(f.name, 'T4:1')
+            _capture_mismatch_gpus_spec(f.name, 'A10G:1')
+            _capture_mismatch_gpus_spec(f.name, 'A10G:0.5')
+            _capture_mismatch_gpus_spec(f.name, 'T4:2')
+            _capture_mismatch_gpus_spec(f.name, 't4:2')
             _capture_mismatch_gpus_spec(f.name, 'T4:0.5')
-            _capture_mismatch_gpus_spec(f.name, 'V100:2')
-            _capture_mismatch_gpus_spec(f.name, 'v100:2')
-            _capture_mismatch_gpus_spec(f.name, 'V100:0.5')
 
-            _capture_match_gpus_spec(f.name, 'V100:1')
-            _capture_match_gpus_spec(f.name, 'V100:1')
-            _capture_match_gpus_spec(f.name, 'V100')
+            _capture_match_gpus_spec(f.name, 'T4:1')
+            _capture_match_gpus_spec(f.name, 'T4:1')
+            _capture_match_gpus_spec(f.name, 'T4')
 
     def test_k8s_alias(self, enable_all_clouds):
         cli_runner = cli_testing.CliRunner()

--- a/tests/test_no_parellel.py
+++ b/tests/test_no_parellel.py
@@ -73,7 +73,7 @@ class TestAllCloudsEnabled:
             _capture_mismatch_gpus_spec(f.name, 'T4:0.5')
 
             _capture_match_gpus_spec(f.name, 'T4:1')
-            _capture_match_gpus_spec(f.name, 'T4:1')
+            _capture_match_gpus_spec(f.name, 't4:1')
             _capture_match_gpus_spec(f.name, 'T4')
 
     def test_k8s_alias(self, enable_all_clouds):

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -96,7 +96,7 @@ def _test_resources_launch(*resources_args,
 
 
 def test_resources_aws(enable_all_clouds):
-    _test_resources_launch(infra='aws', instance_type='p3.2xlarge')
+    _test_resources_launch(infra='aws', instance_type='g4dn.xlarge')
 
 
 def test_resources_azure(enable_all_clouds):
@@ -141,10 +141,10 @@ def test_partial_tpu(enable_all_clouds):
     _test_resources_launch(accelerators='tpu-v3-8')
 
 
-def test_partial_v100(enable_all_clouds):
-    _test_resources_launch(sky.AWS(), accelerators='V100')
-    _test_resources_launch(sky.AWS(), accelerators='V100', use_spot=True)
-    _test_resources_launch(sky.AWS(), accelerators={'V100': 8})
+def test_partial_t4(enable_all_clouds):
+    _test_resources_launch(sky.AWS(), accelerators='T4')
+    _test_resources_launch(sky.AWS(), accelerators='T4', use_spot=True)
+    _test_resources_launch(sky.AWS(), accelerators={'T4': 8})
 
 
 def test_invalid_cloud_tpu(enable_all_clouds):
@@ -320,10 +320,10 @@ def test_instance_type_from_cpu_memory(enable_all_clouds, capfd):
 
 def test_instance_type_mistmatches_accelerators(enable_all_clouds):
     bad_instance_and_accs = [
-        # Actual: V100
-        ('p3.2xlarge', 'K80'),
+        # Actual: T4
+        ('g4dn.xlarge', 'K80'),
         # Actual: None
-        ('m4.2xlarge', 'V100'),
+        ('m4.2xlarge', 'T4'),
     ]
     for instance, acc in bad_instance_and_accs:
         with pytest.raises(exceptions.ResourcesMismatchError) as e:
@@ -346,15 +346,15 @@ def test_instance_type_mistmatches_accelerators(enable_all_clouds):
 
     with pytest.raises(exceptions.ResourcesMismatchError) as e:
         _test_resources_launch(sky.AWS(),
-                               instance_type='p3.16xlarge',
-                               accelerators={'V100': 1})
+                               instance_type='g4dn.12xlarge',
+                               accelerators={'T4': 1})
         assert 'Infeasible resource demands found' in str(e.value)
 
 
 def test_instance_type_matches_accelerators(enable_all_clouds):
     _test_resources_launch(sky.AWS(),
-                           instance_type='p3.2xlarge',
-                           accelerators='V100')
+                           instance_type='g4dn.xlarge',
+                           accelerators='T4')
     _test_resources_launch(sky.GCP(),
                            instance_type='n1-standard-2',
                            accelerators='V100')
@@ -371,8 +371,8 @@ def test_instance_type_matches_accelerators(enable_all_clouds):
                            accelerators={'H100': 8})
 
     _test_resources_launch(sky.AWS(),
-                           instance_type='p3.16xlarge',
-                           accelerators={'V100': 8})
+                           instance_type='g4dn.metal',
+                           accelerators={'T4': 8})
 
 
 def test_invalid_instance_type(enable_all_clouds):
@@ -386,8 +386,8 @@ def test_infer_cloud_from_instance_type(enable_all_clouds):
     # AWS instances
     _test_resources(instance_type='m5.12xlarge', expected_cloud=sky.AWS())
     _test_resources_launch(instance_type='m5.12xlarge')
-    _test_resources(instance_type='p3.8xlarge', expected_cloud=sky.AWS())
-    _test_resources_launch(instance_type='p3.8xlarge')
+    _test_resources(instance_type='g4dn.12xlarge', expected_cloud=sky.AWS())
+    _test_resources_launch(instance_type='g4dn.12xlarge')
     _test_resources(instance_type='g4dn.2xlarge', expected_cloud=sky.AWS())
     _test_resources_launch(instance_type='g4dn.2xlarge')
     # GCP instances


### PR DESCRIPTION
AWS retired the P3 (V100) generation, and the 2026-07-13 AWS catalog refresh — the first since #10095 unblocked the catalog update bot from the unreachable me-south-1 region — dropped all `p3.*` rows. Tests that hardcode `p3.2xlarge` now fail with `ValueError('No instance type p3.2xlarge found.')`: `test_accelerator_mismatch` and the six jobs/serve controller tests that build cluster handles from it.

Switch the affected fixtures to `g4dn.xlarge` (T4:1, present in the current catalog) and move the accelerator match/mismatch pairs from V100/T4 to T4/A10G, preserving each case's intent (wrong type, fractional count, wrong count, case-insensitivity, count default).

Tested (run the relevant ones):

- [x] `pytest tests/test_no_parellel.py::TestAllCloudsEnabled::test_accelerator_mismatch`
- [x] `pytest tests/test_jobs_and_serve.py::TestJobsOperations tests/test_jobs_and_serve.py::TestServeOperations` (previously failing six tests pass)