### PR TITLE
[Jobs] Tolerate transient INIT cluster status before recovering managed jobs

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1111,11 +1111,11 @@ class JobController:
             # cluster failure (unambiguous, and its attribution must not
             # expire while waiting). None/STOPPED verdicts recover
             # immediately.
+            plugin_failures = None
             if (cluster_status == status_lib.ClusterStatus.INIT and
                     not force_transit_to_recovering and
                     (job_status is None or not job_status.is_terminal())):
                 consecutive_init_statuses += 1
-                plugin_failures = None
                 if ExternalFailureSource.is_registered():
                     plugin_failures = await asyncio.to_thread(
                         ExternalFailureSource.get, cluster_name=cluster_name)
@@ -1172,8 +1172,15 @@ class JobController:
                                  f'{common_utils.format_exception(e)}')
 
                 if ExternalFailureSource.is_registered():
-                    cluster_failures = await asyncio.to_thread(
-                        ExternalFailureSource.get, cluster_name=cluster_name)
+                    # Reuse the INIT-tolerance gate's fetch from this tick --
+                    # re-querying could lose the attribution of a record
+                    # that expired in between.
+                    cluster_failures = (
+                        plugin_failures
+                        if plugin_failures is not None else
+                        await asyncio.to_thread(
+                            ExternalFailureSource.get,
+                            cluster_name=cluster_name))
                     if cluster_failures:
                         logger.info(
                             f'Detected cluster failures: {cluster_failures}')

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -67,15 +67,18 @@ else:
 
 logger = sky_logging.init_logger('sky.jobs.controller')
 
-# Grace window before recovering a cluster whose refreshed status is INIT.
+# Tolerance before recovering a cluster whose refreshed status is INIT.
 # INIT is also the verdict a SINGLE failed ray-health probe produces while
 # every cloud node is up (e.g. an SSH timeout to a head node under heavy
 # CPU/IO load), and it is not sticky: each monitor tick force-refreshes the
-# status, and a subsequent healthy probe restores UP. Tolerating INIT for a
-# bounded window turns a transient probe failure into a non-event, while a
-# genuine failure still recovers, merely this many seconds later. None and
-# STOPPED statuses are unambiguous and keep recovering immediately.
-_CLUSTER_INIT_RECOVERY_GRACE_SECONDS = 90.0
+# status, and a subsequent healthy probe restores UP. Recovery of an INIT
+# cluster therefore starts only after this many consecutive INIT
+# observations with no demonstrably healthy job in between (~90s at the
+# 15s monitor cadence). Counting observations rather than wall-clock keeps
+# the tolerance immune to clock steps and to ticks that never probed
+# (e.g. network outages). None and STOPPED statuses are unambiguous and
+# keep recovering immediately.
+_CLUSTER_INIT_RECOVERY_GRACE_PROBES = 6
 
 _background_tasks: Set[asyncio.Task] = set()
 _background_tasks_lock: asyncio.Lock = asyncio.Lock()
@@ -932,8 +935,9 @@ class JobController:
 
         transient_job_check_error_start_time = None
         job_check_backoff = None
-        # Start of the current INIT-status grace episode (None = none).
-        init_grace_start_time = None
+        # Consecutive INIT observations without a demonstrably healthy
+        # job. See _CLUSTER_INIT_RECOVERY_GRACE_PROBES.
+        consecutive_init_statuses = 0
         # External-link labels already surfaced for this task, so we stop
         # polling the worker's metadata once every pattern has matched.
         live_link_labels: Set[str] = set()
@@ -1074,9 +1078,9 @@ class JobController:
             # status.
             if (job_status is not None and not job_status.is_terminal() and
                     task.num_nodes == 1):
-                # A healthy job closes any INIT grace episode -- the cluster
-                # is demonstrably serving.
-                init_grace_start_time = None
+                # A healthy job closes any INIT tolerance episode -- the
+                # cluster is demonstrably serving.
+                consecutive_init_statuses = 0
                 continue
 
             if job_status in job_lib.JobStatus.user_code_failure_states():
@@ -1097,33 +1101,42 @@ class JobController:
 
             external_failures: Optional[List[ExternalClusterFailure]] = None
             cluster_event_reason = None
