### PR TITLE
[API] Add config post-save hook carrying old/new config and user

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1074,10 +1074,7 @@ def register_config_save_validator(
 # Post-save hooks invoked at the end of `update_api_server_config_no_lock`,
 # after the new config has been persisted and reloaded in-process. Unlike
 # `register_config_update_hook`, each hook receives the previously persisted
-# config, the newly persisted config, and the user who made the change, so
-# server-side integrations can record config history or audit trails.
-# Registered at server startup during single-threaded plugin loading, so no
-# lock is needed.
+# config, the newly persisted config, and the user who made the change.
 ConfigPostSaveHook = Callable[
     [config_utils.Config, config_utils.Config, Optional['models.User']], None]
 _CONFIG_POST_SAVE_HOOKS: List[ConfigPostSaveHook] = []
@@ -1385,12 +1382,12 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         assert old_config is not None
         user = common_utils.get_current_user()
         # At this point `config` reflects what was persisted (e.g. with the
-        # ('db',) key stripped); hand hooks a copy so mutations by one hook
-        # cannot leak into another.
-        saved_config = copy.deepcopy(config)
+        # ('db',) key stripped); hand each hook its own copies so mutations
+        # by one hook cannot leak into another.
         for post_save_hook in list(_CONFIG_POST_SAVE_HOOKS):
             try:
-                post_save_hook(old_config, saved_config, user)
+                post_save_hook(copy.deepcopy(old_config), copy.deepcopy(config),
+                               user)
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(
                     f'Config post-save hook {post_save_hook!r} raised: {e}',

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -81,6 +81,8 @@ from sky.utils.kubernetes import config_map_utils
 
 if typing.TYPE_CHECKING:
     import yaml
+
+    from sky import models
 else:
     yaml = adaptors_common.LazyImport('yaml')
 
@@ -1069,6 +1071,34 @@ def register_config_save_validator(
         _CONFIG_SAVE_VALIDATORS.append(fn)
 
 
+# Post-save hooks invoked at the end of `update_api_server_config_no_lock`,
+# after the new config has been persisted and reloaded in-process. Unlike
+# `register_config_update_hook`, each hook receives the previously persisted
+# config, the newly persisted config, and the user who made the change, so
+# server-side integrations can record config history or audit trails.
+# Registered at server startup during single-threaded plugin loading, so no
+# lock is needed.
+ConfigPostSaveHook = Callable[
+    [config_utils.Config, config_utils.Config, Optional['models.User']], None]
+_CONFIG_POST_SAVE_HOOKS: List[ConfigPostSaveHook] = []
+
+
+def register_config_post_save_hook(fn: ConfigPostSaveHook) -> None:
+    """Register a hook invoked after the API server config is saved.
+
+    Called at server startup during plugin loading (single-threaded), so no
+    lock is needed. Each hook is called as ``fn(old, new, user)`` after the
+    new config has been persisted and reloaded, where ``old`` is the
+    previously persisted config, ``new`` is the config that was just saved,
+    and ``user`` is the user who made the change. Hooks receive copies, so
+    mutating them has no effect. Like `register_config_update_hook`,
+    exceptions are caught and logged so a misbehaving hook cannot fail the
+    config update.
+    """
+    if fn not in _CONFIG_POST_SAVE_HOOKS:
+        _CONFIG_POST_SAVE_HOOKS.append(fn)
+
+
 def _get_effective_k8s_config_value(
         cloud: str,
         property_keys: List[Tuple[str, ...]],
@@ -1278,15 +1308,21 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
             constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
         raise ValueError('This function can only be called by the API Server.')
 
+    # Capture the currently persisted config before it is overwritten, for
+    # save validators and post-save hooks (to_dict() returns a fresh copy).
+    old_config: Optional[config_utils.Config] = None
+    if _CONFIG_SAVE_VALIDATORS or _CONFIG_POST_SAVE_HOOKS:
+        old_config = to_dict()
+
     # Run registered validators before persisting the config, so a validator
     # can veto the save by raising; exceptions propagate to abort the update.
     # Validators must not mutate the config, so hand them a deep copy of the
-    # incoming config (to_dict() already returns a fresh copy for `current`).
+    # incoming config.
     if _CONFIG_SAVE_VALIDATORS:
-        current = to_dict()
+        assert old_config is not None
         incoming = copy.deepcopy(config)
         for validator in list(_CONFIG_SAVE_VALIDATORS):
-            validator(current, incoming)
+            validator(old_config, incoming)
 
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
@@ -1345,3 +1381,17 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'Config-update hook {hook!r} raised: {e}',
                            exc_info=True)
+    if _CONFIG_POST_SAVE_HOOKS:
+        assert old_config is not None
+        user = common_utils.get_current_user()
+        # At this point `config` reflects what was persisted (e.g. with the
+        # ('db',) key stripped); hand hooks a copy so mutations by one hook
+        # cannot leak into another.
+        saved_config = copy.deepcopy(config)
+        for post_save_hook in list(_CONFIG_POST_SAVE_HOOKS):
+            try:
+                post_save_hook(old_config, saved_config, user)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Config post-save hook {post_save_hook!r} raised: {e}',
+                    exc_info=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1068,6 +1068,72 @@ def test_config_save_validator(monkeypatch, tmp_path):
     assert skypilot_config._CONFIG_SAVE_VALIDATORS.count(passing_validator) == 1
 
 
+def test_config_post_save_hook(monkeypatch, tmp_path):
+    """Post-save hooks receive the old config, new config, and the user."""
+    monkeypatch.delenv(skypilot_config.ENV_VAR_GLOBAL_CONFIG, raising=False)
+    monkeypatch.delenv(skypilot_config.ENV_VAR_PROJECT_CONFIG, raising=False)
+    # Isolate the hook registries so the test does not leak global state.
+    monkeypatch.setattr(skypilot_config, '_CONFIG_POST_SAVE_HOOKS', [])
+    monkeypatch.setattr(skypilot_config, '_CONFIG_SAVE_VALIDATORS', [])
+    monkeypatch.setattr(skypilot_config, '_CONFIG_UPDATE_HOOKS', [])
+
+    config_path = str(tmp_path / 'server_config.yaml')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    with open(config_path, 'w', encoding='utf-8') as f:
+        f.write(
+            textwrap.dedent("""\
+                aws:
+                    labels:
+                        original: present
+                """))
+    skypilot_config.reload_config()
+
+    new_config = skypilot_config.to_dict()
+    new_config.set_nested(('aws', 'labels', 'added'), 'yes')
+
+    calls = []
+
+    def post_save_hook(old, new, user):
+        calls.append((copy.deepcopy(old), copy.deepcopy(new), user))
+        # A raising hook must not fail the save.
+        raise RuntimeError('hook exploded')
+
+    skypilot_config.register_config_post_save_hook(post_save_hook)
+    skypilot_config.update_api_server_config_no_lock(new_config)
+
+    # The save went through despite the raising hook.
+    assert yaml_utils.read_yaml(config_path) == {
+        'aws': {
+            'labels': {
+                'original': 'present',
+                'added': 'yes'
+            }
+        }
+    }
+    assert len(calls) == 1
+    seen_old, seen_new, seen_user = calls[0]
+    assert seen_old.get_nested(('aws', 'labels', 'added'), None) is None
+    assert seen_old.get_nested(('aws', 'labels', 'original'), None) == 'present'
+    assert seen_new.get_nested(('aws', 'labels', 'added'), None) == 'yes'
+    assert seen_user is not None
+    assert seen_user.id
+
+    # Hooks receive copies: mutating them does not affect the loaded config.
+    def mutating_hook(old, new, user):
+        del old, user
+        new.set_nested(('aws', 'labels', 'mutated'), 'yes')
+
+    monkeypatch.setattr(skypilot_config, '_CONFIG_POST_SAVE_HOOKS', [])
+    skypilot_config.register_config_post_save_hook(mutating_hook)
+    skypilot_config.update_api_server_config_no_lock(new_config)
+    assert skypilot_config.get_nested(
+        ('aws', 'labels', 'mutated'), None) is None
+
+    # Registration is idempotent.
+    skypilot_config.register_config_post_save_hook(mutating_hook)
+    assert skypilot_config._CONFIG_POST_SAVE_HOOKS.count(mutating_hook) == 1
+
+
 def test_kubernetes_context_configs(monkeypatch, tmp_path) -> None:
     """Test that the nested config works."""
     from sky.provision.kubernetes import utils as kubernetes_utils

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1118,16 +1118,27 @@ def test_config_post_save_hook(monkeypatch, tmp_path):
     assert seen_user is not None
     assert seen_user.id
 
-    # Hooks receive copies: mutating them does not affect the loaded config.
+    # Each hook receives its own copies: mutating them affects neither the
+    # loaded config nor the configs seen by subsequent hooks.
+    observed = []
+
     def mutating_hook(old, new, user):
-        del old, user
+        del user
+        old.set_nested(('aws', 'labels', 'mutated_old'), 'yes')
         new.set_nested(('aws', 'labels', 'mutated'), 'yes')
+
+    def observing_hook(old, new, user):
+        del user
+        observed.append((old.get_nested(('aws', 'labels', 'mutated_old'), None),
+                         new.get_nested(('aws', 'labels', 'mutated'), None)))
 
     monkeypatch.setattr(skypilot_config, '_CONFIG_POST_SAVE_HOOKS', [])
     skypilot_config.register_config_post_save_hook(mutating_hook)
+    skypilot_config.register_config_post_save_hook(observing_hook)
     skypilot_config.update_api_server_config_no_lock(new_config)
     assert skypilot_config.get_nested(
         ('aws', 'labels', 'mutated'), None) is None
+    assert observed == [(None, None)]
 
     # Registration is idempotent.
     skypilot_config.register_config_post_save_hook(mutating_hook)


### PR DESCRIPTION
## Summary

- Adds `skypilot_config.register_config_post_save_hook()`, fired at the end of `update_api_server_config_no_lock()` after the new config has been persisted and reloaded.
- Each hook is called as `fn(old_config, new_config, user)`: the previously persisted config, the newly persisted config (post `('db',)`-strip, i.e. exactly what was saved), and the user who made the change (resolved via `common_utils.get_current_user()` in the request worker). This lets server-side integrations record config change history or audit trails — the existing `register_config_update_hook()` is zero-arg (cache invalidation only) and `register_config_save_validator()` is pre-write veto only.
- Hooks receive copies and exceptions are caught and logged, so a misbehaving hook cannot fail or corrupt the config update. The old-config snapshot is shared with the validator path (one `to_dict()` call).

## Tested

- Added `test_config_post_save_hook` covering: hook receives correct old/new/user, a raising hook does not fail the save, hooks get copies (mutation does not leak into the loaded config), and idempotent registration.
- `pytest tests/test_config.py` — 45 passed.
- `pytest tests/unit_tests/test_sky/workspaces/test_workspace_management.py` — passed. (`tests/unit_tests/test_sky/utils/kubernetes/test_skypilot_config_configmap_sync.py` has 2 failures that reproduce identically on clean master in my environment; unrelated to this change.)
- `bash format.sh --files sky/skypilot_config.py tests/test_config.py` — yapf/isort/mypy clean; pylint warnings match the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)