### PR TITLE
[Kubernetes] Fail provisioning on persistent volume mount failures instead of hanging

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -72,6 +72,20 @@ _PENDING_REASON_NORMAL_EVENT_ALLOWLIST = {
     'WaitForFirstConsumer',  # late-binding storage class
 }
 
+# Warning-type pod events (emitted by the kubelet, after scheduling) that
+# indicate a volume attach/mount failure. A pod hit by one of these stays in
+# the uninformative 'ContainerCreating' waiting state, so the failure is only
+# visible through events.
+_MOUNT_FAILURE_EVENT_REASONS = ('FailedMount', 'FailedAttachVolume')
+# How long a pod may continuously report a mount-failure event before
+# provisioning is failed. Mount failures are frequently transient — the
+# kubelet retries with backoff, and e.g. a CSI driver still starting on a
+# freshly scaled-up node or a slow first attach of a network volume resolves
+# on its own — so use a generous window. Persistent failures (mis-configured
+# PVC/storage class, missing secret/configmap) never resolve; without this
+# deadline they would hang provisioning forever with only a spinner update.
+_MOUNT_FAILURE_TIMEOUT_SECONDS = 600
+
 # Pattern to extract SSH user from command output, handling MOTD contamination
 _SSH_USER_PATTERN = re.compile(r'SKYPILOT_SSH_USER: ([^\s\n]+)')
 
@@ -863,6 +877,24 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
         # returned (False, None) silently, masking OOMKilled etc.
         return False, container_reason
 
+    # First time each pod was seen continuously reporting a mount-failure
+    # event, keyed by pod name. Cleared when the pod's pending reason moves
+    # on (the kubelet retry succeeded).
+    mount_failure_first_seen: Dict[str, float] = {}
+
+    def _raise_mount_failure(pod_name: str, reason: str) -> None:
+        # Re-fetch the newest event for the full kubelet message — the wait
+        # loop only tracks the bare reason (e.g. 'FailedMount').
+        detail = ''
+        pending_reason = _get_pod_pending_reason(context, namespace, pod_name)
+        if (pending_reason is not None and
+                pending_reason[0] in _MOUNT_FAILURE_EVENT_REASONS):
+            detail = f': {pending_reason[1]}'
+        raise config_lib.KubernetesError(
+            f'Pod {pod_name} has failed to attach or mount volumes for over '
+            f'{_MOUNT_FAILURE_TIMEOUT_SECONDS // 60} minutes: '
+            f'{reason}{detail}')
+
     missing_pods_retry = 0
     last_status_msg: Optional[str] = None
     while True:
@@ -916,12 +948,27 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
 
         all_pods_running = True
         pending_reasons_count: Dict[str, int] = {}
-        for is_running, pending_reason in pod_statuses:
+        now = time.time()
+        for pod, (is_running, pending_reason) in zip(pods_to_check,
+                                                     pod_statuses):
             if not is_running:
                 all_pods_running = False
             if pending_reason is not None:
                 pending_reasons_count[pending_reason] = (
                     pending_reasons_count.get(pending_reason, 0) + 1)
+            # Escalate a sustained volume attach/mount failure to a
+            # provisioning error. Unlike other kubelet-level failures (which
+            # show up in containerStatuses and raise in _inspect_pod_status),
+            # a mount failure leaves the container in 'ContainerCreating'
+            # indefinitely — without this deadline the loop would spin
+            # forever with only a spinner update.
+            pod_name = pod.metadata.name
+            if pending_reason in _MOUNT_FAILURE_EVENT_REASONS:
+                first_seen = mount_failure_first_seen.setdefault(pod_name, now)
+                if now - first_seen >= _MOUNT_FAILURE_TIMEOUT_SECONDS:
+                    _raise_mount_failure(pod_name, pending_reason)
+            else:
+                mount_failure_first_seen.pop(pod_name, None)
 
         if all_pods_running:
             break

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2152,6 +2152,11 @@ KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     (['Insufficient'],
      'The cluster does not have enough free resources. To fix: View node '
      'allocations at {dashboard_url} or run `kubectl describe nodes`.'),
+    (['FailedMount', 'FailedAttachVolume'],
+     'A volume could not be attached or mounted to the pod. To fix: Verify '
+     'the volume/PVC configuration (existence, storage class, access mode) '
+     'and that any referenced secrets or configmaps exist; run '
+     '`kubectl describe pod <pod-name>` for the full mount error.'),
 ]
 
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2504,6 +2504,38 @@ def test_kubernetes_pod_pending_reason():
 
 
 @pytest.mark.kubernetes
