### PR TITLE
[Docs] Trim redundant optimization section from Overview; link SkyPilot Platform

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -391,38 +391,14 @@ See :ref:`Using Existing Machines <existing-machines>`.
 
 
 
-SkyPilot's cost and capacity optimization
--------------------------------------------------------------------
-
-Whenever new compute is needed for a cluster, job, or service,
-SkyPilot's provisioner natively optimizes for cost and capacity, choosing the infra option that is the cheapest and available.
-
-For example, if you want to launch a cluster with 8 A100 GPUs, SkyPilot will try all infra
-options in the given search space in the "cheapest and available" order,
-with auto-failover:
-
-.. figure:: images/k8s-failover.png
-   :width: 95%
-   :align: center
-   :alt: SkyPilot auto-failover
-   :class: no-scaled-link
-
-As such, SkyPilot users no longer need to worry about specific infra details, manual retry, or manual setup.
-Workloads also obtain higher GPU capacity and cost savings.
-
-Users can specify each workload's search space. It can be as flexible or as specific as desired. Example search spaces that can be specified:
-
-- Use the cheapest and available GPUs out of a set, ``{A10g:8, A10:8, L4:8, A100:8}``
-- Use my Kubernetes cluster, Slurm cluster, or any accessible clouds (pictured above)
-- Use either a spot or on-demand H100 GPU
-- Use AWS's five European regions only
-- Use a specific zone, region, or cloud
-
-Optimization is performed within the search space.
-See :ref:`auto-failover` for details.
-
 Use SkyPilot locally or deploy for a team
 ----------------------------------------------------------
+
+.. tip::
+
+   Running SkyPilot for a larger team or a larger fleet?
+   :ref:`SkyPilot Platform <skypilot-platform>` offers a managed experience with
+   many new features designed for accelerating your GPU fleets and AI workloads.
 
 SkyPilot can be used locally or deployed as a centralized API server for your team.
 


### PR DESCRIPTION
## Summary

Two small edits to `docs/source/overview.rst`:

- Remove the "SkyPilot's cost and capacity optimization" section. It restates what the
  page's own benefit dropdowns already say ("Maximize GPU fleet utilization" covers
  cheapest-and-available provisioning; "Auto-failover across infra choices" covers the
  search space and fallback), and the full treatment — including the same failover
  figure — already lives on the [auto-failover](https://docs.skypilot.co/en/latest/examples/auto-failover.html)
  page. Dropping it shortens the Overview without losing anything unique.
- Add a tip at the top of "Use SkyPilot locally or deploy for a team" pointing readers
  running larger teams/fleets to the SkyPilot Platform page, since that's the natural
  next question once someone is considering a shared API server.

No content is orphaned: `auto-failover` remains in the sidebar toctree and is linked
from 8 other pages, and `images/k8s-failover.png` is still used by
`reference/kubernetes/skypilot-and-vanilla-k8s.rst`.

Docs-only change; no code paths touched.

## Tested

- Built the docs locally and confirmed a clean build (relevant since the doc-build CI
  fails on any warning):

  ```
  cd docs && SPHINX_BUILD_LOCAL=true make html
  # build succeeded, 0 warnings / errors
  ```

- Served `build/html` and checked the rendered `overview.html`:
  - "cost and capacity optimization" no longer appears anywhere on the page.
  - The tip renders in the intended section, above the intro sentence.
  - The cross-reference resolves to `skypilot-platform.html#skypilot-platform`
    (real link, not a broken-ref fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCqLoEppnv3WXF3mYfXrjL
