### PR TITLE
[Core] Surface resolved active_workspace to admin policies

### DIFF
--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -77,7 +77,9 @@ class UserRequest:
 
     Args:
         task: User specified task.
-        skypilot_config: Global skypilot config to be used in this request.
+        skypilot_config: Global skypilot config to be used in this request,
+              with `active_workspace` set to the workspace resolved for this
+              request.
         request_options: Request options. It is None for jobs and services.
         at_client_side: Is the request intercepted by the policy at client-side?
         user: User who made the request.

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -583,27 +583,29 @@ def set_nested(keys: Tuple[str, ...], value: Any) -> Dict[str, Any]:
 
 
 def to_dict() -> config_utils.Config:
-    """Returns a deep-copied version of the current config."""
+    """Returns a deep-copied version of the current config.
+
+    `active_workspace` here is only what the config itself sets; use
+    `resolved_config()` for the workspace the request actually runs in.
+    """
     return copy.deepcopy(_get_loaded_config())
 
 
 def resolved_config() -> config_utils.Config:
-    """Returns the config with the resolved active workspace surfaced.
+    """Returns the config with the effective `active_workspace` filled in.
 
-    `to_dict()` reflects only the file-level config. The active workspace can
-    additionally be resolved into a thread-local context (e.g. by the
-    server-side workspace resolver in
-    `executor.override_request_env_and_config`), which `to_dict()` does not
-    reflect. This returns a copy of the config with `active_workspace` set to
-    the effective value from `get_active_workspace()` (thread-local first,
-    then file config, then the default fallback), so callers that need the
-    resolved workspace — e.g. admin policies — read it reliably.
+    The active workspace can be resolved into a thread-local context instead
+    of the config (the server-side resolver in
+    `executor.override_request_env_and_config` sets it there), so
+    `active_workspace` is taken from `get_active_workspace()`. Callers that
+    need the workspace a request actually runs in — e.g. admin policies —
+    should use this rather than `to_dict()`.
 
-    Do NOT fold this into `to_dict()`: `to_dict()` feeds the client's
-    `override_skypilot_config` on the wire (see
-    `payloads.get_override_skypilot_config_from_client`). Stamping
+    Keep this separate from `to_dict()`, which also feeds the client's
+    `override_skypilot_config` on the wire
+    (`payloads.get_override_skypilot_config_from_client`): stamping
     `active_workspace` there would make `is_active_workspace_set()` always
