### PR TITLE
[SLURM] Implement Slurm cluster registration API and RBAC

### DIFF
--- a/sky/provision/slurm/registration.py
+++ b/sky/provision/slurm/registration.py
@@ -1,0 +1,296 @@
+"""Remote registration of Slurm clusters.
+
+In client-server mode nothing can *register* a Slurm cluster remotely: the
+``~/.slurm/config`` file (an OpenSSH ``ssh_config``-format file) and the
+per-cluster identity / ``known_hosts`` files live only on the API server's
+filesystem, and the only slurm HTTP endpoints upstream are read-only. This
+module provides the read-modify-write core behind the ``/slurm_clusters`` CRUD
+router so an admin control plane (e.g. a multi-tenant enrollment flow) can
+register clusters over HTTP instead of writing daemon-local files by hand.
+
+The ``~/.slurm/config`` file is parsed with ``paramiko.config.SSHConfig`` (see
+``sky.provision.slurm.utils``) which has no writer, so this module renders
+``Host`` blocks itself. Blocks it manages are wrapped in sentinel markers
+(``# BEGIN skypilot-managed <name>`` / ``# END skypilot-managed <name>``); any
+content outside those markers (e.g. hand-added hosts, ``Host *`` defaults) is
+preserved verbatim on every write.
+
+All writes are guarded by a distributed lock (``sky.utils.locks``) because
+concurrent enrollments against a shared API server are the expected use case --
+unlike ``SSHNodePoolManager``'s unlocked read-modify-write.
+"""
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from paramiko.config import SSHConfig
+
+from sky import sky_logging
+from sky.provision.slurm import utils as slurm_utils
+from sky.utils import locks
+
+logger = sky_logging.init_logger(__name__)
+
+# Directory (under the same parent as ~/.slurm/config) holding per-cluster
+# identity files and known_hosts files written by the registration API.
+_SLURM_DIR = os.path.dirname(slurm_utils.DEFAULT_SLURM_PATH)
+KEYS_DIR = os.path.join(_SLURM_DIR, 'keys')
+KNOWN_HOSTS_DIR = os.path.join(_SLURM_DIR, 'known_hosts')
+
+# Lock guarding all rewrites of ~/.slurm/config. Matches the filelock family
+# used for workspace config updates; auto-detects postgres when configured.
+_SLURM_CONFIG_LOCK_ID = 'slurm-config-update'
+_SLURM_CONFIG_LOCK_TIMEOUT_SECONDS = 60
+
+# Sentinel markers wrapping blocks this module owns. Everything outside a
+# BEGIN/END pair is preserved verbatim.
+_BLOCK_BEGIN = '# BEGIN skypilot-managed {name}'
+_BLOCK_END = '# END skypilot-managed {name}'
+
+# A registered cluster name is used as a Host alias and as a filename for its
+# identity / known_hosts files, so keep it to a safe charset.
+_VALID_NAME_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+
+def _validate_name(name: str) -> None:
+    if not name or not _VALID_NAME_RE.match(name):
+        raise ValueError(
+            f'Invalid Slurm cluster name {name!r}: names may only contain '
+            'letters, digits, and the characters ".", "_", and "-".')
+
+
+class SlurmClusterManager:
+    """Read-modify-write manager for ``~/.slurm/config`` and its key files."""
+
+    def __init__(self) -> None:
+        self.config_path = os.path.expanduser(slurm_utils.DEFAULT_SLURM_PATH)
+        self.keys_dir = os.path.expanduser(KEYS_DIR)
+        self.known_hosts_dir = os.path.expanduser(KNOWN_HOSTS_DIR)
+
+    # ---- public read API ------------------------------------------------
+
+    def list_clusters(self) -> Dict[str, Dict[str, Any]]:
+        """Return registered clusters and their non-secret detail.
+
+        Reads via paramiko so both managed and hand-added hosts are listed.
+        Identity file *contents* and host keys are never returned -- only the
+        connection detail needed to identify a cluster.
+        """
+        path = self.config_path
+        if not os.path.exists(path):
+            return {}
+        ssh_config = SSHConfig.from_path(path)
+        clusters: Dict[str, Dict[str, Any]] = {}
+        for name in ssh_config.get_hostnames():
+            if name == '*':
+                continue
+            resolved = ssh_config.lookup(name)
+            clusters[name] = {
+                'name': name,
+                'host': resolved.get('hostname'),
+                'user': resolved.get('user'),
+                'port': int(resolved['port']) if 'port' in resolved else None,
+                'proxy_jump': resolved.get('proxyjump'),
+                'managed': self._is_managed(name),
+            }
+        return clusters
+
+    # ---- public write API (lock-guarded) --------------------------------
+
+    def register_cluster(
+        self,
+        name: str,
+        host: str,
+        user: str,
+        identity_file: str,
+        port: int = 22,
+        host_key: Optional[str] = None,
+        proxy_jump: Optional[str] = None,
+        identities_only: bool = True,
+    ) -> None:
+        """Upsert a cluster block plus its identity / known_hosts files.
+
+        Args:
+            name: Cluster name, used as the ``Host`` alias.
+            host: The ``HostName`` to connect to.
+            user: SSH user.
+            identity_file: Private key *contents* (not a path); stored 0600.
+            port: SSH port.
+            host_key: Optional ``known_hosts`` file *contents*. When provided,
+                the block pins the host key with ``StrictHostKeyChecking yes``
+                and a per-cluster ``UserKnownHostsFile``.
+            proxy_jump: Optional ``ProxyJump`` value (e.g. a bastion alias).
+            identities_only: Whether to set ``IdentitiesOnly yes``.
+        """
+        _validate_name(name)
+        if not host:
+            raise ValueError('`host` is required.')
+        if not user:
+            raise ValueError('`user` is required.')
+        if not identity_file:
+            raise ValueError('`identity_file` (key contents) is required.')
+
+        with locks.get_lock(_SLURM_CONFIG_LOCK_ID,
+                            _SLURM_CONFIG_LOCK_TIMEOUT_SECONDS):
+            identity_path = self._write_identity_file(name, identity_file)
+            known_hosts_path = None
+            if host_key:
+                known_hosts_path = self._write_known_hosts_file(name, host_key)
+
+            block = self._render_block(
+                name=name,
+                host=host,
+                user=user,
+                port=port,
+                identity_path=identity_path,
+                known_hosts_path=known_hosts_path,
+                proxy_jump=proxy_jump,
+                identities_only=identities_only,
+            )
+            content = self._read_config()
+            content = self._replace_block(content, name, block)
+            self._write_config(content)
+
+    def delete_cluster(self, name: str) -> bool:
+        """Remove a managed cluster block and its identity / known_hosts files.
+
+        Returns True if a managed block was removed, False if none existed.
+        """
+        _validate_name(name)
+        with locks.get_lock(_SLURM_CONFIG_LOCK_ID,
+                            _SLURM_CONFIG_LOCK_TIMEOUT_SECONDS):
+            content = self._read_config()
+            new_content = self._replace_block(content, name, block=None)
+            removed = new_content != content
+            if removed:
+                self._write_config(new_content)
+            # Best-effort cleanup of the sidecar files regardless.
+            for path in (os.path.join(self.keys_dir, name),
+                         os.path.join(self.known_hosts_dir, name)):
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError as e:
+                    logger.warning(f'Failed to remove {path}: {e}')
+            return removed
+
+    # ---- internals ------------------------------------------------------
+
+    def _read_config(self) -> str:
+        if not os.path.exists(self.config_path):
+            return ''
+        with open(self.config_path, 'r', encoding='utf-8') as f:
+            return f.read()
+
+    def _write_config(self, content: str) -> None:
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+        # Atomic replace so a concurrent reader never sees a half-written file.
+        tmp_path = f'{self.config_path}.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        os.replace(tmp_path, self.config_path)
+
+    def _write_identity_file(self, name: str, contents: str) -> str:
+        os.makedirs(self.keys_dir, exist_ok=True)
+        path = os.path.join(self.keys_dir, name)
+        # Write then chmod 0600 (ssh refuses world-readable private keys).
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(contents)
+            if not contents.endswith('\n'):
+                f.write('\n')
+        os.chmod(path, 0o600)
+        return path
+
+    def _write_known_hosts_file(self, name: str, contents: str) -> str:
+        os.makedirs(self.known_hosts_dir, exist_ok=True)
+        path = os.path.join(self.known_hosts_dir, name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(contents)
+            if not contents.endswith('\n'):
+                f.write('\n')
+        os.chmod(path, 0o600)
+        return path
+
+    def _is_managed(self, name: str) -> bool:
+        begin = _BLOCK_BEGIN.format(name=name)
+        return begin in self._read_config()
+
+    @staticmethod
+    def _render_block(name: str, host: str, user: str, port: int,
+                      identity_path: str, known_hosts_path: Optional[str],
+                      proxy_jump: Optional[str], identities_only: bool) -> str:
+        lines = [
+            _BLOCK_BEGIN.format(name=name),
+            f'Host {name}',
+            f'    HostName {host}',
+            f'    User {user}',
+            f'    Port {port}',
+            f'    IdentityFile {identity_path}',
+        ]
+        if identities_only:
+            lines.append('    IdentitiesOnly yes')
+        if known_hosts_path is not None:
+            # Pin the host key so a swapped/MITM'd host fails the connection.
+            lines.append('    StrictHostKeyChecking yes')
+            lines.append(f'    UserKnownHostsFile {known_hosts_path}')
+        if proxy_jump:
+            lines.append(f'    ProxyJump {proxy_jump}')
+        lines.append(_BLOCK_END.format(name=name))
+        return '\n'.join(lines) + '\n'
+
+    @staticmethod
+    def _replace_block(content: str, name: str, block: Optional[str]) -> str:
+        """Replace (or delete, when block is None) the managed block for name.
+
+        Content outside the BEGIN/END markers is preserved verbatim. When no
+        managed block exists and ``block`` is given, it is appended.
+        """
+        begin = re.escape(_BLOCK_BEGIN.format(name=name))
+        end = re.escape(_BLOCK_END.format(name=name))
+        # Match the marker pair and any trailing newline after END.
+        pattern = re.compile(rf'{begin}\n.*?{end}\n?', re.DOTALL)
+        if pattern.search(content):
+            replacement = block if block is not None else ''
+            return pattern.sub(lambda _: replacement or '', content, count=1)
+        # No existing managed block.
+        if block is None:
+            return content
+        if content and not content.endswith('\n'):
+            content += '\n'
+        # Separate blocks with a blank line for readability.
+        if content:
+            content += '\n'
+        return content + block
+
+
+# Module-level convenience wrappers (mirrors ssh_node_pools.core).
+
+
+def list_clusters() -> Dict[str, Dict[str, Any]]:
+    return SlurmClusterManager().list_clusters()
+
+
+def register_cluster(name: str,
+                     host: str,
+                     user: str,
+                     identity_file: str,
+                     port: int = 22,
+                     host_key: Optional[str] = None,
+                     proxy_jump: Optional[str] = None,
+                     identities_only: bool = True) -> None:
+    SlurmClusterManager().register_cluster(name=name,
+                                           host=host,
+                                           user=user,
+                                           identity_file=identity_file,
+                                           port=port,
+                                           host_key=host_key,
+                                           proxy_jump=proxy_jump,
+                                           identities_only=identities_only)
+
+
+def delete_cluster(name: str) -> bool:
+    return SlurmClusterManager().delete_cluster(name)
+
+
+def registered_cluster_names() -> List[str]:
+    return list(SlurmClusterManager().list_clusters().keys())

--- a/sky/provision/slurm/server.py
+++ b/sky/provision/slurm/server.py
@@ -1,0 +1,87 @@
+"""Remote Slurm cluster registration API endpoints.
+
+CRUD over ``~/.slurm/config`` (an OpenSSH ``ssh_config``-format file) and the
+per-cluster identity / ``known_hosts`` files on the API server. Mirrors the
+structure of ``sky/ssh_node_pools/server.py``: synchronous handlers that call
+the registration core directly (no long-running work, so no ``executor``).
+
+This is a control-plane surface with no per-caller scoping on the management
+files it writes, so the whole router is blocklisted for the ``user`` role in
+``sky/users/rbac.py``.
+"""
+from typing import Any, Dict, List
+
+import fastapi
+
+from sky.provision.slurm import registration
+from sky.utils import common_utils
+
+router = fastapi.APIRouter()
+
+
+@router.get('')
+def get_slurm_clusters() -> Dict[str, Dict[str, Any]]:
+    """List registered Slurm clusters (names + non-secret detail)."""
+    try:
+        return registration.list_clusters()
+    except Exception as e:  # pylint: disable=broad-except
+        raise fastapi.HTTPException(status_code=500,
+                                    detail='Failed to list Slurm clusters: '
+                                    f'{common_utils.format_exception(e)}')
+
+
+@router.post('')
+def register_slurm_cluster(cluster: Dict[str, Any]) -> Dict[str, str]:
+    """Upsert a Slurm cluster.
+
+    Body fields: ``name``, ``host``, ``user``, ``identity_file`` (private key
+    contents), and optionally ``port`` (default 22), ``host_key``
+    (known_hosts contents, enables host-key pinning), ``proxy_jump``, and
+    ``identities_only`` (default True).
+    """
+    try:
+        registration.register_cluster(
+            name=cluster['name'],
+            host=cluster['host'],
+            user=cluster['user'],
+            identity_file=cluster['identity_file'],
+            port=int(cluster.get('port', 22)),
+            host_key=cluster.get('host_key'),
+            proxy_jump=cluster.get('proxy_jump'),
+            identities_only=cluster.get('identities_only', True),
+        )
+        return {'status': 'success'}
+    except KeyError as e:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=f'Missing required field: {e}')
+    except ValueError as e:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=common_utils.format_exception(e))
+    except Exception as e:  # pylint: disable=broad-except
+        raise fastapi.HTTPException(status_code=500,
+                                    detail='Failed to register Slurm cluster: '
+                                    f'{common_utils.format_exception(e)}')
+
+
+@router.delete('/{name}')
+def delete_slurm_cluster(name: str) -> Dict[str, str]:
+    """Remove a Slurm cluster and its identity / known_hosts files."""
+    try:
+        if registration.delete_cluster(name):
+            return {'status': 'success'}
+        raise fastapi.HTTPException(status_code=404,
+                                    detail=f'Slurm cluster `{name}` not found')
+    except fastapi.HTTPException:
+        raise
+    except ValueError as e:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=common_utils.format_exception(e))
+    except Exception as e:  # pylint: disable=broad-except
+        raise fastapi.HTTPException(status_code=500,
+                                    detail='Failed to delete Slurm cluster: '
+                                    f'{common_utils.format_exception(e)}')
+
+
+# Kept for symmetry with ssh_node_pools; unused today but re-exported so the
+# router module is the single import surface for the registration API.
+__all__: List[str] = ['router']

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -57,6 +57,7 @@ from sky.jobs.server import server as jobs_rest
 from sky.metrics import utils as metrics_utils
 from sky.provision import metadata_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.provision.slurm import server as slurm_clusters_rest
 from sky.provision.slurm import utils as slurm_utils
 from sky.recipes import server as recipes_rest
 from sky.schemas.api import responses
