### PR TITLE
[k8s] Resolve urllib3 logger once at decoration time, not per API call

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -80,13 +80,20 @@ def _api_logging_decorator(logger_src: str, level: int):
     restored: the old restore was racy under concurrent API calls
     (interleaved restores could leave the level set anyway).
     """
+    # Resolve the logger once at decoration (module import) time rather
+    # than inside wrapped(): on Python < 3.13, logging.getLogger() also
+    # acquires the process-wide logging lock on every call (only converted
+    # to the exception-safe context-manager form by the CPython commit
+    # above), so calling it per API call would reintroduce the per-call
+    # global lock traffic this decorator exists to avoid. Loggers are
+    # process-lifetime singletons, so the cached reference stays valid.
+    log = logging.getLogger(logger_src)
 
     def decorated_api(api):
 
         @functools.wraps(api)
         def wrapped(*args, **kwargs):
             result = api(*args, **kwargs)
-            log = logging.getLogger(logger_src)
             if log.level != level:
                 log.setLevel(level)
             return result

--- a/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
@@ -318,16 +318,19 @@ def test_urllib3_log_suppression_survives_client_construction(monkeypatch):
       just once per process.
     - Pre-Python-3.13 fork deadlock
       (https://github.com/python/cpython/pull/109462): Logger.setLevel()
-      acquires logging's process-wide lock, so the adaptor must not call it
-      on every API call — only when a client construction reset the level.
+      AND logging.getLogger() both acquire logging's process-wide lock, so
+      the adaptor must call neither on every API call — setLevel() only
+      when a client construction reset the level, and getLogger() only at
+      decoration time.
     """
     api_client_mock = MagicMock()
+    urllib3_logger = logging.getLogger('urllib3')
 
     def stomping_get_api_client(context=None):
         # Mimic kubernetes.client.Configuration.__init__, which resets the
         # urllib3 logger to WARNING (via the `debug` property setter) every
         # time a client is constructed.
-        logging.getLogger('urllib3').setLevel(logging.WARNING)
+        urllib3_logger.setLevel(logging.WARNING)
         return api_client_mock
 
     monkeypatch.setattr(kubernetes, '_get_api_client', stomping_get_api_client)
@@ -342,7 +345,6 @@ def test_urllib3_log_suppression_survives_client_construction(monkeypatch):
         lambda api_client=None: SimpleNamespace(api_client=api_client),
     )
 
-    urllib3_logger = logging.getLogger('urllib3')
     original_level = urllib3_logger.level
     original_set_level = urllib3_logger.setLevel
     original_set_level(logging.NOTSET)
@@ -355,9 +357,22 @@ def test_urllib3_log_suppression_survives_client_construction(monkeypatch):
 
     monkeypatch.setattr(urllib3_logger, 'setLevel', counting_set_level)
 
+    # logging.getLogger() also acquires logging's process-wide lock on
+    # Python < 3.13, so API calls must not resolve the urllib3 logger anew
+    # each time — the adaptor resolves it once at decoration time.
+    real_get_logger = logging.getLogger
+    resolved_names = []
+
+    def counting_get_logger(name=None):
+        resolved_names.append(name)
+        return real_get_logger(name)
+
+    monkeypatch.setattr(logging, 'getLogger', counting_get_logger)
+
     try:
         annotations.clear_request_level_cache()
         kubernetes.core_api()
+        assert 'urllib3' not in resolved_names
 
         # Despite the construction-time reset to WARNING, warnings must be
         # suppressed on the child loggers urllib3 actually emits through


### PR DESCRIPTION
## Summary

Follow-up to #10104, closing a hole in that fix.

- **Problem:** the level guard added in #10104 still ran `logging.getLogger('urllib3')` inside the per-call wrapper. On Python < 3.13, `Manager.getLogger` acquires logging's process-wide lock on **every** call — even for an already-existing logger — via the pre-3.13 `_acquireLock()/try/finally` pattern. That reintroduced per-API-call acquisitions of exactly the global lock #10104 was meant to stop hammering. CPython commit [74723e11](https://github.com/python/cpython/commit/74723e11109a320e628898817ab449b3dad9ee96) (the same gh-109461 / PR #109462 fix) converts these sites to an exception-safe `with _lock:` form, but only in 3.13+; on ≤ 3.12 the acquire/release windows remain.
- **Fix:** resolve the logger once at decoration (module import) time and close over it. `Logger` objects are process-lifetime singletons (never removed from the manager), so the cached reference stays valid. The per-call path is now a lock-free `log.level != level` attribute read; `setLevel()` (which also takes the global lock) still runs only when a client construction reset the level.

## Test plan

- Extended `test_urllib3_log_suppression_survives_client_construction` to patch `logging.getLogger` with a counting wrapper and assert the urllib3 logger is never resolved during API getter calls. Verified signal: the assertion fails against master's code (`assert 'urllib3' not in ['urllib3']`) and passes with this change.
- `pytest tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py` — 23 passed.
- `format.sh`, mypy, pylint clean.
- Manual: `sky check kubernetes` against an unreachable context still shows the timeout diagnosis with no urllib3 retry-warning spam (suppression behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)