### PR TITLE
[Azure] Implement check_quota_available so failover skips zero-quota regions

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -734,6 +734,31 @@ class Azure(clouds.Cloud):
         return azure_subscription_id
 
     @classmethod
+    def check_quota_available(cls,
+                              resources: 'resources.Resources') -> bool:
+        """Check if Azure quota is available based on `resources`.
+
+        Azure-specific implementation of check_quota_available. The
+        function works by fetching a TTL-cached per-region quota snapshot
+        (the Compute Usage API for per-family and regional vCPU headroom,
+        and the Resource SKUs API for subscription restrictions) and
+        comparing the headroom against the instance type's vCPU count.
+        Mirrors the AWS/GCP contract: False only on a conclusive no; True
+        on any doubt, so a provisionable region is never skipped.
+
+        Returns:
+            False if the region conclusively cannot provision the
+            instance type, and True otherwise.
+        """
+        resources = resources.assert_launchable()
+        instance_type = resources.instance_type
+        region = resources.region
+        if region is None:
+            return True
+        return azure_utils.check_quota_available(instance_type, region,
+                                                 resources.use_spot)
+
+    @classmethod
     def _is_s_series(cls, instance_type: Optional[str]) -> bool:
         # For azure naming convention, see https://learn.microsoft.com/en-us/azure/virtual-machines/vm-naming-conventions  # pylint: disable=line-too-long
         if instance_type is None:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -734,8 +734,7 @@ class Azure(clouds.Cloud):
         return azure_subscription_id
 
     @classmethod
