### PR TITLE
[Metrics] Take local-context detection off the scrape path

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -385,8 +385,8 @@ SKY_APISERVER_LOCAL_CONTEXT_DETECTION_DURATION_SECONDS = prom.Histogram(
 # success | unauthorized | no_credentials | no_uid | error.
 # `unauthorized` means the API server's own service account lacks
 # `get` on the kube-system namespace, which disables detection for
-# every named context; alert on any nonzero
-# rate(sky_apiserver_local_context_anchor_read_total{result="unauthorized"}[15m]).
+# every named context; alert on any nonzero rate of the
+# result="unauthorized" series over a 15m window.
 SKY_APISERVER_LOCAL_CONTEXT_ANCHOR_READ_TOTAL = prom.Counter(
     'sky_apiserver_local_context_anchor_read_total',
     'Count of in-cluster identity-anchor (kube-system) read outcomes',

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -3,12 +3,14 @@ import asyncio
 import contextlib
 import functools
 import os
+import queue
+import random
 import re
 import select
 import subprocess
 import threading
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import httpx
 import prometheus_client as prom
@@ -63,33 +65,74 @@ _CLUSTER_IDENTITY_NAMESPACE = 'kube-system'
 # (_PER_CONTEXT_TIMEOUT_SECONDS) together with the actual metrics request.
 _NAMESPACE_PROBE_TIMEOUT_SECONDS = 5
 
-# TTL for the process-level local-context detection cache. A TTL (instead
-# of caching forever) covers the rare case where a kubeconfig context name
-# is remapped to a different cluster at runtime; a stale entry self-heals
-# within this window. Detection results must NOT live in the request-level
-# cache: gpu_metrics() calls annotations.clear_request_level_cache() on
-# every scrape, which would turn the probe into per-scrape overhead.
+# Interval between re-probes of a context whose detection concluded
+# (local or remote). A periodic refresh (instead of probing once) covers
+# the rare case where a kubeconfig context name is remapped to a
+# different cluster at runtime; a stale verdict self-heals within this
+# window. Detection results must NOT live in the request-level cache:
+# gpu_metrics() calls annotations.clear_request_level_cache() on every
+# scrape, which would turn the probe into per-scrape overhead.
 _LOCAL_CONTEXT_CACHE_TTL_SECONDS = 60 * 60
 
-# Retry interval for inconclusive detections (probe error, no in-cluster
-# identity). Kept much shorter than the cache TTL: a transient failure
-# (RBAC not yet applied, API server hiccup) must not pin a local context
-# as remote — and self-federation running — for a full TTL window.
+# Backoff schedule for inconclusive detections (probe error, no
+# in-cluster identity): the first retry comes quickly, so a transient
+# failure (RBAC not yet applied, API server hiccup) cannot pin a wrong
+# verdict for a full refresh window, then doubles per consecutive
+# failure up to the max. Without the backoff cap, a permanently failing
+# context (dead cluster, missing RBAC) re-probes on every scrape cycle
+# forever, and the resulting thread/subprocess churn runs in the same
+# process that serves /metrics — enough sustained churn and the scrape
+# times out (up == 0) once per cycle.
 _LOCAL_CONTEXT_FAILURE_RETRY_SECONDS = 60
+_LOCAL_CONTEXT_FAILURE_RETRY_MAX_SECONDS = 15 * 60
 
-# Process-level cache: context name -> (is_local, entry expiry time).
-_local_context_cache: Dict[str, Tuple[bool, float]] = {}
+# Fraction of each re-probe interval randomized away so contexts first
+# probed together (process start, kubeconfig upload) do not re-probe in
+# one synchronized burst every cycle thereafter.
+_LOCAL_CONTEXT_REFRESH_JITTER_FRACTION = 0.1
+
+
+class _ContextDetection:
+    """Detection state for one kubeconfig context.
+
+    verdict is the last CONCLUSIVE answer (None until a probe first
+    concludes) and keeps being served until a newer conclusive probe
+    replaces it: an inconclusive refresh must not flip a known-local
+    context to remote (and start self-federation) or a known-remote one
+    to local (and silently drop its federation). next_probe_at gates
+    background re-probes — refresh cadence after success, backoff after
+    failure — and consecutive_failures drives the backoff.
+    """
+
+    __slots__ = ('verdict', 'next_probe_at', 'consecutive_failures')
+
+    def __init__(self) -> None:
+        self.verdict: Optional[bool] = None
+        self.next_probe_at: float = 0.0
+        self.consecutive_failures: int = 0
+
+
+# Process-level detection state: context name -> _ContextDetection,
+# guarded by _local_context_cache_lock.
+_local_context_cache: Dict[str, _ContextDetection] = {}
 _local_context_cache_lock = threading.Lock()
 
-# In-flight probe threads, one per context at most (context name -> thread),
-# guarded by _local_context_cache_lock. Detection runs in a background
-# thread because a probe can hang indefinitely (kubeconfig exec credential
-# plugins run as subprocesses with no timeout, outside _request_timeout),
-# and a hung thread cannot be reaped in Python. Deduping by context bounds
-# the leak to one stranded thread per distinct context instead of one per
-# scrape cycle; probe threads are daemon so a stuck one never blocks
-# interpreter shutdown. Verdicts are read back through _local_context_cache.
-_local_context_probes: Dict[str, threading.Thread] = {}
+# Contexts queued for (or undergoing) a probe, for dedup: scheduling an
+# already-pending context is a no-op, so a hung probe costs one queue
+# slot total rather than one per scrape cycle. Guarded by
+# _local_context_cache_lock.
+_probe_pending: Set[str] = set()
+_probe_queue: 'queue.Queue[str]' = queue.Queue()
+
+# Single daemon worker draining _probe_queue. One worker (instead of a
+# thread per context) serializes probe work: a probe makes blocking
+# Kubernetes reads and may fork a kubeconfig exec-credential plugin
+# subprocess, and running many of those at once contends (GIL, fork,
+# CPU) with the latency-sensitive metrics endpoints served from this
+# same process. Started lazily and re-started if found dead (e.g. in a
+# forked child); daemon because a probe can hang indefinitely and must
+# not block interpreter shutdown.
+_probe_worker: Optional[threading.Thread] = None
 
 # UID of the kube-system namespace as seen through the in-cluster
 # credentials, i.e. the identity of the cluster this API server runs in.
@@ -97,6 +140,12 @@ _local_context_probes: Dict[str, threading.Thread] = {}
 # detection attempt.
 _in_cluster_identity_uid: Optional[str] = None
 _in_cluster_identity_uid_lock = threading.Lock()
+
+# Whether the last in-cluster anchor read failed, so the failure is
+# logged at WARNING once per state change instead of once per probe: a
+# missing RBAC grant would otherwise emit the same multi-line warning on
+# every backoff cycle of every context.
+_anchor_read_failed = False
 
 # Latency buckets shared by histograms that observe seconds. Kept compact to
 # bound time-series cardinality (each labeled series multiplies by len(buckets))
@@ -307,6 +356,63 @@ SKY_APISERVER_FEDERATION_TOTAL = prom.Counter(
     ['context', 'route', 'outcome'],
 )
 
+# Outcome of each completed local-context detection probe, emitted by the
+# background probe worker: local | remote (conclusive) | inconclusive
+# (probe error / timeout / no identity anchor). A sustained inconclusive
+# rate for a context means its verdict never reaches the success refresh
+# interval and keeps re-probing on the failure backoff — the probe-churn
+# signature. Alert on
+# rate(sky_apiserver_local_context_detection_total{result="inconclusive"}[15m]).
+SKY_APISERVER_LOCAL_CONTEXT_DETECTION_TOTAL = prom.Counter(
+    'sky_apiserver_local_context_detection_total',
+    'Count of local-context detection probes per context and result',
+    ['context', 'result'],
+)
+
+# Wall-clock of one detection probe (kubeconfig client construction,
+# exec-credential subprocess if any, and the kube-system read), by
+# result. The p99 here is what each backoff/refresh cycle costs the
+# process; long tails explain metrics-endpoint pressure even when
+# probes eventually conclude.
+SKY_APISERVER_LOCAL_CONTEXT_DETECTION_DURATION_SECONDS = prom.Histogram(
+    'sky_apiserver_local_context_detection_duration_seconds',
+    'Duration of one local-context detection probe, by context and result',
+    ['context', 'result'],
+    buckets=_LATENCY_BUCKETS,
+)
+
+# In-cluster identity-anchor (kube-system) read outcome:
+# success | unauthorized | no_credentials | no_uid | error.
+# `unauthorized` means the API server's own service account lacks
+# `get` on the kube-system namespace, which disables detection for
+# every named context; alert on any nonzero
+# rate(sky_apiserver_local_context_anchor_read_total{result="unauthorized"}[15m]).
+SKY_APISERVER_LOCAL_CONTEXT_ANCHOR_READ_TOTAL = prom.Counter(
+    'sky_apiserver_local_context_anchor_read_total',
+    'Count of in-cluster identity-anchor (kube-system) read outcomes',
+    ['result'],
+)
+
+# Contexts queued for (or undergoing) a detection probe. A value that
+# stays elevated means the single probe worker cannot keep up — most
+# likely one probe is hanging (exec-credential plugin, unreachable API
+# server) and the rest are waiting behind it.
+SKY_APISERVER_LOCAL_CONTEXT_PROBE_QUEUE_DEPTH = prom.Gauge(
+    'sky_apiserver_local_context_probe_queue_depth',
+    'Number of contexts queued for or undergoing a detection probe',
+    multiprocess_mode='livesum',
+)
+
+# What the request path served per context: local | remote (a conclusive
+# verdict existed) | unknown (no verdict yet; served as remote for the
+# request). A context stuck at result="unknown" is one whose probes
+# never conclude.
+SKY_APISERVER_LOCAL_CONTEXT_SERVED_TOTAL = prom.Counter(
+    'sky_apiserver_local_context_served_total',
+    'Verdicts served by the non-blocking request path, per context',
+    ['context', 'result'],
+)
+
 
 def record_federation_phase(context: str, route: str, phase: str,
                             seconds: float) -> None:
@@ -334,6 +440,29 @@ def record_federation_outcome(context: str, route: str, outcome: str) -> None:
         SKY_APISERVER_FEDERATION_TOTAL.labels(context=context,
                                               route=route,
                                               outcome=outcome).inc()
+
+
+def _record_detection_probe(context: str, result: str, seconds: float) -> None:
+    """Records one completed detection probe (non-blocking, best-effort)."""
+    if METRICS_ENABLED:
+        SKY_APISERVER_LOCAL_CONTEXT_DETECTION_TOTAL.labels(context=context,
+                                                           result=result).inc()
+        SKY_APISERVER_LOCAL_CONTEXT_DETECTION_DURATION_SECONDS.labels(
+            context=context, result=result).observe(seconds)
+
+
+def _record_anchor_read(result: str) -> None:
+    """Records one in-cluster identity-anchor read outcome (non-blocking)."""
+    if METRICS_ENABLED:
+        SKY_APISERVER_LOCAL_CONTEXT_ANCHOR_READ_TOTAL.labels(
+            result=result).inc()
+
+
+def _record_served_verdict(context: str, result: str) -> None:
+    """Records the verdict served by the request path (non-blocking)."""
+    if METRICS_ENABLED:
+        SKY_APISERVER_LOCAL_CONTEXT_SERVED_TOTAL.labels(context=context,
+                                                        result=result).inc()
 
 
 class FederationStats:
@@ -460,7 +589,7 @@ def _get_in_cluster_identity_uid() -> Optional[str]:
     read (e.g. missing RBAC); in that case detection is disabled and
     every named context is treated as remote.
     """
-    global _in_cluster_identity_uid
+    global _in_cluster_identity_uid, _anchor_read_failed
     with _in_cluster_identity_uid_lock:
         if _in_cluster_identity_uid is not None:
             return _in_cluster_identity_uid
@@ -468,11 +597,26 @@ def _get_in_cluster_identity_uid() -> Optional[str]:
     # clouds -> metrics).
     # pylint: disable=import-outside-toplevel
     from sky.adaptors import kubernetes as kubernetes_adaptors
+
+    def _log_failure(message: str) -> None:
+        # WARNING once per state change, DEBUG on repeats: a persistent
+        # failure (e.g. missing RBAC) re-reads the anchor on every probe
+        # backoff cycle and would spam the same warning forever.
+        global _anchor_read_failed
+        with _in_cluster_identity_uid_lock:
+            first_failure = not _anchor_read_failed
+            _anchor_read_failed = True
+        if first_failure:
+            logger.warning(message)
+        else:
+            logger.debug(message)
+
     try:
         core = kubernetes_adaptors.core_api(
             kubernetes_adaptors.in_cluster_context_name())
         uid = _read_cluster_identity_uid(core)
         if not uid:
+            _record_anchor_read('no_uid')
             logger.debug(
                 f'The {_CLUSTER_IDENTITY_NAMESPACE!r} namespace was read '
                 f'through in-cluster credentials but carries no UID; '
@@ -482,13 +626,15 @@ def _get_in_cluster_identity_uid() -> Optional[str]:
     except kubernetes_adaptors.config_exception():
         # Not running inside a Kubernetes pod: there are no in-cluster
         # credentials, hence no local cluster to detect.
+        _record_anchor_read('no_credentials')
         logger.debug('No in-cluster credentials; local-context detection '
                      'is disabled.')
         return None
     except kubernetes_adaptors.api_exception() as e:
         status = getattr(e, 'status', None)
         if status in (401, 403):
-            logger.warning(
+            _record_anchor_read('unauthorized')
+            _log_failure(
                 f'The in-cluster service account is not allowed to read '
                 f'the {_CLUSTER_IDENTITY_NAMESPACE!r} namespace '
                 f'(status={status}); local-context detection is disabled '
@@ -499,7 +645,8 @@ def _get_in_cluster_identity_uid() -> Optional[str]:
                 f'default rbac.clusterRules) to enable detection: '
                 f'{common_utils.format_exception(e)}')
         else:
-            logger.warning(
+            _record_anchor_read('error')
+            _log_failure(
                 f'Failed to read the {_CLUSTER_IDENTITY_NAMESPACE!r} '
                 f'namespace through in-cluster credentials '
                 f'(status={status}); local-context detection is disabled '
@@ -507,16 +654,41 @@ def _get_in_cluster_identity_uid() -> Optional[str]:
                 f'{common_utils.format_exception(e)}')
         return None
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(
+        _record_anchor_read('error')
+        _log_failure(
             f'Failed to read the {_CLUSTER_IDENTITY_NAMESPACE!r} namespace '
             f'through in-cluster credentials; local-context detection is '
             f'disabled until the next attempt and only the in-cluster '
             f'context will be treated as local: '
             f'{common_utils.format_exception(e)}')
         return None
+    _record_anchor_read('success')
     with _in_cluster_identity_uid_lock:
+        if _anchor_read_failed:
+            _anchor_read_failed = False
+            logger.info('In-cluster identity anchor read recovered; '
+                        'local-context detection is enabled.')
         _in_cluster_identity_uid = uid
     return _in_cluster_identity_uid
+
+
+def _next_probe_delay(conclusive: bool, consecutive_failures: int) -> float:
+    """Seconds until a context's next probe, with jitter.
+
+    Conclusive verdicts refresh on the cache TTL; inconclusive ones
+    retry on an exponential backoff so a permanently failing context
+    settles at one probe per _LOCAL_CONTEXT_FAILURE_RETRY_MAX_SECONDS
+    instead of one per scrape cycle.
+    """
+    if conclusive:
+        interval: float = _LOCAL_CONTEXT_CACHE_TTL_SECONDS
+    else:
+        interval = min(
+            _LOCAL_CONTEXT_FAILURE_RETRY_SECONDS *
+            2**max(0, consecutive_failures - 1),
+            _LOCAL_CONTEXT_FAILURE_RETRY_MAX_SECONDS)
+    return interval * (1 -
+                       _LOCAL_CONTEXT_REFRESH_JITTER_FRACTION * random.random())
 
 
 def is_local_context(context: str) -> bool:
@@ -525,12 +697,17 @@ def is_local_context(context: str) -> bool:
     The in-cluster context is local by construction (its credentials are
     the pod's own service account). Named contexts are probed: local iff
     the kube-system UID read through the context's credentials matches
-    the API server's own cluster identity. Any failure (no identity
-    anchor, 403, timeout) degrades to remote — the safe answer, since
-    the local cluster stays reachable via the in-cluster context.
-    Conclusive results are cached at process level for
-    _LOCAL_CONTEXT_CACHE_TTL_SECONDS; inconclusive ones only for
-    _LOCAL_CONTEXT_FAILURE_RETRY_SECONDS so they are retried soon.
+    the API server's own cluster identity.
+
+    Blocking (this is the probing primitive, normally run by the
+    background probe worker — the request path reads verdicts through
+    split_local_remote_contexts() instead). A fresh verdict is answered
+    from the cache; otherwise the context is probed inline. Conclusive
+    verdicts are sticky: an inconclusive probe (no identity anchor, 403,
+    timeout) keeps the previous conclusive verdict and only shortens the
+    re-probe interval, and a context that never concluded is remote —
+    the safe answer, since the local cluster stays reachable via the
+    in-cluster context.
     """
     # Import lazily to avoid circular import (metrics -> provision ->
     # clouds -> metrics).
@@ -540,11 +717,12 @@ def is_local_context(context: str) -> bool:
         return True
     now = time.time()
     with _local_context_cache_lock:
-        cached = _local_context_cache.get(context)
-        if cached is not None:
-            is_local, expires_at = cached
-            if now < expires_at:
-                return is_local
+        entry = _local_context_cache.get(context)
+        if entry is not None and now < entry.next_probe_at:
+            # Not due for a probe: serve the verdict (or the safe
+            # remote default while none has concluded yet).
+            return bool(entry.verdict)
+    start = time.monotonic()
     is_local = False
     conclusive = False
     own_uid = _get_in_cluster_identity_uid()
@@ -559,25 +737,41 @@ def is_local_context(context: str) -> bool:
             status_str = f' (status={status})' if status is not None else ''
             logger.warning(
                 f'Failed to probe the {_CLUSTER_IDENTITY_NAMESPACE!r} '
-                f'namespace through context {context!r}{status_str}; '
-                f'assuming the context is remote: '
+                f'namespace through context {context!r}{status_str}: '
                 f'{common_utils.format_exception(e)}')
-    ttl = (_LOCAL_CONTEXT_CACHE_TTL_SECONDS
-           if conclusive else _LOCAL_CONTEXT_FAILURE_RETRY_SECONDS)
+    duration = time.monotonic() - start
     with _local_context_cache_lock:
-        _local_context_cache[context] = (is_local, time.time() + ttl)
-    return is_local
-
-
-# Overall budget for one split_local_remote_contexts() call. The
-# per-probe _request_timeout only bounds the namespace HTTP call;
-# kubeconfig loading, exec credential plugins, or DNS can still hang a
-# probe, and that must not hold up the metrics/dashboard response.
-_DETECTION_TIMEOUT_SECONDS = _NAMESPACE_PROBE_TIMEOUT_SECONDS + 5
+        entry = _local_context_cache.setdefault(context, _ContextDetection())
+        if conclusive:
+            if entry.consecutive_failures > 0 or entry.verdict is None:
+                logger.info(
+                    f'Local-context detection for {context!r} concluded: '
+                    f'{"local" if is_local else "remote"}.')
+            entry.verdict = is_local
+            entry.consecutive_failures = 0
+        else:
+            entry.consecutive_failures += 1
+        entry.next_probe_at = now + _next_probe_delay(
+            conclusive, entry.consecutive_failures)
+        verdict = entry.verdict
+        failures = entry.consecutive_failures
+        retry_in = entry.next_probe_at - now
+    if conclusive:
+        result = 'local' if is_local else 'remote'
+    else:
+        result = 'inconclusive'
+        kept = ('keeping previous verdict '
+                f'{"local" if verdict else "remote"}'
+                if verdict is not None else 'treating it as remote')
+        logger.warning(
+            f'Local-context detection for {context!r} was inconclusive '
+            f'(failure #{failures}); {kept}, retrying in {retry_in:.0f}s.')
+    _record_detection_probe(context, result, duration)
+    return bool(verdict)
 
 
 def _cached_local_verdict(context: str) -> Optional[bool]:
-    """Cached is_local_context verdict, or None if absent/expired.
+    """Last conclusive verdict for a context, or None if none yet.
 
     Never probes, so it is safe to call from latency-sensitive paths.
     """
@@ -588,84 +782,91 @@ def _cached_local_verdict(context: str) -> Optional[bool]:
     if context == kubernetes_adaptors.in_cluster_context_name():
         return True
     with _local_context_cache_lock:
-        cached = _local_context_cache.get(context)
-        if cached is not None:
-            is_local, expires_at = cached
-            if time.time() < expires_at:
-                return is_local
+        entry = _local_context_cache.get(context)
+        if entry is not None:
+            return entry.verdict
     return None
 
 
-def _probe_local_context(context: str) -> None:
-    """Thread target: run detection, which caches its own verdict."""
-    try:
-        is_local_context(context)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Local-context detection failed for {context!r}; '
-                       f'treating it as remote: '
-                       f'{common_utils.format_exception(e)}')
+def _probe_worker_loop() -> None:
+    """Drains the probe queue, one detection probe at a time."""
+    while True:
+        context = _probe_queue.get()
+        try:
+            is_local_context(context)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Local-context detection failed for {context!r}: '
+                           f'{common_utils.format_exception(e)}')
+        finally:
+            with _local_context_cache_lock:
+                _probe_pending.discard(context)
+            if METRICS_ENABLED:
+                SKY_APISERVER_LOCAL_CONTEXT_PROBE_QUEUE_DEPTH.dec()
 
 
-def _ensure_probe(context: str) -> threading.Thread:
-    """Returns a live probe thread for context, starting one if needed.
+def _schedule_probe(context: str) -> None:
+    """Queues a background detection probe for context, deduplicated.
 
-    At most one probe runs per context: a concurrent (or repeated) call
-    for the same context joins the existing thread instead of spawning a
-    new one, so a hung probe costs one stranded thread total rather than
-    one per scrape cycle. A finished thread is replaced, so the next call
-    after cache expiry re-probes through a fresh thread.
+    An already-queued (or in-flight) context is not queued again, so a
+    hung probe costs one queue slot total rather than one per scrape
+    cycle. Starts the worker on first use and restarts it if found dead
+    (threads do not survive fork).
     """
+    global _probe_worker
     with _local_context_cache_lock:
-        thread = _local_context_probes.get(context)
-        if thread is None or not thread.is_alive():
-            # Daemon: probes are read-only and may hang indefinitely in
-            # kubeconfig loading / exec credential plugins; they must not
-            # block interpreter shutdown.
-            thread = threading.Thread(target=_probe_local_context,
-                                      args=(context,),
-                                      name=f'local-context-probe-{context}',
-                                      daemon=True)
-            _local_context_probes[context] = thread
-            thread.start()
-        return thread
+        if context in _probe_pending:
+            return
+        _probe_pending.add(context)
+        if _probe_worker is None or not _probe_worker.is_alive():
+            _probe_worker = threading.Thread(target=_probe_worker_loop,
+                                             name='local-context-probe-worker',
+                                             daemon=True)
+            _probe_worker.start()
+    if METRICS_ENABLED:
+        SKY_APISERVER_LOCAL_CONTEXT_PROBE_QUEUE_DEPTH.inc()
+    _probe_queue.put(context)
 
 
 def split_local_remote_contexts(
         contexts: List[str]) -> Tuple[List[str], List[str]]:
-    """Partitions contexts into (local, remote) via is_local_context().
+    """Partitions contexts into (local, remote), without blocking.
 
     Shared by the federation routes and /dashboard_config so both agree
-    on which contexts point at the API server's own cluster. Cached
-    verdicts are answered inline (no thread). Only uncached contexts are
-    probed, each in a deduped daemon thread, so the first call costs
-    roughly one probe timeout rather than one per context and the warm
-    path spawns no threads at all. A context whose probe does not finish
-    within _DETECTION_TIMEOUT_SECONDS is treated as remote for this call
-    (the safe answer); a straggler still populates the cache when it
-    eventually finishes, and a later call reads it back. Blocking — call
-    from a thread in async code.
+    on which contexts point at the API server's own cluster. Verdicts
+    are answered from the cache; contexts due for a probe (never probed,
+    refresh interval elapsed, or failure backoff expired) are handed to
+    the background probe worker and answered with the last conclusive
+    verdict in the meantime. A context with no conclusive verdict yet is
+    remote for this call — the safe answer; a later call picks up the
+    worker's verdict from the cache. Never probes, joins, or spawns a
+    thread per context, so it cannot stall the metrics event loop no
+    matter how slow or broken a context is.
     """
+    # Import lazily to avoid circular import (metrics -> provision ->
+    # clouds -> metrics).
+    # pylint: disable=import-outside-toplevel
+    from sky.adaptors import kubernetes as kubernetes_adaptors
     if not contexts:
         return [], []
-    # Only uncached contexts need a probe; an in-flight probe is joined
-    # rather than duplicated.
-    pending = {
-        context: _ensure_probe(context)
-        for context in contexts
-        if _cached_local_verdict(context) is None
-    }
-    deadline = time.monotonic() + _DETECTION_TIMEOUT_SECONDS
-    for thread in pending.values():
-        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    in_cluster = kubernetes_adaptors.in_cluster_context_name()
+    now = time.time()
     local: List[str] = []
     remote: List[str] = []
     for context in contexts:
-        verdict = _cached_local_verdict(context)
+        if context == in_cluster:
+            # Local by construction; never probed.
+            local.append(context)
+            continue
+        with _local_context_cache_lock:
+            entry = _local_context_cache.get(context)
+            verdict = entry.verdict if entry is not None else None
+            due = entry is None or now >= entry.next_probe_at
+        if due:
+            _schedule_probe(context)
         if verdict is None:
-            logger.warning(
-                f'Local-context detection for {context!r} did not finish '
-                f'within {_DETECTION_TIMEOUT_SECONDS}s; treating it as '
-                f'remote for this request.')
+            _record_served_verdict(context, 'unknown')
+        else:
+            _record_served_verdict(context, 'local' if verdict else 'remote')
         (local if verdict else remote).append(context)
     return local, remote
 

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -779,10 +779,11 @@ async def gpu_metrics() -> fastapi.Response:
     # Prometheus scrapes the local cluster's exporters directly, so
     # federating them again would only duplicate the raw series under a
     # stamped copy. The dashboard matches the local cluster with cluster=""
-    # (see /dashboard_config local_contexts). Detection may probe each
-    # uncached context once; run in a thread to keep the event loop free.
-    _, remote_contexts = await asyncio.to_thread(
-        metrics_utils.split_local_remote_contexts, contexts)
+    # (see /dashboard_config local_contexts). Non-blocking: verdicts come
+    # from the detection cache and any probing happens in a background
+    # worker, so a slow or broken context cannot stall this scrape (or
+    # the co-located /metrics scrape) no matter how it fails.
+    _, remote_contexts = metrics_utils.split_local_remote_contexts(contexts)
     # One stats record per context, filled in by get_metrics_for_context even
     # if the task is later cancelled by the wait_for timeout — so the timeout
     # log can report how far the attempt got (port-forward vs. federate).
@@ -826,9 +827,8 @@ async def endpoint_metrics() -> fastapi.Response:
     contexts = core.get_all_contexts()
     all_metrics: List[str] = []
 
-    # Same local-context handling as /gpu-metrics above.
-    _, remote_contexts = await asyncio.to_thread(
-        metrics_utils.split_local_remote_contexts, contexts)
+    # Same local-context handling as /gpu-metrics above (non-blocking).
+    _, remote_contexts = metrics_utils.split_local_remote_contexts(contexts)
     stats_list = [metrics_utils.FederationStats() for _ in remote_contexts]
     tasks = [
         asyncio.create_task(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2683,7 +2683,8 @@ def _get_local_contexts() -> List[str]:
     Uses the same detection as the metrics federation routes, so the
     dashboard and the federation always agree on which contexts are
     local (their series are queried with cluster="" instead of a
-    context name).
+    context name). Non-blocking: verdicts come from the detection cache,
+    so this never stalls the event loop on a slow context.
     """
     local_contexts, _ = metrics_utils.split_local_remote_contexts(
         core.get_all_contexts())

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1,5 +1,6 @@
 """Unit tests for sky.metrics.utils."""
 import asyncio
+import queue
 import subprocess
 import threading
 import time
@@ -29,28 +30,53 @@ def _fake_namespace(uid):
     return namespace
 
 
+def _clear_detection_state():
+    # pylint: disable=protected-access
+    with utils._local_context_cache_lock:
+        utils._local_context_cache.clear()
+        utils._probe_pending.clear()
+    while True:
+        try:
+            utils._probe_queue.get_nowait()
+        except queue.Empty:
+            break
+    utils._in_cluster_identity_uid = None
+    utils._anchor_read_failed = False
+
+
 @pytest.fixture(autouse=True)
 def _reset_local_context_detection_state():
-    """Reset the process-level detection caches between tests."""
-    utils._local_context_cache.clear()  # pylint: disable=protected-access
-    utils._local_context_probes.clear()  # pylint: disable=protected-access
-    utils._in_cluster_identity_uid = None  # pylint: disable=protected-access
-    yield
-    utils._local_context_cache.clear()  # pylint: disable=protected-access
-    utils._local_context_probes.clear()  # pylint: disable=protected-access
-    utils._in_cluster_identity_uid = None  # pylint: disable=protected-access
+    """Reset the process-level detection state between tests.
 
-
-def _seed_verdict(context, verdict):
-    """Mimics is_local_context writing its verdict to the shared cache.
-
-    The split tests mock is_local_context, so the real cache write never
-    runs; split_local_remote_contexts reads verdicts back through the
-    cache, so the mock must seed it just like the real probe would.
+    The probe worker thread (if one was started) is deliberately left
+    running: it blocks on the queue when idle and each test starts from
+    an empty queue. Jitter is disabled so re-probe intervals are exact.
     """
-    with utils._local_context_cache_lock:  # pylint: disable=protected-access
-        utils._local_context_cache[context] = (  # pylint: disable=protected-access
-            verdict, time.time() + 3600)
+    _clear_detection_state()
+    with mock.patch.object(utils.random, 'random', return_value=0.0):
+        yield
+    _clear_detection_state()
+
+
+def _wait_probes_drained(timeout=5.0):
+    """Waits until the probe worker has no queued or in-flight probes."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with utils._local_context_cache_lock:  # pylint: disable=protected-access
+            if not utils._probe_pending:  # pylint: disable=protected-access
+                return
+        time.sleep(0.01)
+    raise AssertionError('probe worker did not drain in time')
+
+
+def _seed_verdict(context, verdict, next_probe_in=3600.0):
+    """Writes a conclusive verdict, as a finished probe would."""
+    # pylint: disable=protected-access
+    entry = utils._ContextDetection()
+    entry.verdict = verdict
+    entry.next_probe_at = time.time() + next_probe_in
+    with utils._local_context_cache_lock:
+        utils._local_context_cache[context] = entry
     return verdict
 
 
@@ -189,8 +215,7 @@ def test_is_local_context_probe_failure_retried_soon():
     """A failed probe is retried after the short failure window.
 
     A transient error (RBAC not yet applied, API server hiccup) must not
-    pin a local context as remote — with self-federation running — for
-    the full cache TTL.
+    pin a wrong verdict for the full refresh interval.
     """
     retry = utils._LOCAL_CONTEXT_FAILURE_RETRY_SECONDS  # pylint: disable=protected-access
     fake_now = [0.0]
@@ -211,6 +236,68 @@ def test_is_local_context_probe_failure_retried_soon():
             fake_now[0] = retry + 1.0
             assert utils.is_local_context('ctx-a') is True
             assert len(h.probe_calls) == 2
+
+
+def test_is_local_context_failure_backoff_doubles_to_cap():
+    """Consecutive failures back off exponentially up to the cap.
+
+    Without the backoff, a permanently failing context (dead cluster,
+    missing RBAC) re-probes on every scrape cycle forever — the probe
+    churn that starves the co-located /metrics endpoint.
+    """
+    # pylint: disable=protected-access
+    base = utils._LOCAL_CONTEXT_FAILURE_RETRY_SECONDS
+    cap = utils._LOCAL_CONTEXT_FAILURE_RETRY_MAX_SECONDS
+    fake_now = [0.0]
+    with _DetectionHarness(own_uid='uid-1',
+                           probe_exc=_FakeApiException(403)) as h:
+        with mock.patch.object(utils.time,
+                               'time',
+                               side_effect=lambda: fake_now[0]):
+            expected_delay = base
+            for expected_calls in range(1, 8):
+                utils.is_local_context('ctx-a')
+                assert len(h.probe_calls) == expected_calls
+                entry = utils._local_context_cache['ctx-a']
+                assert entry.consecutive_failures == expected_calls
+                assert entry.next_probe_at == pytest.approx(fake_now[0] +
+                                                            expected_delay)
+                # Probing again before the backoff expires is a no-op.
+                utils.is_local_context('ctx-a')
+                assert len(h.probe_calls) == expected_calls
+                fake_now[0] = entry.next_probe_at + 1.0
+                expected_delay = min(expected_delay * 2, cap)
+            # The schedule has settled at the cap.
+            assert (utils._local_context_cache['ctx-a'].next_probe_at -
+                    fake_now[0]) <= cap
+
+
+def test_is_local_context_conclusive_verdict_sticky_across_failures():
+    """An inconclusive refresh keeps the previous conclusive verdict.
+
+    Flipping a known-local context to remote on a transient probe
+    failure would silently start self-federation; the verdict must
+    survive until a conclusive probe says otherwise.
+    """
+    ttl = utils._LOCAL_CONTEXT_CACHE_TTL_SECONDS  # pylint: disable=protected-access
+    fake_now = [0.0]
+    with _DetectionHarness(own_uid='uid-1',
+                           probe_result=_fake_namespace('uid-1')) as h:
+        with mock.patch.object(utils.time,
+                               'time',
+                               side_effect=lambda: fake_now[0]):
+            assert utils.is_local_context('ctx-a') is True
+            # The refresh probe fails: the local verdict is kept.
+            h._probe_exc = _FakeApiException(403)  # pylint: disable=protected-access
+            fake_now[0] = ttl + 1.0
+            assert utils.is_local_context('ctx-a') is True
+            assert len(h.probe_calls) == 2
+            # A conclusive probe updates the verdict again.
+            h._probe_exc = None  # pylint: disable=protected-access
+            h._probe_result = _fake_namespace('uid-2')  # pylint: disable=protected-access
+            entry = utils._local_context_cache['ctx-a']  # pylint: disable=protected-access
+            fake_now[0] = entry.next_probe_at + 1.0
+            assert utils.is_local_context('ctx-a') is False
 
 
 def test_is_local_context_no_identity_retried_soon():
@@ -255,65 +342,106 @@ def test_is_local_context_renamed_in_cluster_context():
         assert not h.probe_calls
 
 
+class _InClusterName:
+    """Patches the in-cluster context name for split tests."""
+
+    def __init__(self, name='in-cluster'):
+        self._patch = mock.patch(
+            'sky.adaptors.kubernetes.in_cluster_context_name',
+            return_value=name)
+
+    def __enter__(self):
+        self._patch.start()
+        return self
+
+    def __exit__(self, *args):
+        self._patch.stop()
+        return False
+
+
 def test_split_local_remote_contexts():
-    """Contexts are partitioned by is_local_context, order preserved."""
-
-    def _fake_is_local(context):
-        return _seed_verdict(context, context in ('in-cluster', 'ctx-local'))
-
-    with mock.patch.object(utils,
-                           'is_local_context',
-                           side_effect=_fake_is_local):
+    """Contexts are partitioned by cached verdicts, order preserved."""
+    _seed_verdict('ctx-local', True)
+    _seed_verdict('ctx-remote-1', False)
+    _seed_verdict('ctx-remote-2', False)
+    with _InClusterName():
         local, remote = utils.split_local_remote_contexts(
             ['ctx-remote-1', 'in-cluster', 'ctx-local', 'ctx-remote-2'])
     assert local == ['in-cluster', 'ctx-local']
     assert remote == ['ctx-remote-1', 'ctx-remote-2']
 
 
-def test_split_local_remote_contexts_warm_path_spawns_no_threads():
-    """A fully-cached call answers inline without spawning any probe."""
-    for ctx, verdict in (('ctx-local', True), ('ctx-remote', False)):
-        _seed_verdict(ctx, verdict)
+def test_split_local_remote_contexts_warm_path_never_probes():
+    """A call with fresh verdicts answers inline and schedules nothing."""
 
     def _must_not_probe(context):
         raise AssertionError(f'unexpected probe for {context!r}')
 
-    with mock.patch.object(utils,
-                           'is_local_context',
+    for ctx, verdict in (('ctx-local', True), ('ctx-remote', False)):
+        _seed_verdict(ctx, verdict)
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
                            side_effect=_must_not_probe):
         local, remote = utils.split_local_remote_contexts(
             ['ctx-local', 'ctx-remote'])
     assert local == ['ctx-local']
     assert remote == ['ctx-remote']
-    # No probe thread was ever registered for the warm path.
-    assert not utils._local_context_probes  # pylint: disable=protected-access
+    # Nothing was handed to the probe worker.
+    assert not utils._probe_pending  # pylint: disable=protected-access
 
 
-def test_split_local_remote_contexts_dedupes_probe_threads():
-    """Repeated calls for the same context reuse one daemon probe thread."""
-    gate = threading.Event()
-    seen_threads = []
+def test_split_local_remote_contexts_unknown_served_remote_nonblocking():
+    """A context with no verdict is remote for this call, without waiting.
+
+    The probe runs in the background worker; a later call reads its
+    verdict back from the cache.
+    """
+    probed = threading.Event()
 
     def _fake_is_local(context):
-        seen_threads.append(threading.current_thread())
+        _seed_verdict(context, True)
+        probed.set()
+        return True
+
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
+                           side_effect=_fake_is_local):
+        start = time.monotonic()
+        local, remote = utils.split_local_remote_contexts(['ctx-a'])
+        elapsed = time.monotonic() - start
+        # Answered immediately with the safe default.
+        assert (local, remote) == ([], ['ctx-a'])
+        assert elapsed < 1
+        # The worker probes in the background; the next call sees the
+        # verdict.
+        assert probed.wait(5)
+        _wait_probes_drained()
+        local, remote = utils.split_local_remote_contexts(['ctx-a'])
+    assert (local, remote) == (['ctx-a'], [])
+
+
+def test_split_local_remote_contexts_dedupes_pending_probes():
+    """Repeated calls while a probe is in flight schedule it only once."""
+    gate = threading.Event()
+    probe_calls = []
+
+    def _fake_is_local(context):
+        probe_calls.append(context)
         gate.wait(10)
         return _seed_verdict(context, False)
 
-    with mock.patch.object(utils, 'is_local_context',
-                           side_effect=_fake_is_local), \
-         mock.patch.object(utils, '_DETECTION_TIMEOUT_SECONDS', 0.2):
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
+                           side_effect=_fake_is_local):
         utils.split_local_remote_contexts(['ctx-a'])