+def test_kubernetes_pod_failed_mount_escalation():
+    """A persistent volume mount failure must FAIL provisioning (not hang
+    forever in ContainerCreating), and the error must carry the kubelet
+    FailedMount event message so the user can act on it."""
+    name = smoke_tests_utils.get_cluster_name()
+    template_str = pathlib.Path(
+        'tests/test_yamls/test_k8s_pending_volume.yaml.j2').read_text()
+    template = jinja2.Template(template_str)
+    task_yaml_content = template.render()
+
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(task_yaml_content)
+        f.flush()
+
+        test = smoke_tests_utils.Test(
+            'kubernetes_pod_failed_mount_escalation',
+            [
+                # The launch must exit non-zero on its own (the
+                # mount-failure deadline, ~10 min) — a hang here trips the
+                # test timeout instead.
+                f's=$(sky launch -y -c {name} --infra kubernetes {f.name} '
+                f'2>&1); ret=$?; echo "$s"; [ $ret -ne 0 ] || exit 1; '
+                f'echo "$s" | grep "FailedMount" && '
+                f'echo "$s" | grep "MountVolume.SetUp failed"',
+            ],
+            f'sky down -y {name}',
+            timeout=25 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
 def test_kubernetes_pod_long_image_pull():
     """Ensure kubelet image pulling events are surfaced in provision logs."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2887,6 +2887,140 @@ class TestInspectPodStatusTierIntegration:
         assert not lp_calls
 
 
+class TestWaitForPodsToRunMountFailureEscalation:
+    """A sustained FailedMount/FailedAttachVolume pending reason must escalate
+    to a KubernetesError once _MOUNT_FAILURE_TIMEOUT_SECONDS elapses, instead
+    of spinning in _wait_for_pods_to_run forever. Transient mount failures
+    (which the kubelet retries and resolves) must NOT raise, and the timer
+    must reset when the pod's pending reason moves on.
+    """
+
+    _MOUNT_MSG = ('MountVolume.MountDevice failed for volume "csi-fss-123" : '
+                  'rpc error: code = DeadlineExceeded desc = context deadline '
+                  'exceeded')
+
+    @staticmethod
+    def _make_pod(*, phase, running=False, name='pod-0'):
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.deletion_timestamp = None
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: 'cn-on-cloud',
+        }
+        pod.status.phase = phase
+        cs = mock.MagicMock()
+        cs.ready = running
+        cs.state.waiting = (None if running else mock.MagicMock(
+            reason='ContainerCreating', message=None))
+        cs.state.terminated = None
+        cs.state.running = mock.MagicMock() if running else None
+        cs.last_state.terminated = None
+        pod.status.container_statuses = [cs]
+        return pod
+
+    def _run_wait(self,
+                  monkeypatch,
+                  *,
+                  pending_reasons,
+                  clock_step=301.0,
+                  healthy_after=None):
+        """Drive _wait_for_pods_to_run with a scripted pending reason per
+        iteration (the last entry repeats). The fake clock advances by
+        `clock_step` seconds at each end-of-iteration sleep. If
+        `healthy_after` is set, that iteration (0-based) lists an all-Running
+        pod so the loop exits cleanly.
+        """
+        pending_pod = self._make_pod(phase='Pending')
+        healthy_pod = self._make_pod(phase='Running', running=True)
+        iteration = {'n': -1}
+
+        core_api = mock.MagicMock()
+
+        def _list_pods(*args, **kwargs):
+            iteration['n'] += 1
+            if healthy_after is not None and iteration['n'] >= healthy_after:
+                return mock.MagicMock(items=[healthy_pod])
+            return mock.MagicMock(items=[pending_pod])
+
+        core_api.list_namespaced_pod.side_effect = _list_pods
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        def _pending_reason(context, namespace, pod_name):
+            del context, namespace, pod_name  # unused
+            idx = min(max(iteration['n'], 0), len(pending_reasons) - 1)
+            reason = pending_reasons[idx]
+            if reason is None:
+                return None
+            if reason in instance._MOUNT_FAILURE_EVENT_REASONS:
+                return reason, self._MOUNT_MSG
+            return reason, ''
+
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            _pending_reason)
+
+        clock = {'t': 1000.0}
+        monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
+
+        def _sleep(seconds):
+            del seconds  # unused
+            clock['t'] += clock_step
+
+        monkeypatch.setattr(instance.time, 'sleep', _sleep)
+        monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                            lambda fn, items, n: [fn(p) for p in items])
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+
+        instance._wait_for_pods_to_run(namespace='ns',
+                                       context='ctx',
+                                       cluster_name='cn',
+                                       new_pods=[pending_pod])
+
+    @pytest.mark.parametrize('reason', ['FailedMount', 'FailedAttachVolume'])
+    def test_sustained_mount_failure_raises_with_event_message(
+            self, monkeypatch, reason):
+        """Mount failure persisting past the deadline raises, and the error
+        carries both the event reason (for the failure-hint table) and the
+        kubelet's full event message."""
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(monkeypatch, pending_reasons=[reason])
+        msg = str(exc_info.value)
+        assert reason in msg
+        assert 'DeadlineExceeded' in msg
+        assert 'pod-0' in msg
+
+    def test_transient_mount_failure_does_not_raise(self, monkeypatch):
+        """A FailedMount that resolves before the deadline (kubelet retry
+        succeeded, pod goes Running) must not raise."""
+        self._run_wait(monkeypatch,
+                       pending_reasons=['FailedMount'],
+                       healthy_after=2)
+
+    def test_timer_resets_when_pending_reason_moves_on(self, monkeypatch):
+        """FailedMount -> Pulling -> FailedMount: the deadline is measured
+        from the most recent onset, not the first. Total elapsed exceeds the
+        deadline, but no single sustained window does -- must not raise."""
+        self._run_wait(monkeypatch,
+                       pending_reasons=[
+                           'FailedMount', 'Pulling', 'FailedMount',
+                           'FailedMount'
+                       ],
+                       healthy_after=4)
+
+    def test_mount_failure_error_matches_failure_hint(self):
+        """The raised message must trip the KUBERNETES_FAILURE_HINTS entry so
+        provision-failure formatting appends the remediation hint."""
+        message = ('Pod pod-0 has failed to attach or mount volumes for over '
+                   f'10 minutes: FailedMount: {self._MOUNT_MSG}')
+        hint = kubernetes_utils.match_kubernetes_failure_hint(message)
+        assert hint is not None
+        assert 'kubectl describe pod' in hint
+
+
 class TestCheckInitContainersEnrichedRaise:
     """Tests the enriched raise message in _check_init_containers when an
     init container is in CrashLoopBackOff."""


### PR DESCRIPTION
## Summary

A pod whose volume fails to attach or mount (kubelet `FailedMount` / `FailedAttachVolume` events) stays in the uninformative `ContainerCreating` waiting state forever — these failures only surface as pod *events*, never in `pod.status`. `_wait_for_pods_to_run` only raises on informative container waiting reasons and has no deadline, so provisioning hangs indefinitely with only a spinner update (`Launching (1 pod(s) pending due to FailedMount)`), and the user has to go to `kubectl describe pod` to find the cause.

- **Escalate a persistent mount failure to a provisioning error**: if a pod continuously reports `FailedMount`/`FailedAttachVolume` for over 10 minutes, raise `KubernetesError` carrying the full kubelet event message. The window is deliberately generous — mount failures are frequently transient (CSI driver still starting on a freshly scaled-up node, slow first attach of a network volume) and the kubelet retries with backoff — and the per-pod timer resets whenever the pod's pending reason moves on. Persistent failures (mis-configured PVC/storage class, missing secret/configmap) never resolve and previously hung forever.
- **Add a remediation hint**: new `FailedMount`/`FailedAttachVolume` entry in `KUBERNETES_FAILURE_HINTS`, so the provision-failure block includes a `Hint:` line.
- The within-grace-window behavior (pending reason in the spinner and launch logs) is unchanged.

Example failure output (previously: infinite hang):

```
✗ Kubernetes (my-ctx) — (cpus=1, mem=1, ...)
  Failed to acquire resources in context my-ctx for {Kubernetes(cpus=1+)}.
  Reason: Pod my-cluster-head has failed to attach or mount volumes for over 10 minutes: FailedMount: MountVolume.SetUp failed for volume "sharedfs" : hostPath type check failed: /does/not/exist is not a directory
  Hint: A volume could not be attached or mounted to the pod. To fix: Verify the volume/PVC configuration (existence, storage class, access mode) and that any referenced secrets or configmaps exist; run `kubectl describe pod <pod-name>` for the full mount error.
```

## Test plan

- New unit tests in `tests/unit_tests/kubernetes/test_provision.py` (`TestWaitForPodsToRunMountFailureEscalation`): sustained `FailedMount`/`FailedAttachVolume` raises with the event message; a transient failure that resolves before the deadline does not raise; the timer resets when the pending reason changes; the raised message matches the failure-hint table. Full file passes: `pytest tests/unit_tests/kubernetes/test_provision.py` → 127 passed.
- New smoke test `test_kubernetes_pod_failed_mount_escalation` (`tests/smoke_tests/test_cluster_job.py`): launches the existing `test_k8s_pending_volume.yaml.j2` task and asserts the launch exits non-zero on its own with `FailedMount` + `MountVolume.SetUp failed` in the output. The existing `test_kubernetes_pod_pending_reason` is unaffected (it kills the launch at 60s, inside the grace window).
- Manual: launched a task mounting a nonexistent `hostPath` (`type: Directory`) on a live Kubernetes cluster. Observed the pending reason in the spinner/provision log and a `LAUNCH_PROGRESS` cluster event during the grace window, then the launch failed at exactly 10 minutes with the output shown above instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)