### PR TITLE
[Azure] Support pinning an availability zone per region via azure.region_configs

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1515,6 +1515,37 @@ errors from the cloud provider will be surfaced.
       team: ml-infra
       environment: production
 
+.. _config-yaml-azure-region-configs:
+
+``azure.region_configs``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Advanced per-region Azure configuration (optional).
+
+``availability_zone``
+    Availability zone to pin VMs launched in this region to (optional).
+    By default, SkyPilot launches Azure VMs without a zone constraint and
+    Azure picks the placement. In capacity-constrained regions a SKU may
+    only be allocatable in a specific zone, where a zoneless request fails
+    with a capacity error while a zone-pinned request succeeds.
+
+    Azure availability zone labels are region-relative: the same SKU can
+    map to different physical zones under the same label in different
+    regions, so the pin must be configured per region. Regions without a
+    configured zone keep the default zoneless placement.
+
+Example:
+
+.. code-block:: yaml
+
+    azure:
+        # Region-specific configuration
+        region_configs:
+            southcentralus:
+                availability_zone: "2"
+            spaincentral:
+                availability_zone: "1"
+
 .. _config-yaml-azure-vpc-name:
 
 ``azure.vpc_name``

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -213,6 +213,9 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`vpc_name <config-yaml-azure-vpc-name>`: my-vnet
     :ref:`use_internal_ips <config-yaml-azure-use-internal-ips>`: true
     :ref:`ssh_proxy_command <config-yaml-azure-ssh-proxy-command>`: ssh -W %h:%p user@host
+    :ref:`region_configs <config-yaml-azure-region-configs>`:
+      southcentralus:
+        availability_zone: "2"
 
   :ref:`oci <config-yaml-oci>`:
     region_configs:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -431,6 +431,16 @@ class Azure(clouds.Cloud):
                 'image_version': version,
             }
 
+        # Availability zone to pin VMs to, if configured for this
+        # region. Azure zones are region-relative labels (the same SKU can
+        # live in different physical zones under the same label across
+        # regions), so the pin is only configurable per region.
+        availability_zone = skypilot_config.get_effective_region_config(
+            cloud='azure',
+            region=region_name,
+            keys=('availability_zone',),
+            default_value=None)
+
         # Determine resource group for deploying the instance.
         resource_group_name = skypilot_config.get_effective_region_config(
             cloud='azure',
@@ -491,8 +501,9 @@ class Azure(clouds.Cloud):
             'num_gpus': acc_count,
             'use_spot': resources.use_spot,
             'region': region_name,
-            # Azure does not support specific zones.
+            # Azure does not support specific zones in `resources.zone`.
             'zones': None,
+            'availability_zone': availability_zone,
             **image_config,
             'disk_tier': Azure._get_disk_type(disk_tier),
             'cloud_init_setup_commands': cloud_init_setup_commands,

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -298,6 +298,9 @@ def _create_vm(
                 storage_account_type=node_config['azure_arm_parameters']
                 ['osDiskTier']),
             disk_size_gb=node_config['azure_arm_parameters']['osDiskSizeGB']))
