### PR TITLE
[Jobs] Include exit code and log pointer in RECOVERING event for user-job failure restarts

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -16,33 +16,17 @@ import { apiClient } from './client';
 import { trackJobAction } from '@/lib/analytics';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
 
-// Static descriptions for terminal failure states, shown on the status
-// badge hover so users can tell user-program failures from SkyPilot or
-// infra failures without opening the job. The job's dynamic details
-// (which include the exit code) are appended when available.
-const FAILURE_STATUS_DESCRIPTIONS = {
-  FAILED: 'The job program failed (user program failure)',
-  FAILED_SETUP: 'The job setup command failed (user setup failure)',
-  FAILED_PRECHECKS: 'Job prechecks failed (e.g. invalid job configuration)',
-  FAILED_NO_RESOURCE: 'Failed to provision resources for the job',
-  FAILED_CONTROLLER: 'The SkyPilot jobs controller hit an unexpected error',
-};
-
 /**
- * Tooltip for a job's status badge: pending reason for PENDING jobs,
- * failure attribution (static description plus dynamic details, which
- * carry the exit code for user-program failures) for FAILED* jobs.
+ * Tooltip for a job's status badge: pending reason for PENDING jobs, and
+ * the failure details (which carry the failure attribution and exit code,
+ * e.g. "Job exited with exit code 7 (user program failure). ...") for
+ * FAILED* jobs. Same text as the details column, surfaced on hover.
  */
 function getStatusTooltip(job) {
-  if (job.status === 'PENDING') {
-    return job.details || null;
+  if (job.status === 'PENDING' || job.status?.startsWith('FAILED')) {
+    return job.details || job.failure_reason || null;
   }
-  const failureDescription = FAILURE_STATUS_DESCRIPTIONS[job.status];
-  if (!failureDescription) {
-    return null;
-  }
-  const details = job.details || job.failure_reason;
-  return details ? `${failureDescription}\n${details}` : failureDescription;
+  return null;
 }
 
 // ============ Pagination Plugin Integration ============

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -16,6 +16,35 @@ import { apiClient } from './client';
 import { trackJobAction } from '@/lib/analytics';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
 
+// Static descriptions for terminal failure states, shown on the status
+// badge hover so users can tell user-program failures from SkyPilot or
+// infra failures without opening the job. The job's dynamic details
+// (which include the exit code) are appended when available.
+const FAILURE_STATUS_DESCRIPTIONS = {
+  FAILED: 'The job program failed (user program failure)',
+  FAILED_SETUP: 'The job setup command failed (user setup failure)',
+  FAILED_PRECHECKS: 'Job prechecks failed (e.g. invalid job configuration)',
+  FAILED_NO_RESOURCE: 'Failed to provision resources for the job',
+  FAILED_CONTROLLER: 'The SkyPilot jobs controller hit an unexpected error',
+};
+
+/**
+ * Tooltip for a job's status badge: pending reason for PENDING jobs,
+ * failure attribution (static description plus dynamic details, which
+ * carry the exit code for user-program failures) for FAILED* jobs.
+ */
+function getStatusTooltip(job) {
+  if (job.status === 'PENDING') {
+    return job.details || null;
+  }
+  const failureDescription = FAILURE_STATUS_DESCRIPTIONS[job.status];
+  if (!failureDescription) {
+    return null;
+  }
+  const details = job.details || job.failure_reason;
+  return details ? `${failureDescription}\n${details}` : failureDescription;
+}
+
 // ============ Pagination Plugin Integration ============
 
 /**
@@ -328,9 +357,10 @@ export async function getManagedJobs(options = {}) {
         recoveries: job.recovery_count,
         details: job.details || job.failure_reason,
         // Mirror the cluster INIT tooltip: surface the pending reason on
-        // the status badge so users can see why a job is stuck in PENDING
-        // without opening the job details view.
-        statusTooltip: job.status === 'PENDING' ? job.details || null : null,
+        // the status badge so users can see why a job is stuck in PENDING,
+        // and the failure attribution (user program vs SkyPilot/infra) on
+        // FAILED* badges, without opening the job details view.
+        statusTooltip: getStatusTooltip(job),
         user: job.user_name,
         user_hash: job.user_hash,
         submitted_at: job.submitted_at

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1399,7 +1399,12 @@ function JobDetailsContent({
                   <StatusBadge
                     status={computedStatus}
                     statusTooltip={
-                      computedStatus === 'PENDING'
+                      // The connector only sets statusTooltip when it is
+                      // meaningful (PENDING reason, FAILED* attribution),
+                      // but only pass it through when the aggregated
+                      // status matches the connector's row status so a
+                      // tooltip computed for another state is not shown.
+                      computedStatus === jobData.status
                         ? jobData.statusTooltip
                         : null
                     }

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1254,6 +1254,18 @@ class JobController:
                     exit_codes = await self._get_cluster_job_exit_codes(
                         job_id_on_pool_cluster, handle)
 
+                    # Human-readable description of the non-zero exit, used
+                    # in the RECOVERING event when the job is restarted and
+                    # in failure_reason when it is not.
+                    exit_code_desc: Optional[str] = None
+                    if exit_codes:
+                        if len(exit_codes) == 1:
+                            exit_code_desc = ('Job exited with exit code '
+                                              f'{exit_codes[0]}')
+                        else:
+                            exit_code_desc = ('Job exited with exit codes '
+                                              f'{exit_codes}')
+
                     should_restart_on_failure = (
                         executor.should_restart_on_failure(
                             exit_codes=exit_codes))
@@ -1288,13 +1300,8 @@ class JobController:
                         # RECOVERING event (with the exit code and a log
                         # pointer) instead of the generic "Cluster preempted
                         # or failed" copy, which would be misleading here.
-                        if exit_codes:
-                            if len(exit_codes) == 1:
-                                failure_desc = ('Job exited with exit code '
-                                                f'{exit_codes[0]}')
-                            else:
-                                failure_desc = ('Job exited with exit codes '
-                                                f'{exit_codes}')
+                        if exit_code_desc is not None:
+                            failure_desc = exit_code_desc
                         else:
                             # job_status is non-None here: this branch is
                             # only entered for user-code-failure statuses.
@@ -1307,6 +1314,15 @@ class JobController:
                             f'--controller {self._job_id}')
                         # Fall through to recovery
                     else:
+                        if exit_code_desc is not None:
+                            # failure_reason feeds the dashboard details
+                            # column, the CLI queue, and the FAILED job
+                            # event; state that the user program failed and
+                            # with what exit code, not just where the logs
+                            # are.
+                            failure_reason = (
+                                f'{exit_code_desc} (user program failure). '
+                                f'{failure_reason}')
                         logger.info(
                             f'Task {task_id} failed and will not be retried')
                         await managed_job_state.set_failed_async(

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1136,6 +1136,10 @@ class JobController:
 
             external_failures: Optional[List[ExternalClusterFailure]] = None
             cluster_event_reason = None
+            # Set when recovery is triggered by the user job exiting non-zero
+            # (cluster still UP), so the RECOVERING job event can say what
+            # actually happened instead of the generic preemption copy.
+            user_job_failure_reason: Optional[str] = None
             if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster is (partially) preempted or failed. It can be
                 # down, INIT or STOPPED, based on the interruption behavior of
@@ -1260,6 +1264,9 @@ class JobController:
                             f'max_restarts_on_errors is set to {max_restarts}. '
                             f'[{executor.restart_cnt_on_failure}'
                             f'/{max_restarts}])')
+                        restart_detail = (
+                            f'restart {executor.restart_cnt_on_failure} of '
+                            f'{max_restarts} on errors')
                         if exit_codes and executor.recover_on_exit_codes:
                             recover_codes = executor.recover_on_exit_codes
                             matching_codes = [
@@ -1270,9 +1277,34 @@ class JobController:
                                     f'(Exit code(s) {matching_codes} matched '
                                     'recover_on_exit_codes '
                                     f'[{recover_codes}])')
+                                restart_detail = (
+                                    f'exit code(s) {matching_codes} matched '
+                                    f'recover_on_exit_codes {recover_codes}')
                         logger.info(
                             'User program crashed '
                             f'({managed_job_status.value}). {exit_code_msg}')
+                        # The cluster is UP; recovery is happening because
+                        # the user job exited non-zero. Record that on the
+                        # RECOVERING event (with the exit code and a log
+                        # pointer) instead of the generic "Cluster preempted
+                        # or failed" copy, which would be misleading here.
+                        if exit_codes:
+                            if len(exit_codes) == 1:
+                                failure_desc = ('Job exited with exit code '
+                                                f'{exit_codes[0]}')
+                            else:
+                                failure_desc = ('Job exited with exit codes '
+                                                f'{exit_codes}')
+                        else:
+                            # job_status is non-None here: this branch is
+                            # only entered for user-code-failure statuses.
+                            assert job_status is not None
+                            failure_desc = f'Job failed ({job_status.value})'
+                        user_job_failure_reason = (
+                            f'{failure_desc}. Restarting the job '
+                            f'({restart_detail}). To see the job error '
+                            'output, run: sky jobs logs '
+                            f'--controller {self._job_id}')
                         # Fall through to recovery
                     else:
                         logger.info(
@@ -1411,6 +1443,7 @@ class JobController:
                         callback_func=callback_func,
                         external_failures=external_failures,
                         cluster_event_reason=cluster_event_reason,
+                        user_job_failure_reason=user_job_failure_reason,
                         recovery_source=managed_job_state.RecoverySource.
                         RESTART,
                     )
@@ -1422,6 +1455,7 @@ class JobController:
                     callback_func=callback_func,
                     external_failures=external_failures,
                     cluster_event_reason=cluster_event_reason,
+                    user_job_failure_reason=user_job_failure_reason,
                     recovery_source=managed_job_state.RecoverySource.FAILURE,
                 )
 

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1314,15 +1314,20 @@ class JobController:
                             f'--controller {self._job_id}')
                         # Fall through to recovery
                     else:
-                        if exit_code_desc is not None:
-                            # failure_reason feeds the dashboard details
-                            # column, the CLI queue, and the FAILED job
-                            # event; state that the user program failed and
-                            # with what exit code, not just where the logs
-                            # are.
-                            failure_reason = (
-                                f'{exit_code_desc} (user program failure). '
-                                f'{failure_reason}')
+                        # failure_reason feeds the dashboard details column,
+                        # the CLI queue, and the FAILED job event; state that
+                        # the user program failed (with the exit code when
+                        # the fetch above succeeded), not just where the
+                        # logs are.
+                        terminal_desc = exit_code_desc
+                        if terminal_desc is None:
+                            # job_status is non-None here: this branch is
+                            # only entered for user-code-failure statuses.
+                            assert job_status is not None
+                            terminal_desc = f'Job failed ({job_status.value})'
+                        failure_reason = (
+                            f'{terminal_desc} (user program failure). '
+                            f'{failure_reason}')
                         logger.info(
                             f'Task {task_id} failed and will not be retried')
                         await managed_job_state.set_failed_async(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3465,8 +3465,15 @@ async def set_failed_async(
     override_terminal: bool = False,
 ):
     """Set an entire job or task to failed."""
+    # FAILED / FAILED_SETUP mean the user's own program (or setup command)
+    # failed, as opposed to controller / infra / resource failures. Stamp the
+    # machine-readable code so consumers (e.g. dashboard event styling) can
+    # attribute the failure without parsing the reason text.
+    code = (USER_JOB_FAILURE_EVENT_CODE
+            if failure_type in (ManagedJobStatus.FAILED,
+                                ManagedJobStatus.FAILED_SETUP) else None)
     await add_job_event_async(job_id, task_id, failure_type,
-                              f'Job failed: {failure_reason}')
+                              f'Job failed: {failure_reason}', code)
     assert failure_type.is_failed(), failure_type
     end_time = time.time() if end_time is None else end_time
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3073,9 +3073,15 @@ async def set_recovering_async(
     callback_func: AsyncCallbackType,
     external_failures: Optional[List[ExternalClusterFailure]] = None,
     cluster_event_reason: Optional[str] = None,
+    user_job_failure_reason: Optional[str] = None,
     recovery_source: RecoverySource = RecoverySource.FAILURE,
 ):
     """Set the task to recovering state, and update the job duration.
+
+    user_job_failure_reason is set when the recovery was triggered by the
+    user job exiting non-zero on a healthy cluster (max_restarts_on_errors /
+    recover_on_exit_codes), so the event tells the user their program
+    failed instead of claiming the cluster was preempted.
 
     recovery_source records why the job is recovering (defaults to FAILURE,
     i.e. preemption/failure). It is stored on the RECOVERING job event so
@@ -3091,6 +3097,8 @@ async def set_recovering_async(
     if external_failures:
         code = '; '.join(f.code for f in external_failures)
         reason = '; '.join(f.reason for f in external_failures)
+    elif user_job_failure_reason:
+        reason = user_job_failure_reason
     elif cluster_event_reason:
         reason = cluster_event_reason
     else:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3607,8 +3607,6 @@ def update_links(job_id: int, task_id: Optional[int], links: Dict[str,
 async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
     """Set tasks in the job as cancelling, if they are in non-terminal
     states."""
-    await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLING,
-                              'Job is cancelling')
 
     async def _op(session):
         result = await session.execute(
@@ -3624,6 +3622,13 @@ async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
 
     updated = await _retry_session(_op)
     if updated:
+        # Only record the event when a task actually transitioned; the
+        # controller also calls this on already-terminal jobs (e.g. right
+        # after a task fails), and unconditionally writing the event made
+        # every failed job's event log end with a spurious
+        # CANCELLING/CANCELLED pair.
+        await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLING,
+                                  'Job is cancelling')
         logger.info('Cancelling the job...')
         await callback_func('CANCELLING')
     else:
@@ -3632,8 +3637,6 @@ async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
 
 async def set_cancelled_async(job_id: int, callback_func: AsyncCallbackType):
     """Set tasks in the job as cancelled, if they are in CANCELLING state."""
-    await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLED,
-                              'Job has been cancelled')
 
     async def _op(session):
         result = await session.execute(
@@ -3655,6 +3658,10 @@ async def set_cancelled_async(job_id: int, callback_func: AsyncCallbackType):
 
     updated = await _retry_session(_op)
     if updated:
+        # Only record the event when a task actually transitioned; see
+        # set_cancelling_async for why.
+        await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLED,
+                                  'Job has been cancelled')
         logger.info('Job cancelled.')
         await callback_func('CANCELLED')
     else:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -727,6 +727,12 @@ _SPOT_STATUS_TO_COLOR = {
     ManagedJobStatus.DEPRECATED_SUBMITTED: colorama.Fore.BLUE,
 }
 
+# Machine-readable code stored on RECOVERING job events that were triggered
+# by the user job exiting non-zero (as opposed to preemption / infra failures,
+# whose codes come from ExternalClusterFailure). Consumed by dashboard event
+# styling; do not rename without updating consumers.
+USER_JOB_FAILURE_EVENT_CODE = 'USER_JOB_FAILURE'
+
 
 class RecoverySource(enum.Enum):
     """Why a managed job entered the RECOVERING status.
@@ -3098,6 +3104,7 @@ async def set_recovering_async(
         code = '; '.join(f.code for f in external_failures)
         reason = '; '.join(f.reason for f in external_failures)
     elif user_job_failure_reason:
+        code = USER_JOB_FAILURE_EVENT_CODE
         reason = user_job_failure_reason
     elif cluster_event_reason:
         reason = cluster_event_reason

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1302,6 +1302,139 @@ class TestUserJobStatusClassification:
         assert failure_type == managed_job_state.ManagedJobStatus.FAILED
 
 
+class TestUserJobFailureRecoveryEventReason:
+    """The RECOVERING job event must state the real trigger (SKY-6411).
+
+    When recovery is triggered by the user job exiting non-zero on a healthy
+    cluster (max_restarts_on_errors / recover_on_exit_codes), the RECOVERING
+    event must carry the exit code and a pointer to the job logs instead of
+    the generic 'Cluster preempted or failed, recovering' copy, which is
+    misleading (the cluster was not preempted) and unactionable.
+    """
+
+    class _StopLoop(Exception):
+        """Sentinel raised from recover() to end the monitoring loop."""
+
+    def _make_controller(self, exit_codes):
+        controller = JobController.__new__(JobController)
+        controller._job_id = 42
+        controller._pool = None
+        controller._backend = MagicMock()
+        controller.download_log_and_stream = MagicMock()
+        controller._get_cluster_job_exit_codes = AsyncMock(
+            return_value=exit_codes)
+        controller._cleanup_cluster = AsyncMock()
+        return controller
+
+    def _make_executor(self, recover_on_exit_codes=None):
+        executor = MagicMock()
+        executor.should_restart_on_failure.return_value = True
+        executor.max_restarts_on_errors = 3
+        executor.restart_cnt_on_failure = 1
+        executor.recover_on_exit_codes = recover_on_exit_codes
+        executor.recover = AsyncMock(
+            side_effect=TestUserJobFailureRecoveryEventReason._StopLoop())
+        return executor
+
+    async def _run_recovery(self,
+                            controller,
+                            executor,
+                            cluster_status=status_lib.ClusterStatus.UP):
+        """Drive _monitor_one_task through one failed-job iteration up to
+        set_recovering_async, returning its call kwargs."""
+        mock_task = MagicMock()
+        mock_task.name = 'test-task'
+        mock_task.num_nodes = 1
+
+        handle = MagicMock()
+        handle.launched_resources.need_cleanup_after_preemption_or_failure.\
+            return_value = False
+
+        state = controller_module.managed_job_state
+        with patch('asyncio.sleep', new=AsyncMock()), \
+             patch('sky.backends.backend_utils.async_check_network_connection',
+                   new=AsyncMock()), \
+             patch('sky.jobs.utils.get_job_status',
+                   new=AsyncMock(
+                       return_value=(job_lib.JobStatus.FAILED, None))), \
+             patch('sky.jobs.utils.try_to_get_job_end_time',
+                   return_value=12345.0), \
+             patch('sky.backends.backend_utils.refresh_cluster_status_handle',
+                   return_value=(cluster_status, handle)), \
+             patch.object(controller_module.global_user_state,
+                          'get_cluster_events', return_value=[]), \
+             patch.object(controller_module.ExternalFailureSource,
+                          'is_registered', return_value=False), \
+             patch.object(controller_module.managed_job_runtime,
+                          'is_registered', return_value=False), \
+             patch.object(state, 'set_recovering_async',
+                          new=AsyncMock()) as mock_set_recovering:
+            with pytest.raises(TestUserJobFailureRecoveryEventReason._StopLoop):
+                await controller._monitor_one_task(
+                    task_id=0,
+                    task=mock_task,
+                    cluster_name='test-cluster',
+                    executor=executor,
+                    callback_func=MagicMock(),
+                )
+
+        mock_set_recovering.assert_awaited_once()
+        return mock_set_recovering.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_reason_has_exit_code_and_log_pointer(self):
+        controller = self._make_controller(exit_codes=[137])
+        executor = self._make_executor()
+        kwargs = await self._run_recovery(controller, executor)
+
+        reason = kwargs['user_job_failure_reason']
+        assert 'exit code 137' in reason
+        assert 'sky jobs logs --controller 42' in reason
+        assert 'restart 1 of 3' in reason
+        # The event must not claim the cluster was preempted.
+        assert 'preempted' not in reason
+        assert (kwargs['recovery_source'] ==
+                managed_job_state.RecoverySource.FAILURE)
+
+    @pytest.mark.asyncio
+    async def test_multiple_exit_codes(self):
+        controller = self._make_controller(exit_codes=[137, 1])
+        executor = self._make_executor()
+        kwargs = await self._run_recovery(controller, executor)
+
+        assert 'exit codes [137, 1]' in kwargs['user_job_failure_reason']
+
+    @pytest.mark.asyncio
+    async def test_recover_on_exit_codes_match(self):
+        controller = self._make_controller(exit_codes=[137])
+        executor = self._make_executor(recover_on_exit_codes=[137])
+        kwargs = await self._run_recovery(controller, executor)
+
+        reason = kwargs['user_job_failure_reason']
+        assert 'exit code 137' in reason
+        assert 'recover_on_exit_codes' in reason
+
+    @pytest.mark.asyncio
+    async def test_no_exit_codes_falls_back_to_job_status(self):
+        controller = self._make_controller(exit_codes=None)
+        executor = self._make_executor()
+        kwargs = await self._run_recovery(controller, executor)
+
+        reason = kwargs['user_job_failure_reason']
+        assert 'Job failed (FAILED)' in reason
+        assert 'sky jobs logs --controller 42' in reason
+
+    @pytest.mark.asyncio
+    async def test_preemption_path_has_no_user_job_failure_reason(self):
+        """A real preemption (cluster not UP) keeps the preemption copy."""
+        controller = self._make_controller(exit_codes=[137])
+        executor = self._make_executor()
+        kwargs = await self._run_recovery(
+            controller, executor, cluster_status=status_lib.ClusterStatus.INIT)
+
+        assert kwargs['user_job_failure_reason'] is None
+
+
 class TestDunderMainDispatchesToImportedModule:
     """Regression: running this file as `__main__` must dispatch into the
     IMPORTED `sky.jobs.controller` module, not into a second copy of it.

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1318,6 +1318,20 @@ class TestUserJobStatusClassification:
         # The log pointer is appended, not replaced.
         assert 'sky jobs logs --controller' in failure_reason
 
+    @pytest.mark.asyncio
+    async def test_terminal_failure_attribution_without_exit_codes(self):
+        """The user-program attribution is added even when the exit-code
+        fetch fails (returns None), falling back to the job status."""
+
+        controller = self._make_controller()
+        controller._get_cluster_job_exit_codes = AsyncMock(return_value=None)
+        mock_set_failed = await self._run_until_terminal(
+            controller, job_lib.JobStatus.FAILED)
+
+        failure_reason = mock_set_failed.call_args.kwargs['failure_reason']
+        assert 'Job failed (FAILED) (user program failure)' in failure_reason
+        assert 'sky jobs logs --controller' in failure_reason
+
 
 class TestUserJobFailureRecoveryEventReason:
     """The RECOVERING job event must state the real trigger (SKY-6411).

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1301,6 +1301,23 @@ class TestUserJobStatusClassification:
         failure_type = mock_set_failed.call_args.kwargs['failure_type']
         assert failure_type == managed_job_state.ManagedJobStatus.FAILED
 
+    @pytest.mark.asyncio
+    async def test_terminal_failure_reason_includes_exit_code(self):
+        """A non-retried user failure surfaces the exit code and user-error
+        attribution in failure_reason, which feeds the dashboard details
+        and the FAILED job event (SKY-6411)."""
+
+        controller = self._make_controller()
+        controller._get_cluster_job_exit_codes = AsyncMock(return_value=[7])
+        mock_set_failed = await self._run_until_terminal(
+            controller, job_lib.JobStatus.FAILED)
+
+        failure_reason = mock_set_failed.call_args.kwargs['failure_reason']
+        assert ('Job exited with exit code 7 (user program failure)'
+                in failure_reason)
+        # The log pointer is appended, not replaced.
+        assert 'sky jobs logs --controller' in failure_reason
+
 
 class TestUserJobFailureRecoveryEventReason:
     """The RECOVERING job event must state the real trigger (SKY-6411).

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -897,7 +897,7 @@ class TestSetRecoveringEventReason:
         reason, code = await self._run(
             user_job_failure_reason='Job exited with exit code 1')
         assert reason == 'Job exited with exit code 1'
-        assert code is None
+        assert code == state.USER_JOB_FAILURE_EVENT_CODE
 
     @pytest.mark.asyncio
     async def test_user_job_failure_wins_over_cluster_event(self):

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -959,6 +959,44 @@ class TestSetFailedEventCode:
         assert args[4] is None
 
 
+class TestCancelEventsOnlyOnTransition:
+    """CANCELLING/CANCELLED events are recorded only on a real transition.
+
+    The controller also calls these setters on already-terminal jobs (e.g.
+    right after a task fails); previously the event was written before the
+    row update was attempted, so every failed job's event log ended with a
+    spurious CANCELLING/CANCELLED pair.
+    """
+
+    async def _run(self, func, updated):
+        with mock.patch.object(state, 'add_job_event_async',
+                               new=mock.AsyncMock()) as mock_add_event, \
+             mock.patch.object(state, '_retry_session',
+                               new=mock.AsyncMock(return_value=updated)):
+            await func(1, mock.AsyncMock())
+        return mock_add_event
+
+    @pytest.mark.asyncio
+    async def test_cancelling_event_written_on_transition(self):
+        mock_add_event = await self._run(state.set_cancelling_async, True)
+        mock_add_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelling_event_skipped_when_terminal(self):
+        mock_add_event = await self._run(state.set_cancelling_async, False)
+        mock_add_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_event_written_on_transition(self):
+        mock_add_event = await self._run(state.set_cancelled_async, True)
+        mock_add_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_event_skipped_when_not_cancelling(self):
+        mock_add_event = await self._run(state.set_cancelled_async, False)
+        mock_add_event.assert_not_awaited()
+
+
 # Fixed epoch timestamps (seconds) for the time-range fixture. submitted_at is
 # stored as epoch seconds (a sqlalchemy.Float column), matching time.time().
 _T100 = 100.0

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -924,6 +924,41 @@ class TestSetRecoveringEventReason:
         assert code is None
 
 
+class TestSetFailedEventCode:
+    """set_failed_async stamps USER_JOB_FAILURE only for user-error types.
+
+    FAILED and FAILED_SETUP mean the user's own program or setup command
+    failed; controller/infra/resource failure types must not carry the code.
+    """
+
+    async def _run(self, failure_type):
+        with mock.patch.object(state, 'add_job_event_async',
+                               new=mock.AsyncMock()) as mock_add_event, \
+             mock.patch.object(state, '_retry_session',
+                               new=mock.AsyncMock(return_value=True)):
+            await state.set_failed_async(job_id=1,
+                                         task_id=0,
+                                         failure_type=failure_type,
+                                         failure_reason='boom')
+        # add_job_event_async(job_id, task_id, status, reason, code)
+        return mock_add_event.await_args.args
+
+    @pytest.mark.asyncio
+    async def test_failed_stamps_user_job_failure(self):
+        args = await self._run(state.ManagedJobStatus.FAILED)
+        assert args[4] == state.USER_JOB_FAILURE_EVENT_CODE
+
+    @pytest.mark.asyncio
+    async def test_failed_setup_stamps_user_job_failure(self):
+        args = await self._run(state.ManagedJobStatus.FAILED_SETUP)
+        assert args[4] == state.USER_JOB_FAILURE_EVENT_CODE
+
+    @pytest.mark.asyncio
+    async def test_failed_controller_has_no_code(self):
+        args = await self._run(state.ManagedJobStatus.FAILED_CONTROLLER)
+        assert args[4] is None
+
+
 # Fixed epoch timestamps (seconds) for the time-range fixture. submitted_at is
 # stored as epoch seconds (a sqlalchemy.Float column), matching time.time().
 _T100 = 100.0

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -870,6 +870,60 @@ class TestGetLatestRecoveryReasons:
         assert state.get_latest_recovery_and_pending_reasons([1], [])[0] == {}
 
 
+class TestSetRecoveringEventReason:
+    """Reason/code selection for the RECOVERING event in set_recovering_async.
+
+    Priority: external failures (plugin-reported), then a user-job failure
+    reason (non-zero exit on a healthy cluster, SKY-6411), then the last
+    cluster event, then the generic preemption fallback.
+    """
+
+    async def _run(self, **kwargs):
+        with mock.patch.object(state, 'add_job_event_async',
+                               new=mock.AsyncMock()) as mock_add_event, \
+             mock.patch.object(state, '_retry_task_status_update',
+                               new=mock.AsyncMock()):
+            await state.set_recovering_async(job_id=1,
+                                             task_id=0,
+                                             force_transit_to_recovering=False,
+                                             callback_func=mock.AsyncMock(),
+                                             **kwargs)
+        args = mock_add_event.await_args.args
+        # add_job_event_async(job_id, task_id, status, reason, code, ...)
+        return args[3], args[4]
+
+    @pytest.mark.asyncio
+    async def test_user_job_failure_reason_used(self):
+        reason, code = await self._run(
+            user_job_failure_reason='Job exited with exit code 1')
+        assert reason == 'Job exited with exit code 1'
+        assert code is None
+
+    @pytest.mark.asyncio
+    async def test_user_job_failure_wins_over_cluster_event(self):
+        reason, _ = await self._run(
+            cluster_event_reason='some cluster event',
+            user_job_failure_reason='Job exited with exit code 1')
+        assert reason == 'Job exited with exit code 1'
+
+    @pytest.mark.asyncio
+    async def test_external_failures_win_over_user_job_failure(self):
+        failures = [
+            state.ExternalClusterFailure(code='GPU_ERR', reason='gpu died')
+        ]
+        reason, code = await self._run(
+            external_failures=failures,
+            user_job_failure_reason='Job exited with exit code 1')
+        assert reason == 'gpu died'
+        assert code == 'GPU_ERR'
+
+    @pytest.mark.asyncio
+    async def test_default_reason_unchanged(self):
+        reason, code = await self._run()
+        assert reason == 'Cluster preempted or failed, recovering'
+        assert code is None
+
+
 # Fixed epoch timestamps (seconds) for the time-range fixture. submitted_at is
 # stored as epoch seconds (a sqlalchemy.Float column), matching time.time().
 _T100 = 100.0


### PR DESCRIPTION
When a managed job attempt exits non-zero and the controller restarts it (`max_restarts_on_errors` / `recover_on_exit_codes`), the RECOVERING job event previously said only:

```
Cluster preempted or failed, recovering
```

This is misleading (the cluster stayed UP; the user program crashed) and unactionable (no exit code, no pointer to logs). The retry decision already has the exit codes in hand, so surface them, and attribute terminal failures to the user program across the event log, details column, and status hover:

```
RECOVERING  Job exited with exit code 7. Restarting the job (restart 1 of 1 on errors). To see the job error output, run: sky jobs logs --controller 6
FAILED      Job failed: Job exited with exit code 7 (user program failure). To see the details, run: sky jobs logs --controller 6
```

- `sky/jobs/controller.py`: when `should_restart_on_failure()` approves a restart, build a `user_job_failure_reason` containing the exit code(s) (or the worker job status when exit codes are unavailable), the restart budget or matched `recover_on_exit_codes`, and a `sky jobs logs --controller` pointer; pass it to both `set_recovering_async` call sites. When the failure is terminal (no restart budget), always prepend the user-program attribution to `failure_reason`: with the exit code when the (best-effort) fetch succeeds, falling back to the worker job status when it does not. The existing log pointer is kept. This flows into the dashboard details column, the CLI queue, the FAILED job event, and debug dumps.
- `sky/jobs/state.py`: `set_recovering_async` accepts `user_job_failure_reason`, preferring it over `cluster_event_reason` (plugin-reported external failures still take precedence). Both the RECOVERING event and the FAILED / FAILED_SETUP events are stamped with a machine-readable `code='USER_JOB_FAILURE'` so consumers can distinguish user-program failures from controller/infra/resource failures without parsing reason text.
- `sky/jobs/state.py`: `set_cancelling_async` / `set_cancelled_async` wrote their job events before checking whether any row transitioned, so every failed job's event log ended with a spurious CANCELLING/CANCELLED pair (the controller invokes them on already-terminal jobs after a task failure). Events are now recorded only on a real transition; genuine cancellations are unaffected.
- Dashboard: hovering a FAILED* status badge (jobs table and job detail page) now shows the job's failure details, the same text as the details column, which carries the attribution and exit code (e.g. `Job exited with exit code 7 (user program failure). ...`).
- Real preemption / cluster-loss recoveries keep the existing copy. No schema change (reuses existing `job_events.reason` / `code` columns).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests:
- `tests/unit_tests/test_sky/jobs/test_controller.py::TestUserJobFailureRecoveryEventReason`: RECOVERING reason carries exit code + log pointer, multi-node exit codes, `recover_on_exit_codes` match, job-status fallback when exit codes are unavailable, and the preemption path (cluster not UP) passes no user-job reason.
- `tests/unit_tests/test_sky/jobs/test_controller.py::TestUserJobStatusClassification`: terminal failure_reason includes the exit code and user-program attribution (and attributes via job status when the exit-code fetch fails), log pointer preserved.
- `tests/unit_tests/test_sky/jobs/test_jobs_state.py::TestSetRecoveringEventReason`: reason/code precedence in `set_recovering_async` (external failures > user-job failure > cluster event > default), default preemption copy unchanged.
- `tests/unit_tests/test_sky/jobs/test_jobs_state.py::TestSetFailedEventCode`: USER_JOB_FAILURE stamped for FAILED / FAILED_SETUP only, not FAILED_CONTROLLER.
- `tests/unit_tests/test_sky/jobs/test_jobs_state.py::TestCancelEventsOnlyOnTransition`: CANCELLING/CANCELLED events written only when a task actually transitioned.

Manual test plan:
1. Launch a managed job with `job_recovery: {max_restarts_on_errors: 1}` whose `run` exits non-zero (e.g. `sleep 30; exit 7`).
2. Wait for the first attempt to fail; check `sky jobs queue` transitions RUNNING -> RECOVERING; the RECOVERING event shows the exit code, restart budget, and log pointer with `code='USER_JOB_FAILURE'`.
3. After the restart budget is exhausted, the job goes FAILED; the details column shows `Failure: Job exited with exit code 7 (user program failure). ...` and hovering the FAILED badge (jobs table and detail page) shows the attribution plus details.
4. The job's event log ends at FAILED with no trailing CANCELLING/CANCELLED events.
5. Verified end to end on a local API server (consolidation mode, Kubernetes): full event timeline PENDING -> STARTING -> RUNNING -> RECOVERING (exit code 7) -> RUNNING (recovered) -> FAILED (exit code 7, user program failure), matching the copy shown at the top.
6. Preemption-driven recoveries still emit the existing copy (unit-tested; no copy change on the cluster-not-UP path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
