### PR TITLE
[Nebius] Keep personal pricing fetch failures out of CLI output

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -1,8 +1,9 @@
 """Nebius cloud adaptor."""
 import asyncio
+import logging
 import os
 import threading
-from typing import Any, Awaitable, List, Optional
+from typing import Any, Awaitable, Dict, List, Optional
 
 from sky import sky_logging
 from sky import skypilot_config
@@ -19,6 +20,27 @@ _loop_lock = threading.Lock()
 _loop = None
 
 
+def _loop_exception_handler(loop: asyncio.AbstractEventLoop,
+                            context: Dict[str, Any]) -> None:
+    """Exception handler for the dedicated nebius SDK event loop.
+
+    grpc.aio can raise exceptions in loop callbacks (e.g.
+    PollerCompletionQueue._handle_events) when a nebius API call fails.
+    The default asyncio handler logs these at ERROR level to stderr,
+    polluting user-facing CLI output. API errors are still raised to
+    callers through sync_call(), so log the callback noise at debug level
+    for diagnostics instead. This handler is scoped to the dedicated
+    nebius event loop and does not affect other event loops.
+    """
+    del loop  # Unused.
+    message = context.get('message', 'Exception in nebius SDK event loop')
+    exception = context.get('exception')
+    exc_info: Any = False
+    if exception is not None:
+        exc_info = (type(exception), exception, exception.__traceback__)
+    logger.debug(f'nebius SDK event loop: {message}', exc_info=exc_info)
+
+
 def _get_event_loop() -> asyncio.AbstractEventLoop:
     """Get event loop for nebius sdk."""
     global _loop
@@ -29,8 +51,10 @@ def _get_event_loop() -> asyncio.AbstractEventLoop:
     with _loop_lock:
         if _loop is None:
             # Create a new event loop in a dedicated thread
-            _loop = asyncio.new_event_loop()
-            threading.Thread(target=_loop.run_forever, daemon=True).start()
+            loop = asyncio.new_event_loop()
+            loop.set_exception_handler(_loop_exception_handler)
+            threading.Thread(target=loop.run_forever, daemon=True).start()
+            _loop = loop
 
         return _loop
 
@@ -119,11 +143,31 @@ POLL_INTERVAL = 5
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Nebius AI Cloud.'
                          'Try pip install "skypilot[nebius]"')
 
