### PR TITLE
[Test][DO NOT MERGE] Old server + new conda-free K8s image

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -738,11 +738,15 @@ class Kubernetes(clouds.Cloud):
                 if image_id.startswith('docker:'):
                     image_id = image_id[len('docker:'):]
             else:
-                # Select image based on whether we are using GPUs or not.
-                image_id = self.IMAGE_GPU if acc_count > 0 else self.IMAGE_CPU
-                # Get the container image ID from the service catalog.
-                image_id = catalog.get_image_id_from_tag(image_id,
-                                                         clouds='kubernetes')
+                # TEMP(local-test): use locally-built images instead of the
+                # published catalog images. Revert before committing.
+                _ = catalog  # keep import for the real path
+                repo = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s'
+                tag = '202607151006'
+                if acc_count > 0:
+                    image_id = f'{repo}/skypilot-gpu:{tag}'
+                else:
+                    image_id = f'{repo}/skypilot:{tag}'
             return image_id
 
         image_id = _get_image_id(resources)


### PR DESCRIPTION
## Purpose

Test-only branch: upstream `master` (unmodified server) with **only** the default Kubernetes image pinned to a locally-built conda-free image. Used to validate the **old-server + new-image** compatibility scenario for the conda removal work (#10132).

Not for merge — the single change is a temporary image-tag override in `sky/clouds/kubernetes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)