-    def check_quota_available(cls,
-                              resources: 'resources.Resources') -> bool:
+    def check_quota_available(cls, resources: 'resources.Resources') -> bool:
         """Check if Azure quota is available based on `resources`.
 
         Azure-specific implementation of check_quota_available. The

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -910,7 +910,10 @@ class Cloud:
         quota utilization because many cloud providers' APIs don't have a
         built-in command for checking the real-time utilization. Checking
         real-time utilization is a more difficult endeavor that involves
-        observability etc., so we are holding off on that for now.
+        observability etc., so we are holding off on that for now. Clouds
+        whose APIs do expose live utilization (e.g., Azure's Usage API) may
+        additionally treat a fresh headroom reading as conclusive, provided
+        stale readings are re-verified before blocking a region.
 
         If for at any point the function fails, whether it's because we can't
         import the necessary dependencies or a query using a cloud provider's

--- a/sky/clouds/utils/azure_utils.py
+++ b/sky/clouds/utils/azure_utils.py
@@ -249,8 +249,7 @@ def _fetch_region_quota_capacity(region: str) -> RegionQuotaCapacity:
         if usage.limit is None or usage.current_value is None:
             continue
         try:
-            headroom = int(float(usage.limit)) - int(
-                float(usage.current_value))
+            headroom = int(float(usage.limit)) - int(float(usage.current_value))
         except (TypeError, ValueError):
             continue
         name = _normalize_family(str(usage.name.value))
@@ -293,8 +292,8 @@ def get_region_quota_capacity(region: str) -> RegionQuotaCapacity:
     """Returns a TTL-cached quota snapshot for ``region``."""
     with _quota_snapshot_lock:
         cached = _quota_snapshots.get(region)
-        age = None if cached is None else time.monotonic() - cached.fetched_at
-        if age is not None and age < _QUOTA_SNAPSHOT_TTL_SECONDS:
+        if (cached is not None and time.monotonic() - cached.fetched_at <
+                _QUOTA_SNAPSHOT_TTL_SECONDS):
             return cached.capacity
     # Fetch outside the lock so slow Azure calls do not serialize
     # other regions; stamp the time after the fetch so a slow fetch does

--- a/sky/clouds/utils/azure_utils.py
+++ b/sky/clouds/utils/azure_utils.py
@@ -1,5 +1,7 @@
 """Utilies for Azure"""
 
+import threading
+import time
 import typing
 
 from sky import exceptions
@@ -185,3 +187,188 @@ def get_shared_image_gallery_image_size(
     except azure.exceptions().AzureError as e:
         raise exceptions.ResourcesUnavailableError(
             f'Failed to get Shared Image Gallery image size: {e}.') from e
+
+
+class RegionQuotaCapacity(typing.NamedTuple):
+    """One region's quota picture for the current subscription.
+
+    ``family_headroom`` maps a normalized family name (lowercase, spaces
+    stripped, since the Usage API emits names like ``standard NDASv4_A100
+    Family`` with stray spaces) to remaining vCPUs (limit - current).
+    ``family_by_sku`` keeps the Resource SKUs API's original casing;
+    normalize with :func:`_normalize_family` when joining against
+    ``family_headroom``.
+    """
+    family_headroom: typing.Dict[str, int]
+    total_vcpu_headroom: typing.Optional[int]
+    restricted_skus: typing.FrozenSet[str]
+    family_by_sku: typing.Dict[str, str]
+    # SKUs whose CpuArchitectureType capability is not x64 (ARM sizes).
+    # SkyPilot's Azure provisioner deploys x64 images with no architecture
+    # handling, so creates on these sizes always fail.
+    arm64_skus: typing.FrozenSet[str]
+    # SKUs carrying a ConfidentialComputingType capability (DCas/ECas SNP
+    # etc.). They can only be created with securityType=ConfidentialVM;
+    # SkyPilot provisions standard security-type VMs, so Azure rejects the
+    # create ("not supported ... with '<NULL>' security type").
+    confidential_skus: typing.FrozenSet[str]
+
+
+class _TimedQuotaSnapshot(typing.NamedTuple):
+    fetched_at: float
+    capacity: RegionQuotaCapacity
+
+
+# Quota moves as VMs come and go, but the two Azure API round-trips per
+# region take seconds; a short TTL turns a multi-SKU, multi-region
+# failover into at most one fetch per region.
+_QUOTA_SNAPSHOT_TTL_SECONDS = 300.0
+_quota_snapshot_lock = threading.Lock()
+_quota_snapshots: typing.Dict[str, _TimedQuotaSnapshot] = {}
+
+
+def _normalize_family(name: str) -> str:
+    """Normalizes a family name for matching across the two Azure APIs."""
+    return name.replace(' ', '').lower()
+
+
+def _fetch_region_quota_capacity(region: str) -> RegionQuotaCapacity:
+    """Fetches the region's quota picture (Usage + Resource SKUs APIs).
+
+    Raises:
+        Exception: Any Azure SDK failure; callers treat it as
+            inconclusive (quota assumed available).
+    """
+    compute_client = azure.get_client('compute', azure.get_subscription_id())
+
+    family_headroom: typing.Dict[str, int] = {}
+    total_vcpu_headroom: typing.Optional[int] = None
+    for usage in compute_client.usage.list(region):
+        name = _normalize_family(str(usage.name.value))
+        headroom = int(usage.limit) - int(usage.current_value)
+        if name == 'cores':
+            total_vcpu_headroom = headroom
+        else:
+            family_headroom[name] = headroom
+
+    restricted: typing.Set[str] = set()
+    arm64: typing.Set[str] = set()
+    confidential: typing.Set[str] = set()
+    family_by_sku: typing.Dict[str, str] = {}
+    for sku in compute_client.resource_skus.list(
+            filter=f'location eq {region!r}'):
+        if str(sku.resource_type) != 'virtualMachines':
+            continue
+        name = str(sku.name)
+        family_by_sku[name] = str(sku.family or '')
+        for restriction in sku.restrictions or []:
+            if (str(restriction.reason_code) == 'NotAvailableForSubscription'
+                    and 'Location' in str(restriction.type)):
+                restricted.add(name)
+        for capability in sku.capabilities or []:
+            if (str(capability.name) == 'CpuArchitectureType' and
+                    str(capability.value).lower() != 'x64'):
+                arm64.add(name)
+            if str(capability.name) == 'ConfidentialComputingType':
+                confidential.add(name)
+
+    return RegionQuotaCapacity(family_headroom=family_headroom,
+                               total_vcpu_headroom=total_vcpu_headroom,
+                               restricted_skus=frozenset(restricted),
+                               family_by_sku=family_by_sku,
+                               arm64_skus=frozenset(arm64),
+                               confidential_skus=frozenset(confidential))
+
+
+def get_region_quota_capacity(region: str) -> RegionQuotaCapacity:
+    """Returns a TTL-cached quota snapshot for ``region``."""
+    with _quota_snapshot_lock:
+        cached = _quota_snapshots.get(region)
+        age = None if cached is None else time.monotonic() - cached.fetched_at
+        if age is not None and age < _QUOTA_SNAPSHOT_TTL_SECONDS:
+            return cached.capacity
+    # Fetch outside the lock so slow Azure calls do not serialize
+    # other regions; stamp the time after the fetch so a slow fetch does
+    # not shorten the snapshot's effective TTL.
+    capacity = _fetch_region_quota_capacity(region)
+    with _quota_snapshot_lock:
+        _quota_snapshots[region] = _TimedQuotaSnapshot(
+            fetched_at=time.monotonic(), capacity=capacity)
+    return capacity
+
+
+def _instance_type_vcpus(instance_type: str) -> int:
+    """vCPUs the instance type consumes, from the catalog (0 = unknown)."""
+    # pylint: disable=import-outside-toplevel
+    from sky import catalog
+    try:
+        vcpus, _ = catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                            clouds='azure')
+        return int(vcpus) if vcpus else 0
+    except Exception:  # pylint: disable=broad-except
+        # Inconclusive: callers fall back to a nonzero-quota check.
+        return 0
+
+
+def check_quota_available(instance_type: str, region: str,
+                          use_spot: bool) -> bool:
+    """Checks whether ``instance_type`` has launchable quota in ``region``.
+
+    Mirrors the AWS/GCP contract: returns False only on a conclusive no
+    (the SKU is restricted for the subscription in the region, the SKU is
+    not sold there, or the vCPU family / regional-total headroom is smaller
+    than the SKU's vCPUs); returns True on any doubt (API failure, unknown
+    SKU size, missing family row) so a provisionable region is never
+    preemptively skipped.
+
+    Args:
+        instance_type: Azure SKU name (e.g. ``Standard_NC40ads_H100_v5``).
+        region: Azure region name (e.g. ``southcentralus``).
+        use_spot: Whether the check is for a spot instance; gated on the
+            region-wide low-priority vCPU bucket instead of the on-demand
+            family quota.
+
+    Returns:
+        False if the region conclusively cannot provision the instance
+        type, True otherwise.
+    """
+    try:
+        capacity = get_region_quota_capacity(region)
+    except Exception:  # pylint: disable=broad-except
+        # Inconclusive; never block a provision on a failed probe.
+        return True
+
+    if instance_type in capacity.restricted_skus:
+        return False
+    # SKUs SkyPilot's Azure provisioner cannot create as it deploys VMs
+    # today (standard security type, x64 images): a provision attempt is
+    # destined to fail, which is exactly what this check exists to skip.
+    # Once security type / image architecture are modeled in Resources,
+    # these two gates should be conditioned on the request instead.
+    if instance_type in capacity.confidential_skus:
+        return False
+    if instance_type in capacity.arm64_skus:
+        return False
+
+    family_raw = capacity.family_by_sku.get(instance_type)
+    if not family_raw:
+        # The SKU is not sold in this region at all.
+        return False
+    family = _normalize_family(family_raw)
+
+    needed = _instance_type_vcpus(instance_type)
+    if needed <= 0:
+        # Size unknown: only the conclusive zero-quota case can block.
+        needed = 1
+
+    if use_spot:
+        spot_headroom = capacity.family_headroom.get('lowprioritycores')
+        return spot_headroom is None or spot_headroom >= needed
+
+    family_headroom = capacity.family_headroom.get(family)
+    if family_headroom is not None and family_headroom < needed:
+        return False
+    if (capacity.total_vcpu_headroom is not None and
+            capacity.total_vcpu_headroom < needed):
+        return False
+    return True

--- a/sky/clouds/utils/azure_utils.py
+++ b/sky/clouds/utils/azure_utils.py
@@ -244,8 +244,16 @@ def _fetch_region_quota_capacity(region: str) -> RegionQuotaCapacity:
     family_headroom: typing.Dict[str, int] = {}
     total_vcpu_headroom: typing.Optional[int] = None
     for usage in compute_client.usage.list(region):
+        # Skip malformed rows (missing or non-numeric limits) instead of
+        # failing the whole region fetch over one bad entry.
+        if usage.limit is None or usage.current_value is None:
+            continue
+        try:
+            headroom = int(float(usage.limit)) - int(
+                float(usage.current_value))
+        except (TypeError, ValueError):
+            continue
         name = _normalize_family(str(usage.name.value))
-        headroom = int(usage.limit) - int(usage.current_value)
         if name == 'cores':
             total_vcpu_headroom = headroom
         else:
@@ -267,6 +275,7 @@ def _fetch_region_quota_capacity(region: str) -> RegionQuotaCapacity:
                 restricted.add(name)
         for capability in sku.capabilities or []:
             if (str(capability.name) == 'CpuArchitectureType' and
+                    capability.value is not None and
                     str(capability.value).lower() != 'x64'):
                 arm64.add(name)
             if str(capability.name) == 'ConfidentialComputingType':
@@ -350,11 +359,12 @@ def check_quota_available(instance_type: str, region: str,
     if instance_type in capacity.arm64_skus:
         return False
 
-    family_raw = capacity.family_by_sku.get(instance_type)
-    if not family_raw:
+    if instance_type not in capacity.family_by_sku:
         # The SKU is not sold in this region at all.
         return False
-    family = _normalize_family(family_raw)
+    # An empty family name is inconclusive: the family-quota gate below
+    # is skipped, but the regional-total gate still applies.
+    family = _normalize_family(capacity.family_by_sku[instance_type])
 
     needed = _instance_type_vcpus(instance_type)
     if needed <= 0:
@@ -365,9 +375,10 @@ def check_quota_available(instance_type: str, region: str,
         spot_headroom = capacity.family_headroom.get('lowprioritycores')
         return spot_headroom is None or spot_headroom >= needed
 
-    family_headroom = capacity.family_headroom.get(family)
-    if family_headroom is not None and family_headroom < needed:
-        return False
+    if family:
+        family_headroom = capacity.family_headroom.get(family)
+        if family_headroom is not None and family_headroom < needed:
+            return False
     if (capacity.total_vcpu_headroom is not None and
             capacity.total_vcpu_headroom < needed):
         return False

--- a/sky/clouds/utils/azure_utils.py
+++ b/sky/clouds/utils/azure_utils.py
@@ -203,15 +203,6 @@ class RegionQuotaCapacity(typing.NamedTuple):
     total_vcpu_headroom: typing.Optional[int]
     restricted_skus: typing.FrozenSet[str]
     family_by_sku: typing.Dict[str, str]
-    # SKUs whose CpuArchitectureType capability is not x64 (ARM sizes).
-    # SkyPilot's Azure provisioner deploys x64 images with no architecture
-    # handling, so creates on these sizes always fail.
-    arm64_skus: typing.FrozenSet[str]
-    # SKUs carrying a ConfidentialComputingType capability (DCas/ECas SNP
-    # etc.). They can only be created with securityType=ConfidentialVM;
-    # SkyPilot provisions standard security-type VMs, so Azure rejects the
-    # create ("not supported ... with '<NULL>' security type").
-    confidential_skus: typing.FrozenSet[str]
 
 
 class _TimedQuotaSnapshot(typing.NamedTuple):
@@ -223,6 +214,12 @@ class _TimedQuotaSnapshot(typing.NamedTuple):
 # region take seconds; a short TTL turns a multi-SKU, multi-region
 # failover into at most one fetch per region.
 _QUOTA_SNAPSHOT_TTL_SECONDS = 300.0
+# A snapshot older than this cannot conclusively block a region: quota
+# frees up when clusters come down, so a stale "no headroom" reading is
+# re-verified against a fresh snapshot before the region is condemned.
+# (A stale "yes" is harmless - provisioning proceeds and fails over
+# naturally.)
+_QUOTA_BLOCK_MAX_AGE_SECONDS = 30.0
 _quota_snapshot_lock = threading.Lock()
 _quota_snapshots: typing.Dict[str, _TimedQuotaSnapshot] = {}
 
@@ -233,76 +230,63 @@ def _normalize_family(name: str) -> str:
 
 
 def _fetch_region_quota_capacity(region: str) -> RegionQuotaCapacity:
-    """Fetches the region's quota picture (Usage + Resource SKUs APIs).
-
-    Raises:
-        Exception: Any Azure SDK failure; callers treat it as
-            inconclusive (quota assumed available).
-    """
+    """Fetches the region's quota picture (Usage + Resource SKUs APIs)."""
     compute_client = azure.get_client('compute', azure.get_subscription_id())
 
     family_headroom: typing.Dict[str, int] = {}
     total_vcpu_headroom: typing.Optional[int] = None
     for usage in compute_client.usage.list(region):
