### PR TITLE
[Jobs] Reset transient job-status-check window after recovery

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1444,6 +1444,16 @@ class JobController:
 
             logger.info(f'Task {task.name} recovered, continuing monitoring')
 
+            # Recovery relaunches the cluster, so any pending
+            # status-fetch-failure window belongs to the previous cluster and
+            # must not carry over. If it did, the first status-fetch failure
+            # after recovery would measure `elapsed` from before the recovery,
+            # exceed JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS immediately, and
+            # trigger another recovery with no retries. One transient
+            # control-plane error would then become an unbounded recovery loop.
+            transient_job_check_error_start_time = None
+            job_check_backoff = None
+
             # Reset force flag after first recovery
             force_transit_to_recovering = False
 

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -21,6 +21,7 @@ import pytest
 
 from sky.jobs import controller as controller_module
 from sky.jobs import state as managed_job_state
+from sky.jobs import utils as managed_job_utils
 from sky.jobs.controller import ControllerManager
 from sky.jobs.controller import JobController
 from sky.skylet import job_lib
@@ -1360,3 +1361,106 @@ class TestDunderMainDispatchesToImportedModule:
         # The imported module's `main` -- not the `__main__` copy's -- must be
         # the one that was called.
         mock_main.assert_called_once_with('test-uuid')
+
+
+class TestTransientJobStatusRecoveryWindow:
+    """Tests for the transient job-status-check retry window across recovery.
+
+    When the controller cannot fetch a task's job status but the cluster is
+    healthy, it retries for up to JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS before
+    recovering, to avoid a false alarm from a transient control-plane error.
+    That window (`transient_job_check_error_start_time`) must be reset after a
+    recovery; otherwise the first status-fetch failure after a recovery is
+    measured from before the recovery, exceeds the timeout immediately, and
+    triggers another recovery with no retries -- turning one transient error
+    into an unbounded recovery loop.
+    """
+
+    class _StopLoop(Exception):
+        """Sentinel to break the otherwise-infinite monitoring loop."""
+
+    @pytest.mark.asyncio
+    async def test_window_reset_after_recovery(self, monkeypatch):
+        """A transient failure after a recovery starts a fresh retry window.
+
+        Drives ``_monitor_one_task`` through: transient failure (retry) ->
+        transient failure past the timeout (recover) -> transient failure
+        again. With the window reset, the third failure retries instead of
+        recovering, so ``recover`` is called exactly once. Without the reset it
+        would recover a second time immediately.
+        """
+        monkeypatch.setattr(managed_job_utils,
+                            'JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60)
+        monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_CHECK_GAP_SECONDS',
+                            0)
+
+        # A logical clock advanced at the top of each loop iteration (inside
+        # the get_job_status stub) so `elapsed` is fully deterministic:
+        #   iter 1: +0   -> elapsed 0   < 60 -> retry
+        #   iter 2: +100 -> elapsed 100 >= 60 -> recover (#1); window reset
+        #   iter 3: +50  -> fresh window, elapsed 0 < 60 -> retry
+        #   iter 4: stub raises _StopLoop to end the loop
+        clock = {'t': 1000.0}
+        deltas = iter([0.0, 100.0, 50.0])
+        recover_calls = 0
+
+        async def fake_get_job_status(*args, **kwargs):
+            try:
+                clock['t'] += next(deltas)
+            except StopIteration:
+                raise TestTransientJobStatusRecoveryWindow._StopLoop()
+            return None, 'Job status check timed out after 30s.'
+
+        async def fake_recover(*args, **kwargs):
+            nonlocal recover_calls
+            recover_calls += 1
+            return clock['t']
+
+        handle = MagicMock()
+        handle.launched_resources.need_cleanup_after_preemption_or_failure.\
+            return_value = False
+
+        def fake_refresh(*args, **kwargs):
+            return status_lib.ClusterStatus.UP, handle
+
+        mock_self = MagicMock()
+        mock_self._job_id = 1
+        mock_self._pool = None
+
+        executor = MagicMock()
+        executor.recover = AsyncMock(side_effect=fake_recover)
+
+        state = controller_module.managed_job_state
+        with patch.object(controller_module.time, 'time',
+                          side_effect=lambda: clock['t']), \
+             patch.object(managed_job_utils, 'get_job_status',
+                          side_effect=fake_get_job_status), \
+             patch.object(controller_module.backend_utils,
+                          'refresh_cluster_status_handle',
+                          side_effect=fake_refresh), \
+             patch.object(controller_module.backend_utils,
+                          'async_check_network_connection',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(controller_module.managed_job_runtime,
+                          'is_registered', return_value=False), \
+             patch.object(state, 'set_recovering_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(state, 'set_recovered_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(state, 'set_started_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(controller_module.asyncio, 'sleep',
+                          new=AsyncMock(return_value=None)):
+            with pytest.raises(TestTransientJobStatusRecoveryWindow._StopLoop):
+                await controller_module.JobController._monitor_one_task(
+                    mock_self,
+                    task_id=0,
+                    task=MagicMock(name='task'),
+                    cluster_name='cluster',
+                    executor=executor,
+                    callback_func=MagicMock(),
+                    force_transit_to_recovering=False)
+
+        assert recover_calls == 1, (
+            'expected exactly one recovery; a second recovery means the '
+            'transient retry window was not reset after the first recovery')


### PR DESCRIPTION
## Summary

- After `recover()` in `JobController._monitor_one_task()`, reset `transient_job_check_error_start_time` and `job_check_backoff`, so the first status-fetch failure after a recovery gets a fresh retry window instead of inheriting the timestamp from before the recovery.
- Without this, the stale clock makes `elapsed` span the entire previous recovery, instantly exceed `JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS` (60s), and trigger another recovery with zero retries turning one transient control-plane error into an unbounded recovery loop that cancels a healthy job repeatedly.

Fixes #10155.

## Details

`transient_job_check_error_start_time` is only cleared when a status check succeeds. When a recovery is triggered by transient status-fetch failures and the transient condition persists across the recovery, the timer is never reset, so every post-recovery failure is treated as already-timed-out. Resetting it at the recovery-completion point restores the intended "retry for up to 60s before recovering again" behaviour. Real job failures are unaffected they surface as a terminal `JobStatus` on a separate branch, not as a status-fetch failure.

## Test plan

- [x] Code formatting: `bash format.sh` (pylint 10/10 and mypy clean on `sky/jobs/controller.py`; yapf-clean).
- [x] New regression test: `pytest "tests/unit_tests/test_sky/jobs/test_controller.py::TestTransientJobStatusRecoveryWindow"`. It drives `_monitor_one_task` through transient-failure -> recovery -> transient-failure and asserts recovery happens once. I confirmed it **fails without the fix** (a second recovery fires, reproducing the `Failed to fetch the job status after retrying for 150.0 seconds` symptom). Full controller test file: 38 passed.
- [ ] `/quicktest-core` (CI; I am not a repo member so cannot trigger it).
- [ ] Managed-job smoke test: `pytest tests/smoke_tests/test_managed_job.py -k recovery` / `/smoke-test -k recovery` (launches cloud clusters; not run locally).

## Notes

- Touches a "handle with care" critical path (`sky/jobs/controller.py`). The change is deliberately minimal (a state reset at the existing recovery-completion point, next to the existing `force_transit_to_recovering = False` reset) and does not alter control flow.
- No API surface change; no `API_VERSION` bump needed.
