### PR TITLE
[Kubernetes] Display actual pod resource requests when they diverge from the resource spec

### DIFF
--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -192,6 +192,14 @@ class ClusterInfo:
     # Override the ssh_user from the cluster config.
     ssh_user: Optional[str] = None
     custom_ray_options: Optional[Dict[str, Any]] = None
+    # Actual per-node CPU/memory requests observed on the provisioned
+    # instances (e.g., Kubernetes pod resources.requests). These can diverge
+    # from the launched resources spec when the final node config is mutated
+    # out-of-band, e.g., by an admin policy writing kubernetes.pod_config
+    # directly. Only populated by the Kubernetes provisioner; access with
+    # getattr for handles pickled before these fields existed.
+    actual_cpus: Optional[float] = None
+    actual_memory_gb: Optional[float] = None
 
     @property
     def num_instances(self) -> int:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2082,6 +2082,7 @@ def get_cluster_info(
 
     head_pod_name = None
     cpu_request = None
+    memory_request = None
     for pod_name, pod in running_pods.items():
         # Under hostNetwork the pod's network namespace is the host's, so
         # pod_ip is the K8s node's host IP. SkyPilot injects a required
@@ -2115,6 +2116,8 @@ def get_cluster_info(
             limits = (getattr(resources, 'limits', None) if resources else None)
             cpu_request = ((requests or {}).get('cpu') or
                            (limits or {}).get('cpu'))
+            memory_request = ((requests or {}).get('memory') or
+                              (limits or {}).get('memory'))
 
     if cpu_request is None:
         raise RuntimeError(f'Pod {cluster_name_on_cloud}-head not found'
@@ -2154,6 +2157,14 @@ def get_cluster_info(
     # Keep consistent with the logic in clouds/kubernetes.py
     str_cpus = str(max(int(num_cpus), 1))
 
+    # Record the pod's actual resource requests so display paths can show
+    # what the scheduler sees, even when an admin policy has overridden
+    # them via pod_config (bypassing the SkyPilot resources spec).
+    actual_memory_gb = None
+    if memory_request is not None:
+        actual_memory_gb = kubernetes_utils.parse_memory_resource(
+            memory_request, unit='G')
+
     return common.ClusterInfo(
         instances=pods,
         head_instance_id=head_pod_name,
@@ -2166,7 +2177,9 @@ def get_cluster_info(
             'num-cpus': str_cpus,
         },
         provider_name='kubernetes',
-        provider_config=provider_config)
+        provider_config=provider_config,
+        actual_cpus=num_cpus,
+        actual_memory_gb=actual_memory_gb)
 
 
 class NodeHealthInfo:

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -317,8 +317,51 @@ def simplify_ports(ports: List[str]) -> List[str]:
     return port_set_to_ranges(port_ranges_to_set(ports))
 
 
-def format_resource(resource: 'resources_lib.Resources',
-                    simplified_only: bool = False) -> Tuple[str, Optional[str]]:
+# The Kubernetes pod template writes the spec memory as decimal gigabytes
+# ('{{memory}}G'), while the actual request read back from the pod is
+# normalized to GiB (2**30). A spec value of X GB therefore reads back as
+# X * this ratio even when nothing modified the pod, which must not be
+# reported as a divergence.
+_MEM_SPEC_GB_TO_POD_GIB = 1000**3 / 1024**3
+
+
+def _format_cpu_mem_element(
+        name: str,
+        spec_value: Optional[float],
+        actual_value: Optional[float],
+        spec_to_actual_ratio: float = 1.0) -> Optional[Tuple[str, str]]:
+    """Format a cpus=/mem= element, preferring the actual value.
+
+    Returns (simple, full) strings, or None if neither value is set. When
+    the actual value (e.g., the provisioned pod's resource request) differs
+    from the spec-derived value, the full string annotates the spec value
+    so the divergence (e.g., an admin policy override) stays visible.
+    """
+    if actual_value is None:
+        if spec_value is None:
+            return None
+        value_str = common_utils.format_float(spec_value)
+        return f'{name}={value_str}', f'{name}={value_str}'
+    actual_str = common_utils.format_float(actual_value)
+    if spec_value is not None:
+        spec_str = common_utils.format_float(spec_value)
+        if (spec_str == actual_str or math.isclose(
+                actual_value, spec_value * spec_to_actual_ratio, rel_tol=1e-3)):
+            # The actual value is the spec value, possibly written to the
+            # instance in the provisioner's unit convention: no divergence,
+            # keep displaying the spec value.
+            return f'{name}={spec_str}', f'{name}={spec_str}'
+        return (f'{name}={actual_str}',
+                f'{name}={actual_str} (requested: {spec_str})')
+    simple = f'{name}={actual_str}'
+    return simple, simple
+
+
+def format_resource(
+        resource: 'resources_lib.Resources',
+        simplified_only: bool = False,
+        actual_cpus: Optional[float] = None,
+        actual_memory_gb: Optional[float] = None) -> Tuple[str, Optional[str]]:
     resource = resource.assert_launchable()
     is_k8s = resource.cloud.canonical_name() == 'kubernetes'
     vcpu, mem = None, None
@@ -334,18 +377,24 @@ def format_resource(resource: 'resources_lib.Resources',
         elements_simple.append(f'gpus={acc}:{count}')
         elements_full.append(f'gpus={acc}:{count}')
 
+    cpu_element = _format_cpu_mem_element('cpus', vcpu, actual_cpus)
+    mem_element = _format_cpu_mem_element(
+        'mem',
+        mem,
+        actual_memory_gb,
+        spec_to_actual_ratio=_MEM_SPEC_GB_TO_POD_GIB)
     if (resource.accelerators is None or is_k8s):
-        if vcpu is not None:
-            elements_simple.append(f'cpus={common_utils.format_float(vcpu)}')
-            elements_full.append(f'cpus={common_utils.format_float(vcpu)}')
-        if mem is not None:
-            elements_simple.append(f'mem={common_utils.format_float(mem)}')
-            elements_full.append(f'mem={common_utils.format_float(mem)}')
+        if cpu_element is not None:
+            elements_simple.append(cpu_element[0])
+            elements_full.append(cpu_element[1])
+        if mem_element is not None:
+            elements_simple.append(mem_element[0])
+            elements_full.append(mem_element[1])
     elif not simplified_only:
-        if vcpu is not None:
-            elements_full.append(f'cpus={common_utils.format_float(vcpu)}')
-        if mem is not None:
-            elements_full.append(f'mem={common_utils.format_float(mem)}')
+        if cpu_element is not None:
+            elements_full.append(cpu_element[1])
+        if mem_element is not None:
+            elements_full.append(mem_element[1])
 
     is_slurm = resource.cloud.canonical_name() == 'slurm'
     if not is_k8s and not is_slurm:
@@ -384,8 +433,22 @@ def format_resource(resource: 'resources_lib.Resources',
 def get_readable_resources_repr(
         handle: 'backends.CloudVmRayResourceHandle',
         simplified_only: bool = False) -> Tuple[str, Optional[str]]:
+    # Prefer the actual resource requests captured at provision time
+    # (currently Kubernetes only), so the displayed values match what the
+    # scheduler sees even when an admin policy rewrote pod_config directly.
+    # getattr: handles/ClusterInfo pickled by older versions lack these
+    # attributes.
+    actual_cpus = None
+    actual_memory_gb = None
+    cluster_info = getattr(handle, 'cached_cluster_info', None)
+    if cluster_info is not None:
+        actual_cpus = getattr(cluster_info, 'actual_cpus', None)
+        actual_memory_gb = getattr(cluster_info, 'actual_memory_gb', None)
     resource_str_simple, resource_str_full = format_resource(
-        handle.launched_resources, simplified_only)
+        handle.launched_resources,
+        simplified_only,
+        actual_cpus=actual_cpus,
+        actual_memory_gb=actual_memory_gb)
     if not simplified_only:
         assert resource_str_full is not None
     if (handle.launched_nodes is not None and

--- a/tests/unit_tests/test_sky/utils/test_resources_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_resources_utils.py
@@ -1,10 +1,12 @@
 """Tests for resources_utils.py."""
+import types
 import unittest
 
 import pytest
 
 from sky import clouds
 from sky import resources as resources_lib
+from sky.provision import common as provision_common
 from sky.utils import resources_utils
 
 
@@ -118,6 +120,103 @@ def test_aws_instance_type_shown():
     simple, _ = resources_utils.format_resource(resource, simplified_only=False)
 
     assert 'm5.large' in simple
+
+
+def _k8s_resource():
+    return resources_lib.Resources(cloud=clouds.Kubernetes(),
+                                   instance_type='2CPU--4GB',
+                                   cpus=2,
+                                   memory=4)
+
+
+def test_format_resource_prefers_actual_pod_requests():
+    """Actual pod resource requests take precedence over the spec values.
+
+    E.g., an admin policy can rewrite kubernetes.pod_config resource
+    requests without touching the SkyPilot resources spec.
+    """
+    simple, full = resources_utils.format_resource(_k8s_resource(),
+                                                   simplified_only=False,
+                                                   actual_cpus=8.0,
+                                                   actual_memory_gb=1984.0)
+
+    assert 'cpus=8' in simple
+    assert 'mem=1984' in simple
+    assert 'cpus=2' not in simple
+    assert 'mem=4' not in simple
+    # The full string keeps the diverging spec values visible.
+    assert 'cpus=8 (requested: 2)' in full
+    assert 'mem=1984 (requested: 4)' in full
+
+
+def test_format_resource_actual_matches_spec_no_annotation():
+    """No annotation when the actual requests match the spec values."""
+    simple, full = resources_utils.format_resource(_k8s_resource(),
+                                                   simplified_only=False,
+                                                   actual_cpus=2.0,
+                                                   actual_memory_gb=4.0)
+
+    assert 'cpus=2' in simple
+    assert 'mem=4' in simple
+    assert 'requested' not in full
+
+
+def test_format_resource_unmodified_pod_memory_unit_convention():
+    """An unmodified pod must not be reported as a divergence.
+
+    The pod template writes spec memory as decimal G, which reads back
+    in GiB as spec * (1000^3 / 1024^3). This is a unit convention, not
+    an override, so the spec value stays displayed with no annotation.
+    """
+    read_back_gib = 4.0 * (1000**3 / 1024**3)  # ~3.73
+    simple, full = resources_utils.format_resource(
+        _k8s_resource(),
+        simplified_only=False,
+        actual_cpus=2.0,
+        actual_memory_gb=read_back_gib)
+
+    assert 'mem=4' in simple
+    assert 'mem=3.73' not in simple
+    assert 'requested' not in full
+
+
+def test_get_readable_resources_repr_uses_cached_cluster_info():
+    """Handle display prefers actual requests from cached_cluster_info."""
+    cluster_info = provision_common.ClusterInfo(instances={},
+                                                head_instance_id=None,
+                                                provider_name='kubernetes',
+                                                actual_cpus=8.0,
+                                                actual_memory_gb=1984.0)
+    handle = types.SimpleNamespace(launched_resources=_k8s_resource(),
+                                   launched_nodes=2,
+                                   cached_cluster_info=cluster_info)
+
+    simple, full = resources_utils.get_readable_resources_repr(
+        handle, simplified_only=False)
+
+    assert simple.startswith('2x')
+    assert 'cpus=8' in simple
+    assert 'mem=1984' in simple
+    assert 'mem=1984 (requested: 4)' in full
+
+
+def test_get_readable_resources_repr_old_pickled_cluster_info():
+    """ClusterInfo pickled before the actual_* fields existed still works."""
+
+    class _OldClusterInfo:
+        # Simulates an unpickled ClusterInfo from an older version: the
+        # new dataclass fields are absent from __dict__ entirely.
+        pass
+
+    handle = types.SimpleNamespace(launched_resources=_k8s_resource(),
+                                   launched_nodes=1,
+                                   cached_cluster_info=_OldClusterInfo())
+
+    simple, _ = resources_utils.get_readable_resources_repr(
+        handle, simplified_only=False)
+
+    assert 'cpus=2' in simple
+    assert 'mem=4' in simple
 
 
 class TestNormalizeLocalDisk:


### PR DESCRIPTION
## Summary

- Admin policies (or any config layer) can rewrite a pod's CPU/memory requests directly via `kubernetes.pod_config` without touching the SkyPilot-level `resources.cpu` / `resources.memory`. The dashboard, `sky status`, and managed jobs derive the displayed `cpus=`/`mem=` purely from the instance-type string, so they show stale values that do not match what the pod (and schedulers like Kueue) actually request. This misleads debugging and capacity planning.
- Fix: capture the head pod's actual cpu/memory requests in `get_cluster_info()` at provision time (the pod object is already fetched there; no new Kubernetes API calls are added anywhere, and the cluster listing path stays free of cloud calls) and persist them on new `ClusterInfo.actual_cpus` / `actual_memory_gb` fields via the pickled cluster handle.
- Display paths (`get_readable_resources_repr()` / `format_resource()`) prefer the actual values; the full resources string annotates the original spec value when they diverge, e.g. `1x(cpus=2 (requested: 1), mem=4 (requested: 2), disk=256)`. Managed jobs inherit the fix since they use the same helper.
- Unit convention: the pod template writes spec memory as decimal `G` while the read-back normalizes to GiB, so an unmodified pod reads back as `spec * (10^9 / 2^30)`. The comparison treats that ratio as equality so vanilla clusters keep showing the spec value with no false annotation.
- Backward compatibility: handles pickled before these fields existed fall back to the existing instance-type-derived display (`getattr` with defaults); only newly launched clusters show actual values. No API version bump needed, the strings are computed server-side and consumed opaquely by the dashboard/CLI.

## Tested

- Unit tests added in `tests/unit_tests/test_sky/utils/test_resources_utils.py`: actual values preferred and annotated when diverging, no annotation when matching, no false annotation for the decimal-G/GiB template convention, `cached_cluster_info` plumbing through `get_readable_resources_repr()`, and old-pickle fallback. All pass.
- Manual end-to-end on a local API server against an AKS cluster:
  - Control launch (`--cpus 1 --memory 2`, no pod_config): `sky status` shows `1x(cpus=1, mem=2, ...)`, unchanged, no false annotation.
  - Launch with a `kubernetes.pod_config` override setting requests/limits to `cpu: 2, memory: 4Gi`: `sky status` shows `1x(cpus=2, mem=4, ...)` matching `kubectl get pod -o jsonpath='{.spec.containers[0].resources}'`, and `resources_str_full` shows `1x(cpus=2 (requested: 1), mem=4 (requested: 2), disk=256)`.
  - Dashboard serves the updated strings (same precomputed `resources_str`/`resources_str_full` fields).
- `bash format.sh` passes: yapf/isort clean, mypy no errors, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)