-        # Skip malformed rows (missing or non-numeric limits) instead of
-        # failing the whole region fetch over one bad entry.
-        if usage.limit is None or usage.current_value is None:
-            continue
+        # Malformed rows (missing or non-numeric limits) are skipped
+        # instead of failing the whole region fetch over one bad entry.
         try:
             headroom = int(float(usage.limit)) - int(float(usage.current_value))
         except (TypeError, ValueError):
             continue
-        name = _normalize_family(str(usage.name.value))
+        name = _normalize_family(usage.name.value)
         if name == 'cores':
             total_vcpu_headroom = headroom
         else:
             family_headroom[name] = headroom
 
     restricted: typing.Set[str] = set()
-    arm64: typing.Set[str] = set()
-    confidential: typing.Set[str] = set()
     family_by_sku: typing.Dict[str, str] = {}
     for sku in compute_client.resource_skus.list(
             filter=f'location eq {region!r}'):
-        if str(sku.resource_type) != 'virtualMachines':
+        if sku.resource_type != 'virtualMachines':
             continue
-        name = str(sku.name)
-        family_by_sku[name] = str(sku.family or '')
+        family_by_sku[sku.name] = sku.family or ''
         for restriction in sku.restrictions or []:
-            if (str(restriction.reason_code) == 'NotAvailableForSubscription'
-                    and 'Location' in str(restriction.type)):
-                restricted.add(name)
-        for capability in sku.capabilities or []:
-            if (str(capability.name) == 'CpuArchitectureType' and
-                    capability.value is not None and
-                    str(capability.value).lower() != 'x64'):
-                arm64.add(name)
-            if str(capability.name) == 'ConfidentialComputingType':
-                confidential.add(name)
+            if (restriction.reason_code == 'NotAvailableForSubscription' and
+                    restriction.type == 'Location'):
+                restricted.add(sku.name)
 
     return RegionQuotaCapacity(family_headroom=family_headroom,
                                total_vcpu_headroom=total_vcpu_headroom,
                                restricted_skus=frozenset(restricted),
-                               family_by_sku=family_by_sku,
-                               arm64_skus=frozenset(arm64),
-                               confidential_skus=frozenset(confidential))
+                               family_by_sku=family_by_sku)
 
 
-def get_region_quota_capacity(region: str) -> RegionQuotaCapacity:
-    """Returns a TTL-cached quota snapshot for ``region``."""
-    with _quota_snapshot_lock:
-        cached = _quota_snapshots.get(region)
-        if (cached is not None and time.monotonic() - cached.fetched_at <
-                _QUOTA_SNAPSHOT_TTL_SECONDS):
-            return cached.capacity
-    # Fetch outside the lock so slow Azure calls do not serialize
-    # other regions; stamp the time after the fetch so a slow fetch does
-    # not shorten the snapshot's effective TTL.
+def _fetch_and_cache_region_quota(region: str) -> RegionQuotaCapacity:
+    # Fetch outside the lock so slow Azure calls do not serialize other
+    # regions; stamp the time after the fetch so a slow fetch does not
+    # shorten the snapshot's effective TTL.
     capacity = _fetch_region_quota_capacity(region)
     with _quota_snapshot_lock:
         _quota_snapshots[region] = _TimedQuotaSnapshot(
             fetched_at=time.monotonic(), capacity=capacity)
     return capacity