@@ -1086,6 +1087,9 @@ app.include_router(volumes_rest.router, prefix='/volumes', tags=['volumes'])
 app.include_router(ssh_node_pools_rest.router,
                    prefix='/ssh_node_pools',
                    tags=['ssh_node_pools'])
+app.include_router(slurm_clusters_rest.router,
+                   prefix='/slurm_clusters',
+                   tags=['slurm_clusters'])
 app.include_router(recipes_rest.router, prefix='/recipes', tags=['recipes'])
 # increase the resource limit for the server
 soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -12,46 +12,72 @@ logger = sky_logging.init_logger(__name__)
 
 # Default user blocklist for user role
 # Cannot access workspace CUD operations.
-_DEFAULT_USER_BLOCKLIST = [{
-    'path': '/workspaces/config',
-    'method': 'POST'
-}, {
-    'path': '/workspaces/update',
-    'method': 'POST'
-}, {
-    'path': '/workspaces/create',
-    'method': 'POST'
-}, {
-    'path': '/workspaces/delete',
-    'method': 'POST'
-}, {
-    'path': '/workspaces/batch_add_users',
-    'method': 'POST'
-}, {
-    'path': '/workspaces/batch_remove_users',
-    'method': 'POST'
-}, {
-    'path': '/users/delete',
-    'method': 'POST'
-}, {
-    'path': '/users/create',
-    'method': 'POST'
-}, {
-    'path': '/users/batch_update',
-    'method': 'POST'
-}, {
-    'path': '/users/import',
-    'method': 'POST'
-}, {
-    'path': '/users/export',
-    'method': 'GET'
-}, {
-    'path': '/debug/dump_create',
-    'method': 'POST'
-}, {
-    'path': '/debug/dump_download/:filename',
-    'method': 'GET'
-}]
+_DEFAULT_USER_BLOCKLIST = [
+    {
+        'path': '/workspaces/config',
+        'method': 'POST'
+    },
+    {
+        'path': '/workspaces/update',
+        'method': 'POST'
+    },
+    {
+        'path': '/workspaces/create',
+        'method': 'POST'
+    },
+    {
+        'path': '/workspaces/delete',
+        'method': 'POST'
+    },
+    {
+        'path': '/workspaces/batch_add_users',
+        'method': 'POST'
+    },
+    {
+        'path': '/workspaces/batch_remove_users',
+        'method': 'POST'
+    },
+    {
+        'path': '/users/delete',
+        'method': 'POST'
+    },
+    {
+        'path': '/users/create',
+        'method': 'POST'
+    },
+    {
+        'path': '/users/batch_update',
+        'method': 'POST'
+    },
+    {
+        'path': '/users/import',
+        'method': 'POST'
+    },
+    {
+        'path': '/users/export',
+        'method': 'GET'
+    },
+    {
+        'path': '/debug/dump_create',
+        'method': 'POST'
+    },
+    {
+        'path': '/debug/dump_download/:filename',
+        'method': 'GET'
+    },
+    {
+        'path': '/slurm_clusters',
+        'method': 'GET'
+    },
+    {
+        'path': '/slurm_clusters',
+        'method': 'POST'
+    },
+    {
+        'path': '/slurm_clusters/:name',
+        'method': 'DELETE'
+    }
+]
 
 # Default allowlist for the viewer role. Viewer is allowlist-based: any
 # endpoint NOT on this list is denied for viewers, including any new

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2376,10 +2376,10 @@ def get_config_schema():
     allowed_workspace_cloud_names = list(
         constants.ALL_CLOUDS) + constants.STORAGE_ONLY_CLOUDS
     # Create pattern for not supported clouds, i.e.