-            # Tolerate a bounded window of INIT verdicts before recovering:
-            # INIT commonly means "the ray health probe failed while all
-            # nodes are up" -- a verdict a single transient SSH failure
-            # produces -- and each tick's force-refresh re-probes, restoring
-            # UP once the transient clears. None/STOPPED are unambiguous and
-            # recover immediately.
-            if cluster_status == status_lib.ClusterStatus.INIT:
-                if init_grace_start_time is None:
-                    init_grace_start_time = time.time()
-                init_elapsed = time.time() - init_grace_start_time
-                if init_elapsed < _CLUSTER_INIT_RECOVERY_GRACE_SECONDS:
+            # Tolerate a bounded run of INIT verdicts before recovering
+            # (see _CLUSTER_INIT_RECOVERY_GRACE_PROBES). Gated off for
+            # forced recovery (no healthy workload to protect, and the
+            # force path skips the loop's sleep -- the tolerance would
+            # busy-spin and delay the mandated double-submit cleanup), for
+            # terminal job states (the healthy-job premise is known
+            # false), and when a registered plugin reports a concrete
+            # cluster failure (unambiguous, and its attribution must not
+            # expire while waiting). None/STOPPED verdicts recover
+            # immediately.
+            if (cluster_status == status_lib.ClusterStatus.INIT and
+                    not force_transit_to_recovering and
+                    (job_status is None or not job_status.is_terminal())):
+                consecutive_init_statuses += 1
+                plugin_failures = None
+                if ExternalFailureSource.is_registered():
+                    plugin_failures = await asyncio.to_thread(
+                        ExternalFailureSource.get, cluster_name=cluster_name)
+                if (not plugin_failures and consecutive_init_statuses <
+                        _CLUSTER_INIT_RECOVERY_GRACE_PROBES):
                     logger.info(
                         'Cluster status is INIT; tolerating a possibly '
                         'transient health-probe failure before recovery '
-                        f'({init_elapsed:.0f}s/'
-                        f'{_CLUSTER_INIT_RECOVERY_GRACE_SECONDS:.0f}s).')
+                        f'({consecutive_init_statuses}/'
+                        f'{_CLUSTER_INIT_RECOVERY_GRACE_PROBES}).')
                     continue
-            else:
-                init_grace_start_time = None
+            elif cluster_status != status_lib.ClusterStatus.INIT:
+                consecutive_init_statuses = 0
             if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster is (partially) preempted or failed. It can be
                 # down, INIT or STOPPED, based on the interruption behavior of
                 # the cloud. Spot recovery is needed (will be done later in the
                 # code).
