### PR TITLE
[API] Support running multiple isolated local API servers on one machine

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -716,6 +716,7 @@ Starts the SkyPilot API server locally.
 - `--host` (default: `127.0.0.1`) — The host to bind the SkyPilot API server to. To allow remote access, set this to 0.0.0.0; use :: for IPv6 dual-stack.
 - `--foreground` — Run the SkyPilot API server in the foreground and output its logs to stdout/stderr. Allowing external systems to manage the process lifecycle and collect logs directly. This is useful when the API ser...
 - `--enable-basic-auth` — Enable basic authentication in the SkyPilot API server.
+- `--port` — The port to bind the SkyPilot API server to. Defaults to the SKYPILOT_API_SERVER_LOCAL_PORT environment variable, or 46580. Other client commands only find a server on a non-default port if the same e...
 
 ### `sky api status`
 

--- a/agent/skills/skypilot/references/python-sdk.md
+++ b/agent/skills/skypilot/references/python-sdk.md
@@ -976,7 +976,7 @@ Deletes a storage.
 ### `sky.api_start`
 
 ```python
-sky.api_start(*, deploy: bool = False, host: str = '127.0.0.1', foreground: bool = False, metrics: bool = False, metrics_port: Optional[int] = None, enable_basic_auth: bool = False) -> None
+sky.api_start(*, deploy: bool = False, host: str = '127.0.0.1', foreground: bool = False, metrics: bool = False, metrics_port: Optional[int] = None, enable_basic_auth: bool = False, port: Optional[int] = None) -> None
 ```
 
 Starts the API server.
@@ -997,6 +997,10 @@ exist.
     metrics_port: The port to export metrics of the API server.
     enable_basic_auth: Whether to enable basic authentication
         in the API server.
+    port: The port to bind the API server to. Defaults to the
+        SKYPILOT_API_SERVER_LOCAL_PORT environment variable, or 46580.
+        Other client commands only find a server on a non-default port
+        if the same environment variable is exported.
 **Returns:**
     None
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -49,6 +49,7 @@ from sky.serve import serve_utils
 from sky.server.requests import requests as requests_lib
 from sky.skylet import autostop_lib
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.usage import usage_lib
 from sky.utils import auth_utils
 from sky.utils import cluster_utils
@@ -312,8 +313,8 @@ def is_ip(s: str) -> bool:
 def _get_yaml_path_from_cluster_name(cluster_name: str,
                                      prefix: str = constants.SKY_USER_FILE_PATH
                                     ) -> str:
-    output_path = pathlib.Path(
-        prefix).expanduser().resolve() / f'{cluster_name}.yml'
+    output_path = runtime_utils.expanduser_path(
+        pathlib.Path(prefix)).resolve() / f'{cluster_name}.yml'
     os.makedirs(output_path.parents[0], exist_ok=True)
     return str(output_path)
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7897,14 +7897,24 @@ def api():
               default=False,
               required=False,
               help='Enable basic authentication in the SkyPilot API server.')
+@click.option('--port',
+              default=None,
+              type=int,
+              required=False,
+              help=('The port to bind the SkyPilot API server to. Defaults '
+                    'to the SKYPILOT_API_SERVER_LOCAL_PORT environment '
+                    'variable, or 46580. Other client commands only find a '
+                    'server on a non-default port if the same environment '
+                    'variable is exported.'))
 @usage_lib.entrypoint
 def api_start(deploy: bool, host: str, foreground: bool,
-              enable_basic_auth: bool):
+              enable_basic_auth: bool, port: Optional[int]):
     """Starts the SkyPilot API server locally."""
     sdk.api_start(deploy=deploy,
                   host=host,
                   foreground=foreground,
-                  enable_basic_auth=enable_basic_auth)
+                  enable_basic_auth=enable_basic_auth,
+                  port=port)
     api_server_url = server_common.get_server_url(host)
     # Dial via a reachable loopback URL: wildcard bind hosts (0.0.0.0 / ::) are
     # not valid connect targets on all platforms.

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 import sys
 import typing
@@ -46,6 +47,7 @@ from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
 from sky.skylet import autostop_lib
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.ssh_node_pools import utils as ssh_utils
 from sky.usage import usage_lib
 from sky.utils import admin_policy_utils
