### PR TITLE
[Metrics] Stop cluster-label stamping from stalling the metrics server

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1092,29 +1092,30 @@ async def send_metrics_request_with_port_forward(
 # substring `cluster="` can only start an actual label; the lookbehind keeps
 # names like `k8s_cluster` from matching.
 _CLUSTER_LABEL_RE = re.compile(r'(?<![A-Za-z0-9_])cluster="')
+# Cheap necessary condition for _CLUSTER_LABEL_RE to match. The regex only
+# differs from this literal by rejecting a preceding word character, so a
+# line without the literal can never match — the substring test is a
+# false-negative-free pre-filter. It matters because the regex runs once
+# per federated series: at multi-hundred-MiB payloads the regex dominates
+# this loop, while the (almost always false) substring test is a C-level
+# scan an order of magnitude cheaper.
+_CLUSTER_LABEL_LITERAL = 'cluster="'
 
 
-async def add_cluster_name_label(metrics_text: str, context: str) -> str:
-    """Adds a cluster label to each metric line.
+def _stamp_cluster_label(metrics_text: str, context: str) -> str:
+    """Body of add_cluster_name_label(); see it for semantics.
 
-    Skips lines that already carry a `cluster` label (stamped by a
-    previous federation pass, or labeled at the source): re-stamping
-    would produce two `cluster` labels on one line, which is a hard
-    duplicate-label error that makes Prometheus roll back the entire
-    /gpu-metrics scrape body. This is the safety net for the fail-safe
-    path in split_local_remote_contexts(): if a local context is ever
-    misdetected as remote (missing RBAC, cold start, transient probe
-    error), its already-stamped series are federated back here, and
-    skipping keeps them byte-identical to the stored series so ingestion
-    collapses them to a no-op instead of poisoning the scrape.
-
-    Args:
-        metrics_text: The text containing the metrics
-        context: The cluster name
+    Split out as a plain sync function so it can be handed to a worker
+    thread: it is CPU-bound with no await points, and a federated payload
+    can be hundreds of MiB, so running it on the event loop would stall
+    every other endpoint served by the metrics server (notably /metrics)
+    for as long as the stamping takes.
     """
     lines = metrics_text.strip().split('\n')
     modified_lines = []
     already_labeled = 0
+    prefix = f'cluster="{context}",'
+    only_label = f'cluster="{context}"'
 
     for line in lines:
         # keep comment lines and empty lines as-is
@@ -1131,7 +1132,8 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
             existing_labels = line[brace_start + 1:brace_end]
             rest_of_line = line[brace_end + 1:]
 
-            if _CLUSTER_LABEL_RE.search(existing_labels):
+            if (_CLUSTER_LABEL_LITERAL in existing_labels and
+                    _CLUSTER_LABEL_RE.search(existing_labels)):
                 # Already attributed; re-stamping would duplicate the
                 # cluster label and invalidate the whole scrape body.
                 already_labeled += 1
@@ -1139,9 +1141,9 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
                 continue
 
             if existing_labels:
-                new_labels = f'cluster="{context}",{existing_labels}'
+                new_labels = f'{prefix}{existing_labels}'
             else:
-                new_labels = f'cluster="{context}"'
+                new_labels = only_label
 
             modified_line = f'{metric_name}{{{new_labels}}}{rest_of_line}'
             modified_lines.append(modified_line)
@@ -1160,6 +1162,35 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
             f'unstamped.')
 
     return '\n'.join(modified_lines)
+
+
+async def add_cluster_name_label(metrics_text: str, context: str) -> str:
+    """Adds a cluster label to each metric line.
+
+    Skips lines that already carry a `cluster` label (stamped by a
+    previous federation pass, or labeled at the source): re-stamping
+    would produce two `cluster` labels on one line, which is a hard
+    duplicate-label error that makes Prometheus roll back the entire
+    /gpu-metrics scrape body. This is the safety net for the fail-safe
+    path in split_local_remote_contexts(): if a local context is ever
+    misdetected as remote (missing RBAC, cold start, transient probe
+    error), its already-stamped series are federated back here, and
+    skipping keeps them byte-identical to the stored series so ingestion
+    collapses them to a no-op instead of poisoning the scrape.
+
+    Runs in a worker thread: the metrics server serves /metrics,
+    /gpu-metrics and /endpoints-metrics from a single event loop, and a
+    large fleet's federated payload takes tens of seconds of pure CPU to
+    rewrite. Done inline that stalls the loop outright and the
+    concurrent /metrics scrape times out (up == 0) once per federation
+    cycle; in a thread the loop keeps accepting and answering requests
+    while the rewrite proceeds.
+
+    Args:
+        metrics_text: The text containing the metrics
+        context: The cluster name
+    """
+    return await asyncio.to_thread(_stamp_cluster_label, metrics_text, context)
 
 
 # Series federated from each context's Prometheus by /gpu-metrics: DCGM, host

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -657,6 +657,75 @@ def test_add_cluster_name_label_basic():
     assert lines[4] == 'no_labels_metric 2.0'
 
 
+def test_add_cluster_name_label_does_not_block_the_event_loop():
+    """Stamping must not stall the loop that also serves /metrics.
+
+    The metrics server answers /metrics, /gpu-metrics and
+    /endpoints-metrics from one event loop. A large fleet's federated
+    payload takes tens of seconds of pure CPU to rewrite; done inline
+    that starves the concurrent /metrics scrape into a timeout. The
+    rewrite therefore has to happen off the loop.
+    """
+    # Big enough that inline stamping would be clearly visible as a stall.
+    text = '\n'.join(
+        f'metric_{i}{{label="value{i}"}} {i}' for i in range(200_000))
+    served = []
+
+    async def main():
+        stop = asyncio.Event()
+
+        async def loop_consumer():
+            # Stands in for the /metrics handler: needs the loop to
+            # wake it up promptly.
+            while not stop.is_set():
+                await asyncio.sleep(0)
+                served.append(1)
+                await asyncio.sleep(0.001)
+
+        consumer = asyncio.create_task(loop_consumer())
+        await asyncio.sleep(0.05)
+        served.clear()
+        result = await utils.add_cluster_name_label(text, 'ctx-a')
+        stop.set()
+        await consumer
+        return result
+
+    result = asyncio.run(main())
+    # The loop kept running while the payload was rewritten.
+    assert served, 'event loop was starved for the whole stamping duration'
+    # ...and the output is still correct.
+    first = result.split('\n', 1)[0]
+    assert first == 'metric_0{cluster="ctx-a",label="value0"} 0'
+
+
+def test_add_cluster_name_label_prefilter_matches_regex():
+    """The cheap substring pre-filter never changes the verdict.
+
+    Stamping skips already-labeled lines via a literal `cluster="` test
+    before the regex. The literal is a necessary condition for the regex,
+    so the two must agree on every line — including the tricky cases the
+    regex exists to get right (a `cluster` suffix on another label name).
+    """
+    cases = [
+        'foo{cluster="x"} 1',  # labeled -> skip
+        'foo{bar="1",cluster="x"} 1',  # labeled, not first -> skip
+        'foo{my_cluster="x"} 1',  # suffix only -> must still stamp
+        'foo{clusterish="x"} 1',  # prefix only -> must still stamp
+        'foo{bar="baz"} 1',  # unlabeled -> stamp
+        'foo{} 1',  # no labels -> stamp
+    ]
+    for line in cases:
+        brace_start = line.find('{')
+        brace_end = line.rfind('}')
+        labels = line[brace_start + 1:brace_end]
+        regex_hit = bool(utils._CLUSTER_LABEL_RE.search(labels))  # pylint: disable=protected-access
+        prefilter = utils._CLUSTER_LABEL_LITERAL in labels  # pylint: disable=protected-access
+        # The pre-filter may only ever be a superset of the regex.
+        assert regex_hit <= prefilter, line
+        # Combined verdict (what the code actually evaluates) == regex.
+        assert (prefilter and regex_hit) == regex_hit, line
+
+
 def test_add_cluster_name_label_skips_already_labeled():
     """Lines already carrying a cluster label are left untouched.
 


### PR DESCRIPTION
## Summary

`add_cluster_name_label()` rewrites every federated series to carry a `cluster` label. It is declared `async` but contains no `await` points, so it ran to completion **on the metrics server's event loop** — the same loop that serves `/metrics`, `/gpu-metrics` and `/endpoints-metrics`. The work is proportional to the federated payload, and at large fleet sizes a single context's `/federate` response is hundreds of MiB. The loop is therefore blocked for tens of seconds on every federation cycle, and any `/metrics` scrape landing in that window can neither be accepted nor answered — it times out, so `up{job="skypilot-api-server-metrics"}` flaps 0↔1 once per cycle while CPU, memory and the readiness probe all look perfectly healthy.

This PR makes two changes to that function:

- **Run the rewrite in a worker thread.** It is pure CPU with no awaits, so a thread keeps the loop schedulable (the GIL is released every switch interval) instead of dead for the duration. `/metrics` is a small response that only needs the loop to accept it and write it back.
- **Gate the per-line "already labeled" regex behind a plain substring test.** `_CLUSTER_LABEL_RE` is the literal `cluster="` plus a constraint (the preceding character must not be a word character), so the literal is a *necessary* condition for the regex to match — testing it first is a false-negative-free pre-filter. It matters because the regex runs once per federated series and is by far the most expensive operation in the loop.

Behaviour is unchanged: the same lines are stamped, the same already-labeled lines are skipped, and the output is byte-identical.

## Why the regex was so expensive

The pattern begins with a lookbehind, `(?<![A-Za-z0-9_])`, which defeats CPython's literal-prefix optimization — the engine cannot see a literal at position 0, so it attempts a match at every offset instead of fast-scanning for the literal first. Measured on a representative 327-char label section:

| operation | per call |
|---|---|
| `_CLUSTER_LABEL_RE.search(labels)` | 3394 ns |
| `'cluster="' in labels` | 156 ns |
| the same regex *without* the lookbehind | 186 ns |

So the lookbehind alone accounts for an ~18× slowdown, and the substring test is ~22× cheaper than the regex it guards. On a healthy payload no line carries a `cluster` label yet (that is the point — we are adding it), so the pre-filter short-circuits essentially every line and the regex never runs at all.

## Measurements

Taken inside a running API server that federates **1028 MiB + 213 MiB** of DCGM/kube-state series per cycle (a large-scale deployment's payload profile, reproduced on a test deployment with synthetic Prometheus endpoints serving only series matching `GPU_METRICS_MATCH_PATTERNS`, in `/federate` wire format).

**Event-loop starvation, in-process, same 1028 MiB payload:**

| | before | after |
|---|---|---|
| requests the loop served while stamping ran | **0** — loop dead for the entire duration | **1222** |
| stamping wall time | 23.19s | 12.46s |

Stamping 1028 MiB blocked the loop for 23.19s and 213 MiB for a further 4.80s — ~28s of every cycle, which is **longer than the `/metrics` scrape timeout itself**, so roughly half of all scrapes could not succeed.

**End-to-end A/B on the same deployment, same synthetic load, images differing only by this commit:**

| | before | after |
|---|---|---|
| `up{job="skypilot-api-server-metrics"}` downtime | 31% | **0%** |
| flaps | 19 / 30 min | **0 / 15 min** |
| `/metrics` scrape duration, max | 20.0s (= its timeout) | 11.6s |
| `/metrics` scrape duration, median | 13.12s | 4.61s |

**Stamping cost alone**, 205 MiB payload, single-threaded: 2.71s → 0.87s (~3×), which also brings the cost back to roughly what it was before the already-labeled check was introduced.

### Scope

This addresses the `/metrics` starvation only. It does not make federating a very large payload *fast* — `/gpu-metrics` still spends real time fetching and rewriting hundreds of MiB, and reducing that is a matter of trimming what each compute cluster's Prometheus exposes (see the [GPU metrics setup guide](https://docs.skypilot.co/en/latest/reference/api-server/examples/api-server-gpu-metrics-setup.html)). The point of this change is that a slow federation can no longer take the API server's own `/metrics` endpoint down with it.

## Test plan

- New unit tests in `tests/unit_tests/test_sky/metrics/test_metrics_util.py`:
  - `test_add_cluster_name_label_does_not_block_the_event_loop` — a concurrent consumer keeps being served while a 200k-line payload is stamped; before this change it was starved for the whole duration.
  - `test_add_cluster_name_label_prefilter_matches_regex` — the substring pre-filter never changes the verdict, including the near-misses the regex exists to reject (`my_cluster="x"`, `clusterish="x"`).
- Existing stamping tests are unchanged and still pass, including the already-labeled / idempotency cases.
- `pytest tests/unit_tests/test_sky/metrics/test_metrics_util.py` → 41 passed.
- Live: deployed to a Kubernetes API server federating the payloads above and confirmed the `up{}` flap disappears (table above) while `/gpu-metrics` output remains correctly stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeH9TRvsPYTNXVi2vTPigv
