### PR TITLE
[Jobs] Fail jobs terminally when their pool no longer exists

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -590,6 +590,14 @@ class PortDoesNotExistError(Exception):
     """Raised when the port does not exist."""
 
 
+class PoolDoesNotExistError(Exception):
+    """Raised when the pool a managed job is bound to no longer exists.
+
+    This is unrecoverable for the job: it can never launch into the pool
+    again, so callers should fail the job instead of retrying.
+    """
+
+
 class UserRequestRejectedByPolicy(Exception):
     """Raised when a user request is rejected by an admin policy."""
     pass

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -551,6 +551,10 @@ class JobController:
                 2. The cluster is preempted or failed before the job is
                 submitted.
                 3. Any unexpected error happens during the `sky.launch`.
+            exceptions.PoolDoesNotExistError: This will be raised when the
+                pool the job is bound to no longer exists (e.g. the pool was
+                deleted while the job was running or recovering). This is
+                unrecoverable for the job.
         Other exceptions may be raised depending on the backend.
         """
         _add_k8s_annotations(task, self._job_id)
@@ -2172,6 +2176,19 @@ class JobController:
                         managed_job_state.ManagedJobStatus.FAILED_NO_RESOURCE,
                         failure_reason)
                     attempt_done = True
+                except exceptions.PoolDoesNotExistError as e:
+                    # The pool was deleted while the job was still bound to
+                    # it. The job can never launch into the pool again, so
+                    # mark it terminal with a clear reason instead of
+                    # retrying the launch forever.
+                    logger.error(f'Pool no longer exists for task {task_id}')
+                    failure_reason = common_utils.format_exception(e)
+                    logger.error(failure_reason)
+                    await self._update_failed_task_state(
+                        task_id,
+                        managed_job_state.ManagedJobStatus.FAILED_NO_RESOURCE,
+                        failure_reason)
+                    attempt_done = True
                 except exceptions.ClusterSetUpError as e:
                     # Raised by the launch path for a non-retryable setup
                     # failure, e.g. the job's pod was OOMKilled during
@@ -2573,9 +2590,20 @@ class ControllerManager:
                     if pool_cluster_name is not None:
                         cluster_name = pool_cluster_name
                         if job_id_on_pool_cluster is not None:
-                            core.cancel(cluster_name=cluster_name,
-                                        job_ids=[job_id_on_pool_cluster],
-                                        _try_cancel_if_cluster_is_init=True)
+                            try:
+                                core.cancel(cluster_name=cluster_name,
+                                            job_ids=[job_id_on_pool_cluster],
+                                            _try_cancel_if_cluster_is_init=True)
+                            except exceptions.ClusterDoesNotExist:
+                                # The pool worker is already gone (e.g. the
+                                # pool was torn down while the job was still
+                                # bound to it), so there is nothing to
+                                # cancel. Treat as cleaned up rather than
+                                # failing the job with a cleanup error.
+                                logger.info(
+                                    f'Pool worker {cluster_name} no longer '
+                                    'exists; skipping cancellation of the '
+                                    'pool submission.')
             except Exception as e:  # pylint: disable=broad-except
                 error = e
                 logger.warning(

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -815,6 +815,10 @@ class StrategyExecutor:
                 unavailability.
                 2. The cluster is preempted before the job is submitted.
                 3. Any unexpected error happens during the `sky.launch`.
+            exceptions.PoolDoesNotExistError: This will be raised when the
+                pool the job is bound to no longer exists. This is raised
+                regardless of raise_on_failure, since the launch can never
+                succeed and the job should be failed instead of retried.
         Other exceptions may be raised depending on the backend.
         """
         # On recovery, re-read the persisted DAG so an out-of-band priority
@@ -1077,6 +1081,14 @@ class StrategyExecutor:
                         # parked. Notably, this must not fall through to the
                         # teardown/backoff path below: the parked launch keeps
                         # its partially provisioned resources.
