### PR TITLE
[Client] Apply retry_transient_errors to the sync request() path

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -361,9 +361,21 @@ async def handle_server_unavailable_async(
 
 
 @_retry_on_server_unavailable()
+@retry_transient_errors()
 def request(method, url, **kwargs) -> 'requests.Response':
-    """Send a request to the API server, retry on server temporarily
-    unavailable."""
+    """Send a request to the API server.
+
+    Two independent retry layers wrap this call, each handling a distinct
+    recoverable failure so the sync client matches the async client
+    (``request_async``), which already retries both:
+    - ``@_retry_on_server_unavailable`` retries on the server's explicit
+      HTTP 503 backpressure (``ServerTemporarilyUnavailableError``).
+    - ``@retry_transient_errors`` retries transient network errors
+      (``_transient_errors``, which include ``requests.exceptions.ReadTimeout``).
+      A healthy but briefly saturated server can take longer than the read
+      timeout to respond without ever emitting a 503; previously that surfaced
+      as a hard failure even though the next attempt usually succeeds.
+    """
     return request_without_retry(method, url, **kwargs)
 
 


### PR DESCRIPTION
## What

`sky/server/rest.py::request` (the sync SDK request path) is wrapped only by `@_retry_on_server_unavailable` (retries HTTP 503). This module already has a `retry_transient_errors` decorator intended for "idempotent SDK functions to make it more robust to transient errors", but `request()` was not using it. This PR adds it, so the sync client matches `request_async`, which already retries transient errors.

## Why

`_transient_errors` (already defined here) includes `requests.exceptions.ReadTimeout`. A healthy but briefly saturated API server can take longer than a request's read timeout to respond **without ever emitting a 503**, so `@_retry_on_server_unavailable` has nothing to catch and the call fails hard even though the next attempt would succeed. This is reproducible by issuing many launch/cancel SDK calls concurrently (e.g. `test_launch_and_cancel_race_condition`), where an occasional submit/cancel crosses the read timeout under load:

```
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='127.0.0.1', port=46580): Read timed out. (read timeout=5)
```

Before/after, running the concurrent launch+cancel burst against a local kind API server and scaling parallelism until the server is briefly saturated (timeouts = threads that failed with ReadTimeout):

| concurrency | before | after |
|---|---|---|
| 100 | 27 | **0** |
| 120 | 85–86 | **0** |

## Scope / non-goal

This is a **client-robustness** change (parity with the async client). The underlying reason a submit can exceed the read timeout under high concurrency is server-side: request submission serializes writes through a single shared SQLite connection (single-writer) on the single-replica/local path, with no submit-path backpressure. That is a separate, larger change; this PR just stops the sync client from hard-failing on a transient timeout it should tolerate, using machinery already in the file.