### PR TITLE
[Test] Add launch+cancel load-test generator

### DIFF
--- a/tests/load_tests/benchmark_worker.py
+++ b/tests/load_tests/benchmark_worker.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from config import BenchmarkConfig  # noqa: E402
 from config import load_config
 from generators import GeneratorBase  # noqa: E402
+from generators import LaunchCancelGenerator
 from generators import LongConnGenerator
 from generators import QpsGenerator
 from generators import ShellGenerator
@@ -49,6 +50,8 @@ def _make_generators(cfg: BenchmarkConfig,
             gens.append(LongConnGenerator(spec, ctx))
         elif spec.type == 'ssh_bench':
             gens.append(SshBenchGenerator(spec, ctx))
+        elif spec.type == 'launch_cancel':
+            gens.append(LaunchCancelGenerator(spec, ctx))
         else:
             raise ValueError(f'unknown generator type: {spec.type}')
     return gens
@@ -92,6 +95,11 @@ def run_worker(cfg: BenchmarkConfig, worker_id: int, output_dir: str,
         if g.spec.type == 'shell':
             return True
         if g.spec.type == 'ssh_bench' and getattr(g, 'is_bounded', False):
+            return True
+        # launch_cancel drives the run: it finishes on its own bounds
+        # (duration_s / max_launches / drain) or halts on a suspected
+        # wedge — in both cases the worker should wrap up.
+        if g.spec.type == 'launch_cancel':
             return True
         return False
 

--- a/tests/load_tests/config.py
+++ b/tests/load_tests/config.py
@@ -120,6 +120,53 @@ class LongConnGeneratorSpec:
 
 
 @dataclasses.dataclass
+class LaunchCancelGeneratorSpec:
+    """Submit paced sky.launch requests; cancel most after an interval.
+
+    Reproduces cancellation-poisoned executor workers (logging RLock
+    orphaned by cancel-time KeyboardInterrupt); see
+    generators/launch_cancel_generator.py for the mechanism.
+    """
+    name: str
+    # Seconds between submissions (per worker).
+    launch_gap_s: float = 15.0
+    # Cycled per cancel-fated launch; landing SIGTERM at varied points in
+    # the launch is the point of the sweep.
+    cancel_intervals_s: List[float] = dataclasses.field(
+        default_factory=lambda: [4, 6, 8, 10, 13, 16, 20, 25, 30, 40])
+    cancel_jitter_s: float = 3.0
+    # Every Nth launch is a probe: never cancelled, must reach a terminal
+    # state within wedge_after_s. 0 disables probes.
+    probe_every: int = 4
+    # Task shape. More nodes = more main-thread k8s API calls per launch
+    # (bigger poison window + clearer wedge fingerprint).
+    num_nodes: int = 8
+    task_cpus: str = '0.25'
+    task_memory: str = '0.5'
+    infra: str = 'k8s'
+    # Backpressure cap on un-terminal launches.
+    max_inflight: int = 12
+    # A tracked launch RUNNING longer than this is a suspected
+    # poisoned-worker wedge.
+    wedge_after_s: float = 420.0
+    # Freeze all activity when a wedge is suspected (preserve the wedged
+    # worker process for py-spy).
+    halt_on_wedge: bool = True
+    # Tear down clusters of terminal launches; delay lets CANCELLED
+    # launches' partial resources settle first.
+    down_after: bool = True
+    down_delay_s: float = 20.0
+    # Generator-local bounds (0 = unbounded; cfg.duration_s still fences).
+    duration_s: float = 0.0
+    max_launches: int = 0
+    poll_s: float = 10.0
+    drain_timeout_s: float = 600.0
+    cleanup_on_stop: bool = True
+    cluster_prefix: str = 'lc'
+    type: str = 'launch_cancel'
+
+
+@dataclasses.dataclass
 class SshBenchOp:
     kind: str  # ssh | sky_logs
     concurrency_per_worker: int = 4
@@ -221,6 +268,30 @@ def _parse_generator(d: Dict[str, Any]) -> GeneratorSpec:
             health_check_interval_s=int(d.get('health_check_interval_s', 30)),
             reconnect_on_drop=bool(d.get('reconnect_on_drop', True)),
         )
+    if t == 'launch_cancel':
+        spec = LaunchCancelGeneratorSpec(name=name)
+        for field in dataclasses.fields(LaunchCancelGeneratorSpec):
+            if field.name in ('name', 'type'):
+                continue
+            if field.name in d:
+                val = d[field.name]
+                if field.name == 'cancel_intervals_s':
+                    val = [float(v) for v in val]
+                elif field.name in ('task_cpus', 'task_memory', 'infra',
+                                    'cluster_prefix'):
+                    val = str(val)
+                elif field.name in ('probe_every', 'num_nodes', 'max_inflight',
+                                    'max_launches'):
+                    val = int(val)
+                elif field.name in ('halt_on_wedge', 'down_after',
+                                    'cleanup_on_stop'):
+                    val = bool(val)
+                else:
+                    val = float(val)
+                setattr(spec, field.name, val)
+        if not spec.cancel_intervals_s:
+            raise ValueError('launch_cancel: cancel_intervals_s is empty')
+        return spec
     if t == 'ssh_bench':
         raw_ops = d.get('ops')
         # Top-level concurrency_per_worker / total_connections act as

--- a/tests/load_tests/configs/launch_cancel_repro.yaml
+++ b/tests/load_tests/configs/launch_cancel_repro.yaml
@@ -1,0 +1,71 @@
+# Launch+cancel repro for the cancellation-poisoned executor-worker
+# deadlock (logging RLock orphaned by cancel-time KeyboardInterrupt on
+# Python <=3.12). See generators/launch_cancel_generator.py.
+#
+# Run a single in-process client against a dev tenant (no worker VMs, no
+# victim pool needed — launch_cancel provisions its own short-lived k8s
+# clusters):
+#
+#   sky api login -e https://<user>:<pass>@<api-server-host>
+#   python tests/load_tests/benchmark_worker.py \
+#       --config tests/load_tests/configs/launch_cancel_repro.yaml -w 0 \
+#       -o /tmp/lc_results
+#
+# While it runs, watch the api-server executor workers for the wedge
+# fingerprint (N provisioning threads parked at logging._acquireLock):
+#   configs/../pyspy_wedge_watch.sh   (run inside the api-server pod)
+#
+# target.endpoint here is unused by the worker (it uses the ambient sky
+# login); it's only recorded for provenance.
+target:
+  endpoint: "https://<api-server-host>"
+  cloud: kubernetes
+
+workers:
+  count: 1
+
+# Top-level fence for non-driver generators; launch_cancel is a driver and
+# manages its own duration below, so this is just an upper safety bound.
+duration_s: 5400
+
+victim_pool:
+  enabled: false
+
+generators:
+  - name: launch-cancel
+    type: launch_cancel
+    # ~1 launch every 6s; max_inflight keeps several launches mid-provision
+    # so cancels land while the main thread is actively in k8s API calls
+    # (max poison exposure). Bounded to keep dataplane pod count reasonable
+    # on the shared cluster (<= max_inflight * num_nodes pods, churned +
+    # torn down). 10 not 6: probes live ~2min vs ~20s for cancel-fated
+    # launches, so at 6 the probes hog slots and throttle the cancel rate.
+    launch_gap_s: 6
+    max_inflight: 10
+    # 12-node tiny k8s clusters: each launch makes many main-thread k8s API
+    # calls (each = 2x setLevel -> _clear_cache = a poison window), and fans
+    # create_namespaced_pod across a provision-thread pool — the exact
+    # surface that parks at _acquireLock when the RLock is orphaned. More
+    # nodes = wider per-launch poison window + a clearer thread pileup.
+    num_nodes: 12
+    task_cpus: "0.25"
+    task_memory: "0.5"
+    infra: k8s
+    # Sweep the SIGTERM landing point across the launch lifecycle. Most
+    # launches are cancelled; every 4th is an uncancelled probe.
+    cancel_intervals_s: [3, 4, 5, 6, 7, 8, 10, 12, 15, 18, 22, 27, 33, 40]
+    cancel_jitter_s: 3
+    probe_every: 4
+    # A launch still RUNNING after ~3.5 min = suspected poisoned-worker
+    # wedge (client-side halt signal). Normal launches here reach terminal
+    # within ~2 min (provision then fail at the run step, or succeed). The
+    # in-pod pg_wedge_detector confirms authoritatively via py-spy +
+    # postgres pid correlation before this fires.
+    wedge_after_s: 210
+    halt_on_wedge: true
+    down_after: true
+    down_delay_s: 20
+    duration_s: 3600
+    poll_s: 8
+    drain_timeout_s: 600
+    cluster_prefix: lc

--- a/tests/load_tests/generators/__init__.py
+++ b/tests/load_tests/generators/__init__.py
@@ -1,5 +1,6 @@
 """Benchmark load generators."""
 from .base import GeneratorBase
+from .launch_cancel_generator import LaunchCancelGenerator
 from .long_conn_generator import LongConnGenerator
 from .qps_generator import QpsGenerator
 from .shell_generator import ShellGenerator
@@ -11,4 +12,5 @@ __all__ = [
     'QpsGenerator',
     'LongConnGenerator',
     'SshBenchGenerator',
+    'LaunchCancelGenerator',
 ]

--- a/tests/load_tests/generators/launch_cancel_generator.py
+++ b/tests/load_tests/generators/launch_cancel_generator.py
@@ -1,0 +1,431 @@
+"""Launch+cancel generator — reproduces cancellation-poisoned executor workers.
+
+Mechanism under test: cancelling an in-flight
+`sky.launch` SIGTERMs the executor worker running it; the resulting
+KeyboardInterrupt lands at an arbitrary bytecode in the worker's main
+thread. On Python <=3.12, if it lands inside logging's module-lock windows
+(`Logger.setLevel` -> `Manager._clear_cache`, no try/finally), the process
+RLock `logging._lock` is orphaned owned-by-main-thread. The worker is
+REUSED for later requests; the next launch it picks up fans provisioning
+out to a thread pool whose threads all block forever at their first
+`logging.getLogger()` -> `_acquireLock()`. Observable: launch request
+RUNNING forever, provisioning log stalled right after
+`create_namespaced_pod (count=N)`, k8s Services exist but zero pods.
+
+This generator emulates the field pattern that surfaced the bug (a daemon
+cancelling jobs right after submission) while keeping every launch's fate,
+timing, and worker pid on record:
+
+  * Submits paced async `sky.launch` requests of a tiny N-node k8s task.
+  * Cancel-fated launches (most): `sky api cancel` after a per-launch
+    interval cycled from `cancel_intervals_s` (+ jitter). Each cancel that
+    lands while the request is RUNNING is one "dice roll" against the
+    leak window.
+  * Probe launches (every `probe_every`-th): never cancelled; expected to
+    reach terminal state within `wedge_after_s`. A probe (or any tracked
+    launch) still RUNNING past that deadline is flagged as a suspected
+    poisoned-worker wedge, with the worker pid and every earlier
+    cancelled request that ran on the same pid (the poisoning
+    candidates).
+  * On a suspected wedge the generator can halt all further submissions
+    (`halt_on_wedge`) so the wedged process is preserved for py-spy.
+
+The request->pid mapping comes from `sky api status` (RequestPayload.pid),
+so poisoning can be correlated client-side without server access.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import random
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from .base import GeneratorBase
+from .base import summarize_durations
+
+_TERMINAL = frozenset({'SUCCEEDED', 'FAILED', 'CANCELLED'})
+
+
+class LaunchCancelGenerator(GeneratorBase):
+
+    def __init__(self, spec, ctx):
+        super().__init__(spec, ctx)
+        self._seq = 0
+        self._active: Dict[str, Dict[str, Any]] = {}  # rid -> info
+        self._active_lock = threading.Lock()
+        # pid -> [rid, ...] of CANCELLED-while-RUNNING requests (poison
+        # candidates).
+        self._cancelled_pids: Dict[int, List[str]] = {}
+        self._all_pids: Dict[int, int] = {}  # pid -> times seen
+        self._wedges: List[Dict[str, Any]] = []
+        self._halted = threading.Event()
+        self._done = threading.Event()
+        self._dispatcher: Optional[threading.Thread] = None
+        self._monitor: Optional[threading.Thread] = None
+        self._side_pool: Optional[ThreadPoolExecutor] = None
+        self._t0: Optional[float] = None
+        self._dice_rolls = 0  # cancels that hit a RUNNING launch
+
+    # ── lifecycle ────────────────────────────────────────────────
+
+    def start(self) -> None:
+        # Import the sky SDK on the caller's thread BEFORE spawning any
+        # threads: two threads racing the first import of the sky package
+        # graph (dispatch + monitor both importing sky.client.sdk) hit
+        # partially-initialized modules in the sky.serve circular-import
+        # chain (AttributeError: module 'sky.serve' has no 'UpdateMode').
+        import sky  # noqa: WPS433
+        from sky.client import sdk as sky_sdk
+        self._sky = sky
+        self._sdk = sky_sdk
+        self._side_pool = ThreadPoolExecutor(
+            max_workers=max(8, self.spec.max_inflight))
+        self._t0 = time.time()
+        self._dispatcher = threading.Thread(target=self._dispatch_loop,
+                                            daemon=True,
+                                            name=f'lc-dispatch-{self.name}')
+        self._monitor = threading.Thread(target=self._monitor_loop,
+                                         daemon=True,
+                                         name=f'lc-monitor-{self.name}')
+        self._dispatcher.start()
+        self._monitor.start()
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        self._done.wait(timeout)
+
+    def stop(self) -> None:
+        self.request_stop()
+        self._done.set()
+        if self._dispatcher:
+            self._dispatcher.join(timeout=5)
+        if self._monitor:
+            self._monitor.join(timeout=5)
+        # Best-effort teardown of leftovers — but NEVER touch suspected
+        # wedges: the wedged worker process is the evidence.
+        if self.spec.cleanup_on_stop:
+            try:
+                self._cleanup_leftovers()
+            except Exception as e:  # noqa: BLE001
+                print(f'[gen {self.name}] cleanup error: {e}', flush=True)
+        if self._side_pool:
+            self._side_pool.shutdown(wait=False, cancel_futures=True)
+
+    # ── dispatch ─────────────────────────────────────────────────
+
+    def _dispatch_loop(self) -> None:
+        try:
+            self._dispatch(self._sky, self._sdk)
+        finally:
+            # Always release wait()ers, even on unexpected errors.
+            self._drain_then_done()
+
+    def _dispatch(self, sky, sky_sdk) -> None:
+        deadline = (self._t0 +
+                    self.spec.duration_s if self.spec.duration_s > 0 else None)
+        intervals = list(self.spec.cancel_intervals_s)
+        while not self.stopped and not self._halted.is_set():
+            now = time.time()
+            if deadline and now >= deadline:
+                break
+            if (self.spec.max_launches > 0 and
+                    self._seq >= self.spec.max_launches):
+                break
+            if self._num_active() >= self.spec.max_inflight:
+                self._stop.wait(1.0)
+                continue
+
+            seq = self._seq
+            self._seq += 1
+            is_probe = (self.spec.probe_every > 0 and
+                        seq % self.spec.probe_every == 0)
+            interval = None
+            if not is_probe:
+                interval = intervals[seq % len(intervals)]
+                interval += random.uniform(0, self.spec.cancel_jitter_s)
+            cname = (f'{self.spec.cluster_prefix}-w{self.ctx.worker_id}'
+                     f'-{seq}')
+            try:
+                task = sky.Task(name=cname, run='echo repro; sleep 20')
+                task.set_resources(
+                    sky.Resources(infra=self.spec.infra,
+                                  cpus=self.spec.task_cpus,
+                                  memory=self.spec.task_memory))
+                task.num_nodes = self.spec.num_nodes
+                rid = str(sky_sdk.launch(task, cluster_name=cname))
+            except Exception as e:  # noqa: BLE001
+                self._emit({
+                    'event': 'submit_error',
+                    'ts': time.time(),
+                    'seq': seq,
+                    'cluster': cname,
+                    'error': f'{type(e).__name__}: {e}',
+                })
+                self._stop.wait(self.spec.launch_gap_s)
+                continue
+
+            info = {
+                'rid': rid,
+                'cluster': cname,
+                'seq': seq,
+                'fate': 'probe' if is_probe else 'cancel',
+                'cancel_interval_s': interval,
+                't_submit': time.time(),
+                'pid': None,
+                'status': 'PENDING',
+                'wedge_flagged': False,
+            }
+            with self._active_lock:
+                self._active[rid] = info
+            self._emit({
+                'event': 'submit',
+                'ts': info['t_submit'],
+                'rid': rid,
+                'seq': seq,
+                'cluster': cname,
+                'fate': info['fate'],
+                'cancel_interval_s': interval,
+            })
+            if not is_probe:
+                self._side_pool.submit(self._cancel_after, rid, interval)
+            self._stop.wait(self.spec.launch_gap_s)
+
+    def _drain_then_done(self) -> None:
+        """After dispatch ends, wait for active launches to settle."""
+        drain_deadline = time.time() + self.spec.drain_timeout_s
+        while not self.stopped and time.time() < drain_deadline:
+            if self._halted.is_set():
+                break  # wedge found: preserve state, end run now
+            if self._num_active() == 0:
+                break
+            self._stop.wait(5)
+        self._done.set()
+
+    # ── cancel / down side actions ───────────────────────────────
+
+    def _cancel_after(self, rid: str, delay: float) -> None:
+        sky_sdk = self._sdk
+        if self._stop.wait(delay):
+            return
+        if self._halted.is_set():
+            return  # freeze the world once a wedge is suspected
+        prior = None
+        with self._active_lock:
+            info = self._active.get(rid)
+            if info:
+                prior = info['status']
+        t0 = time.time()
+        try:
+            sky_sdk.api_cancel(request_ids=[rid], silent=True)
+            err = None
+        except Exception as e:  # noqa: BLE001
+            err = f'{type(e).__name__}: {e}'
+        if err is None and prior == 'RUNNING':
+            self._dice_rolls += 1
+        self._emit({
+            'event': 'cancel_sent',
+            'ts': t0,
+            'rid': rid,
+            'prior_status': prior,
+            'latency_s': round(time.time() - t0, 3),
+            'error': err,
+        })
+
+    def _down_later(self, cluster: str, delay: float) -> None:
+        sky_sdk = self._sdk
+        if self._stop.wait(delay):
+            return
+        try:
+            sky_sdk.down(cluster)
+            self._emit({
+                'event': 'down_sent',
+                'ts': time.time(),
+                'cluster': cluster,
+                'error': None
+            })
+        except Exception as e:  # noqa: BLE001
+            self._emit({
+                'event': 'down_sent',
+                'ts': time.time(),
+                'cluster': cluster,
+                'error': f'{type(e).__name__}: {e}'
+            })
+
+    # ── monitor ──────────────────────────────────────────────────
+
+    def _num_active(self) -> int:
+        with self._active_lock:
+            return len(self._active)
+
+    def _monitor_loop(self) -> None:
+        sky_sdk = self._sdk
+        while not self.stopped and not self._done.is_set():
+            self._stop.wait(self.spec.poll_s)
+            with self._active_lock:
+                rids = list(self._active.keys())
+            if not rids:
+                continue
+            try:
+                payloads = sky_sdk.api_status(request_ids=rids)
+            except Exception as e:  # noqa: BLE001
+                self._emit({
+                    'event': 'poll_error',
+                    'ts': time.time(),
+                    'error': f'{type(e).__name__}: {e}'
+                })
+                continue
+            now = time.time()
+            for p in payloads:
+                try:
+                    self._handle_poll(p, now)
+                except Exception as e:  # noqa: BLE001
+                    self._emit({
+                        'event': 'poll_error',
+                        'ts': now,
+                        'error': f'{type(e).__name__}: {e}'
+                    })
+
+    def _handle_poll(self, payload, now: float) -> None:
+        rid = payload.request_id
+        status = str(payload.status).rsplit('.', 1)[-1].upper()
+        pid = getattr(payload, 'pid', None)
+        with self._active_lock:
+            info = self._active.get(rid)
+            if info is None:
+                return
+            info['status'] = status
+            if pid and info['pid'] is None:
+                info['pid'] = pid
+                self._all_pids[pid] = self._all_pids.get(pid, 0) + 1
+                self._emit({
+                    'event':
+                        'pid_assigned',
+                    'ts':
+                        now,
+                    'rid':
+                        rid,
+                    'pid':
+                        pid,
+                    'fate':
+                        info['fate'],
+                    'prior_cancels_on_pid':
+                        list(self._cancelled_pids.get(pid, [])),
+                })
+            age = now - info['t_submit']
+            if status in _TERMINAL:
+                del self._active[rid]
+                if status == 'CANCELLED' and info['pid'] is not None:
+                    self._cancelled_pids.setdefault(info['pid'], []).append(rid)
+                self._emit({
+                    'event': 'terminal',
+                    'ts': now,
+                    'rid': rid,
+                    'cluster': info['cluster'],
+                    'fate': info['fate'],
+                    'status': status,
+                    'pid': info['pid'],
+                    'age_s': round(age, 1),
+                })
+                if self.spec.down_after and not self._halted.is_set():
+                    self._side_pool.submit(self._down_later, info['cluster'],
+                                           self.spec.down_delay_s)
+                return
+            # Wedge detection: any tracked launch RUNNING way past the
+            # normal provision time.
+            if (status == 'RUNNING' and age > self.spec.wedge_after_s and
+                    not info['wedge_flagged']):
+                info['wedge_flagged'] = True
+                wedge = {
+                    'event':
+                        'WEDGE_SUSPECT',
+                    'ts':
+                        now,
+                    'rid':
+                        rid,
+                    'cluster':
+                        info['cluster'],
+                    'fate':
+                        info['fate'],
+                    'pid':
+                        info['pid'],
+                    'age_s':
+                        round(age, 1),
+                    'prior_cancels_on_pid':
+                        list(self._cancelled_pids.get(info['pid'], []))
+                        if info['pid'] else [],
+                }
+                self._wedges.append(wedge)
+                self._emit(wedge)
+                print(
+                    f'[gen {self.name}] *** WEDGE SUSPECT: request {rid} '
+                    f'(cluster {info["cluster"]}, pid {info["pid"]}) '
+                    f'RUNNING for {age:.0f}s — prior cancels on this pid: '
+                    f'{wedge["prior_cancels_on_pid"]} ***',
+                    flush=True)
+                if self.spec.halt_on_wedge:
+                    self._halted.set()
+
+    # ── cleanup / summary ────────────────────────────────────────
+
+    def _cleanup_leftovers(self) -> None:
+        if self._halted.is_set():
+            # A wedge was found: freeze EVERYTHING. Extra cancels would be
+            # more dice rolls and downs would disturb the evidence; clean
+            # up manually after py-spy forensics.
+            print(
+                f'[gen {self.name}] halted on wedge — skipping cleanup '
+                '(clusters + requests left as-is for forensics)',
+                flush=True)
+            return
+        sky_sdk = self._sdk
+        with self._active_lock:
+            leftovers = [(rid, i)
+                         for rid, i in self._active.items()
+                         if not i['wedge_flagged']]
+        for rid, info in leftovers:
+            try:
+                sky_sdk.api_cancel(request_ids=[rid], silent=True)
+            except Exception:  # noqa: BLE001
+                pass
+            if self.spec.down_after:
+                try:
+                    sky_sdk.down(info['cluster'])
+                except Exception:  # noqa: BLE001
+                    pass
+
+    def summarize(self) -> Dict[str, Any]:
+        rows = self.records()
+        submits = [r for r in rows if r.get('event') == 'submit']
+        terminals = [r for r in rows if r.get('event') == 'terminal']
+        cancels = [r for r in rows if r.get('event') == 'cancel_sent']
+        by_status: Dict[str, int] = {}
+        for r in terminals:
+            by_status[r['status']] = by_status.get(r['status'], 0) + 1
+        probe_ages = [
+            r['age_s']
+            for r in terminals
+            if r['fate'] == 'probe' and r['status'] == 'SUCCEEDED'
+        ]
+        return {
+            'submitted':
+                len(submits),
+            'terminal_by_status':
+                by_status,
+            'cancels_sent':
+                len(cancels),
+            'dice_rolls (cancelled while RUNNING)':
+                self._dice_rolls,
+            'distinct_worker_pids':
+                len(self._all_pids),
+            'poison_candidate_pids': {
+                str(k): v for k, v in self._cancelled_pids.items()
+            },
+            'probe_success_age_s':
+                summarize_durations([{
+                    'duration_s': a
+                } for a in probe_ages]),
+            'wedge_suspects':
+                self._wedges,
+            'halted_on_wedge':
+                self._halted.is_set(),
+        }

--- a/tests/load_tests/pyspy_wedge_watch.sh
+++ b/tests/load_tests/pyspy_wedge_watch.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Watch SkyPilot executor workers for the cancellation-poisoned deadlock
+# fingerprint: N provisioning threads parked at logging._acquireLock while
+# no thread holds the lock (owner is the idle main thread — reentrant
+# RLock; see generators/launch_cancel_generator.py for the mechanism).
+#
+# Run this INSIDE the api-server pod (it needs to see the executor worker
+# processes and their /proc):
+#   kubectl exec -n sky-tenant-<t> deploy/<release>-api-server -c skypilot-api -- \
+#     bash -s < tests/load_tests/pyspy_wedge_watch.sh
+# or copy it in and run it. Installs py-spy if missing.
+#
+# Env knobs:
+#   INTERVAL   seconds between scans (default 20)
+#   THRESHOLD  min threads at _acquireLock to call it a wedge (default 8)
+#   DUMPDIR    where to write full dumps on a hit (default /tmp/sky-wedge)
+set -uo pipefail
+
+INTERVAL="${INTERVAL:-20}"
+THRESHOLD="${THRESHOLD:-8}"
+DUMPDIR="${DUMPDIR:-/tmp/sky-wedge}"
+mkdir -p "$DUMPDIR"
+
+if ! command -v py-spy >/dev/null 2>&1; then
+  echo "[watch] installing py-spy..." >&2
+  pip install --quiet py-spy 2>/dev/null || pip install --quiet --user py-spy
+fi
+PYSPY="$(command -v py-spy || echo "$HOME/.local/bin/py-spy")"
+
+echo "[watch] interval=${INTERVAL}s threshold=${THRESHOLD} dumpdir=${DUMPDIR}"
+echo "[watch] watching for executor-worker RLock wedges; Ctrl-C to stop"
+
+worker_pids() {
+  # Long-lived spawn'd executor workers name their main thread
+  # 'SkyPilot:executor:long:<pid>'. Fall back to any python running the
+  # executor module.
+  ps -eo pid,comm,args 2>/dev/null | \
+    grep -iE 'SkyPilot:executor|sky.server.requests.executor|spawn_main' | \
+    grep -v grep | awk '{print $1}' | sort -u
+}
+
+scan_pid() {
+  local pid="$1"
+  local dump
+  dump="$($PYSPY dump --pid "$pid" 2>/dev/null)" || return 1
+  local n
+  n="$(printf '%s' "$dump" | grep -c '_acquireLock')"
+  # Is any thread actually inside acquire and past it (holding)? The
+  # fingerprint is: many waiters, and the main thread NOT in _acquireLock
+  # (it owns the lock reentrantly and is idle elsewhere, e.g. pool.next).
+  local mainwait
+  mainwait="$(printf '%s' "$dump" | grep -A2 'MainThread' | grep -c '_acquireLock')"
+  if [[ "$n" -ge "$THRESHOLD" ]]; then
+    local ts stamp
+    ts="$(date -u +%H:%M:%SZ)"
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    echo "[watch $ts] *** PID $pid: $n threads at _acquireLock " \
+         "(main-thread-in-acquire=$mainwait) — WEDGE FINGERPRINT ***"
+    local out="$DUMPDIR/wedge_${pid}_${stamp}.txt"
+    $PYSPY dump --pid "$pid" --locals > "$out" 2>/dev/null
+    echo "[watch $ts]     full --locals dump: $out"
+    # One native dump too (shows if anything is in uv_spawn/native fork).
+    $PYSPY dump --pid "$pid" --native > "${out%.txt}.native.txt" 2>/dev/null || true
+    return 0
+  fi
+  # Non-wedge status line (only when there's some lock traffic).
+  if [[ "$n" -gt 0 ]]; then
+    echo "[watch $(date -u +%H:%M:%SZ)] pid $pid: $n at _acquireLock (below threshold)"
+  fi
+  return 1
+}
+
+while true; do
+  pids="$(worker_pids)"
+  if [[ -z "$pids" ]]; then
+    echo "[watch $(date -u +%H:%M:%SZ)] no executor workers found yet"
+  else
+    for pid in $pids; do
+      scan_pid "$pid" || true
+    done
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

Adds a `launch_cancel` generator to the load-test framework that submits
paced async `sky.launch` requests and cancels most of them after intervals
swept across the launch lifecycle, to exercise the launch + mid-flight
cancellation code path under load and surface executor-worker hangs.

Each request's worker pid is tracked so cancels can be correlated per
worker; any launch still RUNNING past a threshold is flagged as a suspected
wedge (optionally halting the run so the process can be inspected with
py-spy). A companion `pyspy_wedge_watch.sh` scans executor workers in-pod
for the deadlock fingerprint (many threads parked at `logging._acquireLock`
while the main thread owns the lock reentrantly).

### Motivation

Cancelling an in-flight launch SIGTERMs the executor worker, raising
`KeyboardInterrupt` at an arbitrary point in the worker's main thread. On
Python <=3.12, if it lands inside logging's `Manager._clear_cache` (which
has no `try`/`finally`), the module-level logging `RLock` is left orphaned
owned-by-main-thread; the worker is then reused, and the next launch's
provisioning threads block forever at their first `logging._acquireLock()`.
This harness reproduces that class of hang so a fix can be validated.

## Test plan

- Offline: exercised the generator against a mocked SDK covering the
  submit / cancel / terminal / dice-roll / poison-correlation / wedge-trip
  paths.
- Live: drove it against a Kubernetes-backed API server; it submits and
  cancels launches, tracks worker pids, and reliably surfaces the wedge
  (launches stuck RUNNING with provisioning threads parked at
  `logging._acquireLock`), which `pyspy_wedge_watch.sh` confirms via py-spy.
- `yapf` (google style) + `isort` (google profile) on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsxdCe5L77JvxJTCzXWFow