-    return True, disabling the per-user workspace resolver
+    return True and disable the per-user workspace resolver
     (`_should_apply_workspace_resolver`).
     """
     config = to_dict()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -587,6 +587,30 @@ def to_dict() -> config_utils.Config:
     return copy.deepcopy(_get_loaded_config())
 
 
+def resolved_config() -> config_utils.Config:
+    """Returns the config with the resolved active workspace surfaced.
+
+    `to_dict()` reflects only the file-level config. The active workspace can
+    additionally be resolved into a thread-local context (e.g. by the
+    server-side workspace resolver in
+    `executor.override_request_env_and_config`), which `to_dict()` does not
+    reflect. This returns a copy of the config with `active_workspace` set to
+    the effective value from `get_active_workspace()` (thread-local first,
+    then file config, then the default fallback), so callers that need the
+    resolved workspace — e.g. admin policies — read it reliably.
+
+    Do NOT fold this into `to_dict()`: `to_dict()` feeds the client's
+    `override_skypilot_config` on the wire (see
+    `payloads.get_override_skypilot_config_from_client`). Stamping
+    `active_workspace` there would make `is_active_workspace_set()` always
+    return True, disabling the per-user workspace resolver
+    (`_should_apply_workspace_resolver`).
+    """
+    config = to_dict()
+    config['active_workspace'] = get_active_workspace()
+    return config
+
+
 def _get_config_file_path(envvar: str) -> Optional[str]:
     config_path_via_env_var = os.environ.get(envvar)
     if config_path_via_env_var is not None:

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -26,23 +26,6 @@ if typing.TYPE_CHECKING:
     from sky import models
 
 
-def _get_config_with_resolved_workspace() -> config_utils.Config:
-    """Returns the current config with the resolved active workspace surfaced.
-
-    The active workspace may be resolved into a thread-local context (e.g. by
-    the server-side workspace resolver in
-    `executor.override_request_env_and_config`) rather than being written into
-    the config file. `skypilot_config.to_dict()` only reflects the file-level
-    config, so an admin policy reading `active_workspace` from it would see
-    `None` even though a workspace was resolved for the request. Inject the
-    resolved value so both in-process and external (RESTful) admin policies can
-    read `active_workspace` reliably.
-    """
-    config = skypilot_config.to_dict()
-    config['active_workspace'] = skypilot_config.get_active_workspace()
-    return config
-
-
 def _is_url(policy_string: str) -> bool:
     """Check if the policy string is a URL."""
     try:
@@ -113,7 +96,7 @@ def apply_and_use_config_in_current_request(
     # comparison below only triggers a config replacement when the policy
     # actually mutated the config, not merely because `apply()` surfaced the
     # resolved active workspace.
-    original_config = _get_config_with_resolved_workspace()
+    original_config = skypilot_config.resolved_config()
     dag, mutated_config = apply(entrypoint, request_name, request_options,
                                 at_client_side)
     if mutated_config != original_config:
@@ -154,7 +137,7 @@ def apply(
     policy_location = skypilot_config.get_nested(('admin_policy',), None)
     policy = _get_policy_impl(policy_location)
     if policy is None:
-        return dag, _get_config_with_resolved_workspace()
+        return dag, skypilot_config.resolved_config()
 
     user = None
     client_api_version = None
@@ -169,7 +152,7 @@ def apply(
         client_api_version = versions.get_remote_api_version()
         client_version = versions.get_remote_version()
         logger.info(f'Applying server admin policy: {policy}')
-    config = copy.deepcopy(_get_config_with_resolved_workspace())
+    config = copy.deepcopy(skypilot_config.resolved_config())
     mutated_dag = dag_lib.Dag()
     mutated_dag.name = dag.name
     # Preserve DAG execution properties if set

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -26,6 +26,23 @@ if typing.TYPE_CHECKING:
     from sky import models
 
 
+def _get_config_with_resolved_workspace() -> config_utils.Config:
+    """Returns the current config with the resolved active workspace surfaced.
+
+    The active workspace may be resolved into a thread-local context (e.g. by
+    the server-side workspace resolver in
+    `executor.override_request_env_and_config`) rather than being written into
+    the config file. `skypilot_config.to_dict()` only reflects the file-level
+    config, so an admin policy reading `active_workspace` from it would see
+    `None` even though a workspace was resolved for the request. Inject the
+    resolved value so both in-process and external (RESTful) admin policies can
+    read `active_workspace` reliably.
+    """
+    config = skypilot_config.to_dict()
+    config['active_workspace'] = skypilot_config.get_active_workspace()
+    return config
+
+
 def _is_url(policy_string: str) -> bool:
     """Check if the policy string is a URL."""
     try:
@@ -92,7 +109,11 @@ def apply_and_use_config_in_current_request(
 
     Refer to `apply()` for more details.
     """
-    original_config = skypilot_config.to_dict()
+    # Mirror the resolved-workspace injection done in `apply()` so the
+    # comparison below only triggers a config replacement when the policy
+    # actually mutated the config, not merely because `apply()` surfaced the
+    # resolved active workspace.
+    original_config = _get_config_with_resolved_workspace()
     dag, mutated_config = apply(entrypoint, request_name, request_options,
                                 at_client_side)
     if mutated_config != original_config:
@@ -133,7 +154,7 @@ def apply(
     policy_location = skypilot_config.get_nested(('admin_policy',), None)
     policy = _get_policy_impl(policy_location)
     if policy is None:
-        return dag, skypilot_config.to_dict()
+        return dag, _get_config_with_resolved_workspace()
 
     user = None
     client_api_version = None
@@ -148,7 +169,7 @@ def apply(
         client_api_version = versions.get_remote_api_version()
         client_version = versions.get_remote_version()
         logger.info(f'Applying server admin policy: {policy}')
-    config = copy.deepcopy(skypilot_config.to_dict())
+    config = copy.deepcopy(_get_config_with_resolved_workspace())
     mutated_dag = dag_lib.Dag()
     mutated_dag.name = dag.name
     # Preserve DAG execution properties if set

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -560,6 +560,49 @@ def test_apply_no_client_version_at_client_side(add_example_policy_paths, task):
         versions.set_remote_version('unknown')
 
 
+def test_apply_surfaces_resolved_active_workspace(add_example_policy_paths,
+                                                  task):
+    """The resolved active workspace is surfaced to the policy's config.
+
+    The active workspace can be resolved into a thread-local context (e.g. by
+    the server-side workspace resolver) rather than being written into the
+    config file. Verify that admin policies still receive it as
+    `active_workspace` instead of `None`.
+    """
+    captured_requests = []
+
+    class CaptureWorkspacePolicy(sky.AdminPolicy):
+
+        @classmethod
+        def validate_and_mutate(cls, user_request):
+            captured_requests.append(user_request)
+            return sky.MutatedUserRequest(user_request.task,
+                                          user_request.skypilot_config)
+
+    with mock.patch('sky.utils.admin_policy_utils._get_policy_impl',
+                    return_value=CaptureWorkspacePolicy()):
+        # add_labels.yaml does not set active_workspace, so without the fix
+        # the policy would receive `active_workspace: None`.
+        os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = os.path.join(
+            POLICY_PATH, 'add_labels.yaml')
+        importlib.reload(skypilot_config)
+
+        # Simulate the server-side resolver setting the active workspace in a
+        # thread-local context rather than in the config file.
+        with skypilot_config.local_active_workspace_ctx('team-a'):
+            dag, mutated_config = admin_policy_utils.apply(
+                task,
+                request_name=request_names.AdminPolicyRequestName.
+                CLUSTER_LAUNCH,
+                at_client_side=True)
+
+    assert len(captured_requests) == 1
+    assert captured_requests[0].skypilot_config.get(
+        'active_workspace') == 'team-a', (
+            'Policy should receive the resolved active workspace')
+    assert mutated_config.get('active_workspace') == 'team-a'
+
+
 def test_reject_old_clients_policy(add_example_policy_paths, task):
     """Test RejectOldClientsPolicy rejects old clients."""
     from example_policy.skypilot_policy import RejectOldClientsPolicy


### PR DESCRIPTION
## Summary

Admin policies received `active_workspace: None` even when the server had already resolved a workspace for the request.

- The server-side workspace resolver sets the resolved workspace in a **thread-local** context (`skypilot_config.local_active_workspace_ctx`, set in `executor.override_request_env_and_config`).
- But the config handed to admin policies comes from `skypilot_config.to_dict()`, which only reflects the **file-level** config and does not include the thread-local resolved workspace.
- As a result a policy reading `active_workspace` saw `None`, breaking policies that key on the active workspace.

Fix: inject the resolved workspace (via `get_active_workspace()`, which reads the thread-local first) into the config passed to the policy, in `admin_policy_utils.apply()` (and mirror it in `apply_and_use_config_in_current_request`'s comparison baseline so a no-op policy does not spuriously trigger a config replacement). This works for both in-process and external (RESTful) admin policies.

Reported by a customer (via Codex) whose external admin policy stopped working because it received `active_workspace: None`.

## Test plan

**Unit test** — `tests/unit_tests/test_admin_policy.py::test_apply_surfaces_resolved_active_workspace`: simulates the server-side resolver setting the workspace via `local_active_workspace_ctx('team-a')` and asserts the policy receives `active_workspace == 'team-a'`. Verified it fails without the fix and passes with it.

**End-to-end (local API server)** — ran a real `sky launch/sky jobs launch` against a local API server for both policy types. A record-and-passthrough policy logged the `active_workspace` it saw at the admin-policy application for `optimize/launch/jobs.launch`. With a user whose preferred workspace resolves to `team-a`, the executor-worker application (where the resolver has set the thread-local) showed:

| Policy type | before fix | after fix |
|---|---|---|
| in-process | `active_workspace=None` (resolved was `team-a`) | `active_workspace='team-a'` |
| external (RESTful) | `active_workspace=None` | `active_workspace='team-a'` |

In the buggy runs the policy saw `None` while `get_active_workspace()` returned `team-a` — exactly the reported symptom; after the fix the two agree.
