### PR TITLE
[Docker] Bump base image to Python 3.13

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -245,7 +245,7 @@ def _extract_marked_tests(
     extra_args: List[str],
     exclusive_run: bool = False
 ) -> Dict[str, Tuple[List[str], List[str], List[Optional[str]], List[List[str]],
-                     List[bool], List[Optional[str]]]]:
+                     List[bool], List[Optional[str]], List[bool]]]:
     """Extract test functions and filter clouds using pytest.mark
     from a Python test file.
 
@@ -261,7 +261,8 @@ def _extract_marked_tests(
 
     Returns:
         Dict mapping function_name to tuple of:
-        (clouds, queues, params, extra_args, no_auto_retry_flags)
+        (clouds, queues, params, extra_args, no_auto_retry_flags,
+         concurrency_groups, serve_flags)
     """
     # Args are already in the format pytest expects (cloud names like --lambda)
     cmd = f'pytest {file_path} --collect-only {args}'
@@ -329,6 +330,7 @@ def _extract_marked_tests(
                                      'kubernetes' in default_clouds_to_run)
         benchmark_test = 'benchmark' in marks
         no_auto_retry = 'no_auto_retry' in marks
+        serve_test = 'serve' in marks
 
         # A concurrency_group(name) marker serializes this test globally across
         # all builds and pipelines: the step gets that concurrency_group with a
@@ -386,7 +388,7 @@ def _extract_marked_tests(
             extra_args for _ in range(len(final_clouds_to_include))
         ], [no_auto_retry for _ in range(len(final_clouds_to_include))], [
             test_concurrency_group for _ in range(len(final_clouds_to_include))
-        ])
+        ], [serve_test for _ in range(len(final_clouds_to_include))])
 
     return function_cloud_map
 
@@ -412,6 +414,7 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     concurrency_limit = None
     build_id = None
     concurrency_group = None
+    env_file_serve_concurrency_group = None
     if exclusive:
         # Exclusive tests mutate shared server state, so the whole exclusive-only
         # run is serialized to one step at a time. Key the group on the target
@@ -428,9 +431,11 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
                              DEFAULT_ENV_FILE_CONCURRENCY_LIMIT)
         build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
         concurrency_group = f'env-file-smoke-test-{build_id}'
+        tag = hashlib.sha256(env_file.encode()).hexdigest()[:12]
+        env_file_serve_concurrency_group = f'env-file-serve-{tag}'
     for test_function, clouds_queues_param in function_cloud_map.items():
         for (cloud, queue, param, extra_args, no_auto_retry,
-             test_concurrency_group) in zip(*clouds_queues_param):
+             test_concurrency_group, serve_test) in zip(*clouds_queues_param):
             label = f'{test_function} on {cloud}'
             command = f'pytest {test_file}::{test_function} --{cloud}'
             if param:
@@ -461,6 +466,14 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
                 # and pipelines, so instances of this test serialize org-wide.
                 step['concurrency'] = 1
                 step['concurrency_group'] = test_concurrency_group
+            elif (serve_test and
+                  env_file_serve_concurrency_group is not None and
+                  not exclusive):
+                # An env file points every step at the same API server. SkyServe
+                # tests share that server's controller capacity, so serialize
+                # them across builds targeting the same env file.
+                step['concurrency'] = 1
+                step['concurrency_group'] = env_file_serve_concurrency_group
             elif concurrency_limit is not None:
                 step['concurrency'] = concurrency_limit
                 step['concurrency_group'] = concurrency_group

