### PR TITLE
[k8s] Request gzip-compressed API server responses

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -110,6 +110,20 @@ def _get_config_file() -> str:
     return os.environ.get('KUBECONFIG', DEFAULT_KUBECONFIG_PATH)
 
 
+def _enable_response_compression(api_client: Any) -> Any:
+    """Advertise gzip so the API server compresses large response bodies.
+
+    The Kubernetes API server gzip-compresses responses above a size threshold
+    when the client sends ``Accept-Encoding: gzip``. This substantially reduces
+    transfer time for large LIST responses (e.g. listing nodes or pods on large
+    clusters), which is especially impactful on high-latency or low-bandwidth
+    connections to the API server. urllib3 transparently decompresses the body,
+    including when the response is streamed with ``_preload_content=False``.
+    """
+    api_client.set_default_header('Accept-Encoding', 'gzip')
+    return api_client
+
+
 def _get_api_client(context: Optional[str] = None) -> Any:
     """Get an ApiClient for the given context without modifying global config.
 
@@ -200,14 +214,16 @@ def _get_api_client(context: Optional[str] = None) -> Any:
 
             config = kubernetes.client.Configuration()
             kubernetes.config.load_incluster_config(config)
-            return kubernetes.client.ApiClient(configuration=config)
+            return _enable_response_compression(
+                kubernetes.client.ApiClient(configuration=config))
         except kubernetes.config.config_exception.ConfigException:
             if context == in_cluster_context_name():
                 # Explicitly requested in-cluster context but not in a cluster
                 raise
             # Otherwise, if context is None, fall through to kubeconfig
 
-    return _get_api_client_from_kubeconfig(context)
+    return _enable_response_compression(
+        _get_api_client_from_kubeconfig(context))
 
 
 def list_kube_config_contexts():

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -110,7 +110,7 @@ def _get_config_file() -> str:
     return os.environ.get('KUBECONFIG', DEFAULT_KUBECONFIG_PATH)
 
 
-def _enable_response_compression(api_client: Any) -> Any:
+def _enable_response_compression(client: Any) -> Any:
     """Advertise gzip so the API server compresses large response bodies.
 
     The Kubernetes API server gzip-compresses responses above a size threshold
@@ -120,8 +120,8 @@ def _enable_response_compression(api_client: Any) -> Any:
     connections to the API server. urllib3 transparently decompresses the body,
     including when the response is streamed with ``_preload_content=False``.
     """
-    api_client.set_default_header('Accept-Encoding', 'gzip')
-    return api_client
+    client.set_default_header('Accept-Encoding', 'gzip')
+    return client
 
 
 def _get_api_client(context: Optional[str] = None) -> Any:

--- a/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py
@@ -308,6 +308,23 @@ def test_concurrent_context_isolation(monkeypatch, api_func):
         os.unlink(config_file)
 
 
+def test_get_api_client_requests_gzip(monkeypatch):
+    """The API client advertises gzip so the server compresses responses.
+
+    Requesting ``Accept-Encoding: gzip`` lets the API server compress large
+    LIST responses (e.g. nodes/pods on big clusters); urllib3 transparently
+    decompresses them. This substantially cuts transfer time on high-latency
+    or low-bandwidth connections to the API server.
+    """
+    config_file = _create_test_kubeconfig(num_contexts=1)
+    try:
+        monkeypatch.setattr(kubernetes, '_get_config_file', lambda: config_file)
+        client = kubernetes._get_api_client('context-0')  # pylint: disable=protected-access
+        assert client.default_headers.get('Accept-Encoding') == 'gzip'
+    finally:
+        os.unlink(config_file)
+
+
 def test_urllib3_log_suppression_survives_client_construction(monkeypatch):
     """API getters suppress urllib3 warnings with rare setLevel() calls.
 


### PR DESCRIPTION
## Summary

The Kubernetes adaptor builds API clients without advertising `Accept-Encoding: gzip`, so responses from the Kubernetes API server are transferred **uncompressed**. For large LIST responses — e.g. listing nodes or pods on large clusters — this can be several MB of JSON per request.

The API server gzip-compresses response bodies above a size threshold when the client sends `Accept-Encoding: gzip` (this is part of why `kubectl`, which sends the header, is fast). This PR sets the header on every `ApiClient` the adaptor constructs. urllib3 transparently decompresses the body, including streamed responses read with `_preload_content=False` (e.g. `get_kubernetes_nodes`).

The win is largest on high-latency or bandwidth-constrained links to the API server, where the uncompressed transfer dominates request time.

## Benchmark

Listing nodes on a 134-node cluster over a high-latency link (node objects are label/image/status heavy):

| | wire size | time |
|---|---|---|
| no header (current) | ~5 MB | ~9–75 s, highly variable |
| `Accept-Encoding: gzip` | ~1 MB | ~1–2 s |

`get_kubernetes_nodes()` (streaming + ijson) on the same cluster: ~23 s → ~1.2 s, with an identical parsed result.

## Test

- Added `test_get_api_client_requests_gzip` asserting the constructed client advertises `Accept-Encoding: gzip`.
- `pytest tests/unit_tests/test_sky/adaptors/test_kubernetes_adaptor.py` passes.
- Manually verified end-to-end against a live cluster: both `list_node` and the streaming `get_kubernetes_nodes()` path return identical results with the response compressed (`Content-Encoding: gzip`, ~5× smaller wire).