### PR TITLE
[Core] Debug dump: include DB-stored config in server config section

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -350,8 +350,15 @@ def _resolve_server_config_path() -> Optional[str]:
 
 
 def get_server_config() -> config_utils.Config:
-    """Returns the server config."""
-    return _get_config_from_path(_resolve_server_config_path())
+    """Returns the effective server config.
+
+    This is the config file plus the DB-stored config overlay when the
+    server is backed by a database, read fresh from the backing store(s) on
+    every call. Unlike `to_dict()`, it is not affected by request-level
+    client config overrides (see `override_skypilot_config`), so it always
+    reflects the server's own config rather than the requesting client's.
+    """
+    return _compose_server_config()[0]
 
 
 def get_nested(keys: Tuple[str, ...],
@@ -794,13 +801,11 @@ _db_manager = db_utils.DatabaseManager(db_name='config',
                                        create_table_fn=_create_table)
 
 
-def _reload_config_as_server() -> None:
-    # Build the new config fully, then swap it in with a single
-    # `_set_loaded_config` at the end. Do NOT blank the loaded config up front:
-    # `get_nested` reads without the config lock (hot path), so a transient
-    # empty config would be observable by a concurrent reader and e.g. make
-    # `rbac.get_default_role()` fall back to admin. On any exception below the
-    # previously-loaded config is left in place (stale is safer than empty).
+def _compose_server_config() -> Tuple[config_utils.Config, Optional[str]]:
+    """Builds the effective server config: config file + DB-stored overlay.
+
+    Returns (config, config_file_path).
+    """
     server_config_path = _resolve_server_config_path()
     server_config = _get_config_from_path(server_config_path)
     # Get the db url from the env var. _get_config_from_path should have moved
@@ -829,6 +834,17 @@ def _reload_config_as_server() -> None:
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'server config: \n'
                      f'{yaml_utils.dump_yaml_str(dict(server_config))}')
+    return server_config, server_config_path
+
+
+def _reload_config_as_server() -> None:
+    # Build the new config fully, then swap it in with a single
+    # `_set_loaded_config` at the end. Do NOT blank the loaded config up front:
+    # `get_nested` reads without the config lock (hot path), so a transient
+    # empty config would be observable by a concurrent reader and e.g. make
+    # `rbac.get_default_role()` fall back to admin. On any exception below the
+    # previously-loaded config is left in place (stale is safer than empty).
+    server_config, server_config_path = _compose_server_config()
     _set_loaded_config(server_config)
     _set_loaded_config_path(server_config_path)
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -767,7 +767,9 @@ def _dump_server_info(dump_dir: str,
     except Exception as e:  # pylint: disable=broad-except
         server_info['server_uptime_error'] = str(e)
 
-    # Add config info
+    # Add config info. Use get_server_config() (effective config file + DB
+    # overlay), not to_dict(), so per-request client config overrides don't
+    # leak into the reported server config.
     try:
         server_info['jobs_controller_consolidation_mode'] = (
             managed_job_utils.is_consolidation_mode())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,8 @@ import textwrap
 from unittest import mock
 
 import pytest
+import sqlalchemy
+from sqlalchemy import orm
 
 import sky
 from sky import skypilot_config
@@ -994,6 +996,97 @@ def test_hierarchical_server_config(monkeypatch, tmp_path):
         ('gcp', 'labels', 'env-user-config'), None) is None
     assert skypilot_config.get_nested(
         ('gcp', 'labels', 'env-project-config'), None) is None
