### PR TITLE
[Jobs] Collapse repeated job-status polls in the controller log

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -922,6 +922,48 @@ class JobController:
         Returns:
             True if the task succeeded, False otherwise.
         """
+        # Collapses the periodic job-status poll results in the controller log,
+        # so that they do not bury the loglines that are useful for debugging
+        # this task. Owned here, outside the loop, so that the last status the
+        # controller observed is logged even when the loop exits by raising
+        # (e.g. the job is cancelled, or the controller is torn down) rather
+        # than by observing a terminal status.
+        status_logger = managed_job_utils.JobStatusLogger()
+        try:
+            return await self._monitor_one_task_impl(
+                task_id=task_id,
+                task=task,
+                cluster_name=cluster_name,
+                executor=executor,
+                job_id_on_pool_cluster=job_id_on_pool_cluster,
+                callback_func=callback_func,
+                cleanup_cluster_on_success=cleanup_cluster_on_success,
+                force_transit_to_recovering=force_transit_to_recovering,
+                on_recovery=on_recovery,
+                status_logger=status_logger,
+            )
+        finally:
+            status_logger.flush()
+
+    async def _monitor_one_task_impl(
+        self,
+        task_id: int,
+        task: 'sky.Task',
+        cluster_name: str,
+        executor: 'recovery_strategy.StrategyExecutor',
+        status_logger: managed_job_utils.JobStatusLogger,
+        job_id_on_pool_cluster: Optional[int] = None,
+        callback_func: Optional[typing.Callable] = None,
+        cleanup_cluster_on_success: bool = True,
+        force_transit_to_recovering: bool = False,
+        on_recovery: Optional[typing.Callable[[], typing.Coroutine]] = None,
+    ) -> bool:
+        """Body of the monitoring loop; see _monitor_one_task for the contract.
+
+        Args:
+            status_logger: Collapses the periodic job-status poll results.
+                Flushed by _monitor_one_task once the loop exits.
+        """
         if callback_func is None:
             callback_func = managed_job_utils.event_callback_func(
                 job_id=self._job_id, task_id=task_id, task=task)
@@ -972,8 +1014,10 @@ class JobController:
                             self._backend,
                             cluster_name,
                             job_id=job_id_on_pool_cluster,
+                            status_logger=status_logger,
                         ))
                 except exceptions.FetchClusterInfoError as fetch_e:
+                    status_logger.reset()
                     logger.info(
                         'Failed to fetch the job status. Start recovery.\n'
                         f'Exception: {common_utils.format_exception(fetch_e)}\n'
@@ -999,6 +1043,10 @@ class JobController:
             # for job failure, as it could be a transient error for
             # communication issue.
             if transient_job_check_error_reason is not None:
+                # Pin the last status the controller did observe before the
+                # errors start, and log the status in full once the fetches
+                # recover, instead of collapsing it into the pre-error run.
+                status_logger.reset()
                 logger.info(
                     'Potential transient error when fetching the job '
                     f'status. Reason: {transient_job_check_error_reason}.\n'
@@ -1109,6 +1157,7 @@ class JobController:
                 # unreachable. Only when both get_job_status and this refresh
                 # keep failing for JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS is
                 # the error re-raised, escalating to emergency recovery.
+                status_logger.reset()
                 if transient_job_check_error_start_time is None:
                     transient_job_check_error_start_time = time.time()
                     job_check_backoff = common_utils.Backoff(
@@ -1143,6 +1192,9 @@ class JobController:
                 # code).
                 cluster_status_str = ('' if cluster_status is None else
                                       f' (status: {cluster_status.value})')
+                # Pin the last job status observed before the preemption, and
+                # log the post-recovery status in full even if it matches.
+                status_logger.reset()
                 logger.info(
                     f'Cluster is preempted or failed{cluster_status_str}. '
                     'Recovering...')

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -440,14 +440,99 @@ def ha_recovery_for_consolidation_mode() -> None:
         f.write(f'Total recovery time: {time.time() - start} seconds\n')
 
 
+class JobStatusLogger:
+    """Logs job-status poll results, collapsing consecutive identical ones.
+
+    The controller polls the status of its job every
+    JOB_STATUS_CHECK_GAP_SECONDS and logs the result, which for a long-running
+    job is the same on almost every poll. Logging every one of them dominates
+    the controller log and pushes the loglines that are actually useful for
+    debugging the job (recovery reasons, transient cloud API errors,
+    cluster-fetch failures, user-job exit codes) far out of the visible window
+    of the log viewer. So for each run of identical results we keep:
+
+    - the first occurrence, logged as-is;
+    - the last occurrence, logged when the run ends, carrying how long the
+      status was unchanged and over how many checks, so that the time the
+      status was last observed stays recoverable from the log. A run ends when
+      the status changes, when the caller is about to log something interesting
+      (``reset``), or when the polling loop exits (``flush``);
+    - nothing in between. A periodic reminder that the status is still the
+      same would add lines without adding information; the two kept lines
+      already bound the run at both ends.
+
+    One instance tracks one polling loop; it is not thread-safe.
+    """
+
+    def __init__(self) -> None:
+        # Message of the current run of identical results, None if no run is
+        # in progress.
+        self._message: Optional[str] = None
+        self._first_seen = 0.
+        self._last_seen = 0.
+        self._count = 0
+        # Whether the tail of the current run has already been logged, so that
+        # flushing twice (e.g. reset() and then the polling loop exiting) does
+        # not repeat it.
+        self._tail_logged = False
+
+    def log(self, message: str) -> None:
+        """Logs a poll result, collapsing it if it repeats the previous one."""
+        now = time.time()
+        if message != self._message:
+            self.flush()
+            self._message = message
+            self._first_seen = now
+            self._last_seen = now
+            self._count = 1
+            self._tail_logged = False
+            logger.info(message)
+            return
+        self._count += 1
+        self._last_seen = now
+        self._tail_logged = False
+
+    def flush(self) -> None:
+        """Logs the last observation of the current run, if not logged yet."""
+        if self._message is None or self._tail_logged:
+            return
+        if self._count == 1:
+            # The run's only observation was already logged in full.
+            return
+        duration = log_utils.readable_time_duration(self._first_seen,
+                                                    self._last_seen,
+                                                    absolute=True)
+        logger.info(f'{self._message} (unchanged for {duration}, '
+                    f'{self._count} checks)')
+        self._tail_logged = True
+
+    def reset(self) -> None:
+        """Flushes and forgets the current run.
+
+        The next poll result is then logged in full even if it is identical to
+        the last one. Callers use this after something noteworthy happened
+        (e.g. a recovery), so that the status observed afterwards is visible in
+        the log instead of being collapsed into the previous run.
+        """
+        self.flush()
+        self._message = None
+
+
 async def get_job_status(
-    backend: 'backends.CloudVmRayBackend', cluster_name: str,
-    job_id: Optional[int]
+    backend: 'backends.CloudVmRayBackend',
+    cluster_name: str,
+    job_id: Optional[int],
+    status_logger: Optional[JobStatusLogger] = None,
 ) -> Tuple[Optional['job_lib.JobStatus'], Optional[str]]:
     """Check the status of the job running on a managed job cluster.
 
     It can be None, INIT, RUNNING, SUCCEEDED, FAILED, FAILED_DRIVER,
     FAILED_SETUP or CANCELLED.
