### PR TITLE
[Users] Allow specifying a role when creating a service account token

### DIFF
--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -505,6 +505,9 @@ class ServiceAccountTokenCreateBody(RequestBody):
     """The request body for creating a service account token."""
     token_name: str
     expires_in_days: Optional[int] = None
+    # Optional role for the new service account (e.g. 'admin'). When omitted,
+    # the account is seeded with the default role.
+    role: Optional[str] = None
 
 
 class ServiceAccountTokenDeleteBody(RequestBody):

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -827,16 +827,16 @@ def create_service_account_token(
                 status_code=400,
                 detail=f'Invalid role {token_body.role!r}. Supported roles: '
                 f'{", ".join(rbac.get_supported_roles())}.')
-        # Assigning a role is an admin-only operation (mirrors the role-change
-        # endpoints); otherwise any authenticated user could mint a token with
-        # an elevated role. Non-admins get the default seeded role instead.
-        caller_roles = permission.permission_service.get_user_roles(
-            auth_user.id)
-        if not caller_roles or caller_roles[0] != rbac.RoleName.ADMIN.value:
-            raise fastapi.HTTPException(
-                status_code=403,
-                detail='Only admins can set a role when creating a service '
-                'account token.')
+        # Only admins may create an admin-role service account; otherwise a
+        # non-admin could escalate by minting an admin-scoped token.
+        if token_body.role == rbac.RoleName.ADMIN.value:
+            caller_roles = permission.permission_service.get_user_roles(
+                auth_user.id)
+            if not caller_roles or caller_roles[0] != rbac.RoleName.ADMIN.value:
+                raise fastapi.HTTPException(
+                    status_code=403,
+                    detail='Only admins can create a service account with the '
+                    'admin role.')
 
     try:
         # Generate a unique service account user ID

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -820,6 +820,14 @@ def create_service_account_token(
             status_code=400,
             detail='Expiration days must be positive or 0 for never expire')
 
+    # Validate the optional role up front so we fail before creating anything.
+    if (token_body.role is not None and
+            token_body.role not in rbac.get_supported_roles()):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid role {token_body.role!r}. Supported roles: '
+            f'{", ".join(rbac.get_supported_roles())}.')
+
     try:
         # Generate a unique service account user ID
         service_account_user_id = _generate_service_account_user_id()
@@ -844,6 +852,11 @@ def create_service_account_token(
         # an admin's runtime `rbac.default_role` change then applies without a
         # server restart.
         permission.seed_new_user_role(service_account_user_id)
+        # If a role was requested, apply it now so the token is created with the
+        # intended role atomically (no separate update-role round trip).
+        if token_body.role is not None:
+            permission.permission_service.update_role(service_account_user_id,
+                                                      token_body.role)
 
         # Handle expiration: 0 means "never expire"
         expires_in_days = token_body.expires_in_days

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -821,12 +821,22 @@ def create_service_account_token(
             detail='Expiration days must be positive or 0 for never expire')
 
     # Validate the optional role up front so we fail before creating anything.
-    if (token_body.role is not None and
-            token_body.role not in rbac.get_supported_roles()):
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=f'Invalid role {token_body.role!r}. Supported roles: '
-            f'{", ".join(rbac.get_supported_roles())}.')
+    if token_body.role is not None:
+        if token_body.role not in rbac.get_supported_roles():
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Invalid role {token_body.role!r}. Supported roles: '
+                f'{", ".join(rbac.get_supported_roles())}.')
+        # Assigning a role is an admin-only operation (mirrors the role-change
+        # endpoints); otherwise any authenticated user could mint a token with
+        # an elevated role. Non-admins get the default seeded role instead.
+        caller_roles = permission.permission_service.get_user_roles(
+            auth_user.id)
+        if not caller_roles or caller_roles[0] != rbac.RoleName.ADMIN.value:
+            raise fastapi.HTTPException(
+                status_code=403,
+                detail='Only admins can set a role when creating a service '
+                'account token.')
 
     try:
         # Generate a unique service account user ID

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -1,10 +1,22 @@
 """Tests for service account token functionality."""
 
 import os
+import types
 import unittest.mock as mock
 
+import fastapi
+import pytest
+
 from sky.client import service_account_auth
+from sky.server.requests import payloads
 from sky.skylet import constants
+from sky.users import server as users_server
+
+
+def _fake_request(user_id='admin-user'):
+    """A minimal request whose auth_user the handler reads."""
+    return types.SimpleNamespace(state=types.SimpleNamespace(
+        auth_user=types.SimpleNamespace(id=user_id)))
 
 
 class TestServiceAccountTokens:
@@ -70,3 +82,57 @@ class TestServiceAccountTokens:
         # Generate headers
         headers = service_account_auth.get_service_account_headers()
         assert headers['Authorization'] == 'Bearer sky_test_token'
