### PR TITLE
[Test] Mark test_debug_dump_unreachable_context_fast_fail no_dependency

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1832,6 +1832,7 @@ def test_kubernetes_context_failover(unreachable_context):
 
 @pytest.mark.kubernetes
 @pytest.mark.no_remote_server
+@pytest.mark.no_dependency
 def test_debug_dump_unreachable_context_fast_fail(unreachable_context):
     """Debug dump must fast-fail on a dead kube context.
 


### PR DESCRIPTION
## Why

Follow-up to #10116. `test_debug_dump_unreachable_context_fast_fail` still fails in the **`--dependency`** smoke-test variant (`--kubernetes --dependency`).

The `unreachable_context` fixture it depends on injects a dead context into the kubeconfig and then **restarts the API server** (`sky api stop && sky api start`) so the server picks up the kubeconfig change. In the `--dependency` variant the client is installed with a reduced (base-only) dependency set, so restarting the server there brings it back up **without the `kubernetes` extra**. The server then can't service the test's Kubernetes work and fails with:

```
Reason [compute]: [ImportError] Failed to import dependencies for Kubernetes. Try running: pip install "skypilot[kubernetes]"
...
ModuleNotFoundError: No module named 'kubernetes'
  File ".../sky/provision/kubernetes/utils.py", line 3192, in get_all_kube_context_names
```

In short: the test requires restarting the API server, and the restart loses the Kubernetes context/dependencies — which the dependency-minimal test can't support.

## Change

Add `@pytest.mark.no_dependency`, mirroring its sibling `test_kubernetes_context_failover` — which uses the same `unreachable_context` fixture and the same server restart, and is already marked `no_dependency` for exactly this reason.

## Result

With #10116 (`no_remote_server`) plus this (`no_dependency`), the test runs only in the plain `--kubernetes` configuration — where it is green — and is skipped in the remote-server and dependency-minimal variants where its preconditions can't hold. The dead-context debug-dump logic remains pinned by the unit tests in `test_debug_utils.py` and `kubernetes/test_debug.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)