### PR TITLE
[Volumes] Use SHORT queue for volume apply/delete to avoid LONG-pool starvation

### DIFF
--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -52,7 +52,11 @@ async def volume_delete(request: fastapi.Request,
         request_name=request_names.RequestName.VOLUME_DELETE,
         request_body=volume_delete_body,
         func=core.volume_delete,
-        schedule_type=requests_lib.ScheduleType.LONG,
+        # Volume delete is a lightweight, bounded operation (e.g. a single
+        # K8s PVC delete API call, capped by kubernetes.API_TIMEOUT). Use the
+        # SHORT queue so it is not starved behind long-running LONG requests
+        # like cluster launches.
+        schedule_type=requests_lib.ScheduleType.SHORT,
         auth_user=request.state.auth_user,
     )
 
@@ -129,6 +133,10 @@ async def volume_apply(request: fastapi.Request,
         request_name=request_names.RequestName.VOLUME_APPLY,
         request_body=volume_apply_body,
         func=core.volume_apply,
-        schedule_type=requests_lib.ScheduleType.LONG,
+        # Volume apply is a lightweight, bounded operation (e.g. a few K8s PVC
+        # read/create API calls, each capped by kubernetes.API_TIMEOUT). Use
+        # the SHORT queue so it is not starved behind long-running LONG
+        # requests like cluster launches.
+        schedule_type=requests_lib.ScheduleType.SHORT,
         auth_user=request.state.auth_user,
     )

--- a/tests/unit_tests/test_sky/volumes/test_server.py
+++ b/tests/unit_tests/test_sky/volumes/test_server.py
@@ -86,7 +86,7 @@ class TestVolumeServer:
             assert call_args[1]['request_name'] == 'volume_delete'
             assert call_args[1]['func'] == server.core.volume_delete
             assert call_args[1][
-                'schedule_type'] == requests_lib.ScheduleType.LONG
+                'schedule_type'] == requests_lib.ScheduleType.SHORT
             assert isinstance(call_args[1]['request_body'],
                               payloads.VolumeDeleteBody)
 
@@ -142,7 +142,7 @@ class TestVolumeServer:
             assert call_args[1]['request_name'] == 'volume_apply'
             assert call_args[1]['func'] == server.core.volume_apply
             assert call_args[1][
-                'schedule_type'] == requests_lib.ScheduleType.LONG
+                'schedule_type'] == requests_lib.ScheduleType.SHORT
             assert isinstance(call_args[1]['request_body'],
                               payloads.VolumeApplyBody)
 
@@ -196,7 +196,7 @@ class TestVolumeServer:
             assert call_args[1]['request_name'] == 'volume_apply'
             assert call_args[1]['func'] == server.core.volume_apply
             assert call_args[1][
-                'schedule_type'] == requests_lib.ScheduleType.LONG
+                'schedule_type'] == requests_lib.ScheduleType.SHORT
 
     def test_volume_apply_success_pvc_none_config(self, monkeypatch):
         """Test volume_apply endpoint with PVC volume and None config."""
@@ -461,7 +461,7 @@ class TestVolumeServer:
             assert call_args[1]['request_name'] == 'volume_delete'
             assert call_args[1]['func'] == server.core.volume_delete
             assert call_args[1][
-                'schedule_type'] == requests_lib.ScheduleType.LONG
+                'schedule_type'] == requests_lib.ScheduleType.SHORT
 
     def test_volume_validate_success(self, monkeypatch):
         """Test volume_validate endpoint with successful validation."""
@@ -595,7 +595,7 @@ class TestVolumeServer:
             assert call_args[1]['request_name'] == 'volume_apply'
             assert call_args[1]['func'] == server.core.volume_apply
             assert call_args[1][
-                'schedule_type'] == requests_lib.ScheduleType.LONG
+                'schedule_type'] == requests_lib.ScheduleType.SHORT
             assert isinstance(call_args[1]['request_body'],
                               payloads.VolumeApplyBody)
 


### PR DESCRIPTION
## Summary

- Move `volume_apply` and `volume_delete` from the `LONG` request queue to the `SHORT` queue.
- These are lightweight, bounded operations (a few K8s PVC read/create/delete API calls, each capped by `kubernetes.API_TIMEOUT`) — comparable to `stop`/`down`, which already use `SHORT`.

## Motivation

The `LONG` queue has a small, bounded worker pool (`cpu_count * 2`). A burst of long-running `sky.launch` requests can fully occupy the `LONG` pool and starve volume operations indefinitely: they stay `PENDING`, and the dashboard's synchronous wait for the request eventually hits a gateway timeout (**HTTP 524**) when creating/importing a volume.

Observed on a hosted API server: a batch of ~60 concurrent `sky launch` requests (each wedged waiting on GPU pods) held all LONG worker slots for hours, so every subsequent LONG request — including `volume_apply` (volume Import) — never got scheduled. Placing lightweight volume metadata operations on the large `SHORT` pool (50 slots) decouples them from cluster launches.

Note: this does not address the deeper lack of fairness in the LONG pool (a single user's launch batch can still starve other LONG requests such as launches/`start`); that is left for a follow-up.

## Test plan

- `sky volume apply` / import an existing PVC and `sky volume delete` continue to work and return promptly.
- Verify the requests are now scheduled on the SHORT queue (`sky api status -v` shows them completing without waiting behind LONG launches).
- Existing volume unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)