### PR TITLE
[Test] Fix flaky test_pool_scale_down_with_job_count_priority

### DIFF
--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -336,15 +336,24 @@ def wait_for_message_in_pool_logs(pool_name: str,
         'exit 1')
 
 
-def check_worker_id_exists(pool_name: str,
-                           worker_id: int,
-                           timeout: int = 30,
-                           time_between_checks: int = 5):
-    """Check that a specific worker ID exists in the pool status.
+def check_remaining_worker_is_busy(pool_name: str,
+                                   timeout: int = 30,
+                                   time_between_checks: int = 5):
+    """Check that exactly one worker remains and it is the busy one.
+
+    Used after scaling a pool down to a single worker to verify that the idle
+    worker was removed and the worker still running a job was kept.
+
+    We intentionally do NOT assert a specific worker ID here. Scaling a pool
+    bumps its version and performs a rolling update; depending on timing this
+    can either keep the busy worker in place or migrate its job onto a
+    freshly-provisioned replica with a new ID. Asserting a hard-coded ID is
+    therefore flaky. The stable invariant is that the single remaining worker
+    is the busy one, i.e. its USED_BY column (the last column of each
+    "Pool Workers" row) references a job rather than showing "-".
 
     Args:
         pool_name: The name of the pool.
-        worker_id: The worker ID (replica_id) to check for.
         timeout: Maximum time to wait in seconds.
         time_between_checks: Time to wait between checks in seconds.
     """
@@ -352,28 +361,23 @@ def check_worker_id_exists(pool_name: str,
         'start_time=$SECONDS; '
         'while true; do '
         f'if (( $SECONDS - $start_time > {timeout} )); then '
-        f'  echo "Timeout after {timeout} seconds waiting for worker {worker_id} to exist"; exit 1; '
+        f'  echo "Timeout after {timeout} seconds waiting for the remaining '
+        f'worker to be busy"; exit 1; '
         'fi; '
         f's=$(sky jobs pool status {pool_name} -v 2>&1); '
         'echo "$s"; '
-        # Extract worker IDs using awk: look for "Pool Workers" section,
-        # then extract numeric IDs from subsequent lines
-        'worker_ids=($(echo "$s" | awk \'/Pool Workers/{{flag=1; next}} flag && NF>0 {{print $2}}\' | grep -E \'^[0-9]+$\')); '
-        'found=0; '
-        'for id in "${worker_ids[@]}"; do '
-        f'  if [[ "$id" == "{worker_id}" ]]; then '
-        f'    echo "Worker {worker_id} found in pool status"; '
-        '    found=1; '
-        '    break; '
-        '  fi; '
-        'done; '
-        'if [[ $found -eq 1 ]]; then '
+        # USED_BY is the last column of each "Pool Workers" row; a busy worker
+        # shows a numeric job id while an idle worker shows "-".
+        'used_by=($(echo "$s" | awk \'/Pool Workers/{flag=1; next} '
+        f'flag && $1=="{pool_name}" {{print $NF}}\')); '
+        'if [[ ${#used_by[@]} -eq 1 && "${used_by[0]}" =~ ^[0-9]+$ ]]; then '
+        '  echo "Remaining worker is busy (USED_BY=${used_by[0]})"; '
         '  break; '
         'fi; '
         'if echo "$s" | grep "FAILED"; then '
         '  exit 1; '
         'fi; '
-        f'echo "Waiting for worker {worker_id} to appear in pool status..."; '
+        'echo "Waiting for the single remaining worker to be busy..."; '
         f'sleep {time_between_checks}; '
         'done')
 
@@ -2876,7 +2880,10 @@ def test_pool_scale_down_with_job_count_priority(generic_cloud: str):
     7. Cancels the first job
     8. Scales the pool down to 1 worker
     9. Waits for there to be 1 worker
-    10. Confirms that the worker that remains has id 2 (the one with the job)
+    10. Confirms that the worker that remains is the busy one (the one still
+        running the second job), i.e. the idle worker was scaled down. The
+        remaining worker's ID is not asserted because scaling performs a
+        rolling version update that may reassign worker IDs.
     """
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     pool_config = basic_pool_conf(num_workers=1, infra=generic_cloud)
@@ -2930,8 +2937,14 @@ def test_pool_scale_down_with_job_count_priority(generic_cloud: str):
                     _POOL_CHANGE_NUM_WORKERS_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, num_workers=1),
                     wait_until_num_workers(pool_name, 1, timeout=timeout),