+
+
+def test_get_server_config_includes_db_config(monkeypatch, tmp_path):
+    """get_server_config() overlays the DB-stored config onto the file
+    config, the same way the server composes its config at startup."""
+    monkeypatch.delenv(skypilot_config.ENV_VAR_GLOBAL_CONFIG, raising=False)
+    monkeypatch.setenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, 'true')
+
+    # On a DB-backed deployment, the on-disk server config file holds only
+    # the db connection, which parse_and_validate_config_file() pops out
+    # into an env var, leaving the file config empty.
+    server_config_path = tmp_path / 'server_config.yaml'
+    server_config_path.write_text(
+        textwrap.dedent("""\
+            db: sqlite:///unused-marker.db
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        server_config_path)
+    monkeypatch.setenv(constants.ENV_VAR_DB_CONNECTION_URI,
+                       'sqlite:///unused-marker.db')
+
+    # Set up a sqlite engine with the config_yaml_table schema, and a row
+    # holding the DB-stored server config.
+    db_path = tmp_path / 'config.db'
+    engine = sqlalchemy.create_engine(f'sqlite:///{db_path}')
+    skypilot_config.config_yaml_table.metadata.create_all(engine)
+    db_config_yaml = yaml_utils.dump_yaml_str(
+        {'aws': {
+            'labels': {
+                'from-db': 'present'
+            }
+        }})
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.insert(skypilot_config.config_yaml_table).values(
+                key=skypilot_config.API_SERVER_CONFIG_KEY,
+                value=db_config_yaml))
+        session.commit()
+
+    class _StubDBManager:
+        """Stub matching the `_db_manager.get_engine()` interface used by
+        `_compose_server_config()`."""
+
+        def get_engine(self):
+            return engine
+
+    monkeypatch.setattr(skypilot_config, '_db_manager', _StubDBManager())
+
+    config = skypilot_config.get_server_config()
+    assert config.get_nested(('aws', 'labels', 'from-db'), None) == 'present'
+
+
+def test_get_server_config_unaffected_by_request_overrides(
+        monkeypatch, tmp_path):
+    """get_server_config() re-reads the server config fresh from the file
+    (and DB, when applicable), so it must not observe a request-scoped
+    client config override installed via `override_skypilot_config`. This is
+    the reason the debug dump uses `get_server_config()` and not
+    `to_dict()`."""
+    monkeypatch.delenv(skypilot_config.ENV_VAR_GLOBAL_CONFIG, raising=False)
+    monkeypatch.delenv(skypilot_config.ENV_VAR_PROJECT_CONFIG, raising=False)
+    monkeypatch.setenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, 'true')
+
+    server_config_path = tmp_path / 'server_config.yaml'
+    server_config_path.write_text(
+        textwrap.dedent("""\
+            aws:
+                labels:
+                    from-server: present
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        server_config_path)
+    skypilot_config.reload_config()
+    assert skypilot_config.get_server_config().get_nested(
+        ('aws', 'labels', 'from-server'), None) == 'present'
+
+    with skypilot_config.override_skypilot_config(
+        {'aws': {
+            'labels': {
+                'from-client': 'present'
+            }
+        }}):
+        server_config = skypilot_config.get_server_config()
+        assert server_config.get_nested(
+            ('aws', 'labels', 'from-client'), None) is None
+        assert server_config.get_nested(('aws', 'labels', 'from-server'),
+                                        None) == 'present'
+
+        client_config = skypilot_config.to_dict()
+        assert client_config.get_nested(('aws', 'labels', 'from-client'),
+                                        None) == 'present'
 
 
 def test_config_save_validator(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- `skypilot_config.get_server_config()` read only the on-disk config file. On deployments that store the SkyPilot config in the database (Postgres-backed API server), the on-disk file holds just the `db:` connection — which even gets popped into an env var — so the debug dump's `server_info.config` section was silently empty (`{}`), with no error recorded.
- Fix: factor the server-config composition (config file + DB-stored `api_server_config` overlay) out of `_reload_config_as_server()` into `_compose_server_config()`, and make `get_server_config()` return it. The dump keeps calling `get_server_config()`.
- Deliberately NOT switched to `skypilot_config.to_dict()`: inside a request the executor overlays the requesting client's config (`override_skypilot_config`), so `to_dict()` would leak the dumping client's local config into the reported *server* config. A new test pins this distinction.

## Test plan

- New unit test `test_get_server_config_includes_db_config`: file config containing only `db:`, config DB row under `api_server_config` — `get_server_config()` must return the DB-stored values. Verified red on unfixed source (`{}` returned) and green with the fix.
- New unit test `test_get_server_config_unaffected_by_request_overrides`: inside `override_skypilot_config(...)`, `get_server_config()` excludes the client override while `to_dict()` includes it.
- `tests/test_config.py`: 46 passed. `tests/unit_tests/test_sky/utils/test_debug_utils.py`: passed (comment-only change there).
- End-to-end on a local API server backed by Postgres with the config stored in the DB (`update_api_server_config_no_lock`), then `sky debug-dump --recent-minutes 5`:
  - Before: `server_info.json` has `"config": {}` despite the DB row existing.
  - After: `server_info.json` reports the full DB-stored config.

-Claude