### PR TITLE
[Test] Verify volume is actually mounted in test_volume_env_mount_kubernetes

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1531,6 +1531,10 @@ def test_volume_env_mount_kubernetes():
         volumes:
           /mnt/test-data: ${{USERNAME}}-{pvc_name}
         run: |
+          set -e
+          df -h /mnt/test-data
+          touch /mnt/test-data/test.txt
+          ls -lart /mnt/test-data
           echo "Mounted volume"
     """)
     full_pvc_name = f'user-{pvc_name}'


### PR DESCRIPTION
## Summary
- `test_volume_env_mount_kubernetes` launches a managed job with a task-YAML `volumes:` entry but its `run` only echoes, so the test passes even when the volume is silently absent from the pod.
- Make the run block `df`/`touch`/`ls` the mount path (mirroring `tests/test_yamls/test_volume.yaml.j2`) so a missing mount fails the job and the test.

## Test plan
- Test-only change; verified the module parses. The assertion strengthening will be exercised by the existing `/smoke-test --kubernetes` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)