### PR TITLE
helm: make the persisted clients directory subPath configurable

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -357,7 +357,7 @@ spec:
           mountPath: /root/.sky
         - name: state-volume
           mountPath: /root/.sky/api_server/clients
-          subPath: {{ .Values.storage.clientsSubPath | default "api_server/clients" }}
+          subPath: {{ .Values.storage.clientsSubPath | default "api_server/clients" | quote }}
         {{- else }}
         - name: state-volume
           mountPath: /root/.sky

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -357,7 +357,7 @@ spec:
           mountPath: /root/.sky
         - name: state-volume
           mountPath: /root/.sky/api_server/clients
-          subPath: api_server/clients
+          subPath: {{ .Values.storage.clientsSubPath | default "api_server/clients" }}
         {{- else }}
         - name: state-volume
           mountPath: /root/.sky

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -839,6 +839,9 @@
                 "annotations": {
                     "type": "object"
                 },
+                "clientsSubPath": {
+                    "type": "string"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
@@ -855,9 +858,6 @@
                     "type": "string"
                 },
                 "volumeName": {
-                    "type": "string"
-                },
-                "clientsSubPath": {
                     "type": "string"
                 }
             }

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -856,6 +856,9 @@
                 },
                 "volumeName": {
                     "type": "string"
+                },
+                "clientsSubPath": {
+                    "type": "string"
                 }
             }
         },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -373,6 +373,9 @@ storage:
   # upload artifacts). Override when attaching a pre-existing volume whose
   # layout keeps that data under a different directory, so the deployment
   # keeps reading/writing the existing data instead of starting an empty one.
+  # Note: only takes effect when apiService.upgradeStrategy is "RollingUpdate";
+  # under "Recreate" the whole volume is mounted at ~/.sky and the clients
+  # directory is always at <volume>/.sky/api_server/clients.
   clientsSubPath: "api_server/clients"
   # Storage class name - leave empty to use cluster default
   # For RWX storage with RollingUpdate, use a storage class that supports ReadWriteMany access mode:

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -369,6 +369,11 @@ storage:
   # leave empty to provision one from the fields below (subject to
   # storage.enabled).
   existingClaim: ""
+  # Volume subdirectory persisted at ~/.sky/api_server/clients (in-flight
+  # upload artifacts). Override when attaching a pre-existing volume whose
+  # layout keeps that data under a different directory, so the deployment
+  # keeps reading/writing the existing data instead of starting an empty one.
+  clientsSubPath: "api_server/clients"
   # Storage class name - leave empty to use cluster default
   # For RWX storage with RollingUpdate, use a storage class that supports ReadWriteMany access mode:
   # - GKE: Create a Filestore-backed storage class (https://cloud.google.com/filestore/docs/accessing-fileshares)


### PR DESCRIPTION
Adds `storage.clientsSubPath` (default `api_server/clients`, behavior unchanged) to configure the volume subdirectory mounted at `~/.sky/api_server/clients`.

Deployments that attach a pre-existing volume via `storage.existingClaim` may already keep the in-flight upload artifacts under a different directory on that volume; without this knob the chart always mounts `api_server/clients`, so the deployment starts from an empty directory and the existing data becomes unreachable.

## Tested
- `helm lint` green.
- `helm template` with default values renders `subPath: api_server/clients` (byte-identical to before); with `--set storage.clientsSubPath=sky_clients` renders `subPath: sky_clients`.