### PR TITLE
[Dashboard] Restyle the YAML editor's search panel

### DIFF
--- a/sky/dashboard/src/components/ui/yaml-code-block.jsx
+++ b/sky/dashboard/src/components/ui/yaml-code-block.jsx
@@ -11,6 +11,8 @@ import {
   yamlHighlightStyle,
   yamlGutterTheme,
   yamlTextCursorTheme,
+  yamlSearchPanelTheme,
+  yamlSearchTop,
 } from './yaml-editor';
 
 // In read-only mode, suppress CodeMirror's drawn caret so the viewer
@@ -48,6 +50,8 @@ export function YamlCodeBlock({
         extensions={[
           yaml(),
           yamlGutterTheme,
+          yamlSearchPanelTheme,
+          Prec.high(yamlSearchTop),
           ...(readOnly ? [hideCaretTheme] : [yamlTextCursorTheme]),
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),

--- a/sky/dashboard/src/components/ui/yaml-editor.jsx
+++ b/sky/dashboard/src/components/ui/yaml-editor.jsx
@@ -6,8 +6,13 @@ import { EditorView } from '@codemirror/view';
 import { Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { search } from '@codemirror/search';
 import { tags as t } from '@lezer/highlight';
 import { getNonce } from '@/utils/csp';
+
+// Dock the search panel at the top of the editor (like the browser's find bar
+// and most code editors) instead of CodeMirror's default bottom placement.
+export const yamlSearchTop = search({ top: true });
 
 export const yamlHighlightStyle = HighlightStyle.define([
   { tag: t.propertyName, color: '#1E62CC' },
@@ -50,6 +55,140 @@ export const yamlGutterTheme = EditorView.theme({
   },
 });
 
+// Cmd/Ctrl+F opens CodeMirror's built-in search panel (provided by basicSetup's
+// search keymap). We keep that panel and its behavior exactly — Find, next /
+// previous / all, and the match-case / regexp / by-word toggles — and only
+// restyle it so it doesn't look dated, plus hide the replace controls (the YAML
+// editor is find-only). Match highlights are also colored to match the UI.
+export const yamlSearchPanelTheme = EditorView.theme({
+  '.cm-panels': {
+    backgroundColor: '#ffffff',
+    color: '#374151',
+  },
+  '.cm-panels.cm-panels-bottom': {
+    borderTop: '1px solid #e5e7eb',
+  },
+  '.cm-panels.cm-panels-top': {
+    borderBottom: '1px solid #e5e7eb',
+  },
+  '.cm-panel.cm-search': {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '6px',
+    // Right padding leaves room for the absolutely-positioned close button.
+    padding: '8px 34px 8px 10px',
+    fontSize: '13px',
+    fontFamily: 'inherit',
+  },
+  // Find-only: hide CodeMirror's built-in replace row. Selectors include
+  // `.cm-textfield` / `.cm-button` so they outrank the styling rules below
+  // (same base specificity) and actually win.
+  '.cm-panel.cm-search br': { display: 'none' },
+  '.cm-panel.cm-search input.cm-textfield[name="replace"]': {
+    display: 'none',
+  },
+  '.cm-panel.cm-search button.cm-button[name="replace"]': { display: 'none' },
+  '.cm-panel.cm-search button.cm-button[name="replaceAll"]': {
+    display: 'none',
+  },
+  // A shared 30px control height keeps the field, buttons and checkboxes on one
+  // baseline so the row reads as vertically centered.
+  '.cm-panel.cm-search input.cm-textfield': {
+    height: '30px',
+    boxSizing: 'border-box',
+    margin: '0',
+    border: '1px solid hsl(var(--input))',
+    borderRadius: 'calc(var(--radius) - 2px)',
+    padding: '0 10px',
+    fontSize: '13px',
+    backgroundColor: '#ffffff',
+    outline: 'none',
+  },
+  // Subtle focus that hugs the field at its own radius (no offset ring): a soft
+  // neutral halo plus a slightly darker border, derived from the --ring token —
+  // not a heavy black ring, not a custom colour.
+  '.cm-panel.cm-search input.cm-textfield:focus-visible': {
+    borderColor: 'hsl(var(--ring) / 0.4)',
+    boxShadow: '0 0 0 3px hsl(var(--ring) / 0.12)',
+  },
+  '.cm-panel.cm-search button.cm-button': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '30px',
+    boxSizing: 'border-box',
+    margin: '0',
+    backgroundImage: 'none',
+    backgroundColor: '#ffffff',
+    border: '1px solid hsl(var(--input))',
+    borderRadius: 'calc(var(--radius) - 2px)',
+    color: '#374151',
+    padding: '0 12px',
+    fontSize: '13px',
+    lineHeight: '1',
+    cursor: 'pointer',
+  },
+  '.cm-panel.cm-search button.cm-button:hover': {
+    backgroundColor: '#f3f4f6',
+  },
+  '.cm-panel.cm-search button.cm-button:active': {
+    backgroundImage: 'none',
+    backgroundColor: '#e5e7eb',
+  },
+  '.cm-panel.cm-search button.cm-button:focus-visible': {
+    outline: 'none',
+    borderColor: 'hsl(var(--ring) / 0.4)',
+    boxShadow: '0 0 0 3px hsl(var(--ring) / 0.12)',
+  },
+  // Extra left margin gives the three checkbox toggles room to breathe, both
+  // from the buttons and from each other.
+  '.cm-panel.cm-search label': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '5px',
+    height: '30px',
+    margin: '0 0 0 8px',
+    fontSize: '13px',
+    color: '#4b5563',
+    cursor: 'pointer',
+  },
+  '.cm-panel.cm-search label input[type="checkbox"]': {
+    width: '15px',
+    height: '15px',
+    margin: '0',
+    accentColor: '#2563eb',
+    cursor: 'pointer',
+  },
+  '.cm-panel.cm-search button[name="close"]': {
+    position: 'absolute',
+    top: '50%',
+    right: '8px',
+    transform: 'translateY(-50%)',
+    margin: '0',
+    padding: '2px 6px',
+    backgroundColor: 'transparent',
+    backgroundImage: 'none',
+    border: 'none',
+    color: '#9ca3af',
+    fontSize: '18px',
+    lineHeight: '1',
+    cursor: 'pointer',
+  },
+  '.cm-panel.cm-search button[name="close"]:hover': {
+    color: '#374151',
+    backgroundColor: 'transparent',
+  },
+  '.cm-searchMatch': {
+    backgroundColor: 'rgba(250, 204, 21, 0.35)',
+    borderRadius: '2px',
+  },
+  '.cm-searchMatch.cm-searchMatch-selected': {
+    backgroundColor: 'rgba(59, 130, 246, 0.4)',
+  },
+});
+
 /**
  * YAML Editor component with syntax highlighting.
  * Drop-in replacement for Textarea when editing YAML content.
@@ -82,6 +221,8 @@ export function YamlEditor({
           yaml(),
           yamlGutterTheme,
           yamlTextCursorTheme,
+          yamlSearchPanelTheme,
+          Prec.high(yamlSearchTop),
           Prec.highest(syntaxHighlighting(yamlHighlightStyle)),
           // Pass CSP nonce so CodeMirror's injected <style> tags are allowed.
           ...(getNonce() ? [EditorView.cspNonce.of(getNonce())] : []),


### PR DESCRIPTION
## Summary

Cmd/Ctrl+F in the YAML editor and the read-only YAML viewer opens CodeMirror's built-in search panel, whose default base theme looks dated next to the rest of the dashboard.

This keeps the panel's behavior and controls exactly as-is — Find, next / previous / all, and the match-case / regexp / by-word toggles — and only restyles it to match the app:

- Docks the panel at the **top** of the editor (like the browser find bar and most editors) instead of the default bottom placement.
- Uses the app's design tokens for the field and buttons — border (`--input`), radius (`--radius`), and a subtle focus ring (`--ring`) — instead of ad-hoc colors, so it matches other inputs.
- Gives the field, buttons, and checkbox labels a shared control height and consistent spacing so the row reads as aligned.
- Hides the replace controls: the YAML editor is find-only (the read-only viewer already omits them).
- Colors the in-document search-match highlights to match the UI.

No behavior change — the built-in search keymap and all of its controls are untouched.

## Test plan

- `npm run lint` and `prettier --check` pass on the changed files.
- Ran the dashboard locally and opened Cmd/Ctrl+F in an editable YAML editor and the read-only viewer: the panel renders at the top, controls are aligned, the focus state matches other inputs, replace is not shown, and search behavior (typing highlights matches; next/previous/all; match case/regexp/by word; Esc to close) is unchanged.