### PR TITLE
[Nebius] Wait for instance termination before deleting the cluster security group

### DIFF
--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -16,6 +16,12 @@ PENDING_STATUS = ['STARTING', 'DELETING', 'STOPPING']
 
 MAX_RETRIES_TO_LAUNCH = 120  # Maximum number of retries
 
+# Poll attempts (utils.POLL_INTERVAL seconds apart) to wait for a cluster's
+# instances to disappear from the provider after DeleteInstance is issued,
+# before deleting the cluster's security group. 60 * 5s = 5 minutes, which
+# covers typical Nebius instance reap times.
+_TERMINATION_POLL_ATTEMPTS = 60
+
 logger = sky_logging.init_logger(__name__)
 
 
@@ -239,6 +245,80 @@ def stop_instances(
         utils.stop(instance_id)
 
 
+def _wait_for_instances_terminated(region: str, cluster_name_on_cloud: str,
+                                   project_id: str) -> bool:
+    """Waits until the cluster has no instances left at the provider.
+
+    Nebius instance deletion is async: `utils.remove` returns once the
+    DeleteInstance request is accepted, not when the instance (and its
+    NIC's security group attachment) is actually gone. Returns True once
+    the cluster's instance list is empty; False on timeout (the caller may
+    still attempt SG deletion, which retries internally).
+    """
+    for attempt in range(_TERMINATION_POLL_ATTEMPTS):
+        instances = _filter_instances(region,
+                                      cluster_name_on_cloud,
+                                      status_filters=None,
+                                      project_id=project_id)
+        if not instances:
+            return True
+        logger.debug(f'Waiting for {len(instances)} instance(s) of '
+                     f'{cluster_name_on_cloud} to finish terminating '
+                     f'(attempt {attempt + 1}/{_TERMINATION_POLL_ATTEMPTS}).')
+        time.sleep(utils.POLL_INTERVAL)
+    logger.warning(
+        f'Instances of {cluster_name_on_cloud} still present after '
+        f'{_TERMINATION_POLL_ATTEMPTS * utils.POLL_INTERVAL}s; attempting '
+        f'security group deletion anyway.')
+    return False
+
+
+def _cleanup_security_group(cluster_name_on_cloud: str,
+                            provider_config: Dict[str, Any],
+                            project_id: str,
+                            wait_for_instances: bool = True) -> None:
+    """Best-effort deletion of the cluster's SkyPilot-managed SG.
+
+    Skips deletion when the user supplied a BYO SG (ManagedBySkyPilot=
+    False). Mirrors the `ManagedBySkyPilot` guard in
+    `sky.provision.aws.instance.cleanup_ports`. The flag flows through the
+    rendered Ray YAML's `provider.security_group` block from
+    `make_deploy_resources_variables`.
+
+    Never raises: this can run from a `finally` while an instance
+    termination error is propagating, and an orphaned SG is preferable to
+    masking that error (or failing an otherwise-clean teardown).
+    """
+    sg_block = provider_config.get('security_group') or {}
+    managed = bool(sg_block.get('ManagedBySkyPilot', True))
+    if not managed:
+        return
+    sg_name = sg_block.get(
+        'GroupName',
+        nebius_constants.SECURITY_GROUP_TEMPLATE.format(cluster_name_on_cloud))
+    try:
+        sg_id = utils.get_security_group_by_name(project_id, sg_name)
+        if sg_id is None:
+            return
+        if wait_for_instances:
+            # Nebius will not delete an SG that is still referenced by an
+            # instance NIC, and instance deletion is async. Wait for the
+            # cluster's instances to be fully reaped before deleting the
+            # SG, mirroring the wait_until_terminated loop in
+            # `sky.provision.aws.instance.cleanup_ports` (Case 4). Without
+            # this, the SG delete's bounded retry often expires while VMs
+            # still hold the SG, leaking one SG per cluster until the
+            # per-network SG quota is exhausted.
+            _wait_for_instances_terminated(provider_config['region'],
+                                           cluster_name_on_cloud, project_id)
+        utils.delete_security_group(sg_id)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            f'Failed to clean up security group {sg_name!r} for cluster '
+            f'{cluster_name_on_cloud!r}: '
+            f'{common_utils.format_exception(e, use_bracket=False)}')
+
+
 def terminate_instances(
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
@@ -254,46 +334,39 @@ def terminate_instances(
                                   cluster_name_on_cloud,
                                   status_filters=None,
                                   project_id=project_id)
-    for inst_id, inst in instances.items():
-        logger.debug(f'Terminating instance {inst_id}: {inst}')
-        if worker_only and inst['name'].endswith('-head'):
-            continue
-        try:
-            utils.remove(inst_id)
-        except Exception as e:  # pylint: disable=broad-except
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    f'Failed to terminate instance {inst_id}: '
-                    f'{common_utils.format_exception(e, use_bracket=False)}'
-                ) from e
-    if not worker_only:
-        utils.delete_cluster(cluster_name_on_cloud,
-                             provider_config['region'],
-                             project_id=project_id)
-
-    # Delete the cluster's SkyPilot-managed security group. Only when fully
-    # tearing down (worker_only=False) — partial scale-downs leave the SG
-    # in place since the head still uses it. delete_security_group drains
-    # rules first and retries SG-delete on dependency-violation, so it's
-    # safe even when VM termination above hasn't fully settled at the
-    # provider yet.
-    #
-    # Skip deletion when the user supplied a BYO SG (ManagedBySkyPilot=False).
-    # Mirrors the `ManagedBySkyPilot` guard in
-    # `sky.provision.aws.instance.cleanup_ports`. The flag flows
-    # through the rendered Ray YAML's `provider.security_group` block from
-    # `make_deploy_resources_variables`.
-    if not worker_only:
-        sg_block = provider_config.get('security_group') or {}
-        managed = bool(sg_block.get('ManagedBySkyPilot', True))
-        if managed:
-            sg_name = sg_block.get(
-                'GroupName',
-                nebius_constants.SECURITY_GROUP_TEMPLATE.format(
-                    cluster_name_on_cloud))
-            sg_id = utils.get_security_group_by_name(project_id, sg_name)
-            if sg_id is not None:
-                utils.delete_security_group(sg_id)
+    terminated_ok = False
+    try:
+        for inst_id, inst in instances.items():
+            logger.debug(f'Terminating instance {inst_id}: {inst}')
+            if worker_only and inst['name'].endswith('-head'):
+                continue
+            try:
+                utils.remove(inst_id)
+            except Exception as e:  # pylint: disable=broad-except
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        f'Failed to terminate instance {inst_id}: '
+                        f'{common_utils.format_exception(e, use_bracket=False)}'
+                    ) from e
+        if not worker_only:
+            utils.delete_cluster(cluster_name_on_cloud,
+                                 provider_config['region'],
+                                 project_id=project_id)
+        terminated_ok = True
+    finally:
+        # Delete the cluster's SkyPilot-managed security group. Only when
+        # fully tearing down (worker_only=False): partial scale-downs leave
+        # the SG in place since the head still uses it. Runs in a `finally`
+        # so a failed instance termination doesn't leak the SG; the cleanup
+        # is best-effort and never masks an in-flight exception. When the
+        # termination loop failed, skip the wait-for-termination poll (the
+        # instances are known to still exist) and just take a best-effort
+        # shot at the SG delete.
+        if not worker_only:
+            _cleanup_security_group(cluster_name_on_cloud,
+                                    provider_config,
+                                    project_id,
+                                    wait_for_instances=terminated_ok)
 
 
 def get_cluster_info(

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -24,7 +24,12 @@ _NEBIUS_PORTS_PER_RULE = 8
 
 # Backoff attempts when deleting an SG that's still attached to terminating
 # VMs. Mirrors AWS's BOTO_DELETE_MAX_ATTEMPTS (sky/provision/aws/instance.py).
-_SG_DELETE_MAX_ATTEMPTS = 6
+# This is only a backstop: `terminate_instances` waits for the cluster's
+# instances to be fully reaped before calling `delete_security_group`, so
+# by the time this retry loop runs the SG should normally be detachable.
+# 8 attempts with the default Backoff (initial 5s, x1.6, cap 25s) gives an
+# effective window of roughly two minutes.
+_SG_DELETE_MAX_ATTEMPTS = 8
 
 
 def retry(func):
@@ -370,10 +375,11 @@ def delete_security_group(sg_id: str) -> None:
     deleted first) or that is still attached to instances. We:
       1. List + delete all rules in the SG, then poll until the rule list
          is empty (Nebius deletes are async).
