### PR TITLE
[Core] Restore the config override in `replace_skypilot_config` when the body raises

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -989,27 +989,33 @@ def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
     original_config_path = loaded_config_path_serialized()
     original_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
     if new_configs != original_config:
-        # Modify the global config of current process or context
-        _set_loaded_config(new_configs)
-        with tempfile.NamedTemporaryFile(delete=False,
-                                         mode='w',
-                                         prefix='mutated-skypilot-config-',
-                                         suffix='.yaml') as temp_file:
-            yaml_utils.dump_yaml(temp_file.name, dict(**new_configs))
-        # Modify the env var of current process or context so that the
-        # new config will be used by spawned sub-processes.
-        # Note that this code modifies os.environ directly because it
-        # will be hijacked to be context-aware if a context is active.
-        os.environ[ENV_VAR_SKYPILOT_CONFIG] = temp_file.name
-        _set_loaded_config_path(temp_file.name)
-        yield
-        # Restore the original config and env var.
-        _set_loaded_config(original_config)
-        _set_loaded_config_path_serialized(original_config_path)
-        if original_env_var:
-            os.environ[ENV_VAR_SKYPILOT_CONFIG] = original_env_var
-        else:
-            os.environ.pop(ENV_VAR_SKYPILOT_CONFIG, None)
+        try:
+            # Modify the global config of current process or context
+            _set_loaded_config(new_configs)
+            with tempfile.NamedTemporaryFile(delete=False,
+                                             mode='w',
+                                             prefix='mutated-skypilot-config-',
+                                             suffix='.yaml') as temp_file:
+                yaml_utils.dump_yaml(temp_file.name, dict(**new_configs))
+            # Modify the env var of current process or context so that the
+            # new config will be used by spawned sub-processes.
+            # Note that this code modifies os.environ directly because it
+            # will be hijacked to be context-aware if a context is active.
+            os.environ[ENV_VAR_SKYPILOT_CONFIG] = temp_file.name
+            _set_loaded_config_path(temp_file.name)
+            yield
+        finally:
+            # Restore the original config and env var. This must happen even
+            # if the body raises: while ENV_VAR_SKYPILOT_CONFIG is set,
+            # `reload_config()` reads the temporary file instead of the real
+            # config, so leaving it in place makes every later config reload
+            # in this process or context see the replacement config.
+            _set_loaded_config(original_config)
+            _set_loaded_config_path_serialized(original_config_path)
+            if original_env_var:
+                os.environ[ENV_VAR_SKYPILOT_CONFIG] = original_env_var
+            else:
+                os.environ.pop(ENV_VAR_SKYPILOT_CONFIG, None)
     else:
         yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2109,3 +2109,76 @@ class TestRemoveQueueNameFromConfig:
                 ]:
                     assert current.get_nested(
                         keys, 'NOT_SET') is None, (f'Expected None at {keys}')
+
+
+class _BodyError(Exception):
+    """Raised from inside a context manager body."""
+
+
+def test_replace_skypilot_config_restores_on_exception(monkeypatch, tmp_path):
+    """replace_skypilot_config undoes the replacement if the body raises."""
+    os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
+    config_path = tmp_path / 'config.yaml'
+    config_path.write_text(f'aws:\n  vpc_name: {VPC_NAME}\n')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
+                        tmp_path / 'non_existent.yaml')
+    _reload_config()
+    assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+
+    original_config = skypilot_config._get_loaded_config()
+    original_config_path = skypilot_config.loaded_config_path_serialized()
+    new_configs = _make_config({'aws': {'vpc_name': 'replacement-vpc'}})
+
+    with pytest.raises(_BodyError):
+        with skypilot_config.replace_skypilot_config(new_configs):
+            assert skypilot_config.get_nested(('aws', 'vpc_name'),
+                                              None) == 'replacement-vpc'
+            assert os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG].endswith(
+                '.yaml')
+            raise _BodyError()
+
+    assert skypilot_config._get_loaded_config() == original_config
+    assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+    assert (
+        skypilot_config.loaded_config_path_serialized() == original_config_path)
+    # The env var was unset before, so it must be unset again rather than set
+    # to an empty string, which reload_config() would read as a config path.
+    assert skypilot_config.ENV_VAR_SKYPILOT_CONFIG not in os.environ
+
+    # A later reload must see the original config, not the replacement.
+    skypilot_config.reload_config()
+    assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+
+
+def test_replace_skypilot_config_restores_env_var_on_exception(
+        monkeypatch, tmp_path):
+    """A pre-existing config env var is restored if the body raises."""
+    config_path = tmp_path / 'config.yaml'
+    config_path.write_text(f'aws:\n  vpc_name: {VPC_NAME}\n')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
+                        tmp_path / 'non_existent.yaml')
+    monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG,
+                       str(config_path))
+    _reload_config()
+    assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+
+    original_config = skypilot_config._get_loaded_config()
+    original_config_path = skypilot_config.loaded_config_path_serialized()
+    new_configs = _make_config({'aws': {'vpc_name': 'replacement-vpc'}})
+
+    with pytest.raises(_BodyError):
+        with skypilot_config.replace_skypilot_config(new_configs):
+            assert os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] != str(
+                config_path)
+            raise _BodyError()
+
+    assert skypilot_config._get_loaded_config() == original_config
+    assert (
+        skypilot_config.loaded_config_path_serialized() == original_config_path)
+    assert os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] == str(
+        config_path)
+
+    skypilot_config.reload_config()
+    assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME


### PR DESCRIPTION
`replace_skypilot_config` installs a config override — sets the loaded config, writes the new config to a temp file, points `SKYPILOT_CONFIG` at it, sets the loaded-config path — then `yield`s and restores afterwards. The restore is not in a `finally`, so if the body raises, none of it is undone.

That matters because `reload_config()` short-circuits to `_reload_config_from_internal_file()` whenever `SKYPILOT_CONFIG` is set: a leaked override makes every later config reload in that process or context read the stale temp file instead of the real config. Callers wrap substantial work in this context manager — `remove_queue_name_from_config()` around controller launches in `sky/jobs/server/core.py` and `sky/serve/server/impl.py` — so a failure inside any of them leaves the process on the wrong config until it restarts. Background threads that reload config are affected too, since the `os.environ` write is process-global when no context is active.

Fix: wrap the body in `try`/`finally`, mirroring `override_skypilot_config` just above.

Complementary to #10134: that PR makes the mutated config schema-valid by popping the queue-name keys instead of writing nulls; this one makes sure the override is always torn down. They interact — once the leftover config is valid, a leaked override stops raising and instead silently applies the wrong config, so unconditional teardown matters more, not less.

Not addressed here: the temp file is created with `delete=False` and is never cleaned up (pre-existing).

## Test

- Added `test_replace_skypilot_config_restores_on_exception` and `test_replace_skypilot_config_restores_env_var_on_exception` to `tests/test_config.py`, covering both the env-var-unset case (must end unset, not set to an empty string) and the env-var-preset case (must be restored to its prior value). Each also asserts a subsequent `reload_config()` sees the original config.
- Both tests fail against `master` and pass with this change.
- `pytest tests/test_config.py` passes.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
