### PR TITLE
[CI] Tag the commit of each published nightly

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -303,6 +303,38 @@ jobs:
       package_name: skypilot-nightly
     secrets: inherit
 
+  # Tag the published commit so a nightly version maps back to its exact
+  # commit, mirroring the stable release flow (release-publish.yml
+  # `create-release`): an annotated `v<version>` tag pushed with the release
+  # PAT. Gated on a successful publish so only actually-released commits get
+  # tagged.
+  tag-nightly-release:
+    needs: [check-date, nightly-build-pypi, publish-and-validate-both]
+    if: ${{ always() && needs.publish-and-validate-both.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ github.sha }}
+          token: ${{ secrets.GH_PAT_FOR_RELEASE }}
+      - name: Create and push nightly tag
+        run: |
+          VERSION="${{ needs.nightly-build-pypi.outputs.version }}"
+          TAG="v${VERSION}"
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          # Nightly versions are date-based (1.0.0.devYYYYMMDD), so a same-day
+          # re-dispatch reuses the version. Keep the first tag of the day: if it
+          # already exists on origin, log and exit without failing the build.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; leaving it untouched."
+            exit 0
+          fi
+          git tag -a "${TAG}" -m "Nightly release ${TAG}"
+          git push origin "${TAG}"
+          echo "Created and pushed ${TAG} -> ${{ github.sha }}"
+
   # After a nightly is published, dispatch the downstream repo's workflow so it
   # can react without polling PyPI. Fail-loud: a missing secret, bad App creds,
   # or a non-204 turns the run red rather than silently skipping.
@@ -431,7 +463,7 @@ jobs:
 
   notify-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes-resource-heavy, smoke-tests-kubernetes-no-resource-heavy, smoke-tests-kubernetes-no-resource-heavy-limit-deps, smoke-tests-remote-server-kubernetes, smoke-tests-kubernetes-jobs-consolidation, smoke-tests-shared-gke-api-server, smoke-tests-slurm-minimal, backward-compat-test-nightly, backward-compat-test-stable, publish-and-validate-both, trigger-docker-and-helm-release]
+    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes-resource-heavy, smoke-tests-kubernetes-no-resource-heavy, smoke-tests-kubernetes-no-resource-heavy-limit-deps, smoke-tests-remote-server-kubernetes, smoke-tests-kubernetes-jobs-consolidation, smoke-tests-shared-gke-api-server, smoke-tests-slurm-minimal, backward-compat-test-nightly, backward-compat-test-stable, publish-and-validate-both, trigger-docker-and-helm-release, tag-nightly-release]
     # Only run this job if any of the previous jobs failed
     if: failure()
     steps:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -146,8 +146,10 @@ jobs:
           VERSION="${{ needs.extract-version.outputs.version }}"
           echo "Current release version: ${VERSION}"
 
-          # Get all git tags starting with 'v' and sort them
-          ALL_TAGS=$(git tag | grep "^v" | sort -V)
+          # Get all git tags starting with 'v' and sort them. Exclude nightly
+          # tags (v1.0.0.devYYYYMMDD): they version-sort above stable releases
+          # and would otherwise be mis-selected as the previous stable release.
+          ALL_TAGS=$(git tag | grep "^v" | grep -v '\.dev' | sort -V)
           echo "All git tags:"
           echo "$ALL_TAGS"
 


### PR DESCRIPTION
## Summary

- Nightly builds publish `skypilot-nightly==1.0.0.dev<YYYYMMDD>` to PyPI but leave no marker of which commit a given nightly version came from. This adds a `tag-nightly-release` job that pushes an annotated `v<version>` tag (e.g. `v1.0.0.dev20260721`) onto the released commit after a nightly is published — mirroring the stable release flow (`release-publish.yml` → `create-release`) in both tag shape and the `GH_PAT_FOR_RELEASE` push.
- The job is gated on `publish-and-validate-both` success, so only commits actually published to PyPI get tagged. It is added to the `notify-slack-failure` `needs` so a tag-push failure surfaces on Slack.
- Same-day re-dispatches reuse the date-based version, so the step is idempotent: if the tag already exists on origin it logs and exits 0 rather than failing the build (keeps the first tag of the day).
- **`release-publish.yml` fix:** nightly versions (`1.0.0.dev...`) version-sort *above* stable releases, so the stable release's previous-release detection (`git tag | grep "^v" | sort -V`) would mis-select a nightly `v1.0.0.dev…` as the previous stable release. Excludes `.dev` tags from that grep. This is a no-op until nightly tags start appearing.

After this lands, mapping a nightly version to its commit is one lookup:
```bash
git rev-list -n1 v1.0.0.dev20260721   # commit for a nightly version
git tag -l 'v1.0.0.dev*'               # list all nightly tags
```

Note: this intentionally does **not** create a GitHub *Release* per nightly (unlike the stable flow), to avoid ~365 releases/year of noise. The ask was specifically to tag the commit.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open(f))"` parses both workflow files.
- Verified the previous-release grep change against a synthetic tag set (`v0.12.3`, `v0.12.3rc1`, `v0.12.3.post1`, `v0.9.4`, `v1.0.0.dev20260721`, `v1.0.0.dev20260722`):
  - **Old** logic `grep "^v" | sort -V | tail -1` → `v1.0.0.dev20260722` (a nightly — the bug).
  - **New** logic `grep "^v" | grep -v '\.dev' | sort -V | tail -1` → highest stable tag.
- Pre-commit hooks (`check yaml`, trailing whitespace, EOF) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)