### PR TITLE
[Test] Poll for async volume/PVC deletion in test_volumes_on_kubernetes

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -221,6 +221,33 @@ def get_cmd_wait_until_cluster_is_not_found(cluster_name: str, timeout: int):
                                                    timeout=timeout)
 
 
+_WAIT_UNTIL_VOLUME_IS_NOT_FOUND = (
+    # A while loop to wait until a volume no longer appears in
+    # `sky volumes ls`, or timeout. `sky volumes delete` tears down the backing
+    # storage asynchronously, so a single `sky volumes ls` right after the
+    # delete can still list the volume; poll instead of checking once.
+    'start_time=$SECONDS; '
+    'while true; do '
+    'vols=$(sky volumes ls); '
+    'if ! echo "$vols" | grep -q "{volume_name}"; then '
+    '  echo "Volume {volume_name} successfully removed."; break; '
+    'fi; '
+    'if (( $SECONDS - $start_time > {timeout} )); then '
+    '  echo "$vols"; '
+    '  echo "Timeout after {timeout} seconds waiting for volume '
+    '{volume_name} to be removed"; exit 1; '
+    'fi; '
+    'echo "Waiting for volume {volume_name} to be removed..."; '
+    'sleep 5; '
+    'done')
+
+
+def get_cmd_wait_until_volume_is_not_found(volume_name: str,
+                                           timeout: int = 120):
+    return _WAIT_UNTIL_VOLUME_IS_NOT_FOUND.format(volume_name=volume_name,
+                                                  timeout=timeout)
+
+
 _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID = (
     # A while loop to wait until the job status
     # contains certain status, with timeout.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1423,7 +1423,9 @@ def test_volumes_on_kubernetes():
                 'while [ $SECONDS -lt $end ]; do '
                 'if kubectl get pvc existing0; then exit 0; fi; '
                 'sleep 1; '
-                'done; exit 1'),
+                'done; '
+                'echo "Timeout waiting for PVC existing0 to appear"; '
+                'kubectl get pvc; exit 1'),
             f'sky volumes apply -y -n pvc0 --type k8s-pvc --size 2GB',
             f'sky volumes apply -y -n existing0 --type k8s-pvc --size 2GB --use-existing',
             f'sky volumes apply -y -n vol-existing1 --type k8s-pvc --size 2GB --use-existing',
@@ -1441,20 +1443,38 @@ def test_volumes_on_kubernetes():
             f'sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume_with_new.yaml --env HAVE_SUB_DIR=true --env NEW_LAUNCH=true',
             f'sky logs {name} 1 --status',  # Ensure the first job on the new cluster succeeded.
             f'sky down -y {name} && sky volumes ls && sky volumes delete pvc0 existing0 pvc1 vol-existing1 -y',
