### PR TITLE
[Kubernetes] Surface which node a terminated cluster lost

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2987,8 +2987,15 @@ def _update_cluster_status(
             # user-initiated teardown. K8s-only; other clouds keep the generic
             # reason. Best-effort -- fall back to the generic message when the
             # nodes are unknown or all look fine.
-            if not status_reason and isinstance(launched_resources.cloud,
-                                                clouds.Kubernetes):
+            #
+            # Skipped once the cluster is already INIT, mirroring the guard on
+            # the event write below: a cluster stays INIT with the pod missing
+            # until it is downed or relaunched, so without this we would poll
+            # the K8s API once per node every refresh to build a string that
+            # is then discarded.
+            if (status != status_lib.ClusterStatus.INIT and
+                    not status_reason and
+                    isinstance(launched_resources.cloud, clouds.Kubernetes)):
                 try:
                     cluster_info = handle.cached_cluster_info
                     node_names = (cluster_info.get_node_names()

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2980,6 +2980,29 @@ def _update_cluster_status(
         ]
         if some_nodes_terminated:
             init_reason = 'one or more nodes terminated'
+            # Say where the node went. The pods are gone, so their live status
+            # explains nothing, but the Kubernetes nodes they were placed on
+            # still do: a node that no longer exists, or that is NotReady or
+            # cordoned, points at a cluster/cloud-side failure rather than a
+            # user-initiated teardown. K8s-only; other clouds keep the generic
+            # reason. Best-effort -- fall back to the generic message when the
+            # nodes are unknown or all look fine.
+            if not status_reason and isinstance(launched_resources.cloud,
+                                                clouds.Kubernetes):
+                try:
+                    cluster_info = handle.cached_cluster_info
+                    node_names = (cluster_info.get_node_names()
+                                  if cluster_info is not None else None)
+                    if node_names:
+                        ray_config = global_user_state.get_cluster_yaml_dict(
+                            handle.cluster_yaml)
+                        if ray_config and 'provider' in ray_config:
+                            status_reason = (
+                                k8s_instance.get_missing_node_reason(
+                                    node_names, ray_config['provider']) or '')
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Failed to get node state for '
+                                 f'{cluster_name!r}: {e}')
         elif ray_cluster_unhealthy:
             if status_reason:
                 # K8s diagnostics explain the issue — lead with that

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2424,6 +2424,71 @@ def get_node_health_for_cluster(
     return result
 
 
+def get_missing_node_reason(node_names: List[str],
+                            provider_config: Dict[str, Any]) -> Optional[str]:
+    """Best-effort reason a cluster lost node(s), from current node state.
+
+    Answers "where did the node go" by asking Kubernetes about the nodes the
+    cluster's pods were placed on, rather than by replaying the pod's event
+    history. A node that no longer exists, or that exists but is NotReady or
+    cordoned, explains a pod that vanished from under the cluster.
+
+    Reporting current state (rather than a past event) keeps this idempotent:
+    it returns the same answer on every status refresh, with no dependence on
+    what a previous call already consumed.
+
+    Note this deliberately does not use the NodeInfoSource cache that
+    ``_check_nodes_health`` prefers: a node absent from that cache is
+    indistinguishable from a healthy one, and a deleted node is exactly the
+    case this needs to report.
+
+    Args:
+        node_names: The Kubernetes node names the cluster's pods were placed
+            on, e.g. from ``ClusterInfo.get_node_names()``.
+        provider_config: The Kubernetes provider config.
+
+    Returns:
+        A human-readable reason, or None when every node is present and
+        healthy (or none could be checked).
+    """
+    context = kubernetes_utils.get_context_from_config(provider_config)
+    unique_names = sorted({name for name in node_names if name})
+    if not unique_names:
+        return None
+
+    def _inspect_node(name: str) -> Optional[str]:
+        """Returns an issue description for a node, or None if it is fine."""
+        try:
+            node = kubernetes.core_api(context).read_node(
+                name, _request_timeout=kubernetes.API_TIMEOUT)
+        except kubernetes.api_exception() as e:
+            if e.status == 404:
+                return 'no longer exists'
+            logger.debug(f'Failed to read node {name}: {e}')
+            return None
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to read node {name}: {e}')
+            return None
+        # NotReady first: it is more severe than cordoned, and a cordoned
+        # node that has also gone NotReady is described by the former.
+        node_status = getattr(node, 'status', None)
+        for condition in (getattr(node_status, 'conditions', None) or []):
+            if condition.type == 'Ready' and condition.status != 'True':
+                return 'is NotReady'
+        if getattr(getattr(node, 'spec', None), 'unschedulable', False):
+            return 'is cordoned'
+        return None
+
+    issues = subprocess_utils.run_in_parallel(_inspect_node, unique_names)
+    parts = [
+        f'node {name} {issue}' for name, issue in zip(unique_names, issues)
+        if issue is not None
+    ]
+    if not parts:
+        return None
+    return '; '.join(parts)
+
+
 def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     """Get pod termination reason and write to cluster events.
 

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3667,3 +3667,90 @@ class TestCreatePodFinalizerHandling:
         # Must not have touched the live pod.
         core_api_mock.patch_namespaced_pod.assert_not_called()
         core_api_mock.delete_namespaced_pod.assert_not_called()
+
+
+def _fake_node(ready=True, unschedulable=False):
+    node = mock.Mock()
+    condition = mock.Mock()
+    condition.type = 'Ready'
+    condition.status = 'True' if ready else 'False'
+    node.status.conditions = [condition]
+    node.spec.unschedulable = unschedulable
+    return node
+
+
+class TestGetMissingNodeReason:
+    """Tests for explaining a lost node from current Kubernetes node state."""
+
+    def _reason(self, nodes):
+        """nodes: dict of node name -> fake node, or an Exception to raise."""
+
+        def _read_node(name, **kwargs):
+            del kwargs
+            value = nodes[name]
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        core_api = mock.Mock()
+        core_api.read_node.side_effect = _read_node
+        with mock.patch.object(instance.kubernetes,
+                               'core_api',
+                               return_value=core_api):
+            return instance.get_missing_node_reason(list(nodes),
+                                                    {'context': 'ctx'})
+
+    @staticmethod
+    def _not_found():
+        exc = kubernetes.api_exception()(status=404, reason='Not Found')
+        return exc
+
+    def test_no_node_names_returns_none(self):
+        assert instance.get_missing_node_reason([], {'context': 'ctx'}) is None
+        assert instance.get_missing_node_reason([None, ''],
+                                                {'context': 'ctx'}) is None
+
+    def test_healthy_nodes_return_none(self):
+        assert self._reason({'node-1': _fake_node()}) is None
+
+    def test_deleted_node_reported(self):
+        assert self._reason({'node-1': self._not_found()
+                            }) == 'node node-1 no longer exists'
+
+    def test_not_ready_node_reported(self):
+        assert self._reason({'node-1': _fake_node(ready=False)
+                            }) == 'node node-1 is NotReady'
+
+    def test_cordoned_node_reported(self):
+        assert self._reason({'node-1': _fake_node(unschedulable=True)
+                            }) == 'node node-1 is cordoned'
+
+    def test_not_ready_takes_precedence_over_cordoned(self):
+        assert self._reason({
+            'node-1': _fake_node(ready=False, unschedulable=True)
+        }) == 'node node-1 is NotReady'
+
+    def test_healthy_nodes_omitted_from_multi_node_result(self):
+        assert self._reason({
+            'node-1': _fake_node(),
+            'node-2': self._not_found(),
+        }) == 'node node-2 no longer exists'
+
+    def test_multiple_bad_nodes_joined(self):
+        assert self._reason({
+            'node-1': self._not_found(),
+            'node-2': _fake_node(ready=False),
+        }) == 'node node-1 no longer exists; node node-2 is NotReady'
+
+    def test_duplicate_node_names_reported_once(self):
+        # Several pods on one node yield the same name more than once.
+        assert self._reason({'node-1': self._not_found()
+                            }) == 'node node-1 no longer exists'
+
+    def test_non_404_api_error_is_swallowed(self):
+        # A transient API error must not be reported as a node problem.
+        err = kubernetes.api_exception()(status=500, reason='Server Error')
+        assert self._reason({'node-1': err}) is None
+
+    def test_unexpected_error_is_swallowed(self):
+        assert self._reason({'node-1': RuntimeError('boom')}) is None

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -47,13 +47,14 @@ def _make_record(handle, status=status_lib.ClusterStatus.UP):
 
 def _capture_init_log_message(node_statuses,
                               launched_nodes=1,
-                              cached_cluster_info=None):
+                              cached_cluster_info=None,
+                              status=status_lib.ClusterStatus.UP):
     """Drive _update_cluster_status with a fake node_statuses and return
     the log_message passed to global_user_state.add_cluster_event when the
     cluster transitions to INIT."""
     handle = _make_handle(cached_cluster_info=cached_cluster_info)
     handle.launched_nodes = launched_nodes
-    record = _make_record(handle)
+    record = _make_record(handle, status=status)
 
     captured = {}
 
@@ -207,6 +208,21 @@ class TestUpdateClusterStatusInitReason:
                 launched_nodes=2,
                 cached_cluster_info=handle_info)
         assert 'one or more nodes terminated' in msg, msg
+
+    def test_some_nodes_terminated_skips_node_query_when_already_init(self):
+        # A cluster stays INIT with the pod missing until it is downed or
+        # relaunched, and the event is not re-written once it is INIT. Don't
+        # poll the K8s API every refresh to build a discarded string.
+        handle_info = mock.Mock()
+        handle_info.get_node_names.return_value = ['node-0', 'node-1']
+        with mock.patch.object(backend_utils.k8s_instance,
+                               'get_missing_node_reason') as mock_reason:
+            _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)},
+                launched_nodes=2,
+                cached_cluster_info=handle_info,
+                status=status_lib.ClusterStatus.INIT)
+        mock_reason.assert_not_called()
 
     def test_some_nodes_terminated_without_cached_cluster_info(self):
         # No cached ClusterInfo (e.g. an older cluster) -> generic message,

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -16,8 +16,9 @@ from sky.backends import backend_utils
 from sky.utils import status_lib
 
 
-def _make_handle():
+def _make_handle(cached_cluster_info=None):
     handle = mock.Mock(spec=backends.CloudVmRayResourceHandle)
+    handle.cached_cluster_info = cached_cluster_info
     handle.cluster_name = 'test-cluster'
     handle.cluster_name_on_cloud = 'test-cluster-1234'
     handle.cluster_yaml = '/fake/path/cluster.yaml'
@@ -44,11 +45,13 @@ def _make_record(handle, status=status_lib.ClusterStatus.UP):
     }
 
 
-def _capture_init_log_message(node_statuses, launched_nodes=1):
+def _capture_init_log_message(node_statuses,
+                              launched_nodes=1,
+                              cached_cluster_info=None):
     """Drive _update_cluster_status with a fake node_statuses and return
     the log_message passed to global_user_state.add_cluster_event when the
     cluster transitions to INIT."""
-    handle = _make_handle()
+    handle = _make_handle(cached_cluster_info=cached_cluster_info)
     handle.launched_nodes = launched_nodes
     record = _make_record(handle)
 
@@ -163,3 +166,56 @@ class TestUpdateClusterStatusInitReason:
         msg = _capture_init_log_message(
             {'pod-0': (status_lib.ClusterStatus.UP, None)}, launched_nodes=2)
         assert 'one or more nodes terminated' in msg, msg
+
+    def test_some_nodes_terminated_surfaces_node_state(self):
+        # A node that vanished from under the cluster is named in the event.
+        handle_info = mock.Mock()
+        handle_info.get_node_names.return_value = ['node-0', 'node-1']
+        with mock.patch.object(
+                backend_utils.global_user_state,
+                'get_cluster_yaml_dict',
+                return_value={'provider': {
+                    'namespace': 'default',
+                    'context': 'ctx'
+                }}), \
+             mock.patch.object(backend_utils.k8s_instance,
+                               'get_missing_node_reason',
+                               return_value='node node-1 no longer exists'):
+            msg = _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)},
+                launched_nodes=2,
+                cached_cluster_info=handle_info)
+        assert 'one or more nodes terminated' in msg, msg
+        assert 'node node-1 no longer exists' in msg, msg
+
+    def test_some_nodes_terminated_falls_back_when_nodes_healthy(self):
+        # Nodes all present and healthy -> keep the generic message.
+        handle_info = mock.Mock()
+        handle_info.get_node_names.return_value = ['node-0', 'node-1']
+        with mock.patch.object(
+                backend_utils.global_user_state,
+                'get_cluster_yaml_dict',
+                return_value={'provider': {
+                    'namespace': 'default',
+                    'context': 'ctx'
+                }}), \
+             mock.patch.object(backend_utils.k8s_instance,
+                               'get_missing_node_reason',
+                               return_value=None):
+            msg = _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)},
+                launched_nodes=2,
+                cached_cluster_info=handle_info)
+        assert 'one or more nodes terminated' in msg, msg
+
+    def test_some_nodes_terminated_without_cached_cluster_info(self):
+        # No cached ClusterInfo (e.g. an older cluster) -> generic message,
+        # and no attempt to query Kubernetes.
+        with mock.patch.object(backend_utils.k8s_instance,
+                               'get_missing_node_reason') as mock_reason:
+            msg = _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)},
+                launched_nodes=2,
+                cached_cluster_info=None)
+        assert 'one or more nodes terminated' in msg, msg
+        mock_reason.assert_not_called()


### PR DESCRIPTION
## Summary

When a Kubernetes cluster loses a pod, `sky status` refresh records only `one or more nodes terminated`, which doesn't say *where the node went*. The pod is gone, so its live status explains nothing — but the Kubernetes node it was placed on still does.

- Add `get_missing_node_reason()` to the Kubernetes provisioner: for the nodes the cluster's pods were placed on (`ClusterInfo.get_node_names()`), report any that no longer exist, are `NotReady`, or are cordoned. A node that vanished or went unhealthy points at a cluster/cloud-side failure rather than a user-initiated teardown.
- Append that reason to the INIT cluster event when available. Best-effort: falls back to the generic message on any error, for non-Kubernetes clouds, when there's no cached `ClusterInfo`, or when every node looks fine.

The lookup is skipped once the cluster is already `INIT`, mirroring the guard on the event write: a cluster stays `INIT` with the pod missing until it is downed or relaunched, and the background refresh daemon force-refreshes every status every 60s — so without the guard we would call `read_node` once per cluster node every cycle to build a string that is then discarded.

Three deliberate design choices:
- **Reads current node state, not pod event history.** This keeps the call idempotent — the same answer on every status refresh, with no dependence on what a previous call already consumed.
- **Bypasses the `NodeInfoSource` cache** that `_check_nodes_health` prefers. In that cache, a node absent from the listing is indistinguishable from a healthy one — and a deleted node is exactly the case this needs to report.

Before:
```
one or more nodes terminated
```
After:
```
one or more nodes terminated (node gke-pool-abc123 no longer exists)
```

## Test plan

Unit tests added (`148 passed` across the two touched files):

```bash
pytest tests/unit_tests/kubernetes/test_provision.py -k MissingNodeReason
pytest tests/unit_tests/test_backend_utils_init_reason.py
```

`TestGetMissingNodeReason` covers: no node names, healthy nodes, deleted (404), `NotReady`, cordoned, `NotReady` taking precedence over cordoned, healthy nodes omitted from a multi-node result, multiple bad nodes joined, duplicate node names reported once, and non-404 / unexpected API errors swallowed rather than misreported as node problems.

`test_backend_utils_init_reason.py` covers the integration into `_update_cluster_status`: reason surfaced in the event, fallback to the generic message when nodes are healthy, and no Kubernetes query attempted when there's no cached `ClusterInfo` or when the cluster is already `INIT`.

Manual verification on a real Kubernetes cluster:

```bash
sky launch -c test-k8s --infra k8s --num-nodes 2 -- sleep 3600

# Drain the node one of the pods landed on, so the pod is evicted:
kubectl get pods -o wide | grep test-k8s      # find the node name
kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --force

sky status -r test-k8s   # cluster goes INIT
sky status test-k8s -v   # event names the node and says cordoned / NotReady
```

Also verify the fallback path is unchanged for a non-Kubernetes cluster (e.g. AWS) — terminate one node of a 2-node cluster out-of-band and confirm the event still reads `one or more nodes terminated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