-                # Entering recovery closes the INIT grace episode, so a
-                # post-recovery INIT starts a fresh window.
-                init_grace_start_time = None
+                # Entering recovery closes the INIT tolerance episode, so a
+                # post-recovery INIT starts fresh.
+                consecutive_init_statuses = 0
                 cluster_status_str = ('' if cluster_status is None else
                                       f' (status: {cluster_status.value})')
                 logger.info(
@@ -1170,7 +1183,10 @@ class JobController:
             else:
                 # Cluster is UP
                 if job_status is not None and not job_status.is_terminal():
-                    # The multi-node job is still running, continue monitoring.
+                    # The multi-node job is still running, continue
+                    # monitoring; a healthy job closes any INIT tolerance
+                    # episode.
+                    consecutive_init_statuses = 0
                     continue
                 elif (job_status
                       in job_lib.JobStatus.user_code_failure_states() or

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -67,6 +67,16 @@ else:
 
 logger = sky_logging.init_logger('sky.jobs.controller')
 
+# Grace window before recovering a cluster whose refreshed status is INIT.
+# INIT is also the verdict a SINGLE failed ray-health probe produces while
+# every cloud node is up (e.g. an SSH timeout to a head node under heavy
+# CPU/IO load), and it is not sticky: each monitor tick force-refreshes the
+# status, and a subsequent healthy probe restores UP. Tolerating INIT for a
+# bounded window turns a transient probe failure into a non-event, while a
+# genuine failure still recovers, merely this many seconds later. None and
+# STOPPED statuses are unambiguous and keep recovering immediately.
+_CLUSTER_INIT_RECOVERY_GRACE_SECONDS = 90.0
+
 _background_tasks: Set[asyncio.Task] = set()
 _background_tasks_lock: asyncio.Lock = asyncio.Lock()
 
@@ -922,6 +932,8 @@ class JobController:
 
         transient_job_check_error_start_time = None
         job_check_backoff = None
+        # Start of the current INIT-status grace episode (None = none).
+        init_grace_start_time = None
         # External-link labels already surfaced for this task, so we stop
         # polling the worker's metadata once every pattern has matched.
         live_link_labels: Set[str] = set()
@@ -1062,6 +1074,9 @@ class JobController:
             # status.
             if (job_status is not None and not job_status.is_terminal() and
                     task.num_nodes == 1):
+                # A healthy job closes any INIT grace episode -- the cluster
+                # is demonstrably serving.
+                init_grace_start_time = None
                 continue
 
             if job_status in job_lib.JobStatus.user_code_failure_states():
@@ -1082,11 +1097,33 @@ class JobController:
 
             external_failures: Optional[List[ExternalClusterFailure]] = None
             cluster_event_reason = None
+            # Tolerate a bounded window of INIT verdicts before recovering:
+            # INIT commonly means "the ray health probe failed while all
+            # nodes are up" -- a verdict a single transient SSH failure
+            # produces -- and each tick's force-refresh re-probes, restoring
+            # UP once the transient clears. None/STOPPED are unambiguous and
+            # recover immediately.
+            if cluster_status == status_lib.ClusterStatus.INIT:
+                if init_grace_start_time is None:
+                    init_grace_start_time = time.time()
+                init_elapsed = time.time() - init_grace_start_time
+                if init_elapsed < _CLUSTER_INIT_RECOVERY_GRACE_SECONDS:
+                    logger.info(
+                        'Cluster status is INIT; tolerating a possibly '
+                        'transient health-probe failure before recovery '
+                        f'({init_elapsed:.0f}s/'
+                        f'{_CLUSTER_INIT_RECOVERY_GRACE_SECONDS:.0f}s).')
+                    continue
+            else:
+                init_grace_start_time = None
             if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster is (partially) preempted or failed. It can be
                 # down, INIT or STOPPED, based on the interruption behavior of
                 # the cloud. Spot recovery is needed (will be done later in the
                 # code).
+                # Entering recovery closes the INIT grace episode, so a
+                # post-recovery INIT starts a fresh window.
+                init_grace_start_time = None
                 cluster_status_str = ('' if cluster_status is None else
                                       f' (status: {cluster_status.value})')
                 logger.info(


### PR DESCRIPTION
Fixes #10162

## Problem

The managed-jobs monitor recovers a job the instant a refreshed cluster status is non-UP. But `INIT` is also the verdict a **single failed ray-health probe** produces while every cloud node is up (`backend_utils._update_cluster_status`'s non-k8s branch returns `False` on the first SSH failure, no retry → `Cluster is abnormal because ray cluster is unhealthy (None)`). Under head-node load (large solver + artifact upload), one SSH timeout recovers a perfectly healthy job — observed live on 0.12.3 (details in the issue).

This is asymmetric with the existing tolerance for the UP-cluster case: a transient *job-status* fetch error on a healthy cluster already gets retries with backoff up to `JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS` before recovery; the same transient failure hitting the *ray-health probe* is acted on immediately.

## Fix

Tolerate `ClusterStatus.INIT` for a bounded grace window (`_CLUSTER_INIT_RECOVERY_GRACE_SECONDS = 90`, i.e. several monitor ticks) before entering recovery:

- INIT is not sticky — every tick force-refreshes, so a healthy probe restores UP and the window closes with no recovery.
- `None` / `STOPPED` statuses are unambiguous (cluster gone / provider-stopped) and keep recovering immediately, as today.
- A healthy non-terminal job status closes the window (the cluster is demonstrably serving).
- Entering recovery resets the window so a post-recovery INIT starts a fresh episode.

Worst-case cost for a genuine INIT failure is a 90s delay before a recovery that itself takes minutes; the benefit is that transient probe failures no longer kill healthy long-running jobs.

## Tested

- `python -m py_compile` clean.
- The same change is vendored as an overlay onto our 0.12.3 managed-jobs controller deployment (rolling out with our next API-server redeploy); the incident that motivated it is documented in #10162 with full controller logs.
- No behavior change for the `None`/`STOPPED` paths.