@@ -2587,16 +2589,41 @@ def api_cancel(request_ids: Optional[Union[server_common.RequestId[T],
     return server_common.get_request_id(response)
 
 
+def _cmdline_api_server_port(cmdline: List[str]) -> int:
+    """Parses the port of an API server process from its command line.
+
+    Falls back to the default port for servers started without an explicit
+    --port argument (e.g., by an older SkyPilot version). Operates on the
+    joined command line because some platforms (e.g., macOS) report the
+    whole command line as a single element.
+    """
+    match = re.search(r'--port[= ](\d+)', ' '.join(cmdline))
+    if match is not None:
+        return int(match.group(1))
+    return server_common.DEFAULT_SERVER_PORT
+
+
 def _local_api_server_running(kill: bool = False) -> bool:
-    """Checks if the local api server is running."""
+    """Checks if the local api server on the current port is running.
+
+    Only considers server processes bound to the port this client is
+    configured for, so that multiple API servers on one machine (e.g., dev
+    servers on different ports) do not interfere with each other.
+    """
+    target_port = server_common.get_local_api_server_port()
+    found = False
     for process in psutil.process_iter(attrs=['pid', 'cmdline']):
         cmdline = process.info['cmdline']
         if cmdline and server_common.API_SERVER_CMD in ' '.join(cmdline):
+            if _cmdline_api_server_port(cmdline) != target_port:
+                continue
+            found = True
             if kill:
                 subprocess_utils.kill_children_processes(
                     parent_pids=[process.pid], force=True)
-            return True
-    return False
+            else:
+                return True
+    return found
 
 
 @usage_lib.entrypoint
@@ -2694,6 +2721,7 @@ def api_start(
     metrics: bool = False,
     metrics_port: Optional[int] = None,
     enable_basic_auth: bool = False,
+    port: Optional[int] = None,
 ) -> None:
     """Starts the API server.
 
@@ -2713,9 +2741,25 @@ def api_start(
         metrics_port: The port to export metrics of the API server.
         enable_basic_auth: Whether to enable basic authentication
             in the API server.
+        port: The port to bind the API server to. Defaults to the
+            SKYPILOT_API_SERVER_LOCAL_PORT environment variable, or 46580.
+            Other client commands only find a server on a non-default port
+            if the same environment variable is exported.
     Returns:
         None
     """
+    if port is not None:
+        env_port = os.environ.get(constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR)
+        if env_port is not None and env_port != str(port):
+            logger.warning(
+                f'--port={port} overrides '
+                f'{constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR}={env_port} '
+                'for this command only.')
+        os.environ[constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR] = str(port)
+        # These caches may have been populated with URLs built from the old
+        # port; clear them so the override takes effect.
+        server_common.get_server_url.cache_clear()  # type: ignore
+        server_common.is_api_server_local.cache_clear()  # type: ignore
     if deploy:
         # Deploy mode is for remote access, so always bind a wildcard of the
         # requested host's address family.
@@ -2744,6 +2788,12 @@ def api_start(
                 f'{api_server_url}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}'
                 f'View API server logs at: {constants.API_SERVER_LOGS}')
+    local_port = server_common.get_local_api_server_port()
+    if local_port != server_common.DEFAULT_SERVER_PORT:
+        logger.info(
+            'Server is on a non-default port. For other commands and '
+            'terminals to reach it, run: export '
+            f'{constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR}={local_port}')
 
 
 @usage_lib.entrypoint
@@ -2766,8 +2816,10 @@ def api_stop() -> None:
 
     # Acquire the api server creation lock to prevent multiple processes from
     # stopping and starting the API server at the same time.
-    with filelock.FileLock(
-            os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
+    creation_lock_path = runtime_utils.expanduser(
+        constants.API_SERVER_CREATION_LOCK_PATH)
+    os.makedirs(os.path.dirname(creation_lock_path), exist_ok=True)
+    with filelock.FileLock(creation_lock_path):
         try:
             records = scheduler.get_controller_process_records()
             if records is not None:
@@ -2818,7 +2870,7 @@ def api_server_logs(follow: bool = True, tail: Optional[int] = None) -> None:
             tail_args.extend(['-n', '+1'])
         else:
             tail_args.extend(['-n', f'{tail}'])
-        log_path = os.path.expanduser(constants.API_SERVER_LOGS)
+        log_path = runtime_utils.expanduser(constants.API_SERVER_LOGS)
         subprocess.run(['tail', *tail_args, f'{log_path}'], check=False)
     else:
         stream_and_get(log_path=constants.API_SERVER_LOGS, tail=tail)

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -1,6 +1,7 @@
 """Constants used for Managed Jobs."""
-import os
 from typing import Any, Dict, Union
+
+from sky.skylet import runtime_utils
 
 # Environment variable for JobGroup name, injected into all jobs in a JobGroup
 SKYPILOT_JOBGROUP_NAME_ENV_VAR = 'SKYPILOT_JOBGROUP_NAME'
@@ -25,7 +26,7 @@ DEFAULT_MANAGED_JOB_FIELDS = ('job_id', 'task_id', 'workspace', 'job_name',
 
 JOB_CONTROLLER_INDICATOR_FILE = '~/.sky/is_jobs_controller'
 
-CONSOLIDATED_SIGNAL_PATH = os.path.expanduser('~/.sky/signals/')
+CONSOLIDATED_SIGNAL_PATH = runtime_utils.expanduser('~/.sky/signals/')
 SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 
 # The consolidation mode lock ensures that if multiple API servers are running
@@ -46,7 +47,7 @@ CONSOLIDATION_MODE_LOCK_ID = '~/.sky/consolidation_mode_lock'
 #   - _is_consolidation_mode(pool=True) — sizing-only helper.
 # Reading config directly instead diverges under deploy-mode auto-enable
 # (config stays null while this file is written).
-JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE = (
+JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE = runtime_utils.runtime_tilde_path(
     '~/.sky/.jobs_controller_consolidation_reloaded_signal')
 
 # Resources as a dict for the jobs controller.

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -43,6 +43,7 @@ from sky.metrics import utils as metrics_lib
 from sky.server import plugins
 from sky.skylet import constants
 from sky.skylet import job_lib
+from sky.skylet import runtime_utils
 from sky.usage import usage_lib
 from sky.utils import common
 from sky.utils import common_utils
@@ -2980,7 +2981,8 @@ class ControllerManager:
             job_id: The ID of the job to start.
         """
         # Create log file path for job output redirection
-        log_dir = os.path.expanduser(jobs_constants.JOBS_CONTROLLER_LOGS_DIR)
+        log_dir = runtime_utils.expanduser(
+            jobs_constants.JOBS_CONTROLLER_LOGS_DIR)
         os.makedirs(log_dir, exist_ok=True)
         log_file = os.path.join(log_dir, f'{job_id}.log')
 

--- a/sky/jobs/log_gc.py
+++ b/sky/jobs/log_gc.py
@@ -14,12 +14,13 @@ from sky import skypilot_config
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
+from sky.skylet import runtime_utils
 from sky.utils import context
 
 logger = sky_logging.init_logger(__name__)
 
 # Filelock for garbage collector leader election.
-_JOB_CONTROLLER_GC_LOCK_PATH = os.path.expanduser(
+_JOB_CONTROLLER_GC_LOCK_PATH = runtime_utils.expanduser(
     '~/.sky/locks/job_controller_gc.lock')
 
 _DEFAULT_TASK_LOGS_GC_RETENTION_HOURS = 24 * 7
@@ -170,7 +171,8 @@ def _clean_task_logs_with_retention(retention_seconds: int,
 @context.contextual
 def run_log_gc():
     """Run the log garbage collector."""
-    log_dir = os.path.expanduser(managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
+    log_dir = runtime_utils.expanduser(
+        managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
     os.makedirs(log_dir, exist_ok=True)
     log_path = os.path.join(log_dir, 'garbage_collector.log')
     # Remove previous log file

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -64,6 +64,7 @@ from sky.jobs import file_content_utils
 from sky.jobs import state
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
 from sky.utils import subprocess_utils
@@ -79,11 +80,11 @@ logger = sky_logging.init_logger('sky.jobs.controller')
 
 # Job controller lock. This is used to synchronize writing/reading the
 # controller pid file.
-JOB_CONTROLLER_PID_LOCK = os.path.expanduser(
+JOB_CONTROLLER_PID_LOCK = runtime_utils.expanduser(
     '~/.sky/locks/job_controller_pid.lock')
 
-JOB_CONTROLLER_PID_PATH = os.path.expanduser('~/.sky/job_controller_pid')
-JOB_CONTROLLER_ENV_PATH = os.path.expanduser('~/.sky/job_controller_env')
+JOB_CONTROLLER_PID_PATH = runtime_utils.expanduser('~/.sky/job_controller_pid')
+JOB_CONTROLLER_ENV_PATH = runtime_utils.expanduser('~/.sky/job_controller_env')
 
 CURRENT_HASH = os.path.expanduser('~/.sky/wheels/current_sky_wheel_hash')
 
@@ -158,7 +159,7 @@ def start_controller() -> None:
 
     This requires that the env file is already set up.
     """
-    logs_dir = os.path.expanduser(
+    logs_dir = runtime_utils.expanduser(
         managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
     os.makedirs(logs_dir, exist_ok=True)
     controller_uuid = str(uuid.uuid4())

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -49,6 +49,7 @@ from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
+from sky.skylet import runtime_utils
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common as common_lib
@@ -1036,8 +1037,8 @@ def _collect_job_debug_manifest(
     # shared controller_system/*.log set to only the controllers that
     # actually ran this job.
     with _catch_to_errors(errors, 'managed_jobs', f'{job_id}/controller_log'):
-        controller_logs_dir = pathlib.Path(
-            managed_job_constants.JOBS_CONTROLLER_LOGS_DIR).expanduser()
+        controller_logs_dir = runtime_utils.expanduser_path(
+            pathlib.Path(managed_job_constants.JOBS_CONTROLLER_LOGS_DIR))
         log_file = controller_logs_dir / f'{job_id}.log'
         if log_file.is_file():
             file_paths.append({
@@ -1182,8 +1183,8 @@ def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],
     if not relevant_uuids:
         return
     with _catch_to_errors(errors, 'managed_jobs', 'controller_system/logs'):
-        controller_logs_dir = pathlib.Path(
-            managed_job_constants.JOBS_CONTROLLER_LOGS_DIR).expanduser()
+        controller_logs_dir = runtime_utils.expanduser_path(
+            pathlib.Path(managed_job_constants.JOBS_CONTROLLER_LOGS_DIR))
         if not controller_logs_dir.exists():
             return
         for uuid_str in relevant_uuids:
@@ -1489,7 +1490,8 @@ def cancel_managed_jobs(
 
 def controller_log_file_for_job(job_id: int,
                                 create_if_not_exists: bool = False) -> str:
-    log_dir = os.path.expanduser(managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
+    log_dir = runtime_utils.expanduser(
+        managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
     if create_if_not_exists:
         os.makedirs(log_dir, exist_ok=True)
     return os.path.join(log_dir, f'{job_id}.log')

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -16,7 +16,7 @@ import tempfile
 import threading
 import time
 import typing
-from typing import (Any, Callable, cast, Dict, Generic, Literal, Optional,
+from typing import (Any, Callable, cast, Dict, Generic, List, Literal, Optional,
                     Tuple, TypeVar, Union)
 from urllib.request import Request
 import uuid
@@ -40,6 +40,7 @@ from sky.server import rest
 from sky.server import versions
 from sky.server.blob import blob_storage as bs
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common_utils
@@ -60,7 +61,33 @@ else:
     pydantic = adaptors_common.LazyImport('pydantic')
     requests = adaptors_common.LazyImport('requests')
 
-DEFAULT_SERVER_URL = 'http://127.0.0.1:46580'
+DEFAULT_SERVER_PORT = 46580
+
+
+def get_local_api_server_port() -> int:
+    """Port of the local API server.
+
+    Defaults to 46580 and can be overridden with the
+    SKYPILOT_API_SERVER_LOCAL_PORT environment variable, which both the
+    client and the server honor. Together with SKY_RUNTIME_DIR this allows
+    running multiple isolated API servers on the same machine.
+    """
+    port_str = os.environ.get(constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR)
+    if port_str is None:
+        return DEFAULT_SERVER_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'Invalid {constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR} '
+                f'value: {port_str!r}. Expected an integer port '
+                'number.') from None
+
+
+def get_default_server_url() -> str:
+    """Default URL of the local API server, honoring the port override."""
+    return f'http://127.0.0.1:{get_local_api_server_port()}'
 
 
 def _host_to_url_host(host: str) -> str:
@@ -80,16 +107,27 @@ def _host_to_url_host(host: str) -> str:
 AVAILBLE_LOCAL_API_SERVER_HOSTS = [
     '0.0.0.0', 'localhost', '127.0.0.1', '::', '::1'
 ]
-AVAILABLE_LOCAL_API_SERVER_URLS = [
-    f'http://{_host_to_url_host(host)}:46580'
-    for host in AVAILBLE_LOCAL_API_SERVER_HOSTS
-]
+
+
+def get_available_local_api_server_urls() -> List[str]:
+    """URLs at which a locally-started API server may be addressed."""
+    port = get_local_api_server_port()
+    return [
+        f'http://{_host_to_url_host(host)}:{port}'
+        for host in AVAILBLE_LOCAL_API_SERVER_HOSTS
+    ]
+
 
 API_SERVER_CMD = '-m sky.server.server'
 # The client dir on the API server for storing user-specific data, such as file
 # mounts, logs, etc. This dir is ephemeral and will be cleaned up when the API
-# server is restarted.
-API_SERVER_CLIENT_DIR = pathlib.Path('~/.sky/api_server/clients')
+# server is restarted. The '~' form is deliberate: paths under this dir also
+# appear in wire responses (e.g., sync-down log paths) that clients
+# prefix-match machine-independently. When SKY_RUNTIME_DIR is set, the dir is
+# anchored there instead, so that one API server restarting does not wipe the
+# transient client state of another server on the same machine.
+API_SERVER_CLIENT_DIR = pathlib.Path(
+    runtime_utils.runtime_tilde_path('~/.sky/api_server/clients'))
 RETRY_COUNT_ON_TIMEOUT = 3
 
 # The maximum time to wait for the API server to start, set to a conservative
@@ -452,9 +490,10 @@ async def make_authenticated_request_async(
 
 @annotations.lru_cache(scope='global')
 def get_server_url(host: Optional[str] = None) -> str:
-    endpoint = DEFAULT_SERVER_URL
+    endpoint = get_default_server_url()
     if host is not None:
-        endpoint = f'http://{_host_to_url_host(host)}:46580'
+        endpoint = (f'http://{_host_to_url_host(host)}:'
+                    f'{get_local_api_server_port()}')
 
     url = os.environ.get(
         constants.SKY_API_SERVER_URL_ENV_VAR,
@@ -505,7 +544,7 @@ def get_dashboard_url(server_url: str,
 @annotations.lru_cache(scope='global')
 def is_api_server_local(endpoint: Optional[str] = None):
     server_url = endpoint if endpoint is not None else get_server_url()
-    return server_url in AVAILABLE_LOCAL_API_SERVER_URLS
+    return server_url in get_available_local_api_server_urls()
 
 
 def _handle_non_200_server_status(
@@ -725,7 +764,7 @@ def _start_api_server(deploy: bool = False,
     """Starts a SkyPilot API server locally."""
     check_local_api_server_enabled_or_raise()
     server_url = get_server_url(host)
-    assert server_url in AVAILABLE_LOCAL_API_SERVER_URLS, (
+    assert server_url in get_available_local_api_server_urls(), (
         f'server url {server_url} is not a local url')
     # URL to *dial* the server we are about to start. Differs from server_url
     # for wildcard bind hosts (0.0.0.0 / ::), which are not valid connect
@@ -765,6 +804,9 @@ def _start_api_server(deploy: bool = False,
             args += ['--deploy']
         if host is not None:
             args += [f'--host={host}']
+        # Always pass the port explicitly so that `sky api stop` can tell
+        # apart multiple API servers running on the same machine.
+        args += [f'--port={get_local_api_server_port()}']
         if metrics_port is not None:
             args += [f'--metrics-port={metrics_port}']
 
@@ -783,7 +825,7 @@ def _start_api_server(deploy: bool = False,
                                   server_constants.WEBSOCKETS_MAX_NUM_HEADERS)
             os.execvp(args[0], args)
 
-        log_path = os.path.expanduser(constants.API_SERVER_LOGS)
+        log_path = runtime_utils.expanduser(constants.API_SERVER_LOGS)
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
         # For spawn mode, copy the environ to avoid polluting the SDK process.
@@ -991,8 +1033,10 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
         check_local_api_server_enabled_or_raise()
         # Lock to prevent multiple processes from starting the server at the
         # same time, causing issues with database initialization.
-        with filelock.FileLock(
-                os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
+        creation_lock_path = runtime_utils.expanduser(
+            constants.API_SERVER_CREATION_LOCK_PATH)
+        os.makedirs(os.path.dirname(creation_lock_path), exist_ok=True)
+        with filelock.FileLock(creation_lock_path):
             # Check again if server is already running. Other processes may
             # have started the server while we were waiting for the lock.
             get_api_server_status_response.cache_clear()  # type: ignore

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -10,6 +10,7 @@ from sky import sky_logging
 from sky.server import constants as server_constants
 from sky.server import daemons
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import yaml_utils
@@ -323,7 +324,7 @@ def load_server_config() -> config_utils.Config:
     Returns:
         A Config object containing the server configuration.
     """
-    config_path = os.path.expanduser(SERVER_CONFIG_PATH)
+    config_path = runtime_utils.expanduser(SERVER_CONFIG_PATH)
     if not os.path.exists(config_path):
         return config_utils.Config()
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -3,6 +3,7 @@
 import os
 
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 
 # pylint: disable=line-too-long
 # The SkyPilot API version that the code currently use.
@@ -86,8 +87,10 @@ MIN_AVAIL_MEM_GB = 2
 MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE = 4
 # Default encoder/decoder handler name.
 DEFAULT_HANDLER_NAME = 'default'
-# The path to the API request database.
-API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
+# The path to the API request database. Anchored at SKY_RUNTIME_DIR when set,
+# so that multiple API servers on one machine keep separate request state.
+API_SERVER_REQUEST_DB_PATH = runtime_utils.runtime_tilde_path(
+    '~/.sky/api_server/requests.db')
 
 # The interval (seconds) for the cluster status to be refreshed in the
 # background.
@@ -149,8 +152,10 @@ ON_BOOT_CHECK_REQUEST_ID = 'skypilot-server-on-boot-check'
 
 # Request logs are stored in ~/.sky/api_server/request_logs/ to avoid NFS
 # performance issues in Kubernetes deployments where ~/sky_logs/ may be on
-# shared storage.
-REQUEST_LOG_PATH_PREFIX = '~/.sky/api_server/request_logs'
+# shared storage. Anchored at SKY_RUNTIME_DIR when set, since this dir is
+# wiped on every server startup.
+REQUEST_LOG_PATH_PREFIX = runtime_utils.runtime_tilde_path(
+    '~/.sky/api_server/request_logs')
 
 # Default maximum size of a daemon log file before rotation (bytes).
 # When a daemon log exceeds this threshold, it is backed up to .log.1 and

--- a/sky/server/requests/queues/base.py
+++ b/sky/server/requests/queues/base.py
@@ -131,10 +131,10 @@ class LocalQueueBackend(QueueBackend):
 class MultiprocessingQueueBackend(QueueBackend):
     """Queue backed by a multiprocessing.Queue via a manager."""
 
-    def __init__(self,
-                 queue_name: str,
-                 port: int = mp_queue.DEFAULT_QUEUE_MANAGER_PORT):
+    def __init__(self, queue_name: str, port: Optional[int] = None):
         super().__init__()
+        if port is None:
+            port = mp_queue.get_queue_manager_port()
         # queue_name is the schedule type ('long' / 'short'); used as the
         # metric label when reporting queue wait.
         self._schedule_type = queue_name
@@ -169,7 +169,7 @@ class MultiprocessingQueueFactory(QueueBackendFactory):
     def __init__(self, port: Optional[int] = None):
         super().__init__()
         self._port = (port if port is not None else
-                      mp_queue.DEFAULT_QUEUE_MANAGER_PORT)
+                      mp_queue.get_queue_manager_port())
 
     def create_queue(self, schedule_type: str) -> QueueBackend:
         return MultiprocessingQueueBackend(schedule_type, self._port)

--- a/sky/server/requests/queues/mp_queue.py
+++ b/sky/server/requests/queues/mp_queue.py
@@ -3,15 +3,31 @@ import multiprocessing
 from multiprocessing import managers
 import queue
 import time
-from typing import List
+from typing import List, Optional
 
 from sky import sky_logging
+from sky.server import common as server_common
 
 logger = sky_logging.init_logger(__name__)
 
 # The default port used by SkyPilot API server's request queue.
 # We avoid 50010, as it might be taken by HDFS.
 DEFAULT_QUEUE_MANAGER_PORT = 50011
+
+
+def get_queue_manager_port() -> int:
+    """Port for the request queue manager.
+
+    Moves in lockstep with the local API server port override
+    (SKYPILOT_API_SERVER_LOCAL_PORT), so that multiple API servers on one
+    machine do not collide on the internal queue manager port. Kept within
+    [50000, 60000) via modulo.
+    """
+    offset = (server_common.get_local_api_server_port() -
+              server_common.DEFAULT_SERVER_PORT)
+    if offset == 0:
+        return DEFAULT_QUEUE_MANAGER_PORT
+    return 50000 + (DEFAULT_QUEUE_MANAGER_PORT - 50000 + offset) % 10000
 
 
 # Have to create custom manager to handle different processes connecting to the
@@ -21,7 +37,9 @@ class QueueManager(managers.BaseManager):
 
 
 def start_queue_manager(queue_names: List[str],
-                        port: int = DEFAULT_QUEUE_MANAGER_PORT) -> None:
+                        port: Optional[int] = None) -> None:
+    if port is None:
+        port = get_queue_manager_port()
     # Defining a local function instead of a lambda function
     # (e.g. lambda: q) because the lambda function captures q by
     # reference, so by the time lambda is called, the loop has already
@@ -49,8 +67,9 @@ def start_queue_manager(queue_names: List[str],
     server.serve_forever()
 
 
-def get_queue(queue_name: str,
-              port: int = DEFAULT_QUEUE_MANAGER_PORT) -> queue.Queue:
+def get_queue(queue_name: str, port: Optional[int] = None) -> queue.Queue:
+    if port is None:
+        port = get_queue_manager_port()
     QueueManager.register(queue_name)
     manager = QueueManager(address=('localhost', port), authkey=b'skypilot')
     manager.connect()
@@ -59,7 +78,7 @@ def get_queue(queue_name: str,
 
 def wait_for_queues_to_be_ready(queue_names: List[str],
                                 queue_server: multiprocessing.Process,
-                                port: int = DEFAULT_QUEUE_MANAGER_PORT) -> None:
+                                port: Optional[int] = None) -> None:
     """Wait for the queues to be ready after queue manager is just started."""
     initial_time = time.time()
     # Wait for queue manager to be ready. Exit eagerly if the manager process

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -87,6 +87,7 @@ from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
 from sky.server.requests import role_filter
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.ssh_node_pools import server as ssh_node_pools_rest
 from sky.usage import usage_lib
 from sky.users import permission
@@ -2106,30 +2107,30 @@ async def download(download_body: payloads.DownloadBody,
     download_tmp = bs.get_blob_storage().download_tmp_dir(user_hash)
     for folder_path in folder_paths:
         folder_str = str(folder_path)
-        expanded_str = str(folder_path.expanduser())
+        expanded_str = str(runtime_utils.expanduser_path(folder_path))
         if not (folder_str.startswith(str(logs_dir_on_api_server)) or
-                folder_str.startswith(download_tmp) or
-                expanded_str.startswith(os.path.expanduser(download_tmp))):
+                folder_str.startswith(download_tmp) or expanded_str.startswith(
+                    runtime_utils.expanduser(download_tmp))):
             raise fastapi.HTTPException(
                 status_code=400,
                 detail=
                 f'Invalid folder path: {folder_path}; {logs_dir_on_api_server}')
 
-        if not folder_path.expanduser().resolve().exists():
+        if not runtime_utils.expanduser_path(folder_path).resolve().exists():
             raise fastapi.HTTPException(
                 status_code=404, detail=f'Folder not found: {folder_path}')
 
     # Create a temporary zip file
     log_id = str(uuid.uuid4().hex)
     zip_filename = f'folder_{log_id}.zip'
-    zip_path = pathlib.Path(
-        logs_dir_on_api_server).expanduser().resolve() / zip_filename
+    zip_path = runtime_utils.expanduser_path(
+        pathlib.Path(logs_dir_on_api_server)).resolve() / zip_filename
 
     try:
 
         def _zip_files_and_folders(folder_paths, zip_path):
             folders = [
-                str(folder_path.expanduser().resolve())
+                str(runtime_utils.expanduser_path(folder_path).resolve())
                 for folder_path in folder_paths
             ]
             # Check for optional query parameter to control zip entry structure
@@ -2517,8 +2518,8 @@ async def stream(
     else:
         assert log_path is not None, (request_id, log_path)
         if log_path == constants.API_SERVER_LOGS:
-            resolved_log_path = pathlib.Path(
-                constants.API_SERVER_LOGS).expanduser()
+            resolved_log_path = runtime_utils.expanduser_path(
+                pathlib.Path(constants.API_SERVER_LOGS))
             if not resolved_log_path.exists():
                 raise fastapi.HTTPException(
                     status_code=404,
@@ -3658,7 +3659,9 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', default='127.0.0.1')
-    parser.add_argument('--port', default=46580, type=int)
+    parser.add_argument('--port',
+                        default=common.get_local_api_server_port(),
+                        type=int)
     parser.add_argument('--deploy', action='store_true')
     # Serve metrics on a separate port to isolate it from the application APIs:
     # metrics port will not be exposed to the public network typically.

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -10,6 +10,7 @@ import threading
 import colorama
 
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import context
 from sky.utils import env_options
 from sky.utils import rich_utils
@@ -20,7 +21,7 @@ _FORMAT = ('%(levelname).1s %(asctime)s.%(msecs)03d PID=%(process)d '
 _DATE_FORMAT = '%m-%d %H:%M:%S'
 _SENSITIVE_LOGGER = ['sky.provisioner', 'sky.optimizer']
 
-DEBUG_LOG_DIR = os.path.expanduser('~/.sky/api_server/request_debug_logs')
+DEBUG_LOG_DIR = runtime_utils.expanduser('~/.sky/api_server/request_debug_logs')
 
 DEBUG = logging.DEBUG
 INFO = logging.INFO

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -512,6 +512,14 @@ API_SERVER_CREATION_LOCK_PATH = '~/.sky/api_server/.creation.lock'
 # API server.
 SKY_API_SERVER_URL_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}API_SERVER_ENDPOINT'
 
+# The name for the environment variable that overrides the port of the local
+# SkyPilot API server (default: 46580). Both the server and the client honor
+# it, so exporting it in a shell yields a self-consistent environment. Useful
+# together with SKY_RUNTIME_DIR to run multiple isolated API servers on one
+# machine (e.g., for development).
+SKY_API_SERVER_LOCAL_PORT_ENV_VAR = (
+    f'{SKYPILOT_ENV_VAR_PREFIX}API_SERVER_LOCAL_PORT')
+
 # The name for the environment variable that stores the SkyPilot service
 # account token on client side.
 SERVICE_ACCOUNT_TOKEN_ENV_VAR = (

--- a/sky/skylet/runtime_utils.py
+++ b/sky/skylet/runtime_utils.py
@@ -1,5 +1,6 @@
 """Runtime utilities for SkyPilot."""
 import os
+import pathlib
 
 from sky.skylet import constants
 
@@ -19,3 +20,43 @@ def get_runtime_dir_path(path_suffix: str = '') -> str:
     if path_suffix:
         return os.path.join(runtime_dir, path_suffix)
     return runtime_dir
+
+
+def expanduser(path: str) -> str:
+    """Like os.path.expanduser, but roots '~' at the SkyPilot runtime dir.
+
+    When the SKY_RUNTIME_DIR environment variable is set, a leading '~' (with
+    no explicit user name) resolves to the runtime directory instead of $HOME.
+    Falls back to os.path.expanduser otherwise, so behavior is unchanged when
+    the environment variable is unset.
+
+    Use this for paths that belong to a SkyPilot runtime instance (databases,
+    server state, locks, logs), NOT for user-owned paths such as credentials
+    or paths that are sent to another machine for resolution there.
+    """
+    if os.environ.get(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY) is None:
+        return os.path.expanduser(path)
+    if path == '~':
+        return get_runtime_dir_path()
+    if path.startswith('~/'):
+        return get_runtime_dir_path(path[2:])
+    return os.path.expanduser(path)
+
+
+def expanduser_path(path: pathlib.Path) -> pathlib.Path:
+    """pathlib variant of expanduser (see above)."""
+    return pathlib.Path(expanduser(str(path)))
+
+
+def runtime_tilde_path(path: str) -> str:
+    """Anchors a '~/...' path at SKY_RUNTIME_DIR when set; else returns as-is.
+
+    For '~'-relative SkyPilot path constants: when no runtime dir is
+    configured, the constant keeps its portable '~' form and callers expand
+    it at use time as before. When a runtime dir is configured, the path is
+    anchored there, so the subsequent expanduser calls become no-ops and the
+    path stays consistent everywhere it is used within this process.
+    """
+    if os.environ.get(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY) is None:
+        return path
+    return expanduser(path)

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -3,7 +3,6 @@
 import contextlib
 import datetime
 import hashlib
-import os
 import secrets
 import threading
 import time
@@ -14,6 +13,7 @@ import jwt
 
 from sky import global_user_state
 from sky import sky_logging
+from sky.skylet import runtime_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -23,7 +23,7 @@ JWT_ISSUER = 'sky'  # Shortened for compact tokens
 JWT_SECRET_DB_KEY = 'jwt_secret'
 
 # File lock for JWT secret initialization
-JWT_SECRET_LOCK_PATH = os.path.expanduser('~/.sky/.jwt_secret_init.lock')
+JWT_SECRET_LOCK_PATH = runtime_utils.expanduser('~/.sky/.jwt_secret_init.lock')
 JWT_SECRET_LOCK_TIMEOUT_SECONDS = 20
 
 

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -59,7 +59,7 @@ def test_endpoint_output_basic_no_pg_conn_closed_errors(generic_cloud: str):
 def test_endpoint_output_config(generic_cloud: str):
     """Test that sky api info endpoint output is correct when config is set."""
 
-    endpoint = server_common.DEFAULT_SERVER_URL
+    endpoint = server_common.get_default_server_url()
 
     config = textwrap.dedent(f"""
     api_server:
@@ -100,7 +100,8 @@ def test_endpoint_output_env(generic_cloud: str):
                                   teardown=f'sky down -y {name}',
                                   env={
                                       constants.SKY_API_SERVER_URL_ENV_VAR:
-                                          server_common.DEFAULT_SERVER_URL
+                                          server_common.get_default_server_url(
+                                          )
                                   })
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/unit_tests/test_runtime_utils.py
+++ b/tests/unit_tests/test_runtime_utils.py
@@ -1,0 +1,37 @@
+"""Tests for sky.skylet.runtime_utils."""
+import os
+
+from sky.skylet import constants
+from sky.skylet import runtime_utils
+
+
+class TestExpanduser:
+    """Tests for runtime_utils.expanduser."""
+
+    def test_no_runtime_dir_matches_os_expanduser(self, monkeypatch):
+        monkeypatch.delenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           raising=False)
+        for path in ('~', '~/.sky/state.db', '/abs/path', 'relative/path'):
+            assert runtime_utils.expanduser(path) == os.path.expanduser(path)
+
+    def test_runtime_dir_roots_tilde(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(tmp_path))
+        assert runtime_utils.expanduser('~') == str(tmp_path)
+        assert runtime_utils.expanduser('~/.sky/state.db') == str(
+            tmp_path / '.sky/state.db')
+
+    def test_runtime_dir_leaves_other_paths_alone(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(tmp_path))
+        assert runtime_utils.expanduser('/abs/path') == '/abs/path'
+        assert runtime_utils.expanduser('rel/path') == 'rel/path'
+        # '~user' forms are not rooted at the runtime dir.
+        assert runtime_utils.expanduser('~someuser/x') == os.path.expanduser(
+            '~someuser/x')
+
+    def test_runtime_dir_itself_is_expanded(self, monkeypatch):
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           '~/runtime-a')
+        assert runtime_utils.expanduser('~/.sky/x') == os.path.join(
+            os.path.expanduser('~/runtime-a'), '.sky/x')

--- a/tests/unit_tests/test_runtime_utils.py
+++ b/tests/unit_tests/test_runtime_utils.py
@@ -4,26 +4,25 @@ import os
 from sky.skylet import constants
 from sky.skylet import runtime_utils
 
+_RUNTIME_DIR_KEY = constants.SKY_RUNTIME_DIR_ENV_VAR_KEY
+
 
 class TestExpanduser:
     """Tests for runtime_utils.expanduser."""
 
     def test_no_runtime_dir_matches_os_expanduser(self, monkeypatch):
-        monkeypatch.delenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
-                           raising=False)
+        monkeypatch.delenv(_RUNTIME_DIR_KEY, raising=False)
         for path in ('~', '~/.sky/state.db', '/abs/path', 'relative/path'):
             assert runtime_utils.expanduser(path) == os.path.expanduser(path)
 
     def test_runtime_dir_roots_tilde(self, monkeypatch, tmp_path):
-        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
-                           str(tmp_path))
+        monkeypatch.setenv(_RUNTIME_DIR_KEY, str(tmp_path))
         assert runtime_utils.expanduser('~') == str(tmp_path)
         assert runtime_utils.expanduser('~/.sky/state.db') == str(
             tmp_path / '.sky/state.db')
 
     def test_runtime_dir_leaves_other_paths_alone(self, monkeypatch, tmp_path):
-        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
-                           str(tmp_path))
+        monkeypatch.setenv(_RUNTIME_DIR_KEY, str(tmp_path))
         assert runtime_utils.expanduser('/abs/path') == '/abs/path'
         assert runtime_utils.expanduser('rel/path') == 'rel/path'
         # '~user' forms are not rooted at the runtime dir.
@@ -31,7 +30,6 @@ class TestExpanduser:
             '~someuser/x')
 
     def test_runtime_dir_itself_is_expanded(self, monkeypatch):
-        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
-                           '~/runtime-a')
+        monkeypatch.setenv(_RUNTIME_DIR_KEY, '~/runtime-a')
         assert runtime_utils.expanduser('~/.sky/x') == os.path.join(
             os.path.expanduser('~/runtime-a'), '.sky/x')

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -387,16 +387,46 @@ def test_get_server_url_ipv6(monkeypatch):
     assert common.get_server_url('localhost') == 'http://localhost:46580'
 
 
+def test_local_port_env_var_override(monkeypatch):
+    """SKYPILOT_API_SERVER_LOCAL_PORT changes the local port everywhere."""
+    _isolate_server_url(monkeypatch)
+    monkeypatch.setenv(common.constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR,
+                       '46590')
+    common.get_server_url.cache_clear()
+    common.is_api_server_local.cache_clear()
+    assert common.get_local_api_server_port() == 46590
+    assert common.get_default_server_url() == 'http://127.0.0.1:46590'
+    assert common.get_server_url() == 'http://127.0.0.1:46590'
+    assert common.get_server_url('localhost') == 'http://localhost:46590'
+    urls = common.get_available_local_api_server_urls()
+    assert 'http://127.0.0.1:46590' in urls
+    assert all(url.endswith(':46590') for url in urls)
+    assert common.is_api_server_local('http://127.0.0.1:46590')
+    # The default port is no longer considered the local server.
+    assert not common.is_api_server_local('http://127.0.0.1:46580')
+    common.get_server_url.cache_clear()
+    common.is_api_server_local.cache_clear()
+
+
+def test_local_port_env_var_invalid(monkeypatch):
+    """A non-integer port override raises a clear error."""
+    monkeypatch.setenv(common.constants.SKY_API_SERVER_LOCAL_PORT_ENV_VAR,
+                       'not-a-port')
+    with pytest.raises(ValueError, match='SKYPILOT_API_SERVER_LOCAL_PORT'):
+        common.get_local_api_server_port()
+
+
 def test_available_local_api_server_urls_are_wellformed():
     """The precomputed local URLs bracket IPv6 and parse correctly."""
     from urllib.parse import urlparse
 
+    local_urls = common.get_available_local_api_server_urls()
     # IPv6 hosts are present and bracketed; IPv4 hosts are plain.
-    assert 'http://[::]:46580' in common.AVAILABLE_LOCAL_API_SERVER_URLS
-    assert 'http://[::1]:46580' in common.AVAILABLE_LOCAL_API_SERVER_URLS
-    assert 'http://127.0.0.1:46580' in common.AVAILABLE_LOCAL_API_SERVER_URLS
+    assert 'http://[::]:46580' in local_urls
+    assert 'http://[::1]:46580' in local_urls
+    assert 'http://127.0.0.1:46580' in local_urls
     # Every entry is a well-formed URL that urlparse can decompose.
-    for url in common.AVAILABLE_LOCAL_API_SERVER_URLS:
+    for url in local_urls:
         parsed = urlparse(url)
         assert parsed.scheme == 'http'
         assert parsed.port == 46580

--- a/tests/unit_tests/test_sky/test_sdk_local_server.py
+++ b/tests/unit_tests/test_sky/test_sdk_local_server.py
@@ -1,0 +1,23 @@
+"""Tests for local API server process discovery in the client SDK."""
+from sky.client import sdk
+from sky.server import common as server_common
+
+_CMD = ['python', '-m', 'sky.server.server']
+
+
+def test_cmdline_port_equals_form():
+    assert sdk._cmdline_api_server_port(_CMD + ['--port=46590']) == 46590
+
+
+def test_cmdline_port_separate_arg_form():
+    assert sdk._cmdline_api_server_port(_CMD + ['--port', '46591']) == 46591
+
+
+def test_cmdline_port_missing_defaults():
+    assert (sdk._cmdline_api_server_port(_CMD + ['--host=127.0.0.1']) ==
+            server_common.DEFAULT_SERVER_PORT)
+
+
+def test_cmdline_port_malformed_defaults():
+    assert (sdk._cmdline_api_server_port(_CMD + ['--port=oops']) ==
+            server_common.DEFAULT_SERVER_PORT)


### PR DESCRIPTION
## Summary

- Adds a `SKYPILOT_API_SERVER_LOCAL_PORT` environment variable (plus `sky api start --port`) that both the client and the server honor when building the local server URL, the local-URL allowlist, and the spawned server's `--port`. The internal request-queue manager port is derived from the API server port so two servers no longer collide on the fixed 50011 port.
- Makes `sky api stop` port-aware: it only kills the server process whose `--port` matches the configured port, so stopping one dev server no longer kills every other API server on the machine.
- Extends the existing `SKY_RUNTIME_DIR` mechanism to API-server-local state that previously hardcoded `~/.sky`: `requests.db`, request/debug logs, `server.log`, the creation lock, the ephemeral clients dir (wiped on every server startup), `.server.yaml`, the JWT init lock, generated cluster YAMLs, and consolidation-mode jobs state (controller pid/env files, cancel signals, controller logs). New `runtime_utils.expanduser` / `expanduser_path` / `runtime_tilde_path` helpers anchor `~`-relative paths at `SKY_RUNTIME_DIR` when set and are exact no-ops when unset. Wire-format `~` paths (sync-down prefix matching, remote cluster paths) deliberately keep their portable form.

Together these enable a dev workflow where each terminal or worktree runs a fully isolated local API server:

```bash
export SKY_RUNTIME_DIR=~/.sky-runtimes/a
export SKYPILOT_API_SERVER_LOCAL_PORT=46601
sky api start   # own port, own state.db/spot_jobs.db, own request DB/logs/locks
```

Cloud credentials and `~/.sky/config.yaml` stay shared (per-shell `SKYPILOT_GLOBAL_CONFIG` can override the latter). Known remaining shared surfaces, unchanged by design: `~/sky_logs`, `~/.ssh/config` cluster aliases (same-name clusters across servers still resolve to one alias), plugin config, and wheels.

## Test plan

Unit tests (new and updated):
- `tests/unit_tests/test_runtime_utils.py`: runtime-dir-aware expanduser semantics, including the env-unset no-op guarantee.
- `tests/unit_tests/test_sky/test_sdk_local_server.py`: `--port` cmdline parsing for port-aware stop (both `--port=X` and `--port X` forms, missing/malformed fallback).
- `tests/unit_tests/test_sky/server/test_common.py`: port env var override of `get_server_url` / local URL allowlist / `is_api_server_local`, invalid value error.
- Ran `tests/unit_tests/test_sky/server/` and `.../requests/queues/`: no new failures (pre-existing environment-dependent `test_config.py` failures reproduce on clean master on the same machine).

Manual verification on one machine with a pre-existing default server running:
1. Started two extra servers with distinct `SKY_RUNTIME_DIR` + `SKYPILOT_API_SERVER_LOCAL_PORT` (46601/46602). Both healthy via `/api/health`; each runtime dir got its own `state.db`, `spot_jobs.db`, `api_server/` (requests.db, server.log, request logs) and `locks/`.
2. `sky status` against each server works from a shell exporting the matching env vars.
3. `sky api stop` in the 46602 shell killed only the 46602 server; the 46601 server and the pre-existing default-port server (started from an older install without `--port`) kept running and healthy. Then stopped 46601 the same way; default server unaffected.
4. `sky api start` on a non-default port prints a hint to export `SKYPILOT_API_SERVER_LOCAL_PORT` for other shells.
5. With no env vars set, all paths and ports resolve exactly as before (constants keep their `~` form and port 46580).

🤖 Generated with [Claude Code](https://claude.com/claude-code)