### PR TITLE
[Core] Heal launched_resources shape from cloud actuals on provision/start

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -382,6 +382,35 @@ class GangSchedulingStatus(enum.Enum):
     HEAD_FAILED = 2
 
 
+def _shape_overrides_from_cluster_info(
+        launched_resources: 'resources_lib.Resources',
+        cluster_info: provision_common.ClusterInfo) -> Dict[str, Any]:
+    """launched_resources overrides from the shape the cloud reported.
+
+    Out-of-band mutations (a SKU swap or managed-disk grow done behind
+    SkyPilot's back while the cluster was stopped) leave
+    ``handle.launched_resources`` stale forever, because only a fresh
+    provision writes it — so ``sky status`` and the cost report keep
+    showing the old shape. Provisioners that report the head node's
+    ACTUAL shape in ``InstanceInfo`` (``instance_type``,
+    ``os_disk_size_gb``; currently Azure) let every provision/restart
+    heal the record. ``getattr`` guards handles pickled before the
+    fields existed. Returns only the fields that differ; empty dict when
+    nothing to heal.
+    """
+    head = cluster_info.get_head_instance()
+    if head is None:
+        return {}
+    overrides: Dict[str, Any] = {}
+    instance_type = getattr(head, 'instance_type', None)
+    if instance_type and instance_type != launched_resources.instance_type:
+        overrides['instance_type'] = instance_type
+    os_disk_size_gb = getattr(head, 'os_disk_size_gb', None)
+    if os_disk_size_gb and int(os_disk_size_gb) != launched_resources.disk_size:
+        overrides['disk_size'] = int(os_disk_size_gb)
+    return overrides
+
+
 def _add_to_blocked_resources(blocked_resources: Set['resources_lib.Resources'],
                               resources: 'resources_lib.Resources') -> None:
     # If the resources is already blocked by blocked_resources, we don't need to
@@ -3580,6 +3609,23 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # Update launched resources.
                 handle.launched_resources = handle.launched_resources.copy(
                     region=provision_record.region, zone=provision_record.zone)
