### PR TITLE
[Nebius] Add optional boot disk encryption

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -243,6 +243,7 @@ Below is the configuration syntax and some example values. See detailed explanat
         fabric: fabric-5
     :ref:`use_internal_ips <config-yaml-nebius-use-internal-ips>`: true
     :ref:`use_static_ip_address <config-yaml-nebius-use-static-ip-address>`: true
+    :ref:`disk_encrypted <config-yaml-nebius-disk-encrypted>`: true
     :ref:`ssh_proxy_command <config-yaml-nebius-ssh-proxy-command>`: ssh -W %h:%p user@host
     :ref:`tenant_id <config-yaml-nebius-tenant-id>`: tenant-1234567890
     :ref:`domain <config-yaml-nebius-domain>`: api.nebius.cloud:443
@@ -2512,6 +2513,19 @@ Set to ``false`` to use only publicly available pricing information.
 Pricing tiers and free quotas are ignored in this estimate, and the final cost could be lower or higher.
 
 Default: ``true``.
+
+.. _config-yaml-nebius-disk-encrypted:
+
+``nebius.disk_encrypted``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Encrypted boot disk (optional).
+
+Set to ``true`` to enable Nebius-managed encryption for Network SSD
+Non-replicated and Network SSD IO M3 boot disks launched by SkyPilot. Network
+SSD boot disks are encrypted by default.
+
+Default: ``false``.
 
 .. _config-yaml-nebius-ssh-proxy-command:
 

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -340,6 +340,11 @@ class Nebius(clouds.Cloud):
 
         use_static_ip_address = skypilot_config.get_nested(
             ('nebius', 'use_static_ip_address'), default_value=False)
+        disk_encrypted = skypilot_config.get_effective_region_config(
+            cloud='nebius',
+            region=region.name,
+            keys=('disk_encrypted',),
+            default_value=False)
 
         def _get_disk_tier() -> resources_utils.DiskTier:
             logger.debug(f'Getting disk tier for Nebius {resources.disk_tier}.')
@@ -396,6 +401,7 @@ class Nebius(clouds.Cloud):
             'filesystems': resources_vars_fs,
             'network_tier': resources.network_tier,
             'disk_tier': _get_disk_tier(),
+            'disk_encrypted': disk_encrypted,
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group_managed_by_skypilot).lower(),

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -157,6 +157,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
             associate_public_ip_address=(
                 not config.provider_config['use_internal_ips']),
             disk_tier=config.node_config['disk_tier'],
