### PR TITLE
[SSH] Bound the GPU operator readiness wait

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy.py
+++ b/sky/ssh_node_pools/deploy/deploy.py
@@ -923,10 +923,12 @@ def deploy_single_cluster(cluster_name,
             curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&
             chmod 700 get_helm.sh &&
             ./get_helm.sh &&
-            helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update &&
+            helm repo add nvidia https://helm.ngc.nvidia.com/nvidia || true &&
+            helm repo update nvidia &&
             kubectl create namespace gpu-operator --kubeconfig ~/.kube/config || true &&
             sudo -A ln -s /sbin/ldconfig /sbin/ldconfig.real || true &&
-            helm install gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \\
+            helm upgrade --install gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \\
+            --kubeconfig ~/.kube/config \\
             --set 'toolkit.env[0].name=CONTAINERD_CONFIG' \\
             --set 'toolkit.env[0].value=/var/lib/rancher/k3s/agent/etc/containerd/config.toml' \\
             --set 'toolkit.env[1].name=CONTAINERD_SOCKET' \\
@@ -936,10 +938,21 @@ def deploy_single_cluster(cluster_name,
             --set 'devicePlugin.env[0].name=DP_DISABLE_HEALTHCHECKS' \\
             --set 'devicePlugin.env[0].value=all' &&
             echo 'Waiting for GPU operator installation...' &&
-            while ! kubectl describe nodes --kubeconfig ~/.kube/config | grep -q 'nvidia.com/gpu:' || ! kubectl describe nodes --kubeconfig ~/.kube/config | grep -q 'nvidia.com/gpu.product'; do
-                echo 'Waiting for GPU operator...'
-                sleep 5
+            GPU_READY='' &&
+            for i in $(seq 1 60); do
+                NODES=$(kubectl describe nodes --kubeconfig ~/.kube/config 2>/dev/null)
+                if echo "$NODES" | grep -q 'nvidia.com/gpu:' && \\
+                   echo "$NODES" | grep -q 'nvidia.com/gpu.product'; then
+                    GPU_READY='ready' && break
+                fi
+                echo 'Waiting for GPU operator...' >&2
+                sleep 10
             done
+            if [ -z "$GPU_READY" ]; then
+                echo 'GPU operator did not become ready.' >&2
+                kubectl get pods -n gpu-operator --kubeconfig ~/.kube/config >&2 || true
+                exit 1
+            fi
             echo 'GPU operator installed successfully.'
         """
         result = deploy_utils.run_remote(head_node,
@@ -948,8 +961,11 @@ def deploy_single_cluster(cluster_name,
                                          ssh_key,
                                          use_ssh_config=head_use_ssh_config)
         if result is None:
-            logger.error(f'{colorama.Fore.RED}Failed to install GPU Operator.'
-                         f'{RESET_ALL}')
+            logger.error(
+                f'{colorama.Fore.RED}Failed to install GPU Operator. The '
+                f'cluster will still work, but GPUs will not be schedulable '
+                f'until the operator is installed manually. Run `kubectl get '
+                f'pods -n gpu-operator` on the head node to debug.{RESET_ALL}')
         else:
             success_message('GPU Operator installed.')
 


### PR DESCRIPTION
https://github.com/skypilot-org/skypilot/issues/10177

The GPU operator step polled `kubectl describe nodes` in an unbounded
loop, so any failure to become ready (crash-looping operator pods,
driver validation failure) left `sky ssh up` hanging indefinitely with
no output beyond a repeating "Waiting for GPU operator..." line, and no
indication of what went wrong.

Changes, all scoped to the `install_gpu` block in
`sky/ssh_node_pools/deploy/deploy.py`:

- Bound the readiness wait with a retry count, matching the `seq`-based
  pattern already used a few lines below for the dcgm-exporter
  DaemonSet wait. On timeout, dump gpu-operator pod status to stderr
  and exit non-zero so the failure surfaces through `run_remote`.
- Collect `kubectl describe nodes` output once per iteration instead of
  invoking it twice per check.
- Use `helm upgrade --install` and tolerate an already-registered repo,
  matching `_prometheus_install_cmd`, so the step is retryable after a
  failure instead of dying with `cannot re-use a name that is still in
  use`.
- Expand the failure log to note that deployment continues and to point
  at `kubectl get pods -n gpu-operator`, in line with the wording of the
  Prometheus install failure message.

No API surface, payload, or response body is touched, so no
`API_VERSION` bump is needed.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Verified self-SSH or any misconfigured GPU operator now detected and hangs off instead of infinite loop. 