+
+                # Heal the recorded shape from the actuals the provisioner
+                # reported, so out-of-band SKU swaps / disk grows stop
+                # going stale in the state DB. Best-effort —
+                # Resources.copy() re-validates against the catalog and a
+                # heal must never fail a provision/start.
+                try:
+                    shape_overrides = _shape_overrides_from_cluster_info(
+                        handle.launched_resources, cluster_info)
+                    if shape_overrides:
+                        logger.info('Refreshing launched resources from '
+                                    f'cloud actuals: {shape_overrides}')
+                        handle.launched_resources = (
+                            handle.launched_resources.copy(**shape_overrides))
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning('Failed to refresh launched resources '
+                                   f'from cloud actuals: {e}')
 
                 self._update_after_cluster_provisioned(
                     handle, to_provision_config.prev_handle, task,

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -597,6 +597,28 @@ def wait_instances(region: str, cluster_name_on_cloud: str,
     # So we don't need to wait here.
 
 
+def _get_os_disk_size_gb(compute_client: 'azure_compute.ComputeManagementClient',
+                         resource_group: str, instance: Any) -> Optional[int]:
+    """Actual OS disk size of an instance, in GB.
+
+    The VM list response's ``storage_profile.os_disk.disk_size_gb`` goes
+    stale (``None``) after an out-of-band managed-disk grow, so the disk
+    resource itself is the authority when the profile carries no size.
+    Best-effort: shape reporting must never fail a provision/start.
+    """
+    try:
+        os_disk = instance.storage_profile.os_disk
+        if os_disk.disk_size_gb:
+            return int(os_disk.disk_size_gb)
+        disk = compute_client.disks.get(resource_group, os_disk.name)
+        if disk.disk_size_gb:
+            return int(disk.disk_size_gb)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning('Failed to read OS disk size for instance '
+                       f'{instance.name!r}: {e}')
+    return None
+
+
 def get_cluster_info(
         region: str,
         cluster_name_on_cloud: str,
@@ -624,6 +646,16 @@ def get_cluster_info(
         internal_ip, external_ip = _get_instance_ips(network_client, inst,
                                                      resource_group,
                                                      use_internal_ips)
+        # Report the ACTUAL shape so the backend can heal
+        # handle.launched_resources after out-of-band SKU swaps / disk
+        # grows. vm_size comes free with the list response; the disk
+        # size costs one disks.get, so it is fetched for the head node
+        # only (the only node the heal reads).
+        hardware_profile = getattr(inst, 'hardware_profile', None)
+        vm_size = getattr(hardware_profile, 'vm_size', None)
+        os_disk_size_gb = (_get_os_disk_size_gb(compute_client,
+                                                resource_group, inst)
+                           if inst.name == head_instance_id else None)
         instances[inst.name] = [
             common.InstanceInfo(
                 instance_id=inst.name,
@@ -632,6 +664,8 @@ def get_cluster_info(
                 tags=inst.tags,
                 # Azure VM name is the instance_id
                 node_name=inst.name,
+                instance_type=vm_size,
+                os_disk_size_gb=os_disk_size_gb,
             )
         ]
     instances = dict(sorted(instances.items(), key=lambda x: x[0]))

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -168,6 +168,13 @@ class InstanceInfo:
     # For Kubernetes: the k8s node name the pod runs on.
     # For clouds: the instance name (e.g., from AWS Name tag, GCP name).
     node_name: Optional[str] = None
+    # The ACTUAL shape the cloud reported at provision/start time, so the
+    # backend can heal handle.launched_resources after an out-of-band SKU
+    # swap or disk grow (otherwise the record stays stale until the
+    # cluster is re-launched). None = the provisioner does not report it.
+    instance_type: Optional[str] = None
+    # Actual OS/boot disk size in GB.
+    os_disk_size_gb: Optional[int] = None
 
     def get_feasible_ip(self) -> str:
         """Get the most feasible IPs of the instance. This function returns


### PR DESCRIPTION
Fixes #10165

## Problem

Out-of-band VM mutations — a SKU resize or managed-disk grow done while a cluster is stopped (`sky stop` → `az vm resize` / `az disk update` → `sky start`) — never update `handle.launched_resources`, which is only written at provision time. `sky status`, `sky cost-report`, and anything reading `global_user_state.get_clusters()` then show the old shape forever, until the cluster is torn down and re-launched. Observed concretely on Azure: an OS-disk grow 512→1024 GB fully applied on the cloud while sky kept reporting `disk_size=512`.

## Solution

- `provision/common.py`: `InstanceInfo` gains optional `instance_type` / `os_disk_size_gb` — the ACTUAL shape the cloud reported at provision/start time. `None` = the provisioner does not report it, preserving existing behavior for every other cloud.
- `provision/azure/instance.py`: `get_cluster_info` fills them. `vm_size` comes free with the VM list response it already makes; the OS-disk size costs one `disks.get`, fetched for the head node only (the only node the heal reads). The VM profile's `disk_size_gb` reads `None` after an out-of-band grow, so the disk resource is the authority.
- `backends/cloud_vm_ray_backend.py`: at the existing "Update launched resources" site (where region/zone are already refreshed), fold drifted `instance_type` / `disk_size` into `handle.launched_resources` before `_update_after_cluster_provisioned` persists the handle. Best-effort: the heal is wrapped so a failure logs a warning and never fails a provision/start; `getattr` guards `InstanceInfo` objects pickled before these fields existed.

Other clouds can adopt incrementally by filling the two fields (e.g. GCP's `machineType` is similarly free on its list response).

## Tested

- Running this change (rebased onto 0.12.3.post1) on our Azure fleet: after an out-of-band 512→1024 GB OS-disk grow, the first `sky start` heals the record (`disk_size=1024` in `sky status`); no-drift restarts are no-ops; a failing `disks.get` degrades to a warning without affecting the start.
- Unit-tested the heal decision (drifted / in-sync / headless / provisioner-reports-nothing / pre-existing pickled `InstanceInfo`) and the Azure disk-size fallback chain (profile → `disks.get` → never-raise) in our deployment's test suite; happy to move those into `tests/` here if maintainers want them.