### PR TITLE
[Test] Move zero-quota-failover test off retired AWS p3/V100

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -817,13 +817,13 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
 
 
 def get_aws_region_for_quota_failover() -> Optional[str]:
-    candidate_regions = AWS.regions_with_offering(instance_type='p3.16xlarge',
+    candidate_regions = AWS.regions_with_offering(instance_type='p4d.24xlarge',
                                                   accelerators=None,
                                                   use_spot=True,
                                                   region=None,
                                                   zone=None)
     original_resources = sky.Resources(infra='aws',
-                                       instance_type='p3.16xlarge',
+                                       instance_type='p4d.24xlarge',
                                        use_spot=True)
 
     # Filter the regions with proxy command in ~/.sky/config.yaml.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2683,14 +2683,14 @@ def test_aws_zero_quota_failover():
     if not region:
         pytest.xfail(
             'Unable to test zero quota failover optimization — quotas '
-            'for EC2 P3 instances were found on all AWS regions. Is this '
-            'expected for your account?')
+            'for EC2 P4d (A100) instances were found on all AWS regions. Is '
+            'this expected for your account?')
         return
 
     test = smoke_tests_utils.Test(
         'aws-zero-quota-failover',
         [
-            f'sky launch -y -c {name} --infra aws/{region} {smoke_tests_utils.LOW_RESOURCE_ARG} --gpus V100:8 --use-spot | grep "Found no quota"',
+            f'sky launch -y -c {name} --infra aws/{region} {smoke_tests_utils.LOW_RESOURCE_ARG} --gpus A100:8 --use-spot | grep "Found no quota"',
         ],
         f'sky down -y {name}',
     )


### PR DESCRIPTION
## Summary

- AWS retired the **P3 (V100)** generation. The **2026-07-13 04:05 UTC** catalog refresh ([skypilot-catalog `6853820f`](https://github.com/skypilot-org/skypilot-catalog/commit/6853820f6f87)) dropped **all 69 `p3.*` rows** and the plain `V100` accelerator from `v8/aws/vms.csv` (only `V100-32GB` remains).
- #10098 (fixtures) and #10107 (example apps) already moved off retired p3/V100, but **missed `test_aws_zero_quota_failover`**, which still fails in the nightly:

  ```
  ValueError: No instance type p3.16xlarge found.
  ```

- `get_aws_region_for_quota_failover()` hardcoded `p3.16xlarge` (8× V100) and the test launched `--gpus V100:8`. Both are moved to **`p4d.24xlarge` / `A100:8`** — an 8-GPU flagship still in the catalog that accounts typically have **zero spot quota** for, preserving the "find a zero-quota region" intent (T4/g4dn would have quota everywhere and silently `xfail` the test). The `xfail` message is updated accordingly.

Failing nightly build: https://buildkite.com/skypilot-1/smoke-tests/builds/11757 (`test_aws_zero_quota_failover on aws`, failed on all 4 attempts — deterministic, not a flake, since retries reuse the same catalog).

## Test plan

- `p4d.24xlarge` (A100:8) confirmed present in the current live `v8/aws/vms.csv` (28 rows); `p3.16xlarge` is gone (0 rows).
- `bash format.sh` (yapf 0.32.0 / isort / mypy) passes; pre-commit hooks pass.
- Full verification requires an AWS account whose p4d spot quota is 0 in some region; recommend running via `/smoke-test -k test_aws_zero_quota_failover --aws` on CI.