### PR TITLE
[Core] Gate mutating cluster ops by the target cluster's workspace

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1540,6 +1540,24 @@ def get_handle_from_cluster_name(
     return pickle.loads(row.handle)
 
 
+def get_cluster_workspace(cluster_name: str) -> Optional[str]:
+    """Returns the workspace a cluster belongs to, or None if no such cluster.
+
+    Selects only the ``workspace`` column so callers doing a permission check
+    don't pay the cost of unpickling the handle. A stored NULL (clusters that
+    predate the column) is normalized to the default workspace, so a non-None
+    return always means "the cluster exists and lives in this workspace".
+    """
+    engine = _db_manager.get_engine()
+    assert cluster_name is not None, 'cluster_name cannot be None'
+    with orm.Session(engine) as session:
+        row = (session.query(
+            cluster_table.c.workspace).filter_by(name=cluster_name).first())
+    if row is None:
+        return None
+    return row.workspace or constants.SKYPILOT_DEFAULT_WORKSPACE
+
+
 @metrics_lib.time_me
 def get_handles_from_cluster_names(
         cluster_names: Set[str]

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1333,7 +1333,19 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
         if job_status is None:
             logger.info(f'Job {job_id} not found. Skipped.')
             continue
-        elif job_status.is_terminal():
+
+        # Workspace isolation is a permission check and is independent of job
+        # status: a job outside the caller's active workspace must not be acted
+        # on (or have its state revealed) whether it is pending, running, or
+        # already terminal. Enforce it first, before any status-based handling
+        # (terminal skip / PENDING short-circuit / signal) below. Kept after the
+        # existence check above because a missing job has no workspace to check.
+        job_workspace = managed_job_state.get_workspace(job_id)
+        if current_workspace is not None and job_workspace != current_workspace:
+            wrong_workspace_job_ids.append(job_id)
+            continue
+
+        if job_status.is_terminal():
             logger.info(f'Job {job_id} is already in terminal state '
                         f'{job_status.value}. Skipped.')
             continue
@@ -1345,11 +1357,6 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
                 continue
 
         update_managed_jobs_statuses(job_id)
-
-        job_workspace = managed_job_state.get_workspace(job_id)
-        if current_workspace is not None and job_workspace != current_workspace:
-            wrong_workspace_job_ids.append(job_id)
-            continue
 
         if managed_job_state.is_legacy_controller_process(job_id):
             # The job is running on a legacy single-job controller process.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -111,6 +111,7 @@ from sky.utils import ux_utils
 from sky.utils.db import db_utils
 from sky.utils.kubernetes import gpu_labeler
 from sky.volumes.server import server as volumes_rest
+from sky.workspaces import core as workspaces_core
 from sky.workspaces import server as workspaces_rest
 
 if typing.TYPE_CHECKING:
@@ -1877,11 +1878,40 @@ async def launch(launch_body: payloads.LaunchBody,
     )
 
 
+async def _reject_cluster_write_for_unauthorized(
+        request: fastapi.Request, cluster_name: Optional[str]) -> None:
+    """Rejects a mutating request on a cluster the user cannot write to.
+
+    Mutating an *existing* cluster (down/stop/start/autostop/cancel/exec/ssh)
+    must be gated by the cluster's *own* workspace. The executor's active-
+    workspace gate only checks the caller's active workspace (resolved from
+    their own context), which is not the cluster's workspace, so it does not
+    protect an existing cluster from a non-member (see
+    ``workspaces_core.check_cluster_write_permission`` and
+    https://github.com/skypilot-org/skypilot/issues/8072).
+
+    Runs at the API boundary (before a worker is scheduled) so external
+    requests are gated while internal ``core.*`` callers (controllers,
+    recovery, daemons) are untouched. A missing ``auth_user`` (loopback /
+    local CLI) is trusted, matching the RBAC middleware's loopback bypass.
+    """
+    auth_user = request.state.auth_user
+    if auth_user is None or cluster_name is None:
+        return
+    try:
+        await context_utils.to_thread_with_executor(
+            None, workspaces_core.check_cluster_write_permission, auth_user,
+            cluster_name)
+    except exceptions.PermissionDeniedError as e:
+        raise fastapi.HTTPException(status_code=403, detail=str(e)) from e
+
+
 @app.post('/exec')
 # pylint: disable=redefined-builtin
 async def exec(request: fastapi.Request, exec_body: payloads.ExecBody) -> None:
     """Executes a task on an existing cluster."""
     cluster_name = exec_body.cluster_name
+    await _reject_cluster_write_for_unauthorized(request, cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_EXEC,
@@ -1901,6 +1931,8 @@ async def exec(request: fastapi.Request, exec_body: payloads.ExecBody) -> None:
 async def stop(request: fastapi.Request,
                stop_body: payloads.StopOrDownBody) -> None:
     """Stops a cluster."""
+    await _reject_cluster_write_for_unauthorized(request,
+                                                 stop_body.cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_STOP,
@@ -1954,6 +1986,8 @@ async def endpoints(request: fastapi.Request,
 async def down(request: fastapi.Request,
                down_body: payloads.StopOrDownBody) -> None:
     """Tears down a cluster."""
+    await _reject_cluster_write_for_unauthorized(request,
+                                                 down_body.cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_DOWN,
@@ -1969,6 +2003,8 @@ async def down(request: fastapi.Request,
 async def start(request: fastapi.Request,
                 start_body: payloads.StartBody) -> None:
     """Restarts a cluster."""
+    await _reject_cluster_write_for_unauthorized(request,
+                                                 start_body.cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_START,
@@ -1984,6 +2020,8 @@ async def start(request: fastapi.Request,
 async def autostop(request: fastapi.Request,
                    autostop_body: payloads.AutostopBody) -> None:
     """Schedules an autostop/autodown for a cluster."""
+    await _reject_cluster_write_for_unauthorized(request,
+                                                 autostop_body.cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_AUTOSTOP,
@@ -2029,6 +2067,8 @@ async def job_status(request: fastapi.Request,
 async def cancel(request: fastapi.Request,
                  cancel_body: payloads.CancelBody) -> None:
     """Cancels jobs on a cluster."""
+    await _reject_cluster_write_for_unauthorized(request,
+                                                 cancel_body.cluster_name)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.CLUSTER_JOB_CANCEL,
@@ -2967,6 +3007,20 @@ async def _validate_cluster_for_ssh_proxy_ws(
     the caller can bail out cleanly.
     """
     try:
+        # SSH into an existing cluster is a write (it grants an interactive
+        # shell / arbitrary code execution), so gate it by the cluster's own
+        # workspace, not the caller's active workspace. auth_user is set on
+        # the connection scope by the websocket-aware auth middleware; a
+        # missing one (loopback / local CLI) is trusted.
+        auth_user = getattr(websocket.state, 'auth_user', None)
+        if auth_user is not None:
+            try:
+                await context_utils.to_thread_with_executor(
+                    None, workspaces_core.check_cluster_write_permission,
+                    auth_user, cluster_name)
+            except exceptions.PermissionDeniedError as e:
+                raise fastapi.HTTPException(status_code=403,
+                                            detail=str(e)) from e
         return await _get_cluster_and_validate(cluster_name, cloud_type)
     except fastapi.HTTPException as e:
         logger.info(f'Closing SSH proxy websocket for cluster '

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -773,6 +773,35 @@ def reject_request_for_unauthorized_workspace(user: models.User) -> None:
     check_workspace_permission(user, skypilot_config.get_active_workspace())
 
 
+def check_cluster_write_permission(user: models.User,
+                                   cluster_name: str) -> None:
+    """Checks a user may perform a mutating operation on an existing cluster.
+
+    Unlike ``reject_request_for_unauthorized_workspace``, which checks the
+    request's *active* workspace, this checks the workspace the target cluster
+    actually belongs to. Mutating an existing cluster (down/stop/start/
+    autostop/cancel/exec/ssh) must be gated by that cluster's own workspace,
+    not the caller's active workspace: the active workspace is resolved from
+    the caller's own context and may differ from where the cluster lives, so
+    the active-workspace check does not protect the cluster.
+
+    A missing cluster is left to the caller's own not-found handling (there is
+    no workspace to enforce), so this does not raise for unknown names.
+
+    Args:
+        user: The user making the request.
+        cluster_name: The target cluster.
+
+    Raises:
+        PermissionDeniedError: If the user cannot access the cluster's
+            workspace.
+    """
+    workspace = global_user_state.get_cluster_workspace(cluster_name)
+    if workspace is None:
+        return
+    check_workspace_permission(user, workspace)
+
+
 def is_workspace_private(workspace_config: Dict[str, Any]) -> bool:
     """Check if a workspace is private.
 

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from sky import exceptions
+from sky.jobs import constants as managed_job_constants
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as jobs_utils
 
@@ -1557,3 +1558,95 @@ class TestTryToGetJobEndTime:
         monkeypatch.setattr(jobs_utils, 'get_job_timestamp', _raise)
         with pytest.raises(ValueError):
             jobs_utils.try_to_get_job_end_time(MagicMock(), 'cluster', 1)
+
+
+class TestCancelJobsByIdWorkspaceScoping:
+    """cancel_jobs_by_id must only cancel jobs in the active workspace.
+
+    Regression guard for the existing workspace isolation on managed-job
+    cancel: a non-terminal job whose workspace differs from the caller's
+    active workspace must be skipped, not cancelled. Combined with the
+    active-workspace write gate on the server, this is what prevents a
+    non-member from cancelling another workspace's jobs.
+    """
+
+    def _setup(self, monkeypatch, tmp_path, job_workspace, status=None):
+        if status is None:
+            status = managed_job_state.ManagedJobStatus.RUNNING
+        monkeypatch.setattr(managed_job_state, 'get_status',
+                            lambda job_id: status)
+        monkeypatch.setattr(managed_job_state, 'get_workspace',
+                            lambda job_id: job_workspace)
+        monkeypatch.setattr(jobs_utils, 'update_managed_jobs_statuses',
+                            lambda job_id: None)
+        monkeypatch.setattr(managed_job_state, 'is_legacy_controller_process',
+                            lambda job_id: False)
+        # Track PENDING short-circuit cancellations.
+        pending_cancel = MagicMock(return_value=True)
+        monkeypatch.setattr(managed_job_state, 'set_pending_cancelled',
+                            pending_cancel)
+        # Redirect the cancel signal file to a temp dir so the "cancelled"
+        # path is hermetic and observable via the file's presence.
+        monkeypatch.setattr(managed_job_constants, 'CONSOLIDATED_SIGNAL_PATH',
+                            str(tmp_path))
+        return pending_cancel
+
+    def test_running_job_in_other_workspace_is_skipped(self, monkeypatch,
+                                                       tmp_path):
+        self._setup(monkeypatch, tmp_path, job_workspace='ws-b')
+        msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
+        assert 'not in the active workspace' in msg
+        assert "'ws-a'" in msg
+        assert 'scheduled to be cancelled' not in msg
+        # Revert check: if the workspace skip is removed, the cancel signal
+        # would be written for the out-of-workspace job.
+        assert not (tmp_path / '5').exists()
+
+    def test_running_job_in_active_workspace_is_cancelled(
+            self, monkeypatch, tmp_path):
+        # Counterpart: same job, matching workspace -> actually cancelled.
+        self._setup(monkeypatch, tmp_path, job_workspace='ws-a')
+        msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
+        assert 'scheduled to be cancelled' in msg
+        assert (tmp_path / '5').exists()
+
+    def test_pending_job_in_other_workspace_is_not_cancelled(
+            self, monkeypatch, tmp_path):
+        # PENDING jobs must also be workspace-gated: the workspace check runs
+        # before the PENDING set_pending_cancelled short-circuit.
+        pending_cancel = self._setup(
+            monkeypatch,
+            tmp_path,
+            job_workspace='ws-b',
+            status=managed_job_state.ManagedJobStatus.PENDING)
+        msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
+        assert 'not in the active workspace' in msg
+        assert 'scheduled to be cancelled' not in msg
+        # Revert check: before moving the workspace check above the PENDING
+        # branch, this would have been cancelled via set_pending_cancelled.
+        pending_cancel.assert_not_called()
+
+    def test_pending_job_in_active_workspace_is_cancelled(
+            self, monkeypatch, tmp_path):
+        pending_cancel = self._setup(
+            monkeypatch,
+            tmp_path,
+            job_workspace='ws-a',
+            status=managed_job_state.ManagedJobStatus.PENDING)
+        msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
+        assert 'scheduled to be cancelled' in msg
+        pending_cancel.assert_called_once_with(5)
+
+    def test_terminal_job_in_other_workspace_is_denied_not_status_skipped(
+            self, monkeypatch, tmp_path):
+        # The workspace check is status-independent: even a terminal job in
+        # another workspace is reported as out-of-workspace, not silently
+        # skipped as "terminal". Guards the check's placement at the top of
+        # the loop (before the terminal-status branch).
+        self._setup(monkeypatch,
+                    tmp_path,
+                    job_workspace='ws-b',
+                    status=managed_job_state.ManagedJobStatus.SUCCEEDED)
+        msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
+        assert 'not in the active workspace' in msg
+        assert 'terminal' not in msg

--- a/tests/unit_tests/test_sky/workspaces/test_cluster_write_permission.py
+++ b/tests/unit_tests/test_sky/workspaces/test_cluster_write_permission.py
@@ -1,0 +1,69 @@
+"""Unit tests for per-resource cluster write-permission checks.
+
+Covers ``workspaces_core.check_cluster_write_permission``, which gates a
+mutating operation on an *existing* cluster by that cluster's own workspace
+(rather than the caller's active workspace). See
+https://github.com/skypilot-org/skypilot/issues/8072.
+"""
+
+import unittest
+from unittest import mock
+
+from sky import exceptions
+from sky import models
+from sky.workspaces import core as workspaces_core
+
+
+class TestCheckClusterWritePermission(unittest.TestCase):
+    """Test check_cluster_write_permission."""
+
+    def setUp(self):
+        self.user = models.User(id='user1', name='alice')
+
+    @mock.patch('sky.users.permission.permission_service.'
+                'check_workspace_permission')
+    @mock.patch('sky.global_user_state.get_cluster_workspace')
+    def test_denied_when_not_member_of_cluster_workspace(
+            self, mock_get_ws, mock_check):
+        """A user who cannot access the cluster's workspace is rejected."""
+        mock_get_ws.return_value = 'ws-b'
+        mock_check.return_value = False  # not a member of ws-b
+
+        with self.assertRaises(exceptions.PermissionDeniedError):
+            workspaces_core.check_cluster_write_permission(
+                self.user, 'other-users-cluster')
+
+        # The check must consult the *cluster's* workspace, not the active one.
+        mock_get_ws.assert_called_once_with('other-users-cluster')
+        mock_check.assert_called_once_with('user1', 'ws-b')
+
+    @mock.patch('sky.users.permission.permission_service.'
+                'check_workspace_permission')
+    @mock.patch('sky.global_user_state.get_cluster_workspace')
+    def test_allowed_when_member_of_cluster_workspace(self, mock_get_ws,
+                                                      mock_check):
+        """A member of the cluster's workspace passes."""
+        mock_get_ws.return_value = 'ws-a'
+        mock_check.return_value = True
+
+        # Should not raise.
+        workspaces_core.check_cluster_write_permission(self.user, 'my-cluster')
+        mock_check.assert_called_once_with('user1', 'ws-a')
+
+    @mock.patch('sky.users.permission.permission_service.'
+                'check_workspace_permission')
+    @mock.patch('sky.global_user_state.get_cluster_workspace')
+    def test_unknown_cluster_is_not_rejected(self, mock_get_ws, mock_check):
+        """A missing cluster leaves not-found handling to the caller.
+
+        There is no workspace to enforce, so the permission service must not
+        be consulted and no error is raised here.
+        """
+        mock_get_ws.return_value = None
+
+        workspaces_core.check_cluster_write_permission(self.user, 'nonexistent')
+        mock_check.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Mutating an *existing* cluster (`down`/`stop`/`start`/`autostop`/`cancel`/`exec`/ssh) was only gated by the caller's **active** workspace, never the workspace the target cluster actually belongs to. Because the active workspace is resolved from the caller's own context, a user who is a member of *any* workspace could act on a cluster in a workspace they don't belong to if they knew its name — isolation for existing resources relied only on the listing filter hiding the cluster. (Related discussion: #8072.)
- This PR adds a per-resource write check on the cluster's **own** workspace and enforces it at the API boundary for the mutating cluster handlers and both websocket SSH proxies.
- It also closes a related gap in managed-job `cancel`, where the existing `current_workspace` check sat *after* the terminal/PENDING branches, so a PENDING (or terminal) job outside the active workspace could be acted on without a workspace check.

## Details

- `workspaces.core.check_cluster_write_permission(user, cluster_name)` — resolves the cluster's own workspace and checks membership; missing cluster is left to the caller's not-found handling. Backed by a lightweight `global_user_state.get_cluster_workspace()` that selects only the `workspace` column (no handle unpickling).
- Wired at the API boundary (before a worker is scheduled) on `/exec`, `/stop`, `/down`, `/start`, `/autostop`, `/cancel`, and both `/kubernetes-pod-ssh-proxy` and `/slurm-job-ssh-proxy` (shared `_validate_cluster_for_ssh_proxy_ws`). SSH is treated as a write (interactive shell = arbitrary code execution). Internal `core.*` callers (controllers, recovery, daemons) invoke the functions directly and are unaffected.
- Managed-job `cancel`: the `current_workspace` skip is hoisted to the top of the per-job loop (after the existence check), so it applies uniformly regardless of job status.

## Test plan

Unit tests (added, all pass; both revert-checked — i.e. reverting the fix makes them fail):

- `tests/unit_tests/test_sky/workspaces/test_cluster_write_permission.py`
  - non-member of the cluster's workspace → `PermissionDeniedError` (and the check consults the *cluster's* workspace, not the active one)
  - member → allowed
  - unknown cluster → not rejected, permission service not consulted
- `tests/unit_tests/test_sky/jobs/test_utils.py::TestCancelJobsByIdWorkspaceScoping`
  - RUNNING / PENDING / terminal job × in-workspace vs out-of-workspace: out-of-workspace jobs are skipped (never cancelled) regardless of status; in-workspace jobs are cancelled

```
pytest tests/unit_tests/test_sky/workspaces/test_cluster_write_permission.py \
       tests/unit_tests/test_sky/workspaces/test_workspace_permissions.py \
       tests/unit_tests/test_sky/jobs/test_utils.py
# 119 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)