### PR TITLE
[k8s] Avoid per-API-call urllib3 setLevel() to prevent logging fork deadlock on Python < 3.13

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -16,7 +16,7 @@ import platform
 import threading
 import time
 import typing
-from typing import Any, Callable, List, Optional, Set
+from typing import Any, Callable, List, Optional
 
 from sky import sky_logging
 from sky.adaptors import common
@@ -60,39 +60,36 @@ KUBECONFIG_REFRESH_INTERVAL_ENV_VAR = (
 
 logger = sky_logging.init_logger(__name__)
 
-# Loggers whose level has already been set by _api_logging_decorator, so
-# that Logger.setLevel() is called at most once per logger per process.
-# setLevel() acquires the logging module's global lock (via
-# Manager._clear_cache()), and on Python < 3.13 a fork() while another
-# thread holds that lock leaves the lock permanently held in the child,
-# deadlocking its next logging call. Fixed in CPython 3.13 by
-# https://github.com/python/cpython/pull/109462; until then, keep setLevel()
-# calls rare instead of on every API call. Guarded by the GIL only: set
-# membership/add are atomic, and a duplicate setLevel() from a racing first
-# call is idempotent. An explicit lock here would reintroduce a lock that a
-# fork could leave permanently held in the child.
-_leveled_loggers: Set[str] = set()
-
 
 def _api_logging_decorator(logger_src: str, level: int):
-    """Decorator to set the logging level of a logger used by API calls.
+    """Decorator to keep a logger at the given level for API calls.
 
     This is used to suppress the verbose logging from urllib3 when calls to
-    the Kubernetes API timeout. The level is set once per process on first
-    use and never restored: the previous per-call set/restore was racy under
-    concurrent API calls (interleaved restores could leave the level set
-    anyway) and its frequent setLevel() calls made the pre-3.13 fork
-    deadlock described above easy to hit.
+    the Kubernetes API fail. kubernetes.client.Configuration.__init__ resets
+    the urllib3 logger back to WARNING every time a client is constructed
+    (via its `debug` property setter), so the level is re-asserted after the
+    decorated getter runs. The lock-free level read below keeps
+    Logger.setLevel() calls rare (once per client construction, not per API
+    call): setLevel() acquires logging's process-wide lock (via
+    Manager._clear_cache()), and on Python < 3.13 a fork() while another
+    thread holds that lock leaves the lock permanently held in the child,
+    deadlocking its next logging call. Fixed in CPython 3.13 by
+    https://github.com/python/cpython/pull/109462; the previous
+    implementation entered a set/restore context manager on every API
+    method call, making that deadlock easy to hit. The level is never
+    restored: the old restore was racy under concurrent API calls
+    (interleaved restores could leave the level set anyway).
     """
 
     def decorated_api(api):
 
         @functools.wraps(api)
         def wrapped(*args, **kwargs):
-            if logger_src not in _leveled_loggers:
-                logging.getLogger(logger_src).setLevel(level)
-                _leveled_loggers.add(logger_src)
-            return api(*args, **kwargs)
+            result = api(*args, **kwargs)
+            log = logging.getLogger(logger_src)
+            if log.level != level:
+                log.setLevel(level)
+            return result
 
         return wrapped
 

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -67,9 +67,11 @@ logger = sky_logging.init_logger(__name__)
 # thread holds that lock leaves the lock permanently held in the child,
 # deadlocking its next logging call. Fixed in CPython 3.13 by
 # https://github.com/python/cpython/pull/109462; until then, keep setLevel()
-# calls rare instead of on every API call.
+# calls rare instead of on every API call. Guarded by the GIL only: set
+# membership/add are atomic, and a duplicate setLevel() from a racing first
+# call is idempotent. An explicit lock here would reintroduce a lock that a
+# fork could leave permanently held in the child.
 _leveled_loggers: Set[str] = set()
-_leveled_loggers_lock = threading.Lock()
 
 
 def _api_logging_decorator(logger_src: str, level: int):
@@ -88,10 +90,8 @@ def _api_logging_decorator(logger_src: str, level: int):
         @functools.wraps(api)
         def wrapped(*args, **kwargs):
             if logger_src not in _leveled_loggers:
-                with _leveled_loggers_lock:
-                    if logger_src not in _leveled_loggers:
-                        logging.getLogger(logger_src).setLevel(level)
-                        _leveled_loggers.add(logger_src)
+                logging.getLogger(logger_src).setLevel(level)
+                _leveled_loggers.add(logger_src)
             return api(*args, **kwargs)
 
         return wrapped

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -60,38 +60,39 @@ KUBECONFIG_REFRESH_INTERVAL_ENV_VAR = (
 
 logger = sky_logging.init_logger(__name__)
 
-
-def _decorate_methods(obj: Any, decorator: Callable, decoration_type: str):
-    for attr_name in dir(obj):
-        attr = getattr(obj, attr_name)
-        # Skip methods starting with '__' since they are invoked through one
-        # of the main methods, which are already decorated.
-        if callable(attr) and not attr_name.startswith('__'):
-            decorated_types: Set[str] = getattr(attr, '_sky_decorator_types',
-                                                set())
-            if decoration_type not in decorated_types:
-                decorated_attr = decorator(attr)
-                decorated_attr._sky_decorator_types = (  # pylint: disable=protected-access
-                    decorated_types | {decoration_type})
-                setattr(obj, attr_name, decorated_attr)
-    return obj
+# Loggers whose level has already been set by _api_logging_decorator, so
+# that Logger.setLevel() is called at most once per logger per process.
+# setLevel() acquires the logging module's global lock (via
+# Manager._clear_cache()), and on Python < 3.13 a fork() while another
+# thread holds that lock leaves the lock permanently held in the child,
+# deadlocking its next logging call. Fixed in CPython 3.13 by
+# https://github.com/python/cpython/pull/109462; until then, keep setLevel()
+# calls rare instead of on every API call.
+_leveled_loggers: Set[str] = set()
+_leveled_loggers_lock = threading.Lock()
 
 
 def _api_logging_decorator(logger_src: str, level: int):
-    """Decorator to set logging level for API calls.
+    """Decorator to set the logging level of a logger used by API calls.
 
-    This is used to suppress the verbose logging from urllib3 when calls to the
-    Kubernetes API timeout.
+    This is used to suppress the verbose logging from urllib3 when calls to
+    the Kubernetes API timeout. The level is set once per process on first
+    use and never restored: the previous per-call set/restore was racy under
+    concurrent API calls (interleaved restores could leave the level set
+    anyway) and its frequent setLevel() calls made the pre-3.13 fork
+    deadlock described above easy to hit.
     """
 
     def decorated_api(api):
 