+                        raise
+                    except exceptions.PoolDoesNotExistError as e:
+                        # The pool was deleted while this job is still bound
+                        # to it. Launching can never succeed, so propagate
+                        # regardless of raise_on_failure to fail the job
+                        # instead of retrying forever.
+                        logger.error('The pool no longer exists: '
+                                     f'{common_utils.format_exception(e)}')
                         raise
                     except (exceptions.InvalidClusterNameError,
                             exceptions.NoCloudAccessError,

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1153,14 +1153,22 @@ def get_next_cluster_name(
 
     Returns:
         The cluster name if a suitable replica is found, None otherwise.
+
+    Raises:
+        exceptions.PoolDoesNotExistError: If the pool does not exist (e.g. it
+            was deleted while a job bound to it was still running). This is
+            unrecoverable for the calling job, unlike the None return which
+            means no worker is currently free.
     """
     # Check if service exists
     service_status = _get_service_status(service_name,
                                          pool=True,
                                          with_replica_info=False)
     if service_status is None:
-        logger.error(f'Service {service_name!r} does not exist.')
-        return None
+        logger.error(f'Pool {service_name!r} does not exist.')
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.PoolDoesNotExistError(
+                f'Pool {service_name!r} does not exist.')
     if not service_status['pool']:
         logger.error(f'Service {service_name!r} is not a pool.')
         return None

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -62,6 +62,33 @@ def test_task_fits():
     assert serve_utils._task_fits(task_resources, free_resources) is False
 
 
+class TestGetNextClusterName:
+    """Tests for serve_utils.get_next_cluster_name pool-existence handling.
+
+    A missing pool is unrecoverable for the calling job and must raise
+    PoolDoesNotExistError, while a pool with no free worker is a transient
+    condition and must keep returning None (the caller retries).
+    """
+
+    def test_pool_missing_raises(self, monkeypatch):
+        from sky import exceptions
+
+        monkeypatch.setattr(serve_utils, '_get_service_status',
+                            lambda *args, **kwargs: None)
+        with pytest.raises(exceptions.PoolDoesNotExistError):
+            serve_utils.get_next_cluster_name('missing-pool', job_id=1)
+
+    def test_no_free_worker_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(serve_utils, '_get_service_status',
+                            lambda *args, **kwargs: {'pool': True})
+        monkeypatch.setattr(serve_utils, 'get_service_filelock_path',
+                            lambda name: str(tmp_path / f'{name}.lock'))
+        monkeypatch.setattr(serve_utils, 'get_free_worker_resources',
+                            lambda name: {})
+        monkeypatch.setattr(serve_utils, 'get_ready_replicas', lambda name: [])
+        assert serve_utils.get_next_cluster_name('busy-pool', job_id=1) is None
+
+
 def test_serve_preemption_skips_autostopping():
     """Verify serve preemption logic treats AUTOSTOPPING like UP (not preempted)."""
     from sky.utils import status_lib


### PR DESCRIPTION
## Summary

- When a pool is deleted while a managed job is still bound to it, recovery can never succeed, but the jobs controller retried forever at ~1 attempt/second, flipping the job between STARTING/RECOVERING and PENDING indefinitely (observed in production as ~490k retries over 5.7 days and a 4.2M-line controller log). Root cause: `serve_utils.get_next_cluster_name()` returns `None` both for "no free worker right now" (transient) and "pool does not exist" (permanent), and the resulting `NoClusterLaunchedError` lands in `_launch`'s broad transient-retry handler, which uses a hardcoded 1s backoff for pools; `recover()`'s unbounded `while True` never gives up, so no terminal state is ever set.
- Fix: add `exceptions.PoolDoesNotExistError`, raised by `get_next_cluster_name()` when the pool record is gone (returning `None` still means "no free worker, retry"). `_launch` re-raises it regardless of `raise_on_failure`, and the jobs controller maps it to `FAILED_NO_RESOURCE` with the exception text as `failure_reason`.
- Also treat `ClusterDoesNotExist` as already-cleaned-up when cancelling the pool submission during job cleanup, so the terminal state is not overwritten by a bogus `FAILED_CONTROLLER` ("Failed to clean up, resources may have leaked") when the pool worker is already gone.

## Test plan

Reproduced and verified on a local API server (consolidation mode, Kubernetes infra):

1. `sky jobs pool apply -p p1 <1-CPU pool yaml>`; `sky jobs launch --pool p1 'sleep 1000000'`; wait for RUNNING.
2. Simulate the pool record vanishing under the bound job (the state a production job got into): delete the pool's `services` row, then delete the worker pod to force recovery.
3. Before this change: the job flips PENDING/RECOVERING at ~1/s forever; the controller log repeats `Service 'p1' does not exist.` / `NoClusterLaunchedError: No cluster name found in the pool.` / `Retrying to launch the cluster in 1.0 seconds.` (117 retries in the first few minutes). Cancelling the job then ends it as `FAILED_CONTROLLER` with `Failed to clean up ... ClusterDoesNotExist: Cluster 'p1-1' does not exist.`
4. After this change: the job goes terminal in under 2 minutes as `FAILED_NO_RESOURCE` with `failure_reason: sky.exceptions.PoolDoesNotExistError: Pool 'p1' does not exist.`; the controller log shows zero launch retries and `Pool worker p1-1 no longer exists; skipping cancellation of the pool submission.`

Unit tests: added `TestGetNextClusterName` to `tests/unit_tests/test_serve_utils.py` covering pool-missing (raises) vs no-free-worker (returns None); full file passes (43 passed). `format.sh` clean, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)