-    # all clouds except aws, gcp, kubernetes, ssh, nebius
+    # all clouds except aws, gcp, kubernetes, ssh, nebius, slurm
     not_supported_clouds = [
-        cloud for cloud in allowed_workspace_cloud_names
-        if cloud.lower() not in ['aws', 'gcp', 'kubernetes', 'ssh', 'nebius']
+        cloud for cloud in allowed_workspace_cloud_names if cloud.lower() not in
+        ['aws', 'gcp', 'kubernetes', 'ssh', 'nebius', 'slurm']
     ]
     not_supported_cloud_regex = '|'.join(not_supported_clouds)
     workspaces_schema = {
@@ -2452,6 +2452,27 @@ def get_config_schema():
                             'items': {
                                 'type': 'string',
                             },
+                        },
+                        'disabled': {
+                            'type': 'boolean'
+                        },
+                    },
+                    'additionalProperties': False,
+                },
+                'slurm': {
+                    'type': 'object',
+                    'required': [],
+                    'properties': {
+                        'allowed_clusters': {
+                            'oneOf': [{
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
+                            }, {
+                                'type': 'string',
+                                'pattern': '^all$',
+                            }],
                         },
                         'disabled': {
                             'type': 'boolean'

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -50,6 +50,9 @@ class WorkspaceConfigComparison:
         additive_allowed_contexts: True if the only non-user-access change is an
             additive kubernetes.allowed_contexts change (old contexts remain a
             subset of the new contexts)
+        additive_allowed_clusters: True if the only non-user-access change is an
+            additive slurm.allowed_clusters change (old clusters remain a
+            subset of the new clusters)
     """
     only_user_access_changes: bool
     private_changed: bool
@@ -61,6 +64,7 @@ class WorkspaceConfigComparison:
     removed_users: List[str]
     added_users: List[str]
     additive_allowed_contexts: bool = False
+    additive_allowed_clusters: bool = False
 
 
 # =========================
@@ -169,46 +173,56 @@ def _validate_workspace_config(workspace_name: str,
         raise ValueError(str(e)) from e
 
 
-def _extract_k8s_allowed_contexts(
-        config: Dict[str, Any]) -> Tuple[Dict[str, Any], Any]:
-    """Split out kubernetes.allowed_contexts from a workspace config.
+def _extract_scoped_field(config: Dict[str, Any], cloud: str,
+                          field: str) -> Tuple[Dict[str, Any], Any]:
+    """Split out ``<cloud>.<field>`` from a workspace config.
 
-    Returns a tuple of (config_without_that_field, allowed_contexts_value). The
-    value is None when the field is absent. The input config is not mutated.
+    Returns a tuple of (config_without_that_field, field_value). The value is
+    None when the field is absent. The input config is not mutated.
     """
-    # The kubernetes block may be missing or explicitly null (e.g. a bare
+    # The cloud block may be missing or explicitly null (e.g. a bare
     # `kubernetes:` in YAML), so guard against non-dict values.
-    kubernetes_config = config.get('kubernetes')
-    if (not isinstance(kubernetes_config, dict) or
-            'allowed_contexts' not in kubernetes_config):
+    cloud_config = config.get(cloud)
+    if not isinstance(cloud_config, dict) or field not in cloud_config:
         return config, None
     remaining = dict(config)
-    remaining['kubernetes'] = {
-        k: v for k, v in kubernetes_config.items() if k != 'allowed_contexts'
-    }
-    return remaining, kubernetes_config['allowed_contexts']
+    remaining[cloud] = {k: v for k, v in cloud_config.items() if k != field}
+    return remaining, cloud_config[field]
 
 
-def _is_additive_contexts(current_allowed_contexts: Any,
-                          new_allowed_contexts: Any) -> bool:
-    """Return True if allowed_contexts only grew (no existing context dropped).
+def _extract_k8s_allowed_contexts(
+        config: Dict[str, Any]) -> Tuple[Dict[str, Any], Any]:
+    """Split out kubernetes.allowed_contexts from a workspace config."""
+    return _extract_scoped_field(config, 'kubernetes', 'allowed_contexts')
+
+
+def _extract_slurm_allowed_clusters(
+        config: Dict[str, Any]) -> Tuple[Dict[str, Any], Any]:
+    """Split out slurm.allowed_clusters from a workspace config."""
+    return _extract_scoped_field(config, 'slurm', 'allowed_clusters')
+
+
+def _is_additive_allowlist(current_value: Any, new_value: Any) -> bool:
+    """Return True if an allowlist only grew (no existing entry dropped).
+
+    Used for both ``kubernetes.allowed_contexts`` and
+    ``slurm.allowed_clusters``, which share the same list-or-``'all'`` shape.
 
     Additive cases:
-    - list -> list where the old contexts are a subset of the new contexts.
-    - list -> 'all' (broadening to every kubeconfig context).
+    - list -> list where the old entries are a subset of the new entries.
+    - list -> 'all' (broadening to every available entry).
 
     Everything else (no change, 'all' -> list, absent/None on either side,
-    removals, or reorders that drop a context) is not additive.
+    removals, or reorders that drop an entry) is not additive.
     """
-    if current_allowed_contexts == new_allowed_contexts:
+    if current_value == new_value:
         return False
     # list -> 'all' is broadening.
-    if new_allowed_contexts == 'all':
-        return isinstance(current_allowed_contexts, list)
+    if new_value == 'all':
+        return isinstance(current_value, list)
     # list -> list must keep old as a subset of new.
-    if (isinstance(current_allowed_contexts, list) and
-            isinstance(new_allowed_contexts, list)):
-        return set(current_allowed_contexts).issubset(set(new_allowed_contexts))
+    if isinstance(current_value, list) and isinstance(new_value, list):
+        return set(current_value).issubset(set(new_value))
     return False
 
 
@@ -281,7 +295,19 @@ def _compare_workspace_configs(
         _extract_k8s_allowed_contexts(new_without_access))
     additive_allowed_contexts = (
         current_without_contexts == new_without_contexts and
-        _is_additive_contexts(current_allowed_contexts, new_allowed_contexts))
+        _is_additive_allowlist(current_allowed_contexts, new_allowed_contexts))
+
+    # Same treatment for slurm.allowed_clusters: an additive change (e.g.
+    # enrolling a tenant's next cluster) keeps every already-allowed cluster
+    # allowed, so running jobs stay resolvable. Only fires when it is the sole
+    # non-user-access change (the stripped remainders must be equal).
+    current_without_clusters, current_allowed_clusters = (
+        _extract_slurm_allowed_clusters(current_without_access))
+    new_without_clusters, new_allowed_clusters = (
+        _extract_slurm_allowed_clusters(new_without_access))
+    additive_allowed_clusters = (
+        current_without_clusters == new_without_clusters and
+        _is_additive_allowlist(current_allowed_clusters, new_allowed_clusters))
 
     return WorkspaceConfigComparison(
         only_user_access_changes=only_user_access_changes,
@@ -293,7 +319,8 @@ def _compare_workspace_configs(
         allowed_users_new=allowed_users_new,
         removed_users=removed_users,
         added_users=added_users,
-        additive_allowed_contexts=additive_allowed_contexts)
+        additive_allowed_contexts=additive_allowed_contexts,
+        additive_allowed_clusters=additive_allowed_clusters)
 
 
 def _validate_workspace_config_changes_with_lock(
@@ -332,7 +359,8 @@ def _validate_workspace_config_changes(
 
     This function implements the logic:
     - If only allowed_users or private changed, or the only non-user-access
-      change is an additive kubernetes.allowed_contexts change:
+      change is an additive kubernetes.allowed_contexts or
+      slurm.allowed_clusters change:
       - If private changed from true to false: allow it
       - If private changed from false to true: check that all active resources
         belong to allowed_users
@@ -340,9 +368,10 @@ def _validate_workspace_config_changes(
         resources
     - Otherwise: check that workspace has no active resources
 
-    Additive kubernetes.allowed_contexts changes (old contexts remain a subset
-    of the new contexts) are safe because every existing context stays allowed,
-    so running clusters and jobs keep resolving to a still-allowed context.
+    Additive kubernetes.allowed_contexts / slurm.allowed_clusters changes (old
+    entries remain a subset of the new entries) are safe because every existing
+    entry stays allowed, so running clusters and jobs keep resolving to a
+    still-allowed context/cluster.
 
     Args:
         workspace_name: The name of the workspace.
@@ -365,14 +394,21 @@ def _validate_workspace_config_changes(
                                                    resolver=resolver)
 
     if (config_comparison.only_user_access_changes or
-            config_comparison.additive_allowed_contexts):
-        # Only user access settings changed, and/or allowed_contexts grew
-        # additively. Both are safe for active resources; still run the
-        # user-access validation below (a no-op when only contexts changed).
+            config_comparison.additive_allowed_contexts or
+            config_comparison.additive_allowed_clusters):
+        # Only user access settings changed, and/or an allowlist
+        # (allowed_contexts / allowed_clusters) grew additively. All are safe
+        # for active resources; still run the user-access validation below (a
+        # no-op when only the allowlist changed).
         if config_comparison.additive_allowed_contexts:
             logger.info(
                 f'Workspace {workspace_name!r} only adds Kubernetes '
                 'allowed_contexts; existing contexts remain allowed. Skipping '
+                'the active-resource check for this change.')
+        if config_comparison.additive_allowed_clusters:
+            logger.info(
+                f'Workspace {workspace_name!r} only adds Slurm '
+                'allowed_clusters; existing clusters remain allowed. Skipping '
                 'the active-resource check for this change.')
         if config_comparison.private_changed:
             if (config_comparison.private_old and

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1375,3 +1375,130 @@ class TestExpandPathVars:
         result = slurm_utils.expand_path_vars('/home/; rm -rf /',
                                               self.REMOTE_ENV)
         assert result == '/home/; rm -rf /'
+
+
+class TestWorkspaceAllowedClusters:
+    """Per-workspace slurm.allowed_clusters scoping.
+
+    Exercises the full enforcement chain: a workspace-level
+    ``slurm.allowed_clusters`` value (as stored by the workspace schema)
+    resolves through ``existing_allowed_clusters()`` and gates
+    ``regions_with_offering()``. The registered cluster set is mocked because
+    this layer only reads cluster *names* from ``~/.slurm/config`` -- no
+    connectivity is required.
+    """
+
+    def _reload_with(self, tmp_path, config_dict):
+        """Point config loading at a tmp file containing config_dict."""
+        from sky import skypilot_config
+        from sky.utils import yaml_utils
+        config_path = tmp_path / 'config.yaml'
+        config_path.write_text(yaml_utils.dump_yaml_str(config_dict))
+        skypilot_config._GLOBAL_CONFIG_PATH = str(config_path)
+        skypilot_config._PROJECT_CONFIG_PATH = str(tmp_path /
+                                                   'nonexistent.yaml')
+        skypilot_config._global_config_context = (
+            skypilot_config.ConfigContext())
+        skypilot_config.reload_config()
+
+    def _run(self, tmp_path, config_dict, workspace, fn):
+        from sky import skypilot_config
+        saved_global = skypilot_config._GLOBAL_CONFIG_PATH
+        saved_project = skypilot_config._PROJECT_CONFIG_PATH
+        saved_ctx = skypilot_config._global_config_context
+        try:
+            self._reload_with(tmp_path, config_dict)
+            with mock.patch(
+                    'sky.clouds.slurm.slurm_utils.get_all_slurm_cluster_names',
+                    return_value=['slurm-a', 'slurm-b']):
+                if workspace is not None:
+                    with skypilot_config.local_active_workspace_ctx(workspace):
+                        return fn()
+                return fn()
+        finally:
+            skypilot_config._GLOBAL_CONFIG_PATH = saved_global
+            skypilot_config._PROJECT_CONFIG_PATH = saved_project
+            skypilot_config._global_config_context = saved_ctx
+            skypilot_config.reload_config()
+
+    def test_workspace_allowlist_scopes_clusters(self, tmp_path):
+        """A workspace's allowed_clusters wins over the global list."""
+        config = {
+            'slurm': {
+                'allowed_clusters': 'all'
+            },
+            'workspaces': {
+                'tenant-a': {
+                    'slurm': {
+                        'allowed_clusters': ['slurm-a']
+                    }
+                },
+            },
+        }
+        cloud = slurm_cloud.Slurm()
+
+        # Inside tenant-a: only slurm-a is allowed.
+        allowed = self._run(tmp_path, config, 'tenant-a',
+                            cloud.existing_allowed_clusters)
+        assert allowed == ['slurm-a']
+
+        # slurm-b (another tenant's cluster) produces no offering.
+        regions_b = self._run(
+            tmp_path, config, 'tenant-a', lambda: cloud.regions_with_offering(
+                None, None, False, 'slurm-b', None))
+        assert regions_b == []
+
+        # slurm-a resolves to a region.
+        with mock.patch('sky.clouds.slurm.slurm_utils.get_partitions',
+                        return_value=[]):
+            regions_a = self._run(
+                tmp_path, config,
+                'tenant-a', lambda: cloud.regions_with_offering(
+                    None, None, False, 'slurm-a', None))
+        assert [r.name for r in regions_a] == ['slurm-a']
+
+    def test_workspace_deny_all(self, tmp_path):
+        """An empty allowed_clusters list is fail-closed deny-all."""
+        config = {
+            'slurm': {
+                'allowed_clusters': 'all'
+            },
+            'workspaces': {
+                'tenant-a': {
+                    'slurm': {
+                        'allowed_clusters': []
+                    }
+                },
+            },
+        }
+        cloud = slurm_cloud.Slurm()
+        allowed = self._run(tmp_path, config, 'tenant-a',
+                            cloud.existing_allowed_clusters)
+        assert allowed == []
+
+    def test_no_workspace_block_falls_back_to_global(self, tmp_path):
+        """No workspace slurm block -> global allowed_clusters applies."""
+        config = {
+            'slurm': {
+                'allowed_clusters': ['slurm-b']
+            },
+            'workspaces': {
+                'tenant-a': {},
+            },
+        }
+        cloud = slurm_cloud.Slurm()
+        allowed = self._run(tmp_path, config, 'tenant-a',
+                            cloud.existing_allowed_clusters)
+        assert allowed == ['slurm-b']
+
+    def test_global_default_all_when_unset(self, tmp_path):
+        """No workspace block and no global value -> all clusters."""
+        config = {
+            'workspaces': {
+                'tenant-a': {},
+            },
+        }
+        cloud = slurm_cloud.Slurm()
+        allowed = self._run(tmp_path, config, 'tenant-a',
+                            cloud.existing_allowed_clusters)
+        assert sorted(allowed) == ['slurm-a', 'slurm-b']

--- a/tests/unit_tests/test_sky/provision/slurm/test_registration.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_registration.py
@@ -1,0 +1,199 @@
+"""Tests for the remote Slurm cluster registration core."""
+import os
+import stat
+
+from paramiko.config import SSHConfig
+import pytest
+
+from sky.provision.slurm import registration
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """A SlurmClusterManager pointed at an isolated tmp directory."""
+    m = registration.SlurmClusterManager()
+    m.config_path = str(tmp_path / 'config')
+    m.keys_dir = str(tmp_path / 'keys')
+    m.known_hosts_dir = str(tmp_path / 'known_hosts')
+    return m
+
+
+def _resolved(manager, name):
+    return SSHConfig.from_path(manager.config_path).lookup(name)
+
+
+class TestRegisterCluster:
+
+    def test_register_writes_parseable_config(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='PRIVKEY-A',
+                                 port=2222,
+                                 host_key='10.0.0.1 ssh-ed25519 AAAAKEY',
+                                 proxy_jump='bastion')
+
+        # paramiko (the parser slurm actually uses) round-trips it.
+        resolved = _resolved(manager, 'slurm-a')
+        assert resolved['hostname'] == '10.0.0.1'
+        assert resolved['user'] == 'ubuntu'
+        assert resolved['port'] == '2222'
+        assert resolved['proxyjump'] == 'bastion'
+        assert resolved['identitiesonly'] == 'yes'
+        # Host-key pinning is expressed when host_key is provided.
+        assert resolved['stricthostkeychecking'] == 'yes'
+        assert 'userknownhostsfile' in resolved
+
+    def test_identity_file_is_0600(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='PRIVKEY-A')
+        key_path = os.path.join(manager.keys_dir, 'slurm-a')
+        assert os.path.exists(key_path)
+        assert stat.S_IMODE(os.stat(key_path).st_mode) == 0o600
+        assert open(key_path).read().startswith('PRIVKEY-A')
+        # IdentityFile in the config points at the stored key.
+        assert _resolved(manager, 'slurm-a')['identityfile'] == [key_path]
+
+    def test_no_host_key_omits_pinning(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='PRIVKEY-A')
+        resolved = _resolved(manager, 'slurm-a')
+        assert 'stricthostkeychecking' not in resolved
+        assert 'userknownhostsfile' not in resolved
+
+    def test_upsert_does_not_duplicate_block(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='PRIVKEY-A')
+        manager.register_cluster('slurm-a',
+                                 host='10.9.9.9',
+                                 user='ubuntu',
+                                 identity_file='PRIVKEY-A2')
+        content = open(manager.config_path).read()
+        assert content.count('BEGIN skypilot-managed slurm-a') == 1
+        # The updated value wins.
+        assert _resolved(manager, 'slurm-a')['hostname'] == '10.9.9.9'
+
+    def test_multiple_clusters_coexist(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='K')
+        manager.register_cluster('slurm-b',
+                                 host='10.0.0.2',
+                                 user='root',
+                                 identity_file='K')
+        names = [
+            h for h in SSHConfig.from_path(manager.config_path).get_hostnames()
+            if h != '*'
+        ]
+        assert sorted(names) == ['slurm-a', 'slurm-b']
+
+    def test_preserves_unmanaged_content(self, manager):
+        # A hand-authored block outside the sentinel markers must survive.
+        os.makedirs(os.path.dirname(manager.config_path), exist_ok=True)
+        with open(manager.config_path, 'w') as f:
+            f.write('Host hand-edited\n    HostName 1.2.3.4\n')
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='K')
+        content = open(manager.config_path).read()
+        assert 'Host hand-edited' in content
+        assert _resolved(manager, 'hand-edited')['hostname'] == '1.2.3.4'
+        assert _resolved(manager, 'slurm-a')['hostname'] == '10.0.0.1'
+
+    @pytest.mark.parametrize('bad_name', ['../evil', 'a/b', '', 'a b'])
+    def test_invalid_names_rejected(self, manager, bad_name):
+        with pytest.raises(ValueError):
+            manager.register_cluster(bad_name,
+                                     host='10.0.0.1',
+                                     user='ubuntu',
+                                     identity_file='K')
+
+    @pytest.mark.parametrize('missing', ['host', 'user', 'identity_file'])
+    def test_required_fields(self, manager, missing):
+        kwargs = {
+            'host': '10.0.0.1',
+            'user': 'ubuntu',
+            'identity_file': 'K',
+        }
+        kwargs[missing] = ''
+        with pytest.raises(ValueError):
+            manager.register_cluster('slurm-a', **kwargs)
+
+
+class TestDeleteCluster:
+
+    def test_delete_removes_block_and_files(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='K',
+                                 host_key='hostkey')
+        key_path = os.path.join(manager.keys_dir, 'slurm-a')
+        kh_path = os.path.join(manager.known_hosts_dir, 'slurm-a')
+        assert os.path.exists(key_path) and os.path.exists(kh_path)
+
+        assert manager.delete_cluster('slurm-a') is True
+        names = [
+            h for h in SSHConfig.from_path(manager.config_path).get_hostnames()
+            if h != '*'
+        ]
+        assert names == []
+        assert not os.path.exists(key_path)
+        assert not os.path.exists(kh_path)
+
+    def test_delete_missing_returns_false(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='K')
+        assert manager.delete_cluster('slurm-b') is False
+        # slurm-a is untouched.
+        assert _resolved(manager, 'slurm-a')['hostname'] == '10.0.0.1'
+
+    def test_delete_leaves_other_clusters(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='K')
+        manager.register_cluster('slurm-b',
+                                 host='10.0.0.2',
+                                 user='root',
+                                 identity_file='K')
+        manager.delete_cluster('slurm-a')
+        names = [
+            h for h in SSHConfig.from_path(manager.config_path).get_hostnames()
+            if h != '*'
+        ]
+        assert names == ['slurm-b']
+
+
+class TestListClusters:
+
+    def test_list_empty_when_no_file(self, manager):
+        assert manager.list_clusters() == {}
+
+    def test_list_returns_non_secret_detail(self, manager):
+        manager.register_cluster('slurm-a',
+                                 host='10.0.0.1',
+                                 user='ubuntu',
+                                 identity_file='SECRET',
+                                 port=2222,
+                                 proxy_jump='bastion')
+        clusters = manager.list_clusters()
+        assert set(clusters) == {'slurm-a'}
+        entry = clusters['slurm-a']
+        assert entry['host'] == '10.0.0.1'
+        assert entry['user'] == 'ubuntu'
+        assert entry['port'] == 2222
+        assert entry['proxy_jump'] == 'bastion'
+        assert entry['managed'] is True
+        # The private key contents are never exposed via listing.
+        assert 'SECRET' not in str(clusters)

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -96,6 +96,18 @@ class TestGetRolePermissions:
         assert {'path': '/workspaces/config', 'method': 'GET'} in blocklist
         assert {'path': '/foo', 'method': 'POST'} in blocklist
 
+    def test_slurm_clusters_blocked_for_user(self):
+        # The whole /slurm_clusters registration surface (GET included, since
+        # cluster names + hosts are cross-tenant metadata) is control-plane and
+        # blocked for the user role.
+        blocklist = self._user_blocklist(False)
+        assert {'path': '/slurm_clusters', 'method': 'GET'} in blocklist
+        assert {'path': '/slurm_clusters', 'method': 'POST'} in blocklist
+        assert {
+            'path': '/slurm_clusters/:name',
+            'method': 'DELETE'
+        } in blocklist
+
 
 class TestGetViewerAllowlist:
     """rbac.get_viewer_allowlist composes defaults + config + plugin entries."""

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -122,6 +122,11 @@ _KNOWN_VIEWER_DENIED: set = {
     ('/ssh_node_pools/deploy', 'POST'),
     ('/ssh_node_pools/{pool_name}/down', 'POST'),
     ('/ssh_node_pools/down', 'POST'),
+    # --- Slurm cluster registration (control-plane; GET too, since
+    # cluster names + hosts are cross-tenant metadata) ---
+    ('/slurm_clusters', 'GET'),
+    ('/slurm_clusters', 'POST'),
+    ('/slurm_clusters/{name}', 'DELETE'),
     # --- Debug ---
     # /debug/dump_create is intentionally on the viewer allowlist (see
     # _DEFAULT_VIEWER_ALLOWLIST) so viewers can capture support diagnostics;

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -606,6 +606,100 @@ class TestWorkspaceSchema(unittest.TestCase):
                 jsonschema.validate(instance=config,
                                     schema=self.workspaces_schema)
 
+    def test_workspace_slurm_allowed_clusters_valid(self):
+        """slurm.allowed_clusters accepts list / 'all' / [] per workspace."""
+        valid_configs = [
+            # List of cluster names.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': ['slurm-a', 'slurm-b']
+                    }
+                }
+            },
+            # 'all' broadens to every registered cluster.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': 'all'
+                    }
+                }
+            },
+            # Empty list is deny-all (the fail-closed provisioning default).
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': []
+                    }
+                }
+            },
+            # disabled still works, matching the other clouds.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'disabled': True
+                    }
+                }
+            },
+            # allowed_clusters alongside disabled.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': ['slurm-a'],
+                        'disabled': False
+                    }
+                }
+            },
+            # Empty slurm block inherits the global config.
+            {
+                'my-workspace': {
+                    'slurm': {}
+                }
+            },
+        ]
+        for config in valid_configs:
+            try:
+                jsonschema.validate(instance=config,
+                                    schema=self.workspaces_schema)
+            except jsonschema.exceptions.ValidationError as e:
+                self.fail(f'Valid slurm config {config} was rejected: {e}')
+
+    def test_workspace_slurm_allowed_clusters_invalid(self):
+        """Invalid slurm.allowed_clusters shapes / extra props are rejected."""
+        invalid_configs = [
+            # A non-'all' string is not allowed.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': 'everything'
+                    }
+                }
+            },
+            # List items must be strings.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'allowed_clusters': [1, 2]
+                    }
+                }
+            },
+            # Unknown property under slurm is rejected.
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'bogus': True
+                    }
+                }
+            },
+        ]
+        for config in invalid_configs:
+            with self.assertRaises(
+                    jsonschema.exceptions.ValidationError,
+                    msg=f'Invalid slurm workspace config {config!r} should be '
+                    'rejected'):
+                jsonschema.validate(instance=config,
+                                    schema=self.workspaces_schema)
+
 
 class TestKubernetesSchema(unittest.TestCase):
     """Tests for the kubernetes schema in schemas.py."""

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -862,6 +862,122 @@ class TestWorkspaceManagement(unittest.TestCase):
         mock_check_resources.assert_called_once_with([('test-workspace',
                                                        'update')])
 
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_additive_allowed_clusters(
+            self, mock_get_users_for_role, mock_get_users):
+        """slurm.allowed_clusters-only changes are flagged additive or not."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # Sentinel for "allowed_clusters is absent from the slurm block".
+        absent = object()
+
+        def slurm_config(allowed_clusters):
+            slurm = {}
+            if allowed_clusters is not absent:
+                slurm['allowed_clusters'] = allowed_clusters
+            return {'slurm': slurm}
+
+        # (current_clusters, new_clusters, expected_additive)
+        cases = [
+            # The enrollment flow: deny-all -> first cluster.
+            ([], ['slurm-a'], True),
+            (['slurm-a'], ['slurm-a', 'slurm-b'], True),  # enroll second
+            (['slurm-a', 'slurm-b'], ['slurm-a'], False),  # revoke
+            (['slurm-a', 'slurm-b'], ['slurm-b', 'slurm-a'], True),  # reorder
+            (['slurm-a'], 'all', True),  # broaden to all
+            ('all', ['slurm-a'], False),  # narrow from all
+            (absent, ['slurm-a'], False),  # absent -> list
+            (['slurm-a'], absent, False),  # list -> absent
+        ]
+        for current_clusters, new_clusters, expected in cases:
+            with self.subTest(current=current_clusters, new=new_clusters):
+                result = core._compare_workspace_configs(
+                    slurm_config(current_clusters), slurm_config(new_clusters))
+                self.assertEqual(result.additive_allowed_clusters, expected)
+                # allowed_clusters changed, so never user-access-only.
+                self.assertFalse(result.only_user_access_changes)
+
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_additive_clusters_with_other_changes(
+            self, mock_get_users_for_role, mock_get_users):
+        """Additive clusters alongside any other change is not additive."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # Additive clusters but a sibling slurm field also changed.
+        result = core._compare_workspace_configs(
+            {'slurm': {
+                'allowed_clusters': ['slurm-a'],
+                'disabled': False
+            }}, {
+                'slurm': {
+                    'allowed_clusters': ['slurm-a', 'slurm-b'],
+                    'disabled': True
+                }
+            })
+        self.assertFalse(result.additive_allowed_clusters)
+
+        # Additive clusters but a non-slurm field also changed.
+        result = core._compare_workspace_configs(
+            {
+                'slurm': {
+                    'allowed_clusters': ['slurm-a']
+                },
+                'gcp': {
+                    'project_id': 'p1'
+                }
+            }, {
+                'slurm': {
+                    'allowed_clusters': ['slurm-a', 'slurm-b']
+                },
+                'gcp': {
+                    'project_id': 'p2'
+                }
+            })
+        self.assertFalse(result.additive_allowed_clusters)
+
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_slurm_block_is_none(
+            self, mock_get_users_for_role, mock_get_users):
+        """A null slurm block must not crash and is not additive."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # `slurm: null` in YAML parses to None; must not raise TypeError.
+        result = core._compare_workspace_configs(
+            {'slurm': None}, {'slurm': {
+                'allowed_clusters': ['slurm-a']
+            }})
+        self.assertFalse(result.additive_allowed_clusters)
+
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.workspaces.core._compare_workspace_configs')
+    def test_validate_workspace_config_changes_additive_clusters(
+            self, mock_compare_configs, mock_check_resources):
+        """Additive allowed_clusters changes skip the teardown check."""
+        mock_compare_configs.return_value = core.WorkspaceConfigComparison(
+            only_user_access_changes=False,
+            private_changed=False,
+            private_old=False,
+            private_new=False,
+            allowed_users_changed=False,
+            allowed_users_old=[],
+            allowed_users_new=[],
+            removed_users=[],
+            added_users=[],
+            additive_allowed_clusters=True)
+
+        # Should not raise any exception.
+        core._validate_workspace_config_changes('test-workspace', {}, {})
+
+        # Additive cluster changes do not require an empty workspace.
+        mock_check_resources.assert_not_called()
+
 
 class TestWorkspaceNameBackwardCompatibility(unittest.TestCase):
     """Tests that existing workspaces with non-conforming names still work."""


### PR DESCRIPTION

<!-- Describe the changes in this PR -->
- Added a new FastAPI router for managing Slurm clusters, including endpoints for listing, registering, and deleting clusters.
- Integrated the Slurm cluster registration API into the main server application.
- Updated RBAC to block user role access to Slurm cluster management endpoints.
- Enhanced workspace configuration schema to support `slurm.allowed_clusters` with validation for various input shapes.
- Implemented logic for additive changes to `slurm.allowed_clusters` in workspace configurations.
- Added unit tests for Slurm cluster registration, workspace allowed clusters, and RBAC permissions.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
**Tests:**
Schema ([test_schemas.py](tests/unit_tests/test_sky/utils/test_schemas.py)): workspace slurm block accepts l
ist/'all'/[]/disabled; rejects bad strings, non-string items, unknown keys.

Enforcement ([test_slurm.py](tests/unit_tests/test_sky/clouds/test_slurm.py)): with a workspace allowlist, existing_allowed_clusters()/regions_with_offering() scope to allowed clusters; [] = deny-all; no block → global fallback → all.

Registration core ([test_registration.py](tests/unit_tests/test_sky/provision/slurm/test_registration.py)): writes paramiko-parseable ssh_config, 0600 keys, host-key pinning, upsert dedup, preserves unmanaged content, delete cleans up files, list hides secrets, bad input raises.

Additive exemption ([test_workspace_management.py](tests/unit_tests/test_sky/workspaces/test_workspace_management.py)): slurm.allowed_clusters growth (deny-all→add) is additive and skips the teardown check; removals/other-field-changes/null block are not.

RBAC ([test_rbac.py](tests/unit_tests/test_sky/users/test_rbac.py), [test_viewer_route_coverage.py](tests/unit_tests/test_sky/users/test_viewer_route_coverage.py)): /slurm_clusters GET/POST/DELETE blocked for the user role and marked viewer-denied.

~15 methods, all passing, zero regressions.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
