### PR TITLE
[Server] Preload networkx in executor worker initializer

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -179,6 +179,21 @@ def executor_initializer(proc_group: str,
     # request mid-pollution in the main process.
     if clean_env is not None:
         clean_env_module.set_clean_server_env(clean_env)
+    # Preload modules whose import mutates process-global state. Request
+    # cancellation raises KeyboardInterrupt at an arbitrary point in the
+    # worker (see _gated_sigterm_handler); if that lands inside a lazy import,
+    # Python drops the half-executed module from sys.modules while its
+    # completed submodules survive, e.g. networkx's algorithm dispatch
+    # registry stays populated and every re-import in this worker then fails
+    # with "Algorithm already exists in dispatch registry". Importing before
+    # the worker serves requests removes the window: later imports are
+    # sys.modules cache hits that an interrupt cannot corrupt.
+    try:
+        import networkx  # pylint: disable=import-outside-toplevel,unused-import
+    except Exception as e:  # pylint: disable=broad-except
+        # An exception escaping the initializer would mark the pool broken,
+        # which is worse than lazily importing at request time.
+        logger.warning(f'Failed to preload networkx in executor worker: {e}')
     # Executor never stops, unless the whole process is killed.
     threading.Thread(target=metrics_lib.process_monitor,
                      args=(f'worker:{proc_group}', threading.Event()),


### PR DESCRIPTION
## Problem

Request cancellation delivers SIGTERM to the executor worker process, and the gated handler raises `KeyboardInterrupt` at an arbitrary bytecode in the worker's main thread. If that interrupt lands inside the lazy `import networkx` in `sky/dag.py` (a fresh worker's first launch-type request), Python removes the half-executed module from `sys.modules` while completed submodules survive. In particular `networkx.utils.backends` keeps its process-global `_registered_algorithms` dict, so every subsequent `import networkx` in that worker re-executes the missing module, re-registers an already-registered algorithm, and fails deterministically:

```
KeyError: 'Algorithm already exists in dispatch registry: gn_graph'
```

Because `_request_execution_wrapper` catches the `KeyboardInterrupt` and returns, the poisoned worker goes back into the pool and permanently fails every networkx-importing request routed to it (`sky.launch`, `sky.exec`, ...), while non-networkx requests still succeed — so the worker looks healthy to the scheduler. Observed in CI as clusters of instant launch/exec failures following a cancellation burst.

## Fix

Preload networkx in `executor_initializer`, which runs in every executor worker before it accepts requests. A warm worker cannot be poisoned this way: the lazy import in `sky/dag.py` becomes a `sys.modules` cache hit with no module-execution window for the interrupt to corrupt. The import is guarded so an unexpected failure degrades to today's lazy-import behavior instead of raising in the initializer (which would mark the pool broken).

This closes the known instance of the problem. A broader follow-up — retiring a worker after it catches a cancel-time `KeyboardInterrupt`, so no interpreter state corrupted by the async interrupt can survive into later requests — is planned separately.

## Verification

- Deterministic repro of the mechanism: interrupting `import networkx` mid-execution (import hook raising `KeyboardInterrupt`, modeling the async signal), catching it, and re-importing reproduces the exact `KeyError` above; with networkx already imported, the same interrupt scenario has no window to hit.
- Exercised the changed function directly: in a fresh interpreter, `networkx` is absent from `sys.modules` after importing `sky.server.requests.executor` (confirming workers start cold) and present after `executor_initializer()` runs.
- `yapf`/`isort` clean on the changed file.

## Alternative considered: moving the import to top-level in `sky/dag.py`

Escalating the lazy import to module level would also close the window, and we verified the mechanics: `sky.dag` is already in the executor worker's module-import chain (checked empirically — after `import sky.server.requests.executor`, `sky.dag` is in `sys.modules`), and module import completes before the request becomes cancellable (a cancel can only target a worker after its pid is recorded, inside the execution wrapper). So a top-level import would be equally immune.

Rejected because the cost would land on every process, not just server workers: `import sky` unconditionally imports `sky.dag` (verified), so the import cost would be added to every CLI invocation and client SDK import. Measured warm `import networkx`: **~2.8s** in a development venv (stable across 5 runs); `python -X importtime` shows the weight is intrinsic — ~0.65s in `networkx.utils.backends` alone (backend/entry-point dispatch machinery) plus a ~250-module tree — not an artifact of one environment. That is far past the bar enforced by `tests/unit_tests/test_sky_import.py` ("heavy modules (100ms+) should never be imported at `import sky` startup"); networkx isn't on its forbidden list only because it is currently lazy.

The initializer preload in this PR is the same fix scoped to the only processes that have the poisoning window (executor workers, which already pay a full `import sky` at spawn), at zero cost to CLI/client startup.

-Claude
