### PR TITLE
[Shadeform] Accept retry_if_missing in query_instances

### DIFF
--- a/sky/provision/shadeform/instance.py
+++ b/sky/provision/shadeform/instance.py
@@ -312,9 +312,10 @@ def query_instances(
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
+    retry_if_missing: bool = False,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """Query the status of instances."""
-    del cluster_name, provider_config  # unused
+    del cluster_name, provider_config, retry_if_missing  # unused
     instances = _get_cluster_instances(cluster_name_on_cloud)
 
     if not instances:


### PR DESCRIPTION
Fixes a `TypeError` that breaks every Shadeform cluster status refresh performed through the cloud API.

`sky/provision/__init__.py::query_instances` takes a `retry_if_missing` parameter (only meaningful on kubernetes, per its docstring), and `backend_utils._query_cluster_status_via_cloud_api` passes it unconditionally as a keyword argument to every cloud's implementation. All provisioners accept and ignore it (e.g. `sky/provision/runpod/instance.py`) — except Shadeform, whose integration predates the parameter:

```
sky.exceptions.ClusterStatusFetchingError: Failed to query Shadeform cluster 'dev-gpu' status:
[TypeError] query_instances() got an unexpected keyword argument 'retry_if_missing'
```

`sky launch` to Shadeform works (provisioning goes through `run_instances`/`wait_instances`), but the first `sky exec`, `sky status --refresh`, or autostop check against the cluster crashes. Repro:

```
sky launch -c dev --infra shadeform --gpus A6000:1 -y   # works
sky exec dev 'echo hi'                                   # ClusterStatusFetchingError
```

Fix: match the other clouds' signature — accept `retry_if_missing` and ignore it.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh` (yapf clean on the changed file)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual test: deployed a patched API server (helm, consolidation mode) and ran `sky exec` + `sky status -r` against a live Shadeform cluster — the repro above no longer crashes and the task runs.