### PR TITLE
[Test] Mark test_debug_dump_unreachable_context_fast_fail no_remote_server

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1831,6 +1831,7 @@ def test_kubernetes_context_failover(unreachable_context):
 
 
 @pytest.mark.kubernetes
+@pytest.mark.no_remote_server
 def test_debug_dump_unreachable_context_fast_fail(unreachable_context):
     """Debug dump must fast-fail on a dead kube context.
 
@@ -1843,10 +1844,12 @@ def test_debug_dump_unreachable_context_fast_fail(unreachable_context):
     The cluster-on-a-dead-context path (skylet-log and managed-jobs
     gating) can't be built in CI -- a launch on a dead context fails -- and
     is pinned by unit tests instead (test_debug_utils.py).
+
+    Marked no_remote_server: the fixture injects the dead context into the
+    kubeconfig on the machine running the test, but against a remote API
+    server the kubeconfig the server reads lives elsewhere, so the injected
+    context never reaches existing_allowed_contexts() and no marker is dumped.
     """
-    if smoke_tests_utils.is_non_docker_remote_api_server():
-        pytest.skip('Kubernetes configs and credentials are located on the '
-                    'remote API server, not the machine running the test')
     if unreachable_context is None:
         pytest.skip('No kubeconfig available to inject the dead context into')
 


### PR DESCRIPTION
## Why

`test_debug_dump_unreachable_context_fast_fail` (added in #10041) fails deterministically against a remote API server.

The `unreachable_context` fixture injects a dead kube context into the kubeconfig **on the machine running the test**, and the test asserts the debug dump emits a `"reachable": false` marker for it:

```
grep -r '"reachable": false' .../debug_dump_*/kubernetes_contexts/   # returns 1
```

Against a remote API server the server reads a *different* kubeconfig, so the injected context never appears in `Kubernetes.existing_allowed_contexts()`, `_dump_kube_contexts_info` never scrapes it, and no marker is written — the grep fails.

The test already tried to guard this with `is_non_docker_remote_api_server()`, but that only covers the *non-docker* remote case. The docker-backed remote-server variant (`--remote-server`, endpoint via `host.docker.internal`) was not covered and failed every run.

## Change

Replace the in-body `is_non_docker_remote_api_server()` skip with the `@pytest.mark.no_remote_server` marker, which `conftest.py` honors for both `--remote-server` and remote `--env-file` configurations.

## Coverage

Unchanged. The server-side fast-fail behavior runs in the local `--kubernetes` smoke run (passing) and is pinned by unit tests in `test_debug_utils.py` and `kubernetes/test_debug.py`. The remote-server variant could never establish the fixture's precondition, so it was asserting on a setup that cannot hold rather than on real behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)