### PR TITLE
[LLM] slime example: pin image to known-good nightly tag

### DIFF
--- a/llm/slime/coding-agent-2engine.yaml
+++ b/llm/slime/coding-agent-2engine.yaml
@@ -22,7 +22,7 @@ name: sglang
 resources:
   infra: kubernetes          # your H100 Kubernetes context, e.g. kubernetes/my-cluster
   accelerators: H100:1
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy
@@ -33,7 +33,7 @@ name: sglang2
 resources:
   infra: kubernetes
   accelerators: H100:1
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy
@@ -44,7 +44,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engines — jobs co-schedule on one cluster
   accelerators: H100:4
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy

--- a/llm/slime/coding-agent-3engine.yaml
+++ b/llm/slime/coding-agent-3engine.yaml
@@ -24,7 +24,7 @@ name: sglang
 resources:
   infra: kubernetes          # your H100 Kubernetes context, e.g. kubernetes/my-cluster
   accelerators: H100:1
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy
@@ -35,7 +35,7 @@ name: sglang2
 resources:
   infra: kubernetes
   accelerators: H100:1
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy
@@ -46,7 +46,7 @@ name: sglang3
 resources:
   infra: kubernetes
   accelerators: H100:1
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy
@@ -57,7 +57,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engines — jobs co-schedule on one cluster
   accelerators: H100:4
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy

--- a/llm/slime/coding-agent.yaml
+++ b/llm/slime/coding-agent.yaml
@@ -24,7 +24,7 @@ name: sglang
 resources:
   infra: kubernetes          # your H100 Kubernetes context, e.g. kubernetes/my-cluster
   accelerators: H100:1        # engine tensor-parallel = 1 (1 H100/engine; validated repro sizing)
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .                   # so the job can see scripts/
 volumes:
   /shared/policy: slime-policy
@@ -35,7 +35,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engine — jobs co-schedule on one cluster
   accelerators: H100:4
-  image_id: docker:slimerl/slime:latest
+  image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:
   /shared/policy: slime-policy


### PR DESCRIPTION
## Problem

`slimerl/slime:latest` was retagged on 2026-07-23 (now `nightly-dev-20260722a`). That image ships a slime snapshot and an sglang version that are incompatible with each other: slime's `validate_args` reads `args.sglang_data_parallel_size`, a flag auto-generated from sglang's `ServerArgs` dataclass, and the bundled sglang no longer has that field. Every training launch fails immediately:

```
File "/root/slime/slime/backends/sglang_utils/arguments.py", line 142, in validate_args
    args.sglang_dp_size = args.sglang_data_parallel_size
AttributeError: 'Namespace' object has no attribute 'sglang_data_parallel_size'
```

Clusters that cached the older `latest` bytes still work, which masks the breakage — it only fires on a fresh pull. Verified live: the same example YAML trains on `nightly-dev-20260707a` (the previous `latest`) and crashes as above on the current one.

## Fix

Pin all example YAMLs to `slimerl/slime:nightly-dev-20260707a`, the last known-good nightly, so the example is reproducible regardless of upstream retags. We can bump the pin deliberately once a consistent newer nightly is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)