### PR TITLE
[Test] Add managed jobs smoke test for pod_config targeting the ray-node container

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1869,6 +1869,54 @@ def test_managed_jobs_env_isolation(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
+# Only run this test on Kubernetes since this test relies on
+# kubernetes.pod_config
+@pytest.mark.kubernetes
+@pytest.mark.managed_jobs
+def test_managed_jobs_pod_config_ray_node_container(generic_cloud: str):
+    """pod_config targeting the main container by name must merge into it.
+
+    The main container in SkyPilot Kubernetes pods is named ``ray-node``, and
+    user pod_configs commonly target it by that name (e.g. to add
+    volumeMounts). Container entries are patch-merged by name, so a named
+    entry must merge into the existing ``ray-node`` container rather than
+    being treated as a new container. The pod_config lives in the task YAML's
+    ``config`` section (tests/test_yamls/test_k8s_pod_config_ray_node.yaml),
+    which adds an env var and an emptyDir volume mount to the ``ray-node``
+    container; the test asserts both are visible from inside the job.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    task_yaml = 'tests/test_yamls/test_k8s_pod_config_ray_node.yaml'
+    test = smoke_tests_utils.Test(
+        'managed_jobs_pod_config_ray_node_container',
+        [
+            # The task sleeps 60 so the job is still RUNNING when we tail its
+            # logs by name (same workaround as
+            # test_managed_jobs_env_isolation).
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} -y -d {task_yaml}',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}',
+                job_status=[sky.ManagedJobStatus.RUNNING],
+                timeout=600
+                if smoke_tests_utils.is_remote_server_test() else 120),
+            f's=$(sky jobs logs -n {name} --no-follow) && echo "$s" && '
+            f'echo "$s" | grep "pod_env_check: ray-node-pod-config-merged" && '
+            f'echo "$s" | grep "mount_check: ok"',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}',
+                job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                timeout=600
+                if smoke_tests_utils.is_remote_server_test() else 120),
+        ],
+        f'sky jobs cancel -y -n {name}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=20 * 60)
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.no_remote_server
 @pytest.mark.managed_jobs
 def test_managed_jobs_config_labels_isolation(generic_cloud: str, request):

--- a/tests/test_yamls/test_k8s_pod_config_ray_node.yaml
+++ b/tests/test_yamls/test_k8s_pod_config_ray_node.yaml
@@ -1,0 +1,23 @@
+resources:
+  cloud: kubernetes
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+          - name: ray-node
+            env:
+              - name: TEST_POD_CONFIG_ENV
+                value: ray-node-pod-config-merged
+            volumeMounts:
+              - name: smoke-pod-config-vol
+                mountPath: /smoke-pod-config-mount
+        volumes:
+          - name: smoke-pod-config-vol
+            emptyDir: {}
+
+run: |
+  echo "pod_env_check: $TEST_POD_CONFIG_ENV"
+  test -d /smoke-pod-config-mount && echo "mount_check: ok"
+  sleep 60


### PR DESCRIPTION
## Summary

- Existing managed-jobs pod_config coverage (`test_managed_jobs_env_isolation`) uses an unnamed container entry, which merges into the first container regardless of its name — the by-name form is untested for managed jobs.
- Adds `test_managed_jobs_pod_config_ray_node_container`: launches a managed job from a task YAML whose `config.kubernetes.pod_config` targets the `ray-node` container **by name**, adding an env var and an emptyDir volume mount (a common user pattern for mounting volumes).
- Asserts the job reaches RUNNING, that the env var and mount are visible from inside the job (log grep), and that the job SUCCEEDs — so a regression in named-container patch-merge (e.g. the named entry being treated as a brand-new container instead of merging) fails loudly.

## Tested

- `pytest tests/smoke_tests/test_managed_job.py --collect-only -k pod_config_ray_node` collects the test with the expected `kubernetes`/`managed_jobs` marks.
- `sky.Task.from_yaml('tests/test_yamls/test_k8s_pod_config_ray_node.yaml')` parses cleanly.
- `/smoke-test` run of this test on this PR (see comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)