-        probe = utils._local_context_probes['ctx-a']  # pylint: disable=protected-access
-        # Daemon so a hung probe never blocks interpreter shutdown.
-        assert probe.daemon is True
-        # Second call while the first probe is still in flight must not
-        # spawn another thread for the same context.
         utils.split_local_remote_contexts(['ctx-a'])
-        assert utils._local_context_probes['ctx-a'] is probe  # pylint: disable=protected-access
-    gate.set()
-    probe.join(5)
-    # Exactly one probe ran despite two split calls.
-    assert len(seen_threads) == 1
+        utils.split_local_remote_contexts(['ctx-a'])
+        gate.set()
+        _wait_probes_drained()
+    # Exactly one probe ran despite three split calls.
+    assert probe_calls == ['ctx-a']
+    # The worker is a daemon so a hung probe never blocks shutdown.
+    assert utils._probe_worker.daemon is True  # pylint: disable=protected-access
 
 
 def test_split_local_remote_contexts_detection_unavailable():
@@ -325,45 +453,118 @@ def test_split_local_remote_contexts_detection_unavailable():
     assert remote == ['ctx-a']
 
 
-def test_split_local_remote_contexts_hung_probe_treated_remote():
-    """A probe stuck past the detection budget must not block the call."""
+def test_split_local_remote_contexts_hung_probe_never_blocks():
+    """A hung probe must not block any call, ever.
+
+    This is the probe-storm regression: the request path must stay a
+    pure cache read no matter how a context's probe misbehaves.
+    """
     release = threading.Event()
 
     def _fake_is_local(context):
