### PR TITLE
[Kubernetes] OCI network_tier=best: GB200/GB300 NCCL profiles

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -892,8 +892,9 @@ class Kubernetes(clouds.Cloud):
             if clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER \
                     not in unsupported_features:
                 # Add high-performance networking environment variables for
-                # clusters with high performance networking
-                network_env_vars = network_type.get_network_env_vars()
+                # clusters with high performance networking. Pass acc_type so
+                # OCI can pick a shape-specific NCCL profile (e.g. GB200).
+                network_env_vars = network_type.get_network_env_vars(acc_type)
                 k8s_env_vars.update(network_env_vars)
 
         # We specify object-store-memory to be 500MB to avoid taking up too

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -117,8 +117,14 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
     OCI_ROCE = 'oci_roce'
     NONE = 'none'
 
-    def get_network_env_vars(self) -> Dict[str, str]:
-        """Get network environment variables for this cluster type."""
+    def get_network_env_vars(self,
+                             acc_type: Optional[str] = None) -> Dict[str, str]:
+        """Get network environment variables for this cluster type.
+
+        Args:
+            acc_type: The canonical accelerator type requested (e.g. 'GB200').
+                Used by OCI to pick a shape-specific NCCL profile.
+        """
         if self == KubernetesHighPerformanceNetworkType.NEBIUS:
             # Nebius cluster with InfiniBand - use InfiniBand optimizations
             return {
@@ -146,12 +152,66 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
                 'FI_PROVIDER': 'efa',
             }
         elif self == KubernetesHighPerformanceNetworkType.OCI_ROCE:
-            # OCI bare-metal GPU shapes (BM.GPU.*.8) use RoCEv2 over
-            # Mellanox ConnectX. Values per oracle-quickstart/oci-hpc-oke
-            # NCCL reference manifests. Per-shape exact HCA lists give
-            # marginally better perf; the broad 'mlx5' prefix match here
-            # works on all shapes. Users can override via task `envs:`.
+            # OCI bare-metal GPU shapes use RDMA for multi-node NCCL. Values
+            # mirror the oracle-quickstart/oci-hpc-oke NCCL reference params
+            # (the same recommended values OCI's stack bakes into its
+            # `oci-nccl-parameters-<shape>` configmaps). Users can override
+            # any of these via task `envs:`.
             # Refer to the examples https://github.com/oracle-quickstart/oci-hpc-oke/tree/main/manifests/nccl-tests/kueue for more details. # pylint: disable=line-too-long
