### PR TITLE
[Jobs] Clear SKYPILOT_DISABLE_LOCAL_API_SERVER when starting the controller's local API server

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -80,6 +80,10 @@ ENV_VARS_TO_CLEAR = [
     # If this is set, get_server_url() returns a non-local URL and
     # api_start refuses to start a local server. Always start local here.
     constants.SKY_API_SERVER_URL_ENV_VAR,
+    # If this is set, api_start refuses to start a local server even when the
+    # server URL is local (check_local_api_server_enabled_or_raise). The
+    # controller always needs to start a local server here, so clear it too.
+    env_options.Options.DISABLE_LOCAL_API_SERVER.env_key,
 ]
 
 # Interval to poll the status of the underlying sky.launch request while


### PR DESCRIPTION
## Problem

When the managed job controller launches a job's cluster in
`StrategyExecutor._launch` (`sky/jobs/recovery_strategy.py`), it starts a local
API server via `sdk.api_start()`. To force the server to start **locally**, it
clears `SKYPILOT_API_SERVER_ENDPOINT` (already in `ENV_VARS_TO_CLEAR`) so that
`get_server_url()` resolves to the local address, then restores it afterwards.

However, if `SKYPILOT_DISABLE_LOCAL_API_SERVER` is set in the controller's
environment, `check_local_api_server_enabled_or_raise()` makes `api_start`
refuse to start a local server **even when the URL is local**:

```
RuntimeError: No SkyPilot API server endpoint is configured, and starting a
local API server on this machine is disabled (SKYPILOT_DISABLE_LOCAL_API_SERVER=1).
```

`_launch` catches this, logs `Failed to launch a cluster`, and retries every few
minutes indefinitely, so the managed job never leaves `PENDING`.

This happens whenever the controller inherits `SKYPILOT_DISABLE_LOCAL_API_SERVER=1`
from its environment (e.g. it is exported for the process that submits the job
and propagates into the spawned controller).

## Fix

The controller always needs to start a local API server at this point, so add
`SKYPILOT_DISABLE_LOCAL_API_SERVER` to `ENV_VARS_TO_CLEAR`. It is cleared before
`api_start` and restored afterwards, exactly like `SKYPILOT_API_SERVER_ENDPOINT`
is already handled.

```python
ENV_VARS_TO_CLEAR = [
    ...
    constants.SKY_API_SERVER_URL_ENV_VAR,
    # If this is set, api_start refuses to start a local server even when the
    # server URL is local (check_local_api_server_enabled_or_raise). The
    # controller always needs to start a local server here, so clear it too.
    env_options.Options.DISABLE_LOCAL_API_SERVER.env_key,
]
```

## Test plan

Reproduce by exporting `SKYPILOT_DISABLE_LOCAL_API_SERVER=1` in the environment
that submits a managed job, then:

```
SKYPILOT_DISABLE_LOCAL_API_SERVER=1 sky jobs launch -y -n t --infra kubernetes -- echo hi
```

- **Before:** the job stays `PENDING`; the controller loops on
  `recovery_strategy.py` "Retrying to launch the cluster in N seconds" with the
  `RuntimeError` above.
- **After:** the controller starts its local API server, the job cluster is
  provisioned, and the job reaches `SUCCEEDED`.

Verified via the managed-job smoke tests (e.g. `test_debug_dump_job`,
`test_managed_jobs_cli_exit_codes`) on Kubernetes.