--- a/.buildkite/test_buildkite_pipeline_generation.py
+++ b/.buildkite/test_buildkite_pipeline_generation.py
@@ -12,6 +12,7 @@ pytest -n 0 --dist no .buildkite/test_buildkite_pipeline_generation.py
 
 """
 
+import hashlib
 import os
 import pathlib
 import re
@@ -231,6 +232,57 @@ def test_concurrency_group_marker():
             f"concurrency_group step should have concurrency 1: {step}"
         assert step.get('concurrency_group') == 'my-global-lock', \
             f"concurrency_group step should carry the marker name: {step}"
+    finally:
+        test_file.unlink(missing_ok=True)
+
+
+def test_env_file_serializes_serve_tests(tmp_path):
+    """Env-file SkyServe steps serialize without limiting other tests."""
+    test_file = pathlib.Path(
+        'tests/smoke_tests/test_env_file_serve_concurrency_tmp.py')
+    test_file.write_text('import pytest\n'
+                         '\n'
+                         '\n'
+                         '@pytest.mark.aws\n'
+                         '@pytest.mark.serve\n'
+                         'def test_serve_example():\n'
+                         '    pass\n'
+                         '\n'
+                         '\n'
+                         '@pytest.mark.aws\n'
+                         'def test_ordinary_example():\n'
+                         '    pass\n')
+    env_file = tmp_path / 'remote-env.yaml'
+    env_file.write_text('api_server:\n  endpoint: https://example.com\n')
+    try:
+        env = dict(os.environ)
+        env['PYTHONPATH'] = f"{pathlib.Path.cwd()}/tests:" \
+                            f"{env.get('PYTHONPATH', '')}"
+        env['BUILDKITE_BUILD_ID'] = 'test-build'
+
+        subprocess.run([
+            'python', '.buildkite/generate_pipeline.py', '--args',
+            f'--aws --env-file {env_file} --base-branch master',
+            '--file_pattern', 'test_env_file_serve_concurrency_tmp'
+        ],
+                       env=env,
+                       check=True)
+
+        pipeline_path = pathlib.Path(
+            '.buildkite/pipeline_smoke_tests_release.yaml')
+        steps = _extract_steps_from_pipeline(pipeline_path)
+        steps_by_label = {step['label']: step for step in steps}
+
+        serve_step = steps_by_label['test_serve_example on aws']
+        env_file_tag = hashlib.sha256(str(env_file).encode()).hexdigest()[:12]
+        assert serve_step['concurrency'] == 1
+        assert serve_step[
+            'concurrency_group'] == f'env-file-serve-{env_file_tag}'
+
+        ordinary_step = steps_by_label['test_ordinary_example on aws']
+        assert ordinary_step['concurrency'] == 10
+        assert ordinary_step[
+            'concurrency_group'] == 'env-file-smoke-test-test-build'
     finally:
         test_file.unlink(missing_ok=True)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Install Google Cloud SDK using APT
-FROM python:3.10.19-slim AS gcloud-apt-install
+FROM python:3.13.14-slim AS gcloud-apt-install
 
 # Keep in sync with _GCLOUD_VERSION in sky/clouds/gcp.py. Pinned so the apt
 # install layer doesn't bake in a stale version via buildx registry caching
@@ -24,12 +24,14 @@ RUN apt-get update && \
 
 
 # Stage 2: Process the source code for INSTALL_FROM_SOURCE
-FROM python:3.10.19-slim AS process-source
+FROM python:3.13.14-slim AS process-source
 
 # Control installation method - default to install from source
 ARG INSTALL_FROM_SOURCE=true
 ARG NEXT_BASE_PATH=/dashboard
 WORKDIR /skypilot
+
+RUN pip install --no-cache-dir setuptools==78.1.1
 
 # Run NPM and node install in a separate step for caching.
 RUN if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
@@ -75,7 +77,7 @@ RUN cd /skypilot && \
 
 
 # Stage 3: Main image
-FROM python:3.10.19-slim
+FROM python:3.13.14-slim
 
 ARG INSTALL_FROM_SOURCE=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Install Google Cloud SDK using APT
-FROM python:3.10.19-slim AS gcloud-apt-install
+FROM python:3.13.15-slim AS gcloud-apt-install
 
 # Keep in sync with _GCLOUD_VERSION in sky/clouds/gcp.py. Pinned so the apt
 # install layer doesn't bake in a stale version via buildx registry caching
@@ -24,12 +24,14 @@ RUN apt-get update && \
 
 
 # Stage 2: Process the source code for INSTALL_FROM_SOURCE
-FROM python:3.10.19-slim AS process-source
+FROM python:3.13.15-slim AS process-source
 
 # Control installation method - default to install from source
 ARG INSTALL_FROM_SOURCE=true
 ARG NEXT_BASE_PATH=/dashboard
 WORKDIR /skypilot
+
+RUN pip install --no-cache-dir setuptools==78.1.1
 
 # Run NPM and node install in a separate step for caching.
 RUN if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
@@ -75,7 +77,7 @@ RUN cd /skypilot && \
 
 
 # Stage 3: Main image
-FROM python:3.10.19-slim
+FROM python:3.13.15-slim
 
 ARG INSTALL_FROM_SOURCE=true
 

--- a/tests/smoke_tests/test_logs.py
+++ b/tests/smoke_tests/test_logs.py
@@ -12,6 +12,40 @@ from smoke_tests import smoke_tests_utils
 import sky
 
 
+def _get_wait_for_gcp_logs_cmd(log_filter: str) -> str:
+    return textwrap.dedent(f"""\
+        for attempt in {{1..18}}; do
+          output=$(gcloud logging read '{log_filter}' --order=asc --format=json)
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "gcloud logging read failed with exit code $rc"
+            exit "$rc"
+          fi
+
+          all_logs_found=true
+          for i in {{1..10}}; do
+            expected_log='"log": "test output '$i'"'
+            if ! grep -q "$expected_log" <<< "$output"; then
+              all_logs_found=false
+              break
+            fi
+          done
+          if [ "$all_logs_found" = true ]; then
+            echo "$output"
+            echo "===Validated logs from GCP Cloud Logging==="
+            exit 0
+          fi
+
+          if [ "$attempt" -eq 18 ]; then
+            echo "$output"
+            echo "Timed out waiting for logs in GCP Cloud Logging"
+            exit 1
+          fi
+          sleep 10
+        done
+        """)
+
+
 @pytest.mark.no_vast  # Requires GCP
 @pytest.mark.no_shadeform  # Requires GCP
 @pytest.mark.no_fluidstack  # Requires GCP to be enabled
@@ -26,7 +60,7 @@ def test_log_collection_to_gcp(generic_cloud: str):
     with tempfile.NamedTemporaryFile(mode='w') as base, \
         tempfile.NamedTemporaryFile(mode='w') as additional_labels:
         base.write(
-            textwrap.dedent(f"""\
+            textwrap.dedent("""\
                 logs:
                   store: gcp
                 """))