-      2. Attempt the SG delete with retry-on-dependency-violation (covers
-         the case where VMs are still terminating after `terminate_instances`
-         returned — mirrors the retry block in
-         `sky.provision.aws.instance.cleanup_ports`).
+      2. Attempt the SG delete with retry-on-dependency-violation. Callers
+         (`terminate_instances`) wait for the cluster's instances to be
+         fully reaped before calling this, so the retry is a backstop for
+         stragglers rather than the primary wait; mirrors the retry block
+         in `sky.provision.aws.instance.cleanup_ports`.
 
     On exhaustion, log + return rather than raise: an orphaned SG is
     preferable to a teardown failure.

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -2936,26 +2936,34 @@ def test_nebius_sg_reaped_after_down():
         # `cluster_name_on_cloud` is `name` plus a user-hash suffix added
         # by `make_cluster_name_on_cloud`, so the SG name can't be
         # computed from `name` alone. Recover it from the head VM's name
-        # (`<cluster_name_on_cloud>-head`) instead.
+        # instead: `utils.launch` names nodes
+        # `<cluster_name_on_cloud>-<4-hex-uuid>-<node_type>`, so drop the
+        # last two dash-separated segments.
         project_id = nebius_utils.get_project_by_region(region)
         instances = nebius_utils.list_instances(project_id)
