### PR TITLE
[GCP] Support federated credentials for GCS COPY

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -119,16 +119,38 @@ class GcsCloudStorage(CloudStorage):
     @property
     def _gsutil_command(self):
         gsutil_alias, alias_gen = data_utils.get_gsutil_command()
+        default_credential_path = (
+            gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH.replace(
+                '~/', '$HOME/', 1))
+        credential_type_command = ('python3 -c \'import json, sys; '
+                                   'print(json.load(open(sys.argv[1], '
+                                   'encoding="utf-8")).get("type", ""))\' '
+                                   '"$credentials_file" 2> /dev/null || true')
+        gsutil_with_auth = 'skypilot_gsutil_with_auth'
         return (
-            f'{alias_gen}; GOOGLE_APPLICATION_CREDENTIALS='
-            f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH}; '
+            f'{alias_gen}; '
+            f'{gsutil_with_auth}() {{ '
+            'local credentials_file='
+            '"${GOOGLE_APPLICATION_CREDENTIALS:-'
+            f'{default_credential_path}'
+            '}"; '
+            'local credential_type; '
+            f'credential_type=$({credential_type_command}); '
+            'if [[ "$credential_type" == "external_account" ]]; then '
+            'export CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL=0; '
+            f'{gsutil_alias} '
+            '-o "Credentials:gs_external_account_file=$credentials_file" '
+            '"$@"; '
+            'else '
             # Explicitly activate service account. Unlike the gcp packages
             # and other GCP commands, gsutil does not automatically pick up
             # the default credential keys when it is a service account.
             'gcloud auth activate-service-account '