+        @functools.wraps(api)
         def wrapped(*args, **kwargs):
-            obj = api(*args, **kwargs)
-            _decorate_methods(obj,
-                              sky_logging.set_logging_level(logger_src, level),
-                              'api_log')
-            return obj
+            if logger_src not in _leveled_loggers:
+                with _leveled_loggers_lock:
+                    if logger_src not in _leveled_loggers:
+                        logging.getLogger(logger_src).setLevel(level)
+                        _leveled_loggers.add(logger_src)
+            return api(*args, **kwargs)
 
         return wrapped
 

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -163,17 +163,6 @@ def init_logger(name: str) -> logging.Logger:
 
 
 @contextlib.contextmanager
-def set_logging_level(logger: str, level: int):
-    logger = logging.getLogger(logger)
-    original_level = logger.level
-    logger.setLevel(level)
-    try:
-        yield
-    finally:
-        logger.setLevel(original_level)
-
-
-@contextlib.contextmanager
 def set_sky_logging_levels(level: int):
     """Set the logging level for all loggers."""
     # Turn off logger

--- a/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
@@ -2,6 +2,7 @@
 
 import concurrent.futures
 import gc
+import logging
 import os
 import tempfile
 import time
@@ -305,3 +306,63 @@ def test_concurrent_context_isolation(monkeypatch, api_func):
                     f'got {actual_host}. Race condition detected.')
     finally:
         os.unlink(config_file)
