### PR TITLE
[Provisioner] Stream docker pull progress into the provision log

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -197,11 +197,20 @@ def _redact_docker_password(cmd: str) -> str:
 class DockerInitializer:
     """Initializer for docker containers on a remote node."""
 
-    def __init__(self, docker_config: Dict[str, Any],
-                 runner: 'command_runner.CommandRunner', log_path: str):
+    def __init__(self,
+                 docker_config: Dict[str, Any],
+                 runner: 'command_runner.CommandRunner',
+                 log_path: str,
+                 stream_pull_logs: bool = False):
         self.docker_config = docker_config
         self.container_name = docker_config['container_name']
         self.runner = runner
+        # Whether to stream `docker pull` progress to the process stream
+        # (and thus the API server request log that `sky launch` clients
+        # render). Callers enable this for one node only: every node's
+        # initializer shares the same process stdout, so streaming all of
+        # them would interleave unlabeled copies of the pull output.
+        self.stream_pull_logs = stream_pull_logs
         self.home_dir: Optional[str] = None
         self.initialized = False
         # podman is not fully tested yet.
@@ -358,23 +367,23 @@ class DockerInitializer:
 
         # Stream the pull: it is the one docker setup step whose duration
         # scales with image size (a multi-GB image can pull for many
-        # minutes), and without streaming the whole 'Initializing docker
-        # container' phase is silent for `sky launch` clients tailing the
-        # provision log.
+        # minutes). Its output already lands in this node's log file
+        # either way; streaming additionally echoes it to the process
+        # stream, which is what reaches the API server request log and
+        # `sky launch` clients live.
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +
                                     'pull_before_run is specified')
-            logger.info(f'Pulling docker image {specific_image}')
             self._run(f'{self.docker_cmd} pull {specific_image}',
                       wait_for_docker_daemon=True,
-                      stream_logs=True)
+                      stream_logs=self.stream_pull_logs)
         else:
             self._run(
                 f'{self.docker_cmd} image inspect {specific_image} '
                 '1> /dev/null  2>&1 || '
                 f'{self.docker_cmd} pull {specific_image}',
                 wait_for_docker_daemon=True,
-                stream_logs=True)
+                stream_logs=self.stream_pull_logs)
 
         logger.info(f'Starting container {self.container_name} with image '
                     f'{specific_image}')

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -222,6 +222,12 @@ class DockerInitializer:
         log_err_when_fail: bool = True,
         flock_name: Optional[str] = None,
         flock_args: Optional[str] = None,
+        # Streaming tees: output shows up live in the provision log and is
+        # still returned. Only enable it for long-running commands with
+        # line-oriented output (e.g. `docker pull`); probe commands must
+        # stay quiet because their outputs are parsed and their retries
+        # can print transient errors.
+        stream_logs: bool = False,
     ) -> str:
 
         if run_env == 'docker':
@@ -247,7 +253,7 @@ class DockerInitializer:
             rc, stdout, stderr = self.runner.run(
                 cmd,
                 require_outputs=True,
-                stream_logs=False,
+                stream_logs=stream_logs,
                 separate_stderr=separate_stderr,
                 log_path=self.log_path)
             if (DOCKER_PERMISSION_DENIED_STR in stdout + stderr or
@@ -350,17 +356,25 @@ class DockerInitializer:
             # the user did not add it.
             specific_image = docker_login_config.format_image(specific_image)
 
+        # Stream the pull: it is the one docker setup step whose duration
+        # scales with image size (a multi-GB image can pull for many
+        # minutes), and without streaming the whole 'Initializing docker
+        # container' phase is silent for `sky launch` clients tailing the
+        # provision log.
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +
                                     'pull_before_run is specified')
+            logger.info(f'Pulling docker image {specific_image}')
             self._run(f'{self.docker_cmd} pull {specific_image}',
-                      wait_for_docker_daemon=True)
+                      wait_for_docker_daemon=True,
+                      stream_logs=True)
         else:
             self._run(
                 f'{self.docker_cmd} image inspect {specific_image} '
                 '1> /dev/null  2>&1 || '
                 f'{self.docker_cmd} pull {specific_image}',
-                wait_for_docker_daemon=True)
+                wait_for_docker_daemon=True,
+                stream_logs=True)
 
         logger.info(f'Starting container {self.container_name} with image '
                     f'{specific_image}')

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -277,8 +277,13 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
     @_auto_retry(should_retry=lambda e: isinstance(e, exceptions.CommandError)
                  and e.returncode == 255)
     def _initialize_docker(runner: command_runner.CommandRunner, log_path: str):
