### PR TITLE
[Jobs] Add Prometheus gauges for managed-job recovery observability

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1837,6 +1837,99 @@ def get_status_counts_by_workspace_user_cloud(
     return [(row[0], row[1], row[2], str(row[3]), int(row[4])) for row in rows]
 
 
+def get_recovery_event_counts_by_source_workspace(
+) -> List[Tuple[str, Optional[str], int]]:
+    """Return RECOVERING job_events counts grouped by source/workspace.
+
+    Each tuple is (recovery_source, workspace, count). Counts the
+    RECOVERING events currently retained in ``job_events``; the table
+    has a retention window (see the job-event retention daemon), so the
+    numbers are NOT monotone — rows aging out decrease them. Consumers
+    that want rates must window with ``delta`` and clamp, never
+    ``increase``.
+
+    Rows written before the ``recovery_source`` column existed carry
+    NULL and are excluded: user-facing consumers treat NULL as FAILURE
+    for back-compat, but the metric only counts classified recoveries
+    (the ambiguity ages out with the retention window anyway).
+
+    Used by the Prometheus collector to emit per-source labeled gauges.
+    """
+    query = sqlalchemy.select(
+        job_events_table.c.recovery_source,
+        job_info_table.c.workspace,
+        sqlalchemy.func.count().label('cnt'),  # pylint: disable=not-callable
+    ).select_from(
+        job_events_table.outerjoin(
+            job_info_table,
+            job_events_table.c.spot_job_id == job_info_table.c.spot_job_id,
+        )).where(
+            job_events_table.c.new_status == ManagedJobStatus.RECOVERING.value,
+            job_events_table.c.recovery_source.isnot(None),
+        ).group_by(
+            job_events_table.c.recovery_source,
+            job_info_table.c.workspace,
+        )
+
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(query).fetchall()
+    return [(str(row[0]), row[1], int(row[2])) for row in rows]
+
+
+def get_active_emergency_recovery_episodes(
+    now: float,
+    window_seconds: float,
+    limit: int,
+) -> List[Tuple[int, Optional[str], Optional[str], int]]:
+    """Return jobs currently inside an active emergency-recovery episode.
+
+    Each tuple is (spot_job_id, job_name, workspace,
+    emergency_recovery_count). A job qualifies while its most recent
+    emergency attempt is younger than *window_seconds* (the same window
+    the controller uses to reset the retry budget — an episode "ends"
+    after that much quiet) AND at least one of its tasks is
+    non-terminal: a job that reached a terminal status should stop
+    reporting immediately instead of lingering for the rest of the
+    window.
+
+    Ordered by attempt count (highest first) with a deterministic
+    tiebreak (oldest last-attempt first, then job id) so that when a
+    caller truncates to *limit*, the surviving set is stable across
+    calls — an unstable order would rotate which jobs a capped metric
+    reports, flapping alerts built on it.
+    """
+    cutoff = now - window_seconds
+    terminal_values = [
+        status.value for status in ManagedJobStatus.terminal_statuses()
+    ]
+    non_terminal_exists = sqlalchemy.exists().where(
+        spot_table.c.spot_job_id == job_info_table.c.spot_job_id,
+        spot_table.c.status.notin_(terminal_values),
+    )
+    query = sqlalchemy.select(
+        job_info_table.c.spot_job_id,
+        job_info_table.c.name,
+        job_info_table.c.workspace,
+        job_info_table.c.emergency_recovery_count,
+    ).where(
+        job_info_table.c.last_emergency_recovery_at.isnot(None),
+        job_info_table.c.last_emergency_recovery_at >= cutoff,
+        job_info_table.c.emergency_recovery_count.isnot(None),
+        job_info_table.c.emergency_recovery_count > 0,
+        non_terminal_exists,
+    ).order_by(
+        job_info_table.c.emergency_recovery_count.desc(),
+        job_info_table.c.last_emergency_recovery_at.asc(),
+        job_info_table.c.spot_job_id.asc(),
+    ).limit(limit)
+
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(query).fetchall()
+    return [(int(row[0]), row[1], row[2], int(row[3])) for row in rows]
+
+
 def get_managed_jobs_with_filters(
     fields: Optional[List[str]] = None,
     job_ids: Optional[List[int]] = None,

--- a/sky/schemas/db/spot_jobs/023_add_job_events_recovery_index.py
+++ b/sky/schemas/db/spot_jobs/023_add_job_events_recovery_index.py
@@ -1,0 +1,52 @@
+"""Add an index for recovery-event metric queries on job_events.
+
+The Prometheus collector counts RECOVERING job_events rows grouped by
+recovery_source on every cache refresh (see
+sky/jobs/state.py::get_recovery_event_counts_by_source_workspace).
+job_events is the largest table in the managed-jobs DB on busy
+deployments and neither new_status nor recovery_source is indexed, so
+without this index every refresh is a full-table scan.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-07-21
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '023'
+down_revision: Union[str, Sequence[str], None] = '022'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_job_events_new_status_recovery_source'
+
+
+def _existing_indexes(table_name: str) -> set:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix['name'] for ix in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    """Create the index if it doesn't already exist.
+
+    Idempotent, and created inside an autocommit block so PostgreSQL is
+    happy with implicit transactional DDL and SQLite can run the
+    statement directly (same pattern as migration 020).
+    """
+    if _INDEX_NAME in _existing_indexes('job_events'):
+        return
+    with op.get_context().autocommit_block():
+        op.create_index(_INDEX_NAME, 'job_events',
+                        ['new_status', 'recovery_source'])
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -340,17 +340,23 @@ class ManagedJobsCollector:
         # pylint: disable=import-outside-toplevel
         from sky.jobs import constants as managed_job_constants
         from sky.jobs import state as managed_job_state
-        self._cached_rows = (
-            managed_job_state.get_status_counts_by_workspace_user_cloud())
-        self._cached_recovery_rows = (
+
+        # Query into locals first, then assign: a failure mid-refresh
+        # (collect() logs it and serves the cache) must not leave a
+        # mixed-age cache where some metrics updated and others didn't.
+        rows = (managed_job_state.get_status_counts_by_workspace_user_cloud())
+        recovery_rows = (
             managed_job_state.get_recovery_event_counts_by_source_workspace())
-        self._cached_episode_rows = (
+        episode_rows = (
             managed_job_state.get_active_emergency_recovery_episodes(
                 now=time.time(),
                 window_seconds=managed_job_constants.
                 EMERGENCY_RECOVERY_RESET_WINDOW_SECONDS,
                 limit=_EMERGENCY_EPISODES_MAX_SERIES,
             ))
+        self._cached_rows = rows
+        self._cached_recovery_rows = recovery_rows
+        self._cached_episode_rows = episode_rows
 
     def describe(self):
         yield prom_core.GaugeMetricFamily(

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -271,6 +271,29 @@ def _label_or_default(value: Optional[str], default: str) -> str:
     return value if value else default
 
 
+# Hard upper bound on rows emitted by
+# sky_managed_job_emergency_recovery_attempts. Emergencies are rare by
+# construction (a bounded per-job retry budget), but a controller bug
+# hitting many jobs at once could otherwise produce one series per job;
+# capping defends Prometheus's series budget. The query orders by
+# attempt count (highest first, deterministic tiebreak) so the jobs
+# most likely to page survive the cap.
+_EMERGENCY_EPISODES_MAX_SERIES = 100
+
+_RECOVERY_EVENTS_HELP = (
+    'Count of managed-job RECOVERING events currently retained in '
+    'job_events, by recovery source and workspace. NOT monotone: '
+    'job_events has a retention window, so aged-out rows decrease the '
+    'value — use clamp_min(delta(...), 0) for rates, never increase(). '
+    'Events written before recovery_source existed (NULL) are excluded.')
+
+_EMERGENCY_ATTEMPTS_HELP = (
+    'Emergency-recovery attempts used in the managed job\'s current '
+    'episode. The series exists only while the episode is active (last '
+    'attempt within the controller\'s reset window) and the job is '
+    'non-terminal; capped at 100 series, highest attempt counts kept.')
+
+
 class ManagedJobsCollector:
     """Collector for managed job state metrics.
 
@@ -287,6 +310,19 @@ class ManagedJobsCollector:
     window. A proper Counter incremented at the state-transition site
     would be more semantically correct than a gauge here, but is
     deferred.
+
+    Also emits two recovery-observability gauges:
+
+    * ``sky_managed_job_recovery_events_count{recovery_source,
+      workspace}`` — RECOVERING ``job_events`` rows currently retained,
+      by source (FAILURE / EMERGENCY / RESTART). Not monotone (event
+      retention prunes old rows), so rate queries must use
+      ``clamp_min(delta(...), 0)``, never ``increase(...)``.
+    * ``sky_managed_job_emergency_recovery_attempts{job_id, job_name,
+      workspace}`` — per-job attempts used in the job's current
+      emergency-recovery episode, emitted only while the episode is
+      active and the job is non-terminal, so the series (and any alert
+      on it) self-clears. Capped at ``_EMERGENCY_EPISODES_MAX_SERIES``.
     """
 
     def __init__(self):
@@ -295,18 +331,40 @@ class ManagedJobsCollector:
         self._cache_ttl = _COLLECTOR_CACHE_TTL_SECONDS
         # List of (workspace, user_hash, cloud, status, count) tuples.
         self._cached_rows: list = []
+        # List of (recovery_source, workspace, count) tuples.
+        self._cached_recovery_rows: list = []
+        # List of (spot_job_id, job_name, workspace, attempts) tuples.
+        self._cached_episode_rows: list = []
 
     def _refresh(self):
         # pylint: disable=import-outside-toplevel
+        from sky.jobs import constants as managed_job_constants
         from sky.jobs import state as managed_job_state
         self._cached_rows = (
             managed_job_state.get_status_counts_by_workspace_user_cloud())
+        self._cached_recovery_rows = (
+            managed_job_state.get_recovery_event_counts_by_source_workspace())
+        self._cached_episode_rows = (
+            managed_job_state.get_active_emergency_recovery_episodes(
+                now=time.time(),
+                window_seconds=managed_job_constants.
+                EMERGENCY_RECOVERY_RESET_WINDOW_SECONDS,
+                limit=_EMERGENCY_EPISODES_MAX_SERIES,
+            ))
 
     def describe(self):
         yield prom_core.GaugeMetricFamily(
             'sky_managed_jobs_count', ('Current count of managed job tasks by '
                                        'workspace, user, status, and cloud.'),
             labels=['workspace', 'user', 'status', 'cloud'])
+        yield prom_core.GaugeMetricFamily(
+            'sky_managed_job_recovery_events_count',
+            _RECOVERY_EVENTS_HELP,
+            labels=['recovery_source', 'workspace'])
+        yield prom_core.GaugeMetricFamily(
+            'sky_managed_job_emergency_recovery_attempts',
+            _EMERGENCY_ATTEMPTS_HELP,
+            labels=['job_id', 'job_name', 'workspace'])
 
     def collect(self):
         now = time.time()
@@ -318,6 +376,8 @@ class ManagedJobsCollector:
                     logger.exception('Failed to collect managed jobs metrics')
                 self._last_scrape_time = now
             rows = self._cached_rows
+            recovery_rows = self._cached_recovery_rows
+            episode_rows = self._cached_episode_rows
 
         counts: dict = {}
         for workspace, user_hash, cloud, status, count in rows:
@@ -334,6 +394,26 @@ class ManagedJobsCollector:
         for (workspace, user, status, cloud), count in counts.items():
             metric.add_metric([workspace, user, status, cloud], count)
         yield metric
+
+        recovery_metric = prom_core.GaugeMetricFamily(
+            'sky_managed_job_recovery_events_count',
+            _RECOVERY_EVENTS_HELP,
+            labels=['recovery_source', 'workspace'])
+        for source, workspace, count in recovery_rows:
+            ws_label = _label_or_default(workspace, _NULL_WORKSPACE_LABEL)
+            recovery_metric.add_metric([source, ws_label], count)
+        yield recovery_metric
+
+        episode_metric = prom_core.GaugeMetricFamily(
+            'sky_managed_job_emergency_recovery_attempts',
+            _EMERGENCY_ATTEMPTS_HELP,
+            labels=['job_id', 'job_name', 'workspace'])
+        for job_id, job_name, workspace, attempts in episode_rows:
+            ws_label = _label_or_default(workspace, _NULL_WORKSPACE_LABEL)
+            name_label = _label_or_default(job_name, _NULL_LABEL)
+            episode_metric.add_metric([str(job_id), name_label, ws_label],
+                                      attempts)
+        yield episode_metric
 
 
 # Transient statuses we report time-in-state for. UP / STOPPED are steady

--- a/tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py
@@ -22,18 +22,51 @@ class TestManagedJobsCollector:
             # Terminal status is included.
             ('ws', 'u', 'AWS', 'SUCCEEDED', 10),
         ]
+        mock_recovery_rows = [
+            ('EMERGENCY', 'ws', 2),
+            # LEFT JOIN miss: NULL workspace → 'default' label.
+            ('FAILURE', None, 5),
+        ]
+        mock_episode_rows = [
+            (42, 'train-llm', 'ws', 2),
+            # NULL job name → empty label.
+            (43, None, None, 1),
+        ]
 
         collector = metrics.ManagedJobsCollector()
         with patch.object(collector, '_refresh') as mock_refresh:
 
             def side_effect():
                 collector._cached_rows = mock_rows
+                collector._cached_recovery_rows = mock_recovery_rows
+                collector._cached_episode_rows = mock_episode_rows
 
             mock_refresh.side_effect = side_effect
 
             families = list(collector.collect())
 
-        assert len(families) == 1
+        assert len(families) == 3
+
+        recovery_family = families[1]
+        assert recovery_family.name == 'sky_managed_job_recovery_events_count'
+        recovery_samples = {(s.labels['recovery_source'],
+                             s.labels['workspace']): s.value
+                            for s in recovery_family.samples}
+        assert recovery_samples == {
+            ('EMERGENCY', 'ws'): 2,
+            ('FAILURE', 'default'): 5,
+        }
+
+        episode_family = families[2]
+        assert (episode_family.name ==
+                'sky_managed_job_emergency_recovery_attempts')
+        episode_samples = {(s.labels['job_id'], s.labels['job_name'],
+                            s.labels['workspace']): s.value
+                           for s in episode_family.samples}
+        assert episode_samples == {
+            ('42', 'train-llm', 'ws'): 2,
+            ('43', '', 'default'): 1,
+        }
 
         status_family = families[0]
         assert status_family.name == 'sky_managed_jobs_count'
@@ -88,12 +121,12 @@ class TestManagedJobsCollector:
         with patch.object(collector, '_refresh', side_effect=failing_refresh):
             # First collect fails, should yield empty metrics
             families = list(collector.collect())
-            assert len(families) == 1
-            assert list(families[0].samples) == []
+            assert len(families) == 3
+            assert all(list(f.samples) == [] for f in families)
 
             # Second collect retries (not skipped by zero TTL)
             families = list(collector.collect())
-            assert len(families) == 1
+            assert len(families) == 3
             samples = {s.labels['status']: s.value for s in families[0].samples}
             assert samples == {'RUNNING': 1}
 
@@ -105,6 +138,8 @@ class TestManagedJobsCollector:
         families = list(collector.describe())
         names = [f.name for f in families]
         assert 'sky_managed_jobs_count' in names
+        assert 'sky_managed_job_recovery_events_count' in names
+        assert 'sky_managed_job_emergency_recovery_attempts' in names
 
 
 class TestManagedJobsLimitMetrics:

--- a/tests/unit_tests/test_sky/jobs/test_recovery_metrics_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_metrics_state.py
@@ -1,0 +1,193 @@
+"""Unit tests for the recovery-metric query helpers in sky/jobs/state.py.
+
+Runs against a real temporary SQLite database (fixture pattern from
+test_emergency_recovery.py). Covers:
+
+- get_recovery_event_counts_by_source_workspace: grouping, the
+  NULL-recovery_source exclusion, non-RECOVERING exclusion, and the
+  NULL-workspace passthrough.
+- get_active_emergency_recovery_episodes: the activity window, the
+  non-terminal-task requirement, the deterministic ordering, and the
+  limit.
+"""
+import contextlib
+import time
+
+import filelock
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sky.jobs import state
+
+
+@pytest.fixture
+def _mock_managed_jobs_db_conn(tmp_path, monkeypatch):
+    """Create a temporary SQLite DB for managed jobs state."""
+    db_path = tmp_path / 'managed_jobs_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(_section: str):
+        lock_path = tmp_path / f'.{_section}.lock'
+        with filelock.FileLock(str(lock_path), timeout=10):
+            yield
+
+    monkeypatch.setattr(state.migration_utils, 'db_lock', _tmp_db_lock)
+    monkeypatch.setattr(state._db_manager, '_engine', engine)
+    monkeypatch.setattr(state._db_manager, '_engine_async', async_engine)
+    state.create_table(engine)
+    yield engine
+
+
+def _seed_job(engine,
+              job_id: int,
+              status: str = 'RUNNING',
+              workspace: str = 'default',
+              emergency_count=None,
+              last_emergency_at=None):
+    with engine.connect() as conn:
+        conn.execute(state.job_info_table.insert().values(
+            spot_job_id=job_id,
+            name=f'job-{job_id}',
+            workspace=workspace,
+            emergency_recovery_count=emergency_count,
+            last_emergency_recovery_at=last_emergency_at,
+        ))
+        conn.execute(state.spot_table.insert().values(
+            job_name=f'job-{job_id}',
+            status=status,
+            spot_job_id=job_id,
+            task_id=0,
+        ))
+        conn.commit()
+
+
+def _seed_event(engine, job_id: int, new_status: str, recovery_source):
+    with engine.connect() as conn:
+        conn.execute(state.job_events_table.insert().values(
+            spot_job_id=job_id,
+            task_id=0,
+            new_status=new_status,
+            recovery_source=recovery_source,
+        ))
+        conn.commit()
+
+
+class TestRecoveryEventCounts:
+
+    def test_groups_by_source_and_workspace(self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        _seed_job(engine, 1, workspace='ws-a')
+        _seed_job(engine, 2, workspace='ws-b')
+        _seed_event(engine, 1, 'RECOVERING', 'EMERGENCY')
+        _seed_event(engine, 1, 'RECOVERING', 'EMERGENCY')
+        _seed_event(engine, 1, 'RECOVERING', 'FAILURE')
+        _seed_event(engine, 2, 'RECOVERING', 'EMERGENCY')
+
+        rows = set(state.get_recovery_event_counts_by_source_workspace())
+        assert rows == {
+            ('EMERGENCY', 'ws-a', 2),
+            ('FAILURE', 'ws-a', 1),
+            ('EMERGENCY', 'ws-b', 1),
+        }
+
+    def test_excludes_null_source_and_non_recovering(
+            self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        _seed_job(engine, 1)
+        # Pre-migration RECOVERING row: NULL source — excluded.
+        _seed_event(engine, 1, 'RECOVERING', None)
+        # Non-RECOVERING events never count, sourced or not.
+        _seed_event(engine, 1, 'SUCCEEDED', None)
+
+        assert state.get_recovery_event_counts_by_source_workspace() == []
+
+    def test_null_workspace_passthrough(self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        # Event whose job_info row is missing entirely (LEFT JOIN miss).
+        _seed_event(engine, 99, 'RECOVERING', 'RESTART')
+
+        rows = state.get_recovery_event_counts_by_source_workspace()
+        assert rows == [('RESTART', None, 1)]
+
+
+class TestActiveEmergencyEpisodes:
+
+    def test_window_and_terminal_filters(self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        now = time.time()
+        # Active episode, non-terminal job: reported.
+        _seed_job(engine,
+                  1,
+                  status='RUNNING',
+                  emergency_count=2,
+                  last_emergency_at=now - 60)
+        # Episode aged out of the window: not reported.
+        _seed_job(engine,
+                  2,
+                  status='RUNNING',
+                  emergency_count=3,
+                  last_emergency_at=now - 7 * 3600)
+        # Active episode but the job is terminal: not reported.
+        _seed_job(engine,
+                  3,
+                  status='SUCCEEDED',
+                  emergency_count=2,
+                  last_emergency_at=now - 60)
+        # Never had an emergency: not reported.
+        _seed_job(engine, 4, status='RUNNING')
+
+        rows = state.get_active_emergency_recovery_episodes(now=now,
+                                                            window_seconds=6 *
+                                                            3600,
+                                                            limit=100)
+        assert rows == [(1, 'job-1', 'default', 2)]
+
+    def test_ordering_and_limit(self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        now = time.time()
+        # Highest attempt count first; count ties broken by oldest
+        # last-attempt first, then job id.
+        _seed_job(engine, 1, emergency_count=1, last_emergency_at=now - 30)
+        _seed_job(engine, 2, emergency_count=3, last_emergency_at=now - 10)
+        _seed_job(engine, 3, emergency_count=1, last_emergency_at=now - 90)
+        _seed_job(engine, 4, emergency_count=1, last_emergency_at=now - 90)
+
+        rows = state.get_active_emergency_recovery_episodes(now=now,
+                                                            window_seconds=6 *
+                                                            3600,
+                                                            limit=100)
+        assert [r[0] for r in rows] == [2, 3, 4, 1]
+
+        limited = state.get_active_emergency_recovery_episodes(
+            now=now, window_seconds=6 * 3600, limit=2)
+        assert [r[0] for r in limited] == [2, 3]
+
+    def test_multi_task_job_counts_once_while_any_task_active(
+            self, _mock_managed_jobs_db_conn):
+        engine = _mock_managed_jobs_db_conn
+        now = time.time()
+        _seed_job(engine,
+                  1,
+                  status='SUCCEEDED',
+                  emergency_count=2,
+                  last_emergency_at=now - 60)
+        # Second task of the same job still running -> job qualifies,
+        # and only one row comes back for it.
+        with engine.connect() as conn:
+            conn.execute(state.spot_table.insert().values(
+                job_name='job-1',
+                status='RUNNING',
+                spot_job_id=1,
+                task_id=1,
+            ))
+            conn.commit()
+
+        rows = state.get_active_emergency_recovery_episodes(now=now,
+                                                            window_seconds=6 *
+                                                            3600,
+                                                            limit=100)
+        assert rows == [(1, 'job-1', 'default', 2)]


### PR DESCRIPTION
## Problem

Since #9868, a managed job that hits an unexpected controller error is retried in place (*emergency recovery*, `RECOVERING` + `recovery_source=EMERGENCY`) instead of dying to `FAILED_CONTROLLER`. That's right for the job, but it moved the operational signal: the job usually survives, so controller-health incidents no longer show up in `sky_managed_jobs_count{status="FAILED_CONTROLLER"}` — and `sky_managed_jobs_count{status="RECOVERING"}` can't distinguish an emergency from an ordinary preemption recovery. Operators watching `/metrics` have no way to see, or alert on, emergency recoveries.

## What this adds

Two DB-backed gauges on the existing `ManagedJobsCollector` (same 30s cache, same consolidation-mode registration gate, same NULL-label conventions):

- **`sky_managed_job_recovery_events_count{recovery_source, workspace}`** — RECOVERING `job_events` rows currently retained, by source (`FAILURE` / `EMERGENCY` / `RESTART`). For trend dashboards ("how many recoveries of each kind"). **Not monotone**: `job_events` has a retention window, so aged-out rows decrease the value — the help text prescribes `clamp_min(delta(...), 0)` and warns against `increase()` (counter-reset semantics would turn an aged-out row into a huge false increase). Pre-#9868 rows (NULL source) are excluded.
- **`sky_managed_job_emergency_recovery_attempts{job_id, job_name, workspace}`** — per-job attempts used in the job's *current* emergency episode. The series exists only while the episode is active (last attempt within `EMERGENCY_RECOVERY_RESET_WINDOW_SECONDS`) **and** the job is non-terminal, so it — and any alert built on it (e.g. `>= 2` = "repeated emergencies on one job, treat as an incident") — self-clears on recovery, termination, or episode expiry. Bounded per-entity series (cap 100, deterministic keep-highest order) following the `sky_cluster_time_in_state_seconds` precedent: a mass incident can't blow the series budget, and count ties break deterministically so the surviving set doesn't rotate between scrapes and flap alerts.

Migration `023` adds an index on `job_events (new_status, recovery_source)` — the events query groups over that (previously unindexed) pair on every collector refresh, and `job_events` is the largest table in the managed-jobs DB on busy deployments. Same idempotent/autocommit pattern as migration `020`.

## Tests

- `tests/unit_tests/test_sky/jobs/test_recovery_metrics_state.py` (new): the two `sky/jobs/state.py` helpers against a real temp SQLite DB — grouping by source/workspace, NULL-source and non-RECOVERING exclusion, NULL-workspace passthrough, the episode activity window, terminal-job exclusion, deterministic ordering + limit, multi-task jobs reporting once while any task is live.
- `tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py` (extended): the new metric families, label conventions (NULL workspace → `default`, NULL job name → `""`), all-families-empty on refresh error, and `describe()` coverage.
- `pytest tests/unit_tests/test_sky/jobs/test_recovery_metrics_state.py tests/unit_tests/test_sky/jobs/test_managed_jobs_metrics.py`: 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)