### PR TITLE
[Test] Pin failed-mount escalation smoke test to a single Kubernetes context

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2521,15 +2521,32 @@ def test_kubernetes_pod_failed_mount_escalation():
         test = smoke_tests_utils.Test(
             'kubernetes_pod_failed_mount_escalation',
             [
+                # Pin the launch to a single context: the bad mount
+                # reproduces on every context, so on a multi-context API
+                # server an unpinned launch would fail over context after
+                # context — each attempt consuming the full mount-failure
+                # deadline — and could not exit within the test timeout.
+                # Launch the cloud-cmd helper and pin to the context it
+                # lands on (all three steps are no-ops on a local
+                # single-context server).
+                smoke_tests_utils.launch_cluster_for_cloud_cmd(
+                    'kubernetes', name),
+                # Wait for the helper to be UP so its landed context is
+                # resolvable.
+                smoke_tests_utils.run_cloud_cmd_on_cluster(name, 'true'),
+                smoke_tests_utils.resolve_cloud_cmd_k8s_context_cmd(name),
                 # The launch must exit non-zero on its own (the
                 # mount-failure deadline, ~10 min) — a hang here trips the
                 # test timeout instead.
-                f's=$(sky launch -y -c {name} --infra kubernetes {f.name} '
+                f's=$(sky launch -y -c {name} '
+                f'--infra {smoke_tests_utils.cloud_cmd_landed_k8s_infra(name)} '
+                f'{f.name} '
                 f'2>&1); ret=$?; echo "$s"; [ $ret -ne 0 ] || exit 1; '
                 f'echo "$s" | grep "FailedMount" && '
                 f'echo "$s" | grep "MountVolume.SetUp failed"',
             ],
-            f'sky down -y {name}',
+            f'sky down -y {name} && '
+            f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
             timeout=25 * 60,
         )
         smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
## Summary

`test_kubernetes_pod_failed_mount_escalation` (added in #10218) requires `sky launch` to exit non-zero on its own once the mount-failure deadline (~10 min) fires. On an API server with multiple Kubernetes contexts, the bad hostPath mount reproduces on every context, so provisioning fails over context after context — each attempt consuming the full deadline — and the launch cannot exit within the 25-minute test timeout, failing the test on every run.

Fix: pin the launch to a single context so exactly one provisioning attempt is made and the launch fails within one deadline cycle. This reuses the existing cloud-cmd helper machinery — launch the helper, resolve the context it lands on (`resolve_cloud_cmd_k8s_context_cmd`), and pin the mount-failure launch to that context (`cloud_cmd_landed_k8s_infra`). Pinning to the helper's landed context (rather than enumerating contexts client-side) matters because the relevant context set is the *server's*, which the test client can't see on a remote API server; it also guarantees the pinned context is one where a small CPU pod can actually schedule.

On a local single-context server all the helper steps are no-ops (`launch_cluster_for_cloud_cmd` and friends return `true` / plain `kubernetes`), so existing single-context CI behavior is unchanged.

## Test plan

- Verified the multi-context failure mode from a failing run's teardown logs: launch started at T+0, and at test-kill time (T+25 min) the pod under test existed on the *third* context with a creation timestamp of T+20 min — i.e. two full deadline cycles had already elapsed and failover was still walking the context list.
- `yapf`/`isort` clean on the touched file.
- CI smoke test: `/smoke-test -k test_kubernetes_pod_failed_mount_escalation --kubernetes` (single-context path; helper steps no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)