+
+
+def _get_region_quota_capacity(
+        region: str) -> typing.Tuple[RegionQuotaCapacity, float]:
+    """Returns a TTL-cached quota snapshot for ``region`` and its age."""
+    with _quota_snapshot_lock:
+        cached = _quota_snapshots.get(region)
+        if cached is not None:
+            age = time.monotonic() - cached.fetched_at
+            if age < _QUOTA_SNAPSHOT_TTL_SECONDS:
+                return cached.capacity, age
+    return _fetch_and_cache_region_quota(region), 0.0
 
 
 def _instance_type_vcpus(instance_type: str) -> int:
@@ -312,52 +296,17 @@ def _instance_type_vcpus(instance_type: str) -> int:
     try:
         vcpus, _ = catalog.get_vcpus_mem_from_instance_type(instance_type,
                                                             clouds='azure')
-        return int(vcpus) if vcpus else 0
-    except Exception:  # pylint: disable=broad-except
-        # Inconclusive: callers fall back to a nonzero-quota check.
+    except ValueError:
+        # Unknown instance type: callers fall back to a nonzero-quota check.
         return 0
+    return int(vcpus) if vcpus else 0
 
 
-def check_quota_available(instance_type: str, region: str,
-                          use_spot: bool) -> bool:
-    """Checks whether ``instance_type`` has launchable quota in ``region``.
-
-    Mirrors the AWS/GCP contract: returns False only on a conclusive no
-    (the SKU is restricted for the subscription in the region, the SKU is
-    not sold there, or the vCPU family / regional-total headroom is smaller
-    than the SKU's vCPUs); returns True on any doubt (API failure, unknown
-    SKU size, missing family row) so a provisionable region is never
-    preemptively skipped.
-
-    Args:
-        instance_type: Azure SKU name (e.g. ``Standard_NC40ads_H100_v5``).
-        region: Azure region name (e.g. ``southcentralus``).
-        use_spot: Whether the check is for a spot instance; gated on the
-            region-wide low-priority vCPU bucket instead of the on-demand
-            family quota.
-
-    Returns:
-        False if the region conclusively cannot provision the instance
-        type, True otherwise.
-    """
-    try:
-        capacity = get_region_quota_capacity(region)
-    except Exception:  # pylint: disable=broad-except
-        # Inconclusive; never block a provision on a failed probe.
-        return True
-
+def _has_quota_headroom(instance_type: str, capacity: RegionQuotaCapacity,
+                        use_spot: bool) -> bool:
+    """Evaluates one snapshot; True unless it conclusively blocks."""
     if instance_type in capacity.restricted_skus:
         return False
-    # SKUs SkyPilot's Azure provisioner cannot create as it deploys VMs
-    # today (standard security type, x64 images): a provision attempt is
-    # destined to fail, which is exactly what this check exists to skip.
-    # Once security type / image architecture are modeled in Resources,
-    # these two gates should be conditioned on the request instead.
-    if instance_type in capacity.confidential_skus:
-        return False
-    if instance_type in capacity.arm64_skus:
-        return False
-
     if instance_type not in capacity.family_by_sku:
         # The SKU is not sold in this region at all.
         return False
@@ -382,3 +331,39 @@ def check_quota_available(instance_type: str, region: str,
             capacity.total_vcpu_headroom < needed):
         return False
     return True
+
+
+def check_quota_available(instance_type: str, region: str,
+                          use_spot: bool) -> bool:
+    """Checks whether ``instance_type`` has launchable quota in ``region``.
+
+    Mirrors the AWS/GCP contract: returns False only on a conclusive no
+    (the SKU is restricted for the subscription in the region, the SKU is
+    not sold there, or a fresh reading of the vCPU family / regional-total
+    headroom is smaller than the SKU's vCPUs); returns True on any doubt
+    (unknown SKU size, missing family row) so a provisionable region is
+    never preemptively skipped. Azure SDK failures propagate to the call
+    site, which logs them and treats the check as inconclusive.
+
+    Headroom is a live reading, so only a *fresh* snapshot may block: a
+    cached "no headroom" verdict is re-verified against a fresh fetch
+    first (quota may have been freed since the snapshot was taken).
+
+    Args:
+        instance_type: Azure SKU name (e.g. ``Standard_NC40ads_H100_v5``).
+        region: Azure region name (e.g. ``southcentralus``).
+        use_spot: Whether the check is for a spot instance; gated on the
+            region-wide low-priority vCPU bucket instead of the on-demand
+            family quota.
+
+    Returns:
+        False if the region conclusively cannot provision the instance
+        type, True otherwise.
+    """
+    capacity, age = _get_region_quota_capacity(region)
+    if _has_quota_headroom(instance_type, capacity, use_spot):
+        return True
+    if age <= _QUOTA_BLOCK_MAX_AGE_SECONDS:
+        return False
+    return _has_quota_headroom(instance_type,
+                               _fetch_and_cache_region_quota(region), use_spot)

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -278,23 +278,19 @@ class TestCheckQuotaAvailable:
                   family_headroom,
                   total=10_000,
                   restricted=frozenset(),
