### PR TITLE
[Server] Park launch as WAITING on cluster lock contention instead of blocking a worker

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -263,6 +263,14 @@ def _format_provision_failure_blocks(
 # Number of seconds to wait locking the cluster before communicating with user.
 _CLUSTER_LOCK_TIMEOUT = 5.0
 
+# When a provision request cannot get the cluster lock within
+# _CLUSTER_LOCK_TIMEOUT and runs on an API server executor, it is parked as
+# WAITING (releasing the executor worker) until the lock is observed to be
+# acquirable, instead of holding the worker blocked on the lock for the whole
+# duration of the conflicting operation. This gap is the fallback reschedule
+# backoff when waiting on the lock condition fails (e.g. a database glitch).
+_CLUSTER_LOCK_RETRY_GAP_SECONDS = 30
+
 
 def _is_message_too_long(returncode: int,
                          output: Optional[str] = None,
@@ -3304,6 +3312,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 (e.g., cluster name invalid) or a region/zone throwing
                 resource unavailability.
             exceptions.CommandError: any ssh command error.
+            exceptions.ExecutionPausedError: when running on an API server
+                executor worker and the cluster lock is held by another
+                operation: the request is parked as WAITING (releasing the
+                worker) and re-enqueued once the lock is observed to be
+                acquirable, instead of blocking on the lock.
             RuntimeError: raised when 'rsync' is not installed.
             # TODO(zhwu): complete the list of exceptions.
         """
@@ -3326,7 +3339,27 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                               retry_until_up,
                                               skip_unnecessary_provisioning,
                                               resize)
-            except locks.LockTimeout:
+            except locks.LockTimeout as e:
+                # When running a server request that the scheduler can park and
+                # resume, release the worker instead of holding it blocked on
+                # the cluster lock: raising ExecutionPausedError marks the
+                # request WAITING and re-enqueues it once the attached
+                # condition observes the lock to be acquirable. Launches issued
+                # by the jobs controller in-process do not go through the
+                # request scheduler, so they keep the blocking behavior.
+                if (common_utils.is_in_request_context() and
+                        not self._is_launched_by_jobs_controller):
+                    raise exceptions.ExecutionPausedError(
+                        f'Cluster {cluster_name!r} is locked by another '
+                        'operation (e.g. launch, start, stop, autostop or '
+                        'teardown).',
+                        hint=('Waiting for the other operation to finish; '
+                              'will resume once the cluster lock is '
+                              'released. Check concurrent requests: '
+                              f'sky api status -v | grep {cluster_name}'),
+                        retry_wait_seconds=_CLUSTER_LOCK_RETRY_GAP_SECONDS,
+                        continue_condition=locks.LockAcquirableCondition(
+                            lock_id)) from e
                 if not communicated_with_user:
                     rich_utils.force_update_status(
                         ux_utils.spinner_message('Launching - blocked by ' +

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -397,6 +397,20 @@ def get_current_request_id() -> str:
     return 'dummy-request-id'
 
 
+def is_in_request_context() -> bool:
+    """Whether this code runs inside a server-side request execution.
+
+    The API server sets the request context (see ``set_request_context``) for
+    the duration of a request running on an executor worker; it is unset for
+    in-process callers with no request scheduler (e.g. a client, or the jobs
+    controller launching in-process). Long-blocking backend paths use this to
+    decide whether raising ``exceptions.ExecutionRetryableError`` will be
+    handled by the scheduler (parked as WAITING and rescheduled) rather than
+    propagating to a caller that cannot reschedule it.
+    """
+    return context.get_context_var(_REQUEST_ID_KEY) is not None
+
+
 def get_current_command() -> str:
     """Returns the command related to this operation.
 

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -8,7 +8,7 @@ import hashlib
 import logging
 import os
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import filelock
 import psycopg2
@@ -456,3 +456,42 @@ def _detect_lock_type() -> str:
         pass
 
     return 'filelock'
+
+
+class LockAcquirableCondition:
+    """Resume a paused request once a distributed lock looks acquirable.
+
+    Implements the ``wait()`` continue-condition contract consumed by the
+    request scheduler for ``exceptions.ExecutionPausedError`` (duck-typed via
+    that error's ``continue_condition`` field, so no base class is needed).
+
+    Probes the lock with a non-blocking acquire (released immediately on
+    success) instead of a blocking acquire: with the postgres backend a
+    blocking acquire would pin a pooled database connection per parked request
+    for the whole wait and could not interleave cancellation checks. The
+    momentary acquire is a probe, not a reservation -- the resumed request
+    re-acquires the lock itself and parks again if another contender wins the
+    race. Instances are pickled onto the exception, so state stays picklable.
+    """
+
+    def __init__(self, lock_id: str, poll_interval_seconds: float = 5.0):
+        self._lock_id = lock_id
+        self._poll_interval_seconds = poll_interval_seconds
+
+    def wait(self, *, is_cancelled: Callable[[], bool],
+             fallback_wait_seconds: float) -> bool:
+        """Block until the lock is acquirable; return False if cancelled."""
+        # There is no better signal than the probe itself; on probe errors
+        # (e.g. a database glitch) the exception propagates to the scheduler,
+        # which falls back to a fixed ``fallback_wait_seconds`` backoff.
+        del fallback_wait_seconds
+        while True:
+            if is_cancelled():
+                return False
+            try:
+                with get_lock(self._lock_id).acquire(blocking=False):
+                    pass  # Acquirable; release immediately and resume.
+                return True
+            except LockTimeout:
+                pass
+            time.sleep(self._poll_interval_seconds)

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -8,11 +8,13 @@ from unittest.mock import patch
 
 import pytest
 
+from sky import exceptions
 from sky import resources
 from sky import task
 from sky.backends import cloud_vm_ray_backend
 from sky.backends.cloud_vm_ray_backend import CloudVmRayResourceHandle
 from sky.backends.cloud_vm_ray_backend import SSHTunnelInfo
+from sky.utils import locks
 from sky.utils import status_lib
 
 
@@ -633,3 +635,67 @@ class TestNewHandleRuntimeMetadata:
         metadata = handle.provision_runtime_metadata
         assert (metadata.has_ray, metadata.has_skylet, metadata.has_job_queue,
                 metadata.ssh_available) == (False, False, False, False)
+
+
+class TestProvisionClusterLockParking:
+    """_provision on lock contention: park as WAITING only in request ctx."""
+
+    def _run_provision(self,
+                       monkeypatch,
+                       in_request_context,
+                       locked_provision_mock,
+                       is_launched_by_jobs_controller=False):
+        backend = cloud_vm_ray_backend.CloudVmRayBackend()
+        backend._is_launched_by_jobs_controller = (
+            is_launched_by_jobs_controller)
+        monkeypatch.setattr('sky.backends.backend_utils.check_rsync_installed',
+                            lambda: None)
+        monkeypatch.setattr('sky.backends.backend_utils.check_owner_identity',
+                            lambda cluster_name: None)
+        monkeypatch.setattr('sky.utils.common_utils.is_in_request_context',
+                            lambda: in_request_context)
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda msg: None)
+        monkeypatch.setattr(backend, '_locked_provision', locked_provision_mock)
+        return backend._provision(MagicMock(),
+                                  None,
+                                  dryrun=False,
+                                  stream_logs=False,
+                                  cluster_name='test-cluster')
+
+    def test_parks_on_lock_contention_in_request_context(self, monkeypatch):
+        locked_provision = MagicMock(side_effect=locks.LockTimeout('locked'))
+        with pytest.raises(exceptions.ExecutionPausedError) as exc_info:
+            self._run_provision(monkeypatch,
+                                in_request_context=True,
+                                locked_provision_mock=locked_provision)
+        assert 'test-cluster' in str(exc_info.value)
+        assert (exc_info.value.retry_wait_seconds ==
+                cloud_vm_ray_backend._CLUSTER_LOCK_RETRY_GAP_SECONDS)
+        condition = exc_info.value.continue_condition
+        assert isinstance(condition, locks.LockAcquirableCondition)
+        assert condition._lock_id == 'test-cluster_status'
+        assert locked_provision.call_count == 1
+
+    def test_blocks_on_lock_contention_outside_request_context(
+            self, monkeypatch):
+        sentinel = (MagicMock(), False)
+        locked_provision = MagicMock(
+            side_effect=[locks.LockTimeout('locked'), sentinel])
+        result = self._run_provision(monkeypatch,
+                                     in_request_context=False,
+                                     locked_provision_mock=locked_provision)
+        assert result is sentinel
+        assert locked_provision.call_count == 2
+
+    def test_blocks_for_jobs_controller_launch_even_in_request_context(
+            self, monkeypatch):
+        sentinel = (MagicMock(), False)
+        locked_provision = MagicMock(
+            side_effect=[locks.LockTimeout('locked'), sentinel])
+        result = self._run_provision(monkeypatch,
+                                     in_request_context=True,
+                                     locked_provision_mock=locked_provision,
+                                     is_launched_by_jobs_controller=True)
+        assert result is sentinel
+        assert locked_provision.call_count == 2

--- a/tests/unit_tests/test_sky/utils/test_locks.py
+++ b/tests/unit_tests/test_sky/utils/test_locks.py
@@ -754,3 +754,68 @@ class TestDistributedLockIntegration:
             assert isinstance(lock, locks.FileLock)
 
         mock_detect.assert_called_once()
+
+
+class TestLockAcquirableCondition:
+    """LockAcquirableCondition: resume a paused request when a lock frees."""
+
+    @staticmethod
+    def _acquirable_lock():
+        """A lock whose non-blocking acquire succeeds, as a context manager."""
+        lock = mock.MagicMock()
+        proxy = mock.MagicMock()
+        proxy.__enter__ = mock.MagicMock(return_value=lock)
+        proxy.__exit__ = mock.MagicMock(return_value=None)
+        lock.acquire.return_value = proxy
+        return lock, proxy
+
+    def test_resumes_when_lock_free(self, monkeypatch):
+        held_probes = 2
+        lock, proxy = self._acquirable_lock()
+        probes = []
+
+        def fake_get_lock(lock_id):
+            probes.append(lock_id)
+            if len(probes) <= held_probes:
+                held = mock.MagicMock()
+                held.acquire.side_effect = locks.LockTimeout('held')
+                return held
+            return lock
+
+        monkeypatch.setattr(locks, 'get_lock', fake_get_lock)
+        monkeypatch.setattr(locks.time, 'sleep', lambda s: None)
+
+        cond = locks.LockAcquirableCondition('my-cluster_status')
+        assert cond.wait(is_cancelled=lambda: False,
+                         fallback_wait_seconds=30) is True
+        assert probes == ['my-cluster_status'] * (held_probes + 1)
+        # The probe must release the lock immediately: it is a probe, not a
+        # reservation; the resumed request re-acquires the lock itself.
+        lock.acquire.assert_called_once_with(blocking=False)
+        proxy.__exit__.assert_called_once()
+
+    def test_drops_when_cancelled(self, monkeypatch):
+        held = mock.MagicMock()
+        held.acquire.side_effect = locks.LockTimeout('held')
+        monkeypatch.setattr(locks, 'get_lock', lambda lock_id: held)
+        monkeypatch.setattr(locks.time, 'sleep', lambda s: None)
+
+        calls = []
+
+        def is_cancelled():
+            calls.append(None)
+            return len(calls) > 3
+
+        cond = locks.LockAcquirableCondition('my-cluster_status')
+        assert cond.wait(is_cancelled=is_cancelled,
+                         fallback_wait_seconds=30) is False
+
+    def test_is_picklable(self):
+        # Pickled onto ExecutionPausedError; crosses the worker/scheduler
+        # process boundary.
+        import pickle
+        cond = locks.LockAcquirableCondition('my-cluster_status',
+                                             poll_interval_seconds=1.0)
+        restored = pickle.loads(pickle.dumps(cond))
+        assert restored._lock_id == 'my-cluster_status'
+        assert restored._poll_interval_seconds == 1.0


### PR DESCRIPTION
## Summary

Concurrent `sky launch` / `sky start` requests against the same cluster serialize on the per-cluster status lock in `_provision()`. Today a request that loses the race blocks synchronously inside its executor worker (the `while True` loop just re-acquires with a 5s timeout and refreshes the spinner), holding a LONG worker slot for the entire duration of the conflicting operation — potentially many minutes of provisioning. Pile up N launches on one cluster (or N `sky jobs launch` provisioning the same jobs controller) and N workers are pinned doing nothing, starving unrelated requests.

Besides pinned workers, the blocking loop has a second cost with the postgres lock backend: each blocked request keeps borrowing a pooled DB connection and polls `pg_try_advisory_lock` roughly once per second, indefinitely — N blocked launches means ~N held connections plus ~N QPS of lock polling, and the pinned workers force the executor to lazily spawn more worker processes, each with its own connection pool. Parking replaces all of that with one short non-blocking probe per parked request every 5s from the scheduler process's shared pool.

This PR parks such requests as `WAITING` instead, reusing the pause/resume path (#9885): on `LockTimeout`, if the code is running inside a server request execution (where the scheduler can park and resume it), raise `ExecutionPausedError` with a `LockAcquirableCondition`. The scheduler releases the worker immediately, marks the request `WAITING` with a descriptive `status_msg`, and the monitor thread re-enqueues the request once the lock is observed to be acquirable. Nothing has been provisioned at this point, so re-execution from scratch is safe — the same re-execution semantics `retry_until_up` already relies on.

Changes:

- `locks.LockAcquirableCondition`: resumes a parked request once a distributed lock is observed acquirable. It probes with a non-blocking acquire (released immediately on success) every 5s rather than a blocking acquire: with the postgres backend a blocking acquire would pin a pooled DB connection per parked request for the whole wait, and it could not interleave cancellation checks. The probe is not a reservation — the resumed request re-acquires the lock itself and parks again if another contender wins the race. It lives in `sky/utils/locks.py` (next to the lock it probes) and implements the duck-typed `wait()` continue-condition contract, so no backend→server dependency is introduced.
- `common_utils.is_in_request_context()`: reports whether the code runs inside a server-side request execution (the API server sets the request context for the duration of a request on an executor worker; unset for in-process callers with no scheduler, e.g. a client or the jobs controller launching in-process). This lives in the neutral `sky/utils` layer that backends already depend on — the backend does not reach into `sky.server`.
- `CloudVmRayBackend._provision()`: on `LockTimeout`, park via `ExecutionPausedError` when in a request context and not launched by the jobs controller; otherwise fall through to the existing blocking loop. The in-worker 5s acquire window is kept so short contention (e.g. brief status-refresh holds) never parks.

## Test

- [x] Code formatting: `bash format.sh` (yapf + pylint; pylint 10.00/10 on changed files)
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py` (includes new `TestProvisionClusterLockParking`: parks with the lock condition in a request context, keeps blocking outside a request context and for jobs-controller launches)
  - `pytest tests/unit_tests/test_sky/utils/test_locks.py` (includes new `TestLockAcquirableCondition`: resumes when the lock frees, drops when cancelled, picklable across the worker/scheduler boundary)
- [x] End-to-end: 4 concurrent launches to one cluster all parked `WAITING` while the lock was held (0 connections blocked on the lock, a launch to a different cluster still scheduled immediately), and resumed within ~5s of the lock releasing, serializing to completion.
