### PR TITLE
[Core] Price region-free cost estimates with the joint regional minimum

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1829,20 +1829,49 @@ class Resources:
                         'max_hourly_cost must be a positive number, '
                         f'got {self._max_hourly_cost}')
 
-    def get_cost(self, seconds: float) -> float:
-        """Returns cost in USD for the runtime in seconds."""
-        hours = seconds / 3600
-        # Instance.
+    def _get_hourly_cost(self, region: Optional[str],
+                         zone: Optional[str]) -> float:
+        """Returns the joint hourly price of the instance and accelerators."""
         assert self.cloud is not None, 'Cloud must be specified'
         assert self._instance_type is not None, (
             'Instance type must be specified')
+        # Instance.
         hourly_cost = self.cloud.instance_type_to_hourly_cost(
-            self._instance_type, self.use_spot, self._region, self._zone)
+            self._instance_type, self.use_spot, region, zone)
         # Accelerators (if any).
         if self.accelerators is not None:
             hourly_cost += self.cloud.accelerators_to_hourly_cost(
-                self.accelerators, self.use_spot, self._region, self._zone)
-        return float(hourly_cost * hours)
+                self.accelerators, self.use_spot, region, zone)
+        return hourly_cost
+
+    def get_cost(self, seconds: float) -> float:
+        """Returns cost in USD for the runtime in seconds."""
+        hours = seconds / 3600
+        assert self.cloud is not None, 'Cloud must be specified'
+        assert self._instance_type is not None, (
+            'Instance type must be specified')
+        if self._region is None:
+            # Without a pinned region, pricing the instance and the
+            # accelerators independently would take each component's minimum
+            # across all regions, which can combine prices from different
+            # regions into a total that no single region offers (e.g., GCP
+            # a2-megagpu-16g is cheapest in us-central1 while A100 is cheapest
+            # in europe-west4). Take the cheapest *joint* price over the
+            # regions that actually offer these resources instead.
+            hourly_costs = []
+            for region in self.get_valid_regions_for_launchable():
+                try:
+                    hourly_costs.append(self._get_hourly_cost(
+                        region.name, None))
+                except ValueError:
+                    # The instance type or accelerator has no price listed in
+                    # this region.
+                    continue
+            if hourly_costs:
+                return float(min(hourly_costs) * hours)
+            # No region-specific price found; fall through to the region-free
+            # catalog lookup below.
+        return float(self._get_hourly_cost(self._region, self._zone) * hours)
 
     def get_accelerators_str(self) -> str:
         accelerators = self.accelerators

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -39,6 +39,53 @@ def test_get_reservations_available_resources():
         "instance_type", "region", "zone", set())
 
 