-        head_names = [
-            info['name']
-            for info in instances.values()
+        heads = [
+            info for info in instances.values()
             if info.get('name', '').startswith(name) and
             info['name'].endswith('-head')
         ]
-        assert len(head_names) == 1, (
+        assert len(heads) == 1, (
             f'expected exactly one head VM with name prefix {name!r}, '
-            f'got {head_names}; all VM names in project: '
+            f'got {[h["name"] for h in heads]}; all VM names in project: '
             f'{[i.get("name") for i in instances.values()]}')
-        cluster_name_on_cloud = head_names[0][:-len('-head')]
+        cluster_name_on_cloud = heads[0]['name'].rsplit('-', 2)[0]
         sg_name = nebius_utils.SECURITY_GROUP_TEMPLATE.format(
             cluster_name_on_cloud)
         sg_id = nebius_utils.get_security_group_by_name(project_id, sg_name)
         assert sg_id is not None, (
             f'managed SG {sg_name!r} not found while the cluster is up; '
-            f'cannot verify its post-down reaping.')
+            f'cannot verify its post-down reaping. Head VM: '
+            f'{heads[0]["name"]!r}, attached SGs: '
+            f'{heads[0].get("security_group_ids")}')
+        attached = heads[0].get('security_group_ids') or []
+        assert sg_id in attached, (
+            f'SG {sg_name!r} ({sg_id}) exists but is not attached to the '
+            f'head VM (attached: {attached}); the name-derivation in this '
+            f'test is probably stale vs. `utils.launch` naming.')
         state['project_id'] = project_id
         state['sg_name'] = sg_name
 

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -27,7 +27,7 @@ import tempfile
 import textwrap
 import threading
 import time
-from typing import Generator, Optional
+from typing import Dict, Generator, Optional
 
 import pytest
 from smoke_tests import smoke_tests_utils
@@ -2898,6 +2898,98 @@ def test_nebius_security_group_attached_and_enforced():
             f'sky logs {name} 1 --status',
             _verify_sg_attached_and_enforced,
         ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout('nebius'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.nebius
+def test_nebius_sg_reaped_after_down():
+    """`sky down` must delete the cluster's SkyPilot-managed SG.
+
+    Nebius instance deletion is async: DeleteInstance is accepted before
+    the VM (and its NIC's SG attachment) is actually gone, and Nebius
+    refuses to delete an SG that a NIC still references. Without the
+    wait-for-termination in `terminate_instances`, teardowns orphan their
+    `sky-sg-<cluster>` SG; leaks accumulate until the per-network SG
+    quota is exhausted (`vpc.network.max-security-groups-count`) and all
+    launches in the region fail.
+
+    Launches a real 2-node cluster (multi-node covers the N-instance
+    drain and widens the reap window), records the managed SG while the
+    cluster is up, runs `sky down`, then asserts the SG is gone.
+
+    Cheap: 2 small CPU instances, ~5 min including teardown. Skipped by
+    default; runs only with `pytest --nebius`.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.provision.nebius import utils as nebius_utils
+
+    name = smoke_tests_utils.get_cluster_name()
+    region = 'eu-north1'
+    # Populated by `_record_sg` while the cluster is up; consumed by
+    # `_verify_sg_reaped` after `sky down`.
+    state: Dict[str, str] = {}
+
+    def _record_sg():
+        # `cluster_name_on_cloud` is `name` plus a user-hash suffix added
+        # by `make_cluster_name_on_cloud`, so the SG name can't be
+        # computed from `name` alone. Recover it from the head VM's name
+        # (`<cluster_name_on_cloud>-head`) instead.
+        project_id = nebius_utils.get_project_by_region(region)
+        instances = nebius_utils.list_instances(project_id)
+        head_names = [
+            info['name']
+            for info in instances.values()
+            if info.get('name', '').startswith(name) and
+            info['name'].endswith('-head')
+        ]
+        assert len(head_names) == 1, (
+            f'expected exactly one head VM with name prefix {name!r}, '
+            f'got {head_names}; all VM names in project: '
+            f'{[i.get("name") for i in instances.values()]}')
+        cluster_name_on_cloud = head_names[0][:-len('-head')]
+        sg_name = nebius_utils.SECURITY_GROUP_TEMPLATE.format(
+            cluster_name_on_cloud)
+        sg_id = nebius_utils.get_security_group_by_name(project_id, sg_name)
+        assert sg_id is not None, (
+            f'managed SG {sg_name!r} not found while the cluster is up; '
+            f'cannot verify its post-down reaping.')
+        state['project_id'] = project_id
+        state['sg_name'] = sg_name
+
+    def _verify_sg_reaped():
+        assert state, '_record_sg did not run; nothing to verify.'
+        # The SG delete is issued before `sky down` returns, but Nebius
+        # deletes are async; give the control plane a short window to
+        # stop reporting the SG before declaring a leak.
+        sg_id = None
+        for _ in range(6):
+            sg_id = nebius_utils.get_security_group_by_name(
+                state['project_id'], state['sg_name'])
+            if sg_id is None:
+                return
+            time.sleep(5)
+        raise AssertionError(
+            f'security group {state["sg_name"]!r} ({sg_id}) still exists '
+            f'after `sky down` returned: terminate_instances leaked the '
+            f'SG. Each leak consumes one slot of the per-network SG quota '
+            f'until launches fail with '
+            f'vpc.network.max-security-groups-count.')
+
+    test = smoke_tests_utils.Test(
+        'nebius_sg_reaped_after_down',
+        [
+            f'sky launch -y -c {name} --infra nebius --num-nodes 2 '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/minimal.yaml',
+            _record_sg,
+            f'sky down -y {name}',
+            _verify_sg_reaped,
+        ],
+        # Safety net for failures above; `sky down` on an already-downed
+        # cluster is a no-op that exits 0.
         f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('nebius'),
     )

--- a/tests/unit_tests/test_nebius_security_groups.py
+++ b/tests/unit_tests/test_nebius_security_groups.py
@@ -274,6 +274,164 @@ def test_terminate_instances_noop_for_legacy_cluster_sg():
     mock_del.assert_not_called()
 
 
+def test_terminate_instances_waits_for_termination_before_sg_delete():
+    """SG delete must happen only after the cluster's instances are gone.
+
+    Nebius instance deletion is async, so the SG stays attached to
+    terminating VMs for a while after DeleteInstance is accepted. Deleting
+    the SG before the instances are reaped exhausts the bounded retry and
+    leaks one SG per cluster.
+    """
+    order = []
+    # _filter_instances: first call (terminate loop) returns one RUNNING
+    # instance; the wait-for-termination poll then sees one DELETING
+    # instance and finally an empty cluster.
+    filter_results = iter([
+        {
+            'i-1': {
+                'name': 'mycluster-aaaa-head',
+                'status': 'RUNNING'
+            }
+        },
+        {
+            'i-1': {
+                'name': 'mycluster-aaaa-head',
+                'status': 'DELETING'
+            }
+        },
+        {},
+    ])
+
+    def fake_filter(*_args, **_kwargs):
+        result = next(filter_results)
+        order.append(('filter', len(result)))
+        return result
+
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           side_effect=fake_filter), \
+         mock.patch.object(nebius_utils, 'remove',
+                           side_effect=lambda i: order.append(('remove', i))), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value='sg-2'), \
+         mock.patch.object(
+             nebius_utils, 'delete_security_group',
+             side_effect=lambda sg: order.append(('delete_sg', sg))), \
+         mock.patch('time.sleep'):
+        nebius_instance.terminate_instances(
+            'mycluster',
+            provider_config={'region': 'eu-north1'},
+            worker_only=False,
+        )
+
+    # The SG delete comes strictly after the instance list drained.
+    assert order == [
+        ('filter', 1),  # terminate loop enumerates the cluster
+        ('remove', 'i-1'),
+        ('filter', 1),  # wait poll: still DELETING
+        ('filter', 0),  # wait poll: drained
+        ('delete_sg', 'sg-2'),
+    ]
+
+
+def test_terminate_instances_sg_cleanup_runs_when_termination_fails():
+    """A failed instance termination must not leak the SG: cleanup still
+    runs (without the wait poll) and the original error propagates."""
+    with mock.patch.object(
+            nebius_instance, '_filter_instances',
+            return_value={
+                'i-1': {
+                    'name': 'mycluster-aaaa-head',
+                    'status': 'RUNNING'
+                }
+            }) as mock_filter, \
+         mock.patch.object(nebius_utils, 'remove',
+                           side_effect=RuntimeError('boom')), \
+         mock.patch.object(nebius_utils, 'delete_cluster') as mock_del_cluster, \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value='sg-2'), \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del_sg, \
+         mock.patch('time.sleep'):
+        with pytest.raises(RuntimeError, match='Failed to terminate instance'):
+            nebius_instance.terminate_instances(
+                'mycluster',
+                provider_config={'region': 'eu-north1'},
+                worker_only=False,
+            )
+    mock_del_sg.assert_called_once_with('sg-2')
+    mock_del_cluster.assert_not_called()
+    # The error path must not sit in the wait-for-termination poll (the
+    # instances are known to still exist): only the terminate-loop listing
+    # ran.
+    assert mock_filter.call_count == 1
+
+
+def test_terminate_instances_sg_cleanup_error_does_not_mask_failure():
+    """An SG-cleanup error inside the `finally` must never mask the
+    original instance-termination error."""
+    with mock.patch.object(
+            nebius_instance, '_filter_instances',
+            return_value={
+                'i-1': {
+                    'name': 'mycluster-aaaa-head',
+                    'status': 'RUNNING'
+                }
+            }), \
+         mock.patch.object(nebius_utils, 'remove',
+                           side_effect=RuntimeError('boom')), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           side_effect=Exception('sg lookup exploded')), \
+         mock.patch('time.sleep'):
+        with pytest.raises(RuntimeError, match='Failed to terminate instance'):
+            nebius_instance.terminate_instances(
+                'mycluster',
+                provider_config={'region': 'eu-north1'},
+                worker_only=False,
+            )
+
+
+def test_terminate_instances_sg_delete_proceeds_on_wait_timeout():
+    """If instances never drain within the bounded wait, we still take a
+    best-effort shot at the SG delete (its internal retry may catch a
+    late detach) instead of silently skipping it."""
+    filter_calls = {'n': 0}
+
+    def fake_filter(*_args, **_kwargs):
+        filter_calls['n'] += 1
+        return {'i-1': {'name': 'mycluster-aaaa-head', 'status': 'DELETING'}}
+
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           side_effect=fake_filter), \
+         mock.patch.object(nebius_utils, 'remove'), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value='sg-2'), \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del_sg, \
+         mock.patch('time.sleep'), \
+         mock.patch.object(nebius_instance, 'logger') as mock_logger:
+        nebius_instance.terminate_instances(
+            'mycluster',
+            provider_config={'region': 'eu-north1'},
+            worker_only=False,
+        )
+
+    mock_del_sg.assert_called_once_with('sg-2')
+    # Terminate-loop listing + the full bounded wait.
+    # pylint: disable-next=protected-access
+    assert filter_calls['n'] == 1 + nebius_instance._TERMINATION_POLL_ATTEMPTS
+    warn_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+    assert any('still present' in m for m in warn_calls)
+
+
 # --- BYO security group (nebius.security_group_name config) ----------------
 
 


### PR DESCRIPTION
## Summary

- Fixes a security-group leak in the Nebius provisioner: since native security groups replaced UFW (#9563), every cluster teardown could orphan its `sky-sg-<cluster>` SG. Nebius instance deletion is async, so `terminate_instances` returned while VMs still held the SG, and the bounded retry inside `delete_security_group` usually expired before the NICs released it. Orphans accumulate until the per-network quota is exhausted (`QuotaFailure: vpc.network.max-security-groups-count`, 129 of 128) and all launches in the region fail; this has been hitting recurring CI runs in `eu-north1`.
- `terminate_instances` now polls until the cluster's instances are fully reaped (bounded wait, 5 minutes) before calling `delete_security_group`, mirroring the `wait_until_terminated` loop in `sky.provision.aws.instance.cleanup_ports` (Case 4).
- SG cleanup moved into a best-effort `_cleanup_security_group` helper invoked from a `finally` block: a failed instance termination no longer skips SG cleanup, and an SG-cleanup error never masks the original termination error. On the error path the wait poll is skipped (the instances are known to still exist) and we just take a best-effort shot at the delete.
- Bumped the SG-delete retry backstop from 6 to 8 attempts (roughly a two-minute window) for stragglers.

Change is contained to `sky/provision/nebius/instance.py` and `sky/provision/nebius/utils.py`, plus unit tests.

## Tested

- Added unit tests in `tests/unit_tests/test_nebius_security_groups.py`:
  - SG delete happens strictly after the cluster's instance list drains (ordering asserted).
  - SG cleanup still runs when an instance termination raises, without the wait poll, and the original `RuntimeError` propagates.
  - An SG-cleanup error inside the `finally` does not mask the termination error.
  - On wait timeout, the SG delete is still attempted and a warning is logged.
- `pytest tests/unit_tests/test_nebius_security_groups.py tests/unit_tests/test_nebius.py`: 34 passed.
- `bash format.sh`: 10.00/10, mypy clean.
- Manual verification plan: on a Nebius-enabled setup, `sky launch -c neb-sg-test --cloud nebius --cpus 2 -y` then `sky down neb-sg-test -y`; confirm via the Nebius console (or `nebius vpc security-group list`) that `sky-sg-neb-sg-test-...` is gone after teardown instead of lingering. Repeat with a multi-node cluster and with a teardown where one instance delete is slow to confirm no orphan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)