-        docker_user = docker_utils.DockerInitializer(docker_config, runner,
-                                                     log_path).initialize()
+        # Only the head node (the one logging to the provision log) streams
+        # its pull progress; a worker streaming to the shared process
+        # stdout would interleave with the head's output.
+        is_head = log_path == str(provision_logging.get_log_path())
+        docker_user = docker_utils.DockerInitializer(
+            docker_config, runner, log_path,
+            stream_pull_logs=is_head).initialize()
         logger.debug(f'Initialized docker user: {docker_user}')
         return docker_user
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -274,13 +274,18 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
         return None
     _hint_worker_log_path(cluster_name, cluster_info, 'initialize_docker')
 
+    # Resolved here rather than in the closure: the closure runs in the
+    # SSH pool's worker threads, where the thread-local provision-logging
+    # context (and thus get_log_path()) is not set up.
+    provision_log_path = str(provision_logging.get_log_path())
+
     @_auto_retry(should_retry=lambda e: isinstance(e, exceptions.CommandError)
                  and e.returncode == 255)
     def _initialize_docker(runner: command_runner.CommandRunner, log_path: str):
         # Only the head node (the one logging to the provision log) streams
         # its pull progress; a worker streaming to the shared process
         # stdout would interleave with the head's output.
-        is_head = log_path == str(provision_logging.get_log_path())
+        is_head = log_path == provision_log_path
         docker_user = docker_utils.DockerInitializer(
             docker_config, runner, log_path,
             stream_pull_logs=is_head).initialize()

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -794,6 +794,30 @@ def test_private_docker_registry(generic_cloud,
     smoke_tests_utils.run_one_test(test)
 
 
+def test_docker_pull_progress_streaming(generic_cloud: str):
+    """Docker pull progress must stream into the launch output.
+
+    A fresh VM has no cached layers, so the pull emits per-layer progress;
+    with head-node streaming (DockerInitializer stream_pull_logs) those
+    lines must reach the client's captured launch output instead of only
+    the per-node provision log.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'docker_pull_progress_streaming',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} '
+            f'--image-id docker:ubuntu:20.04 --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            'tests/test_yamls/minimal.yaml) && echo "$s" && echo "$s" | '
+            'grep -E "Pull complete|Status: Downloaded newer image"',
+            f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+        ],
+        f'sky down -y {name}',
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 def test_docker_nonroot_user(generic_cloud: str):
     """Test Docker image with non-root default user and ENV HOME override.
 

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -794,6 +794,8 @@ def test_private_docker_registry(generic_cloud,
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.no_kubernetes  # Kubernetes pulls images outside DockerInitializer
+@pytest.mark.no_slurm  # Slurm does not use the VM DockerInitializer path
 def test_docker_pull_progress_streaming(generic_cloud: str):
     """Docker pull progress must stream into the launch output.
 

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -1,0 +1,88 @@
+"""Tests for docker container initialization on a remote node."""
+from unittest import mock
+
+from sky.provision import docker_utils
+
+
+def _make_initializer(docker_config, runs):
+    """Returns a DockerInitializer whose runner records every command."""
+
+    def _fake_run(cmd, **kwargs):
+        runs.append((cmd, kwargs))
+        if 'command -v docker' in cmd:
+            return (0, '/usr/bin/docker', '')
+        if 'printenv HOME' in cmd:
+            return (0, '/root', '')
+        if 'SKYPILOT_DOCKER_USER' in cmd:
+            return (0, 'SKYPILOT_DOCKER_USER: root', '')
+        return (0, '', '')
+
+    runner = mock.MagicMock()
+    runner.run.side_effect = _fake_run
+    return docker_utils.DockerInitializer(docker_config, runner, '/dev/null')
+
+
+def test_run_does_not_stream_by_default():
+    runs = []
+    initializer = _make_initializer(
+        {
+            'container_name': 'sky_container',
+            'image': 'myimage:latest'
+        }, runs)
+    initializer._run('whoami')  # pylint: disable=protected-access
+    assert len(runs) == 1
+    _, kwargs = runs[0]
+    assert kwargs['stream_logs'] is False
+
+
+def test_run_streams_when_requested():
+    runs = []
+    initializer = _make_initializer(
+        {
+            'container_name': 'sky_container',
+            'image': 'myimage:latest'
+        }, runs)
+    # pylint: disable=protected-access
+    initializer._run('docker pull myimage:latest', stream_logs=True)
+    assert len(runs) == 1
+    _, kwargs = runs[0]
+    assert kwargs['stream_logs'] is True
+
+
+def _assert_only_pulls_streamed(runs):
+    pull_runs = [(cmd, kwargs) for cmd, kwargs in runs if ' pull ' in cmd]
+    assert pull_runs, 'initialize() should have pulled the image'
+    for cmd, kwargs in pull_runs:
+        assert kwargs['stream_logs'] is True, (
+            f'Pull command should stream its output: {cmd}')
+    other_runs = [(cmd, kwargs) for cmd, kwargs in runs if ' pull ' not in cmd]
+    assert other_runs, 'initialize() should have run setup commands'
+    for cmd, kwargs in other_runs:
+        assert kwargs['stream_logs'] is False, (
+            f'Non-pull command should not stream its output: {cmd}')
+
+
+def test_initialize_streams_image_pull_only():
+    runs = []
+    initializer = _make_initializer(
+        {
+            'container_name': 'sky_container',
+            'image': 'myimage:latest',
+            'pull_before_run': True,
+        }, runs)
+    docker_user = initializer.initialize()
+    assert docker_user == 'root'
+    _assert_only_pulls_streamed(runs)
+
+
+def test_initialize_streams_conditional_pull():
+    runs = []
+    initializer = _make_initializer(
+        {
+            'container_name': 'sky_container',
+            'image': 'myimage:latest',
+            'pull_before_run': False,
+        }, runs)
+    docker_user = initializer.initialize()
+    assert docker_user == 'root'
+    _assert_only_pulls_streamed(runs)

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -4,7 +4,7 @@ from unittest import mock
 from sky.provision import docker_utils
 
 
-def _make_initializer(docker_config, runs):
+def _make_initializer(docker_config, runs, stream_pull_logs=True):
     """Returns a DockerInitializer whose runner records every command."""
 
     def _fake_run(cmd, **kwargs):
@@ -15,11 +15,16 @@ def _make_initializer(docker_config, runs):
             return (0, '/root', '')
         if 'SKYPILOT_DOCKER_USER' in cmd:
             return (0, 'SKYPILOT_DOCKER_USER: root', '')
+        if '/proc/meminfo' in cmd:
+            return (0, 'MemAvailable:    8388608 kB', '')
         return (0, '', '')
 
     runner = mock.MagicMock()
     runner.run.side_effect = _fake_run
-    return docker_utils.DockerInitializer(docker_config, runner, '/dev/null')
+    return docker_utils.DockerInitializer(docker_config,
+                                          runner,
+                                          '/dev/null',
+                                          stream_pull_logs=stream_pull_logs)
 
 
 def test_run_does_not_stream_by_default():
@@ -86,3 +91,18 @@ def test_initialize_streams_conditional_pull():
     docker_user = initializer.initialize()
     assert docker_user == 'root'
     _assert_only_pulls_streamed(runs)
+
+
+def test_worker_initializer_keeps_pull_quiet():
+    runs = []
+    initializer = _make_initializer(
+        {
+            'container_name': 'sky_container',
+            'image': 'myimage:latest',
+            'pull_before_run': True,
+        },
+        runs,
+        stream_pull_logs=False)
+    docker_user = initializer.initialize()
+    assert docker_user == 'root'
+    assert all(not kwargs['stream_logs'] for _, kwargs in runs)

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -106,3 +106,63 @@ def test_worker_initializer_keeps_pull_quiet():
     docker_user = initializer.initialize()
     assert docker_user == 'root'
     assert all(not kwargs['stream_logs'] for _, kwargs in runs)
+
+
+def test_initialize_docker_streams_head_only(monkeypatch):
+    """Head detection must survive the SSH pool's worker threads.
+
+    The provision-logging context is a threading.local set up in the
+    provisioning thread; resolving it inside the pool-dispatched closure
+    would see the /dev/null default and never stream.
+    """
+    from concurrent import futures
+    import pathlib
+
+    from sky.provision import instance_setup
+    from sky.provision import logging as provision_logging
+
+    head_log_path = '/logs/provision.log'
+    worker_log_path = '/logs/instance/worker.log'
+    monkeypatch.setattr(provision_logging.config,
+                        'log_path',
+                        pathlib.Path(head_log_path),
+                        raising=False)
+
+    constructed = {}
+
+    class _FakeInitializer:
+
+        def __init__(self, docker_config, runner, log_path, stream_pull_logs):
+            del docker_config, runner
+            constructed[log_path] = stream_pull_logs
+
+        def initialize(self):
+            return 'root'
+
+    monkeypatch.setattr(instance_setup.docker_utils, 'DockerInitializer',
+                        _FakeInitializer)
+
+    def _fake_parallel_ssh_with_cache(func, cluster_name, stage_name, digest,
+                                      cluster_info, ssh_credentials):
+        # Mirror the real dispatch: the closure runs in pool threads,
+        # head first with the provision log, workers with instance logs.
+        with futures.ThreadPoolExecutor(max_workers=2) as pool:
+            results = [
+                pool.submit(func, mock.MagicMock(), head_log_path),
+                pool.submit(func, mock.MagicMock(), worker_log_path),
+            ]
+            return [future.result() for future in results]
+
+    monkeypatch.setattr(instance_setup, '_parallel_ssh_with_cache',
+                        _fake_parallel_ssh_with_cache)
+
+    instance_setup.initialize_docker(
+        'test-cluster',
+        docker_config={
+            'container_name': 'c',
+            'image': 'img'
+        },
+        cluster_info=mock.MagicMock(num_instances=2),
+        ssh_credentials={})
+
+    assert constructed == {head_log_path: True, worker_log_path: False}

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -1,7 +1,11 @@
 """Tests for docker container initialization on a remote node."""
+from concurrent import futures
+import pathlib
 from unittest import mock
 
 from sky.provision import docker_utils
+from sky.provision import instance_setup
+from sky.provision import logging as provision_logging
 
 
 def _make_initializer(docker_config, runs, stream_pull_logs=True):
@@ -115,12 +119,6 @@ def test_initialize_docker_streams_head_only(monkeypatch):
     provisioning thread; resolving it inside the pool-dispatched closure
     would see the /dev/null default and never stream.
     """
-    from concurrent import futures
-    import pathlib
-
-    from sky.provision import instance_setup
-    from sky.provision import logging as provision_logging
-
     head_log_path = '/logs/provision.log'
     worker_log_path = '/logs/instance/worker.log'
     monkeypatch.setattr(provision_logging.config,


### PR DESCRIPTION
## Summary

Fixes #10141.

Stream Docker image-pull progress into the provision log and client launch output. Multi-GB images can otherwise pull for many minutes between "Instance is up." and "Docker container is up." with no visible progress, making a healthy launch look hung.

## Changes

- Add a `stream_logs` parameter to `DockerInitializer._run`, defaulting to `False` so probe and identity commands remain quiet.
- Enable streaming for both `docker pull` paths in `initialize()`.
- Stream only the head node to avoid interleaved copies of the same layer progress from workers; worker pulls remain in their per-instance logs.
- Preserve tee behavior, so streamed output is still written to the per-node provision log and returned to callers.
- Resolve the provision-log path before entering the SSH worker pool.
- Add unit coverage for both pull paths, head/worker behavior, and log-path propagation.
- Add a VM-only smoke test that launches with an uncached Docker image and asserts pull progress reaches captured `sky launch` output. Kubernetes and Slurm are excluded because they do not use this VM `DockerInitializer` path.

## Tested

- [x] Code formatting: `bash format.sh`
- [x] Unit tests: `pytest tests/unit_tests/test_docker_utils.py`
- [x] Manual validation on GCP and Azure with a multi-GB image: layer progress reached the API request log and client output
- [x] Smoke-test collection: `pytest --collect-only tests/smoke_tests/test_images.py -k test_docker_pull_progress_streaming --generic-cloud aws`
- [ ] Relevant smoke test: `/smoke-test -k test_docker_pull_progress_streaming --generic-cloud aws`
- [ ] All smoke tests: `/smoke-test`
- [ ] Backward compatibility: `/quicktest-core`