+            disk_encrypted=config.node_config.get('disk_encrypted', False),
             use_static_ip_address=config.provider_config.get(
                 'use_static_ip_address', False),
             filesystems=config.node_config.get('filesystems', []),

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -624,6 +624,11 @@ def launch(cluster_name_on_cloud: str,
         disk_spec.disk_encryption = compute.DiskEncryption(
             type=compute.DiskEncryption.DiskEncryptionType.
             DISK_ENCRYPTION_MANAGED)
+    elif disk_encrypted:
+        logger.warning(
+            f'Disk encryption was requested, but disk type {disk_type.name} '
+            'does not support explicitly configured Nebius-managed '
+            'encryption. Continuing without setting disk encryption.')
     if image_id_or_family.startswith('computeimage-'):
         disk_spec.source_image_id = image_id_or_family
     else:

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -540,6 +540,7 @@ def launch(cluster_name_on_cloud: str,
            associate_public_ip_address: bool,
            filesystems: List[Dict[str, Any]],
            disk_tier: str,
+           disk_encrypted: bool = False,
            use_static_ip_address: bool = False,
            use_spot: bool = False,
            network_tier: Optional[resources_utils.NetworkTier] = None,
@@ -609,10 +610,20 @@ def launch(cluster_name_on_cloud: str,
                 f'Requested {disk_size} GiB, rounding up to '
                 f'{actual_disk_size} GiB.')
 
-    disk_spec = nebius.compute().DiskSpec(
+    compute = nebius.compute()
+    disk_type = _disk_tier_to_disk_type(disk_tier)
+    disk_spec = compute.DiskSpec(
         size_gibibytes=actual_disk_size,
-        type=_disk_tier_to_disk_type(disk_tier),
+        type=disk_type,
     )
+    encryptable_disk_types = (
+        compute.DiskSpec.DiskType.NETWORK_SSD_IO_M3,
+        compute.DiskSpec.DiskType.NETWORK_SSD_NON_REPLICATED,
+    )
+    if disk_encrypted and disk_type in encryptable_disk_types:
+        disk_spec.disk_encryption = compute.DiskEncryption(
+            type=compute.DiskEncryption.DiskEncryptionType.
+            DISK_ENCRYPTION_MANAGED)
     if image_id_or_family.startswith('computeimage-'):
         disk_spec.source_image_id = image_id_or_family
     else:

--- a/sky/templates/nebius-ray.yml.j2
+++ b/sky/templates/nebius-ray.yml.j2
@@ -54,6 +54,7 @@ available_node_types:
       use_spot: {{ use_spot }}
       network_tier: {{network_tier}}
       disk_tier: {{disk_tier}}
+      disk_encrypted: {{disk_encrypted}}
       filesystems:
         {%- for fs in filesystems %}
         - filesystem_id: {{ fs.filesystem_id }}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2166,6 +2166,9 @@ def get_config_schema():
                 **_NETWORK_CONFIG_SCHEMA, 'use_static_ip_address': {
                     'type': 'boolean',
                 },
+                'disk_encrypted': {
+                    'type': 'boolean',
+                },
                 'tenant_id': {
                     'type': 'string',
                 },
@@ -2194,6 +2197,9 @@ def get_config_schema():
                             },
                             'fabric': {
                                 'type': 'string',
+                            },
+                            'disk_encrypted': {
+                                'type': 'boolean',
                             },
                             'filesystems': {
                                 'type': 'array',

--- a/tests/unit_tests/test_nebius_disk_encryption.py
+++ b/tests/unit_tests/test_nebius_disk_encryption.py
@@ -1,0 +1,135 @@
+import importlib.util
+from unittest import mock
+
+import jsonschema
+import pytest
+
+from sky.adaptors import nebius as nebius_adaptor
+from sky.provision.nebius import utils as nebius_utils
+from sky.utils import resources_utils
+from sky.utils import schemas
+
+_HAS_NEBIUS_SDK = importlib.util.find_spec('nebius') is not None
+nebius_sdk_required = pytest.mark.skipif(not _HAS_NEBIUS_SDK,
+                                         reason='Nebius SDK is not installed')
+
+
+@pytest.mark.parametrize(
+    'config',
+    [
+        {
+            'nebius': {
+                'disk_encrypted': True
+            }
+        },
+        {
+            'nebius': {
+                'region_configs': {
+                    'us-central1': {
+                        'disk_encrypted': True
+                    }
+                }
+            }
+        },
+    ],
+)
+def test_disk_encrypted_config_accepts_bool(config):
+    jsonschema.validate(instance=config, schema=schemas.get_config_schema())
+
+
+def test_disk_encrypted_config_rejects_non_bool():
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(
+            instance={'nebius': {
+                'disk_encrypted': 'yes'
+            }},
+            schema=schemas.get_config_schema(),
+        )
+
+
+def _launch_disk_spec(disk_tier, disk_encrypted=False):
+    """
+    Build a Nebius launch request and return its boot disk specification.
+    """
+    compute = nebius_adaptor.compute()
+    service = mock.MagicMock()
+    instance = mock.MagicMock()
+    instance.metadata.id = 'instance-id'
+    instance.status.state.name = 'STARTING'
+
+    with (
+            mock.patch.object(nebius_utils,
+                              'get_project_by_region',
+                              return_value='project-id'),
+            mock.patch.object(nebius_utils,
+                              'get_subnet_id',
+                              return_value='subnet-id'),
+            mock.patch.object(nebius_adaptor, 'sdk'),
+            mock.patch.object(compute,
+                              'InstanceServiceClient',
+                              return_value=service),
+            mock.patch.object(nebius_adaptor,
+                              'sync_call',
+                              side_effect=[None, instance]),
+    ):
+        nebius_utils.launch(
+            cluster_name_on_cloud='cluster',
+            node_type='head',
+            platform='gpu-l40s',
+            preset='1gpu-16vcpu-64gb',
+            region='us-central1',
+            image_id_or_family='computeimage-test',
+            disk_size=93,
+            user_data='',
+            associate_public_ip_address=False,
+            filesystems=[],
+            disk_tier=disk_tier,
+            disk_encrypted=disk_encrypted,
+        )
+
+    request = service.create.call_args.args[0]
+    return request.spec.boot_disk.managed_disk.spec
+
+
+@nebius_sdk_required
+@pytest.mark.parametrize(
+    ('disk_tier', 'expected_disk_type'),
+    [
+        (resources_utils.DiskTier.HIGH, 'NETWORK_SSD_IO_M3'),
+        (resources_utils.DiskTier.LOW, 'NETWORK_SSD_NON_REPLICATED'),
+    ],
+)
+def test_encrypts_supported_disk_types(disk_tier, expected_disk_type):
+    compute = nebius_adaptor.compute()
+    disk_spec = _launch_disk_spec(disk_tier, disk_encrypted=True)
+
+    assert disk_spec.type.name == expected_disk_type
+    assert disk_spec.disk_encryption.type == (
+        compute.DiskEncryption.DiskEncryptionType.DISK_ENCRYPTION_MANAGED)
+
+
+@nebius_sdk_required
+@pytest.mark.parametrize(
+    'disk_tier',
+    [
+        resources_utils.DiskTier.HIGH,
+        resources_utils.DiskTier.LOW,
+    ],
+)
+def test_disk_encryption_defaults_disabled(disk_tier):
+    compute = nebius_adaptor.compute()
+    disk_spec = _launch_disk_spec(disk_tier)
+
+    assert disk_spec.disk_encryption.type == (
+        compute.DiskEncryption.DiskEncryptionType.DISK_ENCRYPTION_UNSPECIFIED)
+
+
+@nebius_sdk_required
+def test_standard_ssd_does_not_set_optional_encryption():
+    compute = nebius_adaptor.compute()
+    disk_spec = _launch_disk_spec(resources_utils.DiskTier.MEDIUM,
+                                  disk_encrypted=True)
+
+    assert disk_spec.type == compute.DiskSpec.DiskType.NETWORK_SSD
+    assert disk_spec.disk_encryption.type == (
+        compute.DiskEncryption.DiskEncryptionType.DISK_ENCRYPTION_UNSPECIFIED)

--- a/tests/unit_tests/test_nebius_disk_encryption.py
+++ b/tests/unit_tests/test_nebius_disk_encryption.py
@@ -125,7 +125,7 @@ def test_disk_encryption_defaults_disabled(disk_tier):
 
 
 @nebius_sdk_required
-def test_standard_ssd_does_not_set_optional_encryption():
+def test_standard_ssd_does_not_set_optional_encryption(caplog):
     compute = nebius_adaptor.compute()
     disk_spec = _launch_disk_spec(resources_utils.DiskTier.MEDIUM,
                                   disk_encrypted=True)
@@ -133,3 +133,5 @@ def test_standard_ssd_does_not_set_optional_encryption():
     assert disk_spec.type == compute.DiskSpec.DiskType.NETWORK_SSD
     assert disk_spec.disk_encryption.type == (
         compute.DiskEncryption.DiskEncryptionType.DISK_ENCRYPTION_UNSPECIFIED)
+    assert ('does not support explicitly configured Nebius-managed encryption'
+            in caplog.text)


### PR DESCRIPTION
**Problem.** Nebius Network SSD IO M3 and Network SSD Non-replicated boot disks are not automatically encrypted, but the Nebius provider has no configuration to request managed encryption, forcing users to patch the SDK at runtime or choose a different disk type.

**Fix.** Add an optional nebius.disk_encrypted boolean, including regional overrides, thread it through deploy variables and provisioning, and set DISK_ENCRYPTION_MANAGED only for M3 and non-replicated SSD while leaving standard Network SSD behavior unchanged because Nebius encrypts that type automatically.