-                  family_by_sku=None,
-                  arm64=frozenset(),
-                  confidential=frozenset()):
+                  family_by_sku=None):
         return azure_utils.RegionQuotaCapacity(family_headroom=family_headroom,
                                                total_vcpu_headroom=total,
                                                restricted_skus=restricted,
                                                family_by_sku=family_by_sku or
-                                               {},
-                                               arm64_skus=arm64,
-                                               confidential_skus=confidential)
+                                               {})
 
     def test_restricted_sku_is_conclusively_unavailable(self, monkeypatch):
         capacity = self._capacity(
             family_headroom={'standardhbv3family': 3540},
             restricted=frozenset({'Standard_HB120rs_v3'}),
             family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                      'southcentralus', False)
@@ -305,7 +301,7 @@ class TestCheckQuotaAvailable:
             family_by_sku={
                 'Standard_NC40ads_H100_v5': 'StandardNCadsH100v5Family'
             })
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 40)
@@ -316,7 +312,7 @@ class TestCheckQuotaAvailable:
         capacity = self._capacity(
             family_headroom={'standardhbv3family': 3540},
             family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 120)
@@ -329,7 +325,7 @@ class TestCheckQuotaAvailable:
             family_headroom={'standardhbv3family': 3540},
             total=100,
             family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 120)
@@ -338,19 +334,21 @@ class TestCheckQuotaAvailable:
 
     def test_sku_not_sold_in_region_blocks(self, monkeypatch):
         capacity = self._capacity(family_headroom={})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                      'koreacentral', False)
 
-    def test_probe_failure_is_inconclusive_never_blocks(self, monkeypatch):
-        # Mirrors AWS/GCP: an API failure must not skip a region.
+    def test_probe_failure_propagates_to_the_caller(self, monkeypatch):
+        # The call site (cloud_vm_ray_backend) catches, logs, and treats
+        # the check as inconclusive; swallowing here would hide the error.
         def boom(region):
             raise RuntimeError('SDK exploded')
 
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity', boom)
-        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
-                                                 'southcentralus', False)
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity', boom)
+        with pytest.raises(RuntimeError, match='SDK exploded'):
+            azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                              'southcentralus', False)
 
     def test_spot_gates_on_low_priority_bucket(self, monkeypatch):
         capacity = self._capacity(
@@ -359,7 +357,7 @@ class TestCheckQuotaAvailable:
                 'lowprioritycores': 8,
             },
             family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 120)
@@ -368,33 +366,12 @@ class TestCheckQuotaAvailable:
         assert azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                  'southcentralus', False)
 
-    def test_arm64_and_confidential_skus_are_unprovisionable(self, monkeypatch):
-        # The provisioner deploys standard-security-type x64 VMs, so these
-        # sizes always fail at create time regardless of quota headroom.
-        capacity = self._capacity(
-            family_headroom={
-                'standarddpsv5family': 64,
-                'standardecadsv5family': 64,
-            },
-            family_by_sku={
-                'Standard_D2ps_v5': 'standardDPSv5Family',
-                'Standard_EC20ads_v5': 'standardECADSv5Family',
-            },
-            arm64=frozenset({'Standard_D2ps_v5'}),
-            confidential=frozenset({'Standard_EC20ads_v5'}))
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
-                            lambda region: capacity)
-        assert not azure_utils.check_quota_available('Standard_D2ps_v5',
-                                                     'southcentralus', False)
-        assert not azure_utils.check_quota_available('Standard_EC20ads_v5',
-                                                     'southcentralus', False)
-
     def test_unknown_instance_size_blocks_only_on_zero_quota(self, monkeypatch):
         # An unsized SKU degrades to a nonzero-quota check (needed=1).
         capacity = self._capacity(
             family_headroom={'standardhbv3family': 0},
             family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 0)
@@ -421,6 +398,70 @@ class TestCheckQuotaAvailable:
                                           False)
         assert calls == ['southcentralus', 'eastus']
 
+        # A snapshot older than the TTL is refetched.
+        snapshot = azure_utils._quota_snapshots['southcentralus']
+        azure_utils._quota_snapshots['southcentralus'] = snapshot._replace(
+            fetched_at=snapshot.fetched_at -
+            azure_utils._QUOTA_SNAPSHOT_TTL_SECONDS - 1)
+        azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                          'southcentralus', False)
+        assert calls == ['southcentralus', 'eastus', 'southcentralus']
+
+    def test_stale_no_headroom_is_reverified_before_blocking(self, monkeypatch):
+        # Quota frees up when clusters come down; a cached "no headroom"
+        # older than the block window must not condemn the region without
+        # a fresh reading.
+        capacities = iter([
+            self._capacity(
+                family_headroom={'standardhbv3family': 0},
+                family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'}),
+            self._capacity(
+                family_headroom={'standardhbv3family': 3540},
+                family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'}),
+        ])
+        calls = []
+
+        def fake_fetch(region):
+            calls.append(region)
+            return next(capacities)
+
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
+                            fake_fetch)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        # Fresh fetch: the zero-headroom verdict is conclusive.
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', False)
+        # Age the snapshot past the block window (still within the TTL):
+        # the stale "no" triggers a re-verify, which now sees headroom.
+        snapshot = azure_utils._quota_snapshots['southcentralus']
+        azure_utils._quota_snapshots['southcentralus'] = snapshot._replace(
+            fetched_at=snapshot.fetched_at -
+            azure_utils._QUOTA_BLOCK_MAX_AGE_SECONDS - 1)
+        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                 'southcentralus', False)
+        assert calls == ['southcentralus', 'southcentralus']
+
+    def test_recent_no_headroom_blocks_without_refetch(self, monkeypatch):
+        calls = []
+
+        def fake_fetch(region):
+            calls.append(region)
+            return self._capacity(
+                family_headroom={'standardhbv3family': 0},
+                family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
+                            fake_fetch)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        # Within the block window a cached "no" is trusted, so a
+        # multi-SKU failover does not refetch per blocked check.
+        for _ in range(3):
+            assert not azure_utils.check_quota_available(
+                'Standard_HB120rs_v3', 'southcentralus', False)
+        assert calls == ['southcentralus']
+
     def test_usage_family_names_are_normalized(self):
         # The Usage API emits family names with stray spaces and mixed
         # casing; matching against Resource SKUs families must survive it.
