### PR TITLE
[Test] Add smoke test for k8s accelerator node-affinity scheduling constraint

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -870,6 +870,90 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     smoke_tests_utils.run_one_test(test)
 
 
+# The whole script is embedded as a *single-quoted* argument to `sky jobs
+# launch` (see below), so it must avoid single quotes (') entirely -- one
+# would prematurely close that quoting before the job is even submitted.
+# Every other character (including '$' and double quotes) is left alone so
+# it's evaluated inside the pod, where the script actually runs.
+_VERIFY_ACCELERATOR_NODE_CONSTRAINT_SH = """\
+set -e
+arch=$(uname -m)
+if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+  arch=arm64
+else
+  arch=amd64
+fi
+if ! command -v kubectl &>/dev/null; then
+  ver=$(curl -sL https://dl.k8s.io/release/stable.txt)
+  curl -sL -o /tmp/kubectl "https://dl.k8s.io/release/$ver/bin/linux/$arch/kubectl"
+  chmod +x /tmp/kubectl
+  kubectl=/tmp/kubectl
+else
+  kubectl=kubectl
+fi
+
+pod_name=$(hostname)
+namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+# The accelerator label key differs per cluster flavor (the SkyPilot
+# labeler, GKE, CoreWeave, GPU Feature Discovery, Karpenter, Nebius, ...), so
+# pull the whole nodeSelector/nodeAffinity portion of the pod spec instead
+# of hardcoding one key, and grep it for the requested GPU name.
+node_selector=$($kubectl get pod "$pod_name" -n "$namespace" -o jsonpath="{.spec.nodeSelector}")
+node_affinity=$($kubectl get pod "$pod_name" -n "$namespace" -o jsonpath="{.spec.affinity.nodeAffinity}")
+constraint="$node_selector $node_affinity"
+echo "pod scheduling constraint: $constraint"
+
+if [ -z "$(echo "$constraint" | tr -d "[:space:]")" ]; then
+  echo "FAIL: pod spec has no nodeSelector/nodeAffinity at all"
+  exit 1
+fi
+if ! echo "$constraint" | grep -qiF -- "__WANT_ACCELERATOR__"; then
+  echo "FAIL: __WANT_ACCELERATOR__ not found in the pod nodeSelector/nodeAffinity"
+  exit 1
+fi
+echo ACCELERATOR_NODE_CONSTRAINT_OK
+"""
+
+
+@pytest.mark.kubernetes
+@pytest.mark.managed_jobs
+@pytest.mark.resource_heavy
+def test_managed_jobs_kubernetes_accelerator_node_constraint():
+    """A managed job's pod must self-verify its own accelerator scheduling
+    constraint.
+
+    SkyPilot pins a Kubernetes pod to nodes carrying the requested
+    accelerator type via a nodeSelector/nodeAffinity constraint on the
+    cluster's accelerator label (see the ``k8s_acc_label_key`` /
+    ``k8s_acc_label_values`` block in
+    ``sky/templates/kubernetes-ray.yml.j2``). This test asserts that
+    contract end-to-end: the job's own pod fetches its own manifest via
+    kubectl (using its bound ServiceAccount for in-cluster auth) and checks
+    that the requested GPU type is present in its own nodeSelector/
+    nodeAffinity values.
+    """
+    gpu_type = smoke_tests_utils.get_available_gpus(infra='kubernetes')
+    if not gpu_type:
+        pytest.fail('No GPUs available on the kubernetes infra.')
+
+    name = smoke_tests_utils.get_cluster_name()
+    run_command = _VERIFY_ACCELERATOR_NODE_CONSTRAINT_SH.replace(
+        '__WANT_ACCELERATOR__', gpu_type)
+
+    test = smoke_tests_utils.Test(
+        'managed_jobs_kubernetes_accelerator_node_constraint',
+        [
+            f"s=$(sky jobs launch --infra kubernetes -n {name} "
+            f"--gpus {gpu_type}:1 -y '{run_command}' 2>&1); echo \"$s\"; "
+            'echo "$s" | grep -q ACCELERATOR_NODE_CONSTRAINT_OK',
+        ],
+        f'sky jobs cancel -y -n {name}',
+        timeout=25 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.aws
 @pytest.mark.managed_jobs
 def test_managed_jobs_pipeline_recovery_aws(aws_config_region):


### PR DESCRIPTION
## Summary

- SkyPilot pins a Kubernetes pod to nodes carrying the requested accelerator type via a nodeSelector/nodeAffinity constraint on the cluster's accelerator label (see the `k8s_acc_label_key` / `k8s_acc_label_values` block in `sky/templates/kubernetes-ray.yml.j2`, lines ~438-454). No smoke test currently asserts this contract end-to-end.
- Adds `test_managed_jobs_kubernetes_accelerator_node_constraint` in `tests/smoke_tests/test_managed_job.py`: a managed job requests a specific GPU type on `--infra kubernetes`, and its own `run` script self-verifies from *inside the pod* that its own pod manifest carries the matching accelerator scheduling constraint.
- The requested GPU type is discovered dynamically via `smoke_tests_utils.get_available_gpus(infra='kubernetes')` (same helper used by existing GPU smoke tests, e.g. `test_min_gpt`/`test_ray_train` in `tests/smoke_tests/test_examples.py`), rather than hardcoded, so the test adapts to whatever GPU the target cluster actually has.
- In-pod verification is a short bash script: it installs `kubectl` via the standard `dl.k8s.io` download (same pattern already used in `sky/utils/controller_utils.py` for the jobs controller — arch-detected, skipped if `kubectl` is already on `PATH`), then runs `kubectl get pod "$pod_name" -n "$namespace" -o jsonpath=...` (in-cluster auth via the pod's bound ServiceAccount — no kubeconfig needed) to pull just the `spec.nodeSelector` and `spec.affinity.nodeAffinity` portions of its own manifest, and `grep`s them for the requested GPU name.
- The accelerator label *key* varies by cluster flavor (SkyPilot's own labeler, GKE, CoreWeave, GPU Feature Discovery, Karpenter, Nebius — see `sky/provision/kubernetes/utils.py`), so rather than hardcoding one key, the script scopes the query to just `nodeSelector`/`nodeAffinity` and checks the requested GPU name is present as a substring anywhere in that fixed jsonpath output.
- SkyPilot's default Kubernetes `remote_identity` (`SERVICE_ACCOUNT`) binds task pods to `skypilot-service-account`, which already has a namespace-scoped Role granting full access (`sky/templates/kubernetes-ray.yml.j2` lines ~76-82), so `kubectl get pod` on its own pod works without any RBAC changes.
- Failure is loud: if the constraint is missing entirely, or present but doesn't reference the requested GPU, the script prints the actual `nodeSelector`/`nodeAffinity` values and exits non-zero, failing the job (and the test).

## Tested

- ⚠️ Not run against a real cluster (no GPU-capable Kubernetes cluster available in this environment). Verified instead:
  - `python3 -c "import ast; ast.parse(...)"` on the modified file — syntax OK.
  - `bash -n` on both the generated outer `sky jobs launch` shell command and the inner in-pod script (with a sample GPU type substituted in) — syntax OK.
  - The `kubectl`-based matching logic was sanity-checked by mocking `kubectl` and the ServiceAccount namespace file locally, covering: a matching constraint (pass), an empty constraint (loud failure), and a constraint referencing the wrong GPU (loud failure). This is an analog check of the shell logic in isolation — it does **not** exercise the real `kubectl` binary, the real download, or a real Kubernetes API call.
  - `pytest --collect-only -k test_managed_jobs_kubernetes_accelerator_node_constraint` — collects cleanly with the expected `kubernetes` / `managed_jobs` / `resource_heavy` marks, no import errors.
  - The actual smoke test (real cluster, real `kubectl` download, real scheduling) has not been executed; that requires a CI-triggered run (`/smoke-test`) against a GPU-capable Kubernetes lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)