### PR TITLE
[Core] debug-dump: collect provision logs from pre-recovery tries + pod scheduling counts at provision failure

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -205,6 +205,14 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('provision_log_path',
                       sqlalchemy.Text,
                       server_default=None),
+    # JSON list of every provision log path recorded for this incarnation,
+    # oldest first. A managed job recovery re-launches the same cluster name
+    # in place, so the scalar provision_log_path only ever holds the latest
+    # try; this keeps the earlier (pre-recovery) tries so the debug dump can
+    # collect them too.
+    sqlalchemy.Column('provision_log_paths',
+                      sqlalchemy.Text,
+                      server_default=None),
     sqlalchemy.Column('last_activity_time',
                       sqlalchemy.Integer,
                       server_default=None,
@@ -674,6 +682,41 @@ def set_user_preferred_workspace(user_id: str,
         return result.rowcount > 0
 
 
+# Cap on the provision log paths retained per cluster-history row. A managed
+# job that keeps crash-recovering re-launches the same cluster name over and
+# over; keep the most recent tries (the old files are reclaimed by log
+# retention anyway) rather than growing the row without bound.
+_MAX_PROVISION_LOG_PATHS = 20
+
+
+def _merge_provision_log_paths(
+        existing_path: Optional[str], existing_paths_json: Optional[str],
+        new_path: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Merge a new provision log path into a history row's recorded paths.
+
+    Returns (latest_path, paths_json) for the row's ``provision_log_path``
+    (scalar, latest try — preserved rather than nulled when ``new_path`` is
+    None) and ``provision_log_paths`` (JSON list, oldest first, deduped).
+    ``existing_path`` is folded into the list so rows written before the list
+    column existed keep their recorded path.
+    """
+    paths: List[str] = []
+    if existing_paths_json:
+        try:
+            loaded = json.loads(existing_paths_json)
+            if isinstance(loaded, list):
+                paths = [p for p in loaded if isinstance(p, str)]
+        except json.JSONDecodeError:
+            pass
+    if existing_path and existing_path not in paths:
+        paths.append(existing_path)
+    if new_path and new_path not in paths:
+        paths.append(new_path)
+    paths = paths[-_MAX_PROVISION_LOG_PATHS:]
+    latest = new_path if new_path is not None else existing_path
+    return latest, json.dumps(paths) if paths else None
+
+
 @metrics_lib.time_me
 def add_or_update_cluster(cluster_name: str,
                           cluster_handle: 'backends.ResourceHandle',
@@ -911,6 +954,18 @@ def add_or_update_cluster(cluster_name: str,
             session.execute(insert_or_update_stmt)
 
         # Modify cluster history table
+        # Merge this launch's provision log path into the history row's
+        # append-only list instead of overwriting: a managed-job recovery
+        # re-launches the same cluster name in place (same cluster_hash), and
+        # post-provision calls pass provision_log_path=None — a plain
+        # overwrite would first lose the pre-recovery try, then null the
+        # column entirely.
+        history_row = session.query(cluster_history_table).filter_by(
+            cluster_hash=cluster_hash).first()
+        hist_log_path, hist_log_paths = (_merge_provision_log_paths(
+            getattr(history_row, 'provision_log_path', None),
+            getattr(history_row, 'provision_log_paths', None),
+            provision_log_path))
         launched_nodes = getattr(cluster_handle, 'launched_nodes', None)
         launched_resources = getattr(cluster_handle, 'launched_resources', None)
         if cluster_row and cluster_row.workspace:
@@ -939,7 +994,8 @@ def add_or_update_cluster(cluster_name: str,
             usage_intervals=pickle.dumps(usage_intervals),
             user_hash=user_hash,
             workspace=history_workspace,
-            provision_log_path=provision_log_path,
+            provision_log_path=hist_log_path,
+            provision_log_paths=hist_log_paths,
             last_activity_time=last_activity_time,
             launched_at=launched_at,
             cloud=cloud,
@@ -962,7 +1018,8 @@ def add_or_update_cluster(cluster_name: str,
                     pickle.dumps(usage_intervals),
                 cluster_history_table.c.user_hash: history_hash,
                 cluster_history_table.c.workspace: history_workspace,
-                cluster_history_table.c.provision_log_path: provision_log_path,
+                cluster_history_table.c.provision_log_path: hist_log_path,
+                cluster_history_table.c.provision_log_paths: hist_log_paths,
                 cluster_history_table.c.last_activity_time: last_activity_time,
                 cluster_history_table.c.launched_at: launched_at,
                 cluster_history_table.c.cloud: cloud,
@@ -1497,13 +1554,27 @@ def remove_cluster(cluster_name: str, terminate: bool) -> None:
 
         if provision_log_path:
             assert cluster_hash is not None, cluster_name
-            session.query(cluster_history_table).filter_by(
-                cluster_hash=cluster_hash
-            ).filter(
-                cluster_history_table.c.provision_log_path.is_(None)
-            ).update({
-                cluster_history_table.c.provision_log_path: provision_log_path
-            })
+            # Backfill from the clusters table for rows written before the
+            # launch-time history merge existed; fold the path into the list
+            # column as well so the dump's multi-try collection sees it.
+            history_row = session.query(cluster_history_table).filter_by(
+                cluster_hash=cluster_hash).first()
+            if history_row is not None:
+                existing_path = getattr(history_row, 'provision_log_path', None)
+                _, merged_paths = _merge_provision_log_paths(
+                    existing_path,
+                    getattr(history_row, 'provision_log_paths', None),
+                    provision_log_path)
+                updates = {
+                    cluster_history_table.c.provision_log_paths: merged_paths,
+                }
+                if existing_path is None:
+                    # Keep the recorded latest if one exists (the
+                    # clusters-table path is the same launch, never newer).
+                    updates[cluster_history_table.c.provision_log_path] = (
+                        provision_log_path)
+                session.query(cluster_history_table).filter_by(
+                    cluster_hash=cluster_hash).update(updates)
 
         if terminate:
             session.query(cluster_table).filter_by(name=cluster_name).delete()
@@ -1752,6 +1823,62 @@ def get_cluster_history_provision_log_path(cluster_name: str) -> Optional[str]:
         latest_row = max(rows,
                          key=lambda r: latest_timestamp(r.usage_intervals))
         return getattr(latest_row, 'provision_log_path', None)
+
+
+@metrics_lib.time_me
+def get_cluster_history_provision_log_paths(cluster_name: str) -> List[str]:
+    """Returns every recorded provision log path for this cluster name.
+
+    Ordered oldest first, deduped, latest try last. Spans all incarnations of
+    the name in cluster_history (a terminate-and-relaunch creates a new
+    cluster_hash and thus a new history row) plus each row's own
+    ``provision_log_paths`` list (an in-place re-launch, e.g. a managed-job
+    recovery, appends to the same row). The clusters-table path is folded in
+    last as the authoritative latest for a live cluster — it also covers rows
+    written before the list column existed.
+
+    Callers should treat entries best-effort: log retention may have removed
+    the older files from disk.
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.query(cluster_history_table).filter_by(
+            name=cluster_name).all()
+
+    def latest_timestamp(usages_bin) -> int:
+        try:
+            intervals = pickle.loads(usages_bin)
+            if not intervals:
+                return -1
+            _, end = intervals[-1]
+            return end if end is not None else int(time.time())
+        except Exception:  # pylint: disable=broad-except
+            return -1
+
+    rows = sorted(rows, key=lambda r: latest_timestamp(r.usage_intervals))
+    paths: List[str] = []
+    for row in rows:
+        row_paths: List[str] = []
+        paths_json = getattr(row, 'provision_log_paths', None)
+        if paths_json:
+            try:
+                loaded = json.loads(paths_json)
+                if isinstance(loaded, list):
+                    row_paths = [p for p in loaded if isinstance(p, str)]
+            except json.JSONDecodeError:
+                pass
+        scalar = getattr(row, 'provision_log_path', None)
+        if scalar and scalar not in row_paths:
+            row_paths.append(scalar)
+        for path in row_paths:
+            if path not in paths:
+                paths.append(path)
+    live_path = get_cluster_provision_log_path(cluster_name)
+    if live_path:
+        if live_path in paths:
+            paths.remove(live_path)
+        paths.append(live_path)
+    return paths
 
 
 @metrics_lib.time_me

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1134,20 +1134,28 @@ def _collect_cluster_debug_manifest(cluster_name: str, job_prefix: str,
                 'content': json.dumps(content, indent=2, default=str),
             })
 
-    # Provision log (FILE — needs rsync). The path is recorded in cluster
-    # history, so this also works for terminated clusters.
+    # Provision logs (FILEs — need rsync). The paths are recorded in cluster
+    # history, so this also works for terminated clusters. All recorded tries
+    # are collected, not just the latest: a recovery re-launches the same
+    # cluster name, and the pre-recovery try's log is often the one that
+    # explains the failure. The latest try keeps the plain 'provision.log'
+    # name; earlier tries get logrotate-style suffixes ('provision.log.1' is
+    # the previous try, higher numbers are older).
     with _catch_to_errors(errors, 'managed_jobs',
                           f'{cluster_name}/provision_log'):
-        provision_log_path = (
-            global_user_state.get_cluster_history_provision_log_path(
+        provision_log_paths = (
+            global_user_state.get_cluster_history_provision_log_paths(
                 cluster_name))
-        if provision_log_path:
-            provision_log = pathlib.Path(provision_log_path).expanduser()
-            if provision_log.is_file():
-                file_paths.append({
-                    'remote_path': str(provision_log),
-                    'relative_path': f'{cluster_prefix}/provision.log',
-                })
+        # Oldest first -> iterate newest first so suffixes grow with age.
+        for age, log_path in enumerate(reversed(provision_log_paths)):
+            provision_log = pathlib.Path(log_path).expanduser()
+            if not provision_log.is_file():
+                continue
+            suffix = f'.{age}' if age else ''
+            file_paths.append({
+                'remote_path': str(provision_log),
+                'relative_path': f'{cluster_prefix}/provision.log{suffix}',
+            })
 
 
 def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -302,6 +302,57 @@ def _get_pvc_binding_status(namespace: str, context: Optional[str],
     return None
 
 
+def _latest_failed_scheduling_message(namespace, context,
+                                      pod_name) -> Optional[str]:
+    """Return the pod's most recent FailedScheduling event message, if any."""
+    events = kubernetes.core_api(context).list_namespaced_event(
+        namespace,
+        field_selector=(f'involvedObject.name={pod_name},'
+                        'involvedObject.kind=Pod'))
+    # Events created in the past hours are kept by
+    # Kubernetes python client and we want to surface
+    # the latest event message
+    events_desc_by_time = sorted(events.items,
+                                 key=lambda e: e.metadata.creation_timestamp,
+                                 reverse=True)
+    for event in events_desc_by_time:
+        if event.reason == 'FailedScheduling':
+            return event.message
+    return None
+
+
+def _log_pod_scheduling_summary(pods, unscheduled_reasons) -> str:
+    """Summarize per-pod scheduling state at provision-failure time.
+
+    The error raised by _raise_pod_scheduling_errors surfaces only the FIRST
+    unscheduled pod's reason — which for a multi-node launch cannot tell "one
+    straggler pod hit X" apart from "no pod scheduled at all". Log a full
+    scheduled-vs-unscheduled breakdown (grouped by failure reason) so the
+    provision log records it at the moment of failure, and return the
+    one-line count for inclusion in the raised error.
+    """
+    n_scheduled = len(pods) - len(unscheduled_reasons)
+    headline = (f'{n_scheduled}/{len(pods)} pods scheduled at provision '
+                f'failure ({len(unscheduled_reasons)} unscheduled)')
+    lines = [f'Pod scheduling summary: {headline}.']
+    # Group unscheduled pods by failure reason: on a large launch most pods
+    # usually share one reason, and the distinct reasons are the signal.
+    pods_by_reason: Dict[str, List[str]] = {}
+    for pod_name, reason in unscheduled_reasons.items():
+        reason = reason or '(no FailedScheduling event)'
+        pods_by_reason.setdefault(reason, []).append(pod_name)
+    for reason, pod_names in pods_by_reason.items():
+        example_pods = ', '.join(sorted(pod_names)[:3])
+        more = (f', and {len(pod_names) - 3} more'
+                if len(pod_names) > 3 else '')
+        lines.append(f'  {len(pod_names)} pod(s) ({example_pods}{more}): '
+                     f'{reason}')
+    # logger.info: recorded in the provision log (its handler is DEBUG-level)
+    # without spamming the console (stream handler is WARNING-level).
+    logger.info('\n'.join(lines))
+    return headline
+
+
 def _raise_pod_scheduling_errors(namespace, context, new_nodes):
     """Raise pod scheduling failure reason.
 
@@ -309,12 +360,28 @@ def _raise_pod_scheduling_errors(namespace, context, new_nodes):
     are recorded as events. This function retrieves those events and raises
     descriptive errors for better debugging and user feedback.
     """
+    # Read every pod's state and FailedScheduling reason first, and log the
+    # full breakdown into the provision log before raising: the raise below
+    # only surfaces one pod's reason, and post-hoc debugging (e.g. from a
+    # debug dump) needs to know how many of the requested pods had actually
+    # been placed when provisioning gave up.
+    pods = [
+        kubernetes.core_api(context).read_namespaced_pod(
+            new_node.metadata.name, namespace) for new_node in new_nodes
+    ]
+    unscheduled_reasons: Dict[str, Optional[str]] = {}
+    for pod in pods:
+        if not _pod_is_scheduled(pod):
+            pod_name = pod.metadata.name
+            unscheduled_reasons[pod_name] = _latest_failed_scheduling_message(
+                namespace, context, pod_name)
+    scheduling_headline = _log_pod_scheduling_summary(pods, unscheduled_reasons)
+
     timeout_err_msg = ('Timed out while waiting for nodes to start. '
                        'Cluster may be out of resources or '
-                       'may be too slow to autoscale.')
-    for new_node in new_nodes:
-        pod = kubernetes.core_api(context).read_namespaced_pod(
-            new_node.metadata.name, namespace)
+                       'may be too slow to autoscale. '
+                       f'({scheduling_headline}.)')
+    for pod in pods:
         pod_status = pod.status.phase
         # When there are multiple pods involved while launching instance,
         # there may be a single pod causing issue while others are
@@ -323,23 +390,14 @@ def _raise_pod_scheduling_errors(namespace, context, new_nodes):
         if pod_status != 'Pending':
             continue
         pod_name = pod._metadata._name  # pylint: disable=protected-access
-        events = kubernetes.core_api(context).list_namespaced_event(
-            namespace,
-            field_selector=(f'involvedObject.name={pod_name},'
-                            'involvedObject.kind=Pod'))
-        # Events created in the past hours are kept by
-        # Kubernetes python client and we want to surface
-        # the latest event message
-        events_desc_by_time = sorted(
-            events.items,
-            key=lambda e: e.metadata.creation_timestamp,
-            reverse=True)
-
-        event_message = None
-        for event in events_desc_by_time:
-            if event.reason == 'FailedScheduling':
-                event_message = event.message
-                break
+        if pod_name in unscheduled_reasons:
+            event_message = unscheduled_reasons[pod_name]
+        else:
+            # Pending but already bound to a node (e.g. still pulling its
+            # image), so it isn't in the unscheduled set; keep the original
+            # per-pod event lookup for this raise path.
+            event_message = _latest_failed_scheduling_message(
+                namespace, context, pod_name)
         if event_message is not None:
             if pod_status == 'Pending':
                 out_of = {}

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -353,6 +353,31 @@ def _log_pod_scheduling_summary(pods, unscheduled_reasons) -> str:
     return headline
 
 
+def _read_pods_for_nodes(namespace, context, new_nodes) -> List[Any]:
+    """Fetch the current pod object for each of the given nodes.
+
+    Prefers a single label-selector list call — one round-trip instead of N
+    sequential reads, which matters for large launches (e.g. 96 pods) — and
+    falls back to per-pod reads if the list fails or comes back incomplete,
+    so this error path degrades to the previous behavior rather than
+    masking the scheduling failure it is trying to report.
+    """
+    try:
+        cluster_name_on_cloud = new_nodes[0].metadata.labels[
+            constants.TAG_SKYPILOT_CLUSTER_NAME]
+        all_pods = kubernetes.core_api(context).list_namespaced_pod(
+            namespace,
+            label_selector=(f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                            f'{cluster_name_on_cloud}')).items
+        pods_by_name = {pod.metadata.name: pod for pod in all_pods}
+        return [pods_by_name[node.metadata.name] for node in new_nodes]
+    except Exception:  # pylint: disable=broad-except
+        return [
+            kubernetes.core_api(context).read_namespaced_pod(
+                node.metadata.name, namespace) for node in new_nodes
+        ]
+
+
 def _raise_pod_scheduling_errors(namespace, context, new_nodes):
     """Raise pod scheduling failure reason.
 
@@ -365,10 +390,7 @@ def _raise_pod_scheduling_errors(namespace, context, new_nodes):
     # only surfaces one pod's reason, and post-hoc debugging (e.g. from a
     # debug dump) needs to know how many of the requested pods had actually
     # been placed when provisioning gave up.
-    pods = [
-        kubernetes.core_api(context).read_namespaced_pod(
-            new_node.metadata.name, namespace) for new_node in new_nodes
-    ]
+    pods = _read_pods_for_nodes(namespace, context, new_nodes)
     unscheduled_reasons: Dict[str, Optional[str]] = {}
     for pod in pods:
         if not _pod_is_scheduled(pod):

--- a/sky/schemas/db/global_user_state/021_provision_log_paths.py
+++ b/sky/schemas/db/global_user_state/021_provision_log_paths.py
@@ -1,0 +1,40 @@
+"""Add provision_log_paths to cluster_history.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-07-13
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '021'
+down_revision: Union[str, Sequence[str], None] = '020'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add provision_log_paths (JSON list, oldest first) to cluster_history.
+
+    The scalar provision_log_path only holds the latest launch try; a
+    managed-job recovery re-launches the same cluster name in place, so the
+    pre-recovery tries' provision logs were unrecoverable from the DB. The
+    list column keeps every try so the debug dump can collect all of them.
+    """
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('cluster_history',
+                                             'provision_log_paths',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '020'  # add is_managed column to cluster_history
+GLOBAL_USER_STATE_VERSION = '021'  # add provision_log_paths to cluster_history
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1460,19 +1460,29 @@ def _dump_one_cluster(
             'traceback': _full_traceback()
         })
 
-    # Copy the provision log if available. The path is recorded in
-    # cluster history, so this also works for terminated clusters.
+    # Copy the provision logs if available. The paths are recorded in
+    # cluster history, so this also works for terminated clusters. Every
+    # recorded try is collected, not just the most recent: when a managed job
+    # recovers, the re-launch overwrites the "latest" path, but the earlier
+    # (pre-recovery) try is often the one that explains the failure. The
+    # latest try keeps the plain 'provision.log' name; earlier tries get
+    # logrotate-style suffixes ('provision.log.1' is the previous try, higher
+    # numbers are older). Missing files are skipped silently — log retention
+    # may have reclaimed old tries.
     try:
-        provision_log_path = (
-            global_user_state.get_cluster_history_provision_log_path(
+        provision_log_paths = (
+            global_user_state.get_cluster_history_provision_log_paths(
                 cluster_name))
-        if provision_log_path:
-            provision_log = pathlib.Path(provision_log_path).expanduser()
-            if provision_log.is_file():
-                shutil.copy2(provision_log,
-                             os.path.join(cluster_dir, 'provision.log'))
-                logger.debug(
-                    f'Copied provision log for cluster {cluster_name!r}')
+        # Oldest first -> iterate newest first so suffixes grow with age.
+        for age, log_path in enumerate(reversed(provision_log_paths)):
+            provision_log = pathlib.Path(log_path).expanduser()
+            if not provision_log.is_file():
+                continue
+            suffix = f'.{age}' if age else ''
+            shutil.copy2(provision_log,
+                         os.path.join(cluster_dir, f'provision.log{suffix}'))
+            logger.debug(f'Copied provision log for cluster '
+                         f'{cluster_name!r} (try age {age})')
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to copy provision log for cluster '
                        f'{cluster_name}: {e}')

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3533,3 +3533,104 @@ class TestCreatePodFinalizerHandling:
         # Must not have touched the live pod.
         core_api_mock.patch_namespaced_pod.assert_not_called()
         core_api_mock.delete_namespaced_pod.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pod scheduling summary at provision failure (SKY-6227)
+# ---------------------------------------------------------------------------
+
+
+def _summary_pod(name, *, scheduled):
+    """A pod mock that _pod_is_scheduled classifies deterministically."""
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod._metadata._name = name  # pylint: disable=protected-access
+    if scheduled:
+        pod.status.phase = 'Running'
+    else:
+        pod.status.phase = 'Pending'
+        pod.spec.node_name = None
+        pod.spec.node_selector = None
+        pod.status.conditions = []
+    return pod
+
+
+def _failed_scheduling_event(message):
+    event = mock.MagicMock()
+    event.metadata.creation_timestamp = '2021-01-01T00:00:00Z'
+    event.reason = 'FailedScheduling'
+    event.message = message
+    return event
+
+
+def test_scheduling_summary_counts_scheduled_vs_pending(monkeypatch):
+    """The provision-failure path must record how many of the requested pods
+    were actually placed (X/N) and each unscheduled pod's reason — the raised
+    error alone only explains a single pod."""
+    reason = ('0/367 nodes are available: 1 cannot allocate all claims, '
+              '366 node(s) had untolerated taints.')
+    pods = {
+        'job-head': _summary_pod('job-head', scheduled=True),
+        'job-worker1': _summary_pod('job-worker1', scheduled=False),
+        'job-worker2': _summary_pod('job-worker2', scheduled=False),
+    }
+    new_nodes = []
+    for name in pods:
+        node = mock.MagicMock()
+        node.metadata.name = name
+        new_nodes.append(node)
+
+    core_api_mock = mock.MagicMock()
+    core_api_mock.read_namespaced_pod.side_effect = (
+        lambda name, _namespace: pods[name])
+    events_mock = mock.MagicMock()
+    events_mock.items = [_failed_scheduling_event(reason)]
+    core_api_mock.list_namespaced_event.return_value = events_mock
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *args, **kwargs: core_api_mock)
+
+    info_output = []
+    monkeypatch.setattr(logger, 'info',
+                        lambda msg, *args: info_output.append(msg))
+
+    with pytest.raises(config_lib.KubernetesError) as e:
+        instance._raise_pod_scheduling_errors('ns', 'ctx', new_nodes)
+
+    # The X/N count is in the raised error, so it survives into failover
+    # handling and the job's failure reason.
+    assert '1/3 pods scheduled' in str(e.value)
+
+    # The full breakdown is logged (landing in provision.log at failure
+    # time), grouped by reason with the pods named.
+    summary = '\n'.join(info_output)
+    assert '1/3 pods scheduled at provision failure (2 unscheduled)' in summary
+    assert '2 pod(s) (job-worker1, job-worker2)' in summary
+    assert reason in summary
+
+
+def test_scheduling_summary_handles_no_failed_scheduling_event(monkeypatch):
+    """An unscheduled pod without a FailedScheduling event yet must still be
+    counted, with a placeholder reason."""
+    pods = {'job-head': _summary_pod('job-head', scheduled=False)}
+    node = mock.MagicMock()
+    node.metadata.name = 'job-head'
+
+    core_api_mock = mock.MagicMock()
+    core_api_mock.read_namespaced_pod.side_effect = (
+        lambda name, _namespace: pods[name])
+    events_mock = mock.MagicMock()
+    events_mock.items = []
+    core_api_mock.list_namespaced_event.return_value = events_mock
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *args, **kwargs: core_api_mock)
+
+    info_output = []
+    monkeypatch.setattr(logger, 'info',
+                        lambda msg, *args: info_output.append(msg))
+
+    with pytest.raises(config_lib.KubernetesError) as e:
+        instance._raise_pod_scheduling_errors('ns', 'ctx', [node])
+
+    assert '0/1 pods scheduled' in str(e.value)
+    summary = '\n'.join(info_output)
+    assert '(no FailedScheduling event)' in summary

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -11,6 +11,7 @@ from sky import resources
 from sky.adaptors import kubernetes
 from sky.backends import cloud_vm_ray_backend
 from sky.provision import common as provision_common
+from sky.provision import constants as provision_constants
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import instance
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -3578,11 +3579,18 @@ def test_scheduling_summary_counts_scheduled_vs_pending(monkeypatch):
     for name in pods:
         node = mock.MagicMock()
         node.metadata.name = name
+        node.metadata.labels = {
+            provision_constants.TAG_SKYPILOT_CLUSTER_NAME: 'job'
+        }
         new_nodes.append(node)
 
     core_api_mock = mock.MagicMock()
-    core_api_mock.read_namespaced_pod.side_effect = (
-        lambda name, _namespace: pods[name])
+    # Pod state comes from a single label-selector list call, not N
+    # sequential per-pod reads (which would be a bottleneck on a large
+    # launch); the per-pod read path is exercised by the fallback test
+    # below.
+    core_api_mock.list_namespaced_pod.return_value = mock.MagicMock(
+        items=list(pods.values()))
     events_mock = mock.MagicMock()
     events_mock.items = [_failed_scheduling_event(reason)]
     core_api_mock.list_namespaced_event.return_value = events_mock
@@ -3595,6 +3603,12 @@ def test_scheduling_summary_counts_scheduled_vs_pending(monkeypatch):
 
     with pytest.raises(config_lib.KubernetesError) as e:
         instance._raise_pod_scheduling_errors('ns', 'ctx', new_nodes)
+
+    # Pods were fetched via the batched list call, not per-pod reads.
+    core_api_mock.read_namespaced_pod.assert_not_called()
+    _, kwargs = core_api_mock.list_namespaced_pod.call_args
+    assert kwargs['label_selector'] == (
+        f'{provision_constants.TAG_SKYPILOT_CLUSTER_NAME}=job')
 
     # The X/N count is in the raised error, so it survives into failover
     # handling and the job's failure reason.
@@ -3610,7 +3624,11 @@ def test_scheduling_summary_counts_scheduled_vs_pending(monkeypatch):
 
 def test_scheduling_summary_handles_no_failed_scheduling_event(monkeypatch):
     """An unscheduled pod without a FailedScheduling event yet must still be
-    counted, with a placeholder reason."""
+    counted, with a placeholder reason.
+
+    This test's loose mocks (MagicMock labels, no list_namespaced_pod setup)
+    also exercise _read_pods_for_nodes' per-pod-read fallback path.
+    """
     pods = {'job-head': _summary_pod('job-head', scheduled=False)}
     node = mock.MagicMock()
     node.metadata.name = 'job-head'

--- a/tests/unit_tests/test_sky/test_global_user_state_provision_log_paths.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_provision_log_paths.py
@@ -48,9 +48,8 @@ def _history_row(name: str):
     engine = global_user_state._db_manager.get_engine()
     from sqlalchemy import orm  # pylint: disable=import-outside-toplevel
     with orm.Session(engine) as session:
-        return session.query(
-            global_user_state.cluster_history_table).filter_by(
-                name=name).first()
+        return session.query(global_user_state.cluster_history_table).filter_by(
+            name=name).first()
 
 
 def test_launch_records_path_in_scalar_and_list(tmp_path, monkeypatch):
@@ -59,9 +58,7 @@ def test_launch_records_path_in_scalar_and_list(tmp_path, monkeypatch):
 
     row = _history_row('c')
     assert row.provision_log_path == '/logs/try1/provision.log'
-    assert json.loads(row.provision_log_paths) == [
-        '/logs/try1/provision.log'
-    ]
+    assert json.loads(row.provision_log_paths) == ['/logs/try1/provision.log']
     assert global_user_state.get_cluster_history_provision_log_paths('c') == [
         '/logs/try1/provision.log'
     ]
@@ -77,9 +74,7 @@ def test_post_provision_update_does_not_null_path(tmp_path, monkeypatch):
 
     row = _history_row('c')
     assert row.provision_log_path == '/logs/try1/provision.log'
-    assert json.loads(row.provision_log_paths) == [
-        '/logs/try1/provision.log'
-    ]
+    assert json.loads(row.provision_log_paths) == ['/logs/try1/provision.log']
 
 
 def test_in_place_relaunch_appends_new_try(tmp_path, monkeypatch):
@@ -119,9 +114,7 @@ def test_relaunch_with_same_path_does_not_duplicate(tmp_path, monkeypatch):
     _add_cluster('c', provision_log_path='/logs/try1/provision.log')
 
     row = _history_row('c')
-    assert json.loads(row.provision_log_paths) == [
-        '/logs/try1/provision.log'
-    ]
+    assert json.loads(row.provision_log_paths) == ['/logs/try1/provision.log']
 
 
 def test_merge_folds_legacy_scalar_into_list():

--- a/tests/unit_tests/test_sky/test_global_user_state_provision_log_paths.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_provision_log_paths.py
@@ -1,0 +1,161 @@
+"""Tests for multi-try provision log path tracking in cluster history.
+
+A managed-job recovery re-launches the same cluster name — either in place
+(same cluster_hash, so the history row is reused) or after a terminate (new
+cluster_hash, new history row). The scalar provision_log_path column only
+ever held the latest try, so the pre-recovery try's provision log was
+unrecoverable from the DB. These tests cover the append-only
+provision_log_paths list and the getter the debug dump uses to collect every
+try.
+"""
+import json
+
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+class _MinimalHandle:
+    """Just enough for global_user_state.add_or_update_cluster to pickle."""
+    launched_resources = None
+
+
+def _add_cluster(name: str, provision_log_path=None, ready=False) -> None:
+    global_user_state.add_or_update_cluster(
+        cluster_name=name,
+        cluster_handle=_MinimalHandle(),
+        requested_resources=set(),
+        ready=ready,
+        provision_log_path=provision_log_path,
+    )
+
+
+def _history_row(name: str):
+    engine = global_user_state._db_manager.get_engine()
+    from sqlalchemy import orm  # pylint: disable=import-outside-toplevel
+    with orm.Session(engine) as session:
+        return session.query(
+            global_user_state.cluster_history_table).filter_by(
+                name=name).first()
+
+
+def test_launch_records_path_in_scalar_and_list(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+
+    row = _history_row('c')
+    assert row.provision_log_path == '/logs/try1/provision.log'
+    assert json.loads(row.provision_log_paths) == [
+        '/logs/try1/provision.log'
+    ]
+    assert global_user_state.get_cluster_history_provision_log_paths('c') == [
+        '/logs/try1/provision.log'
+    ]
+
+
+def test_post_provision_update_does_not_null_path(tmp_path, monkeypatch):
+    """add_or_update_cluster is called again after provisioning completes
+    (ready=True) without a provision_log_path; the recorded path must
+    survive rather than being overwritten with None."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+    _add_cluster('c', ready=True)  # post-provision update, no path
+
+    row = _history_row('c')
+    assert row.provision_log_path == '/logs/try1/provision.log'
+    assert json.loads(row.provision_log_paths) == [
+        '/logs/try1/provision.log'
+    ]
+
+
+def test_in_place_relaunch_appends_new_try(tmp_path, monkeypatch):
+    """A recovery re-launch of a live cluster reuses the cluster_hash; the
+    new try's path must append, keeping the pre-recovery try."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+    _add_cluster('c', ready=True)
+    _add_cluster('c', provision_log_path='/logs/try2/provision.log')
+
+    row = _history_row('c')
+    assert row.provision_log_path == '/logs/try2/provision.log'
+    assert json.loads(row.provision_log_paths) == [
+        '/logs/try1/provision.log', '/logs/try2/provision.log'
+    ]
+    assert global_user_state.get_cluster_history_provision_log_paths('c') == [
+        '/logs/try1/provision.log', '/logs/try2/provision.log'
+    ]
+
+
+def test_terminate_and_relaunch_spans_incarnations(tmp_path, monkeypatch):
+    """A terminate-then-relaunch creates a new history row; the getter must
+    return the paths of every incarnation, oldest first."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+    global_user_state.remove_cluster('c', terminate=True)
+    _add_cluster('c', provision_log_path='/logs/try2/provision.log')
+
+    assert global_user_state.get_cluster_history_provision_log_paths('c') == [
+        '/logs/try1/provision.log', '/logs/try2/provision.log'
+    ]
+
+
+def test_relaunch_with_same_path_does_not_duplicate(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+    _add_cluster('c', provision_log_path='/logs/try1/provision.log')
+
+    row = _history_row('c')
+    assert json.loads(row.provision_log_paths) == [
+        '/logs/try1/provision.log'
+    ]
+
+
+def test_merge_folds_legacy_scalar_into_list():
+    """Rows written before the list column existed have only the scalar; a
+    later merge must not lose it."""
+    latest, paths_json = global_user_state._merge_provision_log_paths(
+        '/logs/old/provision.log', None, '/logs/new/provision.log')
+    assert latest == '/logs/new/provision.log'
+    assert json.loads(paths_json) == [
+        '/logs/old/provision.log', '/logs/new/provision.log'
+    ]
+
+
+def test_merge_preserves_on_none_new_path():
+    latest, paths_json = global_user_state._merge_provision_log_paths(
+        '/logs/old/provision.log', json.dumps(['/logs/old/provision.log']),
+        None)
+    assert latest == '/logs/old/provision.log'
+    assert json.loads(paths_json) == ['/logs/old/provision.log']
+
+
+def test_merge_tolerates_corrupt_json():
+    latest, paths_json = global_user_state._merge_provision_log_paths(
+        None, 'not-json', '/logs/new/provision.log')
+    assert latest == '/logs/new/provision.log'
+    assert json.loads(paths_json) == ['/logs/new/provision.log']
+
+
+def test_merge_caps_retained_paths():
+    existing = [f'/logs/try{i}/provision.log' for i in range(25)]
+    latest, paths_json = global_user_state._merge_provision_log_paths(
+        None, json.dumps(existing), '/logs/new/provision.log')
+    paths = json.loads(paths_json)
+    assert len(paths) == global_user_state._MAX_PROVISION_LOG_PATHS
+    assert paths[-1] == '/logs/new/provision.log'
+    # Oldest entries are the ones evicted.
+    assert '/logs/try0/provision.log' not in paths


### PR DESCRIPTION
## Summary

Closes two debug-dump gaps identified in the 96-node job-hang post-mortem (both hypotheses in that investigation were untestable from the dump alone):

### 1. Provision logs from pre-recovery tries

A managed-job recovery re-launches the same cluster name. Previously the DB only ever held the **latest** try's provision log path, in two ways:

- An **in-place re-launch** (same `cluster_hash`) overwrote `cluster_history.provision_log_path` with the new try's path.
- Worse, **any** `add_or_update_cluster` call without a `provision_log_path` (e.g. the post-provision `ready=True` call) overwrote the history column with `None` — a pre-existing bug that left live clusters with no recorded provision log in history at all (masked for terminated clusters by the `remove_cluster` backfill).

Changes:
- `cluster_history` gains an append-only `provision_log_paths` JSON list (migration `021`, oldest first, deduped, capped at 20 entries — older files are reclaimed by log retention anyway).
- `add_or_update_cluster` merges instead of overwriting: a new path appends; a `None` path no longer nulls the recorded latest.
- The `remove_cluster` backfill also folds the clusters-table path into the list (covers rows written before this change).
- New `get_cluster_history_provision_log_paths()` returns every recorded try across **all incarnations** of the name (terminate-and-relaunch creates a new history row; the old row already kept the old path — but the dump previously only read the current incarnation).
- Both dump collectors — the server-side clusters section (`debug_utils`) and the jobs-controller manifest (`jobs/utils`) — now collect every recorded try: `provision.log` stays the latest, earlier tries get logrotate-style `provision.log.1` / `.2` / … suffixes (higher = older). Missing files (GC'd by retention) are skipped.

`sky logs --provision` / serve log streaming intentionally keep latest-only semantics (they read the clusters table first).

### 2. Per-pod scheduling counts at provision-failure time

On a k8s scheduling timeout, the raised error surfaced a single pod's latest `FailedScheduling` event — for a 96-pod launch that cannot distinguish "1 pod stuck on a DRA claim, 95 placed" (event is the root cause) from "0/96 placed" (event is a red herring).

`_raise_pod_scheduling_errors` now:
- reads every pod's state first and logs a breakdown into the provision log **at the moment of failure**: `X/N pods scheduled at provision failure (M unscheduled)`, with unscheduled pods grouped by `FailedScheduling` reason (up to 3 example pod names per reason);
- includes the `X/N pods scheduled` count in the raised `KubernetesError`, so it also lands in failover handling and the job's failure reason.

Since the provision log is what the dump collects (including pre-recovery tries per part 1), this information is now preserved for post-mortems.

## Test plan

- **Unit:** `pytest tests/unit_tests/kubernetes/test_provision.py tests/unit_tests/test_sky/test_global_user_state_provision_log_paths.py tests/unit_tests/test_sky/test_global_user_state_history_managed.py tests/unit_tests/test_sky/utils/test_debug_utils.py tests/unit_tests/test_jobs_utils.py` — 392 passed. New coverage:
  - launch records path in scalar + list; post-provision `ready=True` call no longer nulls it; in-place relaunch appends; terminate-and-relaunch spans incarnations; dedupe; legacy scalar folded in; corrupt JSON tolerated; cap eviction.
  - scheduling summary: X/N in raised error + grouped per-reason breakdown logged; unscheduled pod with no `FailedScheduling` event gets a placeholder.
- **E2E (kind + local API server running this branch, isolated runtime/config):**
  - *Migration:* DB initialized with master code stamps schema `020`; first touch by this branch's code alembic-upgrades to `021` with both `provision_log_path[s]` columns present. Fresh DBs create `021` directly.
  - *Live-cluster dump (nulling-bug fix):* `sky launch` → `sky debug-dump -c` on the still-UP cluster contains `provision.log` (previously missing for live clusters — the history column was nulled by the post-provision update).
  - *Terminate → relaunch:* two history rows (two hashes); dump contains `provision.log` (new incarnation) + `provision.log.1` (old), content verified by launch timestamps.
  - *Managed-job recovery (the incident case):* `sky jobs launch` on k8s → job RUNNING → `kubectl delete pod` of the job cluster → RECOVERING → RUNNING (`terminate-and-relaunch` path; two controller-side history rows) → `sky debug-dump -j 1` contains `managed_jobs/1/clusters/<name>/provision.log` **and** `provision.log.1` (pre-recovery try), collected via the controller manifest + rsync path.
  - *In-place re-launch (same cluster_hash):* second `sky launch` onto a live cluster appends to the same history row's list — one row, two paths.
  - *Scheduling-failure summary:* 3×4-CPU launch against an 8-CPU kind node → CLI error reads `(1/3 pods scheduled at provision failure (2 unscheduled).)`; `provision.log` carries the grouped breakdown (`2 pod(s) (…worker1, …worker2): 0/1 nodes are available: 1 Insufficient cpu…`); the failed cluster's dump retains it post-teardown. This also live-exercised the batched `list_namespaced_pod` fetch.
- Migration: fresh sqlite DB creates the column via `create_table`; existing DB upgrades via alembic `021`.

## Related

- SKY-6227 (this), SKY-5923 (base provision-log collection), SKY-6225/SKY-6226 (the investigations this unblocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
