### PR TITLE
[Dashboard] Use quicker count for the clusters empty-state CTA

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -43,6 +43,7 @@ import {
 import {
   getClusters,
   getClusterHistory,
+  getOtherUsersClustersCount,
   useClusterData,
 } from '@/data/connectors/clusters';
 import { getWorkspaces } from '@/data/connectors/workspaces';
@@ -989,9 +990,9 @@ export function ClusterTable({
   // "All Clusters" would actually reveal. Used to gate the empty-state CTA so
   // we don't nudge to All when there's nothing to show. Because the table is
   // now scoped to the current user server-side, the scoped data no longer
-  // contains other users' clusters; probe the shared all-users cache (already
-  // warm from the preloader, so this is typically a free read) only when the
-  // "My Clusters" view comes back empty.
+  // contains other users' clusters; probe for the all-users count (a cheap
+  // single-row page on the server-pagination path, or the shared all-users
+  // cache otherwise) only when the "My Clusters" view comes back empty.
   const [othersTotal, setOthersTotal] = useState(0);
   const scopedEmpty = isServerPagination
     ? total === 0
@@ -1011,12 +1012,8 @@ export function ClusterTable({
     }
     (async () => {
       try {
-        const all = await dashboardCache.get(getClusters);
+        const others = await getOtherUsersClustersCount(currentUser);
         if (cancelled) return;
-        const others = (all || []).filter(
-          (item) =>
-            item.user_hash !== currentUser.id && item.user !== currentUser.name
-        ).length;
         setOthersTotal(others);
       } catch (e) {
         if (!cancelled) setOthersTotal(0);

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -30,6 +30,35 @@ function getPaginationFetch() {
   return typeof window !== 'undefined' ? window.__skyPaginationFetch : null;
 }
 
+/**
+ * Count clusters owned by users other than `currentUser`.
+ *
+ * Used to gate the "View all clusters" empty-state CTA when the
+ * current-user scope has no rows. When the pagination extension is
+ * available, ask it for the all-users total with a single-row page
+ * instead of fetching every row just to count them (mirrors the jobs
+ * page's empty-state probe). That total includes the caller's own
+ * clusters, but callers only use this when the current user's view is
+ * empty, so the difference is nil.
+ */
+export async function getOtherUsersClustersCount(currentUser) {
+  if (isPaginationPluginAvailable()) {
+    const pluginFetch = getPaginationFetch();
+    const result = await dashboardCache.get(pluginFetch, [
+      { page: 1, limit: 1, allUsers: true },
+    ]);
+    return result?.total || 0;
+  }
+  const all = (await dashboardCache.get(getClusters)) || [];
+  if (!currentUser) {
+    return all.length;
+  }
+  return all.filter(
+    (item) =>
+      item.user_hash !== currentUser.id && item.user !== currentUser.name
+  ).length;
+}
+
 const DEFAULT_TAIL_LINES = 5000;
 
 /**

--- a/sky/dashboard/src/data/connectors/clusters.test.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.test.jsx
@@ -31,6 +31,7 @@ import { apiClient } from '@/data/connectors/client';
 import {
   getClusters,
   getClusterHistory,
+  getOtherUsersClustersCount,
   useClusterData,
 } from '@/data/connectors/clusters';
 
@@ -54,6 +55,44 @@ describe('getClusters all_users scoping', () => {
     expect(apiClient.fetch).toHaveBeenCalledTimes(1);
     const [, body] = apiClient.fetch.mock.calls[0];
     expect(body.all_users).toBe(false);
+  });
+});
+
+describe('getOtherUsersClustersCount', () => {
+  const currentUser = { id: 'u-1', name: 'alice' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete window.__skyPaginationFetch;
+  });
+
+  it('probes the pagination extension with a single-row page when available', async () => {
+    const pluginFetch = jest.fn();
+    window.__skyPaginationFetch = pluginFetch;
+    dashboardCache.get.mockResolvedValue({ total: 1234, items: [{}] });
+
+    const count = await getOtherUsersClustersCount(currentUser);
+
+    expect(count).toBe(1234);
+    // The probe must go through the plugin fetch with limit 1 rather than
+    // fetching every row just to count them.
+    expect(dashboardCache.get).toHaveBeenCalledWith(pluginFetch, [
+      { page: 1, limit: 1, allUsers: true },
+    ]);
+    expect(dashboardCache.get).not.toHaveBeenCalledWith(getClusters);
+  });
+
+  it("falls back to counting other users' rows from the shared cache", async () => {
+    dashboardCache.get.mockResolvedValue([
+      { cluster: 'mine', user_hash: 'u-1', user: 'alice' },
+      { cluster: 'other-1', user_hash: 'u-2', user: 'bob' },
+      { cluster: 'other-2', user_hash: 'u-3', user: 'carol' },
+    ]);
+
+    const count = await getOtherUsersClustersCount(currentUser);
+
+    expect(count).toBe(2);
+    expect(dashboardCache.get).toHaveBeenCalledWith(getClusters);
   });
 });
 


### PR DESCRIPTION
## Summary

- The "My Clusters" empty-state CTA ("N clusters owned by other users") counts other users' clusters by fetching the entire all-users cluster list, even when alternate methods are available. At deployments with thousands of clusters, that full fetch takes many seconds just to render a count.
- Mirror the jobs page's empty-state probe (`jobs.jsx` `everyoneTotal`): when the pagination extension is available, request a single-row page (`{page: 1, limit: 1, allUsers: true}`) and read the returned `total`.
- The client-side full-list count is kept as the fallback when no pagination extension is present, so plain OSS behavior is unchanged.

## Test plan

- `npx jest src/data/connectors/clusters.test.jsx`: 8 passed, including two new tests covering the extension probe (limit-1 request, no full-list fetch) and the client-side fallback count.
- Manual: local API server with a server-side pagination extension loaded and 152 clusters seeded across 3 users plus an authenticated identity owning none.
  - `/dashboard/clusters?owner=mine` renders the empty state with the correct total ("152 clusters owned by other users") and the "View all clusters" button switches to the All Clusters view (`?owner=all`) showing the paginated rows.
  - Instrumented `window.fetch` confirms the count comes from a single request to the extension endpoint, with no full `/status` fetch triggered by the CTA.
  - Without the extension, the CTA still counts from the shared all-users cache as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)