### PR TITLE
[AWS] Skip default-SG pre-creation for user-specified security groups

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -111,13 +111,21 @@ def bootstrap_instances(
                                                        expected_sg_name,
                                                        extended_ip_rules,
                                                        enable_efa)
-        if expected_sg_name != aws_cloud.DEFAULT_SECURITY_GROUP_NAME:
+        managed_by_skypilot = security_group_config.get('ManagedBySkyPilot',
+                                                        True)
+        if (expected_sg_name != aws_cloud.DEFAULT_SECURITY_GROUP_NAME and
+                managed_by_skypilot):
             logger.debug('Attempting to create the default security group.')
             # Attempt to create the default security group. This is needed
             # to enable us to use the default security group to quickly
             # delete the cluster. If the default security group is not created,
             # we will need to block on instance termination to delete the
             # security group.
+            # When the security group is specified by the user
+            # (ManagedBySkyPilot is False), SkyPilot never deletes it at
+            # teardown (see terminate_instances in instance.py), so the
+            # default security group would never be used. Skip creating it to
+            # avoid a pointless (and possibly denied) CreateSecurityGroup call.
             try:
                 _configure_security_group(ec2, vpc_id,
                                           aws_cloud.DEFAULT_SECURITY_GROUP_NAME,
@@ -743,6 +751,8 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
     if security_group is not None:
         return security_group
 
+    logger.info(f'Security group {expected_sg_name!r} was not found in VPC '
+                f'{vpc_id!r}. Creating a new security group.')
     try:
         # create a new security group with skypilot tag
         ec2.meta.client.create_security_group(
@@ -772,7 +782,8 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
                 f'{security_group.group_name}{colorama.Style.RESET_ALL} '
                 f'[id={security_group.id}]')
             return security_group
-        message = ('Failed to create security group. Error: '
+        message = (f'Failed to create security group {expected_sg_name!r} in '
+                   f'VPC {vpc_id!r}. Error: '
                    f'{common_utils.format_exception(e)}')
         logger.warning(message)
         raise exceptions.NoClusterLaunchedError(message) from e

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -751,8 +751,8 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
     if security_group is not None:
         return security_group
 
-    logger.info(f'Security group {expected_sg_name!r} was not found in VPC '
-                f'{vpc_id!r}. Creating a new security group.')
+    logger.debug(f'Security group {expected_sg_name!r} was not found in VPC '
+                 f'{vpc_id!r}. Creating a new security group.')
     try:
         # create a new security group with skypilot tag
         ec2.meta.client.create_security_group(

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -861,3 +861,93 @@ def test_subnet_names_multi_az_no_error(monkeypatch):
     # Only the subnet in the chosen AZ should remain
     assert len(result_subnets) == 1
     assert result_subnets[0].availability_zone == 'us-east-1a'
+
+
+# --- bootstrap_instances: default security group pre-creation ---------------
+
+
+def _run_bootstrap_sg(security_group_config):
+    """Run bootstrap_instances with mocked AWS calls.
+
+    Returns the mock for _configure_security_group to let tests assert
+    which security groups were configured.
+    """
+    provision_config = provision_common.ProvisionConfig(
+        provider_config={
+            'region': 'us-east-2',
+            'security_group': security_group_config,
+        },
+        authentication_config={},
+        docker_config={},
+        node_config={
+            'ImageId': 'ami-12345',
+            # Skip IAM role configuration.
+            'IamInstanceProfile': {
+                'Name': 'dummy-profile'
+            },
+        },
+        count=1,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+    mock_subnet = MagicMock()
+    mock_subnet.subnet_id = 'subnet-12345'
+    with patch.object(config.aws, 'resource'), \
+            patch.object(config, '_get_subnet_and_vpc_id',
+                         return_value=([mock_subnet], 'vpc-12345')), \
+            patch.object(config, '_configure_security_group',
+                         return_value=['sg-12345']) as mock_configure_sg:
+        config.bootstrap_instances('us-east-2', 'test-cluster',
+                                   provision_config)
+    return mock_configure_sg
+
+
+def test_bootstrap_skips_default_sg_for_user_specified_sg():
+    """No default-SG pre-creation when the SG is specified by the user.
+
+    A user-specified security group (aws.security_group_name) is never
+    deleted by SkyPilot at teardown, so the default security group would
+    never be used; attempting to create it is a pointless CreateSecurityGroup
+    call that surfaces a scary (but harmless) warning for users whose IAM
+    policy denies it.
+    """
+    mock_sg = _run_bootstrap_sg({
+        'GroupName': 'user-sg',
+        'ManagedBySkyPilot': False,
+    })
+    assert mock_sg.call_count == 1
+    assert mock_sg.call_args[0][2] == 'user-sg'
+
+
+def test_bootstrap_precreates_default_sg_for_managed_sg():
+    """Default SG is pre-created for SkyPilot-managed per-cluster SGs.
+
+    These SGs (created when ports are opened) are deleted at teardown;
+    the default SG lets terminate_instances re-parent instances so the
+    per-cluster SG can be deleted without blocking on termination.
+    """
+    mock_sg = _run_bootstrap_sg({
+        'GroupName': 'sky-sg-test-cluster',
+        'ManagedBySkyPilot': True,
+    })
+    assert mock_sg.call_count == 2
+    assert mock_sg.call_args_list[0][0][2] == 'sky-sg-test-cluster'
+    assert (mock_sg.call_args_list[1][0][2] ==
+            config.aws_cloud.DEFAULT_SECURITY_GROUP_NAME)
+
+
+def test_bootstrap_precreates_default_sg_when_flag_absent():
+    """Backward compatibility: older cluster YAMLs lack ManagedBySkyPilot."""
+    mock_sg = _run_bootstrap_sg({
+        'GroupName': 'sky-sg-test-cluster',
+    })
+    assert mock_sg.call_count == 2
+
+
+def test_bootstrap_no_precreate_when_using_default_sg():
+    """No second call when the cluster already uses the default SG."""
+    mock_sg = _run_bootstrap_sg({
+        'GroupName': config.aws_cloud.DEFAULT_SECURITY_GROUP_NAME,
+    })
+    assert mock_sg.call_count == 1


### PR DESCRIPTION
## Summary

When `aws.security_group_name` is set, every launch configured the user's security group and then *also* attempted to pre-create SkyPilot's default security group (`sky-sg-<hash>`) in the same VPC. That pre-create is a teardown optimization: at termination, instances in a **SkyPilot-managed** per-cluster SG are re-parented to the default SG so the per-cluster SG can be deleted without blocking on instance termination (`terminate_instances` Case 3 vs Case 4).

For **user-specified** security groups (`ManagedBySkyPilot: false`), SkyPilot never deletes the SG at teardown (Case 2), so the default SG is never used — but the pre-create still ran on every launch. In environments that explicitly deny `ec2:CreateSecurityGroup` (a common IAM setup when pinning `security_group_name`), this printed a scary, name-less warning on every launch/failover attempt:

```
W ... config.py:775] Failed to create security group. Error: ... UnauthorizedOperation ... explicit deny ...
```

even though the failure is tolerated by design and the launch proceeds normally with the user's SG. This misled a customer (and us) into debugging a non-existent security-group problem when the actual launch failure was unrelated (`InsufficientInstanceCapacity`).

Changes:
- `bootstrap_instances`: only pre-create the default SG when the cluster's SG is managed by SkyPilot (`ManagedBySkyPilot`, defaulting to `True` for cluster YAMLs generated before the flag existed).
- `_get_or_create_vpc_security_group`: include the SG name and VPC id in the create-failure warning, and log (at debug) when a lookup misses and a create is attempted — so future occurrences are diagnosable from server-side logs (previously, finding-and-reusing an SG logged nothing and the failure message didn’t say *which* SG it tried to create).
- Unit tests for all four gating combinations.

Behavior matrix after this change (`expected_sg_name` → default-SG pre-create):
- default SG name → skipped (unchanged)
- user-specified SG, `ManagedBySkyPilot: false` → **skipped (new)**
- SkyPilot ports SG (`sky-sg-<cluster>`), `ManagedBySkyPilot: true` → pre-created (unchanged)
- flag absent (pre-existing cluster YAMLs) → pre-created (unchanged, safe default)

Worst case if the flag is wrong/absent is only the old behavior (a best-effort create), never a correctness change; teardown Case 4 (block on termination) still covers a missing default SG.

## Tested

- `pytest tests/unit_tests/test_aws.py` — 22 passed (4 new tests: user-specified SG skips the pre-create; managed ports-SG still pre-creates; absent flag keeps legacy behavior; default-SG-only launches unchanged).
- `bash format.sh --files sky/provision/aws/config.py tests/unit_tests/test_aws.py` — clean on changed files; `pylint` 10.00/10 on `sky/provision/aws/config.py`.
- Root-caused against a production trace: an enterprise deployment (nightly `1.0.0.dev20260619081521`) with `aws.security_group_name` + an explicit `ec2:CreateSecurityGroup` deny showed the warning on every zone attempt while the real failure was `InsufficientInstanceCapacity`; with this change the pre-create (and warning) no longer fires for that configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLx5Jm2KmEoSo9pwdHqb4j
