### PR TITLE
[Core] Compute Kubernetes pod affinity in Python

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1031,6 +1031,11 @@ class Kubernetes(clouds.Cloud):
             'k8s_acc_label_values': k8s_acc_label_values,
             'k8s_node_affinity': kubernetes_utils.get_node_affinity(
                 k8s_acc_label_key, k8s_acc_label_values, avoid_label_keys),
+            'k8s_pod_affinity': kubernetes_utils.get_pod_affinity(
+                k8s_acc_label_key, k8s_acc_label_values, k8s_efa_same_az,
+                cluster_name.name_on_cloud),
+            'k8s_binpack_label_key': kubernetes_utils.GPU_BINPACK_LABEL_KEY,
+            'k8s_binpack_label_value': kubernetes_utils.GPU_BINPACK_LABEL_VALUE,
             'k8s_service_account_name': k8s_service_account_name,
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2652,6 +2652,73 @@ def get_node_affinity(
     return node_affinity or None
 
 
+# Node label stamped on accelerator pods so they bin-pack toward each other.
+# The pod label (in the manifest metadata) and the podAffinity labelSelector
+# that targets it must agree, so both are rendered from these constants.
+GPU_BINPACK_LABEL_KEY = 'skypilot-binpack'
+GPU_BINPACK_LABEL_VALUE = 'gpu'
+
+
+def get_pod_affinity(
+    acc_label_key: Optional[str],
+    acc_label_values: Optional[List[str]],
+    efa_same_az: bool,
+    cluster_name_on_cloud: str,
+) -> Optional[Dict[str, Any]]:
+    """Builds the pod ``podAffinity`` for accelerator scheduling.
+
+    Only accelerator pods get a ``podAffinity`` (a pod that requests no
+    accelerator has nothing to bin-pack), so this returns None unless an
+    accelerator label key/values are given. When it applies:
+
+    * A preferred term bin-packs accelerator pods cluster-wide by attracting
+      them to nodes already carrying the ``skypilot-binpack: gpu`` label.
+    * When ``efa_same_az`` is set, a required term co-locates every pod of the
+      cluster into one availability zone. An AWS EFA placement group is
+      single-AZ, so every replica must schedule into one zone or the fabric
+      cannot form: the first pod fixes the AZ (Karpenter provisions an EFA node
+      wherever it has capacity) and the rest follow; the user names no zone.
+      Required (not preferred) because cross-AZ EFA is broken -- the pod must
+      pend loudly rather than silently fall back to TCP.
+
+    Args:
+        acc_label_key: Node label key identifying the accelerator type, or None.
+        acc_label_values: Accepted values for ``acc_label_key``, or None.
+        efa_same_az: Whether to pin all cluster pods into one zone for EFA.
+        cluster_name_on_cloud: Cluster name used to co-locate pods for EFA.
+
+    Returns:
+        A ``podAffinity`` dict, or None for a non-accelerator pod.
+    """
+    if acc_label_key is None or acc_label_values is None:
+        return None
+    pod_affinity: Dict[str, Any] = {
+        'preferredDuringSchedulingIgnoredDuringExecution': [{
+            'weight': 1,
+            'podAffinityTerm': {
+                'labelSelector': {
+                    'matchExpressions': [{
+                        'key': GPU_BINPACK_LABEL_KEY,
+                        'operator': 'In',
+                        'values': [GPU_BINPACK_LABEL_VALUE],
+                    }],
+                },
+                'topologyKey': 'kubernetes.io/hostname',
+            },
+        }],
+    }
+    if efa_same_az:
+        pod_affinity['requiredDuringSchedulingIgnoredDuringExecution'] = [{
+            'labelSelector': {
+                'matchLabels': {
+                    'skypilot-cluster-name': cluster_name_on_cloud,
+                },
+            },
+            'topologyKey': 'topology.kubernetes.io/zone',
+        }]
+    return pod_affinity
+
+
 def get_accelerator_label_keys(context: Optional[str],) -> List[str]:
     """Returns the label keys that should be avoided for scheduling
     CPU-only tasks.

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -295,7 +295,7 @@ available_node_types:
             app: {{cluster_name_on_cloud}}
             {% endif %}
             {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) %}
-            skypilot-binpack: "gpu"
+            {{k8s_binpack_label_key}}: {{k8s_binpack_label_value|tojson}}
             {% endif %}
             {% if k8s_kueue_local_queue_name %}
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
@@ -436,38 +436,13 @@ available_node_types:
             cloud.google.com/gke-flex-start: "true"
             {% endif %}
         {% endif %}
-        {% if k8s_node_affinity or k8s_host_network %}
+        {% if k8s_node_affinity or k8s_pod_affinity or k8s_host_network %}
         affinity:
           {% if k8s_node_affinity %}
           nodeAffinity: {{k8s_node_affinity | tojson}}
-          {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
-          podAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 1
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                      - key: "skypilot-binpack"
-                        operator: In
-                        values:
-                          - "gpu"
-                  topologyKey: kubernetes.io/hostname
-            {% if k8s_efa_same_az %}
-            # Multi-node EFA co-location: an AWS EFA placement group is
-            # single-AZ, so every replica of this job must schedule into one
-            # zone or the fabric cannot form. Attract each pod to the zone of
-            # the other pods of the same SkyPilot cluster -- the first pod fixes
-            # the AZ (Karpenter provisions an EFA node wherever it has
-            # capacity) and the rest follow; the user names no zone. required
-            # (not preferred): cross-AZ EFA is broken, so pend loudly rather
-            # than silently fall back to TCP.
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchLabels:
-                    skypilot-cluster-name: {{cluster_name_on_cloud}}
-                topologyKey: topology.kubernetes.io/zone
-            {% endif %}
           {% endif %}
+          {% if k8s_pod_affinity %}
+          podAffinity: {{k8s_pod_affinity | tojson}}
           {% endif %}
           {% if k8s_host_network %}
           # Mode b: one cluster pod per K8s node. Under hostNetwork a pod

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5549,3 +5549,63 @@ class TestGetNodeAffinity:
             'requiredDuringSchedulingIgnoredDuringExecution',
             'preferredDuringSchedulingIgnoredDuringExecution',
         }
+
+
+class TestGetPodAffinity:
+    """Tests for utils.get_pod_affinity."""
+
+    def test_none_when_no_accelerator(self):
+        """A non-accelerator pod has nothing to bin-pack -> no podAffinity,
+        even when efa_same_az is set (EFA co-location is accelerator-only)."""
+        assert utils.get_pod_affinity(None, None, False, 'c') is None
+        assert utils.get_pod_affinity(None, None, True, 'c') is None
+
+    def test_none_when_key_without_values(self):
+        assert utils.get_pod_affinity('skypilot.co/accelerator', None, False,
+                                      'c') is None
+
+    def test_binpack_only(self):
+        affinity = utils.get_pod_affinity('skypilot.co/accelerator', ['H100'],
+                                          False, 'my-cluster')
+        assert affinity == {
+            'preferredDuringSchedulingIgnoredDuringExecution': [{
+                'weight': 1,
+                'podAffinityTerm': {
+                    'labelSelector': {
+                        'matchExpressions': [{
+                            'key': utils.GPU_BINPACK_LABEL_KEY,
+                            'operator': 'In',
+                            'values': [utils.GPU_BINPACK_LABEL_VALUE],
+                        }],
+                    },
+                    'topologyKey': 'kubernetes.io/hostname',
+                },
+            }],
+        }
+
+    def test_binpack_and_efa(self):
+        affinity = utils.get_pod_affinity('skypilot.co/accelerator', ['H100'],
+                                          True, 'my-cluster')
+        assert affinity == {
+            'preferredDuringSchedulingIgnoredDuringExecution': [{
+                'weight': 1,
+                'podAffinityTerm': {
+                    'labelSelector': {
+                        'matchExpressions': [{
+                            'key': utils.GPU_BINPACK_LABEL_KEY,
+                            'operator': 'In',
+                            'values': [utils.GPU_BINPACK_LABEL_VALUE],
+                        }],
+                    },
+                    'topologyKey': 'kubernetes.io/hostname',
+                },
+            }],
+            'requiredDuringSchedulingIgnoredDuringExecution': [{
+                'labelSelector': {
+                    'matchLabels': {
+                        'skypilot-cluster-name': 'my-cluster',
+                    },
+                },
+                'topologyKey': 'topology.kubernetes.io/zone',
+            }],
+        }

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4484,41 +4484,34 @@ class TestKubernetesEfaSameAzAffinity(unittest.TestCase):
             KubernetesHighPerformanceNetworkType as N)
         self.assertFalse(self._deploy_vars(2, N.NONE)['k8s_efa_same_az'])
 
-    def _render_same_az_affinity(self, same_az):
-        """Render just the k8s_efa_same_az podAffinity block from the live
-        template, so a wrong label or topologyKey is caught -- not only the
-        deploy var. Keeps the assertion coupled to the real template file."""
-        import jinja2
-
-        import sky
-        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
-                                     'kubernetes-ray.yml.j2')
-        with open(template_path, 'r', encoding='utf-8') as fin:
-            full = fin.read()
-        begin_marker = '{% if k8s_efa_same_az %}'
-        end_marker = '{% endif %}'
-        begin = full.index(begin_marker)
-        end = full.index(end_marker, begin) + len(end_marker)
-        snippet = full[begin:end]
-        return jinja2.Template(snippet).render(
-            k8s_efa_same_az=same_az, cluster_name_on_cloud='my-cluster')
-
-    def test_same_az_affinity_renders_cluster_name_label_and_zone(self):
-        # When the flag is set the rendered podAffinity must carry the
-        # (non-deprecated) cluster-name label and the single-AZ topology key.
-        rendered = self._render_same_az_affinity(same_az=True)
-        self.assertIn('requiredDuringSchedulingIgnoredDuringExecution',
-                      rendered)
-        self.assertIn('skypilot-cluster-name: my-cluster', rendered)
-        self.assertIn('topologyKey: topology.kubernetes.io/zone', rendered)
-        # Must not use the deprecated skypilot-cluster label.
-        self.assertNotIn('skypilot-cluster:', rendered)
+    def test_same_az_affinity_sets_cluster_name_label_and_zone(self):
+        # Multi-node EFA sets a required same-zone podAffinity term keyed on the
+        # (non-deprecated) cluster-name label. Asserting on the k8s_pod_affinity
+        # deploy var catches a wrong label or topologyKey; full-template
+        # rendering of the term is covered by the snapshot goldens.
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        pod_affinity = self._deploy_vars(2, N.AWS_EFA)['k8s_pod_affinity']
+        required = pod_affinity[
+            'requiredDuringSchedulingIgnoredDuringExecution']
+        assert required == [{
+            'labelSelector': {
+                'matchLabels': {
+                    'skypilot-cluster-name': 'c',
+                },
+            },
+            'topologyKey': 'topology.kubernetes.io/zone',
+        }]
 
     def test_same_az_affinity_absent_when_flag_unset(self):
-        # When the flag is unset the same-AZ affinity must not be rendered.
-        rendered = self._render_same_az_affinity(same_az=False)
-        self.assertNotIn('topology.kubernetes.io/zone', rendered)
-        self.assertNotIn('skypilot-cluster-name', rendered)
+        # A multi-node non-EFA GPU job still bin-packs (preferred term) but has
+        # no required same-zone term.
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        pod_affinity = self._deploy_vars(2, N.NONE)['k8s_pod_affinity']
+        assert 'requiredDuringSchedulingIgnoredDuringExecution' not in (
+            pod_affinity)
+        assert 'preferredDuringSchedulingIgnoredDuringExecution' in pod_affinity
 
 
 class TestKubernetesSpotLabelContext(unittest.TestCase):

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -438,11 +438,13 @@ CASES: Dict[str, Dict[str, Any]] = {
 def _build_variables(case_name: str) -> Dict[str, Any]:
     """Merges a case onto the base and derives the computed template vars.
 
-    ``k8s_node_affinity`` is built by calling the same production helper
-    (``kubernetes_utils.get_node_affinity``) that
-    ``make_deploy_resources_variables`` uses, from the raw accelerator-label
-    vars the case carries. Deriving it here rather than hard-coding it is what
-    makes the goldens a semantic-identity proof for the Python lift.
+    ``k8s_node_affinity`` / ``k8s_pod_affinity`` and the binpack-label vars are
+    built by calling the same production helpers and constants
+    (``kubernetes_utils.get_node_affinity`` / ``get_pod_affinity`` /
+    ``GPU_BINPACK_LABEL_*``) that ``make_deploy_resources_variables`` uses, from
+    the raw vars the case carries. Deriving them here rather than hard-coding
+    them is what makes the goldens a semantic-identity proof for the Python
+    lift.
     """
     variables = base_variables()
     variables.update(CASES[case_name])
@@ -451,6 +453,15 @@ def _build_variables(case_name: str) -> Dict[str, Any]:
         variables['k8s_acc_label_values'],
         variables['avoid_label_keys'],
     )
+    variables['k8s_pod_affinity'] = kubernetes_utils.get_pod_affinity(
+        variables['k8s_acc_label_key'],
+        variables['k8s_acc_label_values'],
+        variables['k8s_efa_same_az'],
+        variables['cluster_name_on_cloud'],
+    )
+    variables['k8s_binpack_label_key'] = kubernetes_utils.GPU_BINPACK_LABEL_KEY
+    variables['k8s_binpack_label_value'] = (
+        kubernetes_utils.GPU_BINPACK_LABEL_VALUE)
     return variables
 
 


### PR DESCRIPTION
## Summary

The pod `podAffinity` for accelerator scheduling in `sky/templates/kubernetes-ray.yml.j2` was hand-written YAML: a GPU bin-pack preferred term (attracting accelerator pods to nodes carrying the `skypilot-binpack` label) plus, for EFA jobs, a required same-zone term. Both were built inline with nested Jinja conditionals, and the `skypilot-binpack` label was defined twice — once in the `labelSelector` and once in a separate pod-label line.

This PR moves the construction into a pure helper, `kubernetes_utils.get_pod_affinity`, returning the `podAffinity` dict (or `None` for a non-accelerator pod). `make_deploy_resources_variables` calls it and exposes one structured template var, `k8s_pod_affinity`, which the template renders with `| tojson` as a **sibling** of `nodeAffinity` under `affinity:` (previously the podAffinity block was nested inside the nodeAffinity gate; siblings are more robust and semantically identical here since an accelerator pod always has both). The EFA rationale (single-AZ placement group, required-not-preferred) moves into the helper's docstring.

**Single source of truth for the binpack label:** module-level `GPU_BINPACK_LABEL_KEY` / `GPU_BINPACK_LABEL_VALUE` constants are now used by both the helper's `labelSelector` matchExpressions and the template's pod-label line (via `k8s_binpack_label_key` / `k8s_binpack_label_value` vars) — the label and the affinity that targets it can no longer drift apart.

The raw `k8s_acc_label_key` / `k8s_acc_label_values` vars remain exposed: the pod-label line still gates on them (the only remaining template consumer).

**Why the goldens are the evidence:** the snapshot fixture derives `k8s_pod_affinity` and the label vars from the same helper/constants, so the goldens being unchanged proves the rendered manifest is byte-for-byte identical after the refactor. The existing matrix already exercises these gates (`gpu_*` cases and `efa_same_az_multinode`), so no new golden cases and no regeneration.

Based on #10232 (stacked on `kevinmingtarja/k8s-template-lift-accelerator-affinity`; retargets to `master` when #10232 merges).

## Tested

Run against the branch's own `sky/` (verified via `sky.__file__`), all green:

- `tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py` — **48 passed**, `git status` shows **zero modified goldens**. Ran twice; deterministic.
- New `TestGetPodAffinity` unit tests (none/off cases, binpack-only, binpack+EFA, exact-dict assertions) and the existing `TestGetNodeAffinity` suite — **10 passed**.
- `TestKubernetesEfaSameAzAffinity` in `test_kubernetes.py` rewritten to assert on the `k8s_pod_affinity` deploy var (its old template-snippet parse no longer applies) — passing.
- Broader `tests/unit_tests/test_sky/clouds/` + `tests/unit_tests/kubernetes/test_kubernetes_utils.py` — all passing (exit 0).
- `bash format.sh --files <the changed files>` — clean (only pre-existing advisory warnings in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)