### PR TITLE
[Test] Add golden snapshot tests for kubernetes-ray.yml.j2 rendering

### DIFF
--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -1,0 +1,531 @@
+"""Golden snapshot tests for sky/templates/kubernetes-ray.yml.j2.
+
+``kubernetes-ray.yml.j2`` is a large, load-bearing template: it renders the
+full Ray autoscaler config and Kubernetes pod spec for every cluster launched
+on Kubernetes. It has many Jinja guards (``is defined`` / ``is not none``) whose
+combinations decide which node selectors, affinities, tolerations, sidecars,
+volumes and resource requests appear in the rendered manifest.
+
+These tests pin the *rendered output* for a representative set of input
+permutations so that a future refactor of the template — or of the variable
+plumbing that feeds it — can be checked against a golden baseline. A refactor
+that changes the rendered manifest for any covered input shows up as a readable
+diff instead of a silent behavior change.
+
+How it renders
+--------------
+Each case is rendered through the same helper production uses,
+``common_utils.fill_template``, so the tests exercise the real Jinja
+environment (undefined-variable and whitespace semantics), not a hand-rolled
+one.
+
+The fixture
+-----------
+``base_variables()`` returns the variables dict for a minimal CPU-only,
+single-node launch. Its keys are derived from the two places that build the
+template variables in production:
+
+* ``Kubernetes.make_deploy_resources_variables`` (sky/clouds/kubernetes.py) —
+  the ``deploy_vars`` dict and its conditionally-added keys
+  (``k8s_cpu_limit``, ``k8s_ephemeral_storage``, the ``k8s_enable_*`` docker /
+  gpudirect flags, ...).
+* ``backend_utils.write_cluster_config`` — the extra keys merged on top
+  (``cluster_name_on_cloud``, ``num_nodes``, ``credentials``, ``labels``,
+  ``volume_mounts``, the install-command blobs, ...), plus
+  ``initial_setup_commands`` from ``resources.py``.
+
+Opaque command blobs (e.g. ``ray_installation_commands``) are set to short
+placeholder strings rather than the real multi-hundred-line constants: the
+goal is to pin the *template structure*, not to re-pin an unrelated constant
+every time it changes. Machine- or time-specific values (usernames, wheel
+hashes, local paths) are pinned to fixed literals so the goldens are
+deterministic. Volume-mount entries are plain dicts with the same fields as the
+``VolumeInfo`` objects production passes (Jinja attribute access falls back to
+dict lookup), keeping the fixture self-contained and JSON-serializable.
+
+To extend the fixture when the template starts consuming a new variable, add it
+to ``base_variables()`` (and, if it is only set on some paths, to the relevant
+cases below).
+
+Golden format
+-------------
+The refactor-safety goal is *semantic* identity of the rendered manifest, so
+each golden is the parsed YAML normalized to canonical JSON (``yaml.safe_load``
+-> ``json.dumps`` with sorted keys). This ignores benign whitespace/key-order
+churn and fails only on a real structural change. Goldens live in
+``testdata/kubernetes_ray_template/<case>.json``.
+
+The goldens pin the manifest's structural and scheduling-relevant fields
+(node selectors, affinities, tolerations, resource requests/limits, volumes,
+sidecars, annotations, ...). The large generated shell blobs -- the container
+``command``/``args`` and the Ray ``setup_commands`` -- are *not* pinned: they
+are multi-kilobyte bash scripts that churn with unrelated constant changes and
+would make golden diffs unreviewable. ``_OMITTED_FIELDS`` lists them; each is
+replaced by a fixed sentinel during normalization so the field's *presence*
+(and its place in the structure) is still pinned, but its content is not.
+
+To update the goldens after an intentional template change, run this file with
+``UPDATE_SNAPSHOT=1`` set, e.g.::
+
+    UPDATE_SNAPSHOT=1 pytest <path to this test file>
+
+Review the resulting diff before committing.
+"""
+import copy
+import difflib
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+from sky.utils import common_utils
+
+TEMPLATE_NAME = 'kubernetes-ray.yml.j2'
+TESTDATA_DIR = (Path(__file__).parent / 'testdata' / 'kubernetes_ray_template')
+
+
+def base_variables() -> Dict[str, Any]:
+    """Variables for a minimal CPU-only, single-node Kubernetes launch.
+
+    See the module docstring for how the key set is derived and how to extend
+    it. Conditionally-added keys that production only sets on some paths (the
+    ``is defined`` guards: ``k8s_ephemeral_storage``, ``k8s_cpu_limit``,
+    ``k8s_memory_limit``, ``k8s_ephemeral_storage_limit``,
+    ``preemption_hook_timeout``) are intentionally absent from the base so those
+    template branches stay off unless a case adds them.
+    """
+    return {
+        # --- Kubernetes.make_deploy_resources_variables ---
+        'instance_type': '4CPU--16GB',
+        'custom_resources': None,
+        'cpus': '4',
+        'memory': '16',
+        'accelerator_count': '0',
+        'timeout': '600',
+        'k8s_efa_count': None,
+        'k8s_efa_same_az': False,
+        'k8s_port_mode': 'portforward',
+        'k8s_acc_label_key': None,
+        'k8s_acc_label_values': None,
+        'k8s_service_account_name': 'skypilot-service-account',
+        'k8s_automount_sa_token': 'true',
+        'k8s_fuse_device_required': False,
+        'k8s_kueue_local_queue_name': None,
+        'k8s_skypilot_system_namespace': 'skypilot-system',
+        'k8s_fusermount_shared_dir': '/var/run/fusermount',
+        'k8s_fusermount_setup_command': 'FUSERMOUNT_SETUP_COMMAND',
+        'k8s_spot_label_key': None,
+        'k8s_spot_label_value': None,
+        'tpu_requested': False,
+        'k8s_topology_label_key': None,
+        'k8s_topology_label_value': None,
+        'k8s_resource_key': None,
+        'k8s_env_vars': {
+            'SKYPILOT_IN_CLUSTER_CONTEXT_NAME': 'my-k8s-context',
+            'NVIDIA_VISIBLE_DEVICES': 'none',
+        },
+        'image_id': 'us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest',
+        'ray_installation_commands': 'RAY_INSTALLATION_COMMANDS',
+        'ray_head_start_command': 'RAY_HEAD_START_COMMAND',
+        'skypilot_ray_port': 6380,
+        'ray_worker_start_command': 'RAY_WORKER_START_COMMAND',
+        'k8s_high_availability_deployment_volume_mount_name': 'sky-persistent',
+        'k8s_high_availability_deployment_volume_mount_path': '/sky-persistent',
+        'k8s_high_availability_deployment_setup_script_path': '/sky-setup.sh',
+        'k8s_high_availability_deployment_run_script_dir': '/sky-run',
+        'k8s_high_availability_restarting_signal_file': '/sky-restart',
+        'ha_recovery_log_path': '/sky-recovery.log',
+        'sky_python_cmd': 'python3',
+        'sky_unset_pythonpath_and_set_cwd': 'unset PYTHONPATH && cd ~',
+        'k8s_high_availability_storage_class_name': None,
+        'avoid_label_keys': None,
+        'k8s_enable_flex_start': False,
+        'k8s_max_run_duration_seconds': None,
+        'k8s_network_type': 'none',
+        'k8s_context': 'my-k8s-context',
+        'k8s_namespace': 'default',
+        'k8s_host_network': False,
+        'k8s_enable_gpudirect_tcpx': False,
+        'k8s_enable_gpudirect_tcpxo': False,
+        'k8s_enable_gpudirect_rdma': False,
+        'k8s_enable_gpudirect_rdma_a4': False,
+        'k8s_ipc_lock_capability': False,
+        'k8s_enable_oci_roce': False,
+        'k8s_apt_mirrors': None,
+        'k8s_enable_docker_all': False,
+        'k8s_enable_docker_build': False,
+        'k8s_docker_config_dict': None,
+        # --- backend_utils.write_cluster_config ---
+        'cluster_name_on_cloud': 'sky-cluster-abc123',
+        'num_nodes': 1,
+        'disk_size': 256,
+        'user': 'testuser',
+        'workspace': 'default',
+        'original_user': 'testuser',
+        'labels': {},
+        'conda_installation_commands': 'CONDA_INSTALLATION_COMMANDS',
+        'uv_installation_commands': 'UV_INSTALLATION_COMMANDS',
+        'skypilot_wheel_installation_commands': 'WHEEL_INSTALLATION_COMMANDS',
+        'copy_skypilot_templates_commands': 'COPY_TEMPLATES_COMMANDS',
+        'ray_port': 6379,
+        'ray_dashboard_port': 8265,
+        'credentials': {},
+        'sky_remote_path': '/tmp/sky_wheels',
+        'sky_local_path': '/tmp/local_wheel.whl',
+        'sky_ray_yaml_remote_path': '~/.sky/sky_ray.yml',
+        'sky_ray_yaml_local_path': '/tmp/sky_ray.yml',
+        'sky_wheel_hash': 'WHEELHASH',
+        'ssh_max_sessions_config': 'SSH_MAX_SESSIONS_CONFIG',
+        'ssh_private_key': '~/.ssh/sky-key',
+        'high_availability': False,
+        'volume_mounts': [],
+        'ephemeral_volume_mounts': [],
+        'volume_mount_rw_paths': [],
+        'runcmd': [],
+        'priority_class': None,
+        # --- resources.py extra_template_variables ---
+        'initial_setup_commands': [],
+        'k8s_networking_mode': 'portforward',
+    }
+
+
+# GPU node selector labels reused across the accelerator cases.
+_GPU_LABEL_KEY = 'skypilot.co/accelerator'
+_GPU_ENV_VARS = {'SKYPILOT_IN_CLUSTER_CONTEXT_NAME': 'my-k8s-context'}
+
+# A ReadWriteMany PVC mount and a hostPath mount, shaped like the VolumeInfo
+# objects write_cluster_config passes to the template.
+_VOLUME_MOUNTS = [
+    {
+        'name': 'my-pvc-volume',
+        'path': '/mnt/pvc',
+        'volume_name_on_cloud': 'sky-pvc-abc123',
+        'volume_id_on_cloud': None,
+        'sub_path': 'subdir',
+        'volume_type': 'k8s-pvc',
+        'host_path': None,
+    },
+    {
+        'name': 'my-hostpath-volume',
+        'path': '/mnt/host',
+        'volume_name_on_cloud': None,
+        'volume_id_on_cloud': None,
+        'sub_path': None,
+        'volume_type': 'k8s-hostpath',
+        'host_path': '/data/on/host',
+    },
+]
+_EPHEMERAL_VOLUME_MOUNTS = [{
+    'name': 'sky-cluster-abc123-ephemeral',
+    'path': '/mnt/scratch',
+    'volume_type': 'k8s-pvc',
+    'size': '100',
+}]
+
+# Each case is a set of overrides merged onto base_variables(). Cases are
+# one-dimension-at-a-time from the base unless named "everything_*".
+CASES: Dict[str, Dict[str, Any]] = {
+    'base_cpu': {},
+    'gpu_single_label_value': {
+        'accelerator_count': '1',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'gpu_multiple_label_values': {
+        'accelerator_count': '1',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['A100', 'A100-80GB', 'A100-SXM'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'tpu': {
+        'accelerator_count': '4',
+        'tpu_requested': True,
+        'k8s_acc_label_key': 'cloud.google.com/gke-tpu-accelerator',
+        'k8s_acc_label_values': ['tpu-v5-lite-podslice'],
+        'k8s_topology_label_key': 'cloud.google.com/gke-tpu-topology',
+        'k8s_topology_label_value': '2x2',
+        'k8s_resource_key': 'google.com/tpu',
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'cpu_avoid_label_keys': {
+        'avoid_label_keys': [
+            'nvidia.com/gpu.present', 'cloud.google.com/gke-tpu-accelerator'
+        ],
+    },
+    'spot': {
+        'k8s_spot_label_key': 'cloud.google.com/gke-spot',
+        'k8s_spot_label_value': 'true',
+    },
+    'ephemeral_storage': {
+        'k8s_ephemeral_storage': '256',
+    },
+    'pod_resource_limits': {
+        'k8s_cpu_limit': 4.0,
+        'k8s_memory_limit': 16.0,
+        'k8s_ephemeral_storage_limit': 256.0,
+    },
+    'custom_service_account': {
+        'k8s_service_account_name': 'my-custom-sa',
+        'k8s_automount_sa_token': 'false',
+    },
+    'user_labels': {
+        'labels': {
+            'team': 'research',
+            'cost-center': 'ml-platform',
+            'env': 'staging',
+        },
+    },
+    'fuse_enabled': {
+        'k8s_fuse_device_required': True,
+    },
+    'high_availability': {
+        'high_availability': True,
+        'k8s_high_availability_storage_class_name': 'standard-rwo',
+    },
+    'multinode': {
+        'num_nodes': 3,
+    },
+    'kueue': {
+        'k8s_kueue_local_queue_name': 'user-queue',
+        'k8s_max_run_duration_seconds': 3600,
+    },
+    'docker_all': {
+        'k8s_enable_docker_all': True,
+        'k8s_docker_dind_image': 'docker:29.3-dind',
+        'k8s_docker_buildkit_image': 'moby/buildkit:v0.28.0-rootless',
+        'k8s_docker_config_dict': {
+            'mode': 'all',
+            'cache_volume': None
+        },
+    },
+    'docker_build': {
+        'k8s_enable_docker_build': True,
+        'k8s_docker_dind_image': 'docker:29.3-dind',
+        'k8s_docker_buildkit_image': 'moby/buildkit:v0.28.0-rootless',
+        'k8s_docker_config_dict': {
+            'mode': 'build',
+            'cache_volume': 'buildkit-cache'
+        },
+    },
+    'gpudirect_tcpx': {
+        'accelerator_count': '8',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_network_type': 'gcp_tcpx',
+        'k8s_enable_gpudirect_tcpx': True,
+        'k8s_ipc_lock_capability': True,
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'efa_same_az_multinode': {
+        'num_nodes': 2,
+        'accelerator_count': '8',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_network_type': 'aws_efa',
+        'k8s_efa_count': '4',
+        'k8s_efa_same_az': True,
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'host_network': {
+        'k8s_host_network': True,
+        'k8s_env_vars': {
+            'SKYPILOT_IN_CLUSTER_CONTEXT_NAME': 'my-k8s-context',
+            'NVIDIA_VISIBLE_DEVICES': 'none',
+            'SKYPILOT_HOST_NETWORK': '1',
+            'SKYPILOT_RAY_PORTS_CONFIGMAP_NAME': 'sky-cluster-abc123-ray-ports',
+            'SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE': 'default',
+        },
+    },
+    'oci_roce': {
+        'accelerator_count': '8',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_network_type': 'oci_roce',
+        'k8s_enable_oci_roce': True,
+        'k8s_ipc_lock_capability': True,
+        'k8s_host_network': True,
+        'k8s_env_vars': _GPU_ENV_VARS,
+    },
+    'volume_mounts': {
+        'volume_mounts': _VOLUME_MOUNTS,
+        'volume_mount_rw_paths': ['/mnt/pvc', '/mnt/host'],
+        'ephemeral_volume_mounts': _EPHEMERAL_VOLUME_MOUNTS,
+    },
+    'flex_start_priority_preemption': {
+        'k8s_enable_flex_start': True,
+        'priority_class': 'high-priority',
+        'preemption_hook_timeout': 120,
+    },
+    'everything_on_gpu_singlenode': {
+        'accelerator_count': '8',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100', 'H100-80GB'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'k8s_network_type': 'together',
+        'k8s_ipc_lock_capability': True,
+        'k8s_env_vars': _GPU_ENV_VARS,
+        'k8s_spot_label_key': 'cloud.google.com/gke-spot',
+        'k8s_spot_label_value': 'true',
+        'k8s_fuse_device_required': True,
+        'k8s_kueue_local_queue_name': 'user-queue',
+        'k8s_max_run_duration_seconds': 7200,
+        'k8s_service_account_name': 'my-custom-sa',
+        'priority_class': 'high-priority',
+        'preemption_hook_timeout': 120,
+        'labels': {
+            'team': 'research'
+        },
+        'k8s_ephemeral_storage': '512',
+        'k8s_cpu_limit': 8.0,
+        'k8s_memory_limit': 64.0,
+        'k8s_ephemeral_storage_limit': 512.0,
+        'volume_mounts': _VOLUME_MOUNTS,
+        'volume_mount_rw_paths': ['/mnt/pvc'],
+        'k8s_enable_docker_all': True,
+        'k8s_docker_dind_image': 'docker:29.3-dind',
+        'k8s_docker_buildkit_image': 'moby/buildkit:v0.28.0-rootless',
+        'k8s_docker_config_dict': {
+            'mode': 'all',
+            'cache_volume': None
+        },
+        'initial_setup_commands': ['echo hello', 'echo world'],
+        'runcmd': ['echo "runcmd first"'],
+    },
+    'everything_on_multinode_ha': {
+        'num_nodes': 4,
+        'accelerator_count': '8',
+        'k8s_acc_label_key': _GPU_LABEL_KEY,
+        'k8s_acc_label_values': ['H100'],
+        'k8s_resource_key': 'nvidia.com/gpu',
+        'high_availability': True,
+        'k8s_high_availability_storage_class_name': 'standard-rwo',
+        'k8s_host_network': True,
+        'k8s_network_type': 'gcp_gpudirect_rdma',
+        'k8s_enable_gpudirect_rdma': True,
+        'k8s_enable_gpudirect_rdma_a4': True,
+        'k8s_ipc_lock_capability': True,
+        'k8s_env_vars': {
+            'SKYPILOT_IN_CLUSTER_CONTEXT_NAME': 'my-k8s-context',
+            'SKYPILOT_HOST_NETWORK': '1',
+            'SKYPILOT_RAY_PORTS_CONFIGMAP_NAME': 'sky-cluster-abc123-ray-ports',
+            'SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE': 'default',
+        },
+        'k8s_enable_docker_build': True,
+        'k8s_docker_dind_image': 'docker:29.3-dind',
+        'k8s_docker_buildkit_image': 'moby/buildkit:v0.28.0-rootless',
+        'k8s_docker_config_dict': {
+            'mode': 'build',
+            'cache_volume': 'buildkit-cache'
+        },
+        'preemption_hook_timeout': 300,
+        'k8s_apt_mirrors': ['mirror.example.com', 'mirror2.example.com'],
+    },
+}
+
+
+def _render(variables: Dict[str, Any]) -> str:
+    """Render the template through the production fill_template helper."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, 'rendered.yml')
+        common_utils.fill_template(TEMPLATE_NAME, variables, output_path)
+        with open(output_path, 'r', encoding='utf-8') as f:
+            return f.read()
+
+
+# Fields whose values are large generated shell blobs, not structural or
+# scheduling-relevant manifest content. They are multi-kilobyte bash scripts
+# (the main container args is ~23 KB) that churn with unrelated constant
+# changes and would drown out the meaningful diff. Each is replaced by a
+# sentinel during normalization so its presence is still pinned but its content
+# is not. This is a deliberate list, not a size heuristic; extend it if a new
+# opaque command/script field appears in the manifest.
+#   - args, command: every container's entrypoint/args (main pod, DinD /
+#     BuildKit sidecars, init containers, the HA deployment).
+#   - setup_commands: the Ray autoscaler's top-level setup script.
+_OMITTED_FIELDS = frozenset({'args', 'command', 'setup_commands'})
+_OMITTED_SENTINEL = '<omitted>'
+
+
+def _omit_opaque_fields(obj: Any) -> Any:
+    """Recursively replace _OMITTED_FIELDS values with the sentinel."""
+    if isinstance(obj, dict):
+        return {
+            k: (_OMITTED_SENTINEL
+                if k in _OMITTED_FIELDS else _omit_opaque_fields(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_omit_opaque_fields(v) for v in obj]
+    return obj
+
+
+def _normalize(rendered: str) -> str:
+    """Normalize rendered YAML to canonical, deterministic JSON.
+
+    Parsing then re-serializing with sorted keys collapses benign
+    whitespace/key-order differences so the golden fails only on a real
+    structural change to the manifest. Opaque command/script fields
+    (``_OMITTED_FIELDS``) are replaced by a sentinel first.
+    """
+    parsed = _omit_opaque_fields(yaml.safe_load(rendered))
+    return json.dumps(parsed, indent=2, sort_keys=True) + '\n'
+
+
+def _assert_matches_snapshot(case_name: str, normalized: str) -> None:
+    snapshot_path = TESTDATA_DIR / f'{case_name}.json'
+
+    if os.environ.get('UPDATE_SNAPSHOT') == '1':
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(normalized, encoding='utf-8')
+        return
+
+    if not snapshot_path.exists():
+        pytest.fail(f'Snapshot file not found: {snapshot_path}\n'
+                    f'Run with UPDATE_SNAPSHOT=1 to create it.')
+
+    expected = snapshot_path.read_text(encoding='utf-8')
+    if normalized != expected:
+        diff = difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            normalized.splitlines(keepends=True),
+            fromfile=f'{case_name}.json (expected)',
+            tofile=f'{case_name}.json (actual)',
+        )
+        pytest.fail(
+            f'Rendered manifest does not match snapshot: {snapshot_path}\n\n'
+            f'Diff:\n{"".join(diff)}\n\n'
+            f'Run with UPDATE_SNAPSHOT=1 to update the snapshot.')
+
+
+@pytest.mark.parametrize('case_name', list(CASES.keys()))
+def test_kubernetes_ray_template_snapshot(case_name: str) -> None:
+    """Rendered manifest matches the golden for each input permutation."""
+    variables = base_variables()
+    variables.update(CASES[case_name])
+    rendered = _render(variables)
+    _assert_matches_snapshot(case_name, _normalize(rendered))
+
+
+@pytest.mark.parametrize('case_name', list(CASES.keys()))
+def test_kubernetes_ray_template_render_is_deterministic(
+        case_name: str) -> None:
+    """Rendering the same variables twice yields byte-identical output.
+
+    Guards against nondeterminism (unordered iteration, time/random values)
+    leaking into the goldens.
+    """
+    variables = base_variables()
+    variables.update(CASES[case_name])
+    first = _normalize(_render(copy.deepcopy(variables)))
+    second = _normalize(_render(copy.deepcopy(variables)))
+    assert first == second

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/base_cpu.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/base_cpu.json
@@ -1,0 +1,451 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/cpu_avoid_label_keys.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/cpu_avoid_label_keys.json
@@ -1,0 +1,472 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "preference": {
+                    "matchExpressions": [
+                      {
+                        "key": "nvidia.com/gpu.present",
+                        "operator": "DoesNotExist"
+                      },
+                      {
+                        "key": "cloud.google.com/gke-tpu-accelerator",
+                        "operator": "DoesNotExist"
+                      }
+                    ]
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/custom_service_account.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/custom_service_account.json
@@ -1,0 +1,451 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": false,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "my-custom-sa",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_all.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_all.json
@@ -1,0 +1,487 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                },
+                {
+                  "name": "DOCKER_HOST",
+                  "value": "unix:///var/run/dind/docker.sock"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/var/run/dind",
+                  "name": "docker-sock"
+                }
+              ]
+            },
+            {
+              "args": "<omitted>",
+              "env": [
+                {
+                  "name": "DOCKER_TLS_CERTDIR",
+                  "value": ""
+                }
+              ],
+              "image": "docker:29.3-dind",
+              "name": "dind",
+              "securityContext": {
+                "privileged": true
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/dind",
+                  "name": "docker-sock"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "emptyDir": {},
+              "name": "docker-sock"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "docker_config": {
+      "cache_volume": null,
+      "mode": "all"
+    },
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_build.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_build.json
@@ -1,0 +1,488 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                },
+                {
+                  "name": "BUILDKIT_HOST",
+                  "value": "unix:///run/buildkit/buildkitd.sock"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/run/buildkit",
+                  "name": "buildkit-sock"
+                }
+              ]
+            },
+            {
+              "args": "<omitted>",
+              "image": "moby/buildkit:v0.28.0-rootless",
+              "name": "buildkitd",
+              "securityContext": {
+                "appArmorProfile": {
+                  "type": "Unconfined"
+                },
+                "runAsGroup": 1000,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "Unconfined"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/run/buildkit",
+                  "name": "buildkit-sock"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "emptyDir": {},
+              "name": "buildkit-sock"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "docker_config": {
+      "cache_volume": "buildkit-cache",
+      "mode": "build"
+    },
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/efa_same_az_multinode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/efa_same_az_multinode.json
@@ -1,0 +1,523 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ],
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "skypilot-cluster-name": "sky-cluster-abc123"
+                    }
+                  },
+                  "topologyKey": "topology.kubernetes.io/zone"
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 8,
+                  "vpc.amazonaws.com/efa": 4
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 8,
+                  "vpc.amazonaws.com/efa": 4
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 1,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker1"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker1"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 1
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/ephemeral_storage.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/ephemeral_storage.json
@@ -1,0 +1,452 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "ephemeral-storage": "256G",
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_gpu_singlenode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_gpu_singlenode.json
@@ -1,0 +1,610 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "kueue.x-k8s.io/pod-group-total-count": "1",
+            "kueue.x-k8s.io/retriable-in-group": "false",
+            "provreq.kueue.x-k8s.io/maxRunDurationSeconds": "7200",
+            "skypilot-priority-class": "high-priority",
+            "skypilot-user": "testuser",
+            "skypilot-workspace": "default"
+          },
+          "labels": {
+            "kueue.x-k8s.io/pod-group-name": "sky-cluster-abc123",
+            "kueue.x-k8s.io/queue-name": "user-queue",
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser",
+            "team": "research"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100",
+                          "H100-80GB"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "DOCKER_HOST",
+                  "value": "unix:///var/run/dind/docker.sock"
+                },
+                {
+                  "name": "FUSERMOUNT_SHARED_DIR",
+                  "value": "/var/run/fusermount"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "lifecycle": {
+                "preStop": {
+                  "exec": {
+                    "command": "<omitted>"
+                  }
+                }
+              },
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "cpu": 8.0,
+                  "ephemeral-storage": "512.0G",
+                  "memory": "64.0G",
+                  "nvidia.com/gpu": 8,
+                  "nvidia.com/rdma_ib": 8
+                },
+                "requests": {
+                  "cpu": 4,
+                  "ephemeral-storage": "512G",
+                  "memory": "16G",
+                  "nvidia.com/gpu": 8,
+                  "nvidia.com/rdma_ib": 8
+                }
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "IPC_LOCK"
+                  ]
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/var/run/fusermount",
+                  "name": "fusermount-shared-dir"
+                },
+                {
+                  "mountPath": "/var/run/dind",
+                  "name": "docker-sock"
+                },
+                {
+                  "mountPath": "/mnt/pvc",
+                  "name": "my-pvc-volume",
+                  "subPath": "subdir"
+                },
+                {
+                  "mountPath": "/mnt/host",
+                  "name": "my-hostpath-volume"
+                }
+              ]
+            },
+            {
+              "args": "<omitted>",
+              "env": [
+                {
+                  "name": "DOCKER_TLS_CERTDIR",
+                  "value": ""
+                }
+              ],
+              "image": "docker:29.3-dind",
+              "name": "dind",
+              "securityContext": {
+                "privileged": true
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/dind",
+                  "name": "docker-sock"
+                }
+              ]
+            }
+          ],
+          "nodeSelector": {
+            "cloud.google.com/gke-spot": "true"
+          },
+          "restartPolicy": "Never",
+          "securityContext": {
+            "fsGroup": 1000,
+            "fsGroupChangePolicy": "OnRootMismatch"
+          },
+          "serviceAccountName": "my-custom-sa",
+          "terminationGracePeriodSeconds": 120,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cloud.google.com/gke-spot",
+              "operator": "Equal",
+              "value": "true"
+            }
+          ],
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "hostPath": {
+                "path": "/var/run/fusermount",
+                "type": "DirectoryOrCreate"
+              },
+              "name": "fusermount-shared-dir"
+            },
+            {
+              "name": "my-pvc-volume",
+              "persistentVolumeClaim": {
+                "claimName": "sky-pvc-abc123"
+              }
+            },
+            {
+              "hostPath": {
+                "path": "/data/on/host",
+                "type": "DirectoryOrCreate"
+              },
+              "name": "my-hostpath-volume"
+            },
+            {
+              "emptyDir": {},
+              "name": "docker-sock"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "docker_config": {
+      "cache_volume": null,
+      "mode": "all"
+    },
+    "fuse_device_required": true,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
@@ -1,0 +1,760 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "deployment_spec": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "sky-cluster-abc123-deployment",
+            "namespace": "default"
+          },
+          "spec": {
+            "replicas": 1,
+            "selector": {
+              "matchLabels": {
+                "app": "sky-cluster-abc123"
+              }
+            },
+            "template": {
+              "metadata": null,
+              "spec": {
+                "initContainers": [
+                  {
+                    "args": "<omitted>",
+                    "command": "<omitted>",
+                    "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+                    "name": "init-copy-home",
+                    "volumeMounts": [
+                      {
+                        "mountPath": "/mnt/home",
+                        "name": "sky-persistent"
+                      }
+                    ]
+                  }
+                ],
+                "securityContext": {
+                  "fsGroup": 1000
+                }
+              }
+            }
+          }
+        },
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "networking.gke.io/default-interface": "eth0",
+            "networking.gke.io/interfaces": "[\n  {\"interfaceName\":\"eth0\",\"network\":\"default\"},\n  {\"interfaceName\":\"eth1\",\"network\":\"gvnic-1\"},\n  {\"interfaceName\":\"eth2\",\"network\":\"rdma-0\"},\n  {\"interfaceName\":\"eth3\",\"network\":\"rdma-1\"},\n  {\"interfaceName\":\"eth4\",\"network\":\"rdma-2\"},\n  {\"interfaceName\":\"eth5\",\"network\":\"rdma-3\"},\n  {\"interfaceName\":\"eth6\",\"network\":\"rdma-4\"},\n  {\"interfaceName\":\"eth7\",\"network\":\"rdma-5\"},\n  {\"interfaceName\":\"eth8\",\"network\":\"rdma-6\"},\n  {\"interfaceName\":\"eth9\",\"network\":\"rdma-7\"}\n]\n",
+            "skypilot-user": "testuser",
+            "skypilot-workspace": "default"
+          },
+          "labels": {
+            "app": "sky-cluster-abc123",
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "pvc_spec": {
+          "apiVersion": "v1",
+          "kind": "PersistentVolumeClaim",
+          "metadata": {
+            "name": "sky-cluster-abc123-sky-persistent",
+            "namespace": "default"
+          },
+          "spec": {
+            "accessModes": [
+              "ReadWriteOnce"
+            ],
+            "resources": {
+              "requests": {
+                "storage": "256Gi"
+              }
+            },
+            "storageClassName": "standard-rwo"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            },
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "skypilot-cluster": "sky-cluster-abc123"
+                    }
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_NAME",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.name"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_UID",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.uid"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "SKYPILOT_HOST_NETWORK",
+                  "value": "1"
+                },
+                {
+                  "name": "SKYPILOT_RAY_PORTS_CONFIGMAP_NAME",
+                  "value": "sky-cluster-abc123-ray-ports"
+                },
+                {
+                  "name": "SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE",
+                  "value": "default"
+                },
+                {
+                  "name": "BUILDKIT_HOST",
+                  "value": "unix:///run/buildkit/buildkitd.sock"
+                },
+                {
+                  "name": "LD_LIBRARY_PATH",
+                  "value": "/usr/local/nvidia/lib64"
+                },
+                {
+                  "name": "NCCL_NET",
+                  "value": "gIB"
+                },
+                {
+                  "name": "NCCL_CROSS_NIC",
+                  "value": "0"
+                },
+                {
+                  "name": "NCCL_NET_GDR_LEVEL",
+                  "value": "PIX"
+                },
+                {
+                  "name": "NCCL_P2P_NET_CHUNKSIZE",
+                  "value": "131072"
+                },
+                {
+                  "name": "NCCL_NVLS_CHUNKSIZE",
+                  "value": "524288"
+                },
+                {
+                  "name": "NCCL_IB_ADAPTIVE_ROUTING",
+                  "value": "1"
+                },
+                {
+                  "name": "NCCL_IB_QPS_PER_CONNECTION",
+                  "value": "4"
+                },
+                {
+                  "name": "NCCL_IB_TC",
+                  "value": "52"
+                },
+                {
+                  "name": "NCCL_IB_FIFO_TC",
+                  "value": "84"
+                },
+                {
+                  "name": "NCCL_TUNER_CONFIG_PATH",
+                  "value": "/usr/local/gib/configs/tuner_config_a4.txtpb"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "lifecycle": {
+                "preStop": {
+                  "exec": {
+                    "command": "<omitted>"
+                  }
+                }
+              },
+              "name": "ray-node",
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 8
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 8
+                }
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "IPC_LOCK"
+                  ]
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/usr/local/nvidia",
+                  "name": "library-dir-host"
+                },
+                {
+                  "mountPath": "/usr/local/gib",
+                  "name": "gib"
+                },
+                {
+                  "mountPath": "/sky-persistent",
+                  "name": "sky-persistent"
+                },
+                {
+                  "mountPath": "/run/buildkit",
+                  "name": "buildkit-sock"
+                }
+              ]
+            },
+            {
+              "args": "<omitted>",
+              "image": "moby/buildkit:v0.28.0-rootless",
+              "name": "buildkitd",
+              "securityContext": {
+                "appArmorProfile": {
+                  "type": "Unconfined"
+                },
+                "runAsGroup": 1000,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "Unconfined"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/run/buildkit",
+                  "name": "buildkit-sock"
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "ClusterFirstWithHostNet",
+          "restartPolicy": "Always",
+          "serviceAccountName": "skypilot-service-account",
+          "terminationGracePeriodSeconds": 300,
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "name": "sky-persistent",
+              "persistentVolumeClaim": {
+                "claimName": "sky-cluster-abc123-sky-persistent"
+              }
+            },
+            {
+              "hostPath": {
+                "path": "/home/kubernetes/bin/nvidia"
+              },
+              "name": "library-dir-host"
+            },
+            {
+              "hostPath": {
+                "path": "/home/kubernetes/bin/gib"
+              },
+              "name": "gib"
+            },
+            {
+              "emptyDir": {},
+              "name": "buildkit-sock"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 3,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "docker_config": {
+      "cache_volume": "buildkit-cache",
+      "mode": "build"
+    },
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker1"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker1"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker2"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker2"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker3"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker3"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 3
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/flex_start_priority_preemption.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/flex_start_priority_preemption.json
@@ -1,0 +1,462 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "lifecycle": {
+                "preStop": {
+                  "exec": {
+                    "command": "<omitted>"
+                  }
+                }
+              },
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "nodeSelector": {
+            "cloud.google.com/gke-flex-start": "true"
+          },
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/fuse_enabled.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/fuse_enabled.json
@@ -1,0 +1,466 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                },
+                {
+                  "name": "FUSERMOUNT_SHARED_DIR",
+                  "value": "/var/run/fusermount"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/var/run/fusermount",
+                  "name": "fusermount-shared-dir"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "hostPath": {
+                "path": "/var/run/fusermount",
+                "type": "DirectoryOrCreate"
+              },
+              "name": "fusermount-shared-dir"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": true,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_multiple_label_values.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_multiple_label_values.json
@@ -1,0 +1,494 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "A100",
+                          "A100-80GB",
+                          "A100-SXM"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 1
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 1
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_single_label_value.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_single_label_value.json
@@ -1,0 +1,492 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 1
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 1
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpudirect_tcpx.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpudirect_tcpx.json
@@ -1,0 +1,668 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "devices.gke.io/container.tcpx-daemon": "- path: /dev/nvidia0\n- path: /dev/nvidia1\n- path: /dev/nvidia2\n- path: /dev/nvidia3\n- path: /dev/nvidia4\n- path: /dev/nvidia5\n- path: /dev/nvidia6\n- path: /dev/nvidia7\n- path: /dev/nvidiactl\n- path: /dev/nvidia-uvm\n",
+            "networking.gke.io/default-interface": "eth0",
+            "networking.gke.io/interfaces": "[\n  {\"interfaceName\":\"eth0\",\"network\":\"default\"},\n  {\"interfaceName\":\"eth1\",\"network\":\"vpc1\"},\n  {\"interfaceName\":\"eth2\",\"network\":\"vpc2\"},\n  {\"interfaceName\":\"eth3\",\"network\":\"vpc3\"},\n  {\"interfaceName\":\"eth4\",\"network\":\"vpc4\"}\n]\n",
+            "skypilot-user": "testuser",
+            "skypilot-workspace": "default"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "LD_LIBRARY_PATH",
+                  "value": "/usr/local/nvidia/lib64:/usr/local/tcpx/lib64"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_SOCKET_IFNAME",
+                  "value": "eth1,eth2,eth3,eth4"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_CTRL_DEV",
+                  "value": "eth0"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_TX_BINDINGS",
+                  "value": "eth1:8-21,112-125;eth2:8-21,112-125;eth3:60-73,164-177;eth4:60-73,164-177"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_RX_BINDINGS",
+                  "value": "eth1:22-35,126-139;eth2:22-35,126-139;eth3:74-87,178-191;eth4:74-87,178-191"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS",
+                  "value": "500000"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX",
+                  "value": "/tmp"
+                },
+                {
+                  "name": "NCCL_GPUDIRECTTCPX_FORCE_ACK",
+                  "value": "0"
+                },
+                {
+                  "name": "NCCL_SOCKET_IFNAME",
+                  "value": "eth0"
+                },
+                {
+                  "name": "NCCL_CROSS_NIC",
+                  "value": "0"
+                },
+                {
+                  "name": "NCCL_ALGO",
+                  "value": "Ring"
+                },
+                {
+                  "name": "NCCL_PROTO",
+                  "value": "Simple"
+                },
+                {
+                  "name": "NCCL_NSOCKS_PERTHREAD",
+                  "value": "4"
+                },
+                {
+                  "name": "NCCL_SOCKET_NTHREADS",
+                  "value": "1"
+                },
+                {
+                  "name": "NCCL_NET_GDR_LEVEL",
+                  "value": "PIX"
+                },
+                {
+                  "name": "NCCL_DYNAMIC_CHUNK_SIZE",
+                  "value": "524288"
+                },
+                {
+                  "name": "NCCL_P2P_PXN_LEVEL",
+                  "value": "0"
+                },
+                {
+                  "name": "NCCL_P2P_NET_CHUNKSIZE",
+                  "value": "524288"
+                },
+                {
+                  "name": "NCCL_P2P_PCI_CHUNKSIZE",
+                  "value": "524288"
+                },
+                {
+                  "name": "NCCL_P2P_NVL_CHUNKSIZE",
+                  "value": "1048576"
+                },
+                {
+                  "name": "NCCL_BUFFSIZE",
+                  "value": "4194304"
+                },
+                {
+                  "name": "NCCL_MAX_NCHANNELS",
+                  "value": "8"
+                },
+                {
+                  "name": "NCCL_MIN_NCHANNELS",
+                  "value": "8"
+                },
+                {
+                  "name": "CUDA_VISIBLE_DEVICES",
+                  "value": "0,1,2,3,4,5,6,7"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 8
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 8
+                }
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "IPC_LOCK"
+                  ]
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tcpx-socket"
+                },
+                {
+                  "mountPath": "/usr/local/nvidia/lib64",
+                  "name": "libraries",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "LD_LIBRARY_PATH",
+                  "value": "/usr/local/nvidia/lib64"
+                }
+              ],
+              "image": "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.11",
+              "imagePullPolicy": "Always",
+              "name": "tcpx-daemon",
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "NET_ADMIN"
+                  ]
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/usr/local/nvidia/lib64",
+                  "name": "libraries",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/run/tcpx",
+                  "name": "tcpx-socket"
+                },
+                {
+                  "mountPath": "/hostsysfs",
+                  "name": "sys"
+                },
+                {
+                  "mountPath": "/hostprocsysfs",
+                  "name": "proc-sys"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "hostPath": {
+                "path": "/home/kubernetes/bin/nvidia/lib64"
+              },
+              "name": "libraries"
+            },
+            {
+              "emptyDir": {},
+              "name": "tcpx-socket"
+            },
+            {
+              "hostPath": {
+                "path": "/sys"
+              },
+              "name": "sys"
+            },
+            {
+              "hostPath": {
+                "path": "/proc/sys"
+              },
+              "name": "proc-sys"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/high_availability.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/high_availability.json
@@ -1,0 +1,519 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "deployment_spec": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "sky-cluster-abc123-deployment",
+            "namespace": "default"
+          },
+          "spec": {
+            "replicas": 1,
+            "selector": {
+              "matchLabels": {
+                "app": "sky-cluster-abc123"
+              }
+            },
+            "template": {
+              "metadata": null,
+              "spec": {
+                "initContainers": [
+                  {
+                    "args": "<omitted>",
+                    "command": "<omitted>",
+                    "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+                    "name": "init-copy-home",
+                    "volumeMounts": [
+                      {
+                        "mountPath": "/mnt/home",
+                        "name": "sky-persistent"
+                      }
+                    ]
+                  }
+                ],
+                "securityContext": {
+                  "fsGroup": 1000
+                }
+              }
+            }
+          }
+        },
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "app": "sky-cluster-abc123",
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "pvc_spec": {
+          "apiVersion": "v1",
+          "kind": "PersistentVolumeClaim",
+          "metadata": {
+            "name": "sky-cluster-abc123-sky-persistent",
+            "namespace": "default"
+          },
+          "spec": {
+            "accessModes": [
+              "ReadWriteOnce"
+            ],
+            "resources": {
+              "requests": {
+                "storage": "256Gi"
+              }
+            },
+            "storageClassName": "standard-rwo"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/sky-persistent",
+                  "name": "sky-persistent"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Always",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "name": "sky-persistent",
+              "persistentVolumeClaim": {
+                "claimName": "sky-cluster-abc123-sky-persistent"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
@@ -1,0 +1,477 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "skypilot-cluster": "sky-cluster-abc123"
+                    }
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_NAME",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.name"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_UID",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.uid"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                },
+                {
+                  "name": "SKYPILOT_HOST_NETWORK",
+                  "value": "1"
+                },
+                {
+                  "name": "SKYPILOT_RAY_PORTS_CONFIGMAP_NAME",
+                  "value": "sky-cluster-abc123-ray-ports"
+                },
+                {
+                  "name": "SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE",
+                  "value": "default"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "ClusterFirstWithHostNet",
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/kueue.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/kueue.json
@@ -1,0 +1,457 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "kueue.x-k8s.io/pod-group-total-count": "1",
+            "kueue.x-k8s.io/retriable-in-group": "false",
+            "provreq.kueue.x-k8s.io/maxRunDurationSeconds": "3600",
+            "skypilot-user": "testuser",
+            "skypilot-workspace": "default"
+          },
+          "labels": {
+            "kueue.x-k8s.io/pod-group-name": "sky-cluster-abc123",
+            "kueue.x-k8s.io/queue-name": "user-queue",
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/multinode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/multinode.json
@@ -1,0 +1,489 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 2,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker1"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker1"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker2"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker2"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 2
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/oci_roce.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/oci_roce.json
@@ -1,0 +1,524 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "skypilot.co/accelerator",
+                        "operator": "In",
+                        "values": [
+                          "H100"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            },
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "skypilot-cluster": "sky-cluster-abc123"
+                    }
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_NAME",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.name"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_UID",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.uid"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "resources": {
+                "limits": {
+                  "nvidia.com/gpu": 8
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G",
+                  "nvidia.com/gpu": 8
+                }
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "IPC_LOCK"
+                  ]
+                },
+                "privileged": true
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/dev/infiniband",
+                  "name": "devinf"
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "ClusterFirstWithHostNet",
+          "hostNetwork": true,
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "hostPath": {
+                "path": "/dev/infiniband",
+                "type": "Directory"
+              },
+              "name": "devinf"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/pod_resource_limits.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/pod_resource_limits.json
@@ -1,0 +1,456 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "cpu": 4.0,
+                  "ephemeral-storage": "256.0G",
+                  "memory": "16.0G"
+                },
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/spot.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/spot.json
@@ -1,0 +1,462 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "nodeSelector": {
+            "cloud.google.com/gke-spot": "true"
+          },
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cloud.google.com/gke-spot",
+              "operator": "Equal",
+              "value": "true"
+            }
+          ],
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/tpu.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/tpu.json
@@ -1,0 +1,495 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-binpack": "gpu",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cloud.google.com/gke-tpu-accelerator",
+                        "operator": "In",
+                        "values": [
+                          "tpu-v5-lite-podslice"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "podAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "skypilot-binpack",
+                          "operator": "In",
+                          "values": [
+                            "gpu"
+                          ]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
+                  },
+                  "weight": 1
+                }
+              ]
+            }
+          },
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "google.com/tpu": 4
+                },
+                "requests": {
+                  "cpu": 4,
+                  "google.com/tpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "nodeSelector": {
+            "cloud.google.com/gke-tpu-topology": "2x2"
+          },
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/user_labels.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/user_labels.json
@@ -1,0 +1,454 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "cost-center": "ml-platform",
+            "env": "staging",
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser",
+            "team": "research"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/volume_mounts.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/volume_mounts.json
@@ -1,0 +1,485 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "skypilot-user": "testuser"
+          },
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                },
+                {
+                  "mountPath": "/mnt/pvc",
+                  "name": "my-pvc-volume",
+                  "subPath": "subdir"
+                },
+                {
+                  "mountPath": "/mnt/host",
+                  "name": "my-hostpath-volume"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "securityContext": {
+            "fsGroup": 1000,
+            "fsGroupChangePolicy": "OnRootMismatch"
+          },
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            },
+            {
+              "name": "my-pvc-volume",
+              "persistentVolumeClaim": {
+                "claimName": "sky-pvc-abc123"
+              }
+            },
+            {
+              "hostPath": {
+                "path": "/data/on/host",
+                "type": "DirectoryOrCreate"
+              },
+              "name": "my-hostpath-volume"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 0,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "ephemeral_volume_specs": [
+      {
+        "name": "sky-cluster-abc123-ephemeral",
+        "path": "/mnt/scratch",
+        "size": "100",
+        "volume_type": "k8s-pvc"
+      }
+    ],
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 0
+}


### PR DESCRIPTION
## Summary

`sky/templates/kubernetes-ray.yml.j2` is large and load-bearing — it renders the full Ray autoscaler config and Kubernetes pod spec for every Kubernetes launch. Its many `is defined` / `is not none` Jinja guards make it easy for a refactor of the template (or of the variable plumbing that feeds it) to silently change the rendered manifest.

This PR adds a **pure test suite** (no logic or template changes) that pins the rendered output across a matrix of representative inputs, so any change to the rendered manifest surfaces as a readable golden diff.

## How it works

- Each case renders the template through the same helper production uses, `common_utils.fill_template`, exercising the real Jinja environment (undefined-variable / whitespace semantics) rather than a hand-rolled one.
- The base fixture (`base_variables()`) is a CPU-only, single-node variable dict whose key set is derived from `Kubernetes.make_deploy_resources_variables` and the additions in `backend_utils.write_cluster_config`. Opaque command blobs use short placeholders (the goal is to pin template structure, not re-pin unrelated constants), and machine/time-specific values are fixed literals for determinism.

## Golden format

Each golden is the rendered YAML parsed and re-serialized to canonical JSON with sorted keys (`yaml.safe_load` → `json.dumps(sort_keys=True)`). The refactor-safety goal is *semantic* identity of the manifest, so normalizing this way ignores benign whitespace/key-order churn and false-fails only on a real structural change; raw text would false-fail on trivial indentation edits.

The goldens pin the manifest's **structural and scheduling-relevant fields** (node selectors, affinities, tolerations, resource requests/limits, volumes, sidecars, annotations, ...). The large generated **shell blobs are deliberately normalized out**: the container `command`/`args` and the Ray `setup_commands` are multi-kilobyte bash scripts (the main container's `args` is ~23 KB) that churn with unrelated constant changes and would make golden diffs unreviewable. `_OMITTED_FIELDS = {args, command, setup_commands}` lists them explicitly (a deliberate list, not a size heuristic); during normalization each is replaced by a `"<omitted>"` sentinel so the field's *presence* and place in the structure are still pinned, but its content is not. Extend the list if a new opaque command/script field appears.

One golden per case under `testdata/kubernetes_ray_template/`.

## Matrix (24 cases)

Base plus one-dimension-at-a-time variants: CPU-only base, single/multiple GPU node-selector label values, TPU (with topology label), CPU GPU-avoidance labels, spot tolerations, ephemeral-storage request, pod resource limits, custom service account + automount, user labels, fuse device, high availability + storage class, multi-node, Kueue queue + max-run-duration, docker DinD sidecar, docker BuildKit sidecar, GPUDirect TCPX, AWS EFA same-AZ multi-node, host network, OCI RoCE, volume mounts (PVC + hostPath + ephemeral), flex-start + priority class + preemption hook — plus two combined "everything on" cases (single-node GPU, multi-node HA).

A second parametrized test renders each case twice and asserts byte-identical output to guard against nondeterminism leaking into goldens.

## Regenerating goldens

After an intentional template change, run this file with `UPDATE_SNAPSHOT=1` set and review the diff before committing (documented in the test's module docstring).

## Tested

- `pytest tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py` — **48 passed** (24 snapshot + 24 determinism).
- Ran the full suite twice back-to-back; both green and goldens byte-stable (determinism).
- `bash format.sh --files ...` clean (yapf/isort/mypy pass, pylint 10.00/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)