@@ -439,14 +480,15 @@ class TestCheckQuotaAvailable:
         roomy = self._capacity(family_headroom={},
                                total=10_000,
                                family_by_sku={'Standard_HB120rs_v3': ''})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: roomy)
         assert azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                  'southcentralus', False)
+        azure_utils._quota_snapshots.clear()
         cramped = self._capacity(family_headroom={},
                                  total=8,
                                  family_by_sku={'Standard_HB120rs_v3': ''})
-        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
                             lambda region: cramped)
         assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                      'southcentralus', False)
@@ -466,21 +508,20 @@ class _FakeUsage:
         self.current_value = current_value
 
 
-class _FakeCapability:
+class _FakeRestriction:
 
-    def __init__(self, name, value):
-        self.name = name
-        self.value = value
+    def __init__(self, reason_code, restriction_type):
+        self.reason_code = reason_code
+        self.type = restriction_type
 
 
 class _FakeSku:
 
-    def __init__(self, name, family, capabilities=()):
+    def __init__(self, name, family, restrictions=()):
         self.resource_type = 'virtualMachines'
         self.name = name
         self.family = family
-        self.restrictions = []
-        self.capabilities = list(capabilities)
+        self.restrictions = list(restrictions)
 
 
 class _FakeComputeClient:
@@ -502,28 +543,30 @@ class _FakeComputeClient:
 class TestFetchRegionQuotaCapacity:
     """Tests for the Azure API response parsing."""
 
