### PR TITLE
[Azure] Restrict SSH ingress for private-IP clusters

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1552,6 +1552,11 @@ If true, SkyPilot will not create public IP addresses for Azure instances and on
 private IPs (optional). Requires a network setup that allows SSH access to private IPs
 (e.g., a VPN or ``ssh_proxy_command``).
 
+For SkyPilot-managed Network Security Groups, enabling this option restricts inbound
+SSH to Azure's ``VirtualNetwork`` service tag instead of allowing SSH from every
+source. When an existing VNet subnet supplies its own Network Security Group, that
+group remains user-managed.
+
 This flag is typically set together with ``vpc_name`` above and
 ``ssh_proxy_command`` below.
 

--- a/sky/provision/azure/azure-config-template.json
+++ b/sky/provision/azure/azure-config-template.json
@@ -25,6 +25,13 @@
             "metadata": {
                 "description": "Name of the Network Security Group associated with the SkyPilot cluster."
             }
+        },
+        "sshSourceAddressPrefix": {
+            "type": "string",
+            "defaultValue": "*",
+            "metadata": {
+                "description": "Source address prefix allowed to reach SSH on the SkyPilot cluster."
+            }
         }
     },
     "variables": {
@@ -72,7 +79,7 @@
                             "protocol": "TCP",
                             "access": "Allow",
                             "direction": "Inbound",
-                            "sourceAddressPrefix": "*",
+                            "sourceAddressPrefix": "[parameters('sshSourceAddressPrefix')]",
                             "sourcePortRange": "*",
                             "destinationAddressPrefix": "*",
                             "destinationPortRange": "22"

--- a/sky/provision/azure/config.py
+++ b/sky/provision/azure/config.py
@@ -55,6 +55,11 @@ def get_cluster_id_and_nsg_name(resource_group: str,
     return cluster_id, nsg_name
 
 
+def _get_ssh_source_address_prefix(use_internal_ips: bool) -> str:
+    """Returns the SSH source for a SkyPilot-managed network security group."""
+    return 'VirtualNetwork' if use_internal_ips else '*'
+
+
 @common.log_function_start_end
 def bootstrap_instances(
         region: str, cluster_name_on_cloud: str,
@@ -186,6 +191,10 @@ def bootstrap_instances(
                 },
                 'nsgName': {
                     'value': nsg_name
+                },
+                'sshSourceAddressPrefix': {
+                    'value': _get_ssh_source_address_prefix(
+                        provider_config.get('use_internal_ips', False))
                 },
                 'location': {
                     'value': params['location']

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -2484,6 +2484,64 @@ def test_lambda_cloud_open_ports():
                 # Don't fail the test if cleanup fails
 
 
+@pytest.mark.azure
+def test_azure_private_ip_managed_nsg():
+    """Private-IP bootstrap restricts SSH in the live Azure-managed NSG.
+
+    This exercises the ARM deployment without launching a VM. It creates an
+    isolated resource group, inspects the resulting SSH rule, and deletes the
+    resource group during teardown.
+    """
+    # pylint: disable=import-outside-toplevel
+    import uuid
+
+    from sky.adaptors import azure
+    from sky.provision import common as provision_common
+    from sky.provision.azure import config as azure_config
+
+    region = 'eastus'
+    suffix = uuid.uuid4().hex[:8]
+    cluster_name = f'nsg-smoke-{suffix}'
+    resource_group = f'sky-nsg-smoke-{suffix}'
+    subscription_id = azure.get_subscription_id()
+    config = provision_common.ProvisionConfig(
+        provider_config={
+            'subscription_id': subscription_id,
+            'resource_group': resource_group,
+            'location': region,
+            'use_external_resource_group': False,
+            'use_internal_ips': True,
+        },
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+
+    try:
+        config = azure_config.bootstrap_instances(region, cluster_name, config)
+        nsg_name = config.provider_config['nsg'].rsplit('/', 1)[-1]
+        network_client = azure.get_client('network', subscription_id)
+        nsg = network_client.network_security_groups.get(
+            resource_group_name=resource_group,
+            network_security_group_name=nsg_name)
+        ssh_rule = next(
+            rule for rule in nsg.security_rules if rule.name == 'SSH')
+        assert ssh_rule.source_address_prefix == 'VirtualNetwork'
+    finally:
+        resource_client = azure.get_client('resource', subscription_id)
+        delete_resource_group = azure_config.get_azure_sdk_function(
+            client=resource_client.resource_groups, function_name='delete')
+        try:
+            delete_resource_group(resource_group_name=resource_group,
+                                  force_deletion_types=None).wait()
+        except azure.exceptions().ResourceNotFoundError:
+            pass
+
+
 @pytest.mark.nebius
 # Smoke test verifies API integration; `list_security_rules` is the only
 # way to introspect SG state, hence the protected-access exception here.

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -1,4 +1,6 @@
 """Tests for Azure utilities and provisioning config."""
+import json
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -7,6 +9,7 @@ from sky import clouds
 from sky import exceptions
 from sky.adaptors import azure
 from sky.clouds.utils import azure_utils
+from sky.provision.azure.config import _get_ssh_source_address_prefix
 from sky.provision.azure.config import _remove_msi_resources_from_template
 from sky.provision.azure.config import _remove_network_resources_from_template
 from sky.provision.azure.config import _resolve_custom_managed_identity
@@ -14,6 +17,28 @@ from sky.provision.azure.config import _resolve_custom_managed_identity
 _SIG_IMAGE_ID = ('/subscriptions/sub-123/resourceGroups/my-rg/providers/'
                  'Microsoft.Compute/galleries/my-gallery/images/my-image/'
                  'versions/1.0.3')
+
+
+def test_ssh_source_address_prefix():
+    assert _get_ssh_source_address_prefix(use_internal_ips=True) \
+        == 'VirtualNetwork'
+    assert _get_ssh_source_address_prefix(use_internal_ips=False) == '*'
+
+
+def test_azure_config_template_uses_ssh_source_parameter():
+    template_path = (Path(__file__).parents[2] / 'sky' / 'provision' / 'azure' /
+                     'azure-config-template.json')
+    template = json.loads(template_path.read_text(encoding='utf-8'))
+    assert template['parameters']['sshSourceAddressPrefix'][
+        'defaultValue'] == '*'
+    network_security_group = next(
+        resource for resource in template['resources']
+        if resource['type'] == 'Microsoft.Network/networkSecurityGroups')
+    ssh_rule = next(
+        rule for rule in network_security_group['properties']['securityRules']
+        if rule['name'] == 'SSH')
+    assert ssh_rule['properties']['sourceAddressPrefix'] == (
+        '[parameters(\'sshSourceAddressPrefix\')]')
 
 
 def test_validate_image_id():


### PR DESCRIPTION
## Summary

Fixes #10271.

Azure clusters created with `azure.use_internal_ips: true` do not receive public IP addresses, but SkyPilot's managed Network Security Group still permits port 22 from every source. This change applies the private-networking intent to the managed NSG as defense in depth.

## Changes

- Use Azure's `VirtualNetwork` service tag as the SSH source for private-IP clusters.
- Preserve the existing `*` source for public-IP clusters.
- Leave existing/custom subnet NSGs under user control.
- Document the managed-NSG behavior.
- Cover the selection logic and ARM-template wiring with unit tests.
- Add a live Azure smoke test that bootstraps the ARM resources without a VM, inspects the managed NSG's SSH rule, and removes its isolated resource group.

This builds on the Azure networking controls added in #8986 and does not add deployment-specific addresses or resources.

## Tested

- [x] Code formatting: `bash format.sh --files sky/provision/azure/config.py tests/unit_tests/test_azure_utils.py`
- [x] Unit tests: `pytest -q tests/unit_tests/test_azure_utils.py` (18 passed)
- [x] ARM template: `python -m json.tool sky/provision/azure/azure-config-template.json`
- [x] Smoke-test collection: `pytest --collect-only tests/smoke_tests/test_basic.py -k test_azure_private_ip_managed_nsg --azure`
- [ ] Relevant smoke test: `/smoke-test -k test_azure_private_ip_managed_nsg --azure`
- [ ] All smoke tests: `/smoke-test`
- [ ] Backward compatibility: `/quicktest-core`