+    availability_zone = node_config['azure_arm_parameters'].get(
+        'availabilityZone', None)
+    zones = None if availability_zone is None else [str(availability_zone)]
     vm_instance = compute.VirtualMachine(
         location=provider_config['location'],
         tags=node_tags,
@@ -308,6 +311,7 @@ def _create_vm(
         identity=compute.VirtualMachineIdentity(
             type='UserAssigned',
             user_assigned_identities={provider_config['msi']: {}}),
+        zones=zones,
         priority=node_config['azure_arm_parameters'].get('priority', None))
     vm_poller = compute_client.virtual_machines.begin_create_or_update(
         resource_group_name=provider_config['resource_group'],

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -86,6 +86,10 @@ available_node_types:
             sharedGalleryImageId: {{shared_gallery_image_id}}
             osDiskSizeGB: {{disk_size}}
             osDiskTier: {{disk_tier}}
+            {%- if availability_zone is not none %}
+            # Availability zone to pin the VM to (region-relative label).
+            availabilityZone: "{{availability_zone}}"
+            {%- endif %}
             {%- if use_spot %}
             # optionally set priority to use Spot instances
             priority: Spot

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -6,7 +6,7 @@ from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
-_REGION_CONFIG_CLOUDS = ['nebius', 'oci']
+_REGION_CONFIG_CLOUDS = ['azure', 'nebius', 'oci']
 
 # Kubernetes API use list to represent dictionary fields with patch strategy
 # merge and each item is indexed by the patch merge key. The following map

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1968,7 +1968,13 @@ def get_config_schema():
                         'additionalProperties': False,
                         'properties': {
                             'availability_zone': {
-                                'type': 'string',
+                                'anyOf': [{
+                                    'type': 'string',
+                                }, {
+                                    'type': 'integer',
+                                }, {
+                                    'type': 'null',
+                                }],
                             },
                         },
                     },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1957,6 +1957,22 @@ def get_config_schema():
                         'type': 'null',
                     }]
                 },
+                'region_configs': {
+                    'type': 'object',
+                    'required': [],
+                    'properties': {},
+                    # Keyed by Azure region name (e.g. 'eastus').
+                    'additionalProperties': {
+                        'type': 'object',
+                        'required': [],
+                        'additionalProperties': False,
+                        'properties': {
+                            'availability_zone': {
+                                'type': 'string',
+                            },
+                        },
+                    },
+                },
                 **_LABELS_SCHEMA,
                 **_CAPABILITIES_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1968,13 +1968,21 @@ def get_config_schema():
                         'additionalProperties': False,
                         'properties': {
                             'availability_zone': {
-                                'anyOf': [{
-                                    'type': 'string',
-                                }, {
-                                    'type': 'integer',
-                                }, {
-                                    'type': 'null',
-                                }],
+                                'anyOf': [
+                                    {
+                                        'type': 'string',
+                                        # Azure zone labels are numeric strings;
+                                        # reject typos (and empty strings) at
+                                        # validation instead of at the Azure API.
+                                        'pattern': '^[0-9]+$',
+                                    },
+                                    {
+                                        'type': 'integer',
+                                    },
+                                    {
+                                        'type': 'null',
+                                    }
+                                ],
                             },
                         },
                     },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1971,9 +1971,10 @@ def get_config_schema():
                                 'anyOf': [
                                     {
                                         'type': 'string',
-                                        # Azure zone labels are numeric strings;
-                                        # reject typos (and empty strings) at
-                                        # validation instead of at the Azure API.
+                                        # Azure zone labels are numeric
+                                        # strings; reject typos (and empty
+                                        # strings) at validation instead of
+                                        # at the Azure API.
                                         'pattern': '^[0-9]+$',
                                     },
                                     {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1975,7 +1975,7 @@ def get_config_schema():
                                         # strings; reject typos (and empty
                                         # strings) at validation instead of
                                         # at the Azure API.
-                                        'pattern': '^[0-9]+$',
+                                        'pattern': '^[0-9]+\\Z',
                                     },
                                     {
                                         'type': 'integer',

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -163,6 +163,39 @@ def test_ibm_region():
 
 
 @pytest.mark.azure
+def test_azure_region_config_availability_zone():
+    """Pins the VM to an availability zone via azure.region_configs.
+
+    Launches with the per-region pin set through a config override and
+    verifies with the Azure CLI that the created VM actually landed in
+    that zone (SkyPilot deploys Azure VMs zoneless by default).
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    region = 'eastus'
+    zone = '2'
+    test = smoke_tests_utils.Test(
+        'azure_region_config_availability_zone',
+        [
+            smoke_tests_utils.launch_cluster_for_cloud_cmd('azure', name),
+            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'--infra azure/{region} '
+            f'--config azure.region_configs.{region}.availability_zone={zone} '
+            'tests/test_yamls/minimal.yaml',
+            f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+            # Verify with the Azure CLI that the VM is in the pinned zone.
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name, 'az vm list '
+                f'--query "[?starts_with(name, \'{name}\') '
+                f'&& zones[0]==\'{zone}\'].name" '
+                '--output tsv | grep .'),
+        ],
+        f'sky down -y {name} && '
+        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.azure
 def test_azure_region():
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1231,7 +1231,7 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
 def test_standardized_region_configs(monkeypatch, tmp_path) -> None:
     """Test that nested per-region standardized config works
 
-    Current clouds: Nebius, OCI"""
+    Current clouds: Azure, Nebius, OCI"""
     from sky.provision.kubernetes import utils as kubernetes_utils
     with open(tmp_path / 'region_configs.yaml', 'w', encoding='utf-8') as f:
         f.write(f"""\
@@ -1262,6 +1262,11 @@ def test_standardized_region_configs(monkeypatch, tmp_path) -> None:
                 ap-seoul-1:
                     vcn_ocid: vcn_ocid1
                     vcn_subnet: vcn_subnet1
+
+        azure:
+            region_configs:
+                southcentralus:
+                    availability_zone: "2"
         """)
     monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
                         tmp_path / 'region_configs.yaml')
@@ -1314,6 +1319,17 @@ def test_standardized_region_configs(monkeypatch, tmp_path) -> None:
         keys=('filesystems',),
         default_value=[])
     assert len(filesystems) == 2
