### PR TITLE
[Core] Avoid reinstalling jq during Docker setup

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -379,7 +379,8 @@ class DockerInitializer:
             # issue with nvidia container toolkit:
             # https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
             self._run(
-                '{ which jq || sudo apt update && sudo apt install -y jq; } && '
+                '{ which jq || '
+                '{ sudo apt update && sudo apt install -y jq; }; } && '
                 '{ [ -f /etc/docker/daemon.json ] || '
                 'echo "{}" | sudo tee /etc/docker/daemon.json;'
                 'sudo jq \'.["exec-opts"] = ["native.cgroupdriver=cgroupfs"]\' '


### PR DESCRIPTION
Summary: Fixes shell grouping so jq installation runs only when jq is absent, removing about 2.6 seconds from an already-baked Docker node. Test plan: SkyPilot YAPF/isort and shell checks for both installed and missing branches; repo-wide mypy reached unrelated missing third-party stubs in the temporary environment.