### PR TITLE
[Storage] Fix awscli bootstrap in R2/OciS3/Nebius/CoreWeave/Vast stores (check PATH, exec venv)

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -53,15 +53,21 @@ class CloudStorage:
         raise NotImplementedError
 
 
+# Commands an S3-compatible store runs before its sync command to resolve the
+# AWS CLI: prefer a preinstalled `aws` on PATH, otherwise install awscli into
+# the SkyPilot runtime venv. Either way the sync command invokes the resolved
+# binary via `$awscli_path`.
+_AWSCLI_RESOLVE_CMDS = [
+    'awscli_path=$(command -v aws) || '
+    f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+    f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
+]
+
+
 class S3CloudStorage(CloudStorage):
     """AWS Cloud Storage."""
 
-    # List of commands to install AWS CLI
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Returns whether S3 'url' is a directory.
@@ -364,12 +370,7 @@ class AzureBlobCloudStorage(CloudStorage):
 class R2CloudStorage(CloudStorage):
     """Cloudflare Cloud Storage."""
 
-    # List of commands to install AWS CLI
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Returns whether R2 'url' is a directory.
@@ -562,12 +563,7 @@ class OciS3CloudStorage(CloudStorage):
     native OCI credentials.
     """
 
-    # List of commands to install AWS CLI
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Returns whether OCI 'url' is a directory.
@@ -641,12 +637,7 @@ class OciS3CloudStorage(CloudStorage):
 class NebiusCloudStorage(CloudStorage):
     """Nebius Cloud Storage."""
 
-    # List of commands to install AWS CLI
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Returns whether nebius 'url' is a directory.
@@ -702,12 +693,7 @@ class NebiusCloudStorage(CloudStorage):
 class CoreWeaveCloudStorage(CloudStorage):
     """CoreWeave Cloud Storage."""
 
-    # List of commands to install AWS CLI
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Checks if the coreweave object is a directory.
@@ -778,11 +764,7 @@ class VastDataCloudStorage(CloudStorage):
     (GPU compute).
     """
 
-    _GET_AWSCLI = [
-        'awscli_path=$(which aws) || '
-        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
-        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
-    ]
+    _GET_AWSCLI = _AWSCLI_RESOLVE_CMDS
 
     def is_directory(self, url: str) -> bool:
         """Returns whether VastData 'url' is a directory."""

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -54,11 +54,13 @@ class CloudStorage:
 
 
 # Commands an S3-compatible store runs before its sync command to resolve the
-# AWS CLI: prefer a preinstalled `aws` on PATH, otherwise install awscli into
-# the SkyPilot runtime venv. Either way the sync command invokes the resolved
-# binary via `$awscli_path`.
+# AWS CLI: prefer a preinstalled, working `aws` on PATH (the --version probe
+# rejects broken binaries and shell aliases, which `command -v` also
+# resolves), otherwise install awscli into the SkyPilot runtime venv. Either
+# way the sync command invokes the resolved binary via `$awscli_path`.
 _AWSCLI_RESOLVE_CMDS = [
-    'awscli_path=$(command -v aws) || '
+    'awscli_path=$(command -v aws) && '
+    '"$awscli_path" --version >/dev/null 2>&1 || '
     f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
     f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
 ]
@@ -96,7 +98,7 @@ class S3CloudStorage(CloudStorage):
         # AWS Sync by default uses 10 threads to upload files to the bucket.
         # To increase parallelism, modify max_concurrent_requests in your
         # aws config file (Default path: ~/.aws/config).