@@ -41,35 +75,33 @@ def test_log_collection_to_gcp(generic_cloud: str):
                 """))
         additional_labels.flush()
         logs_cmd = 'for i in {1..10}; do echo "test output $i"; done'
-        validate_logs_cmd = (
-            'echo $output && echo "===Validate logs from GCP Cloud Logging===" && '
-            'for i in {1..10}; do echo $output | grep -q "test output $i"; done'
-        )
         test = smoke_tests_utils.Test(
             'log_collection_to_gcp',
             [
                 smoke_tests_utils.with_config(
-                    f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
+                    f'sky launch -y -c {name} --infra {generic_cloud} '
+                    f'{smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
                     base.name),
                 f'sky logs {name} 1',
-                # Wait for the logs to be available in the GCP Cloud Logging.
-                'sleep 10',
-                # Use grep instead of jq to avoid the dependency on jq.
-                (f'output=$(gcloud logging read \'labels.skypilot_cluster_name={name} AND timestamp>="{one_hour_ago}"\' --order=asc --format=json | grep \'"log":\') && '
-                 f'{validate_logs_cmd}'),
+                _get_wait_for_gcp_logs_cmd(
+                    f'labels.skypilot_cluster_name={name} AND '
+                    f'timestamp>="{one_hour_ago}"'),
                 smoke_tests_utils.with_config(
-                    f'sky jobs launch -y -n {name}-job --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
+                    f'sky jobs launch -y -n {name}-job '
+                    f'--infra {generic_cloud} '
+                    f'{smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
                     base.name),
-                'sleep 10',
-                (f'output=$(gcloud logging read \'jsonPayload.log_path:{name}-job AND timestamp>="{one_hour_ago}"\' --order=asc --format=json | grep \'"log":\') && '
-                 f'{validate_logs_cmd}'),
+                _get_wait_for_gcp_logs_cmd(
+                    f'jsonPayload.log_path:{name}-job AND '
+                    f'timestamp>="{one_hour_ago}"'),
                 f'sky down -y {name}',
                 smoke_tests_utils.with_config(
-                    f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
+                    f'sky launch -y -c {name} --infra {generic_cloud} '
+                    f'{smoke_tests_utils.LOW_RESOURCE_ARG} \'{logs_cmd}\'',
                     additional_labels.name),
-                'sleep 10',
-                (f'output=$(gcloud logging read \'labels.skypilot_smoke_test_case={name}-case AND timestamp>="{one_hour_ago}"\' --order=asc --format=json | grep \'"log":\') && '
-                 f'{validate_logs_cmd}'),
+                _get_wait_for_gcp_logs_cmd(
+                    f'labels.skypilot_smoke_test_case={name}-case AND '
+                    f'timestamp>="{one_hour_ago}"'),
             ],
             f'sky down -y {name}',
             timeout=smoke_tests_utils.LOG_STORE_CMD_TIMEOUT,
@@ -102,6 +134,9 @@ def test_managed_job_logs_with_log_store(generic_cloud: str):
         'awk -v n=' + job_name +
         ' \'{for (i=1; i<=NF; i++) if ($i==n) {print $1; break}}\' | '
         'sort -un | head -1')
+    wait_for_managed_job = (
+        smoke_tests_utils.
+        get_cmd_wait_until_managed_job_status_contains_matching_job_name)
     with tempfile.NamedTemporaryFile(mode='w') as base:
         base.write(
             textwrap.dedent("""\
