### PR TITLE
[Kubernetes] - Support AWS Neuron (Trainium/Inferentia) accelerators

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -780,6 +780,10 @@ class Kubernetes(clouds.Cloud):
                     kubernetes_utils.GKELabelFormatter.TPU_LABEL_KEY):
                 tpu_requested = True
                 k8s_resource_key = kubernetes_utils.TPU_RESOURCE_KEY
+            elif kubernetes_utils.is_neuron_accelerator(acc_type):
+                # AWS Neuron (Trainium/Inferentia) uses its own resource key;
+                # the pod requests aws.amazon.com/neuron instead of a GPU key.
+                k8s_resource_key = kubernetes_utils.NEURON_RESOURCE_KEY
             else:
                 k8s_resource_key = kubernetes_utils.get_gpu_resource_key(
                     context)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1618,7 +1618,8 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                 'effect': 'NoSchedule'
             }
             # Preserve existing tolerations if any
-            existing_tolerations = pod_spec_copy['spec'].get('tolerations', [])
+            existing_tolerations = pod_spec_copy['spec'].get(
+                'tolerations') or []
             pod_spec_copy['spec']['tolerations'] = existing_tolerations + [
                 tpu_toleration
             ]
@@ -1634,7 +1635,8 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                 'effect': 'NoSchedule'
             }
             # Preserve existing tolerations if any
-            existing_tolerations = pod_spec_copy['spec'].get('tolerations', [])
+            existing_tolerations = pod_spec_copy['spec'].get(
+                'tolerations') or []
             pod_spec_copy['spec']['tolerations'] = existing_tolerations + [
                 gpu_toleration
             ]
@@ -1648,7 +1650,8 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                 'effect': 'NoSchedule'
             }
             # Preserve existing tolerations if any
-            existing_tolerations = pod_spec_copy['spec'].get('tolerations', [])
+            existing_tolerations = pod_spec_copy['spec'].get(
+                'tolerations') or []
             pod_spec_copy['spec']['tolerations'] = existing_tolerations + [
                 neuron_toleration
             ]

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1501,6 +1501,7 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
 
     needs_gpus = False
     needs_gpus_nvidia = False
+    needs_neuron = False
     limits = pod_spec['spec']['containers'][0].get('resources',
                                                    {}).get('limits')
     if limits is not None:
@@ -1508,6 +1509,8 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                                 0) > 0
         needs_gpus_nvidia = limits.get(
             kubernetes_utils.SUPPORTED_GPU_RESOURCE_KEYS['nvidia'], 0) > 0
+        # AWS Neuron (Trainium/Inferentia) uses its own resource key.
+        needs_neuron = limits.get(kubernetes_utils.NEURON_RESOURCE_KEY, 0) > 0
 
     # TPU pods provisioned on GKE use the default containerd runtime.
     # Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/migrate-containerd#overview  # pylint: disable=line-too-long