-        if context == 'ctx-hung':
-            release.wait(10)
-        return _seed_verdict(context, context == 'ctx-local')
+        release.wait(10)
+        return _seed_verdict(context, False)
 
-    with mock.patch.object(utils, 'is_local_context',
-                           side_effect=_fake_is_local), \
-         mock.patch.object(utils, '_DETECTION_TIMEOUT_SECONDS', 0.2):
+    _seed_verdict('ctx-local', True)
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
+                           side_effect=_fake_is_local):
         start = time.monotonic()
-        local, remote = utils.split_local_remote_contexts(
-            ['ctx-hung', 'ctx-local'])
+        for _ in range(3):
+            local, remote = utils.split_local_remote_contexts(
+                ['ctx-hung', 'ctx-local'])
         elapsed = time.monotonic() - start
-    release.set()
-    # The hung probe is treated as remote (the safe answer) and the
-    # call returns within the detection budget, not the probe duration.
+        release.set()
+        _wait_probes_drained()
+    # The hung probe is served as remote (the safe answer) and no call
+    # waited on it.
     assert local == ['ctx-local']
     assert remote == ['ctx-hung']
-    assert elapsed < 5
+    assert elapsed < 1
 
 
 def test_split_local_remote_contexts_probe_exception_treated_remote():
