### PR TITLE
[Core] Surface concise health-probe failures in unhealthy-cluster events

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1420,6 +1420,23 @@ def get_timestamp_from_run_timestamp(run_timestamp: str) -> float:
         run_timestamp.partition('-')[2], '%Y-%m-%d-%H-%M-%S-%f').timestamp()
 
 
+def _summarize_probe_failure(e: exceptions.CommandError) -> str:
+    """Extract a concise, user-facing reason from a failed health probe.
+
+    str(e) embeds the entire remote ray-status command, which is too noisy
+    for the cluster event surfaced on the dashboard and CLI. The actionable
+    part is the last stderr line (e.g. 'ssh: connect to host 1.2.3.4 port
+    22: Operation timed out').
+    """
+    for source in (e.detailed_reason, e.error_msg):
+        if not source:
+            continue
+        lines = [line.strip() for line in source.splitlines() if line.strip()]
+        if lines:
+            return f'health probe failed: {lines[-1]}'
+    return f'health probe failed with return code {e.returncode}'
+
+
 def _count_healthy_nodes_from_ray(output: str,
                                   is_local_cloud: bool = False
                                  ) -> Tuple[int, int]:
@@ -2668,6 +2685,10 @@ def _update_cluster_status(
                                 f'If the cluster was restarted manually, try running: '
                                 f'{reset}{bright}sky start {cluster_name}{reset} '
                                 f'{yellow}to recover from INIT status.{reset}')
+                            # Record the probe failure so the cluster event
+                            # explains the INIT transition instead of showing
+                            # 'ray cluster is unhealthy (None)'.
+                            ray_status_details = _summarize_probe_failure(e)
                             return False
                         raise e
                     # We retry for kubernetes because coreweave can have a
@@ -2706,6 +2727,13 @@ def _update_cluster_status(
             if ray_status_details is None:
                 ray_status_details = str(e)
             logger.debug(common_utils.format_exception(e))
+        except exceptions.CommandError as e:
+            # The health probe command itself failed (e.g. SSH to the head
+            # node is unreachable). Record the concise failure instead of
+            # str(e), which embeds the whole remote command.
+            ray_status_details = _summarize_probe_failure(e)
+            logger.debug(f'Refreshing status ({cluster_name!r}) probe failed: ',
+                         exc_info=e)
         except Exception as e:  # pylint: disable=broad-except
             # This can be raised by `external_ssh_ports()`, due to the
             # underlying call to kubernetes API.

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -1,5 +1,7 @@
-"""Tests for _summarize_pod_reasons in backend_utils."""
+"""Tests for the summarize helpers in backend_utils."""
+from sky import exceptions
 from sky.backends.backend_utils import _summarize_pod_reasons
+from sky.backends.backend_utils import _summarize_probe_failure
 from sky.provision.kubernetes.instance import NodeHealthInfo
 from sky.utils import status_lib
 
@@ -172,3 +174,53 @@ class TestStatusReasonIntegration:
             else:
                 init_reason = f'ray cluster is unhealthy ({ray_status_details})'
         assert 'ray cluster is unhealthy' in init_reason
+
+
+class TestSummarizeProbeFailure:
+    """Tests for _summarize_probe_failure."""
+
+    def _make_error(self,
+                    detailed_reason,
+                    error_msg='Failed to check ray '
+                    'cluster\'s healthiness.\n-- stdout --\n\n'):
+        return exceptions.CommandError(255, 'x' * 700, error_msg,
+                                       detailed_reason)
+
+    def test_uses_last_stderr_line(self):
+        e = self._make_error(
+            'mux_client_request_session: read from master failed: '
+            'Broken pipe\n'
+            'ssh: connect to host 1.2.3.4 port 22: Operation timed out\n')
+        result = _summarize_probe_failure(e)
+        assert result == ('health probe failed: ssh: connect to host '
+                          '1.2.3.4 port 22: Operation timed out')
+
+    def test_connection_refused(self):
+        e = self._make_error(
+            'ssh: connect to host 1.2.3.4 port 22: Connection refused')
+        result = _summarize_probe_failure(e)
+        assert result == ('health probe failed: ssh: connect to host '
+                          '1.2.3.4 port 22: Connection refused')
+
+    def test_excludes_remote_command(self):
+        # str(e) embeds the (long) remote command; the summary must not.
+        e = self._make_error('ssh: connect to host 1.2.3.4 port 22: '
+                             'Connection refused')
+        result = _summarize_probe_failure(e)
+        assert 'x' * 100 not in result
+        assert len(result) < 200
+
+    def test_falls_back_to_error_msg(self):
+        e = self._make_error(None, error_msg='Ray cluster is not found.')
+        result = _summarize_probe_failure(e)
+        assert result == 'health probe failed: Ray cluster is not found.'
+
+    def test_whitespace_stderr_falls_back(self):
+        e = self._make_error('  \n \n', error_msg='some error')
+        result = _summarize_probe_failure(e)
+        assert result == 'health probe failed: some error'
+
+    def test_no_detail_uses_return_code(self):
+        e = self._make_error(None, error_msg='')
+        result = _summarize_probe_failure(e)
+        assert result == 'health probe failed with return code 255'


### PR DESCRIPTION
## Summary

- When a status refresh finds all nodes up but the ray health probe fails (e.g. SSH to the head node is unreachable), the recorded cluster event was built from `str(CommandError)`, which embeds the entire remote ray-status command (700+ characters). The actionable part, the last stderr line such as `ssh: connect to host <ip> port 22: Connection refused`, was buried at the very end. This event backs the `init_status_reason` field, the dashboard UNHEALTHY badge tooltip, and the cluster events table, so the noise is user-facing.
- Adds a `_summarize_probe_failure` helper that extracts the last non-empty stderr line (falling back to `error_msg`, then the return code) and uses it in the probe's `CommandError` handler.
- Also fixes the SSH-timeout early-return path, which previously recorded no detail at all, yielding a literal `ray cluster is unhealthy (None)` event.

Before (1280 chars, real repro):
```
Cluster is abnormal because ray cluster is unhealthy (Command RAY_PORT=$(env -u PYTHONPATH -C $HOME ... [~700 chars of remote command] ... failed with return code 255.
Failed to check ray cluster's healthiness.
-- stdout --

mux_client_request_session: read from master failed: Broken pipe
ssh: connect to host <ip> port 22: Operation timed out
). Transitioned to INIT (details: cluster is unhealthy).
```

After (193 chars, real repro):
```
Cluster is abnormal because ray cluster is unhealthy (health probe failed: ssh: connect to host <ip> port 22: Connection refused). Transitioned to INIT (details: cluster is unhealthy).
```

Note: the full command leaks into the event because the status-refresh daemon runs at DEBUG log level by default and `sky_logging.set_sky_logging_levels` sets `SKYPILOT_DEBUG=1` process-wide, which disables the 100-char command truncation in `CommandFailureException`. Building the event text from stderr sidesteps that for this path; the env-var leak itself is left for a follow-up.

## Tested

- Unit tests: added `TestSummarizeProbeFailure` (6 cases) to `tests/unit_tests/test_backend_utils_summarize.py`; full file passes.
- Manual: launched a 1-node AWS cluster, made SSH to the head unreachable (stopped sshd / firewalled port 22), ran `sky status -r`. Cluster transitions to INIT with the concise event above; the dashboard badge tooltip and events table show the same text. Restoring SSH and refreshing returns the cluster to UP.
- `bash format.sh` clean; pylint 10.00/10 on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)