### PR TITLE
[Dashboard] Fix top-bar logo vertical alignment

### DIFF
--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -513,7 +513,7 @@ export function TopBar() {
 
             <Link
               href="/"
-              className="flex items-center px-1 pt-1 h-full"
+              className="flex items-center px-1 h-full"
               prefetch={false}
             >
               <div className={`h-20 w-20 flex items-center justify-center`}>


### PR DESCRIPTION
## Summary

The SkyPilot logo in the dashboard top bar sits a couple of pixels lower than the adjacent nav links. The logo's `<Link>` carries the same `pt-1` top padding as the nav links, but the nav links offset that padding with their `border-b-2` active-underline — the logo has no bottom border, so the padding just pushes it down and it no longer lines up with the nav items.

This removes the `pt-1` from the logo link so it centers within the header via `items-center`, matching the nav items. No size change; the `skypilot.svg` asset is untouched.

## Test plan

- Built the dashboard (`npm run build`) and loaded the top bar.
- Verified the logo now centers on the same line as the Clusters / Jobs / Volumes links (previously ~2–3px low).