+
+
+def test_urllib3_log_suppression_is_set_once_per_process(monkeypatch):
+    """API getters suppress urllib3 warnings via a single setLevel() call.
+
+    Regression test for the pre-Python-3.13 fork deadlock
+    (https://github.com/python/cpython/pull/109462): Logger.setLevel()
+    acquires logging's process-wide lock, so it must be called once per
+    process on first k8s API use, not on every API call, while still
+    suppressing urllib3's verbose retry warnings.
+    """
+    api_client_mock = MagicMock()
+    monkeypatch.setattr(kubernetes,
+                        '_get_api_client',
+                        lambda context=None: api_client_mock)
+    monkeypatch.setattr(
+        kubernetes.kubernetes.client,
+        'CoreV1Api',
+        lambda api_client=None: SimpleNamespace(api_client=api_client),
+    )
+    monkeypatch.setattr(
+        kubernetes.kubernetes.client,
+        'BatchV1Api',
+        lambda api_client=None: SimpleNamespace(api_client=api_client),
+    )
+
+    urllib3_logger = logging.getLogger('urllib3')
+    original_level = urllib3_logger.level
+    original_set_level = urllib3_logger.setLevel
+    # Reset process-global suppression state so the test is self-contained
+    # even if another test already triggered a k8s API getter.
+    monkeypatch.setattr(kubernetes, '_leveled_loggers', set())
+    original_set_level(logging.NOTSET)
+
+    set_level_calls = []
+
+    def counting_set_level(level):
+        set_level_calls.append(level)
+        original_set_level(level)
+
+    monkeypatch.setattr(urllib3_logger, 'setLevel', counting_set_level)
+
+    try:
+        annotations.clear_request_level_cache()
+        kubernetes.core_api()
+
+        # Warnings are suppressed on the child loggers urllib3 actually
+        # emits through (e.g. urllib3.connectionpool retry warnings), which
+        # inherit the parent's effective level.
+        child_logger = logging.getLogger('urllib3.connectionpool')
+        assert not child_logger.isEnabledFor(logging.WARNING)
+        assert child_logger.isEnabledFor(logging.ERROR)
+
+        # Repeated and cross-API calls must not call setLevel() again.
+        kubernetes.core_api()
+        kubernetes.batch_api()
+        assert set_level_calls == [logging.ERROR]
+    finally:
+        annotations.clear_request_level_cache()
+        original_set_level(original_level)

--- a/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
@@ -308,19 +308,29 @@ def test_concurrent_context_isolation(monkeypatch, api_func):
         os.unlink(config_file)
 
 
-def test_urllib3_log_suppression_is_set_once_per_process(monkeypatch):
-    """API getters suppress urllib3 warnings via a single setLevel() call.
+def test_urllib3_log_suppression_survives_client_construction(monkeypatch):
+    """API getters suppress urllib3 warnings with rare setLevel() calls.
 