-            '--key-file=$GOOGLE_APPLICATION_CREDENTIALS '
-            '2> /dev/null || true; '
-            f'{gsutil_alias}')
+            '--key-file="$credentials_file" 2> /dev/null || true; '
+            f'{gsutil_alias} "$@"; '
+            'fi; '
+            '}; '
+            f'{gsutil_with_auth}')
 
     def is_directory(self, url: str) -> bool:
         """Returns whether 'url' is a directory.

--- a/tests/unit_tests/test_sky/storage/test_cloud_stores.py
+++ b/tests/unit_tests/test_sky/storage/test_cloud_stores.py
@@ -1,0 +1,125 @@
+"""Unit tests for generated cloud storage COPY commands."""
+
+import json
+import os
+import pathlib
+import subprocess
+from typing import Any, Dict
+
+from sky import cloud_stores
+
+
+def _write_executable(path: pathlib.Path, content: str) -> None:
+    path.write_text(content, encoding='utf-8')
+    path.chmod(0o755)
+
+
+def _run_gcs_copy_command(
+    tmp_path: pathlib.Path,
+    monkeypatch,
+    credentials: Dict[str, Any],
+    *,
+    gcloud_exit_code: int = 0,
+) -> tuple[str, pathlib.Path]:
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    log_path = tmp_path / 'commands.log'
+    credential_dir = tmp_path / 'credential files'
+    credential_dir.mkdir()
+    credential_path = credential_dir / 'adc.json'
+    credential_path.write_text(json.dumps(credentials), encoding='utf-8')
+
+    _write_executable(
+        bin_dir / 'gcloud',
+        '#!/bin/bash\n'
+        'printf "gcloud:%s\\n" "$*" >> "$SKYPILOT_TEST_LOG"\n'
+        'exit "${SKYPILOT_TEST_GCLOUD_EXIT_CODE:-0}"\n',
+    )
+    _write_executable(
+        bin_dir / 'gsutil',
+        '#!/bin/bash\n'
+        'printf "gsutil:%s\\n" "$*" >> "$SKYPILOT_TEST_LOG"\n'
+        'printf "pass_credentials:%s\\n" '
+        '"${CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL:-unset}" '
+        '>> "$SKYPILOT_TEST_LOG"\n',
+    )
+
+    monkeypatch.setattr(cloud_stores.GcsCloudStorage, '_INSTALL_GSUTIL', 'true')
+    env = os.environ.copy()
+    env['PATH'] = f'{bin_dir}:{env["PATH"]}'
+    env['GOOGLE_APPLICATION_CREDENTIALS'] = str(credential_path)
+    env['SKYPILOT_TEST_LOG'] = str(log_path)
+    env['SKYPILOT_TEST_GCLOUD_EXIT_CODE'] = str(gcloud_exit_code)
+
+    command = cloud_stores.GcsCloudStorage().make_sync_file_command(
+        'gs://private-bucket/object', '/tmp/object')
+    subprocess.run(command,
+                   shell=True,
+                   check=True,
+                   executable='/bin/bash',
+                   env=env)
+    return log_path.read_text(encoding='utf-8'), credential_path
+
+
+def test_gcs_copy_uses_external_account_without_gcloud_activation(
+        tmp_path, monkeypatch):
+    log, credential_path = _run_gcs_copy_command(
+        tmp_path,
+        monkeypatch,
+        {
+            'type': 'external_account',
+            'audience': '//iam.googleapis.com/projects/123/locations/global/'
+                        'workloadIdentityPools/pool/providers/provider',
+            'subject_token_type': 'urn:ietf:params:oauth:token-type:jwt',
+            'token_url': 'https://sts.googleapis.com/v1/token',
+            'credential_source': {
+                'file': '/var/run/secrets/skypilot-gcp/token',
+            },
+        },
+    )
+
+    assert 'gcloud:' not in log
+    assert f'Credentials:gs_external_account_file={credential_path}' in log
+    assert 'pass_credentials:0' in log
+    assert 'cp gs://private-bucket/object /tmp/object' in log
+
+
+def test_gcs_copy_activates_service_account_from_configured_path(
+        tmp_path, monkeypatch):
+    log, credential_path = _run_gcs_copy_command(
+        tmp_path,
+        monkeypatch,
+        {
+            'type': 'service_account',
+        },
+    )
+
+    assert 'gcloud:auth activate-service-account' in log
+    assert f'--key-file={credential_path}' in log
+    assert 'Credentials:gs_external_account_file=' not in log
+    assert 'cp gs://private-bucket/object /tmp/object' in log
+
+
+def test_gcs_copy_keeps_user_credential_fallback(tmp_path, monkeypatch):
+    log, _ = _run_gcs_copy_command(
+        tmp_path,
+        monkeypatch,
+        {
+            'type': 'authorized_user',
+            'client_id': 'client-id',
+        },
+        gcloud_exit_code=1,
+    )
+
+    assert 'gcloud:auth activate-service-account' in log
+    assert 'Credentials:gs_external_account_file=' not in log
+    assert 'cp gs://private-bucket/object /tmp/object' in log
+
+
+def test_gcs_directory_copy_keeps_rsync_arguments(monkeypatch):
+    monkeypatch.setattr(cloud_stores.GcsCloudStorage, '_INSTALL_GSUTIL', 'true')
+
+    command = cloud_stores.GcsCloudStorage().make_sync_dir_command(
+        'gs://private-bucket/prefix', '/tmp/prefix')
+
+    assert 'rsync -e -r gs://private-bucket/prefix /tmp/prefix' in command

--- a/tests/unit_tests/test_sky/storage/test_cloud_stores.py
+++ b/tests/unit_tests/test_sky/storage/test_cloud_stores.py
@@ -4,7 +4,9 @@ import json
 import os
 import pathlib
 import subprocess
-from typing import Any, Dict
+from typing import Any, Optional
+
+import pytest
 
 from sky import cloud_stores
 
@@ -17,9 +19,11 @@ def _write_executable(path: pathlib.Path, content: str) -> None:
 def _run_gcs_copy_command(
     tmp_path: pathlib.Path,
     monkeypatch,
-    credentials: Dict[str, Any],
+    credentials: Optional[Any] = None,
     *,
+    raw_credentials: Optional[str] = None,
     gcloud_exit_code: int = 0,
+    platform: str = 'Linux',
 ) -> tuple[str, pathlib.Path]:
     bin_dir = tmp_path / 'bin'
     bin_dir.mkdir()
@@ -27,8 +31,16 @@ def _run_gcs_copy_command(
     credential_dir = tmp_path / 'credential files'
     credential_dir.mkdir()
     credential_path = credential_dir / 'adc.json'
-    credential_path.write_text(json.dumps(credentials), encoding='utf-8')
+    if raw_credentials is not None:
+        credential_path.write_text(raw_credentials, encoding='utf-8')
+    elif credentials is not None:
+        credential_path.write_text(json.dumps(credentials), encoding='utf-8')
 
+    _write_executable(
+        bin_dir / 'uname',
+        '#!/bin/bash\n'
+        f'printf "%s\\n" "{platform}"\n',
+    )
     _write_executable(
         bin_dir / 'gcloud',
         '#!/bin/bash\n'
@@ -114,6 +126,61 @@ def test_gcs_copy_keeps_user_credential_fallback(tmp_path, monkeypatch):
     assert 'gcloud:auth activate-service-account' in log
     assert 'Credentials:gs_external_account_file=' not in log
     assert 'cp gs://private-bucket/object /tmp/object' in log
+
+
+@pytest.mark.parametrize(
+    ('credentials', 'raw_credentials'),
+    (
+        (None, None),
+        (None, '{invalid json'),
+        (['external_account'], None),
+    ),
+)
+def test_gcs_copy_falls_back_when_adc_is_not_external_account(
+    tmp_path,
+    monkeypatch,
+    credentials,
+    raw_credentials,
+):
+    log, credential_path = _run_gcs_copy_command(
+        tmp_path,
+        monkeypatch,
+        credentials,
+        raw_credentials=raw_credentials,
+        gcloud_exit_code=1,
+    )
+
+    assert 'gcloud:auth activate-service-account' in log
+    assert f'--key-file={credential_path}' in log
+    assert 'Credentials:gs_external_account_file=' not in log
+    assert 'cp gs://private-bucket/object /tmp/object' in log
+
+
+@pytest.mark.parametrize(
+    ('platform', 'has_multiprocessing_option'),
+    (
+        ('Linux', False),
+        ('Darwin', True),
+    ),
+)
+def test_external_account_copy_preserves_platform_gsutil_options(
+    tmp_path,
+    monkeypatch,
+    platform,
+    has_multiprocessing_option,
+):
+    log, _ = _run_gcs_copy_command(
+        tmp_path,
+        monkeypatch,
+        {
+            'type': 'external_account',
+        },
+        platform=platform,
+    )
+
+    assert 'gcloud:' not in log
+    assert ('GSUtil:parallel_process_count=1'
+            in log) is has_multiprocessing_option
 
 
 def test_gcs_directory_copy_keeps_rsync_arguments(monkeypatch):


### PR DESCRIPTION
## Summary
- Let GCS COPY commands pass `external_account` ADC configurations directly to gsutil.
- Disable Cloud SDK credential forwarding for federated COPY operations to prevent identity fallback.
- Preserve the existing service-account and user-credential behavior.

## Test plan
- [x] `pytest -n 0 tests/unit_tests/test_sky/storage/test_cloud_stores.py tests/unit_tests/test_sky/storage/test_huggingface.py tests/unit_tests/test_sky/storage/test_oci_s3_store.py -q`
- [x] `bash format.sh --files sky/cloud_stores.py tests/unit_tests/test_sky/storage/test_cloud_stores.py`
- [x] Deployed the custom image to our own SkyPilot GKE cluster; the API pod reached `3/3 Running`, and the deployment, CPU/GPU functional tests, and integration tests passed. This covers the native GKE Workload Identity regression path.
- [x] Run a Kubernetes workload with a projected OIDC token and `external_account` ADC configuration; verify COPY from a private `gs://` source succeeds without a service-account key.