### PR TITLE
[Azure] Support ACR authentication via the VM's managed identity

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -246,6 +246,37 @@ you can use :ref:`task environment variables <env-vars>`:
             Note that the base64 encoding option is only available on Artifact Registry, not Container Registry (GCR).
 
 
+    .. tab-item:: Azure ACR
+        :sync: azure-acr-tab
+
+        We support private Azure Container Registries with an `access token or service principal <https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication>`_:
+
+        .. code-block:: yaml
+
+          resources:
+            image_id: docker:<repo>:<tag>
+
+          envs:
+            SKYPILOT_DOCKER_USERNAME: <token-name-or-service-principal-id>
+            SKYPILOT_DOCKER_PASSWORD: <token-or-service-principal-password>
+            SKYPILOT_DOCKER_SERVER: <your-registry>.azurecr.io
+
+        .. note::
+
+            If your cluster is on Azure, SkyPilot will automatically use the VM's managed identity to authenticate with ACR, if the ``SKYPILOT_DOCKER_USERNAME`` and ``SKYPILOT_DOCKER_PASSWORD`` are set to empty strings:
+
+            .. code-block:: yaml
+
+              resources:
+                image_id: docker:<repo>:<tag>
+
+              envs:
+                SKYPILOT_DOCKER_USERNAME: ""
+                SKYPILOT_DOCKER_PASSWORD: ""
+                SKYPILOT_DOCKER_SERVER: <your-registry>.azurecr.io
+
+            **Important**: Ensure the cluster's managed identity has the ``AcrPull`` role on the registry (SkyPilot's default managed identity or a custom one via ``remote_identity``).
+
     .. tab-item:: NVIDIA NGC
         :sync: nvidia-container-registry-tab
 

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -597,6 +597,22 @@ def wait_instances(region: str, cluster_name_on_cloud: str,
     # So we don't need to wait here.
 
 
+def _vm_user_assigned_identity(vm) -> Optional[str]:
+    """The VM's user-assigned managed identity resource ID, if unambiguous.
+
+    Returns None when the VM has no user-assigned identity or more than
+    one: callers cannot know which of several identities carries the
+    intended permissions, so disambiguation is left to the user.
+    """
+    identity = getattr(vm, 'identity', None)
+    if identity is None or not identity.user_assigned_identities:
+        return None
+    identity_ids = list(identity.user_assigned_identities.keys())
+    if len(identity_ids) != 1:
+        return None
+    return identity_ids[0]
+
+
 def get_cluster_info(
         region: str,
         cluster_name_on_cloud: str,
@@ -617,6 +633,19 @@ def get_cluster_info(
         filters,
         status_filters=[AzureInstanceStatus.RUNNING])
     head_instance_id = _get_head_instance_id(running_instances)
+
+    # Surface the cluster's user-assigned managed identity so
+    # post-provision steps can authenticate as that exact identity (e.g.
+    # the ACR docker login in DockerInitializer). The 'msi' key is only
+    # present in the in-memory bootstrap config during creation, so on
+    # restarts it must be re-derived from the live VM.
+    if 'msi' not in provider_config:
+        for inst in running_instances:
+            if inst.name == head_instance_id:
+                msi = _vm_user_assigned_identity(inst)
+                if msi is not None:
+                    provider_config = dict(provider_config, msi=msi)
+                break
 
     instances = {}
     use_internal_ips = provider_config.get('use_internal_ips', False)

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -49,6 +49,16 @@ INSTALL_AWS_CLI_CMD = (
     'unzip -q /tmp/awscliv2.zip -d /tmp && sudo /tmp/aws/install '
     '&& rm -rf /tmp/awscliv2.zip /tmp/aws)')
 
+# The Azure CLI is only needed when pulling a private ACR image with the
+# VM's managed identity, so keep the install lazy.
+INSTALL_AZURE_CLI_CMD = ('which az || '
+                         '(curl -sL https://aka.ms/InstallAzureCLIDeb | '
+                         'sudo bash)')
+
+# The documented username for `docker login` with an ACR access token. See:
+# https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication#az-acr-login-with---expose-token  # pylint: disable=line-too-long
+ACR_TOKEN_USERNAME = '00000000-0000-0000-0000-000000000000'
+
 # Pattern to extract SSH user from command output, handling MOTD contamination
 _DOCKER_USER_PATTERN = re.compile(r'SKYPILOT_DOCKER_USER: ([^\s\n]+)')
 
@@ -346,6 +356,32 @@ class DockerInitializer:
                 self._run('sudo gcloud auth configure-docker '
                           f'{shlex.quote(docker_login_config.server)} '
                           '--quiet || true')
+            elif docker_login_config.server.endswith('.azurecr.io'):
+                # Azure ACR: an empty password means the VM's managed
+                # identity is the credential, mirroring the ECR branch
+                # above. Feed the minted token to `{docker_cmd} login` so
+                # the credential lands in the docker config the sudo'd
+                # docker commands read (plain `az acr login` writes the SSH
+                # user's ~/.docker/config.json instead — see #8906).
+                self._run(INSTALL_AZURE_CLI_CMD, wait_for_docker_daemon=False)
+                identity = self.docker_config.get('azure_managed_identity',
+                                                  None)
+                # With no explicit identity, `az login --identity` uses the
+                # VM's only identity; the resource ID disambiguates when the
+                # VM has more than one.
+                identity_flag = ('' if identity is None else
+                                 f' --resource-id {shlex.quote(identity)}')
+                registry_name = docker_login_config.server.split('.', 1)[0]
+                self._run(
+                    f'az login --identity{identity_flag} '
+                    '--allow-no-subscriptions --output none && '
+                    f'az acr login --name {shlex.quote(registry_name)} '
+                    '--expose-token --output tsv --query accessToken | '
+                    f'{self.docker_cmd} login '
+                    f'{shlex.quote(docker_login_config.server)} '
+                    f'--username {ACR_TOKEN_USERNAME} '
+                    '--password-stdin',
+                    wait_for_docker_daemon=True)
             # We automatically add the server prefix to the image name if
             # the user did not add it.
             specific_image = docker_login_config.format_image(specific_image)

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -367,10 +367,16 @@ class DockerInitializer:
                 identity = self.docker_config.get('azure_managed_identity',
                                                   None)
                 # With no explicit identity, `az login --identity` uses the
-                # VM's only identity; the resource ID disambiguates when the
-                # VM has more than one.
-                identity_flag = ('' if identity is None else
-                                 f' --resource-id {shlex.quote(identity)}')
+                # VM's only identity. New Azure CLI releases accept a resource
+                # ID via --resource-id; LTS releases use --username for the
+                # same value. Detect the supported spelling to work with an
+                # Azure CLI already present on a custom image.
+                identity_flag = ''
+                if identity is not None:
+                    identity_flag = (
+                        ' $(az login --help | grep -q -- "--resource-id" && '
+                        'printf %s --resource-id || printf %s --username) '
+                        f'{shlex.quote(identity)}')
                 registry_name = docker_login_config.server.split('.', 1)[0]
                 # An isolated, throwaway AZURE_CONFIG_DIR keeps the MSI
                 # login from clobbering any `az` account state of the SSH

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -52,7 +52,7 @@ INSTALL_AWS_CLI_CMD = (
 # The Azure CLI is only needed when pulling a private ACR image with the
 # VM's managed identity, so keep the install lazy.
 INSTALL_AZURE_CLI_CMD = ('which az || '
-                         '(curl -sL https://aka.ms/InstallAzureCLIDeb | '
+                         '(curl -fsSL https://aka.ms/InstallAzureCLIDeb | '
                          'sudo bash)')
 
 # The documented username for `docker login` with an ACR access token. See:
@@ -372,7 +372,12 @@ class DockerInitializer:
                 identity_flag = ('' if identity is None else
                                  f' --resource-id {shlex.quote(identity)}')
                 registry_name = docker_login_config.server.split('.', 1)[0]
+                # An isolated, throwaway AZURE_CONFIG_DIR keeps the MSI
+                # login from clobbering any `az` account state of the SSH
+                # user (initialize() re-runs on every `sky start`).
                 self._run(
+                    'export AZURE_CONFIG_DIR=$(mktemp -d) && '
+                    'trap \'rm -rf "$AZURE_CONFIG_DIR"\' EXIT && '
                     f'az login --identity{identity_flag} '
                     '--allow-no-subscriptions --output none && '
                     f'az acr login --name {shlex.quote(registry_name)} '

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -51,7 +51,7 @@ INSTALL_AWS_CLI_CMD = (
 
 # The Azure CLI is only needed when pulling a private ACR image with the
 # VM's managed identity, so keep the install lazy.
-INSTALL_AZURE_CLI_CMD = ('which az || '
+INSTALL_AZURE_CLI_CMD = ('command -v az || '
                          '(curl -fsSL https://aka.ms/InstallAzureCLIDeb | '
                          'sudo bash)')
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -495,6 +495,13 @@ def _post_provision_setup(
     ssh_credentials = backend_utils.ssh_credential_from_yaml(
         handle_cluster_yaml, ssh_user=cluster_info.ssh_user)
     docker_config = config_from_yaml.get('docker', {})
+    if docker_config and cloud_name.lower() == 'azure':
+        # Pass the VM's managed identity through so a private ACR pull can
+        # authenticate as that exact identity on the host, before the task
+        # container exists. See DockerInitializer.initialize.
+        msi = (cluster_info.provider_config or {}).get('msi', None)
+        if msi is not None:
+            docker_config['azure_managed_identity'] = msi
 
     with rich_utils.safe_status(
             ux_utils.spinner_message('Launching - Waiting for SSH access',

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -126,6 +126,60 @@ def test_azure_private_image():
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.azure
+def test_azure_acr_managed_identity_image():
+    """Pulls a private ACR image authenticated by the VM's managed identity.
+
+    Mirrors the SIG fixture in test_azure_private_image: the registry and
+    identity live in SkyPilot's Azure CI subscription. Required one-time
+    setup (names are fixture constants below):
+
+      az acr create -g skypilot-sig-test -n skypilotcitest --sku Basic
+      az acr import -n skypilotcitest --source docker.io/library/ubuntu:22.04 \
+          --image skypilot-ci-test:latest
+      az identity create -g skypilot-sig-test -n skypilot-ci-acr-pull
+      az role assignment create --role AcrPull \
+          --assignee-object-id $(az identity show -g skypilot-sig-test \
+              -n skypilot-ci-acr-pull --query principalId -o tsv) \
+          --scope $(az acr show -n skypilotcitest --query id -o tsv)
+
+    Empty docker credentials select the managed-identity path; the identity
+    is attached to the VM via azure.remote_identity.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    registry = 'skypilotcitest.azurecr.io'
+    subscription_id = azure.get_subscription_id()
+    identity = (f'/subscriptions/{subscription_id}/resourceGroups/'
+                'skypilot-sig-test/providers/Microsoft.ManagedIdentity/'
+                'userAssignedIdentities/skypilot-ci-acr-pull')
+    task_yaml = textwrap.dedent(f"""\
+        resources:
+          infra: azure/eastus
+          image_id: docker:{registry}/skypilot-ci-test:latest
+        envs:
+          SKYPILOT_DOCKER_USERNAME: ""
+          SKYPILOT_DOCKER_PASSWORD: ""
+          SKYPILOT_DOCKER_SERVER: {registry}
+        run: |
+          echo hello-from-acr-image
+        """)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(task_yaml)
+        f.flush()
+        test = smoke_tests_utils.Test(
+            'azure_acr_managed_identity_image',
+            [
+                f'sky launch -y -c {name} '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+                f'--config azure.remote_identity={identity} {f.name}',
+                f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+                f'sky logs {name} 1 | grep hello-from-acr-image',
+            ],
+            f'sky down -y {name}',
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.aws
 def test_aws_image_id_dict():
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -24,6 +24,7 @@ import pathlib
 import subprocess
 import tempfile
 import textwrap
+import uuid
 
 import jinja2
 import pytest
@@ -130,28 +131,21 @@ def test_azure_private_image():
 def test_azure_acr_managed_identity_image():
     """Pulls a private ACR image authenticated by the VM's managed identity.
 
-    Mirrors the SIG fixture in test_azure_private_image: the registry and
-    identity live in SkyPilot's Azure CI subscription. Required one-time
-    setup (names are fixture constants below):
-
-      az acr create -g skypilot-sig-test -n skypilotcitest --sku Basic
-      az acr import -n skypilotcitest --source docker.io/library/ubuntu:22.04 \
-          --image skypilot-ci-test:latest
-      az identity create -g skypilot-sig-test -n skypilot-ci-acr-pull
-      az role assignment create --role AcrPull \
-          --assignee-object-id $(az identity show -g skypilot-sig-test \
-              -n skypilot-ci-acr-pull --query principalId -o tsv) \
-          --scope $(az acr show -n skypilotcitest --query id -o tsv)
-
-    Empty docker credentials select the managed-identity path; the identity
-    is attached to the VM via azure.remote_identity.
+    The test creates an isolated registry and user-assigned identity, grants
+    AcrPull, and removes the resource group during teardown. Empty docker
+    credentials select the managed-identity path; azure.remote_identity
+    attaches the generated identity to the VM.
     """
     name = smoke_tests_utils.get_cluster_name()
-    registry = 'skypilotcitest.azurecr.io'
+    suffix = uuid.uuid4().hex[:10]
+    resource_group = f'sky-acr-smoke-{suffix}'
+    registry_name = f'skyacr{suffix}'
+    registry = f'{registry_name}.azurecr.io'
+    identity_name = f'sky-acr-pull-{suffix}'
     subscription_id = azure.get_subscription_id()
     identity = (f'/subscriptions/{subscription_id}/resourceGroups/'
-                'skypilot-sig-test/providers/Microsoft.ManagedIdentity/'
-                'userAssignedIdentities/skypilot-ci-acr-pull')
+                f'{resource_group}/providers/Microsoft.ManagedIdentity/'
+                f'userAssignedIdentities/{identity_name}')
     task_yaml = textwrap.dedent(f"""\
         resources:
           infra: azure/eastus
@@ -169,13 +163,33 @@ def test_azure_acr_managed_identity_image():
         test = smoke_tests_utils.Test(
             'azure_acr_managed_identity_image',
             [
+                f'az group create --name {resource_group} '
+                '--location eastus --output none',
+                f'az acr create --resource-group {resource_group} '
+                f'--name {registry_name} --sku Basic --output none',
+                f'az acr import --name {registry_name} '
+                '--source docker.io/library/ubuntu:22.04 '
+                '--image skypilot-ci-test:latest --force --output none',
+                f'az identity create --resource-group {resource_group} '
+                f'--name {identity_name} --output none',
+                f'principal_id=$(az identity show --resource-group '
+                f'{resource_group} --name {identity_name} '
+                '--query principalId --output tsv) && '
+                f'scope=$(az acr show --name {registry_name} '
+                '--query id --output tsv) && '
+                'az role assignment create '
+                '--assignee-principal-type ServicePrincipal '
+                '--assignee-object-id "$principal_id" --role AcrPull '
+                '--scope "$scope" --output none',
                 f'sky launch -y -c {name} '
                 f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
                 f'--config azure.remote_identity={identity} {f.name}',
                 f'sky logs {name} 1 --status',  # Ensure the job succeeded.
                 f'sky logs {name} 1 | grep hello-from-acr-image',
             ],
-            f'sky down -y {name}',
+            f'sky down -y {name}; '
+            f'az group delete --name {resource_group} --yes --no-wait',
+            timeout=30 * 60,
         )
         smoke_tests_utils.run_one_test(test)
 

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -7,6 +7,7 @@ from sky import clouds
 from sky import exceptions
 from sky.adaptors import azure
 from sky.clouds.utils import azure_utils
+from sky.provision.azure import instance
 from sky.provision.azure.config import _remove_msi_resources_from_template
 from sky.provision.azure.config import _remove_network_resources_from_template
 from sky.provision.azure.config import _resolve_custom_managed_identity
@@ -263,3 +264,32 @@ def _make_arm_template():
             },
         }
     }
+
+
+class TestVmUserAssignedIdentity:
+    """Tests for deriving a VM's managed identity in get_cluster_info."""
+
+    @staticmethod
+    def _vm(identity_ids):
+        identity = None
+        if identity_ids is not None:
+            identity = mock.MagicMock()
+            identity.user_assigned_identities = {
+                identity_id: {} for identity_id in identity_ids
+            }
+        vm = mock.MagicMock()
+        vm.identity = identity
+        return vm
+
+    def test_single_identity_is_returned(self):
+        msi = ('/subscriptions/sub/resourceGroups/rg/providers/'
+               'Microsoft.ManagedIdentity/userAssignedIdentities/mi')
+        assert instance._vm_user_assigned_identity(self._vm([msi])) == msi
+
+    def test_no_identity_returns_none(self):
+        assert instance._vm_user_assigned_identity(self._vm(None)) is None
+        assert instance._vm_user_assigned_identity(self._vm([])) is None
+
+    def test_multiple_identities_are_ambiguous(self):
+        assert instance._vm_user_assigned_identity(self._vm(['/a', '/b'
+                                                            ])) is None

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -54,6 +54,8 @@ def test_acr_empty_password_uses_managed_identity():
     login_cmds = [c for c in commands if 'az login --identity' in c]
     assert len(login_cmds) == 1
     login_cmd = login_cmds[0]
+    # The login must not touch the SSH user's persistent az profile.
+    assert 'export AZURE_CONFIG_DIR=$(mktemp -d)' in login_cmd
     assert f'--resource-id {_MSI_ID}' in login_cmd
     assert 'az acr login --name myregistry' in login_cmd
     assert (f'login {_ACR_SERVER} '

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -1,0 +1,87 @@
+"""Tests for docker container initialization on a remote node."""
+from unittest import mock
+
+from sky.provision import docker_utils
+
+_ACR_SERVER = 'myregistry.azurecr.io'
+_MSI_ID = ('/subscriptions/sub-123/resourceGroups/my-rg/providers/'
+           'Microsoft.ManagedIdentity/userAssignedIdentities/my-identity')
+
+
+def _make_initializer(docker_config, runs):
+    """Returns a DockerInitializer whose runner records every command."""
+
+    def _fake_run(cmd, **kwargs):
+        runs.append((cmd, kwargs))
+        if 'command -v docker' in cmd:
+            return (0, '/usr/bin/docker', '')
+        if 'printenv HOME' in cmd:
+            return (0, '/root', '')
+        if 'SKYPILOT_DOCKER_USER' in cmd:
+            return (0, 'SKYPILOT_DOCKER_USER: root', '')
+        return (0, '', '')
+
+    runner = mock.MagicMock()
+    runner.run.side_effect = _fake_run
+    return docker_utils.DockerInitializer(docker_config, runner, '/dev/null')
+
+
+def _acr_docker_config(password='', with_identity=True):
+    config = {
+        'container_name': 'sky_container',
+        'image': 'myimage:latest',
+        'pull_before_run': True,
+        'docker_login_config': {
+            'username': '' if not password else 'token-name',
+            'password': password,
+            'server': _ACR_SERVER,
+        },
+    }
+    if with_identity:
+        config['azure_managed_identity'] = _MSI_ID
+    return config
+
+
+def test_acr_empty_password_uses_managed_identity():
+    runs = []
+    initializer = _make_initializer(_acr_docker_config(), runs)
+    initializer.initialize()
+    commands = [cmd for cmd, _ in runs]
+
+    install_cmds = [c for c in commands if 'InstallAzureCLIDeb' in c]
+    assert install_cmds, 'The Azure CLI should be installed lazily'
+
+    login_cmds = [c for c in commands if 'az login --identity' in c]
+    assert len(login_cmds) == 1
+    login_cmd = login_cmds[0]
+    assert f'--resource-id {_MSI_ID}' in login_cmd
+    assert 'az acr login --name myregistry' in login_cmd
+    assert (f'login {_ACR_SERVER} '
+            f'--username {docker_utils.ACR_TOKEN_USERNAME} '
+            '--password-stdin') in login_cmd
+
+    pull_cmds = [c for c in commands if ' pull ' in c]
+    assert pull_cmds, 'initialize() should have pulled the image'
+    # The registry prefix is added to the image automatically.
+    assert f'{_ACR_SERVER}/myimage:latest' in pull_cmds[0]
+
+
+def test_acr_login_without_identity_omits_resource_id():
+    runs = []
+    initializer = _make_initializer(_acr_docker_config(with_identity=False),
+                                    runs)
+    initializer.initialize()
+    login_cmds = [cmd for cmd, _ in runs if 'az login --identity' in cmd]
+    assert len(login_cmds) == 1
+    assert '--resource-id' not in login_cmds[0]
+
+
+def test_acr_password_takes_precedence_over_managed_identity():
+    runs = []
+    initializer = _make_initializer(_acr_docker_config(password='secret'), runs)
+    initializer.initialize()
+    commands = [cmd for cmd, _ in runs]
+    assert not any('az login' in c for c in commands)
+    assert any(
+        f'login --username token-name --password secret {_ACR_SERVER}' in c
+        for c in commands)

--- a/tests/unit_tests/test_docker_utils.py
+++ b/tests/unit_tests/test_docker_utils.py
@@ -56,7 +56,9 @@ def test_acr_empty_password_uses_managed_identity():
     login_cmd = login_cmds[0]
     # The login must not touch the SSH user's persistent az profile.
     assert 'export AZURE_CONFIG_DIR=$(mktemp -d)' in login_cmd
-    assert f'--resource-id {_MSI_ID}' in login_cmd
+    assert 'az login --help | grep -q -- "--resource-id"' in login_cmd
+    assert 'printf %s --resource-id || printf %s --username' in login_cmd
+    assert _MSI_ID in login_cmd
     assert 'az acr login --name myregistry' in login_cmd
     assert (f'login {_ACR_SERVER} '
             f'--username {docker_utils.ACR_TOKEN_USERNAME} '
@@ -75,7 +77,9 @@ def test_acr_login_without_identity_omits_resource_id():
     initializer.initialize()
     login_cmds = [cmd for cmd, _ in runs if 'az login --identity' in cmd]
     assert len(login_cmds) == 1
-    assert '--resource-id' not in login_cmds[0]
+    managed_identity_login = login_cmds[0].split('az acr login', 1)[0]
+    assert '--resource-id' not in managed_identity_login
+    assert '--username' not in managed_identity_login
 
 
 def test_acr_password_takes_precedence_over_managed_identity():


### PR DESCRIPTION
## Summary

Fixes #10147.

Add credential-free Azure Container Registry authentication using the Azure VM's managed identity, matching SkyPilot's existing ECR and GCR/Artifact Registry paths.

Private ACR images currently require a static credential in `SKYPILOT_DOCKER_PASSWORD`. That secret persists with the task configuration, and short-lived credentials can expire before a managed job recovers. With this change, empty Docker credentials on an `.azurecr.io` server select the VM identity path:

```yaml
resources:
  image_id: docker:<repo>:<tag>
envs:
  SKYPILOT_DOCKER_USERNAME: ""
  SKYPILOT_DOCKER_PASSWORD: ""
  SKYPILOT_DOCKER_SERVER: <registry>.azurecr.io
```

## Changes

- Lazily install the Azure CLI when the ACR identity path is used.
- Log in as the VM's managed identity under an isolated temporary `AZURE_CONFIG_DIR`.
- Support current Azure CLI's `--resource-id` spelling and the LTS-compatible `--username` spelling when a custom image already has an older CLI.
- Mint an ACR access token with `az acr login --expose-token` and pipe it to the root Docker config via `docker login --password-stdin`.
- Derive a single attached user-assigned identity from live Azure VM metadata so `sky start` and managed-job recovery can authenticate after the original bootstrap process is gone.
- Pass the identity through the provisioner Docker configuration.
- Document the empty-credential contract and required `AcrPull` role.
- Add a self-contained Azure smoke test that creates an isolated ACR and identity, grants `AcrPull`, pulls a private image through SkyPilot, and deletes the fixture resource group.

Explicit username/password credentials retain precedence and are unchanged.

## Tested

- [x] Code formatting: `bash format.sh`
- [x] Unit tests: `pytest tests/unit_tests/test_docker_utils.py tests/unit_tests/test_azure_utils.py`
- [x] Login command exercised against stub `az` and `docker` binaries to verify pipe and cleanup semantics
- [x] Smoke-test collection: `pytest --collect-only tests/smoke_tests/test_images.py -k test_azure_acr_managed_identity_image --azure`
- [ ] Relevant smoke test: `/smoke-test -k test_azure_acr_managed_identity_image --azure`
- [ ] All smoke tests: `/smoke-test`
- [ ] Backward compatibility: `/quicktest-core`