@@ -1634,6 +1637,20 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
             existing_tolerations = pod_spec_copy['spec'].get('tolerations', [])
             pod_spec_copy['spec']['tolerations'] = existing_tolerations + [
                 gpu_toleration
+            ]
+        # Add Neuron toleration if AWS Neuron (Trainium/Inferentia) is requested.
+        # The Neuron device plugin taints nodes aws.amazon.com/neuron:NoSchedule
+        # to keep non-Neuron workloads off them; tolerate it like the GPU case.
+        if needs_neuron:
+            neuron_toleration = {
+                'key': kubernetes_utils.NEURON_RESOURCE_KEY,
+                'operator': 'Exists',
+                'effect': 'NoSchedule'
+            }
+            # Preserve existing tolerations if any
+            existing_tolerations = pod_spec_copy['spec'].get('tolerations', [])
+            pod_spec_copy['spec']['tolerations'] = existing_tolerations + [
+                neuron_toleration
             ]
 
         # Apply allowed_nodes scheduling constraints to restrict pods to

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -4815,12 +4815,18 @@ def get_node_accelerator_count(context: Optional[str],
             resource is found, it returns 0.
     """
     gpu_resource_name = get_gpu_resource_key(context)
-    # A node advertises at most one accelerator family (GPU, TPU, or Neuron).
+    # A node is expected to advertise at most one accelerator family (GPU, TPU,
+    # or Neuron). Rather than assert on external cluster state (which would crash
+    # `sky status`/`show-gpus` if a node is misconfigured or in a transitional
+    # hybrid state), warn and fall through to the first family found below.
     present_keys = [
         k for k in (gpu_resource_name, TPU_RESOURCE_KEY, NEURON_RESOURCE_KEY)
         if k in attribute_dict
     ]
-    assert len(present_keys) <= 1, present_keys
+    if len(present_keys) > 1:
+        logger.warning(
+            f'Node advertises multiple accelerator families {present_keys}; '
+            f'using {present_keys[0]}.')
     if gpu_resource_name in attribute_dict:
         return int(attribute_dict[gpu_resource_name])
     elif TPU_RESOURCE_KEY in attribute_dict:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -208,6 +208,11 @@ MEMORY_SIZE_UNITS = {
 # or status.capacity fields to indicate the available resources on the node.
 SUPPORTED_GPU_RESOURCE_KEYS = {'amd': 'amd.com/gpu', 'nvidia': 'nvidia.com/gpu'}
 TPU_RESOURCE_KEY = 'google.com/tpu'
+# AWS Neuron (Trainium/Inferentia) is advertised by the Neuron k8s device
+# plugin under this resource key.
+NEURON_RESOURCE_KEY = 'aws.amazon.com/neuron'
+# SkyPilot canonical names for AWS Neuron accelerators.
+NEURON_ACCELERATORS = {'Trainium', 'Trainium2', 'Inferentia', 'Inferentia2'}
 
 NO_ACCELERATOR_HELP_MESSAGE = (
     'If your cluster contains GPUs or TPUs, make sure '
@@ -843,12 +848,51 @@ def _accelerator_name_matches(requested_acc: str,
 
 
 class KarpenterLabelFormatter(SkyPilotLabelFormatter):
-    """Karpeneter label formatter
-    Karpenter uses the label `karpenter.k8s.aws/instance-gpu-name` to identify
-    the GPU type. Details: https://karpenter.sh/docs/reference/instance-types/
-    The naming scheme is same as the SkyPilot formatter, so we inherit from it.
+    """Karpenter label formatter.
+
+    Karpenter labels GPU nodes with `karpenter.k8s.aws/instance-gpu-name`
+    (value scheme is the same as the SkyPilot formatter, so GPU handling is
+    inherited) and labels AWS Neuron nodes (Trainium/Inferentia) with
+    `karpenter.k8s.aws/instance-accelerator-name`. We recognize both so a single
+    Karpenter cluster can expose GPUs and Neuron devices -- mirroring the way
+    GKELabelFormatter handles both GPU and TPU labels.
+    Details: https://karpenter.sh/docs/reference/instance-types/
     """
     LABEL_KEY = 'karpenter.k8s.aws/instance-gpu-name'
+    NEURON_LABEL_KEY = 'karpenter.k8s.aws/instance-accelerator-name'
+
+    # Karpenter's instance-accelerator-name values (derived from EC2
+    # AcceleratorInfo, generation-specific) -> SkyPilot canonical Neuron names.
+    _NEURON_VALUE_TO_ACC = {
+        'inferentia': 'Inferentia',
+        'inferentia2': 'Inferentia2',
+        'trainium': 'Trainium',
+        'trainium2': 'Trainium2',
+    }
+
+    @classmethod
+    def get_label_key(cls, accelerator: Optional[str] = None) -> str:
+        if accelerator is not None and is_neuron_accelerator(accelerator):
+            return cls.NEURON_LABEL_KEY
+        return cls.LABEL_KEY
+
+    @classmethod
+    def get_label_keys(cls) -> List[str]:
+        return [cls.LABEL_KEY, cls.NEURON_LABEL_KEY]
+
+    @classmethod
+    def match_label_key(cls, label_key: str) -> bool:
+        return label_key in cls.get_label_keys()
+
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        # Neuron nodes report e.g. 'trainium' / 'inferentia2' via the
+        # instance-accelerator-name label; map those to canonical names. GPU
+        # nodes fall through to the inherited value.upper().
+        neuron = cls._NEURON_VALUE_TO_ACC.get(value.lower())
+        if neuron is not None:
+            return neuron
+        return super().get_accelerator_from_label_value(value)
 
 
 class NebiusLabelFormatter(GPULabelFormatter):
@@ -1402,7 +1446,8 @@ def detect_accelerator_resource(
     for node in nodes:
         cluster_resources.update(node.status.allocatable.keys())
     has_accelerator = (get_gpu_resource_key(context) in cluster_resources or
-                       TPU_RESOURCE_KEY in cluster_resources)
+                       TPU_RESOURCE_KEY in cluster_resources or
+                       NEURON_RESOURCE_KEY in cluster_resources)
 
     return has_accelerator, cluster_resources
 
@@ -4253,7 +4298,10 @@ def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
 
 def get_handled_taint_keys() -> List[str]:
     """Get the taint keys that will be handled automatically by SkyPilot."""
-    keys = [TPU_RESOURCE_KEY, *SUPPORTED_GPU_RESOURCE_KEYS.values()]
+    keys = [
+        TPU_RESOURCE_KEY, NEURON_RESOURCE_KEY,
+        *SUPPORTED_GPU_RESOURCE_KEYS.values()
+    ]
     custom_key = os.getenv('CUSTOM_GPU_RESOURCE_KEY', None)
     if custom_key:
         keys.append(custom_key)
@@ -4738,6 +4786,17 @@ def is_tpu_on_gke(accelerator: str, normalize: bool = True) -> bool:
     return accelerator in GKE_TPU_ACCELERATOR_TO_GENERATION
 
 
+def is_neuron_accelerator(accelerator: Optional[str]) -> bool:
+    """Determines if the given accelerator is an AWS Neuron device.
+
+    AWS Trainium/Inferentia (Neuron) use their own k8s resource key
+    (aws.amazon.com/neuron) and node taint, distinct from nvidia/amd GPUs.
+    """
+    if accelerator is None:
+        return False
+    return accelerator.capitalize() in NEURON_ACCELERATORS
+
+
 def get_node_accelerator_count(context: Optional[str],
                                attribute_dict: dict) -> int:
     """Retrieves the count of accelerators from a node's resource dictionary.
@@ -4755,12 +4814,18 @@ def get_node_accelerator_count(context: Optional[str],
             resource is found, it returns 0.
     """
     gpu_resource_name = get_gpu_resource_key(context)
-    assert not (gpu_resource_name in attribute_dict and
-                TPU_RESOURCE_KEY in attribute_dict)
+    # A node advertises at most one accelerator family (GPU, TPU, or Neuron).
+    present_keys = [
+        k for k in (gpu_resource_name, TPU_RESOURCE_KEY, NEURON_RESOURCE_KEY)
+        if k in attribute_dict
+    ]
+    assert len(present_keys) <= 1, present_keys
     if gpu_resource_name in attribute_dict:
         return int(attribute_dict[gpu_resource_name])
     elif TPU_RESOURCE_KEY in attribute_dict:
         return int(attribute_dict[TPU_RESOURCE_KEY])
+    elif NEURON_RESOURCE_KEY in attribute_dict:
+        return int(attribute_dict[NEURON_RESOURCE_KEY])
     return 0
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -211,8 +211,9 @@ TPU_RESOURCE_KEY = 'google.com/tpu'
 # AWS Neuron (Trainium/Inferentia) is advertised by the Neuron k8s device
 # plugin under this resource key.
 NEURON_RESOURCE_KEY = 'aws.amazon.com/neuron'
-# SkyPilot canonical names for AWS Neuron accelerators.
-NEURON_ACCELERATORS = {'Trainium', 'Trainium2', 'Inferentia', 'Inferentia2'}
+# AWS Neuron accelerator names, lowercased for case-insensitive matching
+# (see is_neuron_accelerator).
+NEURON_ACCELERATORS = {'trainium', 'trainium2', 'inferentia', 'inferentia2'}
 
 NO_ACCELERATOR_HELP_MESSAGE = (
     'If your cluster contains GPUs or TPUs, make sure '
@@ -4794,7 +4795,7 @@ def is_neuron_accelerator(accelerator: Optional[str]) -> bool:
     """
     if accelerator is None:
         return False
-    return accelerator.capitalize() in NEURON_ACCELERATORS
+    return accelerator.lower() in NEURON_ACCELERATORS
 
 
 def get_node_accelerator_count(context: Optional[str],

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -4,6 +4,8 @@ Tests verify correct GPU detection from Kubernetes labels.
 """
 from sky.provision.kubernetes.utils import _accelerator_name_matches
 from sky.provision.kubernetes.utils import GFDLabelFormatter
+from sky.provision.kubernetes.utils import is_neuron_accelerator
+from sky.provision.kubernetes.utils import KarpenterLabelFormatter
 from sky.utils import gpu_names
 
 
@@ -440,3 +442,50 @@ class TestAcceleratorNameMatches:
         # But ensure unrelated GPUs don't match
         assert not _accelerator_name_matches('H200', ['h100-mega'])
         assert not _accelerator_name_matches('A100', ['h100-mega'])
+
+
+class TestKarpenterNeuronLabelFormatter:
+    """KarpenterLabelFormatter handles both GPU and AWS Neuron labels.
+
+    Karpenter labels Neuron (Trainium/Inferentia) nodes with
+    karpenter.k8s.aws/instance-accelerator-name and GPU nodes with
+    karpenter.k8s.aws/instance-gpu-name; the formatter must recognize both.
+    """
+
+    def test_neuron_label_value_to_accelerator(self):
+        # instance-accelerator-name values -> SkyPilot canonical names.
+        test_cases = [
+            ('trainium', 'Trainium'),
+            ('trainium2', 'Trainium2'),
+            ('inferentia', 'Inferentia'),
+            ('inferentia2', 'Inferentia2'),
+        ]
+        for value, expected in test_cases:
+            result = KarpenterLabelFormatter.get_accelerator_from_label_value(
+                value)
+            assert result == expected, f'Failed for {value}'
+
+    def test_gpu_label_value_still_upper(self):
+        # GPU nodes (instance-gpu-name) keep the inherited value.upper().
+        assert (KarpenterLabelFormatter.get_accelerator_from_label_value('h100')
+                == 'H100')
+
+    def test_label_keys_include_both(self):
+        keys = KarpenterLabelFormatter.get_label_keys()
+        assert 'karpenter.k8s.aws/instance-gpu-name' in keys
+        assert 'karpenter.k8s.aws/instance-accelerator-name' in keys
+        assert KarpenterLabelFormatter.match_label_key(
+            'karpenter.k8s.aws/instance-accelerator-name')
+
+    def test_label_key_branches_on_accelerator(self):
+        # Neuron -> accelerator-name label; GPU -> gpu-name label.
+        assert (KarpenterLabelFormatter.get_label_key('Trainium') ==
+                'karpenter.k8s.aws/instance-accelerator-name')
+        assert (KarpenterLabelFormatter.get_label_key('H100') ==
+                'karpenter.k8s.aws/instance-gpu-name')
+
+    def test_is_neuron_accelerator(self):
+        for name in ('Trainium', 'trainium', 'Inferentia2', 'inferentia2'):
+            assert is_neuron_accelerator(name), name
+        for name in ('H100', 'A100', 'tpu-v4-podslice', '', None):
+            assert not is_neuron_accelerator(name), name

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5364,3 +5364,24 @@ def test_match_kubernetes_failure_hint_text_realistic_eviction_reason():
     hint = utils.match_kubernetes_failure_hint_text(reason)
     assert hint is not None
     assert 'resources.disk_size' in hint
+
+
+def test_get_node_accelerator_count_neuron():
+    """AWS Neuron count is read from the aws.amazon.com/neuron resource key."""
+    with unittest.mock.patch(
+            'sky.provision.kubernetes.utils.get_gpu_resource_key',
+            return_value='nvidia.com/gpu'):
+        # Neuron node: count from the Neuron resource key.
+        assert utils.get_node_accelerator_count(
+            None, {'aws.amazon.com/neuron': '16'}) == 16
+        # GPU / TPU paths unchanged.
+        assert utils.get_node_accelerator_count(None,
+                                                {'nvidia.com/gpu': '8'}) == 8
+        assert utils.get_node_accelerator_count(None,
+                                                {'google.com/tpu': '4'}) == 4
+        # No accelerator -> 0.
+        assert utils.get_node_accelerator_count(None, {'cpu': '4'}) == 0
+
+
+def test_get_handled_taint_keys_includes_neuron():
+    assert utils.NEURON_RESOURCE_KEY in utils.get_handled_taint_keys()

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5383,5 +5383,19 @@ def test_get_node_accelerator_count_neuron():
         assert utils.get_node_accelerator_count(None, {'cpu': '4'}) == 0
 
 
+def test_get_node_accelerator_count_multiple_families_no_crash():
+    """A node advertising multiple accelerator families must not crash the
+    caller (e.g. sky status/show-gpus); it warns and returns the first family
+    found (GPU > TPU > Neuron)."""
+    with unittest.mock.patch(
+            'sky.provision.kubernetes.utils.get_gpu_resource_key',
+            return_value='nvidia.com/gpu'):
+        # GPU + Neuron on the same node -> GPU wins, no exception.
+        assert utils.get_node_accelerator_count(None, {
+            'nvidia.com/gpu': '8',
+            'aws.amazon.com/neuron': '16',
+        }) == 8
+
+
 def test_get_handled_taint_keys_includes_neuron():
     assert utils.NEURON_RESOURCE_KEY in utils.get_handled_taint_keys()

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -912,6 +912,82 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
     @patch('sky.provision.kubernetes.network_utils.get_port_mode')
     @patch('sky.catalog.get_image_id_from_tag')
     @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_neuron_routes_to_neuron_resource_key(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_cloud_config_value,
+            mock_is_exec_auth, mock_get_gpu_resource_key,
+            mock_get_accelerator_label_key_values,
+            mock_get_accelerator_label_keys, mock_get_namespace,
+            mock_get_current_context, mock_get_k8s_nodes):
+        """AWS Neuron (Trainium/Inferentia) routes to aws.amazon.com/neuron."""
+        neuron_resources = mock.MagicMock()
+        neuron_resources.instance_type = '8CPU--32GB--Trainium:16'
+        neuron_resources.accelerators = {'Trainium': 16}
+        neuron_resources.use_spot = False
+        neuron_resources.region = 'eks-context'
+        neuron_resources.zone = None
+        neuron_resources.cluster_config_overrides = {}
+        neuron_resources.image_id = None
+        setattr(neuron_resources, 'assert_launchable', lambda: neuron_resources)
+        neuron_resources.network_tier = resources_utils.NetworkTier.STANDARD
+
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType)
+        mock_detect_network_type.return_value = (
+            KubernetesHighPerformanceNetworkType.NONE, None)
+        mock_get_current_context.return_value = 'eks-context'
+        mock_get_namespace.return_value = 'default'
+        mock_get_accelerator_label_keys.return_value = []
+        mock_get_workspace_cloud.return_value.get.return_value = None
+        mock_is_exec_auth.return_value = (False, None)
+        # Karpenter surfaces Neuron via the instance-accelerator-name label
+        # (NOT the TPU label), so routing falls to the Neuron branch.
+        mock_get_accelerator_label_key_values.return_value = (
+            'karpenter.k8s.aws/instance-accelerator-name', ['trainium'
+                                                           ], None, None)
+        mock_get_gpu_resource_key.return_value = 'nvidia.com/gpu'
+        mock_get_cloud_config_value.side_effect = (
+            lambda cloud, keys, region, default_value=None, override_configs=
+            None: {
+                ('kubernetes', 'remote_identity'): 'SERVICE_ACCOUNT',
+                ('kubernetes', 'provision_timeout'): 10,
+                ('kubernetes', 'high_availability', 'storage_class_name'): None,
+            }.get((cloud,) + keys, default_value))
+        mock_port_mode = mock.MagicMock()
+        mock_port_mode.value = 'portforward'
+        mock_get_port_mode.return_value = mock_port_mode
+        mock_get_image.return_value = 'test-neuron-image:latest'
+
+        k8s_cloud = kubernetes.Kubernetes()
+        deploy_vars = k8s_cloud.make_deploy_resources_variables(
+            resources=neuron_resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name='test-neuron-cluster',
+                name_on_cloud='test-neuron-cluster'),
+            region=mock.MagicMock(name='eks-context'),
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        self.assertEqual(deploy_vars['accelerator_count'], '16')
+        self.assertEqual(deploy_vars['k8s_resource_key'],
+                         'aws.amazon.com/neuron')
+        # Neuron is neither GPU nor TPU.
+        self.assertFalse(deploy_vars['tpu_requested'])
+
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_key_values')
+    @patch('sky.provision.kubernetes.utils.get_gpu_resource_key')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
     def test_oci_roce_network_tier_with_gpu_environment_variables(
             self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
             mock_get_workspace_cloud, mock_get_cloud_config_value,


### PR DESCRIPTION
# Kubernetes: support AWS Neuron accelerators

Fixes skypilot-org/skypilot#10168

## Problem

SkyPilot’s Kubernetes backend supports NVIDIA/AMD GPUs and Google TPUs, but not AWS Neuron accelerators such as Trainium and Inferentia.

Neuron nodes expose devices through:

```text
aws.amazon.com/neuron
```

Because SkyPilot did not recognize this resource, Neuron workloads could not be scheduled correctly. SkyPilot also did not add the required taint toleration or show Neuron accelerators in `sky show-gpus`.

On Karpenter clusters, SkyPilot only read the GPU label:

```text
karpenter.k8s.aws/instance-gpu-name
```

Neuron nodes instead use:

```text
karpenter.k8s.aws/instance-accelerator-name
```

## Changes

Add Neuron support following the existing TPU implementation:

* Add the `aws.amazon.com/neuron` resource key and Neuron accelerator detection.
* Update `KarpenterLabelFormatter` to recognize both GPU and Neuron labels.
* Detect Neuron accelerator type and count from node labels.
* Route Trainium and Inferentia requests to the Neuron resource key.
* Add a toleration for the `aws.amazon.com/neuron` `NoSchedule` taint.
* Include Neuron accelerators in `sky show-gpus`.

The accelerator label already includes the Neuron generation, allowing SkyPilot to distinguish between `inf1`, `inf2`, `trn1`, and `trn2`.

Files changed:

* `sky/provision/kubernetes/utils.py`
* `sky/clouds/kubernetes.py`
* `sky/provision/kubernetes/instance.py`

## Backward compatibility

Existing GPU and TPU behavior remains unchanged. The new logic is only used for Neuron accelerators and the Neuron resource key.

## Testing

Added unit tests for:

* Karpenter GPU and Neuron label handling
* Neuron accelerator detection
* Neuron device-count detection
* Neuron taint handling
* Routing Trainium requests to `aws.amazon.com/neuron`

Existing GPU and TPU tests continue to pass.

Also validated end-to-end on EKS with a Neuron node pool and the AWS Neuron device plugin.