### PR TITLE
[Volume] Reject negative ephemeral volume sizes

### DIFF
--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -154,7 +154,7 @@ class VolumeMount:
             size = resources_utils.parse_memory_resource(size_config,
                                                          'size',
                                                          allow_rounding=True)
-            if size == '0':
+            if int(size) < 1:
                 raise ValueError('Size must be no less than 1Gi')
         except ValueError as e:
             raise ValueError(

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -130,11 +130,12 @@ class TestVolumeMount:
         assert 'Unsupported ephemeral volume type' in str(exc_info.value)
         assert 'invalid-type' in str(exc_info.value)
 
-    def test_resolve_ephemeral_config_zero_size(self):
-        """Test resolve_ephemeral_config with zero size."""
+    @pytest.mark.parametrize('size', ['0', -1, '-1Gi'])
+    def test_resolve_ephemeral_config_non_positive_size(self, size):
+        """Test resolve_ephemeral_config with non-positive size."""
         path = '/data'
         config = {
-            'size': '0',
+            'size': size,
         }
 
         with pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
## Summary

- Reject negative ephemeral volume sizes during task validation instead of passing invalid PVC requests to Kubernetes.
- Cover zero, plain negative, and unit-suffixed negative inputs with the existing validation error.

## Root cause

`parse_memory_resource()` accepts signed numeric values, while ephemeral volume validation only rejected the exact string `0`. Values such as `-1` and `-1Gi` therefore reached provisioning as a `-1Gi` storage request.

## Tested

- `yapf --diff sky/utils/volume.py tests/unit_tests/test_sky/utils/test_volume_utils.py`
- `isort --check-only sky/utils/volume.py tests/unit_tests/test_sky/utils/test_volume_utils.py`
- `python -m compileall -q sky/utils/volume.py tests/unit_tests/test_sky/utils/test_volume_utils.py`
- `pylint sky/utils/volume.py` (10.00/10)
- `mypy sky/utils/volume.py`
- Direct method harness: `0`, `-1`, and `-1Gi` rejected; `1Gi` accepted