### PR TITLE
[Test] Fix apiserver-start-stop smoke test setup on bare cloud VMs

### DIFF
--- a/tests/test_yamls/apiserver-start-stop.yaml
+++ b/tests/test_yamls/apiserver-start-stop.yaml
@@ -7,11 +7,15 @@ workdir: .
 setup: |
   set -e
   sudo apt update
-  # Install into the default user venv (activated by SkyPilot), not --system:
-  # conda is no longer installed by default, so the system python is not
-  # writable by the non-root cluster user.
-  uv pip install --prerelease allow "azure-cli<2.87.0"
-  uv pip install -e '.[all]'
+  # On images where SkyPilot activates a writable user venv (e.g. the default
+  # Kubernetes images, where the system Python is read-only for the non-root
+  # user), `uv pip install` targets that venv. On images with no active venv
+  # (bare cloud VMs), fall back to `--system`, otherwise `uv pip install` aborts
+  # with "No virtual environment found".
+  uv_system_flag=""
+  [ -z "${VIRTUAL_ENV:-}" ] && uv_system_flag="--system"
+  uv pip install ${uv_system_flag} --prerelease allow "azure-cli<2.87.0"
+  uv pip install ${uv_system_flag} -e '.[all]'
 
 run: |
   set -euo pipefail


### PR DESCRIPTION
## Problem

The nightly cloud smoke test `test_api_server_start_stop` fails during `sky launch` setup on bare cloud VMs (e.g. AWS):

```
(setup) error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
✓ Job finished (status: FAILED_SETUP).
[test_api_server_start_stop] Reason: sky launch -n ... --cloud aws tests/test_yamls/apiserver-start-stop.yaml -y --cpus 2+ --memory 4+
```

### Root cause

#10132 dropped conda from the default images and moved user installs to a writable **user venv that SkyPilot activates** — but that venv is only created on the images that ship it (the default Kubernetes images). In the same change, this test's setup was switched from `uv pip install --system` to a plain `uv pip install`, on the assumption that a venv is always active.

On a **bare cloud VM** there is no such venv active in the setup shell (`VIRTUAL_ENV` is empty, `~/sky-user-env` does not exist), so `uv pip install` aborts before installing anything. The Kubernetes lane still passes because the user venv is present and activated there.

## Fix

Pass `--system` only when no virtual environment is active:

```bash
uv_system_flag=""
[ -z "${VIRTUAL_ENV:-}" ] && uv_system_flag="--system"
uv pip install ${uv_system_flag} --prerelease allow "azure-cli<2.87.0"
uv pip install ${uv_system_flag} -e '.[all]'
```

- **Images with a user venv** (default K8s): `VIRTUAL_ENV` is set → no `--system` → installs into the venv (unchanged behavior, keeps the K8s lane green).
- **Bare cloud VMs**: no venv → `--system` → installs into the system environment.

The idiom is `set -e`-safe (the `[ … ] &&` test is not the final command in the list, so a false test does not abort setup).

## Verification

Reproduced and verified on a real cloud VM running the same runtime:

- No venv (as the failing setup) → the exact `No virtual environment found` error, exit 2.
- With `--system` (this fix's fallback) → dependency resolution completes, exit 0.

The environment on that VM matched the diagnosis: not a container image, `~/sky-user-env` absent, `VIRTUAL_ENV`/`CONDA_PREFIX` empty in the setup shell.

## Note (separate issue, not fixed here)

`test_custom_default_conda_env` also fails on cloud VMs after #10132, for an unrelated reason: the cloud image provisioner (`sky/catalog/images/provisioners/skypilot.sh`) still bakes Miniconda `py310_23.11.0`, while `CONDA_INSTALLATION_COMMANDS` only installs Miniforge when `which conda` finds nothing. So on a cloud VM the opt-in install is skipped and the yaml's `conda --version | grep -v 23.11.0` regression guard trips. Fixing that means bumping the baked image conda (and rebuilding images), so it is left for a separate change.