### PR TITLE
[Dashboard] Defer cluster fetch to background preload on the jobs page

### DIFF
--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -77,7 +77,18 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
   // Page-specific function requirements
   pages: {
     clusters: ['getClusters', 'getWorkspaces'],
-    jobs: ['getManagedJobs', 'getClusters', 'getWorkspaces', 'getUsers'],
+    // getClusters is intentionally NOT a foreground requirement here. Its
+    // only /jobs consumer is the controller-stopped/launching banner
+    // (components/jobs.jsx), which runs only when the queue endpoint reports
+    // the controller unreachable — and fetchData already skips /status when
+    // it is reachable. Foreground-preloading it made every /jobs load await a
+    // /status -> /api/get round trip (and gate pagination re-fetches via
+    // preloadingComplete) to warm data a healthy page never reads. It is
+    // still warmed by _backgroundPreloadOtherPages (which always adds
+    // getClusters off the infra page), so the banner and Clusters-page
+    // navigation stay fast; a cold banner just falls back to an on-demand
+    // fetch.
+    jobs: ['getManagedJobs', 'getWorkspaces', 'getUsers'],
     infra: [
       // Empty - infra page uses progressive loading via fetchData()
       // All infra functions are background-preloaded from other pages


### PR DESCRIPTION
## Summary

On the managed jobs page, `getClusters` was listed as a **foreground** preload
requirement (`DASHBOARD_CACHE_FUNCTIONS.pages.jobs` in `cache-preloader.js`), so
every `/jobs` load awaited a `/status` → `/api/get` round trip before
`preloadingComplete` flipped — which also gates the jobs table's re-fetches on
page/filter/sort changes.

The only consumer of cluster data on the jobs page is the
controller-stopped/launching banner (`components/jobs.jsx`), which is resolved
**only** when the queue endpoint reports the controller unreachable; the healthy
path already skips `/status` (see the existing comment there about saving
hundreds of ms per load and per periodic refresh). So foreground-preloading
`getClusters` put a `/status` round trip on the critical path of every
jobs-page load to warm data a healthy page never reads — a cost that grows when
the API server is far from the clusters or the fleet is large.

This moves `getClusters` to **background-only** preload for the jobs page. It is
still warmed unconditionally by `_backgroundPreloadOtherPages` (which always
adds `getClusters` when not on the infra page), so:
- the controller banner and Clusters-page navigation stay fast (cache warm), and
- if the banner is needed before the background preload finishes, `fetchData`
  already falls back to an on-demand `dashboardCache.get(getClusters)`.

No behavior change for the banner — only its warm-up moves from blocking to
background.

## Test plan

- `npm --prefix sky/dashboard install && npm --prefix sky/dashboard run build`
  (lint/build).
- Load `/dashboard/jobs`: the jobs table renders without a `/status` request on
  the critical path; `getClusters` now appears as a background fetch
  (`_backgroundPreloadOtherPages`) rather than a foreground blocker.
- With the jobs controller stopped, reload `/dashboard/jobs`: the
  "controller stopped/launching" banner still appears (on-demand fallback fetch).
- Navigate Jobs → Clusters: the clusters page remains fast (background-warmed
  cache).
