### PR TITLE
[Core] Skip Ray stop after instance boot

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -393,7 +393,8 @@ _SHARED_RAY_PORT_FLAGS = (
 
 
 def ray_head_start_command(custom_resource: Optional[str],
-                           custom_ray_options: Optional[Dict[str, Any]]) -> str:
+                           custom_ray_options: Optional[Dict[str, Any]],
+                           no_restart: bool = False) -> str:
     """Returns the command to start Ray on the head node."""
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
@@ -416,8 +417,9 @@ def ray_head_start_command(custom_resource: Optional[str],
         for key, value in custom_ray_options.items():
             ray_options += f' --{key}={value}'
 
+    stop_ray = '' if no_restart else f'{constants.SKY_RAY_CMD} stop; '
     cmd = (
-        _host_network_probe_cmd('head') + f'{constants.SKY_RAY_CMD} stop; '
+        _host_network_probe_cmd('head') + stop_ray +
         'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
         # worker_maximum_startup_concurrency controls the maximum number of
         # workers that can be started concurrently. However, it also controls
@@ -481,7 +483,8 @@ def ray_worker_start_command(custom_resource: Optional[str],
 @timeline.event
 def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
                            cluster_info: common.ClusterInfo,
-                           ssh_credentials: Dict[str, Any]) -> None:
+                           ssh_credentials: Dict[str, Any],
+                           no_restart: bool) -> None:
     """Start Ray on the head node."""
     runners = provision.get_command_runners(cluster_info.provider_name,
                                             cluster_info, **ssh_credentials)
@@ -492,7 +495,7 @@ def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
     # Log the head node's output to the provision.log
     log_path_abs = str(provision_logging.get_log_path())
     cmd = ray_head_start_command(custom_resource,
-                                 cluster_info.custom_ray_options)
+                                 cluster_info.custom_ray_options, no_restart)
     logger.info(f'Running command on head node: {cmd}')
     # TODO(zhwu): add the output to log files.
     returncode, stdout, stderr = head_runner.run(

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -690,7 +690,9 @@ def _post_provision_setup(
                 cluster_name.name_on_cloud,
                 custom_resource=custom_resource,
                 cluster_info=cluster_info,
-                ssh_credentials=ssh_credentials)
+                ssh_credentials=ssh_credentials,
+                no_restart=provision_record.is_instance_just_booted(
+                    head_instance.instance_id))
         else:
             logger.debug('Ray cluster on head is ready. Skip starting ray '
                          'cluster on head node.')

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -62,6 +62,17 @@ class TestProbePorts:
 class TestRayStartCommands:
     """ray_head_start_command / ray_worker_start_command behavior."""
 
+    def test_head_stops_ray_by_default(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        assert f'{constants.SKY_RAY_CMD} stop; ' in cmd
+
+    def test_head_skips_ray_stop_after_boot(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None,
+                                                    no_restart=True)
+        assert f'{constants.SKY_RAY_CMD} stop; ' not in cmd
+
     def test_head_uses_default_ports_when_env_vars_unset(self):
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
                                                     custom_ray_options=None)


### PR DESCRIPTION
Summary: Uses the provision record contract that freshly created or resumed nodes have no running services to skip an unnecessary ray stop, worth about 3.2 seconds in the measured launch. Test plan: 29 focused unit tests passed plus SkyPilot YAPF/isort; repo-wide mypy reached unrelated missing third-party stubs in the temporary environment.