+
+    Args:
+        status_logger: If provided, the result is logged through it, so that
+            consecutive identical results are collapsed into one logline. If
+            None, every result is logged.
 
     Returns:
         job_status: The status of the job.
@@ -460,14 +545,14 @@ async def get_job_status(
     handle = await asyncio.to_thread(
         global_user_state.get_handle_from_cluster_name, cluster_name)
 
-    def _log_job_status(status: Optional['job_lib.JobStatus']) -> None:
-        if status is None:
-            logger.info('No job found.')
+    def _log(message: str) -> None:
+        if status_logger is not None:
+            status_logger.log(message)
         else:
-            logger.info(f'Job status: {status}')
-        logger.info('=' * 34)
+            logger.info(message)
 
-    logger.info('=== Checking the job status... ===')
+    def _log_job_status(status: Optional['job_lib.JobStatus']) -> None:
+        _log('No job found.' if status is None else f'Job status: {status}')
 
     if managed_job_runtime.is_registered():
         result = await asyncio.to_thread(managed_job_runtime.get_job_status,
@@ -480,7 +565,7 @@ async def get_job_status(
     if handle is None:
         # This can happen if the cluster was preempted and background status
         # refresh already noticed and cleaned it up.
-        logger.info(f'Cluster {cluster_name} not found.')
+        _log(f'Cluster {cluster_name} not found.')
         return None, None
     assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
     job_ids = None if job_id is None else [job_id]

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -9,6 +9,7 @@ import pytest
 from sky.backends import cloud_vm_ray_backend
 from sky.exceptions import ClusterDoesNotExist
 from sky.jobs import utils
+from sky.skylet import job_lib
 
 # String path for mock.patch — can't use the constant directly because
 # mock.patch needs the dotted path to the attribute being patched.
@@ -104,9 +105,9 @@ async def test_get_job_status_timeout(mock_get_handle, mock_logger):
         f'Expected timeout around {timeout_override}s, '
         f'but took {elapsed_time}s')
 
-    # Verify only one attempt was made (no retry in get_job_status)
-    # === Checking the job status... ===
-    assert mock_logger.info.call_count == 1
+    # No status logline is emitted when the fetch fails - the caller logs the
+    # transient error reason instead.
+    assert mock_logger.info.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -135,8 +136,166 @@ async def test_get_job_status_returns_error_reason_on_failure(
     assert error_reason is not None, 'Expected error reason on failure'
     assert 'timed out' in error_reason
 
-    # Verify only one attempt was made (no retry in get_job_status)
-    assert mock_logger.info.call_count == 1
+    # No status logline is emitted when the fetch fails - the caller logs the
+    # transient error reason instead.
+    assert mock_logger.info.call_count == 0
+
+
+def _info_messages(mock_logger):
+    """The messages passed to logger.info(), in order."""
+    return [call.args[0] for call in mock_logger.info.call_args_list]
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_collapses_repeats(mock_logger):
+    """Repeated statuses are logged once, then flushed with a count."""
+    status_logger = utils.JobStatusLogger()
+    for _ in range(5):
+        status_logger.log('Job status: JobStatus.RUNNING')
+
+    assert _info_messages(mock_logger) == ['Job status: JobStatus.RUNNING']
+
+    # The last occurrence of the run is kept, so the time the status was last
+    # observed is still recoverable from the log.
+    status_logger.flush()
+    messages = _info_messages(mock_logger)
+    assert len(messages) == 2
+    assert messages[1].startswith('Job status: JobStatus.RUNNING (unchanged '
+                                  'for ')
+    assert '5 checks' in messages[1]
+
+    # Nothing left to flush.
+    status_logger.flush()
+    assert len(_info_messages(mock_logger)) == 2
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_flushes_on_status_change(mock_logger):
+    """A new status flushes the previous run before being logged."""
+    status_logger = utils.JobStatusLogger()
+    status_logger.log('Job status: JobStatus.SETTING_UP')
+    for _ in range(3):
+        status_logger.log('Job status: JobStatus.RUNNING')
+    status_logger.log('Job status: JobStatus.FAILED')
+
+    messages = _info_messages(mock_logger)
+    assert messages[0] == 'Job status: JobStatus.SETTING_UP'
+    assert messages[1] == 'Job status: JobStatus.RUNNING'
+    assert '3 checks' in messages[2]
+    assert messages[3] == 'Job status: JobStatus.FAILED'
+    assert len(messages) == 4
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_logs_nothing_mid_run(mock_logger):
+    """An unchanged status is never re-emitted while the run is open."""
+    status_logger = utils.JobStatusLogger()
+    for _ in range(500):
+        status_logger.log('Job status: JobStatus.RUNNING')
+
+    assert _info_messages(mock_logger) == ['Job status: JobStatus.RUNNING']
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_flush_is_idempotent(mock_logger):
+    """Flushing an already-flushed run does not repeat the tail line."""
+    status_logger = utils.JobStatusLogger()
+    for _ in range(3):
+        status_logger.log('Job status: JobStatus.RUNNING')
+
+    # reset() flushes; the polling loop exiting then flushes again.
+    status_logger.reset()
+    status_logger.flush()
+
+    messages = _info_messages(mock_logger)
+    assert len(messages) == 2
+    assert '3 checks' in messages[1]
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_single_observation_not_repeated(mock_logger):
+    """A run seen exactly once is not followed by a redundant tail line."""
+    status_logger = utils.JobStatusLogger()
+    status_logger.log('Job status: JobStatus.RUNNING')
+    status_logger.flush()
+
+    assert _info_messages(mock_logger) == ['Job status: JobStatus.RUNNING']
+
+
+@mock.patch('sky.jobs.utils.logger')
+def test_job_status_logger_reset(mock_logger):
+    """After a reset, an identical status is logged in full again."""
+    status_logger = utils.JobStatusLogger()
+    status_logger.log('Job status: JobStatus.RUNNING')
+    status_logger.log('Job status: JobStatus.RUNNING')
+    status_logger.reset()
+    status_logger.log('Job status: JobStatus.RUNNING')
+
+    messages = _info_messages(mock_logger)
+    assert messages[0] == 'Job status: JobStatus.RUNNING'
+    assert '2 checks' in messages[1]
+    assert messages[2] == 'Job status: JobStatus.RUNNING'
+    assert len(messages) == 3
+
+
+@pytest.mark.asyncio
+@mock.patch('sky.jobs.utils.logger')
+@mock.patch('sky.global_user_state.get_handle_from_cluster_name')
+async def test_get_job_status_collapses_repeats(mock_get_handle, mock_logger):
+    """get_job_status routes its result through the status logger."""
+    mock_handle = mock.MagicMock(
+        spec=cloud_vm_ray_backend.CloudVmRayResourceHandle)
+    mock_get_handle.return_value = mock_handle
+
+    mock_backend = mock.MagicMock(spec=cloud_vm_ray_backend.CloudVmRayBackend)
+    mock_backend.get_job_status.return_value = {1: job_lib.JobStatus.RUNNING}
+
+    status_logger = utils.JobStatusLogger()
+    for _ in range(4):
+        job_status, error_reason = await utils.get_job_status(
+            backend=mock_backend,
+            cluster_name='test-cluster',
+            job_id=1,
+            status_logger=status_logger)
+        assert job_status == job_lib.JobStatus.RUNNING
+        assert error_reason is None
+
+    assert _info_messages(mock_logger) == [
+        f'Job status: {job_lib.JobStatus.RUNNING}'
+    ]
+
+    mock_backend.get_job_status.return_value = {1: job_lib.JobStatus.SUCCEEDED}
+    await utils.get_job_status(backend=mock_backend,
+                               cluster_name='test-cluster',
+                               job_id=1,
+                               status_logger=status_logger)
+
+    messages = _info_messages(mock_logger)
+    assert len(messages) == 3
+    assert '4 checks' in messages[1]
+    assert messages[2] == f'Job status: {job_lib.JobStatus.SUCCEEDED}'
+
+
+@pytest.mark.asyncio
+@mock.patch('sky.jobs.utils.logger')
+@mock.patch('sky.global_user_state.get_handle_from_cluster_name')
+async def test_get_job_status_logs_every_poll_without_logger(
+        mock_get_handle, mock_logger):
+    """Without a status logger, every poll result is logged."""
+    mock_handle = mock.MagicMock(
+        spec=cloud_vm_ray_backend.CloudVmRayResourceHandle)
+    mock_get_handle.return_value = mock_handle
+
+    mock_backend = mock.MagicMock(spec=cloud_vm_ray_backend.CloudVmRayBackend)
+    mock_backend.get_job_status.return_value = {1: job_lib.JobStatus.RUNNING}
+
+    for _ in range(3):
+        await utils.get_job_status(backend=mock_backend,
+                                   cluster_name='test-cluster',
+                                   job_id=1)
+
+    assert _info_messages(mock_logger) == (
+        [f'Job status: {job_lib.JobStatus.RUNNING}'] * 3)
 
 
 @mock.patch('sky.utils.controller_utils.warn_jobs_consolidation_mode_intent')

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1383,11 +1383,16 @@ class TestTransientJobStatusRecoveryWindow:
     async def test_window_reset_after_recovery(self, monkeypatch):
         """A transient failure after a recovery starts a fresh retry window.
 
-        Drives ``_monitor_one_task`` through: transient failure (retry) ->
+        Drives ``_monitor_one_task_impl`` through: transient failure (retry) ->
         transient failure past the timeout (recover) -> transient failure
         again. With the window reset, the third failure retries instead of
         recovering, so ``recover`` is called exactly once. Without the reset it
         would recover a second time immediately.
+
+        Calls the ``_impl`` body rather than ``_monitor_one_task``: the retry
+        window lives entirely in the body, and the wrapper only owns the status
+        logger's lifecycle (covered by
+        ``test_status_logger_flushed_when_body_raises``).
         """
         monkeypatch.setattr(managed_job_utils,
                             'JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60)
@@ -1452,15 +1457,47 @@ class TestTransientJobStatusRecoveryWindow:
              patch.object(controller_module.asyncio, 'sleep',
                           new=AsyncMock(return_value=None)):
             with pytest.raises(TestTransientJobStatusRecoveryWindow._StopLoop):
-                await controller_module.JobController._monitor_one_task(
+                await controller_module.JobController._monitor_one_task_impl(
                     mock_self,
                     task_id=0,
                     task=MagicMock(name='task'),
                     cluster_name='cluster',
                     executor=executor,
+                    status_logger=managed_job_utils.JobStatusLogger(),
                     callback_func=MagicMock(),
                     force_transit_to_recovering=False)
 
         assert recover_calls == 1, (
             'expected exactly one recovery; a second recovery means the '
             'transient retry window was not reset after the first recovery')
+
+    @pytest.mark.asyncio
+    async def test_status_logger_flushed_when_body_raises(self, monkeypatch):
+        """The status logger is flushed even when the loop exits by raising.
+
+        ``_monitor_one_task`` owns the logger outside the loop precisely so the
+        last status the controller observed reaches the log when the loop exits
+        by raising (job cancelled, controller torn down) rather than by
+        observing a terminal status. Without the ``finally``, a collapsed run's
+        closing logline -- the only record of when that status was last seen --
+        would be dropped on exactly the paths where it is most useful.
+        """
+        status_logger = MagicMock()
+        monkeypatch.setattr(managed_job_utils, 'JobStatusLogger',
+                            lambda: status_logger)
+
+        async def raise_stop_loop(*args, **kwargs):
+            raise TestTransientJobStatusRecoveryWindow._StopLoop()
+
+        mock_self = MagicMock()
+        mock_self._monitor_one_task_impl = raise_stop_loop
+
+        with pytest.raises(TestTransientJobStatusRecoveryWindow._StopLoop):
+            await controller_module.JobController._monitor_one_task(
+                mock_self,
+                task_id=0,
+                task=MagicMock(name='task'),
+                cluster_name='cluster',
+                executor=MagicMock())
+
+        status_logger.flush.assert_called_once()


### PR DESCRIPTION
## Summary

The controller polls its job's status every `JOB_STATUS_CHECK_GAP_SECONDS` (15s) and logs a three-line blob per poll:

```
=== Checking the job status... ===
Job status: JobStatus.RUNNING
==================================
```

For a long-running job those blobs dominate `controller.log` (2160 lines per 3 hours) and push the loglines that actually matter — recovery reasons, transient cloud-provider API errors, `ClusterStatusFetchingError`, `Ray OutOfDiskError`, user-job exit codes — far out of the visible window of the dashboard log viewer. Investigating a customer job today, those lines were only discoverable by downloading the full log and grepping; from the UI all you see is `Cluster preempted or failed, recovering` with a wall of `Job status: JobStatus.RUNNING` above it.

* Add `JobStatusLogger` (`sky/jobs/utils.py`), which collapses each run of consecutive identical poll results into **two** loglines: the first occurrence, and the last one, carrying how long the status was unchanged and over how many checks — so when the status was last observed stays recoverable. A run ends when the status changes, when the caller is about to log something interesting (`reset()`), or when the polling loop exits (`flush()`). Nothing is logged in between: a periodic reminder that the status is still the same adds lines without adding information, and the two kept lines already bound the run at both ends.
* `get_job_status()` takes an optional `status_logger`; without one every poll result is logged as before. The `=== Checking the job status... ===` framing is dropped — it carries no information the timestamped status line doesn't, and 3 lines per poll become 1.
* The controller's monitoring loop owns one logger per task (so parallel job-group tasks don't share state) and `reset()`s it right before each interesting logline group — fetch-cluster-info error, transient job-status error, cluster-status-fetching error, cluster preempted/failed — so the collapsed run is closed off *before* those lines and the post-event status is logged in full instead of vanishing into the previous run.
* Split the loop body out into `_monitor_one_task_impl` so that `_monitor_one_task` can own the logger and flush it in a `finally`. A loop that exits by raising (the job is cancelled, or the controller is torn down) rather than by observing a terminal status would otherwise never log the last status it saw. Done as a wrapper rather than wrapping the loop in place because the loop body is ~585 lines and re-indenting all of it would bury the real change in a file the repo flags as handle-with-care.

A 3h job with one transient error and one preemption goes from 2160 lines of status blobs to 9.

### Note on in-place updating

An earlier revision emitted a heartbeat line every 10 minutes for an unchanged status. That was dropped: it is the only liveness evidence the controller log carries during a long quiet run, but the poll loop's health is already observable from job state in the DB, and the lines otherwise carry no information.

Rewriting a single self-updating line (`\r`) is not available here — the sink is an append-only file (`~/sky_logs/jobs_controller/<job_id>.log`, opened `'a'` in `sky/utils/context.py`), not a TTY; `\r` would not reduce the bytes written; the dashboard viewer splits on `\n` and never interprets `\r`; and `sky jobs logs --controller` replays history before following. Retroactively erasing lines is also out: live readers (`sky/jobs/utils.py` follow loop, the API server's `_tail_log_file`) hold byte offsets into the file, and the bytes have already been streamed to the dashboard.

## Test plan

Unit tests (`pytest tests/unit_tests/test_jobs_utils.py` → **63 passed**): eight new tests —

* `test_job_status_logger_collapses_repeats`
* `test_job_status_logger_flushes_on_status_change`
* `test_job_status_logger_logs_nothing_mid_run` (500 polls → 1 line)
* `test_job_status_logger_flush_is_idempotent` (`reset()` then the terminal `flush()` must not repeat the tail)
* `test_job_status_logger_single_observation_not_repeated` (a status seen once gets no redundant tail line)
* `test_job_status_logger_reset`
* `test_get_job_status_collapses_repeats`
* `test_get_job_status_logs_every_poll_without_logger`

Two existing tests asserted the now-removed header line and were updated.

Simulation of the 3h job described above (15s polls, one transient error, one preemption) against a fake clock — 720 polls, 9 status lines:

```
Job status: JobStatus.SETTING_UP
Job status: JobStatus.SETTING_UP (unchanged for 1m 45s, 8 checks)
Job status: JobStatus.RUNNING
Job status: JobStatus.RUNNING (unchanged for 59m 45s, 240 checks)
   <transient job-status error logline from the controller>
Job status: JobStatus.RUNNING
Job status: JobStatus.RUNNING (unchanged for 59m 45s, 240 checks)
   <Cluster is preempted or failed. Recovering... + cluster events>
Job status: JobStatus.RUNNING
Job status: JobStatus.RUNNING (unchanged for 57m 45s, 232 checks)
Job status: JobStatus.SUCCEEDED
```

Manual verification:

1. `sky api stop; sky api start`, then `sky jobs launch -n dedupe-check --infra k8s -- 'sleep 1200'`.
2. `sky jobs logs --controller <job-id>` after ~15 minutes: expect exactly one `Job status: JobStatus.RUNNING` line for the whole stretch — not a blob every 15 seconds, and no periodic repetition.
3. Kill the job's pod (`kubectl delete pod <pod>`) to force a recovery: expect the run to be closed with an `(unchanged for …, N checks)` line, then `Cluster is preempted or failed…` / recovery lines, then a fresh full `Job status: …` line after recovery.
4. `sky jobs cancel <job-id>` and confirm the last observed status is still flushed (the `finally` path) and the terminal status appears on its own line.

Smoke tests that grep `controller.log` for `Job status: JobStatus.{SETTING_UP,RUNNING,SUCCEEDED,FAILED,CANCELLED}` (`test_managed_job.py`, `test_pools.py`) still match: the first occurrence of each distinct status and every collapsed line keep that prefix.

`bash format.sh` — mypy clean, no new pylint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
