### PR TITLE
[Dashboard] Show PENDING job reason in status tooltip

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -327,6 +327,10 @@ export async function getManagedJobs(options = {}) {
         full_infra: full_infra,
         recoveries: job.recovery_count,
         details: job.details || job.failure_reason,
+        // Mirror the cluster INIT tooltip: surface the pending reason on
+        // the status badge so users can see why a job is stuck in PENDING
+        // without opening the job details view.
+        statusTooltip: job.status === 'PENDING' ? job.details || null : null,
         user: job.user_name,
         user_hash: job.user_hash,
         submitted_at: job.submitted_at

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -482,7 +482,10 @@ function JobDetails() {
                                 </Link>
                               </TableCell>
                               <TableCell>
-                                <StatusBadge status={task.status} />
+                                <StatusBadge
+                                  status={task.status}
+                                  statusTooltip={task.statusTooltip}
+                                />
                               </TableCell>
                               <TableCell>
                                 {formatDuration(task.job_duration)}
@@ -1392,7 +1395,16 @@ function JobDetailsContent({
               <PluginSlot
                 name="jobs.detail.status.badge"
                 context={jobData}
-                fallback={<StatusBadge status={computedStatus} />}
+                fallback={
+                  <StatusBadge
+                    status={computedStatus}
+                    statusTooltip={
+                      computedStatus === 'PENDING'
+                        ? jobData.statusTooltip
+                        : null
+                    }
+                  />
+                }
               />
             );
           })()}


### PR DESCRIPTION
Follow-up to #10010. Closes the parity gap with the cluster INIT status tooltip.

<img width="2822" height="292" alt="image" src="https://github.com/user-attachments/assets/f25448d4-314d-430a-9579-a2d5f514f3b5" />

## Summary

- When a managed job is `PENDING`, hovering its status chip on the jobs list now shows the pending reason (queue wait, launch backoff, quota, etc.) in a tooltip, the same pattern clusters use for `INIT` (`statusTooltip` set in the data connector from the reason surfaced by #10010 via the `details` field).
- The job detail page status badge and the per-task table in job groups get the same tooltip.
- Non-PENDING statuses are unchanged (tooltip falls back to the status name as before).

## Test plan

Verified on a locally deployed API server (`sky api start` from this branch with the dashboard rebuilt), with consolidation mode enabled and PENDING managed jobs holding each `details` code path (freshly submitted "Job submitted to queue", a launch-backoff quota message, and schedule-state waiting):

- Jobs list: hovering the `PENDING` status chip shows the full reason in a tooltip for both the fresh-submit and backoff jobs (Playwright browser check asserting on the rendered tooltip element).
- Job detail page: hovering the status badge shows the same reason.
- Negative control: hovering a `FAILED_CONTROLLER` badge shows only the status name, no reason leak.
- `bash format.sh` passes (ESLint + prettier clean).

Manual verification: launch enough managed jobs to keep one in `PENDING` (or in launch backoff), open the dashboard jobs page, and hover the job's status chip; the tooltip should show the same text as the Details column/field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)