### PR TITLE
[Dashboard] Render dynamically-registered columns on the Users table

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -76,6 +76,7 @@ import {
   BatchRemoveFromWorkspacesDialog,
 } from '@/components/users-batch-dialogs';
 import { PluginSlot } from '@/plugins/PluginSlot';
+import { useTableColumns } from '@/plugins/PluginProvider';
 import { statusGroups } from '@/components/jobs';
 import {
   FilterDropdown,
@@ -2073,6 +2074,15 @@ function UsersTable({
     return '';
   };
 
+  // Columns contributed via useTableColumns() are rendered after the built-in
+  // Jobs column and sorted among themselves by header.order. Brings the Users
+  // table to parity with the clusters/jobs/volumes tables, which already render
+  // these dynamically-registered columns.
+  const extraColumns = useTableColumns('users', {});
+  const sortedExtraColumns = [...extraColumns].sort(
+    (a, b) => (a.header?.order ?? 100) - (b.header?.order ?? 100)
+  );
+
   const handleEditClick = async (userId, currentRole) => {
     await checkPermissionAndAct('cannot edit user role', () => {
       setEditingUserId(userId);
@@ -2452,6 +2462,23 @@ function UsersTable({
                 >
                   Jobs{getSortDirection('jobCount')}
                 </TableHead>
+                {sortedExtraColumns.map((col) => {
+                  const sortKey = col.header?.sortKey;
+                  return (
+                    <TableHead
+                      key={col.id}
+                      onClick={sortKey ? () => requestSort(sortKey) : undefined}
+                      className={`whitespace-nowrap w-1/6${
+                        sortKey
+                          ? ' sortable cursor-pointer hover:bg-gray-50'
+                          : ''
+                      }${col.header?.className ? ' ' + col.header.className : ''}`}
+                    >
+                      {col.header?.label}
+                      {sortKey ? getSortDirection(sortKey) : ''}
+                    </TableHead>
+                  );
+                })}
                 {/* Show Actions column if basicAuthEnabled and not deduplicating */}
                 {!deduplicateUsers &&
                   (basicAuthEnabled || currentUserRole === 'admin') && (
@@ -2639,6 +2666,14 @@ function UsersTable({
                         </Link>
                       )}
                     </TableCell>
+                    {sortedExtraColumns.map((col) => (
+                      <TableCell
+                        key={col.id}
+                        className={col.cell?.className || ''}
+                      >
+                        {col.cell?.render?.(user, { item: user })}
+                      </TableCell>
+                    ))}
                     {/* Actions cell logic - hide when deduplicating */}
                     {!deduplicateUsers &&
                       (basicAuthEnabled || currentUserRole === 'admin') && (

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2078,7 +2078,7 @@ function UsersTable({
   // Jobs column and sorted among themselves by header.order. Brings the Users
   // table to parity with the clusters/jobs/volumes tables, which already render
   // these dynamically-registered columns.
-  const extraColumns = useTableColumns('users', {});
+  const extraColumns = useTableColumns('users', { deduplicateUsers });
   const sortedExtraColumns = [...extraColumns].sort(
     (a, b) => (a.header?.order ?? 100) - (b.header?.order ?? 100)
   );


### PR DESCRIPTION
## Summary

The clusters, jobs, and volumes tables render columns contributed via
`useTableColumns()`, but the Users table renders a fixed, hardcoded set of
columns. This wires the same `useTableColumns('users')` hook into `UsersTable`
so any registered columns render after the built-in **Jobs** column (sorted
among themselves by `header.order`), bringing the Users table to parity with
the other resource tables.

There is no behavior change when nothing registers a column for the `users`
table: the added header/cell loops simply iterate an empty list.

## Test plan

- `npm run build` in `sky/dashboard` succeeds.
- With a column registered for the `users` table, verified the header and a
  per-row cell render after the Jobs column on the Users page (dev build);
  existing columns and sorting are unaffected.
- With nothing registered, the Users table renders exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->