### PR TITLE
[Core] Compute Kubernetes accelerator node affinity in Python

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1025,6 +1025,8 @@ class Kubernetes(clouds.Cloud):
             'k8s_port_mode': port_mode.value,
             'k8s_acc_label_key': k8s_acc_label_key,
             'k8s_acc_label_values': k8s_acc_label_values,
+            'k8s_node_affinity': kubernetes_utils.get_node_affinity(
+                k8s_acc_label_key, k8s_acc_label_values, avoid_label_keys),
             'k8s_service_account_name': k8s_service_account_name,
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2604,6 +2604,54 @@ def check_instance_fits(
         return fits, reason
 
 
+def get_node_affinity(
+    acc_label_key: Optional[str],
+    acc_label_values: Optional[List[str]],
+    avoid_label_keys: Optional[List[str]],
+) -> Optional[Dict[str, Any]]:
+    """Builds the pod ``nodeAffinity`` for accelerator scheduling.
+
+    Two independent terms, either of which may be absent:
+
+    * When an accelerator label key/values are given, a required term pins the
+      pod to nodes whose ``acc_label_key`` is one of ``acc_label_values``.
+    * When ``avoid_label_keys`` are given (a CPU-only task), a preferred term
+      steers the pod away from accelerator nodes so they stay free for GPU/TPU
+      work.
+
+    Args:
+        acc_label_key: Node label key identifying the accelerator type, or None.
+        acc_label_values: Accepted values for ``acc_label_key``, or None.
+        avoid_label_keys: Node label keys the pod should prefer not to have set,
+            or None.
+
+    Returns:
+        A ``nodeAffinity`` dict, or None when neither term applies.
+    """
+    node_affinity: Dict[str, Any] = {}
+    if acc_label_key is not None and acc_label_values is not None:
+        node_affinity['requiredDuringSchedulingIgnoredDuringExecution'] = {
+            'nodeSelectorTerms': [{
+                'matchExpressions': [{
+                    'key': acc_label_key,
+                    'operator': 'In',
+                    'values': list(acc_label_values),
+                }],
+            }],
+        }
+    if avoid_label_keys is not None:
+        node_affinity['preferredDuringSchedulingIgnoredDuringExecution'] = [{
+            'weight': 1,
+            'preference': {
+                'matchExpressions': [{
+                    'key': avoid_label_key,
+                    'operator': 'DoesNotExist',
+                } for avoid_label_key in avoid_label_keys],
+            },
+        }]
+    return node_affinity or None
+
+
 def get_accelerator_label_keys(context: Optional[str],) -> List[str]:
     """Returns the label keys that should be avoided for scheduling
     CPU-only tasks.

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -436,32 +436,10 @@ available_node_types:
             cloud.google.com/gke-flex-start: "true"
             {% endif %}
         {% endif %}
-        {% set _affinity_node = (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
-        {% if _affinity_node or k8s_host_network %}
+        {% if k8s_node_affinity or k8s_host_network %}
         affinity:
-          {% if _affinity_node %}
-          nodeAffinity:
-            {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: {{k8s_acc_label_key}}
-                  operator: In
-                  values:
-                  {% for label_value in k8s_acc_label_values %}
-                  - {{label_value}}
-                  {% endfor %}
-            {% endif %}
-            {% if avoid_label_keys is not none %}
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              preference:
-                matchExpressions:
-                {% for avoid_label_key in avoid_label_keys %}
-                - key: {{avoid_label_key}}
-                  operator: DoesNotExist
-                {% endfor %}
-            {% endif %}
+          {% if k8s_node_affinity %}
+          nodeAffinity: {{k8s_node_affinity | tojson}}
           {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5475,3 +5475,77 @@ class TestOCINetworkEnvVars:
         coreweave = utils.KubernetesHighPerformanceNetworkType.COREWEAVE
         assert (coreweave.get_network_env_vars('GB200') ==
                 coreweave.get_network_env_vars(None))
+
+
+class TestGetNodeAffinity:
+    """Tests for utils.get_node_affinity."""
+
+    def test_none_when_no_terms(self):
+        """No accelerator key and no avoid keys -> no affinity."""
+        assert utils.get_node_affinity(None, None, None) is None
+
+    def test_none_when_key_without_values(self):
+        """A key with None values does not produce a required term."""
+        assert utils.get_node_affinity('skypilot.co/accelerator', None,
+                                       None) is None
+
+    def test_required_term_single_value(self):
+        affinity = utils.get_node_affinity('skypilot.co/accelerator', ['H100'],
+                                           None)
+        assert affinity == {
+            'requiredDuringSchedulingIgnoredDuringExecution': {
+                'nodeSelectorTerms': [{
+                    'matchExpressions': [{
+                        'key': 'skypilot.co/accelerator',
+                        'operator': 'In',
+                        'values': ['H100'],
+                    }],
+                }],
+            },
+        }
+
+    def test_required_term_multiple_values(self):
+        affinity = utils.get_node_affinity('skypilot.co/accelerator',
+                                           ['A100', 'A100-80GB'], None)
+        assert affinity == {
+            'requiredDuringSchedulingIgnoredDuringExecution': {
+                'nodeSelectorTerms': [{
+                    'matchExpressions': [{
+                        'key': 'skypilot.co/accelerator',
+                        'operator': 'In',
+                        'values': ['A100', 'A100-80GB'],
+                    }],
+                }],
+            },
+        }
+
+    def test_preferred_term_only(self):
+        """CPU-only: avoid keys steer away from accelerator nodes."""
+        affinity = utils.get_node_affinity(
+            None, None, ['nvidia.com/gpu.present', 'gke-tpu-accelerator'])
+        assert affinity == {
+            'preferredDuringSchedulingIgnoredDuringExecution': [{
+                'weight': 1,
+                'preference': {
+                    'matchExpressions': [
+                        {
+                            'key': 'nvidia.com/gpu.present',
+                            'operator': 'DoesNotExist',
+                        },
+                        {
+                            'key': 'gke-tpu-accelerator',
+                            'operator': 'DoesNotExist',
+                        },
+                    ],
+                },
+            }],
+        }
+
+    def test_both_terms(self):
+        affinity = utils.get_node_affinity('skypilot.co/accelerator', ['H100'],
+                                           ['some-other-key'])
+        assert affinity is not None
+        assert set(affinity.keys()) == {
+            'requiredDuringSchedulingIgnoredDuringExecution',
+            'preferredDuringSchedulingIgnoredDuringExecution',
+        }

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -82,6 +82,7 @@ from typing import Any, Dict
 import pytest
 import yaml
 
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import common_utils
 
 TEMPLATE_NAME = 'kubernetes-ray.yml.j2'
@@ -433,6 +434,25 @@ CASES: Dict[str, Dict[str, Any]] = {
 }
 
 
+def _build_variables(case_name: str) -> Dict[str, Any]:
+    """Merges a case onto the base and derives the computed template vars.
+
+    ``k8s_node_affinity`` is built by calling the same production helper
+    (``kubernetes_utils.get_node_affinity``) that
+    ``make_deploy_resources_variables`` uses, from the raw accelerator-label
+    vars the case carries. Deriving it here rather than hard-coding it is what
+    makes the goldens a semantic-identity proof for the Python lift.
+    """
+    variables = base_variables()
+    variables.update(CASES[case_name])
+    variables['k8s_node_affinity'] = kubernetes_utils.get_node_affinity(
+        variables['k8s_acc_label_key'],
+        variables['k8s_acc_label_values'],
+        variables['avoid_label_keys'],
+    )
+    return variables
+
+
 def _render(variables: Dict[str, Any]) -> str:
     """Render the template through the production fill_template helper."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -510,8 +530,7 @@ def _assert_matches_snapshot(case_name: str, normalized: str) -> None:
 @pytest.mark.parametrize('case_name', list(CASES.keys()))
 def test_kubernetes_ray_template_snapshot(case_name: str) -> None:
     """Rendered manifest matches the golden for each input permutation."""
-    variables = base_variables()
-    variables.update(CASES[case_name])
+    variables = _build_variables(case_name)
     rendered = _render(variables)
     _assert_matches_snapshot(case_name, _normalize(rendered))
 
@@ -524,8 +543,7 @@ def test_kubernetes_ray_template_render_is_deterministic(
     Guards against nondeterminism (unordered iteration, time/random values)
     leaking into the goldens.
     """
-    variables = base_variables()
-    variables.update(CASES[case_name])
+    variables = _build_variables(case_name)
     first = _normalize(_render(copy.deepcopy(variables)))
     second = _normalize(_render(copy.deepcopy(variables)))
     assert first == second


### PR DESCRIPTION
## Summary

The pod `nodeAffinity` for accelerator scheduling in `sky/templates/kubernetes-ray.yml.j2` was hand-written YAML, built from raw template vars (`k8s_acc_label_key`, `k8s_acc_label_values`, `avoid_label_keys`) via nested Jinja conditionals and loops. That block is impossible to unit-test and adds to the template's already-large body of scheduling logic.

This PR moves the construction into a small pure helper, `kubernetes_utils.get_node_affinity`, which returns the `nodeAffinity` dict (or `None`). `make_deploy_resources_variables` calls it and exposes the result as a single structured template var, `k8s_node_affinity`; the template renders it with `| tojson` in place of the hand-written block.

The raw `k8s_acc_label_key` / `k8s_acc_label_values` vars remain exposed because the pod's `nodeSelector` (`skypilot-binpack` label) and `podAffinity` (binpack + EFA co-location) blocks still consume them — only the `nodeAffinity` block's consumption changed.

**Why the goldens are the evidence:** the golden snapshot tests render from a hand-built variables dict. The fixture now derives `k8s_node_affinity` by calling the same helper with the same raw inputs the old fixture vars carried. The goldens being unchanged is therefore a semantic-identity proof that the rendered manifest is equivalent after the refactor — the template logic moved to tested Python without changing a single byte of the parsed manifest.

This is the first of a planned series of small template-simplification PRs; it is the MVP that proves the snapshot harness catches and clears such refactors.

Based on #10226 (this PR is stacked on `kevinmingtarja/k8s-template-snapshot-tests`, which brings the goldens; it retargets to `master` once that merges).

## Tested

Run against the branch's own `sky/`, all green:

- `tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py` — **48 passed**, and `git status` shows **zero modified goldens** (the headline evidence). Ran twice; output deterministic.
- New direct unit tests for the helper, `tests/unit_tests/kubernetes/test_kubernetes_utils.py::TestGetNodeAffinity` — **6 passed** (covers: no terms → `None`, key-without-values → `None`, required term single/multiple values, preferred-only avoid term, both terms).
- Broader `tests/unit_tests/test_sky/clouds/` + `tests/unit_tests/kubernetes/test_kubernetes_utils.py` — **630 passed**.
- `bash format.sh --files <the changed files>` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)