@@ -118,8 +153,7 @@ def test_managed_job_logs_with_log_store(generic_cloud: str):
                     f'{smoke_tests_utils.LOW_RESOURCE_ARG} \'{run_cmd}\'',
                     base.name),
                 # Running state: logs stream from the cluster.
-                smoke_tests_utils.
-                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                wait_for_managed_job(
                     job_name=job_name,
                     job_status=[sky.ManagedJobStatus.RUNNING],
                     timeout=smoke_tests_utils.LOG_STORE_JOB_START_TIMEOUT),
@@ -128,8 +162,7 @@ def test_managed_job_logs_with_log_store(generic_cloud: str):
                 f'echo "$s" | grep "{marker}_1"',
                 # Terminal state: logs are still retrievable (served from the
                 # controller-local copy when the store has no read-back path).
-                smoke_tests_utils.
-                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                wait_for_managed_job(
                     job_name=job_name,
                     job_status=[sky.ManagedJobStatus.SUCCEEDED],
                     timeout=360),

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -197,15 +197,18 @@ def test_gzip_stall_names_the_compression_call_site(stall_logs):
 
     _run_with_watchdog(compress_on_loop, threshold=0.2, recover=0.6)
 
-    gzip_stalls = _messages_matching(stall_logs, 'gzip:write')
+    gzip_stalls = [
+        detail for detail in _details(stall_logs)
+        if detail['source'].startswith('gzip:')
+    ]
     assert gzip_stalls, ('gzip stall not attributed, got: '
                          f'{[r.getMessage() for r in stall_logs]}')
-    message = gzip_stalls[0]
+    detail = gzip_stalls[0]
     # gzip is not framework plumbing, so it is named directly rather than
     # being collapsed into its caller.
-    assert 'gzip.py:' in message
+    assert 'gzip.py:' in detail['blocking']
     # The chain back to the code that chose to compress on the loop is kept.
-    assert 'in compress_on_loop' in message
+    assert any('in compress_on_loop' in frame for frame in detail['frames'])
 
 
 def test_long_stall_is_sampled_more_than_once(stall_logs):

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -540,17 +540,18 @@ class TestQueueJsonOutput:
                                   job_name='train-b',
                                   status=job_lib.JobStatus.SUCCEEDED)
         ]
-        call_count = {'n': 0}
+        records_by_request = {
+            'cluster-a': records_a,
+            'cluster-b': records_b,
+        }
 
-        def mock_stream_and_get(*a, **kw):
-            call_count['n'] += 1
-            if call_count['n'] == 1:
-                return records_a
-            return records_b
+        def mock_stream_and_get(request_id, *a, **kw):
+            return records_by_request[request_id]
 
         monkeypatch.setattr('sky.client.sdk.stream_and_get',
                             mock_stream_and_get)
-        monkeypatch.setattr('sky.client.sdk.queue', lambda *a, **kw: 'mock_req')
+        monkeypatch.setattr('sky.client.sdk.queue',
+                            lambda cluster, *a, **kw: cluster)
         monkeypatch.setattr(
             'sky.client.cli.command._get_cluster_records_and_set_ssh_config',
             lambda *a, **kw: [])


### PR DESCRIPTION
## Summary

- Move all release Dockerfile stages from Python 3.10.19 to 3.13.14.
- Install setuptools explicitly in the source-processing stage because it is not included in the Python 3.13 slim image.

Cancelling a request on the API server can permanently deadlock executor workers by leaking `logging._lock`, the stdlib logging module's global `threading.RLock`. If SIGTERM → `KeyboardInterrupt` lands inside CPython's logging lock acquire/release window—a real, reproducible race on Python ≤ 3.12—the global lock is acquired and never released. Any future request on that executor that touches logging, which is effectively all of them, then blocks forever.

CPython fixed this in Python 3.13 via [python/cpython#109462](https://github.com/python/cpython/pull/109462). The `set_logging_level` call that exposes SkyPilot to this window was introduced in the much older [skypilot-org/skypilot#3674](https://github.com/skypilot-org/skypilot/pull/3674). This is why the image needs to move directly to Python 3.13 rather than the intermediate Python 3.11 proposed in [#9965](https://github.com/skypilot-org/skypilot/pull/9965).

## Test plan

- Built the release Dockerfile for Linux/amd64 with `docker buildx build`.
- Confirmed the resulting image reports Python 3.13.14 and imports SkyPilot successfully.
