### PR TITLE
[Jobs] Make no-follow logs a true snapshot

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2087,8 +2087,11 @@ def stream_logs_by_id(
             # the table before the managed job state is updated by the
             # controller. In this case, we should skip the logging, and wait for
             # the next round of status check.
-            if (handle is None or managed_job_status !=
-                    managed_job_state.ManagedJobStatus.RUNNING):
+            if handle is None and not follow:
+                # Snapshot mode must not wait for a worker to be provisioned.
+                return '', exceptions.JobExitCode.SUCCEEDED
+            if (handle is None or (follow and managed_job_status !=
+                                   managed_job_state.ManagedJobStatus.RUNNING)):
                 status_str = ''
                 if (managed_job_status is not None and managed_job_status !=
                         managed_job_state.ManagedJobStatus.RUNNING):
@@ -2133,8 +2136,9 @@ def stream_logs_by_id(
                 assert latest_task_id is not None, (job_id, latest_task_id)
                 task_id = latest_task_id
                 continue
-            assert (managed_job_status ==
-                    managed_job_state.ManagedJobStatus.RUNNING)
+            if follow:
+                assert (managed_job_status ==
+                        managed_job_state.ManagedJobStatus.RUNNING)
             assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
             status_display.stop()
             returncode = None
@@ -2161,6 +2165,11 @@ def stream_logs_by_id(
                                       follow=follow,
                                       tail=tail_param,
                                       tail_offset=tail_offset))
+            if not follow:
+                # A snapshot performs at most one worker-log read. In
+                # particular, do not query remote job status or enter recovery
+                # polling after the requested bytes have been returned.
+                break
             if returncode in [rc.value for rc in exceptions.JobExitCode]:
                 # If the log tailing exits with a known exit code we can safely
                 # break the loop because it indicates the tailing process
@@ -2184,9 +2193,6 @@ def stream_logs_by_id(
                 assert task_id is not None, job_id
 
                 if job_status != job_lib.JobStatus.CANCELLED:
-                    if not follow:
-                        break
-
                     # Logs for retrying failed tasks.
                     if (job_status
                             in job_lib.JobStatus.user_code_failure_states()):

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -320,6 +320,51 @@ def test_managed_jobs_num_jobs_without_pool(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_no_follow_pending_task_snapshot(generic_cloud: str):
+    """Non-following logs return while a pipeline task is still pending."""
+    name = smoke_tests_utils.get_cluster_name()
+    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
+                      f'awk \'{{print $1}}\'')
+
+    template_str = pathlib.Path(
+        'tests/test_yamls/pipeline_cancel_logs.yaml.j2').read_text()
+    template = jinja2.Template(template_str)
+    content = template.render(cloud=generic_cloud)
+
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(content)
+        f.flush()
+        test = smoke_tests_utils.Test(
+            'managed_jobs_no_follow_pending_task_snapshot',
+            [
+                f'sky jobs launch -n {name} '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+                f'--infra {generic_cloud} {f.name} -y -d',
+                smoke_tests_utils.get_cmd_wait_until_pipeline_task_status(
+                    job_name=name,
+                    task_line=2,
+                    expected_status='RUNNING',
+                    timeout=360),
+                smoke_tests_utils.get_cmd_wait_until_pipeline_task_status(
+                    job_name=name,
+                    task_line=3,
+                    expected_status='PENDING',
+                    timeout=60),
+                f'JOB_ID=$({get_job_id_cmd}) && '
+                'output=$(timeout 30 sky jobs logs "$JOB_ID" task-b '
+                '--no-follow) && echo "$output" && '
+                'echo "Pending task snapshot returned"',
+            ],
+            f'sky jobs cancel -y -n {name}',
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            timeout=15 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
     """Test that logs are accessible after a managed job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1088,6 +1088,100 @@ class TestStreamLogsByIdTaskFiltering:
         assert 'Valid task IDs are 0.' in msg or 'Valid task IDs are 0,' in msg
 
 
+class TestStreamLogsByIdNoFollow:
+    """Snapshot reads do not enter managed-job status polling."""
+
+    def _patch_nonterminal_job(self, monkeypatch, status, handle):
+        mock_state = MagicMock(wraps=managed_job_state)
+        mock_state.ManagedJobStatus = managed_job_state.ManagedJobStatus
+        mock_state.get_num_tasks.return_value = 1
+        mock_state.get_status.return_value = status
+        mock_state.is_batch_job.return_value = False
+        # End an accidental polling loop on its second iteration so a
+        # regression fails assertions below instead of hanging the test.
+        mock_state.get_latest_task_id_status.side_effect = [
+            (0, status),
+            (0, managed_job_state.ManagedJobStatus.SUCCEEDED),
+        ]
+        mock_state.get_pool_from_job_id.return_value = None
+        mock_state.get_task_name.return_value = 'task'
+        monkeypatch.setattr(jobs_utils, 'managed_job_state', mock_state)
+
+        status_display = MagicMock()
+        status_display.__enter__.return_value = status_display
+        monkeypatch.setattr(
+            jobs_utils.rich_utils,
+            'safe_status',
+            lambda _: status_display,
+        )
+        monkeypatch.setattr(
+            jobs_utils.global_user_state,
+            'get_handle_from_cluster_name',
+            lambda _: handle,
+        )
+        monkeypatch.setattr(jobs_utils, 'JOB_STATUS_CHECK_GAP_SECONDS', 0)
+
+        backend = MagicMock()
+        backend.tail_logs.return_value = exceptions.JobExitCode.SUCCEEDED.value
+        backend.get_job_status.side_effect = AssertionError(
+            'follow=False must not query remote job status after its snapshot')
+        monkeypatch.setattr(jobs_utils.backends, 'CloudVmRayBackend',
+                            lambda: backend)
+        monkeypatch.setattr(jobs_utils.managed_job_runtime, 'is_registered',
+                            lambda: False)
+        return backend, mock_state, status_display
+
+    def test_pending_without_handle_returns_immediately(self, monkeypatch):
+        backend, mock_state, status_display = self._patch_nonterminal_job(
+            monkeypatch,
+            managed_job_state.ManagedJobStatus.PENDING,
+            handle=None,
+        )
+
+        message, code = jobs_utils.stream_logs_by_id(1, follow=False)
+
+        assert message == ''
+        assert code == exceptions.JobExitCode.SUCCEEDED
+        backend.tail_logs.assert_not_called()
+        mock_state.get_latest_task_id_status.assert_called_once_with(1)
+        status_display.update.assert_not_called()
+
+    def test_starting_with_handle_reads_one_snapshot(self, monkeypatch):
+        handle = MagicMock(spec=jobs_utils.backends.CloudVmRayResourceHandle)
+        backend, mock_state, status_display = self._patch_nonterminal_job(
+            monkeypatch,
+            managed_job_state.ManagedJobStatus.STARTING,
+            handle=handle,
+        )
+
+        message, code = jobs_utils.stream_logs_by_id(1, follow=False, tail=20)
+
+        assert message == ''
+        assert code == exceptions.JobExitCode.SUCCEEDED
+        backend.tail_logs.assert_called_once_with(handle,
+                                                  job_id=None,
+                                                  managed_job_id=1,
+                                                  follow=False,
+                                                  tail=20,
+                                                  tail_offset=None)
+        backend.get_job_status.assert_not_called()
+        mock_state.get_latest_task_id_status.assert_called_once_with(1)
+        status_display.update.assert_not_called()
+
+    def test_follow_still_polls_for_pending_worker(self, monkeypatch):
+        backend, mock_state, status_display = self._patch_nonterminal_job(
+            monkeypatch,
+            managed_job_state.ManagedJobStatus.PENDING,
+            handle=None,
+        )
+
+        jobs_utils.stream_logs_by_id(1, follow=True)
+
+        assert mock_state.get_latest_task_id_status.call_count == 2
+        status_display.update.assert_called_once()
+        backend.tail_logs.assert_not_called()
+
+
 class TestFormatJobDetails:
     """Tests for _format_job_details (the 'details' column)."""
 


### PR DESCRIPTION
## Summary

Fixes #10253.

Make direct managed-job `follow=False` reads honor their snapshot contract while a job is still provisioning or recovering.

Today, `stream_logs_by_id()` enters its worker-handle/status polling loop before checking `follow`. As a result, both:

```console
sky jobs logs --no-follow JOB_ID
```

and:

```python
sky.jobs.tail_logs(job_id=job_id, follow=False)
```

can remain active until a `PENDING` or `STARTING` task becomes `RUNNING` or terminal, contrary to the CLI's "print the log so far and exit" contract.

## Changes

- Return immediately in snapshot mode when no worker handle exists.
- Perform at most one non-follow worker-log read when a handle exists, including during a state-transition window.
- Skip remote job-status, provisioning, and recovery polling after the snapshot read.
- Keep follow mode unchanged.
- Add an end-to-end managed-jobs smoke test using a two-task pipeline: while task A is running and task B is still `PENDING`, task B's non-follow log request must return within 30 seconds.

## Scope

This is a direct CLI/SDK behavior fix. The dashboard already avoids task-log requests while jobs are pending or recovering and shows controller logs for lifecycle progress.

## Tested

- [x] Code formatting: `bash format.sh`
- [x] Focused unit regression: `pytest -q -n 0 tests/unit_tests/test_sky/jobs/test_utils.py -k TestStreamLogsByIdNoFollow` (3 passed)
- [x] Affected unit suites: `pytest -q tests/unit_tests/test_sky/jobs/test_utils.py tests/unit_tests/test_sky/test_cli_jobs_logs_tail.py`
- [x] Smoke-test collection: `pytest --collect-only tests/smoke_tests/test_managed_job.py -k test_managed_jobs_no_follow_pending_task_snapshot --managed-jobs`
- [ ] Relevant smoke test: `/smoke-test -k test_managed_jobs_no_follow_pending_task_snapshot --managed-jobs --generic-cloud aws`
- [ ] All smoke tests: `/smoke-test`
- [ ] Backward compatibility: `/quicktest-core`