-            f'vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "pvc0"); if [ -n "$vol" ]; then echo "pvc0 not deleted" && exit 1; else echo "pvc0 deleted"; fi',
-            f'vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "existing0"); if [ -n "$vol" ]; then echo "existing0 not deleted" && exit 1; else echo "existing0 deleted"; fi',
-            f'vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "pvc1"); if [ -n "$vol" ]; then echo "pvc1 not deleted" && exit 1; else echo "pvc1 deleted"; fi',
-            f'vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "vol-existing1"); if [ -n "$vol" ]; then echo "vol-existing1 not deleted" && exit 1; else echo "vol-existing1 deleted"; fi',
-            f'vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "{name}"); if [ -n "$vol" ]; then echo "ephemeral volume for cluster {name} not deleted" && exit 1; else echo "ephemeral volume for cluster {name} deleted"; fi',
+            # Volume deletion is asynchronous, so poll until each deleted
+            # volume disappears from `sky volumes ls` instead of checking once.
+            smoke_tests_utils.get_cmd_wait_until_volume_is_not_found('pvc0'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_not_found(
+                'existing0'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_not_found('pvc1'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_not_found(
+                'vol-existing1'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_not_found(name),
             smoke_tests_utils.run_cloud_cmd_on_cluster(
                 name,
-                'pvcs=$(kubectl get pvc) && echo "$pvcs" && pvc=$(echo "$pvcs" | grep "pvc0"); if [ -n "$pvc" ]; then echo "pvc for volume pvc0 not deleted" && exit 1; else echo "pvc for volume pvc0 deleted"; fi && '
+                # PVC teardown for deleted volumes is asynchronous, so poll
+                # until the PVCs backing the deleted volumes disappear before
+                # asserting. The PVCs backing imported (use_existing) volumes
+                # must be preserved.
+                'end=$((SECONDS+120)); '
+                'while [ $SECONDS -lt $end ]; do '
+                'pvcs=$(kubectl get pvc); echo "$pvcs"; '
+                'if ! echo "$pvcs" | grep -q "pvc0" && '
+                '! echo "$pvcs" | grep -q "pvc1" && '
+                f'! echo "$pvcs" | grep -q "{name}"; then break; fi; '
+                'echo "Waiting for deleted volume PVCs to be removed..."; '
+                'sleep 5; '
+                'done && '
+                'pvcs=$(kubectl get pvc) && echo "$pvcs" && '
+                'if echo "$pvcs" | grep -q "pvc0"; then echo "pvc for volume pvc0 not deleted" && exit 1; else echo "pvc for volume pvc0 deleted"; fi && '
+                'if echo "$pvcs" | grep -q "pvc1"; then echo "pvc for volume pvc1 not deleted" && exit 1; else echo "pvc for volume pvc1 deleted"; fi && '
+                f'if echo "$pvcs" | grep -q "{name}"; then echo "pvc for ephemeral volume of cluster {name} not deleted" && exit 1; else echo "pvc for ephemeral volume of cluster {name} deleted"; fi && '
                 # existing0 was imported with use_existing=True; the underlying PVC is preserved on delete.
-                'pvc=$(echo "$pvcs" | grep "existing0"); if [ -z "$pvc" ]; then echo "pvc for imported volume existing0 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume existing0 preserved"; fi && '
-                'pvc=$(echo "$pvcs" | grep "pvc1"); if [ -n "$pvc" ]; then echo "pvc for volume pvc1 not deleted" && exit 1; else echo "pvc for volume pvc1 deleted"; fi && '
+                'if ! echo "$pvcs" | grep -q "existing0"; then echo "pvc for imported volume existing0 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume existing0 preserved"; fi && '
                 # vol-existing1 wraps an imported PVC named "existing1" (matched by label); that PVC is preserved on delete.
-                'pvc=$(echo "$pvcs" | grep "existing1"); if [ -z "$pvc" ]; then echo "pvc for imported volume vol-existing1 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume vol-existing1 preserved"; fi && '
-                f'pvc=$(echo "$pvcs" | grep "{name}"); if [ -n "$pvc" ]; then echo "pvc for ephemeral volume of cluster {name} not deleted" && exit 1; else echo "pvc for ephemeral volume of cluster {name} deleted"; fi',
+                'if ! echo "$pvcs" | grep -q "existing1"; then echo "pvc for imported volume vol-existing1 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume vol-existing1 preserved"; fi',
             ),
         ],
         f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)} && vols=$(sky volumes ls) && echo "$vols" && vol=$(echo "$vols" | grep "existing0"); if [ -n "$vol" ]; then sky volumes delete existing0 -y; fi && vol=$(echo "$vols" | grep "pvc0"); if [ -n "$vol" ]; then sky volumes delete pvc0 -y; fi && vol=$(echo "$vols" | grep "pvc1"); if [ -n "$vol" ]; then sky volumes delete pvc1 -y; fi && vol=$(echo "$vols" | grep "vol-existing1"); if [ -n "$vol" ]; then sky volumes delete vol-existing1 -y; fi',


### PR DESCRIPTION
## Problem

`test_volumes_on_kubernetes` verifies the post-delete state of the volumes and their backing PVCs with a **single** `sky volumes ls` / `kubectl get pvc` run **immediately** after `sky volumes delete`:

```python
f'... sky volumes delete pvc0 existing0 pvc1 vol-existing1 -y',
f'vols=$(sky volumes ls) && ... grep "pvc0"; if [ -n "$vol" ]; then echo "pvc0 not deleted" && exit 1; ...',
# ... one check per volume, then a single `kubectl get pvc` check
```

Volume and PVC teardown is **asynchronous**, so on a slower/busier cluster the listing can still show a just-deleted resource at the instant of the check, failing the test spuriously (e.g. `pvc0 not deleted`). This is a check-once-after-async-op race in the test itself, not a product bug.

## Fix

Poll until each deleted volume/PVC disappears, bounded by a timeout, instead of checking exactly once:

- New `get_cmd_wait_until_volume_is_not_found(volume_name, timeout=120)` helper in `smoke_tests_utils.py`, mirroring the existing `get_cmd_wait_until_cluster_is_not_found`, used for the five `sky volumes ls` deletion checks.
- The `kubectl get pvc` check now polls for the deleted PVCs (`pvc0`, `pvc1`, ephemeral) to disappear, then asserts that the imported (`use_existing`) PVCs (`existing0`, `existing1`) are still preserved. Assertion semantics are unchanged.
- When the pre-existing "wait for PVC `existing0` to appear" loop times out, it now dumps `kubectl get pvc` before exiting so the failure is diagnosable (previously it exited silently).

No change to product code and no new dependencies; this only makes the test tolerant of asynchronous deletion latency.

## Test

- `yapf`, `isort`, `mypy` pre-commit hooks pass.
- Logic verified by rendering the generated shell and running `bash -n` on it; the polling loops fall through to the original hard assertions on timeout, so a genuinely-undeleted volume still fails the test.