### PR TITLE
[Test] Pin zone in skyserve auto_restart.yaml so replica termination finds the instance

### DIFF
--- a/tests/skyserve/auto_restart.yaml
+++ b/tests/skyserve/auto_restart.yaml
@@ -7,7 +7,10 @@ service:
 
 resources:
   ports: 8080
-  infra: gcp
+  # Pin the zone so that terminate_gcp_replica in
+  # test_skyserve_auto_restart, which queries instances with
+  # --zones=us-central1-a, can find the replica to terminate.
+  infra: gcp/*/us-central1-a
 
 workdir: examples/serve/http_server
 


### PR DESCRIPTION
## Summary
- **Test:** `test_skyserve_auto_restart` on `gcp`
- **Classification:** test infra zone mismatch
- **Confidence:** HIGH

## Root Cause
The test simulates preemption via `smoke_tests_utils.terminate_gcp_replica(name, zone, 1)` with a hardcoded `zone = 'us-central1-a'`, which runs `gcloud compute instances delete --zone=us-central1-a --quiet $(gcloud compute instances list --filter="(labels.ray-cluster-name:...)" --zones=us-central1-a ...)`. However, `tests/skyserve/auto_restart.yaml` only specifies `infra: gcp` with no zone pin, so the replica can be provisioned in a different zone. In the failing run the replica landed in `us-central1-b` (n4-highcpu-2), the zone-scoped instance list returned nothing, and `gcloud compute instances delete` failed with `argument INSTANCE_NAMES [INSTANCE_NAMES ...]: Must be specified` on all 3 attempts.

## Fix
Pin the replica zone in `tests/skyserve/auto_restart.yaml` to `infra: gcp/*/us-central1-a`, matching the pattern already used by the other tests that share the same `terminate_gcp_replica` helper and hardcoded zone (`tests/skyserve/spot/recovery.yaml` and `tests/skyserve/spot/dynamic_ondemand_fallback.yaml`).

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/123#019f908f-858c-44c2-ba44-0cdd4121bcfc

## Tested
- `bash format.sh` passes; no Python files changed, yapf/isort/mypy/dashboard lint all clean.
- Smoke test will be triggered on this PR via `/smoke-test -k test_skyserve_auto_restart --gcp`.

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)