-                    # Verify that worker 2 remains (the one with the job)
-                    check_worker_id_exists(pool_name, 2, timeout=timeout),
+                    # The second job must survive the scale-down: its worker is
+                    # the busy one and should be kept over the idle worker.
+                    wait_until_job_status(job_name_2, ['RUNNING'],
+                                          timeout=timeout),
+                    # Verify the remaining worker is the busy one (the one with
+                    # the job), rather than asserting a specific worker ID which
+                    # is not stable across the rolling scale-down update.
+                    check_remaining_worker_is_busy(pool_name, timeout=timeout),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),


### PR DESCRIPTION
## Summary

`test_pool_scale_down_with_job_count_priority` is flaky. It creates a pool with
1 worker, scales up to 2, then back down to 1, and asserted the surviving
worker had a **hard-coded ID of `2`**. That assumption does not hold:
`sky jobs pool apply --workers N` performs a **rolling update that bumps the
pool version**, and depending on timing the busy worker is either kept in place
(ID stays `2`) or drained while its running job is migrated onto a
freshly-provisioned replica with a **new ID** (e.g. `3`). The surviving
worker's ID is not stable, so the test fails whenever the busy worker gets a
new ID — while the feature under test (keep the worker that has the job, scale
down the idle one) actually worked correctly.

This fix replaces the hard-coded ID check with the stable invariant the test
really cares about: after scaling down, **exactly one worker remains and it is
the busy one** (its `USED_BY` column references a job, i.e. the idle worker was
the one scaled down). It also asserts the second job stays `RUNNING` across the
scale-down.

## Root cause / proof

Observed on nightly [build 11891](https://buildkite.com/skypilot-1/smoke-tests/builds/11891)
(`--kubernetes --jobs-consolidation`), which timed out for 900s waiting for
worker id `2`; the surviving worker was id `3` (running the second job). The
prior nightly of the same config passed, and the only commit in between was an
unrelated `[Metrics]` change — i.e. no code regression.

To confirm it is nondeterministic rather than a regression, I reproduced the
exact CLI sequence on a kind cluster **6 times on the same commit**:

| Run | Surviving worker ID | Old assertion |
|-----|--------------------|---------------|
| 1 | 2 | pass |
| 2 | 2 | pass |
| 3 | **3** | **fail** (reproduces the nightly) |
| 4 | 2 | pass |
| 5 | 2 | pass |
| 6 | 2 | pass |

Same code, same commands, same cluster → the surviving ID varies (2 vs 3). In
both cases the surviving worker is the one running the second job
(`USED_BY` = that job), which is why the new check is stable. The per-run
failure rate is timing/load-dependent, which is why a heavily-loaded nightly VM
failed all retries while a clean VM mostly passes.

## Test plan

- `pytest tests/smoke_tests/test_pools.py::test_pool_scale_down_with_job_count_priority --kubernetes --jobs-consolidation`
- Verified the new `check_remaining_worker_is_busy` bash accepts the previously
  failing case (single surviving worker with `USED_BY` = a job id, regardless of
  whether that worker's ID is `2` or `3`) and keeps waiting/fails if the
  surviving worker is idle (`USED_BY` = `-`).
- `bash format.sh --files tests/smoke_tests/test_pools.py` (isort/mypy/yapf pass).