-    """An exception escaping a probe thread degrades that context to remote."""
+    """An exception escaping a probe leaves that context remote."""
 
     def _fake_is_local(context):
         if context == 'ctx-broken':
             raise RuntimeError('kubeconfig exploded')
-        return _seed_verdict(context, context == 'ctx-local')
+        return _seed_verdict(context, True)
 
-    with mock.patch.object(utils,
-                           'is_local_context',
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
                            side_effect=_fake_is_local):
+        local, remote = utils.split_local_remote_contexts(
+            ['ctx-broken', 'ctx-local'])
+        assert (local, remote) == ([], ['ctx-broken', 'ctx-local'])
+        _wait_probes_drained()
+        # ctx-broken raised (stays remote), ctx-local concluded local.
         local, remote = utils.split_local_remote_contexts(
             ['ctx-broken', 'ctx-local'])
     assert local == ['ctx-local']
     assert remote == ['ctx-broken']
+
+
+def test_split_local_remote_contexts_serves_stale_while_refreshing():
+    """A due verdict is refreshed in the background, not on the call.
+
+    The hourly refresh must not take the request path back to probing:
+    the stale verdict is served now and the worker updates it for later
+    calls.
+    """
+    refreshed = threading.Event()
+
+    def _fake_is_local(context):
+        _seed_verdict(context, False)
+        refreshed.set()
+        return False
+
+    # Conclusive verdict whose refresh interval has already elapsed.
+    _seed_verdict('ctx-a', True, next_probe_in=-1.0)
+    with _InClusterName(), \
+         mock.patch.object(utils, 'is_local_context',
+                           side_effect=_fake_is_local):
+        local, remote = utils.split_local_remote_contexts(['ctx-a'])
+        # Served the stale verdict without waiting for the refresh.
+        assert (local, remote) == (['ctx-a'], [])
+        assert refreshed.wait(5)
+        _wait_probes_drained()
+        local, remote = utils.split_local_remote_contexts(['ctx-a'])
+    # The background refresh concluded remote; later calls see it.
+    assert (local, remote) == ([], ['ctx-a'])
+
+
+def test_split_local_remote_contexts_emits_served_and_probe_metrics():
+    """The new instrumentation reflects what the request path served."""
+
+    def _sample(metric, **labels):
+        for family in metric.collect():
+            for sample in family.samples:
+                if (sample.name.endswith('_total') and all(
+                        sample.labels.get(k) == v for k, v in labels.items())):
+                    return sample.value
+        return 0.0
+
+    served = utils.SKY_APISERVER_LOCAL_CONTEXT_SERVED_TOTAL
+    detected = utils.SKY_APISERVER_LOCAL_CONTEXT_DETECTION_TOTAL
+    before_unknown = _sample(served, context='ctx-m', result='unknown')
+    before_remote = _sample(served, context='ctx-m', result='remote')
+    before_inconclusive = _sample(detected,
+                                  context='ctx-m',
+                                  result='inconclusive')
+    with mock.patch.object(utils, 'METRICS_ENABLED', True), \
+         _DetectionHarness(own_uid=None):
+        utils.split_local_remote_contexts(['ctx-m'])
+        _wait_probes_drained()
+        utils.split_local_remote_contexts(['ctx-m'])
+    # First call served 'unknown'; the probe concluded nothing (no
+    # anchor), so the second call served 'unknown' again — and the
+    # worker recorded an inconclusive probe.
+    assert _sample(served, context='ctx-m',
+                   result='unknown') >= before_unknown + 2
+    assert _sample(detected, context='ctx-m',
+                   result='inconclusive') >= before_inconclusive + 1
+    assert _sample(served, context='ctx-m', result='remote') == before_remote
 
 
 class _IdentityUidHarness:


### PR DESCRIPTION
## Summary

- `/gpu-metrics` and `/endpoints-metrics` ran local-context detection on every scrape: a daemon thread per uncached context making blocking `kube-system` reads (possibly forking kubeconfig exec-credential subprocesses), joined for up to 10s. Inconclusive verdicts were cached for only 60s, so a permanently failing context (unreachable cluster, missing RBAC) re-probed **every scrape cycle forever**. All of that churn runs in the same single-worker process that serves `/metrics` — under enough of it, the `/metrics` scrape times out once per cycle and `up{}` flaps 0↔1 while CPU/memory/readiness stay green. Even all-healthy contexts re-probed inline at every hourly TTL expiry, causing a smaller once-per-hour flap.
- This PR takes detection **off the scrape path entirely**: `split_local_remote_contexts()` becomes a pure cache read; probing moves to a single background worker (dedup queue, one probe at a time); conclusive verdicts are sticky and refreshed stale-while-revalidate on the existing 1h interval; inconclusive probes retry on an exponential backoff (60s → 15min cap, jittered). A context with no verdict yet is served as remote — the safe answer — instead of being waited on. `/dashboard_config` also stops blocking its event loop on probes.
- Adds the instrumentation the path was missing (it only logged): `sky_apiserver_local_context_detection_total{context,result}` + `_duration_seconds` (probe outcomes/latency), `..._anchor_read_total{result}` (`unauthorized` pinpoints the missing `namespaces/kube-system` RBAC grant), `..._probe_queue_depth`, and `..._served_total{context,result}` (`unknown` marks never-concluded contexts). The repeated anchor-read RBAC warning is rate-limited to state changes.