+
+
+class TestCreateServiceAccountTokenRole:
+    """The create endpoint applies an optional role atomically."""
+
+    def test_invalid_role_rejected(self):
+        """An unknown role is rejected before anything is created."""
+        body = payloads.ServiceAccountTokenCreateBody(
+            token_name='scim_provisioning', expires_in_days=0, role='bogus')
+        with pytest.raises(fastapi.HTTPException) as exc:
+            users_server.create_service_account_token(_fake_request(), body)
+        assert exc.value.status_code == 400
+        assert 'Invalid role' in exc.value.detail
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.token_service')
+    @mock.patch('sky.users.server.permission')
+    def test_role_applied_at_create(self, mock_perm, mock_token_service,
+                                    mock_gus):
+        """A valid role is applied in the same handler (no separate call)."""
+        mock_gus.add_or_update_user.return_value = True  # new user
+        mock_token_service.token_service.create_token.return_value = {
+            'token_id': 'tid',
+            'token_hash': 'h',
+            'token': 'sky_x',
+            'expires_at': None,
+        }
+        body = payloads.ServiceAccountTokenCreateBody(
+            token_name='scim_provisioning', expires_in_days=0, role='admin')
+        result = users_server.create_service_account_token(
+            _fake_request(), body)
+        assert result['token'] == 'sky_x'
+        mock_perm.permission_service.update_role.assert_called_once()
+        assert mock_perm.permission_service.update_role.call_args[0][
+            1] == 'admin'
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.token_service')
+    @mock.patch('sky.users.server.permission')
+    def test_no_role_keeps_default_seed(self, mock_perm, mock_token_service,
+                                        mock_gus):
+        """Without a role, only the default seed runs (no update_role)."""
+        mock_gus.add_or_update_user.return_value = True
+        mock_token_service.token_service.create_token.return_value = {
+            'token_id': 'tid',
+            'token_hash': 'h',
+            'token': 'sky_x',
+            'expires_at': None,
+        }
+        body = payloads.ServiceAccountTokenCreateBody(token_name='sa_default',
+                                                      expires_in_days=0)
+        users_server.create_service_account_token(_fake_request(), body)
+        mock_perm.seed_new_user_role.assert_called_once()
+        mock_perm.permission_service.update_role.assert_not_called()

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -96,13 +96,26 @@ class TestCreateServiceAccountTokenRole:
         assert exc.value.status_code == 400
         assert 'Invalid role' in exc.value.detail
 
+    @mock.patch('sky.users.server.permission')
+    def test_non_admin_cannot_set_role(self, mock_perm):
+        """A non-admin caller can't create a token with an explicit role."""
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
+        body = payloads.ServiceAccountTokenCreateBody(
+            token_name='scim_provisioning', expires_in_days=0, role='admin')
+        with pytest.raises(fastapi.HTTPException) as exc:
+            users_server.create_service_account_token(
+                _fake_request(user_id='regular-user'), body)
+        assert exc.value.status_code == 403
+        assert 'Only admins' in exc.value.detail
+
     @mock.patch('sky.users.server.global_user_state')
     @mock.patch('sky.users.server.token_service')
     @mock.patch('sky.users.server.permission')
     def test_role_applied_at_create(self, mock_perm, mock_token_service,
                                     mock_gus):
-        """A valid role is applied in the same handler (no separate call)."""
+        """An admin's requested role is applied in the same handler."""
         mock_gus.add_or_update_user.return_value = True  # new user
+        mock_perm.permission_service.get_user_roles.return_value = ['admin']
         mock_token_service.token_service.create_token.return_value = {
             'token_id': 'tid',
             'token_hash': 'h',

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -97,8 +97,8 @@ class TestCreateServiceAccountTokenRole:
         assert 'Invalid role' in exc.value.detail
 
     @mock.patch('sky.users.server.permission')
-    def test_non_admin_cannot_set_role(self, mock_perm):
-        """A non-admin caller can't create a token with an explicit role."""
+    def test_non_admin_cannot_set_admin_role(self, mock_perm):
+        """A non-admin caller can't create an admin-role token."""
         mock_perm.permission_service.get_user_roles.return_value = ['user']
         body = payloads.ServiceAccountTokenCreateBody(
             token_name='scim_provisioning', expires_in_days=0, role='admin')
@@ -107,6 +107,29 @@ class TestCreateServiceAccountTokenRole:
                 _fake_request(user_id='regular-user'), body)
         assert exc.value.status_code == 403
         assert 'Only admins' in exc.value.detail
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.token_service')
+    @mock.patch('sky.users.server.permission')
+    def test_non_admin_can_set_non_admin_role(self, mock_perm,
+                                              mock_token_service, mock_gus):
+        """A non-admin may create a token with a non-admin role."""
+        mock_gus.add_or_update_user.return_value = True
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
+        mock_token_service.token_service.create_token.return_value = {
+            'token_id': 'tid',
+            'token_hash': 'h',
+            'token': 'sky_x',
+            'expires_at': None,
+        }
+        body = payloads.ServiceAccountTokenCreateBody(token_name='sa_user',
+                                                      expires_in_days=0,
+                                                      role='user')
+        result = users_server.create_service_account_token(
+            _fake_request(user_id='regular-user'), body)
+        assert result['token'] == 'sky_x'
+        assert mock_perm.permission_service.update_role.call_args[0][
+            1] == 'user'
 
     @mock.patch('sky.users.server.global_user_state')
     @mock.patch('sky.users.server.token_service')


### PR DESCRIPTION
## Summary

- Add an optional `role` field to `ServiceAccountTokenCreateBody`.
- `POST /service-account-tokens` validates `role` against the supported roles (400 on an unknown role, before anything is created) and applies it right after the default seed — so a service account token can be created with its intended role in a single request, instead of a create followed by a separate `update-role` call.
- When `role` is omitted, behavior is unchanged (the account keeps the default seeded role).

This is backward compatible: `role` is optional; existing callers are unaffected.

## Test plan

- `pytest tests/unit_tests/test_sky/users/test_service_account_tokens.py`
  - `test_invalid_role_rejected` — unknown role → 400 before any creation.
  - `test_role_applied_at_create` — a valid role is applied in the same handler (no separate call).
  - `test_no_role_keeps_default_seed` — without a role, only the default seed runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)