-    Regression test for the pre-Python-3.13 fork deadlock
-    (https://github.com/python/cpython/pull/109462): Logger.setLevel()
-    acquires logging's process-wide lock, so it must be called once per
-    process on first k8s API use, not on every API call, while still
-    suppressing urllib3's verbose retry warnings.
+    Two regression targets:
+    - kubernetes.client.Configuration.__init__ resets the urllib3 logger to
+      WARNING on every client construction (its `debug` property setter), so
+      the adaptor must re-assert the level *after* constructing a client, not
+      just once per process.
+    - Pre-Python-3.13 fork deadlock
+      (https://github.com/python/cpython/pull/109462): Logger.setLevel()
+      acquires logging's process-wide lock, so the adaptor must not call it
+      on every API call — only when a client construction reset the level.
     """
     api_client_mock = MagicMock()
-    monkeypatch.setattr(kubernetes,
-                        '_get_api_client',
-                        lambda context=None: api_client_mock)
+
+    def stomping_get_api_client(context=None):
+        # Mimic kubernetes.client.Configuration.__init__, which resets the
+        # urllib3 logger to WARNING (via the `debug` property setter) every
+        # time a client is constructed.
+        logging.getLogger('urllib3').setLevel(logging.WARNING)
+        return api_client_mock
+
+    monkeypatch.setattr(kubernetes, '_get_api_client', stomping_get_api_client)
     monkeypatch.setattr(
         kubernetes.kubernetes.client,
         'CoreV1Api',
@@ -335,9 +345,6 @@ def test_urllib3_log_suppression_is_set_once_per_process(monkeypatch):
     urllib3_logger = logging.getLogger('urllib3')
     original_level = urllib3_logger.level
     original_set_level = urllib3_logger.setLevel
-    # Reset process-global suppression state so the test is self-contained
-    # even if another test already triggered a k8s API getter.
-    monkeypatch.setattr(kubernetes, '_leveled_loggers', set())
     original_set_level(logging.NOTSET)
 
     set_level_calls = []
@@ -352,17 +359,30 @@ def test_urllib3_log_suppression_is_set_once_per_process(monkeypatch):
         annotations.clear_request_level_cache()
         kubernetes.core_api()
 
-        # Warnings are suppressed on the child loggers urllib3 actually
-        # emits through (e.g. urllib3.connectionpool retry warnings), which
-        # inherit the parent's effective level.
+        # Despite the construction-time reset to WARNING, warnings must be
+        # suppressed on the child loggers urllib3 actually emits through
+        # (e.g. urllib3.connectionpool retry warnings), which inherit the
+        # parent's effective level.
         child_logger = logging.getLogger('urllib3.connectionpool')
         assert not child_logger.isEnabledFor(logging.WARNING)
         assert child_logger.isEnabledFor(logging.ERROR)
 
-        # Repeated and cross-API calls must not call setLevel() again.
+        # First getter call: one reset from client construction, one
+        # re-assert from the adaptor.
+        assert set_level_calls == [logging.WARNING, logging.ERROR]
+
+        # Cached getter calls construct no client, so the level is
+        # untouched and no setLevel() runs at all.
         kubernetes.core_api()
+        assert set_level_calls == [logging.WARNING, logging.ERROR]
+
+        # A different API getter constructs a new client (new reset), which
+        # must be re-asserted again.
         kubernetes.batch_api()
-        assert set_level_calls == [logging.ERROR]
+        assert set_level_calls == [
+            logging.WARNING, logging.ERROR, logging.WARNING, logging.ERROR
+        ]
+        assert not child_logger.isEnabledFor(logging.WARNING)
     finally:
         annotations.clear_request_level_cache()
         original_set_level(original_level)


### PR DESCRIPTION
## Summary

Fixes a fork deadlock risk on Python < 3.13 by making k8s API calls stop toggling the urllib3 log level on every invocation.

- **Problem:** `_api_logging_decorator` re-decorated every method of the Kubernetes client on each API getter call, so every k8s API method invocation entered the `set_logging_level` context manager and called `Logger.setLevel()` twice (suppress + restore). `setLevel()` acquires the logging module's process-wide lock via `Manager._clear_cache()`; on Python < 3.13, a `fork()` that lands while another thread holds that lock leaves the lock permanently held in the child, deadlocking the child's next logging call. Fixed upstream in CPython 3.13 (https://github.com/python/cpython/pull/109462), which SkyPilot cannot rely on yet.
- **Fix:** re-assert the urllib3 logger level to ERROR after each API getter runs, guarded by a lock-free level read so `setLevel()` only fires when the level actually changed. A pure set-once-per-process is not possible: `kubernetes.client.Configuration.__init__` resets the urllib3 logger to WARNING on every client construction (via its `debug` property setter) — found via real-cluster testing. With the guard, `setLevel()` runs once per client construction (per context / per kubeconfig refresh) instead of twice per API call, shrinking the fork-deadlock window by orders of magnitude while keeping urllib3 retry-warning suppression intact.
- **Behavior note:** the level is no longer restored between calls. The old set/restore was already racy under concurrent API calls (thread B could capture ERROR as the "original" level while thread A was mid-call, leaving the level stuck at ERROR), so effective behavior is unchanged.
- **Cleanup:** removes `_decorate_methods` (a `dir()` + `getattr` sweep on every getter call that force-materialized every method on `RetryableClientWrapper`) and the now-unused `sky_logging.set_logging_level`.

## Test plan

- Regression test: `tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py::test_urllib3_log_suppression_survives_client_construction` — simulates the `Configuration` level reset during client construction and verifies (a) urllib3 warnings are suppressed afterwards (checked on the child loggers urllib3 actually emits through, e.g. `urllib3.connectionpool`), and (b) `setLevel()` runs only on construction-time resets, not on cached getter calls.
- Real-cluster verification: with a kubeconfig context whose API server is unreachable (DNS failure → urllib3 retries), `sky check kubernetes`:
  - without the post-construction re-assert: `WARNING:urllib3.connectionpool:Retrying (...)` spam leaked to the CLI output;
  - with it: same timeout diagnosis, no urllib3 warnings.
- `pytest tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py` (23 passed) and `tests/unit_tests/kubernetes/` (396 passed) pass.
- `format.sh`, mypy, and pylint clean on the modified files.
- `/smoke-test --kubernetes` triggered on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
