### PR TITLE
[Docker] Skip jq install when already available

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -379,7 +379,8 @@ class DockerInitializer:
             # issue with nvidia container toolkit:
             # https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
             self._run(
-                '{ which jq || sudo apt update && sudo apt install -y jq; } && '
+                '{ command -v jq >/dev/null 2>&1 || '
+                '{ sudo apt-get update && sudo apt-get install -y jq; }; } && '
                 '{ [ -f /etc/docker/daemon.json ] || '
                 'echo "{}" | sudo tee /etc/docker/daemon.json;'
                 'sudo jq \'.["exec-opts"] = ["native.cgroupdriver=cgroupfs"]\' '


### PR DESCRIPTION
**Problem.** The shell expression that ensures jq exists is evaluated as (which jq || apt update) && apt install, so apt install runs even when which jq succeeds; an observed launch printed /usr/bin/jq and then entered apt anyway, with the combined daemon-configuration command taking about 2.6 seconds.

**Fix.** Use a quiet command -v check and group apt-get update plus install as the right-hand side of ||, preserving installation when jq is absent and performing no package-manager work when it is present.