-nebius = common.LazyImport(
-    'nebius',
-    import_error_message=_IMPORT_ERROR_MESSAGE,
+
+class _NebiusDeprecationFilter(logging.Filter):
+    """Drops nebius SDK records logged to the 'deprecation' logger.
+
+    The nebius SDK emits deprecated-field warnings (e.g.
+    'Field .nebius.compute.v1.PreemptibleSpec.priority is deprecated')
+    to a logger named 'deprecation'. They are not actionable by users and
+    pollute user-facing CLI output. Only records originating from the
+    nebius package are dropped, so other libraries using the same logger
+    name are unaffected.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return f'{os.sep}nebius{os.sep}' not in record.pathname
+
+
+def _set_nebius_loggers() -> None:
     # https://github.com/grpc/grpc/issues/37642 to avoid spam in console
-    set_loggers=lambda: os.environ.update({'GRPC_VERBOSITY': 'NONE'}))
+    os.environ['GRPC_VERBOSITY'] = 'NONE'
+    logging.getLogger('deprecation').addFilter(_NebiusDeprecationFilter())
+
+
+nebius = common.LazyImport('nebius',
+                           import_error_message=_IMPORT_ERROR_MESSAGE,
+                           set_loggers=_set_nebius_loggers)
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',
                              import_error_message=_IMPORT_ERROR_MESSAGE)

--- a/sky/catalog/nebius_catalog.py
+++ b/sky/catalog/nebius_catalog.py
@@ -78,8 +78,11 @@ def _get_df() -> Union[pd.DataFrame, common.LazyDataFrame]:
         from sky.adaptors import nebius
         tenant_id = nebius.get_tenant_id()
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning('Failed to get Nebius tenant ID. '
-                       f'{common_utils.format_exception(e)}')
+        # Log at debug level: personal pricing is best-effort and falls
+        # back to the static catalog, so a flaky external API must not
+        # pollute user-facing CLI output (e.g. mid `sky launch`).
+        logger.debug('Failed to get Nebius tenant ID. Falling back to the '
+                     f'static catalog. {common_utils.format_exception(e)}')
         return _static_df
 
     if tenant_id is None:
@@ -113,8 +116,13 @@ def _get_df() -> Union[pd.DataFrame, common.LazyDataFrame]:
                 df=personal_df, expires_at=expires_at)
             return personal_df
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning('Failed to fetch personal pricing. '
-                           f'{common_utils.format_exception(e)}')
+            # Log at debug level: personal pricing is best-effort and falls
+            # back to the static (or stale personal) catalog, so a flaky
+            # external API must not pollute user-facing CLI output (e.g.
+            # mid `sky launch`).
+            logger.debug('Failed to fetch personal pricing. Falling back to '
+                         'the static catalog. '
+                         f'{common_utils.format_exception(e)}')
             stale_df = entry.df if entry is not None else None
             _personal_catalogs[tenant_id] = _PersonalCatalogEntry(
                 df=stale_df,

--- a/tests/unit_tests/test_nebius.py
+++ b/tests/unit_tests/test_nebius.py
@@ -1,8 +1,12 @@
+# pylint: disable=protected-access
+import logging
+import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from sky import clouds
 from sky import resources as resources_lib
+from sky.adaptors import nebius as nebius_adaptor
 from sky.clouds import nebius
 from sky.utils import resources_utils
 
@@ -126,3 +130,61 @@ class TestNebiusNetworkTier:
         # Should NOT include InfiniBand options since network_tier != best
         assert '--device=/dev/infiniband' not in docker_options
         assert '--cap-add=IPC_LOCK' not in docker_options
+
+
+class TestNebiusAdaptorLogging:
+    """Nebius SDK log noise must not reach user-facing CLI output."""
+
+    def test_loop_exception_handler_logs_at_debug(self):
+        """Callback exceptions in the SDK loop are logged at debug only."""
+        records = []
+
+        class _CaptureHandler(logging.Handler):
+
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = _CaptureHandler(level=logging.DEBUG)
+        previous_level = nebius_adaptor.logger.level
+        nebius_adaptor.logger.addHandler(handler)
+        nebius_adaptor.logger.setLevel(logging.DEBUG)
+        try:
+            context = {
+                'message': ('Exception in callback '
+                            'PollerCompletionQueue._handle_events'),
+                'exception': RuntimeError('unresolved sku'),
+            }
+            nebius_adaptor._loop_exception_handler(MagicMock(), context)
+        finally:
+            nebius_adaptor.logger.removeHandler(handler)
+            nebius_adaptor.logger.setLevel(previous_level)
+
+        assert records, 'Expected a debug record for diagnostics'
+        assert all(r.levelno == logging.DEBUG for r in records)
+
+    def test_dedicated_loop_has_exception_handler(self):
+        with patch.object(nebius_adaptor, '_loop', None):
+            loop = nebius_adaptor._get_event_loop()
+            try:
+                assert (loop.get_exception_handler() is
+                        nebius_adaptor._loop_exception_handler)
+            finally:
+                loop.call_soon_threadsafe(loop.stop)
+
+    def test_deprecation_filter_drops_only_nebius_records(self):
+        log_filter = nebius_adaptor._NebiusDeprecationFilter()
+
+        def _record(pathname: str) -> logging.LogRecord:
+            return logging.LogRecord(name='deprecation',
+                                     level=logging.WARNING,
+                                     pathname=pathname,
+                                     lineno=1,
+                                     msg='Field x is deprecated',
+                                     args=None,
+                                     exc_info=None)
+
+        nebius_path = os.path.join('site-packages', 'nebius', 'aio',
+                                   'client.py')
+        other_path = os.path.join('site-packages', 'otherlib', 'client.py')
+        assert not log_filter.filter(_record(nebius_path))
+        assert log_filter.filter(_record(other_path))

--- a/tests/unit_tests/test_nebius_catalog.py
+++ b/tests/unit_tests/test_nebius_catalog.py
@@ -1,6 +1,7 @@
 """Tests for the Nebius personalized pricing catalog cache."""
 
 # pylint: disable=protected-access
+import logging
 import threading
 from unittest import mock
 
@@ -170,3 +171,46 @@ def test_slow_tenant_fetch_does_not_block_other_tenant_cache_hit():
     assert not errors
     assert results['tenant-b'] is tenant_b_df
     assert results['tenant-a'].iloc[0]['Price'] == 0.5
+
+
+def test_personal_catalog_fetch_failure_is_quiet():
+    """A failing personal pricing fetch must not log at WARNING or above.
+
+    The fetch hits an external API mid `sky launch`; failures fall back to
+    the static catalog and must not pollute user-facing CLI output.
+    """
+    static_df = _catalog(1.0)
+    fetch = mock.Mock(side_effect=RuntimeError(
+        'RequestError INVALID_ARGUMENT: unresolved sku'))
+
+    records = []
+
+    class _CaptureHandler(logging.Handler):
+
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _CaptureHandler(level=logging.DEBUG)
+    logger = nebius_catalog.logger
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        with mock.patch.object(nebius_catalog, '_static_df', static_df), \
+             mock.patch.object(nebius_catalog.skypilot_config,
+                               'get_nested',
+                               return_value=True), \
+             mock.patch('sky.adaptors.nebius.get_tenant_id',
+                        return_value='tenant-a'), \
+             mock.patch.object(nebius_catalog, '_fetch_user_catalog', fetch):
+            assert nebius_catalog._get_df() is static_df
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    assert fetch.call_count == 1
+    loud_records = [r for r in records if r.levelno >= logging.WARNING]
+    assert not loud_records, [r.getMessage() for r in loud_records]
+    # The failure is still recorded at debug level for diagnostics.
+    assert any(
+        'Failed to fetch personal pricing' in r.getMessage() for r in records)


### PR DESCRIPTION
## Summary

The Nebius billing API recently started returning `RequestError INVALID_ARGUMENT: ... unresolved sku: there is no SKU for the resource` when SkyPilot fetches personalized pricing. The fallback to the static catalog works as designed, but the failure leaked log noise into user-visible CLI output mid `sky launch` (between "Job submitted, ID: N" and "Waiting for task resources on ..."). This broke roughly 40 nebius smoke tests in release CI, since the standard launch-output validation asserts those lines are adjacent. External API flakiness must not be able to poison CLI output, so this PR removes all three noise sources:

- Demote the `Failed to fetch personal pricing` (and `Failed to get Nebius tenant ID`) warnings in `sky/catalog/nebius_catalog.py` to `logger.debug`. The fetch is best-effort and falls back to the static (or stale personal) catalog, and the existing retry cache already prevents hammering the API.
- Install an asyncio exception handler on the dedicated nebius SDK event loop in `sky/adaptors/nebius.py`. grpc.aio raises callback exceptions (`ERROR:asyncio: Exception in callback PollerCompletionQueue._handle_events...` with a full traceback) that the default handler logs to stderr. The new handler logs them at debug instead. It is scoped to the nebius SDK's private background loop only, so asyncio error reporting for every other event loop in the process is unaffected; real API errors still propagate to callers through `sync_call()`.
- Filter the nebius SDK's field-deprecation spam (`WARNING:deprecation:Field .nebius.compute.v1.PreemptibleSpec.priority is deprecated...`). The SDK logs these to a logger literally named `deprecation`; the filter drops only records whose `pathname` is inside the nebius package, so other libraries that use the same logger name are unaffected. Installed via the existing `set_loggers` hook on the nebius `LazyImport`, alongside the existing `GRPC_VERBOSITY` suppression.

This is a cherry-pick candidate for the release branch, since the release smoke tests are currently failing whenever the Nebius billing API returns this error.

## Tested

- New unit test `test_personal_catalog_fetch_failure_is_quiet` (tests/unit_tests/test_nebius_catalog.py): a raising `_fetch_user_catalog` returns the static catalog without logging at WARNING or above, while still recording the failure at debug for diagnostics.
- New unit tests in tests/unit_tests/test_nebius.py: the dedicated SDK loop has the scoped exception handler installed, the handler logs at debug only, and the deprecation filter drops nebius-originated records while passing records from other libraries.
- `pytest tests/unit_tests/test_nebius_catalog.py tests/unit_tests/test_nebius.py`: 12 passed (all pre-existing tests still pass).
- Manual simulation with a root stderr log handler configured: scheduled a raising callback on the nebius SDK loop and emitted nebius-style and non-nebius records to the `deprecation` logger. Result: no `ERROR:asyncio` traceback, nebius deprecation record suppressed, non-nebius deprecation record still printed.
- `bash format.sh`: mypy clean, pylint 10.00/10.

Manual verification on a machine with nebius credentials where the billing API returns the SKU error: run `sky launch --infra nebius ...` and confirm the output between "Job submitted, ID: N" and "Waiting for task resources on ..." contains no warning, asyncio traceback, or deprecation lines, and that `SKYPILOT_DEBUG=1` still shows the fetch failure in debug logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)