### PR TITLE
[Core] Status refresh: do not mark a cluster UP when its handle has no cached IPs

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2769,9 +2769,26 @@ def _update_cluster_status(
     # from cloud -> provision layer.
     should_check_ray = (cloud is not None and cloud.uses_ray() and
                         handle.provision_runtime_metadata.has_ray)
-    if (all_nodes_up and (not should_check_ray or
-                          run_ray_status_to_check_ray_cluster_healthy()) and
-            not external_cluster_failures):
+    # A handle without cached IPs is the bare pre-provision handle that
+    # `sky launch` persists (at INIT) before provisioning starts; the
+    # completed handle (with IPs and has_ray=True) is only persisted after
+    # runtime setup finishes. If the launch is interrupted in that window
+    # (process death, cancellation, a lost cluster lock) while the nodes
+    # keep running, all_nodes_up can be True here — e.g. Kubernetes pods
+    # report Running long before the runtime is set up. Never mark such a
+    # cluster UP: with has_ray=False the ray health check (which fails
+    # closed on missing IPs) is skipped entirely, and every operation on
+    # an UP cluster requires handle.head_ip (see check_cluster_available),
+    # so promoting would only trade INIT for a ClusterNotUpError later.
+    # Fall through to the abnormal-cluster handling below to keep it INIT.
+    handle_has_cached_ips = handle.head_ip is not None
+    if all_nodes_up and not handle_has_cached_ips:
+        ray_status_details = ('no cached IPs on the cluster handle; the '
+                              'last launch was likely interrupted before '
+                              'the SkyPilot runtime was set up')
+    if (all_nodes_up and handle_has_cached_ips and
+        (not should_check_ray or run_ray_status_to_check_ray_cluster_healthy())
+            and not external_cluster_failures):
         # NOTE: all_nodes_up calculation is fast due to calling cloud CLI;
         # run_ray_status_to_check_all_nodes_up() is slow due to calling `ray get
         # head-ip/worker-ips`.

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -2204,6 +2204,80 @@ def test_cancel_launch_and_exec_async(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+# Regression: a launch interrupted after its pods are Running but before the
+# SkyPilot runtime is set up leaves the DB with the bare pre-provision handle
+# (no cached IPs, has_ray=False). A status refresh used to see all pods up,
+# skip the ray health check, and promote the cluster to UP with that bare
+# handle -- wedging it in a state where `sky exec`/ssh fail with
+# ClusterNotUpError and plain `sky start` no-ops ("already up"). The refresh
+# must keep such a cluster INIT so `sky start` can recover it.
+# Kubernetes-only: pods report Running long before runtime setup finishes,
+# which is the window this race needs.
+@pytest.mark.kubernetes
+def test_status_refresh_keeps_interrupted_launch_init(generic_cloud: str):
+    del generic_cloud  # Kubernetes-specific.
+    name = smoke_tests_utils.get_cluster_name()
+    req_file = f'/tmp/{name}.req'
+    # Capture the async launch's request id so we can cancel it mid-flight.
+    launch = (f'req=$(sky launch -c {name} --infra kubernetes '
+              f'{smoke_tests_utils.LOW_RESOURCE_ARG} -y --async '
+              f'| grep -oE \'request: [0-9a-f-]+\' | head -1 | '
+              f'awk \'{{print $2}}\'); '
+              f'echo "captured request id: $req"; test -n "$req"; '
+              f'echo "$req" > {req_file}')
+    # 'Pod is up.' is logged when provisioning finishes and runtime setup
+    # starts; from here until the completed handle is persisted, the DB holds
+    # the bare handle while the pod is Running.
+    wait_runtime_setup = (
+        f'req=$(cat {req_file}); start=$SECONDS; '
+        f'until sky api logs "$req" --no-follow 2>&1 | '
+        f'grep -q "Pod is up."; do '
+        f'  if [ $((SECONDS - start)) -gt 480 ]; then '
+        f'    echo "timed out waiting for runtime setup to start"; '
+        f'    sky api status -a "$req"; exit 1; '
+        f'  fi; '
+        f'  sleep 2; '
+        f'done; echo "runtime setup started"')
+    # Interrupt the launch and wait for the worker to actually die, so the
+    # per-cluster lock is released and the refresh below really evaluates
+    # (instead of timing out on the lock and returning the cached record).
+    cancel = (f'req=$(cat {req_file}); sky api cancel "$req" -y; '
+              f'start=$SECONDS; '
+              f'until sky api status -a "$req" | grep -qw CANCELLED; do '
+              f'  if [ $((SECONDS - start)) -gt 120 ]; then '
+              f'    echo "timed out waiting for cancellation"; '
+              f'    sky api status -a "$req"; exit 1; '
+              f'  fi; '
+              f'  sleep 2; '
+              f'done; echo "request cancelled"')
+    test = smoke_tests_utils.Test(
+        'status_refresh_keeps_interrupted_launch_init',
+        [
+            launch,
+            wait_runtime_setup,
+            cancel,
+            # Force a refresh (same code path as the status refresh daemon):
+            # the pod is Running but the handle has no cached IPs, so the
+            # cluster must stay INIT. Pre-fix, the row shows UP here.
+            f's=$(sky status -r {name}); echo "$s"; '
+            f'echo "$s" | grep {name} | grep INIT',
+            # INIT is recoverable with a plain `sky start` (the hint the CLI
+            # gives for INIT clusters); a false UP is not, since `sky start`
+            # no-ops on UP clusters.
+            f'sky start -y {name}',
+            f'sky status {name} | grep UP',
+            f'sky exec {name} \'echo recovered\'',
+            f'sky logs {name} 1 --status | grep SUCCEEDED',
+        ],
+        teardown=(f'req=$(cat {req_file} 2>/dev/null); '
+                  f'sky api cancel "$req" -y 2>/dev/null || true; '
+                  f'sky down -y {name} 2>/dev/null || true; '
+                  f'rm -f {req_file}'),
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Testing Exit Codes for CLI commands ----------
 def test_cli_exit_codes(generic_cloud: str):
     """Test that CLI commands properly return exit codes based on job success/failure."""

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -2268,6 +2268,10 @@ def test_status_refresh_keeps_interrupted_launch_init(generic_cloud: str):
             f'sky status {name} | grep UP',
             f'sky exec {name} \'echo recovered\'',
             f'sky logs {name} 1 --status | grep SUCCEEDED',
+            # Direct ssh exercises the ssh config that `sky status` writes,
+            # which the bare handle used to break.
+            f's=$(ssh {name} \'echo ssh_works\' 2>&1) && '
+            f'echo "$s" | grep ssh_works',
         ],
         teardown=(f'req=$(cat {req_file} 2>/dev/null); '
                   f'sky api cancel "$req" -y 2>/dev/null || true; '

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -163,3 +163,83 @@ class TestUpdateClusterStatusInitReason:
         msg = _capture_init_log_message(
             {'pod-0': (status_lib.ClusterStatus.UP, None)}, launched_nodes=2)
         assert 'one or more nodes terminated' in msg, msg
+
+
+class TestUpdateClusterStatusBareHandle:
+    """A bare pre-provision handle (no cached IPs, has_ray=False) must not
+    be promoted to UP by a status refresh.
+
+    `sky launch` persists such a handle at INIT before provisioning starts;
+    the completed handle is only persisted after runtime setup. If the launch
+    is interrupted in between while the nodes keep running (on Kubernetes,
+    pods report Running long before runtime setup finishes), a refresh used
+    to skip the ray health check (has_ray=False) and mark the cluster UP
+    with head_ip=None — making every subsequent operation (e.g. sky exec)
+    fail with ClusterNotUpError.
+    """
+
+    def _refresh(self, handle):
+        record = _make_record(handle, status=status_lib.ClusterStatus.INIT)
+
+        backend = mock.Mock(spec=backends.CloudVmRayBackend)
+        backend.is_definitely_autostopping.return_value = False
+
+        external_failure = mock.Mock()
+        external_failure.get.return_value = None
+
+        events = []
+
+        def _capture_event(cluster_name, new_status, message, event_type,
+                           **kwargs):
+            events.append((new_status, message))
+
+        add_or_update = mock.Mock()
+        with mock.patch.object(backend_utils,
+                               '_query_cluster_status_via_cloud_api',
+                               return_value={
+                                   'pod-0': (status_lib.ClusterStatus.UP, None)
+                               }), \
+             mock.patch.object(backend_utils, 'ExternalFailureSource',
+                               external_failure), \
+             mock.patch.object(backend_utils, 'get_backend_from_handle',
+                               return_value=backend), \
+             mock.patch.object(backend_utils.global_user_state,
+                               'add_cluster_event',
+                               side_effect=_capture_event), \
+             mock.patch.object(backend_utils.global_user_state,
+                               'add_or_update_cluster', add_or_update), \
+             mock.patch.object(backend_utils.global_user_state,
+                               'get_cluster_from_name',
+                               return_value=record):
+            backend_utils._update_cluster_status('test-cluster',
+                                                 record,
+                                                 retry_if_missing=False)
+        return add_or_update, events
+
+    def test_no_cached_ips_is_not_promoted_to_up(self):
+        handle = _make_handle()
+        handle.provision_runtime_metadata.has_ray = False
+        handle.head_ip = None
+
+        add_or_update, events = self._refresh(handle)
+
+        assert add_or_update.call_count == 1
+        assert add_or_update.call_args.kwargs['ready'] is False
+        # The cluster must not be marked UP (no UP status event either; the
+        # record is already INIT so no INIT event is re-added).
+        up_events = [e for e in events if e[0] == status_lib.ClusterStatus.UP]
+        assert not up_events, up_events
+
+    def test_cached_ips_without_ray_is_promoted_to_up(self):
+        # A fully provisioned cluster whose runtime legitimately has no ray
+        # (has_ray=False) but has cached IPs must still be marked UP.
+        handle = _make_handle()
+        handle.provision_runtime_metadata.has_ray = False
+        handle.head_ip = '1.2.3.4'
+
+        add_or_update, events = self._refresh(handle)
+
+        assert add_or_update.call_count == 1
+        assert add_or_update.call_args.kwargs['ready'] is True
+        assert any(status == status_lib.ClusterStatus.UP
+                   for status, _ in events), events


### PR DESCRIPTION
Fixes a status-refresh race that can promote a still-provisioning Kubernetes cluster to `UP` while its persisted handle has no cached IPs, making every subsequent operation on it fail with `ClusterNotUpError` even though the pods are healthy.

How it happens:

- `sky launch` persists a bare pre-provision handle (no cached IPs; `provision_runtime_metadata.has_ray=False` since #9845) to the DB at `INIT` before provisioning starts. The completed handle (with IPs and `has_ray=True`) is only persisted after `post_provision_runtime_setup` finishes.
- If the launch is interrupted in that window (process death, cancellation, a lost per-cluster lock) while the nodes keep running, a later status refresh finds all nodes up — on Kubernetes, pods report `Running` long before runtime setup completes.
- With `has_ray=False`, the refresh skips the ray health check (which fails closed on missing IPs) and writes `status=UP` reusing the bare, IP-less handle.
- `sky exec` then passes the `status == UP` gate in `check_cluster_available` and raises `ClusterNotUpError: ... has been stopped or not properly set up` at the `handle.head_ip is None` check.

Fix: gate the healthy-promotion write in `_update_cluster_status` on the handle having cached IPs (`handle.head_ip is not None`). A bare handle now falls through to the existing abnormal-cluster handling and stays `INIT`, with `ray_status_details` explaining the missing IPs — matching the fail-closed behavior the ray health check already has for this case. A fully provisioned cluster that legitimately runs without ray (`has_ray=False`) still promotes, since its persisted handle has cached IPs.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): added `TestUpdateClusterStatusBareHandle` to `tests/unit_tests/test_backend_utils_init_reason.py` — `test_no_cached_ips_is_not_promoted_to_up` fails without the fix and passes with it; `test_cached_ips_without_ray_is_promoted_to_up` pins that a provisioned no-ray cluster with cached IPs still promotes to UP.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: added smoke test `test_status_refresh_keeps_interrupted_launch_init` (Kubernetes), which reproduces the incident end-to-end: cancel an async launch right after `Pod is up.` (bare handle still in the DB), force a refresh, assert the cluster stays `INIT`, then recover with plain `sky start` and verify both `sky exec` and direct `ssh`. Validated red→green against a local API server: on a pre-fix build the test fails at the `grep INIT` step with the cluster wrongly showing `UP`; on this branch's build it passes end-to-end.
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
