### PR TITLE
[Test] Make sky status -o json output tests hermetic

### DIFF
--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -14,6 +14,7 @@ import pytest
 from sky.catalog import common as catalog_common
 from sky.client import sdk
 from sky.client.cli import command
+from sky.client.cli import utils as cli_utils
 from sky.jobs import state as job_state
 from sky.schemas.api import responses
 from sky.server.requests import payloads
@@ -23,6 +24,30 @@ from sky.utils import status_lib
 
 class TestStatusJsonOutput:
     """Tests for `sky status -o json` output format."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_side_fetches(self, monkeypatch):
+        """Stub every server fetch `sky status` makes besides the cluster
+        records (which each test stubs itself with its own data).
+
+        The status command also submits workspace / enabled-clouds /
+        user-workspace / managed-jobs / services / pools requests for the
+        table view. These tests only assert on the JSON output shape, but
+        without stubs those submissions hit the shared live API server the
+        CI workers auto-start — and a transient connection reset there
+        failed the test even though it could never affect the JSON output
+        (a frequent CI flake: ConnectionResetError(104)).
+        """
+        monkeypatch.setattr(
+            'sky.client.cli.utils.get_managed_job_queue', lambda **kw:
+            (None, cli_utils.QueueResultVersion.V1))
+        monkeypatch.setattr('sky.serve.status', lambda **kw: None)
+        monkeypatch.setattr('sky.jobs.pool_status', lambda **kw: None)
+        monkeypatch.setattr('sky.client.sdk.workspaces', lambda *a, **kw: None)
+        monkeypatch.setattr('sky.client.sdk.enabled_clouds',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr('sky.client.sdk.get_user_workspace',
+                            lambda *a, **kw: {})
 
     def _make_cluster_record(self, name='mycluster', **kwargs):
         defaults = dict(


### PR DESCRIPTION
## Summary

- `TestStatusJsonOutput` stubs the cluster-records fetch but left `sky status`'s other submissions (workspaces, enabled clouds, user workspace, managed jobs, services, pools) hitting the live API server that CI's `pytest -n 4` xdist workers share. A transient connection reset there failed whichever json test was in flight — the roaming `ConnectionResetError(104)` flake (master pytest runs: 4/40 failures over Jul 5–10 → 6/20 over Jul 11–13), even though those results are discarded by the `-o json` path and can never affect the asserted output.
- Adds an autouse fixture stubbing those side-fetches, matching the sibling classes in the same file (which already stub their side-calls completely). Stubs are shape-faithful where the code consumes the value (the managed-jobs `(request_id, version)` tuple; `get_user_workspace().get(...)`) and `None` where the production code either never reads the result on this path or explicitly None-guards it — so a future change that starts consuming these in json output fails loudly instead of silently passing on fabricated data.

## Test plan

- Deterministic repro of the CI failure: `SKYPILOT_API_SERVER_ENDPOINT=http://127.0.0.1:9 pytest tests/unit_tests/test_sky/test_cli_json_output.py` — **before:** the 4 `TestStatusJsonOutput` tests fail with the exact CI signature (`ConnectionResetError` → exit code 1); **after:** all 31 tests in the file pass, i.e. the whole file now runs with zero network.
- `pytest tests/unit_tests/test_sky/test_cli_json_output.py` — 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)