### PR TITLE
[Buildkite] Add concurrency_group marker for global per-test serialization

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -245,7 +245,7 @@ def _extract_marked_tests(
     extra_args: List[str],
     exclusive_run: bool = False
 ) -> Dict[str, Tuple[List[str], List[str], List[Optional[str]], List[List[str]],
-                     List[bool]]]:
+                     List[bool], List[Optional[str]]]]:
     """Extract test functions and filter clouds using pytest.mark
     from a Python test file.
 

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -330,6 +330,18 @@ def _extract_marked_tests(
         benchmark_test = 'benchmark' in marks
         no_auto_retry = 'no_auto_retry' in marks
 
+        # A concurrency_group(name) marker serializes this test globally across
+        # all builds and pipelines: the step gets that concurrency_group with a
+        # limit of 1, so only one instance runs at a time org-wide while every
+        # other step is unaffected. conftest.py renders the marker as
+        # 'concurrency_group(<name>)' in the collect-only output.
+        test_concurrency_group = None
+        for mark in marks:
+            group_match = re.match(r'concurrency_group\((.+)\)$', mark)
+            if group_match:
+                test_concurrency_group = group_match.group(1).strip()
+                break
+
         for mark in marks:
             if mark not in PYTEST_TO_CLOUD_KEYWORD:
                 # This mark does not specify a cloud, so we skip it.
@@ -372,7 +384,9 @@ def _extract_marked_tests(
             for cloud in final_clouds_to_include
         ], param_list, [
             extra_args for _ in range(len(final_clouds_to_include))
-        ], [no_auto_retry for _ in range(len(final_clouds_to_include))])
+        ], [no_auto_retry for _ in range(len(final_clouds_to_include))], [
+            test_concurrency_group for _ in range(len(final_clouds_to_include))
+        ])
 
     return function_cloud_map
 
@@ -415,8 +429,8 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
         build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
         concurrency_group = f'env-file-smoke-test-{build_id}'
     for test_function, clouds_queues_param in function_cloud_map.items():
-        for cloud, queue, param, extra_args, no_auto_retry in zip(
-                *clouds_queues_param):
+        for (cloud, queue, param, extra_args, no_auto_retry,
+             test_concurrency_group) in zip(*clouds_queues_param):
             label = f'{test_function} on {cloud}'
             command = f'pytest {test_file}::{test_function} --{cloud}'
             if param:
@@ -440,7 +454,14 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
                     'queue': queue
                 }
             }
-            if concurrency_limit is not None:
+            if test_concurrency_group is not None:
+                # Per-test global serialization takes precedence over any
+                # run-wide group: a Buildkite step has a single concurrency
+                # group, and this one is a fixed name shared across all builds
+                # and pipelines, so instances of this test serialize org-wide.
+                step['concurrency'] = 1
+                step['concurrency_group'] = test_concurrency_group
+            elif concurrency_limit is not None:
                 step['concurrency'] = concurrency_limit
                 step['concurrency_group'] = concurrency_group
             if no_auto_retry:

--- a/.buildkite/test_buildkite_pipeline_generation.py
+++ b/.buildkite/test_buildkite_pipeline_generation.py
@@ -183,6 +183,58 @@ def test_no_auto_retry_marker():
         f"no_auto_retry step should allow manual retry: {retry}"
 
 
+def test_concurrency_group_marker():
+    """Test that a concurrency_group(name) marker serializes a test globally.
+
+    The marker should make the generated step carry that concurrency_group with
+    a limit of 1, so instances of the test serialize across all builds and
+    pipelines while every other step is unaffected.
+    """
+    # The generator only walks tests/smoke_tests, so the marked test must live
+    # there. Use a throwaway file (removed in the finally block) rather than
+    # marking a real test, so no real test's CI concurrency is changed.
+    test_file = pathlib.Path(
+        'tests/smoke_tests/test_concurrency_group_marker_tmp.py')
+    test_file.write_text('import pytest\n'
+                         '\n'
+                         '\n'
+                         '@pytest.mark.kubernetes\n'
+                         '@pytest.mark.concurrency_group("my-global-lock")\n'
+                         'def test_concurrency_group_example():\n'
+                         '    pass\n')
+    try:
+        env = dict(os.environ)
+        env['PYTHONPATH'] = f"{pathlib.Path.cwd()}/tests:" \
+                            f"{env.get('PYTHONPATH', '')}"
+
+        subprocess.run([
+            'python', '.buildkite/generate_pipeline.py', '--args',
+            '--kubernetes', '--file_pattern',
+            'test_concurrency_group_marker_tmp'
+        ],
+                       env=env,
+                       check=True)
+
+        pipeline_path = pathlib.Path(
+            '.buildkite/pipeline_smoke_tests_release.yaml')
+        steps = _extract_steps_from_pipeline(pipeline_path)
+
+        target_steps = [
+            s for s in steps
+            if 'test_concurrency_group_example' in s.get('label', '')
+        ]
+        assert len(target_steps) == 1, \
+            f"Expected 1 step, got {len(target_steps)}"
+
+        step = target_steps[0]
+        assert step.get('concurrency') == 1, \
+            f"concurrency_group step should have concurrency 1: {step}"
+        assert step.get('concurrency_group') == 'my-global-lock', \
+            f"concurrency_group step should carry the marker name: {step}"
+    finally:
+        test_file.unlink(missing_ok=True)
+
+
 @pytest.mark.parametrize('args', [
     '',
     '--aws',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,14 @@ def pytest_configure(config):
         'markers', 'exclusive: mark test that mutates shared server state and '
         'must run serially; selected only by the pipeline generator\'s '
         '--exclusive flag and excluded from normal parallel runs')
+    config.addinivalue_line(
+        'markers',
+        'concurrency_group(name): serialize this test globally across all '
+        'Buildkite builds and pipelines by emitting a shared concurrency_group '
+        'with concurrency 1. Use for a test that mutates a shared external '
+        'resource so only one instance runs at a time org-wide, while every '
+        'other test still runs in parallel. The name must be a plain slug '
+        '(no commas or quotes)')
     for cloud in all_clouds_in_smoke_tests:
         cloud_keyword = cloud_to_pytest_keyword[cloud]
         config.addinivalue_line(
@@ -516,7 +524,15 @@ def pytest_collection_modifyitems(config, items):
     if config.option.collectonly:
         for item in items:
             full_name = item.nodeid
-            marks = [mark.name for mark in item.iter_markers()]
+            marks = []
+            for mark in item.iter_markers():
+                # Surface the argument of a concurrency_group(name) marker so
+                # the pipeline generator can read the group name (all other
+                # markers are matched by name only, so keep them name-only).
+                if mark.name == 'concurrency_group' and mark.args:
+                    marks.append(f'{mark.name}({mark.args[0]})')
+                else:
+                    marks.append(mark.name)
             print(f"Collected {full_name} with marks: {marks}")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -529,8 +529,13 @@ def pytest_collection_modifyitems(config, items):
                 # Surface the argument of a concurrency_group(name) marker so
                 # the pipeline generator can read the group name (all other
                 # markers are matched by name only, so keep them name-only).
-                if mark.name == 'concurrency_group' and mark.args:
-                    marks.append(f'{mark.name}({mark.args[0]})')
+                # Accept both positional (concurrency_group('x')) and keyword
+                # (concurrency_group(name='x')) forms.
+                if mark.name == 'concurrency_group':
+                    group_name = (mark.args[0]
+                                  if mark.args else mark.kwargs.get('name'))
+                    marks.append(f'{mark.name}({group_name})'
+                                 if group_name else mark.name)
                 else:
                     marks.append(mark.name)
             print(f"Collected {full_name} with marks: {marks}")


### PR DESCRIPTION
## Summary

Adds a `@pytest.mark.concurrency_group(name)` marker that makes the smoke-test
pipeline generator emit a Buildkite [concurrency group](https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-groups)
with `concurrency: 1` on that test's step.

A Buildkite concurrency group is **org-wide**: a fixed group name serializes
every instance of that step **across all builds and all pipelines**, so only
one runs at a time while every other step keeps running in parallel, unaffected.

### Why

Some smoke tests mutate a **shared external resource** (a cluster object, a
global config, a third-party service) that is fixed by the test's nature and
can't be made unique per run. If two builds run such a test simultaneously they
clobber each other.

The existing `exclusive` mechanism doesn't cover this: it serializes only
*within a single build* (its concurrency group is keyed on the build id), so two
different builds can still run the same mutating test at the same time. A fixed,
per-test concurrency group is the missing primitive — it's the Buildkite
equivalent of GitHub Actions' job-level `concurrency`.

### Changes

- **`tests/conftest.py`** — register the `concurrency_group` marker, and surface
  its argument in the `pytest --collect-only` output (`concurrency_group(<name>)`);
  all other markers stay name-only.
- **`.buildkite/generate_pipeline.py`** — parse `concurrency_group(<name>)` per
  test and set the step's `concurrency: 1` + `concurrency_group: <name>`. It
  takes precedence over any run-wide group (a step can only carry one).
- **`.buildkite/test_buildkite_pipeline_generation.py`** — add a test asserting
  the emitted step carries the group.

### Usage

```python
@pytest.mark.concurrency_group('my-global-lock')
def test_that_mutates_a_shared_resource():
    ...
```

Every step generated for this test, in any build or pipeline, shares the
`my-global-lock` group at concurrency 1 → serialized org-wide; all other steps
are untouched.

## Test plan

- `PYTHONPATH=$(pwd)/tests pytest -n 0 --dist no .buildkite/test_buildkite_pipeline_generation.py::test_concurrency_group_marker` — passes; the generated step has `concurrency: 1` and `concurrency_group: my-global-lock`.
- `test_no_auto_retry_marker` still passes (the generator tuple gained a field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)