-    def test_malformed_rows_and_null_capabilities_are_tolerated(
+    def test_malformed_rows_are_tolerated_and_restrictions_parse(
             self, monkeypatch):
         usages = [
-            # Float-string limits parse; None limits are skipped rather
-            # than failing the whole region fetch.
+            # Float-string limits parse; None and garbage limits are
+            # skipped rather than failing the whole region fetch.
             _FakeUsage('standardHBv3Family', '3600.0', '60.0'),
             _FakeUsage('brokenFamily', None, 5),
             _FakeUsage('alsoBroken', 'not-a-number', 5),
             _FakeUsage('cores', 10_000, 120),
         ]
         skus = [
-            # A None CpuArchitectureType value must not classify the SKU
-            # as ARM (str(None).lower() != 'x64' would).
-            _FakeSku('Standard_HB120rs_v3',
-                     'standardHBv3Family',
-                     capabilities=[
-                         _FakeCapability('CpuArchitectureType', None),
+            _FakeSku('Standard_HB120rs_v3', 'standardHBv3Family'),
+            _FakeSku('Standard_ND96asr_v4',
+                     'standardNDASv4_A100Family',
+                     restrictions=[
+                         _FakeRestriction('NotAvailableForSubscription',
+                                          'Location'),
                      ]),
-            _FakeSku('Standard_D2ps_v5',
-                     'standardDPSv5Family',
-                     capabilities=[
-                         _FakeCapability('CpuArchitectureType', 'Arm64'),
+            # Zone-scoped restrictions do not restrict the region.
+            _FakeSku('Standard_NC24ads_A100_v4',
+                     'standardNCADSA100v4Family',
+                     restrictions=[
+                         _FakeRestriction('NotAvailableForSubscription',
+                                          'Zone'),
                      ]),
         ]
         monkeypatch.setattr(
@@ -536,6 +579,6 @@ class TestFetchRegionQuotaCapacity:
 
         assert capacity.family_headroom == {'standardhbv3family': 3540}
         assert capacity.total_vcpu_headroom == 9880
-        assert capacity.arm64_skus == frozenset({'Standard_D2ps_v5'})
+        assert capacity.restricted_skus == frozenset({'Standard_ND96asr_v4'})
         assert capacity.family_by_sku['Standard_HB120rs_v3'] == (
             'standardHBv3Family')

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -281,13 +281,13 @@ class TestCheckQuotaAvailable:
                   family_by_sku=None,
                   arm64=frozenset(),
                   confidential=frozenset()):
-        return azure_utils.RegionQuotaCapacity(
-            family_headroom=family_headroom,
-            total_vcpu_headroom=total,
-            restricted_skus=restricted,
-            family_by_sku=family_by_sku or {},
-            arm64_skus=arm64,
-            confidential_skus=confidential)
+        return azure_utils.RegionQuotaCapacity(family_headroom=family_headroom,
+                                               total_vcpu_headroom=total,
+                                               restricted_skus=restricted,
+                                               family_by_sku=family_by_sku or
+                                               {},
+                                               arm64_skus=arm64,
+                                               confidential_skus=confidential)
 
     def test_restricted_sku_is_conclusively_unavailable(self, monkeypatch):
         capacity = self._capacity(
@@ -302,14 +302,15 @@ class TestCheckQuotaAvailable:
     def test_insufficient_family_headroom_blocks(self, monkeypatch):
         capacity = self._capacity(
             family_headroom={'standardncadsh100v5family': 20},
-            family_by_sku={'Standard_NC40ads_H100_v5':
-                               'StandardNCadsH100v5Family'})
+            family_by_sku={
+                'Standard_NC40ads_H100_v5': 'StandardNCadsH100v5Family'
+            })
         monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
                             lambda region: capacity)
         monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
                             lambda instance_type: 40)
-        assert not azure_utils.check_quota_available(
-            'Standard_NC40ads_H100_v5', 'australiaeast', False)
+        assert not azure_utils.check_quota_available('Standard_NC40ads_H100_v5',
+                                                     'australiaeast', False)
 
     def test_sufficient_headroom_allows(self, monkeypatch):
         capacity = self._capacity(
@@ -367,8 +368,7 @@ class TestCheckQuotaAvailable:
         assert azure_utils.check_quota_available('Standard_HB120rs_v3',
                                                  'southcentralus', False)
 
-    def test_arm64_and_confidential_skus_are_unprovisionable(
-            self, monkeypatch):
+    def test_arm64_and_confidential_skus_are_unprovisionable(self, monkeypatch):
         # The provisioner deploys standard-security-type x64 VMs, so these
         # sizes always fail at create time regardless of quota headroom.
         capacity = self._capacity(
@@ -384,13 +384,12 @@ class TestCheckQuotaAvailable:
             confidential=frozenset({'Standard_EC20ads_v5'}))
         monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
                             lambda region: capacity)
-        assert not azure_utils.check_quota_available(
-            'Standard_D2ps_v5', 'southcentralus', False)
-        assert not azure_utils.check_quota_available(
-            'Standard_EC20ads_v5', 'southcentralus', False)
+        assert not azure_utils.check_quota_available('Standard_D2ps_v5',
+                                                     'southcentralus', False)
+        assert not azure_utils.check_quota_available('Standard_EC20ads_v5',
+                                                     'southcentralus', False)
 
-    def test_unknown_instance_size_blocks_only_on_zero_quota(
-            self, monkeypatch):
+    def test_unknown_instance_size_blocks_only_on_zero_quota(self, monkeypatch):
         # An unsized SKU degrades to a nonzero-quota check (needed=1).
         capacity = self._capacity(
             family_headroom={'standardhbv3family': 0},

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -263,3 +263,169 @@ def _make_arm_template():
             },
         }
     }
+
+
+class TestCheckQuotaAvailable:
+    """Tests for azure_utils.check_quota_available."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_snapshots(self):
+        azure_utils._quota_snapshots.clear()
+        yield
+        azure_utils._quota_snapshots.clear()
+
+    def _capacity(self,
+                  family_headroom,
+                  total=10_000,
+                  restricted=frozenset(),
+                  family_by_sku=None,
+                  arm64=frozenset(),
+                  confidential=frozenset()):
+        return azure_utils.RegionQuotaCapacity(
+            family_headroom=family_headroom,
+            total_vcpu_headroom=total,
+            restricted_skus=restricted,
+            family_by_sku=family_by_sku or {},
+            arm64_skus=arm64,
+            confidential_skus=confidential)
+
+    def test_restricted_sku_is_conclusively_unavailable(self, monkeypatch):
+        capacity = self._capacity(
+            family_headroom={'standardhbv3family': 3540},
+            restricted=frozenset({'Standard_HB120rs_v3'}),
+            family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', False)
+
+    def test_insufficient_family_headroom_blocks(self, monkeypatch):
+        capacity = self._capacity(
+            family_headroom={'standardncadsh100v5family': 20},
+            family_by_sku={'Standard_NC40ads_H100_v5':
+                               'StandardNCadsH100v5Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 40)
+        assert not azure_utils.check_quota_available(
+            'Standard_NC40ads_H100_v5', 'australiaeast', False)
+
+    def test_sufficient_headroom_allows(self, monkeypatch):
+        capacity = self._capacity(
+            family_headroom={'standardhbv3family': 3540},
+            family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                 'southcentralus', False)
+
+    def test_total_regional_vcpu_headroom_blocks(self, monkeypatch):
+        # Family quota alone is not enough; the regional total gates too.
+        capacity = self._capacity(
+            family_headroom={'standardhbv3family': 3540},
+            total=100,
+            family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', False)
+
+    def test_sku_not_sold_in_region_blocks(self, monkeypatch):
+        capacity = self._capacity(family_headroom={})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'koreacentral', False)
+
+    def test_probe_failure_is_inconclusive_never_blocks(self, monkeypatch):
+        # Mirrors AWS/GCP: an API failure must not skip a region.
+        def boom(region):
+            raise RuntimeError('SDK exploded')
+
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity', boom)
+        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                 'southcentralus', False)
+
+    def test_spot_gates_on_low_priority_bucket(self, monkeypatch):
+        capacity = self._capacity(
+            family_headroom={
+                'standardhbv3family': 3540,
+                'lowprioritycores': 8,
+            },
+            family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', True)
+        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                 'southcentralus', False)
+
+    def test_arm64_and_confidential_skus_are_unprovisionable(
+            self, monkeypatch):
+        # The provisioner deploys standard-security-type x64 VMs, so these
+        # sizes always fail at create time regardless of quota headroom.
+        capacity = self._capacity(
+            family_headroom={
+                'standarddpsv5family': 64,
+                'standardecadsv5family': 64,
+            },
+            family_by_sku={
+                'Standard_D2ps_v5': 'standardDPSv5Family',
+                'Standard_EC20ads_v5': 'standardECADSv5Family',
+            },
+            arm64=frozenset({'Standard_D2ps_v5'}),
+            confidential=frozenset({'Standard_EC20ads_v5'}))
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        assert not azure_utils.check_quota_available(
+            'Standard_D2ps_v5', 'southcentralus', False)
+        assert not azure_utils.check_quota_available(
+            'Standard_EC20ads_v5', 'southcentralus', False)
+
+    def test_unknown_instance_size_blocks_only_on_zero_quota(
+            self, monkeypatch):
+        # An unsized SKU degrades to a nonzero-quota check (needed=1).
+        capacity = self._capacity(
+            family_headroom={'standardhbv3family': 0},
+            family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: capacity)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 0)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', False)
+
+    def test_snapshot_is_ttl_cached_per_region(self, monkeypatch):
+        calls = []
+
+        def fake_fetch(region):
+            calls.append(region)
+            return self._capacity(
+                family_headroom={'standardhbv3family': 3540},
+                family_by_sku={'Standard_HB120rs_v3': 'standardHBv3Family'})
+
+        monkeypatch.setattr(azure_utils, '_fetch_region_quota_capacity',
+                            fake_fetch)
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        for _ in range(3):
+            azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                              'southcentralus', False)
+        azure_utils.check_quota_available('Standard_HB120rs_v3', 'eastus',
+                                          False)
+        assert calls == ['southcentralus', 'eastus']
+
+    def test_usage_family_names_are_normalized(self):
+        # The Usage API emits family names with stray spaces and mixed
+        # casing; matching against Resource SKUs families must survive it.
+        assert azure_utils._normalize_family(
+            'standard NDASv4_A100 Family') == 'standardndasv4_a100family'
+        assert azure_utils._normalize_family(
+            'StandardHBv3Family') == 'standardhbv3family'

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -429,3 +429,114 @@ class TestCheckQuotaAvailable:
             'standard NDASv4_A100 Family') == 'standardndasv4_a100family'
         assert azure_utils._normalize_family(
             'StandardHBv3Family') == 'standardhbv3family'
+
+    def test_empty_family_name_skips_family_gate_not_the_total_gate(
+            self, monkeypatch):
+        # A SKU sold in the region whose family name the API omits is NOT
+        # a conclusive no: the family gate is skipped, but the
+        # regional-total gate still applies.
+        monkeypatch.setattr(azure_utils, '_instance_type_vcpus',
+                            lambda instance_type: 120)
+        roomy = self._capacity(family_headroom={},
+                               total=10_000,
+                               family_by_sku={'Standard_HB120rs_v3': ''})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: roomy)
+        assert azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                 'southcentralus', False)
+        cramped = self._capacity(family_headroom={},
+                                 total=8,
+                                 family_by_sku={'Standard_HB120rs_v3': ''})
+        monkeypatch.setattr(azure_utils, 'get_region_quota_capacity',
+                            lambda region: cramped)
+        assert not azure_utils.check_quota_available('Standard_HB120rs_v3',
+                                                     'southcentralus', False)
+
+
+class _FakeUsageName:
+
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeUsage:
+
+    def __init__(self, name, limit, current_value):
+        self.name = _FakeUsageName(name)
+        self.limit = limit
+        self.current_value = current_value
+
+
+class _FakeCapability:
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+class _FakeSku:
+
+    def __init__(self, name, family, capabilities=()):
+        self.resource_type = 'virtualMachines'
+        self.name = name
+        self.family = family
+        self.restrictions = []
+        self.capabilities = list(capabilities)
+
+
+class _FakeComputeClient:
+
+    def __init__(self, usages, skus):
+        self.usage = self
+        self.resource_skus = self
+        self._usages = usages
+        self._skus = skus
+
+    def list(self, *args, **kwargs):
+        # Dispatched by the argument shape: usage.list(region) is
+        # positional, resource_skus.list(filter=...) is keyword-only.
+        if 'filter' in kwargs:
+            return list(self._skus)
+        return list(self._usages)
+
+
+class TestFetchRegionQuotaCapacity:
+    """Tests for the Azure API response parsing."""
+
+    def test_malformed_rows_and_null_capabilities_are_tolerated(
+            self, monkeypatch):
+        usages = [
+            # Float-string limits parse; None limits are skipped rather
+            # than failing the whole region fetch.
+            _FakeUsage('standardHBv3Family', '3600.0', '60.0'),
+            _FakeUsage('brokenFamily', None, 5),
+            _FakeUsage('alsoBroken', 'not-a-number', 5),
+            _FakeUsage('cores', 10_000, 120),
+        ]
+        skus = [
+            # A None CpuArchitectureType value must not classify the SKU
+            # as ARM (str(None).lower() != 'x64' would).
+            _FakeSku('Standard_HB120rs_v3',
+                     'standardHBv3Family',
+                     capabilities=[
+                         _FakeCapability('CpuArchitectureType', None),
+                     ]),
+            _FakeSku('Standard_D2ps_v5',
+                     'standardDPSv5Family',
+                     capabilities=[
+                         _FakeCapability('CpuArchitectureType', 'Arm64'),
+                     ]),
+        ]
+        monkeypatch.setattr(
+            azure_utils.azure, 'get_client',
+            lambda name, subscription_id: _FakeComputeClient(usages, skus))
+        monkeypatch.setattr(azure_utils.azure, 'get_subscription_id',
+                            lambda: 'sub-id')
+
+        capacity = azure_utils._fetch_region_quota_capacity('southcentralus')
+
+        assert capacity.family_headroom == {'standardhbv3family': 3540}
+        assert capacity.total_vcpu_headroom == 9880
+        assert capacity.arm64_skus == frozenset({'Standard_D2ps_v5'})
+        assert capacity.family_by_sku['Standard_HB120rs_v3'] == (
+            'standardHBv3Family')


### PR DESCRIPTION
Fixes #10119.

Azure inherits the base `check_quota_available` stub that always returns True, so the provisioning failover burns 30+ seconds per zero-quota region attempting provisions that are destined to fail — while AWS and GCP both implement real checks. This PR implements it for Azure.

Design:

- `sky/clouds/utils/azure_utils.py`: a per-region quota snapshot combining the Compute **Usage API** (per-family and regional-total vCPU headroom; family names normalized across the two APIs' inconsistent spacing/casing) and the **Resource SKUs API** (subscription restrictions, SKU-to-family mapping). Snapshots are TTL-cached (300s) behind a lock so a multi-SKU, multi-region failover costs at most one fetch pair per region.
- **Conclusive-no-only contract**, mirroring AWS/GCP: False only when the SKU is restricted for the subscription, not sold in the region, or a **fresh** headroom reading is smaller than the SKU's vCPU count. True on any doubt (unknown SKU size, missing family row, empty family name). Azure SDK failures propagate to the call site, which already logs them and treats the check as inconclusive.
- **Stale readings never condemn a region**: headroom is a live signal, so a cached "no headroom" older than 30s is re-verified against a fresh fetch before returning False (quota frees up when clusters come down — e.g. right after a `sky down` of the cluster that held the quota). A stale "yes" is harmless: provisioning proceeds and fails over naturally.
- Spot requests gate on the region-wide low-priority-cores bucket, matching how Azure actually enforces spot quota.
- `sky/clouds/azure.py`: thin `check_quota_available` classmethod in the AWS layout, delegating to the utils module.
- `tests/unit_tests/test_azure_utils.py`: 15 tests covering every gate, the fail-open paths, malformed API rows, restriction scoping (region vs zone), TTL caching + expiry, and the stale-no re-verification.

Note: this checks live headroom (limit - usage), which goes one step beyond the nonzero-limit-only checks on AWS/GCP — Azure's Usage API exposes it directly, and the 30s freshness bound on any blocking verdict addresses the staleness concern that motivated the nonzero-only design. The base-class docstring is updated to reflect that option.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): `pytest tests/unit_tests/test_azure_utils.py` (30 passed). The quota probe runs in production on our Azure fleet (as a vendored patch this PR replaces): ordered-region failover skips conclusively-unlaunchable regions in ~1s instead of failing 30s+ provisions.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)