+def test_get_cost_without_region_uses_joint_regional_price():
+    """get_cost() with no region must not mix per-component minimums.
+
+    The cheapest instance price and the cheapest accelerator price can live in
+    different regions; the cost estimate must be the cheapest joint price a
+    single region offers, not the (unachievable) sum of the two minimums.
+    """
+    instance_prices = {'cheap-instance-region': 8.0, 'cheap-accel-region': 9.0}
+    accel_prices = {'cheap-instance-region': 47.0, 'cheap-accel-region': 26.0}
+
+    mock_cloud = mock.Mock()
+    mock_cloud.instance_type_to_hourly_cost.side_effect = (
+        lambda instance_type, use_spot, region, zone: instance_prices[region])
+    mock_cloud.accelerators_to_hourly_cost.side_effect = (
+        lambda accelerators, use_spot, region, zone: accel_prices[region])
+
+    r = Resources(cloud=mock_cloud,
+                  instance_type='instance_type',
+                  accelerators={'A100': 16})
+    regions = [
+        clouds.Region(name=region_name) for region_name in instance_prices
+    ]
+    with mock.patch.object(Resources,
+                           'get_valid_regions_for_launchable',
+                           return_value=regions):
+        # Cheapest joint price is cheap-accel-region: 9 + 26 = 35, cheaper
+        # than cheap-instance-region (8 + 47 = 55) and than the region-mixed
+        # sum of minimums (8 + 26 = 34), which no region offers.
+        assert r.get_cost(3600) == 35.0
+
+
+def test_get_cost_with_region_prices_that_region():
+    mock_cloud = mock.Mock()
+    mock_cloud.instance_type_to_hourly_cost.return_value = 8.0
+    mock_cloud.accelerators_to_hourly_cost.return_value = 26.0
+    mock_cloud.validate_region_zone.return_value = ('some-region', None)
+    r = Resources(cloud=mock_cloud,
+                  instance_type='instance_type',
+                  accelerators={'A100': 16},
+                  region='some-region')
+    assert r.get_cost(3600) == 34.0
+    mock_cloud.instance_type_to_hourly_cost.assert_called_once_with(
+        'instance_type', False, 'some-region', None)
+    mock_cloud.accelerators_to_hourly_cost.assert_called_once_with(
+        {'A100': 16}, False, 'some-region', None)
+
+
 def _run_label_test(allowed_labels: Dict[str, str],
                     invalid_labels: Dict[str, str],
                     cloud: clouds.Cloud = None):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`Resources.get_cost()` with no region pinned summed the cheapest instance price and the cheapest accelerator price **independently across regions**. When those minimums live in different regions, the estimate is an hourly rate no single region actually offers. Concretely, in the current `v8` GCP catalog, `a2-megagpu-16g` is cheapest in `us-central1` ($8.80/hr) while 16x A100 is cheapest in `europe-west4` ($25.82/hr): the region-free estimate came out to $34.62/hr, but the best real (joint) price is `europe-west4` at $35.50/hr.

This is what has been breaking `tests/test_optimizer_random_dag.py` on every branch (including master pushes) since ~17:14 UTC Jul 22: the test's brute-force baseline prices region-free `Resources` via `get_cost(region=None)` and got the unachievable $34.62 bound, while the optimizer (correctly) charged its region-bound choice `europe-west4` — a $5.21 "regression" for a 10-node task (`assert 5.210899544245876 < 2`). The price spread has been in the catalog since Jul 14; the failures only started when a batch of catalog bot updates (AWS/Nebius/RunPod/Shadeform/Verda/Seeweb, 15:47–16:10 UTC) reshuffled the `sky.list_accelerators()` pool that the seeded random DAG draws from, making seed 2 land on `a2-megagpu-16g`. The failure can therefore also disappear again on any future catalog update — this PR removes the underlying inconsistency instead.

Changes:
- `Resources.get_cost()`: when no region is pinned, take the minimum of the **joint** (instance + accelerator) hourly price over `get_valid_regions_for_launchable()`, skipping regions with no listed price; fall back to the previous region-free lookup if no per-region price is available. Region-pinned calls (optimizer launchables, launched clusters, cost reports) are unchanged.
- Extracted the shared instance+accelerator pricing into `Resources._get_hourly_cost()`.

Note: the random-DAG test's brute-force loop calls `get_cost(region=None)` heavily, so that one test goes from ~60s to ~140s locally; the optimizer's own hot path is unaffected since its candidates are region-bound.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual/new tests:
- New unit tests: `pytest tests/unit_tests/test_resources.py -k get_cost` — asserts region-free pricing returns the cheapest joint regional price (35) rather than the region-mixed sum of minimums (34), and that region-pinned pricing still queries that region.
- `pytest tests/unit_tests/test_resources.py` — 67 passed.
- `pytest tests/test_optimizer_random_dag.py -n 0 --dist no` with today's live catalog — previously failed with `assert 5.210899544245876 < 2`, now passes (all 3 seeds).
- Manually verified against the live GCP catalog that `Resources(infra='gcp', instance_type='a2-megagpu-16g', accelerators={'A100': 16}).get_cost(3600)` now returns the achievable `europe-west4` joint price instead of a cross-region mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSEKM9A2VoNJw8ySSGdcUu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSEKM9A2VoNJw8ySSGdcUu)_