### PR TITLE
[Core] Guard source ~/.bashrc against a missing ~/.bashrc

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -176,7 +176,7 @@ def docker_start_cmds(
 
 def _with_interactive(cmd):
     force_interactive = (
-        f'source ~/.bashrc; '
+        f'[ -f ~/.bashrc ] && source ~/.bashrc; '
         f'export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ({cmd})')
     return ['bash', '--login', '-c', '-i', shlex.quote(force_interactive)]
 

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -366,7 +366,7 @@ def make_task_bash_script(codegen: str,
     script = [
         textwrap.dedent(f"""\
             #!/bin/bash
-            source ~/.bashrc
+            [ -f ~/.bashrc ] && source ~/.bashrc
             set -a
             . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh > /dev/null 2>&1 || true
             set +a

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -384,9 +384,14 @@ class CommandRunner:
             command += [
                 # Need this `-i` option to make sure `source ~/.bashrc` work.
                 # Sourcing bashrc may take a few seconds causing overheads.
+                # Guard on existence: ~/.bashrc may be absent (e.g. envs
+                # without conda, which used to create it via `conda init`).
+                # `source` of a missing file returns non-zero, which would
+                # break this `&&` chain.
                 '-i',
                 shlex.quote(
-                    f'true && source ~/.bashrc && export OMP_NUM_THREADS=1 '
+                    f'true && ([ -f ~/.bashrc ] && source ~/.bashrc || true)'
+                    f' && export OMP_NUM_THREADS=1 '
                     f'PYTHONWARNINGS=ignore && ({cmd})'),
             ]
         else:

--- a/tests/unit_tests/test_sky/backends/testdata/ray_codegen/multi_node_2nodes.py
+++ b/tests/unit_tests/test_sky/backends/testdata/ray_codegen/multi_node_2nodes.py
@@ -411,7 +411,7 @@ def make_task_bash_script(codegen: str,
     script = [
         textwrap.dedent(f"""\
             #!/bin/bash
-            source ~/.bashrc
+            [ -f ~/.bashrc ] && source ~/.bashrc
             set -a
             . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh > /dev/null 2>&1 || true
             set +a

--- a/tests/unit_tests/test_sky/backends/testdata/ray_codegen/single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/ray_codegen/single_node_with_gpu.py
@@ -411,7 +411,7 @@ def make_task_bash_script(codegen: str,
     script = [
         textwrap.dedent(f"""\
             #!/bin/bash
-            source ~/.bashrc
+            [ -f ~/.bashrc ] && source ~/.bashrc
             set -a
             . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh > /dev/null 2>&1 || true
             set +a

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
@@ -346,7 +346,7 @@ def make_task_bash_script(codegen: str,
     script = [
         textwrap.dedent(f"""\
             #!/bin/bash
-            source ~/.bashrc
+            [ -f ~/.bashrc ] && source ~/.bashrc
             set -a
             . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh > /dev/null 2>&1 || true
             set +a

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -346,7 +346,7 @@ def make_task_bash_script(codegen: str,
     script = [
         textwrap.dedent(f"""\
             #!/bin/bash
-            source ~/.bashrc
+            [ -f ~/.bashrc ] && source ~/.bashrc
             set -a
             . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh > /dev/null 2>&1 || true
             set +a


### PR DESCRIPTION
## Summary
Fixes a cloud/Slurm-only regression from #10132. After conda stopped being installed by default, nothing creates `~/.bashrc` on environments that used to rely on `conda init` to write it — e.g. **Slurm** clusters (fresh per-cluster HOME) and bring-your-own images without conda. The unguarded `source ~/.bashrc` then prints `bash: ~/.bashrc: No such file or directory` into task output.

This broke the Slurm smoke tests `test_minimal` and `test_minimal_with_git_workdir`: the job itself **SUCCEEDS**, but the spurious error line lands in the streamed task output and trips the strict output-format assertions (the `grep -A 1 "Job started…" | grep "(setup" | grep "running setup"` check). Both nightly-only Slurm lanes went red on the first post-#10132 nightly; K8s is unaffected because the default images bake `~/.bashrc`.

## Changes
Guard all three `source ~/.bashrc` call sites so a missing file is a harmless no-op:
- `sky/skylet/log_lib.py` — `make_task_bash_script` (runs for every task on every cluster). **This is the one that broke the Slurm tests.**
- `sky/utils/command_runner.py` — the `source_bashrc=True` path; here `source ~/.bashrc` was in an `&&` chain, so a missing file would **hard-fail the whole command** (defensive fix for bashrc-less envs doing skylet setup).
- `sky/provision/docker_utils.py` — `_with_interactive` (docker exec wrapper).
- Refreshed the ray/slurm codegen snapshots (`make_task_bash_script` is embedded via `inspect.getsource`).

## Test plan
- `pytest tests/unit_tests/test_sky/backends/test_task_codegen.py` (snapshots match).
- Nightly `--slurm`: `test_minimal` / `test_minimal_with_git_workdir` — previously red with `bash: ~/.bashrc: No such file or directory` polluting output; pass after this change. K8s/cloud lanes unaffected.