-        download_via_awscli = (f'$awscli_path s3 sync --no-follow-symlinks '
+        download_via_awscli = (f'"$awscli_path" s3 sync --no-follow-symlinks '
                                f'{source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
@@ -105,7 +107,7 @@ class S3CloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
-        download_via_awscli = (f'$awscli_path s3 cp {source} {destination}')
+        download_via_awscli = (f'"$awscli_path" s3 cp {source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)
@@ -404,7 +406,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               '$awscli_path s3 '
+                               '"$awscli_path" s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--endpoint {endpoint_url} '
@@ -421,7 +423,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               '$awscli_path s3 '
+                               '"$awscli_path" s3 '
                                f'cp {source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -603,7 +605,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
@@ -625,7 +627,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             f'cp {source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
 
@@ -668,7 +670,7 @@ class NebiusCloudStorage(CloudStorage):
         # aws config file (Default path: ~/.aws/config).
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = ('$awscli_path s3 '
+        download_via_awscli = ('"$awscli_path" s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
@@ -681,7 +683,7 @@ class NebiusCloudStorage(CloudStorage):
         """Downloads a file using AWS CLI."""
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = ('$awscli_path s3 '
+        download_via_awscli = ('"$awscli_path" s3 '
                                f'cp {source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
 
@@ -731,7 +733,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
@@ -748,7 +750,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             f'cp {source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
 
@@ -791,7 +793,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--endpoint {endpoint_url} '
@@ -810,7 +812,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            '$awscli_path s3 '
+            '"$awscli_path" s3 '
             f'cp {source} {destination} '
             f'--endpoint {endpoint_url} '
             f'--profile={vastdata.VASTDATA_PROFILE_NAME}')

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -366,8 +366,9 @@ class R2CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -402,7 +403,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               '$awscli_path s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--endpoint {endpoint_url} '
@@ -419,7 +420,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               '$awscli_path s3 '
                                f'cp {source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -563,8 +564,9 @@ class OciS3CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -605,7 +607,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
@@ -627,7 +629,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
 
@@ -641,8 +643,9 @@ class NebiusCloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -674,7 +677,7 @@ class NebiusCloudStorage(CloudStorage):
         # aws config file (Default path: ~/.aws/config).
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+        download_via_awscli = ('$awscli_path s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
@@ -687,7 +690,7 @@ class NebiusCloudStorage(CloudStorage):
         """Downloads a file using AWS CLI."""
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+        download_via_awscli = ('$awscli_path s3 '
                                f'cp {source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
 
@@ -701,8 +704,9 @@ class CoreWeaveCloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -741,7 +745,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
@@ -758,7 +762,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
 
@@ -775,8 +779,9 @@ class VastDataCloudStorage(CloudStorage):
     """
 
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -804,7 +809,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--endpoint {endpoint_url} '
@@ -823,7 +828,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--endpoint {endpoint_url} '
             f'--profile={vastdata.VASTDATA_PROFILE_NAME}')

--- a/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
@@ -152,7 +152,7 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
         # The CLI resolves to a preinstalled `aws` when present, or the
         # runtime-venv binary after a fallback install.
         self.assertIn('awscli_path=$(command -v aws)', cmd)
-        self.assertIn('$awscli_path s3 sync', cmd)
+        self.assertIn('"$awscli_path" s3 sync', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('AWS_CONFIG_FILE=~/.oci/s3.config', cmd)
         self.assertIn('--profile=oci', cmd)
@@ -163,7 +163,7 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
         self.assertIn('s3://bucket/path/file', cmd)
         self.assertNotIn('oci://', cmd)
         self.assertIn('awscli_path=$(command -v aws)', cmd)
-        self.assertIn('$awscli_path s3 cp', cmd)
+        self.assertIn('"$awscli_path" s3 cp', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('--profile=oci', cmd)
 

--- a/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
@@ -149,7 +149,10 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
             'oci://bucket/path', '/dest')
         self.assertIn('s3://bucket/path', cmd)
         self.assertNotIn('oci://', cmd)
-        self.assertIn('aws s3 sync', cmd)
+        # The CLI resolves to a preinstalled `aws` when present, or the
+        # runtime-venv binary after a fallback install.
+        self.assertIn('awscli_path=$(command -v aws)', cmd)
+        self.assertIn('$awscli_path s3 sync', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('AWS_CONFIG_FILE=~/.oci/s3.config', cmd)
         self.assertIn('--profile=oci', cmd)
@@ -159,7 +162,8 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
             'oci://bucket/path/file', '/dest')
         self.assertIn('s3://bucket/path/file', cmd)
         self.assertNotIn('oci://', cmd)
-        self.assertIn('aws s3 cp', cmd)
+        self.assertIn('awscli_path=$(command -v aws)', cmd)
+        self.assertIn('$awscli_path s3 cp', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('--profile=oci', cmd)
 


### PR DESCRIPTION
Fixes #10125.

Five S3-compatible stores (`R2CloudStorage`, `OciS3CloudStorage`, `NebiusCloudStorage`, `CoreWeaveCloudStorage`, `VastCloudStorage`) checked for a preinstalled `aws` binary but then unconditionally executed the runtime-venv `aws` — on images that ship their own awscli (where the venv copy is absent), every sync failed even though a working CLI was on PATH.

This PR makes the check and the invocation agree, using the same pattern `S3CloudStorage` already uses: resolve the CLI once (`command -v aws`, falling back to installing awscli into the runtime venv) and invoke the resolved `$awscli_path` in the sync command.

Review notes:

- All six stores (the five fixed ones plus `S3CloudStorage`, whose inline copy predates this PR) now share one module-level `_AWSCLI_RESOLVE_CMDS`, so the resolve logic exists in exactly one place. Net diff is -9 lines.
- `command -v` (POSIX builtin) instead of `which` (external binary, absent in slim images), per review.
- `tests/unit_tests/test_sky/storage/test_oci_s3_store.py` assertions updated to the resolved-path command shape.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): `pytest tests/unit_tests/test_sky/storage/test_oci_s3_store.py` (14 passed). Manually reproduced the original failure on a worker image shipping a system awscli (R2 store, sync failed with the venv path missing) and verified the fix syncs via the preinstalled CLI.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)