### PR TITLE
[Test] Replace retired p3/V100 AWS resources in examples

### DIFF
--- a/examples/containerized_app.py
+++ b/examples/containerized_app.py
@@ -22,6 +22,6 @@ run_command = 'docker run -v ~/mnist/:/mnist/ --runtime=nvidia --rm cemizm/tf-be
 
 with sky.Dag() as dag:
     t = sky.Task(run=run_command, setup=setup_cmd)
-    t.set_resources(sky.Resources(infra='aws', accelerators='V100'))
+    t.set_resources(sky.Resources(infra='aws', accelerators='T4'))
 
 sky.launch(dag)

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -41,9 +41,9 @@ def make_application():
 
         train_op.set_resources({
             sky.Resources(infra='aws',
-                          instance_type='p3.2xlarge'),  # 1 V100, EC2.
+                          instance_type='g4dn.xlarge'),  # 1 T4, EC2.
             sky.Resources(infra='aws',
-                          instance_type='p3.8xlarge'),  # 4 V100s, EC2.
+                          instance_type='g4dn.12xlarge'),  # 4 T4s, EC2.
             # Tuples mean all resources are required.
             sky.Resources(infra='gcp', accelerators='tpu-v3-8'),
         })
@@ -61,7 +61,7 @@ def make_application():
 
         infer_op.set_resources({
             sky.Resources(infra='aws', instance_type='inf1.2xlarge'),
-            sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+            sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
             sky.Resources(infra='gcp',
                           instance_type='n1-standard-4',
                           accelerators='T4'),

--- a/examples/horovod_distributed_tf_app.py
+++ b/examples/horovod_distributed_tf_app.py
@@ -55,7 +55,7 @@ with sky.Dag() as dag:
                      estimated_size_gigabytes=70)
     train.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
     train.set_resources({
-        sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+        sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
     })
 
 dag = sky.Optimizer.optimize(dag)

--- a/examples/huggingface_glue_imdb_grid_search_app.py
+++ b/examples/huggingface_glue_imdb_grid_search_app.py
@@ -1,7 +1,7 @@
 """Grid search version of huggingface_glue_imdb_app.py."""
 import sky
 
-resources_to_launch = sky.Resources(infra='aws', accelerators={'V100': 4})
+resources_to_launch = sky.Resources(infra='aws', accelerators={'T4': 4})
 with sky.Dag() as dag:
     # Setup command, run once (pip, download dataset).
     common_setup = """\

--- a/examples/ray_tune_app.py
+++ b/examples/ray_tune_app.py
@@ -30,7 +30,7 @@ with sky.Dag() as dag:
     )
 
     train.set_resources({
-        sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+        sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
     })
 
 sky.launch(dag)

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -68,7 +68,7 @@ task.set_inputs('gs://cloud-tpu-test-datasets/fake_imagenet',
 task.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
 task.set_resources({
     ##### Fully specified
-    # sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+    # sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
     # sky.Resources(infra='gcp', instance_type='n1-standard-16'),
     # sky.Resources(
     #     infra='gcp',
@@ -85,10 +85,10 @@ task.set_resources({
     # sky.Resources(accelerators='tpu-v3-8'),
     # sky.Resources(accelerators='V100', use_spot=True),
     # sky.Resources(accelerators={'T4': 4}),
-    sky.Resources(infra='aws', accelerators='V100'),
+    sky.Resources(infra='aws', accelerators='T4'),
     # sky.Resources(infra='gcp', accelerators={'V100': 4}),
-    # sky.Resources(infra='aws', accelerators='V100', use_spot=True),
-    # sky.Resources(infra='aws', accelerators={'V100': 8}),
+    # sky.Resources(infra='aws', accelerators='T4', use_spot=True),
+    # sky.Resources(infra='aws', accelerators={'T4': 8}),
 })
 
 # Optionally, specify a time estimator: Resources -> time in seconds.

--- a/examples/resnet_app_storage.py
+++ b/examples/resnet_app_storage.py
@@ -71,7 +71,7 @@ with sky.Dag() as dag:
     train.set_inputs('s3://imagenet-bucket', estimated_size_gigabytes=150)
     train.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
     train.set_resources({
-        sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+        sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
     })
 
 sky.launch(dag)

--- a/examples/resnet_app_storage.yaml
+++ b/examples/resnet_app_storage.yaml
@@ -3,7 +3,7 @@ workdir: ~/Downloads/tpu
 
 resources:
   infra: aws
-  instance_type: p3.2xlarge
+  instance_type: g4dn.xlarge
 
 inputs: {
   gs://cloud-tpu-test-dataset/fake_imagenet: 70,

--- a/examples/resnet_distributed_tf_app.py
+++ b/examples/resnet_distributed_tf_app.py
@@ -75,7 +75,7 @@ def run(cluster: Optional[str] = None, infra: Optional[str] = None):
         train.set_inputs('gs://cloud-tpu-test-datasets/fake_imagenet',
                          estimated_size_gigabytes=70)
         train.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
-        train.set_resources(sky.Resources(infra=infra, accelerators='V100'))
+        train.set_resources(sky.Resources(infra=infra, accelerators='T4'))
 
     sky.launch(dag, cluster_name=cluster, retry_until_up=True)
 

--- a/examples/resnet_distributed_torch_app.py
+++ b/examples/resnet_distributed_torch_app.py
@@ -35,7 +35,7 @@ train = sky.Task(
 
 train.set_resources({
     ##### Fully specified
-    sky.Resources(infra='aws', instance_type='p3.2xlarge'),
+    sky.Resources(infra='aws', instance_type='g4dn.xlarge'),
     # sky.Resources(infra='gcp', instance_type='n1-standard-16'),
     #sky.Resources(
     #     infra='gcp',
@@ -46,8 +46,8 @@ train.set_resources({
     ##### Partially specified
     #sky.Resources(accelerators='V100'),
     # sky.Resources(accelerators='tpu-v3-8'),
-    # sky.Resources(infra='aws', accelerators={'V100': 4}),
-    # sky.Resources(infra='aws', accelerators='V100'),
+    # sky.Resources(infra='aws', accelerators={'T4': 4}),
+    # sky.Resources(infra='aws', accelerators='T4'),
 })
 
 sky.launch(train, cluster_name='dth')

--- a/examples/tensorboard_app.py
+++ b/examples/tensorboard_app.py
@@ -19,7 +19,7 @@ with sky.Dag() as dag:
            cd models && pip install -e .)'
 
     task = sky.Task('setup', workdir=workdir, setup=setup)
-    task.set_resources(sky.Resources(infra='aws', accelerators={'V100': 1}))
+    task.set_resources(sky.Resources(infra='aws', accelerators={'T4': 1}))
 sky.stream_and_get(sky.launch(dag, cluster_name='tb'))
 
 # Run the training task.

--- a/examples/time_estimators.py
+++ b/examples/time_estimators.py
@@ -3,33 +3,33 @@ from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
+# Peak 16-bit throughput, in FLOPS.
+V100_PEAK_FLOPS = 120 * (10**12)
+T4_PEAK_FLOPS = 65 * (10**12)
+
 
 def resnet50_estimate_runtime(resources):
     """A simple runtime model for Resnet50."""
     # 3.8 G Multiply-Adds, 2 FLOPs per MADD, 3 for fwd+bwd.
     flops_for_one_image = 3.8 * (10**9) * 2 * 3
 
-    def _v100(num_v100s):
+    def _gpu(num_gpus, peak_flops):
         # Adds communication overheads per step (in seconds).
         communication_slack = 0.0
-        if num_v100s == 4:
+        if num_gpus == 4:
             communication_slack = 0.15
-        elif num_v100s == 8:
+        elif num_gpus == 8:
             communication_slack = 0.30
 
         max_per_device_batch_size = 256
-        effective_batch_size = max_per_device_batch_size * num_v100s
+        effective_batch_size = max_per_device_batch_size * num_gpus
 
         # 112590 steps, 1024 BS = 90 epochs.
         total_steps = 112590 * (1024.0 / effective_batch_size)
         flops_for_one_batch = flops_for_one_image * max_per_device_batch_size
 
-        # 27 TFLOPs, harmonic mean b/t 15TFLOPs (single-precision) & 120 TFLOPs
-        # (16 bit).
-        utilized_flops = 27 * (10**12)
-
-        # print('****** trying 1/3 util for v100')
-        utilized_flops = 120 * (10**12) / 3
+        # Assume the model sustains 1/3 of the device's peak throughput.
+        utilized_flops = peak_flops / 3
 
         estimated_step_time_seconds = flops_for_one_batch / utilized_flops \
           + communication_slack
@@ -38,15 +38,15 @@ def resnet50_estimate_runtime(resources):
 
     if isinstance(resources.cloud, sky.AWS):
         instance = resources.instance_type
-        if instance == 'p3.2xlarge':
-            num_v100s = 1
-        elif instance == 'p3.8xlarge':
-            num_v100s = 4
-        elif instance == 'p3.16xlarge':
-            num_v100s = 8
+        if instance == 'g4dn.xlarge':
+            num_t4s = 1
+        elif instance == 'g4dn.12xlarge':
+            num_t4s = 4
+        elif instance == 'g4dn.metal':
+            num_t4s = 8
         else:
             assert False, 'Not supported: {}'.format(resources)
-        return _v100(num_v100s)
+        return _gpu(num_t4s, T4_PEAK_FLOPS)
 
     elif isinstance(resources.cloud, sky.GCP):
         accelerators = resources.accelerators
@@ -56,9 +56,10 @@ def resnet50_estimate_runtime(resources):
         assert len(accelerators) == 1, resources
         for acc, acc_count in accelerators.items():
             break
+        # GCP still offers V100s, unlike AWS.
         if acc == 'V100':
             assert acc_count in [1, 2, 4, 8], resources
-            return _v100(acc_count)
+            return _gpu(acc_count, V100_PEAK_FLOPS)
 
         assert acc == 'tpu-v3-8', resources
         tpu_v3_8_flops = 420 * (10**12)
@@ -96,32 +97,8 @@ def resnet50_infer_estimate_runtime(resources):
     num_images = 70 * 1e6  # TODO: vary this.
 
     instance = resources.instance_type
-    # assert instance in ['p3.2xlarge', 'inf1.2xlarge', 'nvidia-t4'], instance
 
-    if instance == 'p3.2xlarge':
-        # 120 TFLOPS TensorCore.
-        logger.debug('****** trying 1/3 util for v100')
-        utilized_flops = 120 * (10**12) / 3
-
-        # # Max bs to keep p99 < 15ms.
-        # max_per_device_batch_size = 8
-        # max_per_device_batch_size = 8*1e3
-        # max_per_device_batch_size = 1
-
-        # num_v100s = 1
-        # effective_batch_size = max_per_device_batch_size * num_v100s
-
-        # # 112590 steps, 1024 BS = 90 epochs.
-        # total_steps = num_images // effective_batch_size
-        # flops_for_one_batch = flops_for_one_image * max_per_device_batch_size
-
-        # estimated_step_time_seconds = flops_for_one_batch / utilized_flops
-        # estimated_run_time_seconds = estimated_step_time_seconds * total_steps
-
-        # TODO: this ignores offline vs. online.  It's a huge batch.
-        estimated_run_time_seconds = \
-            flops_for_one_image * num_images / utilized_flops
-    elif instance == 'inf1.2xlarge':
+    if instance == 'inf1.2xlarge':
         # Inferentia: 1 chip = 128T[F?]OPS
         # Each AWS Inferentia chip supports up to 128 TOPS (trillions of
         # operations per second) of performance [assume 16, as it casts to
@@ -136,8 +113,7 @@ def resnet50_infer_estimate_runtime(resources):
         for acc, acc_count in accs.items():
             break
         assert acc == 'T4' and acc_count == 1, resources
-        # T4 GPU: 65 TFLOPS fp16
-        utilized_flops = 65 * (10**12) / 3
+        utilized_flops = T4_PEAK_FLOPS / 3
         estimated_run_time_seconds = \
             flops_for_one_image * num_images / utilized_flops
     else:

--- a/examples/time_estimators.py
+++ b/examples/time_estimators.py
@@ -45,7 +45,7 @@ def resnet50_estimate_runtime(resources):
         elif instance == 'g4dn.metal':
             num_t4s = 8
         else:
-            assert False, 'Not supported: {}'.format(resources)
+            raise ValueError('Not supported: {}'.format(resources))
         return _gpu(num_t4s, T4_PEAK_FLOPS)
 
     elif isinstance(resources.cloud, sky.GCP):

--- a/examples/timm_app.py
+++ b/examples/timm_app.py
@@ -49,6 +49,6 @@ with sky.Dag() as dag:
         # Download from GCS.
         '/tmp/fake_imagenet': 'gs://cloud-tpu-test-datasets/fake_imagenet',
     })
-    train.set_resources({sky.Resources(infra='aws', accelerators='V100')})
+    train.set_resources({sky.Resources(infra='aws', accelerators='T4')})
 
 sky.launch(dag)


### PR DESCRIPTION
AWS retired the P3 (V100) generation, and the 2026-07-13 catalog refresh dropped all `p3.*` rows (and the plain `V100` accelerator on AWS — only `V100-32GB` survives). #10098 fixed the *test fixtures* that hardcoded `p3.2xlarge`, but not the example apps.

`examples/example_app.py` is run verbatim by the `test_example_app` smoke test (`python examples/example_app.py`), which fails at DAG serialization, before the optimizer even runs:

```
File "sky/catalog/common.py", line 451, in get_vcpus_mem_from_instance_type_impl
    raise ValueError(f"No instance type {instance_type} found.")
ValueError: No instance type p3.2xlarge found.
```

## Changes

Move the **AWS-pinned** resources off retired hardware (13 sites, 10 files):

- `p3.2xlarge` → `g4dn.xlarge` (T4:1) and `p3.8xlarge` → `g4dn.12xlarge` (T4:4), matching the `g4dn.xlarge` choice already made in #10098.
- AWS-pinned `accelerators='V100'` → `'T4'`.
- `examples/resnet_distributed_tf_app.py` takes its cloud from argv (the smoke test passes `generic_cloud`), so its `V100` was latently broken for `--aws`. T4 exists on AWS/GCP/Azure, so it is now portable across all of them.

`examples/time_estimators.py` needed a real change, not just a rename: its AWS branch keyed off the `p3.*` instance names and hard-asserted on anything else, so swapping instance types alone would have traded the `ValueError` for `AssertionError: Not supported`. The V100-specific FLOPs model is generalized into `_gpu(num_gpus, peak_flops)` and the AWS branch mapped onto the g4dn 1/4/8 ladder (`g4dn.xlarge` / `g4dn.12xlarge` / `g4dn.metal`). In the infer estimator the `p3.2xlarge` branch is deleted outright — `Resources` infers `{"T4": 1}` from `g4dn.xlarge`, so it falls through to the existing T4 branch.

**The GCP V100 path is deliberately untouched: GCP still offers V100s.** Likewise, cloud-agnostic `accelerators: V100` (the many example YAMLs) is left alone — still satisfiable on GCP/Azure. Only AWS-pinned V100/p3 is broken.

## Tested

- [x] `python examples/example_app.py` — the exact failing smoke-test command. Previously `ValueError`, now exits 0 and prints a plan (`train_op` → `g4dn.xlarge` T4:1, `infer_op` → `inf1.2xlarge`).
- [x] Every estimator branch exercised directly (AWS g4dn 1/4/8, GCP V100:1/4, GCP tpu-v3-8, infer on inf1.2xlarge + g4dn.xlarge). GCP V100 estimates are **numerically identical** to before; T4 comes out 120/65× slower, as expected.
- [x] Verified against the current AWS catalog that `g4dn.xlarge` / `g4dn.12xlarge` / `g4dn.metal` / `inf1.2xlarge` exist and that T4:1/4/8 resolve to real launchable instances, while `p3.*` matches zero rows.
- [x] `grep` confirms no AWS-pinned `p3.*` or plain-`V100` references remain under `examples/`.
- [x] yapf + isort clean.

Note: `examples/resnet_app_storage.yaml` could not be dry-run locally because the example points `workdir` at a user-specific `~/Downloads/tpu` (pre-existing, unrelated); its only change is `instance_type`, verified present in the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)