### PR TITLE
[Core] Handle missing Git during commit metadata collection

### DIFF
--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -109,6 +109,10 @@ def get_git_commit(path: Optional[str] = None) -> Optional[str]:
                                 cwd=path,
                                 check=True)
         return result.stdout.strip()
+    except FileNotFoundError as error:
+        if error.filename == 'git':
+            return None
+        raise
     except subprocess.CalledProcessError:
         return None
 

--- a/tests/unit_tests/test_sky/test_git_commit_metadata.py
+++ b/tests/unit_tests/test_sky/test_git_commit_metadata.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 import tempfile
+from unittest import mock
 
 from sky import task as task_lib
 from sky.utils import dag_utils
@@ -57,6 +58,16 @@ class TestWorkdirGitCommit:
         with tempfile.TemporaryDirectory() as d:
             t = task_lib.Task(workdir=d)
             t.expand_and_validate_workdir()
+            assert t.metadata.get('git_commit') is None
+
+    def test_workdir_without_git_executable(self):
+        """Git commit is None when the Git executable is unavailable."""
+        with tempfile.TemporaryDirectory() as d:
+            t = task_lib.Task(workdir=d)
+            error = FileNotFoundError(2, 'No such file or directory', 'git')
+            with mock.patch('sky.utils.common_utils.subprocess.run',
+                            side_effect=error):
+                t.expand_and_validate_workdir()
             assert t.metadata.get('git_commit') is None
 
     def test_no_workdir(self):


### PR DESCRIPTION
## Summary

Workdir validation calls `git rev-parse HEAD` to collect optional commit metadata. `get_git_commit()` catches  `subprocess.CalledProcessError` for non-Git directories, but a missing executable raises `FileNotFoundError` before Git can run. The exception escapes and blocks submission.

```
FileNotFoundError: [Errno 2] No such file or directory: 'git'
```

The fix:

- Treat a missing Git executable as unavailable optional commit metadata instead of failing task validation.
- Add regression coverage for a missing Git executable.

## Test Plan

- [x] Manually verified local workdir validation succeeds with Git removed
  from `PATH`.

  ```bash
  python3 - <<'PY'
  import os
  import tempfile
  from unittest import mock

  import sky

  with tempfile.TemporaryDirectory() as workdir:
      task = sky.Task(workdir=workdir, run='echo hello')
      with mock.patch.dict(os.environ, {'PATH': '/__skypilot_no_git__'}):
          task.expand_and_validate_workdir()

  print('Success: workdir validated without Git')
  PY
  ```

  Expected output: `Success: workdir validated without Git` with the fix, `FileNotFoundError` without it.

- [x] `bash format.sh --files sky/utils/common_utils.py tests/unit_tests/test_sky/test_git_commit_metadata.py`
- [x] `pytest tests/unit_tests/test_sky/test_git_commit_metadata.py -q`
