### PR TITLE
[Jobs] Throttle job status polling in the log tail follow loop

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2365,7 +2365,7 @@ def stream_logs(job_id: Optional[int],
                     # Flush.
                     print(end='', flush=True)
 
-                    if (time.time() - last_status_check >=
+                    if (time.monotonic() - last_status_check >=
                             JOB_STATUS_CHECK_GAP_SECONDS):
                         # Check if the job if finished.
                         # TODO(cooperc): The controller can still be
@@ -2376,7 +2376,7 @@ def stream_logs(job_id: Optional[int],
                         assert job_status is not None, (job_id, job_name)
                         if job_status.is_terminal():
                             break
-                        last_status_check = time.time()
+                        last_status_check = time.monotonic()
 
                     time.sleep(log_lib.SKY_LOG_TAILING_GAP_SECONDS)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2342,6 +2342,18 @@ def stream_logs(job_id: Optional[int],
             with open(controller_log_path, 'r', newline='',
                       encoding='utf-8') as f:
                 f.seek(end_pos)
+                # The loop below wakes up every SKY_LOG_TAILING_GAP_SECONDS
+                # (0.2s) to read new log lines, but each get_status() call
+                # is a database query. On DB-backed deployments (e.g.
+                # consolidation mode with Postgres) querying the status on
+                # every tick costs 5 queries/s - each on a fresh connection
+                # - per followed job, which can dominate database CPU with
+                # many concurrent tails. Keep the 0.2s cadence for log
+                # reads but only check the status every
+                # JOB_STATUS_CHECK_GAP_SECONDS; the only cost is that the
+                # tail of a finished job lingers up to that long before
+                # exiting.
+                last_status_check = float('-inf')
                 while True:
                     # Print all new lines, if there are any.
                     line = f.readline()
@@ -2353,15 +2365,18 @@ def stream_logs(job_id: Optional[int],
                     # Flush.
                     print(end='', flush=True)
 
-                    # Check if the job if finished.
-                    # TODO(cooperc): The controller can still be
-                    # cleaning up if job is in a terminal status
-                    # (e.g. SUCCEEDED). We want to follow those logs
-                    # too. Use DONE instead?
-                    job_status = managed_job_state.get_status(job_id)
-                    assert job_status is not None, (job_id, job_name)
-                    if job_status.is_terminal():
-                        break
+                    if (time.time() - last_status_check >=
+                            JOB_STATUS_CHECK_GAP_SECONDS):
+                        # Check if the job if finished.
+                        # TODO(cooperc): The controller can still be
+                        # cleaning up if job is in a terminal status
+                        # (e.g. SUCCEEDED). We want to follow those logs
+                        # too. Use DONE instead?
+                        job_status = managed_job_state.get_status(job_id)
+                        assert job_status is not None, (job_id, job_name)
+                        if job_status.is_terminal():
+                            break
+                        last_status_check = time.time()
 
                     time.sleep(log_lib.SKY_LOG_TAILING_GAP_SECONDS)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `follow` loop in `stream_logs()` wakes up every `SKY_LOG_TAILING_GAP_SECONDS` (0.2s) to read new log lines, and also queried the job status from the jobs DB on every tick. On DB-backed deployments (consolidation mode with Postgres) each `get_status()` runs on a fresh connection, so every followed job costs 5 connections+queries per second for its entire lifetime. On one production API server we observed ~70 concurrent `--follow` tails driving ~350 new Postgres connections/s, consuming ~5 of 8 vCPUs on the shared DB instance (connection setup cost dominates; the queries themselves are cheap).

This PR keeps the 0.2s log-read cadence but only checks the job status every `JOB_STATUS_CHECK_GAP_SECONDS` (15s), reducing per-tail DB load ~75x. The only behavior change: the tail of a finished job may linger up to 15s before exiting (log output itself is unaffected).

Tested (run the relevant ones):

- [x] Code formatting: `yapf==0.32.0 --diff` clean on the changed file
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)