### PR TITLE
[Jobs] Env override for the job-status-fetch total timeout (healthy-cluster recovery false positives)

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -108,8 +108,15 @@ _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
 # the workload is perfectly healthy, and a recovery relaunch destroys it —
 # so operators running such workloads can extend the budget via the
 # environment on the jobs controller. See skypilot-org/skypilot#10123.
-JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = int(
-    os.environ.get('SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60))
+try:
+    JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = int(
+        os.environ.get('SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60))
+except ValueError:
+    logger.warning(
+        'Invalid SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS value '
+        f'{os.environ.get("SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS")!r}'
+        '; falling back to 60 seconds.')
+    JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
 
 # Pattern matching the "From controller <UUID>" line that the controller
 # emits at job-claim time (see sky/jobs/controller.py: run_job). Used by

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -108,15 +108,34 @@ _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
 # the workload is perfectly healthy, and a recovery relaunch destroys it —
 # so operators running such workloads can extend the budget via the
 # environment on the jobs controller. See skypilot-org/skypilot#10123.
-try:
-    JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = int(
-        os.environ.get('SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60))
-except ValueError:
-    logger.warning(
-        'Invalid SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS value '
-        f'{os.environ.get("SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS")!r}'
-        '; falling back to 60 seconds.')
-    JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
+_JOB_STATUS_FETCH_TOTAL_TIMEOUT_ENV_VAR = (
+    'SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS')
+_JOB_STATUS_FETCH_TOTAL_TIMEOUT_DEFAULT_SECONDS = 60
+
+
+def _job_status_fetch_total_timeout_seconds() -> int:
+    """Parses the timeout override, falling back on invalid values."""
+    raw = os.environ.get(_JOB_STATUS_FETCH_TOTAL_TIMEOUT_ENV_VAR)
+    if raw is None:
+        return _JOB_STATUS_FETCH_TOTAL_TIMEOUT_DEFAULT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        value = -1
+    if value <= 0:
+        # A non-positive timeout would disable the retry budget entirely
+        # and recover (relaunch) a healthy job on the first transient
+        # error - the exact failure this knob exists to prevent.
+        logger.warning(
+            f'Invalid {_JOB_STATUS_FETCH_TOTAL_TIMEOUT_ENV_VAR} value '
+            f'{raw!r}; must be a positive integer. Falling back to '
+            f'{_JOB_STATUS_FETCH_TOTAL_TIMEOUT_DEFAULT_SECONDS} seconds.')
+        return _JOB_STATUS_FETCH_TOTAL_TIMEOUT_DEFAULT_SECONDS
+    return value
+
+
+JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = (
+    _job_status_fetch_total_timeout_seconds())
 
 # Pattern matching the "From controller <UUID>" line that the controller
 # emits at job-claim time (see sky/jobs/controller.py: run_job). Used by

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -101,7 +101,15 @@ _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5
 _PROVISION_LOG_POLL_GAP_SECONDS = 1
 
 _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
-JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
+# Total budget of consecutive failed job-status fetches the controller
+# tolerates while the cluster is confirmed UP, before it recovers
+# (relaunches) the job. On busy HPC-style nodes (e.g. an MPI solve pinning
+# every core) SSH-based status fetches can stall well past a minute while
+# the workload is perfectly healthy, and a recovery relaunch destroys it —
+# so operators running such workloads can extend the budget via the
+# environment on the jobs controller. See skypilot-org/skypilot#10123.
+JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = int(
+    os.environ.get('SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60))
 
 # Pattern matching the "From controller <UUID>" line that the controller
 # emits at job-claim time (see sky/jobs/controller.py: run_job). Used by

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -1305,3 +1305,24 @@ class TestCleanupExpiredApiAccessTokens:
     def test_no_expired_tokens_is_noop(self, mock_get_expired):
         mock_get_expired.return_value = []
         assert utils.cleanup_expired_api_access_tokens() == 0
+
+
+class TestJobStatusFetchTotalTimeoutOverride:
+    """Tests for the SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS knob."""
+
+    _ENV_VAR = 'SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS'
+
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv(self._ENV_VAR, raising=False)
+        assert utils._job_status_fetch_total_timeout_seconds() == 60
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv(self._ENV_VAR, '600')
+        assert utils._job_status_fetch_total_timeout_seconds() == 600
+
+    @pytest.mark.parametrize('raw', ['120s', ' 60 x', '', '0', '-30'])
+    def test_invalid_or_non_positive_falls_back(self, raw, monkeypatch):
+        monkeypatch.setenv(self._ENV_VAR, raw)
+        with mock.patch.object(utils.logger, 'warning') as mock_warning:
+            assert utils._job_status_fetch_total_timeout_seconds() == 60
+        assert mock_warning.call_count == 1


### PR DESCRIPTION
Closes #10123.

The jobs controller tolerates only `JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60` seconds of consecutive failed job-status fetches — even in the branch where it has just confirmed the cluster is UP (`job_status is None but cluster is UP - transient error`) — before recovering, i.e. relaunching, the job.

For workloads that pin every core (120-rank MPI CFD solves in our case), SSH-based status fetches can stall past that budget while the job is demonstrably healthy (we observed the worker uploading telemetry to object storage during the exact window the controller declared it lost; the cloud activity log showed no VM events, on-demand instance). The relaunch then destroys the run.

This PR keeps the default behavior identical and lets operators extend the budget via `SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS` in the jobs-controller environment.

Happy to reshape this as a `jobs:` config knob instead if that's preferred.

## Tested

- With the patched module on `PYTHONPATH`: `SKYPILOT_JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS=600` yields a budget of 600, and with the env unset the default stays 60 (`import sky.jobs.utils` assertion both ways).
- Our production controller still runs 0.12.3.post1, so this exact override has not yet been exercised on a live controller; the incident analysis in #10123 is from that deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)