+
+    # azure: test availability_zone property
+    scus_zone = skypilot_config.get_effective_region_config(
+        cloud='azure', region='southcentralus', keys=('availability_zone',))
+    assert scus_zone == '2'
+    unpinned_zone = skypilot_config.get_effective_region_config(
+        cloud='azure',
+        region='eastus',
+        keys=('availability_zone',),
+        default_value=None)
+    assert unpinned_zone is None
 
     # oci: test general
     vcn_ocid = skypilot_config.get_effective_region_config(cloud='oci',

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -314,6 +314,20 @@ class TestRegionAvailabilityZone:
             }
             jsonschema.validate(config, schemas.get_config_schema())
 
+    def test_schema_rejects_non_numeric_zone_strings(self):
+        for zone in ('', 'us-east-1a', ' 2'):
+            config = {
+                'azure': {
+                    'region_configs': {
+                        'southcentralus': {
+                            'availability_zone': zone,
+                        },
+                    },
+                },
+            }
+            with pytest.raises(jsonschema.ValidationError):
+                jsonschema.validate(config, schemas.get_config_schema())
+
     def test_schema_rejects_cloud_level_availability_zone(self):
         config = {'azure': {'availability_zone': '2'}}
         with pytest.raises(jsonschema.ValidationError):

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -1,6 +1,7 @@
 """Tests for Azure utilities and provisioning config."""
 from unittest import mock
 
+import jsonschema
 import pytest
 
 from sky import clouds
@@ -10,6 +11,8 @@ from sky.clouds.utils import azure_utils
 from sky.provision.azure.config import _remove_msi_resources_from_template
 from sky.provision.azure.config import _remove_network_resources_from_template
 from sky.provision.azure.config import _resolve_custom_managed_identity
+from sky.utils import config_utils
+from sky.utils import schemas
 
 _SIG_IMAGE_ID = ('/subscriptions/sub-123/resourceGroups/my-rg/providers/'
                  'Microsoft.Compute/galleries/my-gallery/images/my-image/'
@@ -263,3 +266,54 @@ def _make_arm_template():
             },
         }
     }
