### PR TITLE
[Test] Cover more documented env vars in managed jobs env smoke test

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1745,7 +1745,7 @@ def test_managed_jobs_inline_env(generic_cloud: str):
     test = smoke_tests_utils.Test(
         'test-managed-jobs-inline-env',
         [
-            rf'sky jobs launch -n {name} -y --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} --env TEST_ENV="hello world" -- "echo "\$TEST_ENV"; ([[ ! -z \"\$TEST_ENV\" ]] && [[ ! -z \"\${constants.SKYPILOT_NODE_IPS}\" ]] && [[ ! -z \"\${constants.SKYPILOT_NODE_RANK}\" ]] && [[ ! -z \"\${constants.SKYPILOT_NUM_NODES}\" ]]) || exit 1"',
+            rf'sky jobs launch -n {name} -y --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} --env TEST_ENV="hello world" -- "echo "\$TEST_ENV"; ([[ ! -z \"\$TEST_ENV\" ]] && [[ ! -z \"\${constants.SKYPILOT_NODE_IPS}\" ]] && [[ ! -z \"\${constants.SKYPILOT_NODE_RANK}\" ]] && [[ ! -z \"\${constants.SKYPILOT_NUM_NODES}\" ]] && [[ ! -z \"\$SKYPILOT_CLUSTER_INFO\" ]] && [[ ! -z \"\${constants.USER_ENV_VAR}\" ]] && [[ ! -z \"\${constants.TASK_ID_ENV_VAR}\" ]]) || exit 1"',
             smoke_tests_utils.
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=name,


### PR DESCRIPTION
## Summary

The managed-jobs env smoke test (`test_managed_jobs_inline_env`) only asserted a subset of the task environment variables documented in `docs/source/running-jobs/environment-variables.rst` for the `run` stage. This extends the assertion to also require `SKYPILOT_CLUSTER_INFO`, `SKYPILOT_USER`, and `SKYPILOT_TASK_ID` to be non-empty, in addition to the existing `TEST_ENV`, `SKYPILOT_NODE_IPS`, `SKYPILOT_NODE_RANK`, and `SKYPILOT_NUM_NODES` checks.

## Tested

- `python3 -c "import ast; ast.parse(...)"` on the modified file — passes.
- `pytest tests/smoke_tests/test_managed_job.py --collect-only -q -k inline_env` — passes (exit code 0, `test_managed_jobs_inline_env` collected successfully).
- Did **not** run the smoke test itself (it launches cloud resources); CI will run it via `/smoke-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)