### PR TITLE
[k8s] sky local up: add --num-nodes for multi-node local clusters

### DIFF
--- a/agent/skills/skypilot/references/python-sdk.md
+++ b/agent/skills/skypilot/references/python-sdk.md
@@ -1373,7 +1373,7 @@ Tears down the Kubernetes cluster started by local_up.
 ### `sky.local_up`
 
 ```python
-sky.local_up(gpus: bool, name: Optional[str] = None, port_start: Optional[int] = None) -> server_common.RequestId[None]
+sky.local_up(gpus: bool, name: Optional[str] = None, port_start: Optional[int] = None, num_nodes: int = 1) -> server_common.RequestId[None]
 ```
 
 Launches a Kubernetes cluster on local machines.

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7824,7 +7824,7 @@ def local():
     'Used without ip list.')
 @click.option(
     '--num-nodes',
-    type=int,
+    type=click.IntRange(min=1),
     default=1,
     show_default=True,
     required=False,

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7822,14 +7822,23 @@ def local():
     help='Starting port range for the local kind cluster. Needs to be a '
     'multiple of 100. If not given, a random range will be used. '
     'Used without ip list.')
+@click.option(
+    '--num-nodes',
+    type=int,
+    default=1,
+    show_default=True,
+    required=False,
+    help='Number of nodes in the local kind cluster. A value greater than 1 '
+    'adds worker nodes, useful for testing multi-node scheduling locally. '
+    'Used without ip list.')
 @local.command('up', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @_add_click_options(flags.COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, name: Optional[str], port_start: Optional[int],
-             async_call: bool):
+             num_nodes: int, async_call: bool):
     """Creates a local cluster."""
-    request_id = sdk.local_up(gpus, name, port_start)
+    request_id = sdk.local_up(gpus, name, port_start, num_nodes)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2115,7 +2115,8 @@ def storage_delete(name: str) -> server_common.RequestId[None]:
 @annotations.client_api
 def local_up(gpus: bool,
              name: Optional[str] = None,
-             port_start: Optional[int] = None) -> server_common.RequestId[None]:
+             port_start: Optional[int] = None,
+             num_nodes: int = 1) -> server_common.RequestId[None]:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:
@@ -2129,7 +2130,10 @@ def local_up(gpus: bool,
             raise ValueError('`sky local up` is only supported when '
                              'running SkyPilot locally.')
 
-    body = payloads.LocalUpBody(gpus=gpus, name=name, port_start=port_start)
+    body = payloads.LocalUpBody(gpus=gpus,
+                                name=name,
+                                port_start=port_start,
+                                num_nodes=num_nodes)
     response = server_common.make_authenticated_request(
         'POST', '/local_up', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1942,9 +1942,11 @@ def realtime_slurm_gpu_availability(
 @usage_lib.entrypoint
 def local_up(gpus: bool,
              name: Optional[str] = None,
-             port_start: Optional[int] = None) -> None:
+             port_start: Optional[int] = None,
+             num_nodes: int = 1) -> None:
     """Creates a local cluster."""
-    kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus)
+    kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus,
+                                                 num_nodes)
 
 
 def local_down(name: Optional[str] = None) -> None:

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -820,6 +820,7 @@ class LocalUpBody(RequestBody):
     gpus: bool = True
     name: Optional[str] = None
     port_start: Optional[int] = None
+    num_nodes: int = 1
 
 
 class LocalDownBody(RequestBody):

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -111,8 +111,10 @@ def _get_port_range(name: str, port_start: Optional[int]) -> Tuple[int, int]:
     return port_start, port_end
 
 
-def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
-                         gpus: bool):
+def deploy_local_cluster(name: Optional[str],
+                         port_start: Optional[int],
+                         gpus: bool,
+                         num_nodes: int = 1):
     name = name or DEFAULT_LOCAL_CLUSTER_NAME
     port_start, port_end = _get_port_range(name, port_start)
     context_name = f'kind-{name}'
@@ -140,7 +142,8 @@ def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
         # Choose random port range to use on the host machine.
         # Port range is port_start - port_start + 99 (exactly 100 ports).
         logger.debug(f'Using host port range {port_start}-{port_end}')
-        f.write(generate_kind_config(port_start, gpus=gpus))
+        f.write(generate_kind_config(port_start, num_nodes=num_nodes,
+                                     gpus=gpus))
         f.flush()
 
         path_to_package = os.path.dirname(__file__)

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -115,6 +115,8 @@ def deploy_local_cluster(name: Optional[str],
                          port_start: Optional[int],
                          gpus: bool,
                          num_nodes: int = 1):
+    if num_nodes < 1:
+        raise ValueError(f'num_nodes must be at least 1, got {num_nodes}')
     name = name or DEFAULT_LOCAL_CLUSTER_NAME
     port_start, port_end = _get_port_range(name, port_start)
     context_name = f'kind-{name}'


### PR DESCRIPTION
## Summary

`sky local up` always provisions a **single-node** kind cluster, so there is no
way to exercise multi-node behavior on a local cluster. This adds an opt-in
`--num-nodes N` flag (default `1`, so existing behavior is unchanged) that adds
`N-1` worker nodes to the local kind cluster.

Multi-node local clusters make it possible to develop and test multi-node
scheduling and topology-aware placement locally, without needing a cloud or
remote Kubernetes cluster.

The value is threaded straight through the existing call chain:

```
sky local up --num-nodes N        (CLI, sky/client/cli/command.py)
  -> sdk.local_up(..., num_nodes)  (sky/client/sdk.py)
  -> LocalUpBody(num_nodes=...)    (sky/server/requests/payloads.py)
  -> core.local_up(..., num_nodes) (sky/core.py)
  -> deploy_local_cluster(..., num_nodes)
  -> generate_kind_config(port_start, num_nodes=num_nodes, gpus=gpus)
```

`generate_kind_config()` already accepted a `num_nodes` argument (it appends a
`- role: worker` entry per extra node); this change simply exposes it
end-to-end. No default behavior changes for existing users.

## Tested

- `generate_kind_config(port, num_nodes=N)` emits `N-1` `role: worker` nodes
  (`1 -> 0`, `2 -> 1`, `3 -> 2`).
- `sky local up --help` shows the new `--num-nodes` option; the flag parses and
  threads through the CLI -> SDK -> payload -> core -> deploy path.
- `sky local up --num-nodes 2` brings up a control-plane + 1 worker kind cluster
  (`kubectl get nodes` reports 2 `Ready` nodes); `sky local up` with no flag
  still yields a single-node cluster.
