### PR TITLE
Cap provisioning thread pools at the number of work items(2)

### DIFF
--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -246,7 +246,8 @@ def run_in_parallel(func: Callable,
 
     processes = (num_threads
                  if num_threads is not None else get_parallel_threads())
-
+    # len(args) is guaranteed to be greater than 1.
+    processes = min(processes, len(args))
     with pool.ThreadPool(processes=processes) as p:
         ordered_iterators = p.imap(func, args)
         return list(ordered_iterators)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Followup to https://github.com/skypilot-org/skypilot/pull/10111 for a more generalized enforcement of what that PR does 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
