### PR TITLE
[Core] PostgresLock: run advisory-lock statements in autocommit mode

### DIFF
--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -213,7 +213,18 @@ class PostgresLock(DistributedLock):
         # Borrow a dedicated connection from the pool. Idempotent under
         # retry: raw_connection() either returns a checked-out conn or
         # raises with nothing taken — no partial state, no leak.
-        return engine.raw_connection()
+        connection = engine.raw_connection()
+        # Advisory locks are session-scoped: they need no transaction and
+        # persist until explicitly released or the session ends. Without
+        # autocommit, the first lock query implicitly opens a transaction
+        # that stays open for the entire lock hold, leaving the session
+        # 'idle in transaction' — tying up a pooled connection in a state
+        # that can exhaust the pool and, if the session ever holds a
+        # snapshot or xid, pin the vacuum horizon. Autocommit for the
+        # lifetime of the checkout; _close_connection restores the default
+        # before the connection is returned to the pool.
+        connection.driver_connection.autocommit = True
+        return connection
 
     def acquire(self, blocking: bool = True) -> AcquireReturnProxy:
         """Acquire the postgres advisory lock."""
@@ -347,7 +358,18 @@ class PostgresLock(DistributedLock):
                 if invalidate:
                     self._connection.invalidate()
                 else:
-                    self._connection.close()
+                    # Restore the default transactional mode before the
+                    # connection is returned to the pool: other borrowers
+                    # expect a non-autocommit connection. If the restore
+                    # fails (typically a dead connection), invalidate
+                    # instead of returning an autocommit-mode connection
+                    # to the pool.
+                    try:
+                        self._connection.driver_connection.autocommit = False
+                    except Exception:  # pylint: disable=broad-except
+                        self._connection.invalidate()
+                    else:
+                        self._connection.close()
             except Exception as e:  # pylint: disable=broad-except
                 if invalidate:
                     logger.debug(

--- a/tests/unit_tests/test_sky/utils/test_locks.py
+++ b/tests/unit_tests/test_sky/utils/test_locks.py
@@ -590,6 +590,85 @@ class TestPostgresLock:
         assert 'shared' in error_msg
 
 
+class _RaisingAutocommitDriverConn:
+    """Driver connection stub whose autocommit setter raises (dead conn)."""
+
+    @property
+    def autocommit(self):
+        return True
+
+    @autocommit.setter
+    def autocommit(self, value):
+        raise RuntimeError('server closed the connection unexpectedly')
+
+
+class TestPostgresLockAutocommit:
+    """Test that lock connections run in autocommit mode.
+
+    Session-level advisory locks need no transaction; without autocommit
+    the first lock statement opens an implicit transaction that stays open
+    for the whole lock hold, leaving the session 'idle in transaction'.
+    """
+
+    @mock.patch.object(global_user_state, 'initialize_and_get_db')
+    def test_get_connection_enables_autocommit(self, mock_init_db):
+        """_get_connection puts the borrowed connection in autocommit."""
+        mock_engine = mock.Mock()
+        mock_engine.dialect.name = db_utils.SQLAlchemyDialect.POSTGRESQL.value
+        mock_connection = mock.Mock()
+        mock_engine.raw_connection.return_value = mock_connection
+        mock_init_db.return_value = mock_engine
+
+        lock = locks.PostgresLock('test_lock')
+        result = lock._get_connection()
+
+        assert result is mock_connection
+        assert result.driver_connection.autocommit is True
+
+    def test_close_connection_restores_transactional_mode(self):
+        """_close_connection restores autocommit=False before returning the
+        connection to the pool (other borrowers expect transactional mode)."""
+        connection = mock.Mock()
+        lock = locks.PostgresLock('test_lock')
+        lock._connection = connection
+
+        lock._close_connection()
+
+        assert connection.driver_connection.autocommit is False
+        connection.close.assert_called_once()
+        connection.invalidate.assert_not_called()
+        assert lock._connection is None
+
+    def test_close_connection_invalidate_skips_restore(self):
+        """The invalidate path discards the connection without touching
+        autocommit (the connection never returns to the pool)."""
+        connection = mock.Mock()
+        lock = locks.PostgresLock('test_lock')
+        lock._connection = connection
+
+        lock._close_connection(invalidate=True)
+
+        connection.invalidate.assert_called_once()
+        connection.close.assert_not_called()
+        # autocommit must not have been assigned a bool by the restore path.
+        assert not isinstance(connection.driver_connection.autocommit, bool)
+
+    def test_close_connection_restore_failure_invalidates(self):
+        """If restoring transactional mode fails (dead connection), the
+        connection is invalidated instead of being returned to the pool in
+        autocommit mode."""
+        connection = mock.Mock()
+        connection.driver_connection = _RaisingAutocommitDriverConn()
+        lock = locks.PostgresLock('test_lock')
+        lock._connection = connection
+
+        lock._close_connection()
+
+        connection.invalidate.assert_called_once()
+        connection.close.assert_not_called()
+        assert lock._connection is None
+
+
 class TestGetLock:
     """Test get_lock factory function."""
 


### PR DESCRIPTION
## Problem

`PostgresLock` borrows a dedicated pooled psycopg2 connection and holds it for the lifetime of the lock — that part is by design, since session-level advisory locks are bound to the session that took them. But the connection is left in psycopg2's default transactional mode, so the first `SELECT pg_try_advisory_lock(...)` implicitly opens a transaction that is never committed. The backing Postgres session therefore shows **`idle in transaction`** for the entire lock hold:

- Long-lived holders (daemon leader locks, the consolidation-mode refresh thread's lock) keep sessions in that state for the **process lifetime**.
- Blocked waiters polling for a contended lock sit inside one open transaction for the whole wait.
- Short-held locks (cluster status, config, scheduler) each contribute an idle-in-transaction session while held.

Consequences:

1. `pg_stat_activity` fills with idle-in-transaction sessions whose transaction age equals process uptime. This reads as an application bug, and it buries real offenders — a genuinely stuck write transaction looks identical to lock wallpaper.
2. `idle_in_transaction_session_timeout` — a common Postgres hardening flag — cannot be enabled on the SkyPilot database: it would kill lock-holder sessions, silently releasing their advisory locks mid-hold (for the consolidation-mode refresh thread, lock loss triggers leader step-down).
3. If any future code performs a write on the lock connection, the implicit transaction acquires an xid and pins the vacuum horizon for the lock's lifetime.

## Fix

Session-level advisory locks need no transaction at all: they persist until explicitly released or the session ends.

- `_get_connection()`: put the borrowed connection in **autocommit** mode for the lifetime of the checkout. Every lock/unlock/probe statement is self-contained; the session shows plain `idle` while holding the lock.
- `_close_connection()`: restore the default transactional mode before returning the connection to the pool (other borrowers expect it); if the restore fails — typically a dead connection — invalidate instead of re-lending an autocommit-mode connection.

No change to locking semantics: `pg_try_advisory_lock` / `pg_advisory_unlock` behave identically under autocommit; `release()`'s `commit()` becomes a harmless no-op; exclusivity is unaffected.

## Validation: A/B on a live deployment

Two 25-minute runs on identical infrastructure — two API-server replicas in consolidation mode sharing a fresh Postgres 16 database, with ~45 real managed jobs churning on a Kubernetes cluster (~25–30 concurrently STARTING, 10–30 PENDING) — differing only in this patch. `pg_stat_activity` was sampled every 5 s (~140–160 samples per arm):

| metric | stock | patched |
|---|---|---|
| idle-in-txn median | 14 | **0** (103/160 samples = 0) |
| idle-in-txn p95 / max | 25 / 29 | 2 / 4 |
| idle-in-txn floor | 4 — never zero (140/140 samples) | 0 |
| oldest transaction age | 1688 s (= process lifetime) | 12 s |
| plain `idle` median | 0 | 15 |
| total connections median | 15 | 15 |

Why these numbers make sense:

- **Stock floor of 4** = the two long-held daemon locks in this deployment × (1 holder + 1 poller on the second replica). These never release, so the count never reaches zero and the oldest transaction age grows without bound.
- **Stock band above the floor (up to 29)** = short-held locks in flight at each sampling instant (job scheduler, status refresh, launch controllers) — it scales with activity.
- **Patched median 0**, with brief 1–2 session blips: the only idle-in-transaction sessions left are genuine data transactions caught between statements. The mid-run session dump shows e.g. an `UPDATE job_info SET schedule_state=...` 0.2 s old holding a real xid — exactly what that state is supposed to mean. Under stock, every single idle-in-transaction row was a lock session (`pg_try_advisory_lock` or the keepalive `SELECT 1` probe).
- **Total connections unchanged** (median 15 in both arms): the fix changes session *state*, not connection usage — a session-level advisory lock still requires a live session for as long as it is held. This patch is not a connection reducer.

Also verified in both arms: lock sessions hold no `backend_xmin` / `backend_xid` (at READ COMMITTED a snapshot exists only while a statement runs), i.e. the stock behavior wastes monitoring clarity rather than pinning vacuum — this is hardening, not a bloat fix.

## Note for operators

After this change, `idle_in_transaction_session_timeout` becomes safe to enable on the SkyPilot database. Upgrade to a server including this patch **before** enabling that flag: with the old code, the timeout kills lock-holder sessions and releases their locks mid-hold.

## Tested

- Unit tests: `pytest tests/unit_tests/test_sky/utils/test_locks.py` — new `TestPostgresLockAutocommit` class covering autocommit-on-checkout, restore-before-pool-return, invalidate-path skip, and invalidate-on-restore-failure; all pre-existing lock tests pass.
- A/B experiment above; exclusivity confirmed throughout via `pg_locks` (one granted holder per lock key), leader election and the refresh thread's `is_session_alive` probes stable under the patched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