+
+
+class TestRegionAvailabilityZone:
+    """Tests for the azure.region_configs.<region>.availability_zone pin."""
+
+    _CONFIG = {
+        'azure': {
+            'region_configs': {
+                'southcentralus': {
+                    'availability_zone': '2',
+                },
+            },
+        },
+    }
+
+    def _resolve(self, region):
+        return config_utils.get_cloud_config_value_from_dict(
+            dict_config=self._CONFIG,
+            cloud='azure',
+            region=region,
+            keys=('availability_zone',))
+
+    def test_pinned_region_resolves_zone(self):
+        assert self._resolve('southcentralus') == '2'
+
+    def test_unpinned_region_stays_zoneless(self):
+        assert self._resolve('eastus') is None
+
+    def test_no_region_configs_stays_zoneless(self):
+        assert config_utils.get_cloud_config_value_from_dict(
+            dict_config={'azure': {}},
+            cloud='azure',
+            region='southcentralus',
+            keys=('availability_zone',)) is None
+
+    def test_schema_accepts_region_configs(self):
+        config = {
+            'azure': {
+                'region_configs': {
+                    'southcentralus': {
+                        'availability_zone': '2',
+                    },
+                },
+            },
+        }
+        jsonschema.validate(config, schemas.get_config_schema())
+
+    def test_schema_rejects_cloud_level_availability_zone(self):
+        config = {'azure': {'availability_zone': '2'}}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(config, schemas.get_config_schema())

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -302,16 +302,17 @@ class TestRegionAvailabilityZone:
             keys=('availability_zone',)) is None
 
     def test_schema_accepts_region_configs(self):
-        config = {
-            'azure': {
-                'region_configs': {
-                    'southcentralus': {
-                        'availability_zone': '2',
+        for zone in ('2', 2, None):
+            config = {
+                'azure': {
+                    'region_configs': {
+                        'southcentralus': {
+                            'availability_zone': zone,
+                        },
                     },
                 },
-            },
-        }
-        jsonschema.validate(config, schemas.get_config_schema())
+            }
+            jsonschema.validate(config, schemas.get_config_schema())
 
     def test_schema_rejects_cloud_level_availability_zone(self):
         config = {'azure': {'availability_zone': '2'}}


### PR DESCRIPTION
Fixes #10145.

SkyPilot deploys Azure VMs zoneless. In capacity-constrained regions a SKU can be allocatable in a single zone only (e.g. `Standard_HB120rs_v3` in `southcentralus` allocates in zone 2 only), so the zoneless request fails with a generic capacity error while a zone-pinned request succeeds — and SkyPilot has no way to express the pin.

This PR adds per-region zone pinning through the existing `region_configs` mechanism (already used by OCI and Nebius):

```yaml
azure:
  region_configs:
    southcentralus:
      availability_zone: "2"
```

Design notes:

- **Per-region, not cloud-level, by design**: Azure zone labels are region-relative (the same label can map to different physical zones across regions/subscriptions), so the schema only accepts the key inside `region_configs` — a cloud-level `azure.availability_zone` is rejected by validation (covered by a test).
- **Not `resources.zone`**: full zone support would need Azure zone data in the catalog and zone-aware failover; this is the minimal operator-level pin. Regions without a pin keep today's zoneless placement, and `resources.zone` stays unsupported for Azure (unchanged assert).
- Plumbing follows the existing patterns: `sky/clouds/azure.py` resolves the pin with `skypilot_config.get_effective_region_config` (same call shape as `resource_group_vm`, whose call site already passed `region=` in anticipation of per-region support), the template renders it into `azure_arm_parameters`, and `_create_vm` sets `zones` on the `VirtualMachine` (same path as `sharedGalleryImageId` from #9843).

Changes:

- `sky/utils/config_utils.py`: add `azure` to `_REGION_CONFIG_CLOUDS`.
- `sky/utils/schemas.py`: `azure.region_configs.<region>.availability_zone` (string).
- `sky/clouds/azure.py`: resolve the configured pin for the target region and emit it as a deploy variable.
- `sky/templates/azure-ray.yml.j2`: render `availabilityZone` into `azure_arm_parameters` when configured.
- `sky/provision/azure/instance.py`: pass `zones=[<pin>]` to `VirtualMachine` when present, `None` otherwise (today's behavior).
- `docs/source/reference/config.rst`: `azure.region_configs` reference entry.
- `tests/unit_tests/test_azure_utils.py`: resolution per region, zoneless defaults, schema accept/reject cases.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): `pytest tests/unit_tests/test_azure_utils.py` (21 passed). The zone-pin behavior itself has been running in production on our Azure fleet (as a vendored patch this PR replaces): HBv3 launches in `southcentralus` fail zoneless and succeed pinned to zone 2.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)