+            acc = (acc_type or '').upper()
+            if acc == 'GB200':
+                # GB200 NVL72 runs Quantum-2 InfiniBand plus rack-scale
+                # multi-node NVLink (MNNVL) and NVLink SHARP (NVLS) -- a
+                # distinct profile from the RoCEv2 shapes below. It drops the
+                # RoCE-only DSCP/GID/UCX knobs and turns on MNNVL/NVLS/cumem.
+                # The HCA list is the exact set OCI validated for BM.GPU.GB200.4.
+                logger.info('OCI network_tier=best: using GB200 NCCL profile '
+                            '(MNNVL/NVLS).')
+                return {
+                    'NCCL_DEBUG': 'WARN',
+                    # Multi-node NVLink across the NVL72 rack.
+                    'NCCL_MNNVL_ENABLE': '1',
+                    # Required for MNNVL to work.
+                    'NCCL_CUMEM_ENABLE': '1',
+                    'NCCL_NET_PLUGIN': 'sys',
+                    'NCCL_IB_HCA': 'mlx5_0,mlx5_1,mlx5_3,mlx5_4',
+                    # NVLink SHARP in-network reductions.
+                    'NCCL_NVLS_ENABLE': '1',
+                    'NCCL_SOCKET_IFNAME': 'eth0',
+                }
+            if acc == 'GB300':
+                # GB300 NVL72 is MNNVL/NVLS like GB200 but keeps the RoCE IB
+                # tuning knobs and disables the net plugin (NET_PLUGIN=none).
+                # Values per OCI's BM.GPU.GB300.4 reference set. The leading
+                # '=' in NCCL_IB_HCA is NCCL's exact-name-match prefix, not a
+                # typo -- keep it.
+                logger.info('OCI network_tier=best: using GB300 NCCL profile '
+                            '(MNNVL/NVLS).')
+                return {
+                    'NCCL_DEBUG': 'WARN',
+                    'NCCL_MNNVL_ENABLE': '1',
+                    'NCCL_CUMEM_ENABLE': '1',
+                    'NCCL_NET_PLUGIN': 'none',
+                    'NCCL_IB_HCA': ('=mlx5_0,mlx5_1,mlx5_2,mlx5_3,'
+                                    'mlx5_5,mlx5_6,mlx5_7,mlx5_8'),
+                    'NCCL_NVLS_ENABLE': '1',
+                    'NCCL_SOCKET_IFNAME': 'eth0',
+                    # GPU-to-CPU (C2C) GPUDirect over the Grace link.
+                    'NCCL_NET_GDR_C2C': '1',
+                    'NCCL_IB_GID_INDEX': '3',
+                    'NCCL_IB_TC': '41',
+                    'NCCL_IB_SL': '0',
+                    'NCCL_IB_TIMEOUT': '22',
+                    'NCCL_BUFFSIZE': '16777216',
+                    'NCCL_IB_QPS_PER_CONNECTION': '4',
+                    'NCCL_IB_SPLIT_DATA_ON_QPS': '0',
+                    'NCCL_DMABUF_ENABLE': '1',
+                }
+            # RoCEv2 shapes (H100/H200/B200). The broad 'mlx5' prefix match
+            # works across shapes; per-shape exact HCA lists give marginally
+            # better perf (tracked as a follow-up).
+            logger.info('OCI network_tier=best: using default RoCE NCCL '
+                        f'profile (acc_type={acc_type!r}).')
             return {
                 'NCCL_IB_HCA': 'mlx5',
                 # RoCEv2 GID index. Fixed on OCI's bare-metal GPU images.

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5399,3 +5399,79 @@ def test_get_node_accelerator_count_multiple_families_no_crash():
 
 def test_get_handled_taint_keys_includes_neuron():
     assert utils.NEURON_RESOURCE_KEY in utils.get_handled_taint_keys()
+
+
+class TestOCINetworkEnvVars:
+    """OCI network_tier: best NCCL env-var injection per GPU shape."""
+
+    _NET = utils.KubernetesHighPerformanceNetworkType.OCI_ROCE
+
+    def test_gb200_profile(self):
+        """GB200 gets the MNNVL/NVLS InfiniBand profile, not RoCEv2."""
+        env = self._NET.get_network_env_vars('GB200')
+        # The rack-scale NVLink knobs that make GB200 distinct.
+        assert env['NCCL_MNNVL_ENABLE'] == '1'
+        assert env['NCCL_NVLS_ENABLE'] == '1'
+        assert env['NCCL_NET_PLUGIN'] == 'sys'
+        assert env['NCCL_CUMEM_ENABLE'] == '1'
+        assert env['NCCL_IB_HCA'] == 'mlx5_0,mlx5_1,mlx5_3,mlx5_4'
+        assert env['NCCL_SOCKET_IFNAME'] == 'eth0'
+
+    def test_gb200_is_replacement_not_union(self):
+        """GB200 must drop the RoCEv2-only knobs, not merge them in.
+
+        The official OCI GB200 configmap omits DSCP/GID/UCX; folding the
+        RoCE defaults in would inject values OCI does not ship for GB200.
+        """
+        env = self._NET.get_network_env_vars('GB200')
+        for absent in ('NCCL_IB_GID_INDEX', 'NCCL_IB_TC', 'UCX_TLS',
+                       'UCX_NET_DEVICES'):
+            assert absent not in env, absent
+
+    def test_gb200_case_insensitive(self):
+        env = self._NET.get_network_env_vars('gb200')
+        assert env['NCCL_MNNVL_ENABLE'] == '1'
+
+    def test_gb300_profile(self):
+        """GB300 is MNNVL/NVLS but keeps IB tuning and NET_PLUGIN=none."""
+        env = self._NET.get_network_env_vars('GB300')
+        assert env['NCCL_MNNVL_ENABLE'] == '1'
+        assert env['NCCL_NVLS_ENABLE'] == '1'
+        assert env['NCCL_NET_PLUGIN'] == 'none'
+        # Leading '=' is NCCL's exact-name-match prefix; must be preserved.
+        assert env['NCCL_IB_HCA'] == ('=mlx5_0,mlx5_1,mlx5_2,mlx5_3,'
+                                      'mlx5_5,mlx5_6,mlx5_7,mlx5_8')
+        # GB300-specific knobs absent from GB200.
+        assert env['NCCL_NET_GDR_C2C'] == '1'
+        assert env['NCCL_DMABUF_ENABLE'] == '1'
+        assert env['NCCL_IB_TIMEOUT'] == '22'
+
+    def test_gb200_and_gb300_are_distinct(self):
+        """The two GB profiles must not be identical (NET_PLUGIN differs)."""
+        gb200 = self._NET.get_network_env_vars('GB200')
+        gb300 = self._NET.get_network_env_vars('GB300')
+        assert gb200 != gb300
+        assert gb200['NCCL_NET_PLUGIN'] == 'sys'
+        assert gb300['NCCL_NET_PLUGIN'] == 'none'
+
+    def test_default_roce_profile_for_other_shapes(self):
+        """H100/None fall back to the existing RoCEv2 profile unchanged."""
+        expected = {
+            'NCCL_IB_HCA': 'mlx5',
+            'NCCL_IB_GID_INDEX': '3',
+            'NCCL_IB_TC': '41',
+            'NCCL_SOCKET_IFNAME': 'eth0',
+            'UCX_TLS': 'tcp',
+            'UCX_NET_DEVICES': 'eth0',
+        }
+        assert self._NET.get_network_env_vars('H100') == expected
+        assert self._NET.get_network_env_vars(None) == expected
+        # GB200/GB300 must NOT return the default RoCE profile.
+        assert self._NET.get_network_env_vars('GB200') != expected
+        assert self._NET.get_network_env_vars('GB300') != expected
+
+    def test_non_oci_types_ignore_acc_type(self):
+        """acc_type only affects OCI; other types return their fixed dict."""
+        coreweave = utils.KubernetesHighPerformanceNetworkType.COREWEAVE
+        assert (coreweave.get_network_env_vars('GB200') ==
+                coreweave.get_network_env_vars(None))


### PR DESCRIPTION
## Summary

`network_tier: best` on OCI injected a single RoCEv2 NCCL env profile for every OCI bare-metal GPU shape. GB200/GB300 NVL72 run Quantum-2 InfiniBand with rack-scale multi-node NVLink (MNNVL) and NVLink SHARP (NVLS), which need a different NCCL env set than the RoCEv2 shapes. This selects the profile by accelerator type inside the OCI branch:

- **GB200**: `NCCL_MNNVL_ENABLE`/`NCCL_NVLS_ENABLE`/`NCCL_CUMEM_ENABLE=1` + `NCCL_NET_PLUGIN=sys` + exact 4-HCA list; drops the RoCE-only DSCP/GID/UCX knobs.
- **GB300**: MNNVL/NVLS + `NCCL_NET_PLUGIN=none` + 8-HCA (exact-name-match) plus IB tuning knobs and GDR C2C / DMABUF.
- **All other shapes (H100/H200/B200)**: unchanged RoCEv2 profile.

Values mirror the [oracle-quickstart/oci-hpc-oke](https://github.com/oracle-quickstart/oci-hpc-oke/blob/main/docs/recommended-nccl-rccl-parameters-by-shape.md) recommended NCCL params — the same values OCI's stack bakes into its per-shape `oci-nccl-parameters-<shape>` configmaps. Users can still override any of these via task `envs:` (which are exported into the workload process on top of the pod env). The selected profile is logged so a shape mismatch is diagnosable instead of silently degrading to the default RoCE profile.

## Test plan

- Added `TestOCINetworkEnvVars` in `tests/unit_tests/kubernetes/test_kubernetes_utils.py` (7 cases): GB200 profile; GB200 is a replacement not a union (asserts RoCE-only keys absent); GB300 profile incl. preserved leading `=` on `NCCL_IB_HCA`; GB200 vs GB300 distinct; default RoCE regression for H100/None; case-insensitivity; non-OCI network types ignore `acc_type`.
  ```
  pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py::TestOCINetworkEnvVars
  # 7 passed
  ```
- Revert check: reverting the GB200/GB300 branches makes the profile assertions fail (KeyError on `NCCL_MNNVL_ENABLE`, RoCE keys present).

### Follow-ups (not in this PR)
- Align the default RoCE profile (H100/H200/B200) with OCI's per-shape recommended params (missing `NCCL_IB_TIMEOUT`/`NCCL_IB_SL`/`NCCL_IB_SPLIT_DATA_ON_QPS`/`NCCL_CUMEM_ENABLE=0`, exact per-shape HCA lists) — needs regression testing against live OCI RoCE clusters.
- GB300 has no live cluster to validate against yet; confirm the node label resolves to canonical `GB300` and run a multi-node NCCL check when one is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)