## Details

Observed failure signature this fixes (reproduced on a test deployment by registering kubeconfig contexts pointing at unreachable endpoints and exec-credential plugins): `up{job="skypilot-api-server-metrics"}` flapping on a ~60–90s cadence with `scrape_duration_seconds` pinned at the scrape timeout, while the readiness probe stays green — starting exactly when a build containing per-scrape detection is deployed, and sustained indefinitely by the 60s failure-retry cache.

With this change, a permanently failing context settles at ~4 cheap background probes/hour and the request path never blocks, so the co-located `/metrics` endpoint is unaffected regardless of how any context misbehaves.

## Tested

- Rewritten/extended unit tests (`tests/unit_tests/test_sky/metrics/test_metrics_util.py`, 39 tests): non-blocking split under hung/broken/never-concluded probes, probe dedup while in flight, failure backoff doubling to the cap, sticky verdicts across failed refreshes, stale-while-revalidate refresh, and metric emission. `tests/unit_tests/test_sky/server/test_server.py` (36 tests) still passes.
- Live A/B on a Kubernetes test deployment: with 16 registered contexts whose exec-credential plugin burns CPU and fails plus 2 pointing at blackholed IPs, the pre-fix build logs a probe join-timeout storm every 60s cycle and its gpu-metrics scrape duration triples; results with the fixed build posted in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeH9TRvsPYTNXVi2vTPigv
