### PR TITLE
[Nebius] Suppress grpc.aio poller callback noise on the asyncio logger

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -159,10 +159,30 @@ class _NebiusDeprecationFilter(logging.Filter):
         return f'{os.sep}nebius{os.sep}' not in record.pathname
 
 
+class _GrpcAioPollerNoiseFilter(logging.Filter):
+    """Drops grpc.aio poller callback noise logged to the 'asyncio' logger.
+
+    grpc.aio's internal polling can raise known-harmless exceptions (e.g.
+    BlockingIOError: [Errno 11] Resource temporarily unavailable) inside
+    PollerCompletionQueue._handle_events loop callbacks. The nebius SDK
+    may run grpc.aio on event loops it creates internally (see
+    nebius.aio.channel.Channel.run_sync), where the default asyncio
+    exception handler logs a full traceback at ERROR level to stderr,
+    polluting user-facing CLI output. Only records referencing the grpc.aio
+    poller callback are dropped; all other asyncio error reporting is
+    unaffected, and API errors still propagate to callers as exceptions.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return ('PollerCompletionQueue._handle_events'
+                not in record.getMessage())
+
+
 def _set_nebius_loggers() -> None:
     # https://github.com/grpc/grpc/issues/37642 to avoid spam in console
     os.environ['GRPC_VERBOSITY'] = 'NONE'
     logging.getLogger('deprecation').addFilter(_NebiusDeprecationFilter())
+    logging.getLogger('asyncio').addFilter(_GrpcAioPollerNoiseFilter())
 
 
 nebius = common.LazyImport('nebius',

--- a/tests/unit_tests/test_nebius.py
+++ b/tests/unit_tests/test_nebius.py
@@ -188,3 +188,62 @@ class TestNebiusAdaptorLogging:
         other_path = os.path.join('site-packages', 'otherlib', 'client.py')
         assert not log_filter.filter(_record(nebius_path))
         assert log_filter.filter(_record(other_path))
+
+    def test_grpc_aio_poller_filter_drops_only_poller_noise(self):
+        log_filter = nebius_adaptor._GrpcAioPollerNoiseFilter()
+
+        def _record(msg: str) -> logging.LogRecord:
+            return logging.LogRecord(name='asyncio',
+                                     level=logging.ERROR,
+                                     pathname='asyncio/base_events.py',
+                                     lineno=1,
+                                     msg=msg,
+                                     args=None,
+                                     exc_info=None)
+
+        # As emitted by asyncio's default exception handler when grpc.aio
+        # polling raises (e.g. BlockingIOError) in a loop callback.
+        poller_msg = (
+            'Exception in callback PollerCompletionQueue._handle_events('
+            '<_UnixSelecto...e debug=False>)()\n'
+            'handle: <Handle PollerCompletionQueue._handle_events('
+            '<_UnixSelecto...e debug=False>)()>')
+        assert not log_filter.filter(_record(poller_msg))
+        # Unrelated asyncio error reporting must be unaffected.
+        assert log_filter.filter(_record('Task exception was never retrieved'))
+        assert log_filter.filter(_record('Exception in callback my_callback()'))
+
+    def test_set_nebius_loggers_suppresses_poller_noise_end_to_end(self):
+        records = []
+
+        class _CaptureHandler(logging.Handler):
+
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        asyncio_logger = logging.getLogger('asyncio')
+        deprecation_logger = logging.getLogger('deprecation')
+        previous_filters = list(asyncio_logger.filters)
+        previous_deprecation_filters = list(deprecation_logger.filters)
+        previous_grpc_verbosity = os.environ.get('GRPC_VERBOSITY')
+        handler = _CaptureHandler(level=logging.DEBUG)
+        asyncio_logger.addHandler(handler)
+        try:
+            nebius_adaptor._set_nebius_loggers()
+            asyncio_logger.error('Exception in callback '
+                                 'PollerCompletionQueue._handle_events('
+                                 '<_UnixSelecto...e debug=False>)()')
+            asyncio_logger.error('some real asyncio error')
+        finally:
+            asyncio_logger.removeHandler(handler)
+            asyncio_logger.filters[:] = previous_filters
+            deprecation_logger.filters[:] = previous_deprecation_filters
+            if previous_grpc_verbosity is None:
+                os.environ.pop('GRPC_VERBOSITY', None)
+            else:
+                os.environ['GRPC_VERBOSITY'] = previous_grpc_verbosity
+
+        messages = [r.getMessage() for r in records]
+        assert not any(
+            'PollerCompletionQueue' in m for m in messages), (messages)
+        assert any('some real asyncio error' in m for m in messages), messages


### PR DESCRIPTION
## Summary

Follow-up to #10222. That PR silenced the personal pricing fetch warning, the nebius SDK deprecation spam, and callback exceptions on the adaptor's dedicated event loop. Release smoke-test validation (build with #10222 cherry-picked) confirmed those are gone, but one leak remained mid `sky launch` (between "Job submitted, ID: N" and "Waiting for task resources on ..."):

```
ERROR:asyncio:Exception in callback PollerCompletionQueue._handle_events(<_UnixSelecto...e debug=False>)()
handle: <Handle PollerCompletionQueue._handle_events(<_UnixSelecto...e debug=False>)()>
Traceback (most recent call last):
  ...
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi", line 147, in grpc._cython.cygrpc.PollerCompletionQueue._handle_events
BlockingIOError: [Errno 11] Resource temporarily unavailable
```

Root cause: the nebius SDK can run grpc.aio on event loops it creates internally (`nebius.aio.channel.Channel.run_sync` falls back to `get_event_loop()` / `new_event_loop()`), so the grpc.aio poller can be registered on a loop that does not have the exception handler installed by #10222 on the adaptor's dedicated loop. The default asyncio exception handler then logs the full traceback at ERROR to stderr through the `asyncio` logger, and per-loop handlers cannot reliably cover loops the SDK creates itself.

Fix: add a tightly scoped `logging.Filter` on the `asyncio` logger that drops only records whose formatted message references `PollerCompletionQueue._handle_events` (grpc.aio internal polling noise; the `BlockingIOError: [Errno 11]` there is known-harmless). All other asyncio error reporting, including other callback exceptions, is unaffected, and real API errors still propagate to callers as exceptions. The filter is installed alongside the existing suppressions in `_set_nebius_loggers`, which only runs once the nebius SDK is actually loaded.

This broke release smoke-test launch-output validation when the Nebius billing API started erroring, and it is a cherry-pick candidate for the release branch, same as #10222.

## Tested

- New unit test `test_grpc_aio_poller_filter_drops_only_poller_noise`: the filter drops the poller record and passes unrelated asyncio error records, including other callback exceptions.
- New unit test `test_set_nebius_loggers_suppresses_poller_noise_end_to_end`: after `_set_nebius_loggers()`, a poller-noise record logged through `logging.getLogger('asyncio')` is dropped while a normal asyncio error record is still emitted; also verifies composition with the filters from #10222 (with cleanup restoring logger state).
- `pytest tests/unit_tests/test_nebius.py tests/unit_tests/test_nebius_catalog.py`: 14 passed (all tests from #10222 still pass).
- Manual simulation with a root stderr handler: imported the adaptor, triggered `_set_nebius_loggers`, then scheduled a `BlockingIOError`-raising `PollerCompletionQueue._handle_events` callback on a fresh event loop with no custom exception handler (mimicking an SDK-internal loop). Result: no `ERROR:asyncio` output for the poller callback, while an unrelated raising callback on the same loop still printed its full traceback.
- `bash format.sh`: mypy clean, pylint 10.00/10.

Manual verification on a machine with nebius credentials where the billing API returns the SKU error: run `sky launch --infra nebius ...` and confirm no `ERROR:asyncio` lines appear between "Job submitted, ID: N" and "Waiting for task resources on ...".

🤖 Generated with [Claude Code](https://claude.com/claude-code)