### PR TITLE
[Docker] Skip apt for preinstalled dependencies

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -423,12 +423,15 @@ class DockerInitializer:
             'exec 200>/var/tmp/sky_apt.lock; '
             'flock -x -w 120 200 || exit 1; '
             'export DEBIAN_FRONTEND=noninteractive; '
+            'packages="rsync curl wget patch openssh-server python3-pip fuse"; '
+            'if dpkg-query -W -f=\'${Status}\\n\' ${packages} 2>&1 | '
+            'grep -qv "^install ok installed$"; then '
             'apt-get -yq update && '
             # Our mount script will install gcsfuse without fuse package.
             # We need to install fuse package first to enable storage mount.
             # The dpkg option is to suppress the prompt for fuse installation.
             'apt-get -o DPkg::Options::=--force-confnew install -y '
-            'rsync curl wget patch openssh-server python3-pip fuse\'')
+            '${packages}; fi\'')
         self._run(cmd, run_env='docker')
 
         # Copy local authorized_keys to docker container.


### PR DESCRIPTION
**Problem.** Docker initialization always performs apt-get update and installs its seven runtime dependencies, even when a golden image already contains every package; in an observed launch this took about 6.3 seconds and upgraded wget despite no missing dependency.

**Fix.** Query each package status with dpkg-query and run the existing update/install block unless every result is exactly install ok installed, so incomplete or deinstalled packages retain current installation behavior while pre-baked images skip apt entirely.