### PR TITLE
[Jobs] Reduce jobs queue payload for field-filtered requests

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -50,7 +50,10 @@ import {
   getEnabledCloudsBatch,
 } from '@/data/connectors/workspaces';
 import { getClusters } from '@/data/connectors/clusters';
-import { getManagedJobs } from '@/data/connectors/jobs';
+import {
+  getManagedJobs,
+  MANAGED_JOBS_SUMMARY_ARGS,
+} from '@/data/connectors/jobs';
 import { apiClient } from '@/data/connectors/client';
 import { getDashboardConfig } from '@/data/connectors/dashboard_config';
 import {
@@ -2359,9 +2362,9 @@ export function GPUs() {
     try {
       // Always use cache - it's already invalidated if refreshing
       // Jobs data doesn't depend on sky check, so no need to bypass cache
-      // Use shared cache key (no field filtering) - preloader uses same args
+      // Shared cache key — must match the preloader's args exactly
       const jobsData = await dashboardCache.get(getManagedJobs, [
-        { allUsers: true, skipFinished: true },
+        MANAGED_JOBS_SUMMARY_ARGS,
       ]);
       const jobs = jobsData?.jobs || [];
       setSshAndKubeJobsData(await getContextJobs(jobs));
@@ -2621,9 +2624,7 @@ export function GPUs() {
     trackInfraAction('refresh');
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getClusters);
-    dashboardCache.invalidate(getManagedJobs, [
-      { allUsers: true, skipFinished: true },
-    ]);
+    dashboardCache.invalidate(getManagedJobs, [MANAGED_JOBS_SUMMARY_ARGS]);
     dashboardCache.invalidate(getWorkspaceContexts);
     dashboardCache.invalidate(getWorkspaceInfrastructure); // Keep for backwards compatibility
     dashboardCache.invalidate(getEnabledCloudsList);

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -27,7 +27,10 @@ import {
   isServiceAccountTokensPaginationAvailable,
 } from '@/data/connectors/users';
 import { getClusters } from '@/data/connectors/clusters';
-import { getManagedJobs } from '@/data/connectors/jobs';
+import {
+  getManagedJobs,
+  MANAGED_JOBS_SUMMARY_ARGS,
+} from '@/data/connectors/jobs';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
 import { REFRESH_INTERVALS } from '@/lib/config';
@@ -197,10 +200,8 @@ export const getJobGpuCount = (job) => {
 const fetchClustersAndJobs = async () => {
   const [clustersResult, jobsResult] = await Promise.allSettled([
     dashboardCache.get(getClusters),
-    // Use shared cache key (no field filtering) - preloader uses same args
-    dashboardCache.get(getManagedJobs, [
-      { allUsers: true, skipFinished: true },
-    ]),
+    // Shared cache key — must match the preloader's args exactly
+    dashboardCache.get(getManagedJobs, [MANAGED_JOBS_SUMMARY_ARGS]),
   ]);
 
   const clustersData =
@@ -548,9 +549,7 @@ export function Users() {
     trackUserAction('refresh');
     dashboardCache.invalidate(getUsers);
     dashboardCache.invalidate(getClusters);
-    dashboardCache.invalidate(getManagedJobs, [
-      { allUsers: true, skipFinished: true },
-    ]);
+    dashboardCache.invalidate(getManagedJobs, [MANAGED_JOBS_SUMMARY_ARGS]);
 
     if (refreshDataRef.current) {
       refreshDataRef.current();

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -58,7 +58,10 @@ import {
   CLUSTER_NOT_UP_ERROR,
 } from '@/data/connectors/constants';
 import { getClusters } from '@/data/connectors/clusters';
-import { getManagedJobs } from '@/data/connectors/jobs';
+import {
+  getManagedJobs,
+  MANAGED_JOBS_SUMMARY_ARGS,
+} from '@/data/connectors/jobs';
 import Link from 'next/link';
 
 // Workspace-aware API functions - use cached global data and filter by workspace
@@ -85,7 +88,7 @@ export async function getWorkspaceManagedJobs(workspaceName) {
     // Use cached global managed jobs data and filter by workspace
     // This avoids making separate API calls per workspace
     const allJobsData = await dashboardCache.get(getManagedJobs, [
-      { allUsers: true, skipFinished: true },
+      MANAGED_JOBS_SUMMARY_ARGS,
     ]);
 
     const allJobs = allJobsData?.jobs || [];
@@ -422,7 +425,7 @@ export function Workspaces() {
   const fetchJobsData = useCallback(async (workspaceNames) => {
     try {
       const allJobsData = await dashboardCache.get(getManagedJobs, [
-        { allUsers: true, skipFinished: true },
+        MANAGED_JOBS_SUMMARY_ARGS,
       ]);
       const jobs = allJobsData?.jobs || [];
 

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -81,7 +81,9 @@ export async function getEnabledCloudsList() {
 
 export async function getCloudInfrastructure(forceRefresh = false) {
   const { getClusters } = await import('@/data/connectors/clusters');
-  const { getManagedJobs } = await import('@/data/connectors/jobs');
+  const { getManagedJobs, MANAGED_JOBS_SUMMARY_ARGS } = await import(
+    '@/data/connectors/jobs'
+  );
   const { getWorkspaces, getEnabledCloudsBatch } = await import(
     '@/data/connectors/workspaces'
   );
@@ -89,9 +91,9 @@ export async function getCloudInfrastructure(forceRefresh = false) {
   try {
     // Fetch jobs, clusters, and workspaces in parallel for better performance
     const [jobsResult, clustersResult, workspacesData] = await Promise.all([
-      // Use shared cache key (no field filtering) - preloader uses same args
+      // Shared cache key — must match the preloader's args exactly
       dashboardCache
-        .get(getManagedJobs, [{ allUsers: true, skipFinished: true }])
+        .get(getManagedJobs, [MANAGED_JOBS_SUMMARY_ARGS])
         .catch((error) => {
           console.error('Error fetching managed jobs:', error);
           return { jobs: [] };

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -116,6 +116,41 @@ export function computeJobGroupStatus(tasks) {
   return 'SUCCEEDED';
 }
 
+/**
+ * Shared fetch args for the cross-page managed-jobs summary cache entry
+ * (the `getManagedJobsForOtherPages` preload key, also read directly by the
+ * infra/users/workspaces pages).
+ *
+ * Every reader and the preloader MUST use this exact object so the cache key
+ * (function name + JSON.stringify(args), see lib/cache.js) stays shared.
+ *
+ * `fields` is the union of what those consumers actually read (plus the
+ * request fields the connector transform derives them from: `infra` and
+ * `resources_str_full` come from cloud/region/cluster_resources*). Without
+ * the trim, this fetch returns every non-finished job with its full inline
+ * YAML — tens of MB at 10k+ pending jobs — and each visit both writes that
+ * blob into the API server's requests DB and reads it back out through a
+ * per-process serialized reader, which is measurably what makes the
+ * dashboard's critical-path /api/get calls (and hence perceived page load)
+ * slow under concurrent use.
+ */
+export const MANAGED_JOBS_SUMMARY_ARGS = Object.freeze({
+  allUsers: true,
+  skipFinished: true,
+  fields: Object.freeze([
+    'job_id',
+    'job_name',
+    'status',
+    'user_hash',
+    'workspace',
+    'cloud',
+    'region',
+    'accelerators',
+    'cluster_resources',
+    'cluster_resources_full',
+  ]),
+});
+
 export async function getManagedJobs(options = {}) {
   try {
     const {

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -6,6 +6,7 @@ import { getClusters } from '@/data/connectors/clusters';
 import {
   getManagedJobs,
   getManagedJobsWithClientPagination,
+  MANAGED_JOBS_SUMMARY_ARGS,
 } from '@/data/connectors/jobs';
 import {
   getWorkspaces,
@@ -45,10 +46,15 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
       fn: getManagedJobsWithClientPagination,
       args: [{ allUsers: true }],
     },
-    // For infra/users/workspaces pages - shared cache entry
+    // For infra/users/workspaces pages - shared cache entry.
+    // Field-trimmed via MANAGED_JOBS_SUMMARY_ARGS: the untrimmed fetch
+    // returns every non-finished job with full inline YAML (tens of MB at
+    // 10k+ jobs), and concurrent reads of that blob through the API
+    // server's serialized requests-DB reader degrade every page's
+    // critical-path /api/get calls.
     getManagedJobsForOtherPages: {
       fn: getManagedJobs,
-      args: [{ allUsers: true, skipFinished: true }],
+      args: [MANAGED_JOBS_SUMMARY_ARGS],
     },
     getWorkspaces: { fn: getWorkspaces, args: [] },
     getUsers: { fn: getUsers, args: [] },

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1254,6 +1254,18 @@ def queue_v2_api(
         refresh, skip_finished, all_users, job_ids, user_match, workspace_match,
         name_match, pool_match, page, limit, statuses, fields, sort_by,
         sort_order, submitted_after, submitted_before)
+    if fields:
+        # The queue records carry every known column (None for the ones the
+        # query didn't select). Callers that pass ``fields`` have declared
+        # exactly what they read, so drop the other keys here; the response
+        # encoder's exclude_unset then leaves them out of the payload
+        # entirely. On wide job tables the key/None overhead otherwise
+        # dominates the response size (~1.4KB per job — tens of MB at tens
+        # of thousands of jobs). ``job_id``, ``task_id`` and ``status`` are
+        # always kept: the server force-selects them (see _update_fields)
+        # and clients key records on them.
+        keep = set(fields) | {'job_id', 'task_id', 'status'}
+        jobs = [{k: v for k, v in job.items() if k in keep} for job in jobs]
     return [responses.ManagedJobRecord(**job) for job in jobs
            ], total, status_counts, total_no_filter
 

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -174,7 +174,13 @@ def encode_jobs_queue_v2(
     else:
         jobs = jobs_or_tuple
         total = None
-    jobs_dict = [job.model_dump(by_alias=True) for job in jobs]
+    # exclude_unset: fields the server never populated (because the request's
+    # ``fields`` filter excluded them) are omitted from the payload instead of
+    # being emitted as explicit nulls. Requests without a ``fields`` filter
+    # populate every field, so their responses are unchanged.
+    jobs_dict = [
+        job.model_dump(by_alias=True, exclude_unset=True) for job in jobs
+    ]
     for job in jobs_dict:
         job['status'] = job['status'].value
     if total is None:


### PR DESCRIPTION
## Summary

At large job counts, the dashboard's cross-page managed-jobs summary fetch (`getManagedJobsForOtherPages`, shared by the infra/users/workspaces pages) returns tens of MB: at 10k non-finished jobs it measures **27.2MB per fetch**. Because async request results are staged through the API server's requests DB and read back through a per-process serialized reader, concurrent fetches of that size measurably degrade every request that touches the requests DB — including the dashboard's own critical-path `/api/get` calls, i.e. perceived page-load latency.

Two independent reductions, one per commit:

**1. [Dashboard] Trim the cross-page summary fetch (27.2MB → 14.1MB)**
- The fetch previously requested the jobs-page default field set (`DEFAULT_FIELDS`), which includes the full inline task YAML (`user_yaml`) — none of which the consuming pages read.
- Adds `MANAGED_JOBS_SUMMARY_ARGS`: shared, frozen fetch args trimmed to the union of fields the consuming pages actually read. Every consumer call site uses the constant so the cache key (function name + `JSON.stringify(args)`) stays shared.
- Prefetch timing/frequency unchanged — only the payload shrinks.

**2. [API] Omit unrequested fields from `queue_v2` responses (14.1MB → 2.75MB)**
- Job records carry every known column (the state layer fills unselected columns with `None`) and the encoder serialized all of them — a 10-field request still received ~58 keys per job, mostly explicit nulls (~1.4KB/job of structure).
- `queue_v2_api` now drops keys the caller did not request (always keeping `job_id`/`task_id`/`status`, which the server force-selects and clients key on); the `jobs.queue_v2` encoder uses `model_dump(exclude_unset=True)` so those fields are omitted instead of shipped as nulls.
- Requests without a `fields` filter populate every field and their responses are byte-for-byte unchanged. Typed clients are unaffected: the client-side decoder rebuilds `ManagedJobRecord`, where absent keys become the same `None` attributes as today. The v1 `queue()` wrapper and skylet/gRPC paths call `queue_v2` directly and are untouched.

Combined: **27.2MB → 2.75MB (~275B/job)** for the dashboard summary fetch at 10k jobs, and the payload slope drops from ~1.4KB/job to ~275B/job for any field-filtered API consumer.

## Tested

- Payload measurements against a server with 10k pending managed jobs (PostgreSQL backend): trimmed-fields fetch 14.1MB → 2.75MB; `DEFAULT_FIELDS` fetch 27.2MB → 20.4MB (null-key overhead removed); no-`fields` fetch unchanged.
- Load test at 4x peak dashboard traffic (10k pending jobs, browser-shaped keep-alive clients, the summary fetch firing on every visit): perceived page-load p50 3.1s / p99 9.3s before → 0.69s / 1.6s after, matching a no-fetch control within noise; zero errors across ~1000 visits.
- `sky jobs queue --all-users` renders all 10k rows correctly against the patched server (typed decode path).
- Field sufficiency audited for every consumer of the shared cache entry (users/infra/workspaces pages + connectors): all displayed properties derive from the trimmed field set; `prettier --check` clean on all touched dashboard files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)