### PR TITLE
[Test] Poll for STOPPED after sky stop in test_resize

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3671,9 +3671,17 @@ def test_resize(generic_cloud: str):
     stopped_resize_commands = []
     if generic_cloud != 'kubernetes':
         stopped_resize_commands = [
-            # Stop the (now 1-node) cluster.
+            # Stop the (now 1-node) cluster. Poll for STOPPED instead of
+            # checking `sky status` output once: a background status refresh
+            # that raced with the teardown (its per-cluster lock is
+            # force-unlocked by `sky stop`) can transiently overwrite the
+            # freshly-written STOPPED state with INIT/UNHEALTHY, which
+            # self-corrects on the next refresh.
             f'sky stop -y {name}',
-            f's=$(sky status {name}) && echo "$s" && echo "$s" | grep {name} | grep STOPPED',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=120),
             # --- Resize a STOPPED cluster: scale up (restarts + grows) ---
             f'sky launch -y -c {name} --resize --num-nodes 2',
             f's=$(sky status {name}) && echo "$s" && echo "$s" | grep "2x" && echo "$s" | grep UP',


### PR DESCRIPTION
## Summary
- **Test:** `test_resize` on `azure` (release full-smoke-tests-run, 0.13.1rc1)
- **Classification:** TEST_ASSERTION (status race)
- **Confidence:** MEDIUM

## Root Cause
The test asserted `sky status | grep STOPPED` exactly once, immediately after `sky stop` returned. The status showed `UNHEALTHY` instead: a cluster status refresh that was already in flight when the stop began (teardown force-unlocks the per-cluster status lock in `CloudVmRayBackend.teardown`, so an in-progress `_update_cluster_status` keeps running) had queried the cloud while the VM was still running, then found the Ray runtime dead because the teardown had just run `ray stop --force`. It concluded the cluster was abnormal and wrote INIT (rendered as UNHEALTHY) after the stop had written STOPPED. The background refresh daemon (`refresh_cluster_records`, every 60s, force-refreshes all clusters and only skips ones with active `sky.launch` requests) makes this overlap likely, and the near-deterministic test timeline made it reproduce on all 3 attempts. The bad state self-corrects on the next refresh, which sees the deallocated VM and writes STOPPED again.

## Fix
Replace the single-shot `grep STOPPED` with `smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(..., [sky.ClusterStatus.STOPPED], timeout=120)`, the same polling helper the autostop tests use after stop transitions. It polls `sky status --refresh` every 10s, so a transient INIT/UNHEALTHY snapshot no longer fails the test.

Note: the underlying product race (a force-unlocked in-flight refresh can briefly overwrite a fresh STOPPED state with INIT/UNHEALTHY until the next refresh) still exists and may deserve a separate fix, e.g. having the refresh re-validate lock ownership or cluster state before writing, or skipping daemon refresh for clusters with active stop/down requests.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/123#019f9079-0868-4156-9e71-6c4b13e05fc2

## Tested
- `bash format.sh` passes clean.
- Triggered `/smoke-test -k test_resize --azure` on this PR (see comment below) to validate on Azure end to end.

---
> **Note:** This fix was auto-generated. Confidence level: MEDIUM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)