### PR TITLE
[Server] Fail /api/get definitively for requests interrupted by a server restart

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -178,6 +178,11 @@ def retry_transient_errors(max_retries: int = 3,
                     # new replica.
                     except exceptions.RequestInterruptedError:
                         _handle_exception()
+                        if consecutive_failed_count >= max_retries:
+                            # Retries exhausted: surface the interruption
+                            # instead of falling out of the loop and
+                            # silently returning None to the caller.
+                            raise
                         logger.debug('Request interrupted. Retry immediately.')
                         continue
                     except Exception as e:  # pylint: disable=broad-except

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2395,15 +2395,20 @@ async def api_get(request_id: str) -> payloads.RequestPayload:
         # Back off: 10ms -> 20ms -> 40ms -> 80ms -> 100ms (cap)
         poll_interval = min(poll_interval * 2, 0.1)
     request_task = await requests_lib.get_request_async(request_id)
-    # TODO(aylei): refine this, /api/get will not be retried and this is
-    # meaningless to retry. It is the original request that should be retried.
-    if request_task.should_retry:
-        raise fastapi.HTTPException(
-            status_code=503, detail=f'Request {request_id!r} should be retried')
+    # Check the error before should_retry: an interrupted request is in a
+    # terminal state (the server does not re-execute it after a restart),
+    # so clients polling /api/get must get a definitive error telling them
+    # to re-submit the original request. Returning a retryable 503 here
+    # would make the client retry /api/get itself forever.
     request_error = request_task.get_error()
     if request_error is not None:
         raise fastapi.HTTPException(status_code=500,
                                     detail=request_task.encode().model_dump())
+    if request_task.should_retry:
+        # Requests interrupted by legacy server versions carry no error
+        # object; keep the retryable 503 for them.
+        raise fastapi.HTTPException(
+            status_code=503, detail=f'Request {request_id!r} should be retried')
     return request_task.encode()
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2405,10 +2405,18 @@ async def api_get(request_id: str) -> payloads.RequestPayload:
         raise fastapi.HTTPException(status_code=500,
                                     detail=request_task.encode().model_dump())
     if request_task.should_retry:
-        # Requests interrupted by legacy server versions carry no error
-        # object; keep the retryable 503 for them.
-        raise fastapi.HTTPException(
-            status_code=503, detail=f'Request {request_id!r} should be retried')
+        # Interrupted by a server version that recorded no error object —
+        # including the very rolling update that ships this code, whose
+        # draining (old) servers still write bare should_retry rows.
+        # Synthesize the same terminal error at read time so those rows,
+        # and any already stuck in the database, stop 503ing on deploy.
+        request_task.set_error(
+            exceptions.RequestInterruptedError(
+                f'Request {request_id!r} was interrupted by an API server '
+                'restart and will not be resumed. Please re-submit the '
+                'original request.'))
+        raise fastapi.HTTPException(status_code=500,
+                                    detail=request_task.encode().model_dump())
     return request_task.encode()
 
 

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -230,6 +230,10 @@ class Server(uvicorn.Server):
                     logger.debug(f'Process {req.pid} already finished.')
             req.status = requests_lib.RequestStatus.CANCELLED
             req.should_retry = True
+            # Stamp finished_at: retention cleanup selects finished
+            # requests with finished_at < cutoff, so a NULL finished_at
+            # would keep the cancelled row around forever.
+            req.finished_at = time.time()
             # Also record a terminal error so that clients polling
             # /api/get get a definitive answer instead of a retryable
             # 503 forever: the server does not re-execute interrupted

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -201,8 +201,18 @@ class Server(uvicorn.Server):
             if time.time() - start_time > _WAIT_REQUESTS_TIMEOUT_SECONDS:
                 logger.warning('Timeout waiting for on-going requests to '
                                'finish, cancelling all on-going requests.')
-                for request_id, _ in requests:
-                    self.interrupt_request_for_retry(request_id)
+                for request_id, name in requests:
+                    # should_retry means "the client can meaningfully retry
+                    # by re-submitting" — true only for the logs requests
+                    # (their SDK wrappers re-POST a fresh request) and
+                    # internal daemons (re-registered on boot). For anything
+                    # else, e.g. sky.launch, the client's retry unit only
+                    # re-attaches the same dead request id, so signal a
+                    # plain terminal cancellation instead.
+                    self.interrupt_request_for_retry(
+                        request_id,
+                        should_retry=(name in _RETRIABLE_REQUEST_NAMES or
+                                      request_id in internal_request_ids))
                 break
             interrupted = 0
             for request_id, name in requests:
@@ -218,8 +228,19 @@ class Server(uvicorn.Server):
             if interrupted < len(requests):
                 time.sleep(_WAIT_REQUESTS_INTERVAL_SECONDS)
 
-    def interrupt_request_for_retry(self, request_id: str) -> None:
-        """Interrupt a request for retry."""
+    def interrupt_request_for_retry(self,
+                                    request_id: str,
+                                    should_retry: bool = True) -> None:
+        """Interrupt a request, optionally signaling clients to re-submit.
+
+        Args:
+            request_id: The request to interrupt.
+            should_retry: Whether clients can recover by re-submitting the
+                original request. True for the logs requests (SDK wrappers
+                re-POST a fresh request on interruption) and internal
+                daemons; False for requests whose client-side retry would
+                only re-attach the same interrupted request id.
+        """
         with requests_lib.update_request(request_id) as req:
             if req is None:
                 return
@@ -229,7 +250,7 @@ class Server(uvicorn.Server):
                 except ProcessLookupError:
                     logger.debug(f'Process {req.pid} already finished.')
             req.status = requests_lib.RequestStatus.CANCELLED
-            req.should_retry = True
+            req.should_retry = should_retry
             # Stamp finished_at: retention cleanup selects finished
             # requests with finished_at < cutoff, so a NULL finished_at
             # would keep the cancelled row around forever.
@@ -244,8 +265,10 @@ class Server(uvicorn.Server):
                     f'Request {request_id!r} was interrupted by an API '
                     'server restart and will not be resumed. Please '
                     're-submit the original request.'))
-        logger.info(f'Request {request_id} interrupted; the client will be '
-                    'instructed to re-submit it.')
+        outcome = ('instructed to re-submit it'
+                   if should_retry else 'given a terminal error')
+        logger.info(
+            f'Request {request_id} interrupted; the client will be {outcome}.')
 
     def run(self, *args, **kwargs):
         """Run the server process."""

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -18,6 +18,7 @@ import filelock
 import uvicorn
 from uvicorn.supervisors import multiprocess
 
+from sky import exceptions
 from sky import sky_logging
 from sky.server import daemons
 from sky.server import metrics as metrics_lib
@@ -229,8 +230,18 @@ class Server(uvicorn.Server):
                     logger.debug(f'Process {req.pid} already finished.')
             req.status = requests_lib.RequestStatus.CANCELLED
             req.should_retry = True
-        logger.info(
-            f'Request {request_id} interrupted and will be retried by client.')
+            # Also record a terminal error so that clients polling
+            # /api/get get a definitive answer instead of a retryable
+            # 503 forever: the server does not re-execute interrupted
+            # requests after a restart, so the original request must be
+            # re-submitted by the client.
+            req.set_error(
+                exceptions.RequestInterruptedError(
+                    f'Request {request_id!r} was interrupted by an API '
+                    'server restart and will not be resumed. Please '
+                    're-submit the original request.'))
+        logger.info(f'Request {request_id} interrupted; the client will be '
+                    'instructed to re-submit it.')
 
     def run(self, *args, **kwargs):
         """Run the server process."""

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2135,6 +2135,9 @@ async def test_interrupt_request_for_retry_records_terminal_error(
     assert interrupted is not None
     assert interrupted.status == RequestStatus.CANCELLED
     assert interrupted.should_retry is True
+    # finished_at must be stamped, otherwise retention cleanup
+    # (finished_at < cutoff) never garbage-collects the row.
+    assert interrupted.finished_at is not None
     error = interrupted.get_error()
     assert error is not None
     assert isinstance(error['object'], exceptions.RequestInterruptedError)

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2141,3 +2141,37 @@ async def test_interrupt_request_for_retry_records_terminal_error(
     error = interrupted.get_error()
     assert error is not None
     assert isinstance(error['object'], exceptions.RequestInterruptedError)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_request_without_retry_records_plain_cancellation(
+        isolated_database):
+    """should_retry=False marks the interrupt as a plain terminal
+    cancellation: no re-submit signal on /api/stream (Control.RETRY), just
+    the stored error. Used for requests whose client-side retry unit can
+    only re-attach the same dead request id (e.g. sky.launch at the
+    shutdown drain timeout)."""
+    from sky import exceptions
+    from sky.server import uvicorn as sky_uvicorn
+
+    request = requests.Request(request_id='interrupt-no-retry',
+                               name='sky.launch',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.RUNNING,
+                               created_at=time.time(),
+                               user_id='test-user')
+    assert await requests.create_if_not_exists_async(request)
+
+    sky_uvicorn.Server.interrupt_request_for_retry(mock.MagicMock(),
+                                                   'interrupt-no-retry',
+                                                   should_retry=False)
+
+    interrupted = requests.get_request('interrupt-no-retry')
+    assert interrupted is not None
+    assert interrupted.status == RequestStatus.CANCELLED
+    assert interrupted.should_retry is False
+    assert interrupted.finished_at is not None
+    error = interrupted.get_error()
+    assert error is not None
+    assert isinstance(error['object'], exceptions.RequestInterruptedError)

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2103,3 +2103,38 @@ async def test_request_id_lookup_uses_index(isolated_database):
         f'WHERE {where}', params).fetchall()
     plan_text = ' '.join(str(row) for row in plan)
     assert 'SEARCH' in plan_text and 'SCAN' not in plan_text, plan_text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_request_for_retry_records_terminal_error(
+        isolated_database):
+    """Interrupting a request records a terminal error.
+
+    Interrupted requests are never re-executed after a server restart, so
+    the stored error lets /api/get fail definitively (telling the client to
+    re-submit the original request) instead of serving a retryable 503
+    forever.
+    """
+    from sky import exceptions
+    from sky.server import uvicorn as sky_uvicorn
+
+    request = requests.Request(request_id='interrupt-me',
+                               name='test-request',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.RUNNING,
+                               created_at=time.time(),
+                               user_id='test-user')
+    assert await requests.create_if_not_exists_async(request)
+
+    # The method does not use self beyond being an instance method.
+    sky_uvicorn.Server.interrupt_request_for_retry(mock.MagicMock(),
+                                                   'interrupt-me')
+
+    interrupted = requests.get_request('interrupt-me')
+    assert interrupted is not None
+    assert interrupted.status == RequestStatus.CANCELLED
+    assert interrupted.should_retry is True
+    error = interrupted.get_error()
+    assert error is not None
+    assert isinstance(error['object'], exceptions.RequestInterruptedError)

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -978,3 +978,40 @@ def test_get_request_id():
     mock_response.reason = 'OK'
     request_id = server_common.get_request_id(mock_response)
     assert request_id == 'test_request_id'
+
+
+def _interrupted_entrypoint():
+    """Module-level entrypoint so Request.encode() can pickle it."""
+
+
+def test_get_interrupted_request_raises_request_interrupted_error():
+    """sdk.get() rebuilds the server's 500 payload into
+    RequestInterruptedError — not a generic RuntimeError — so callers (and
+    the retry decorator) can react to the interruption specifically."""
+    from sky import exceptions
+    from sky.server.requests import payloads as requests_payloads
+    from sky.server.requests import requests as requests_lib
+
+    request = requests_lib.Request(request_id='interrupted-req',
+                                   name='sky.launch',
+                                   entrypoint=_interrupted_entrypoint,
+                                   request_body=requests_payloads.RequestBody(),
+                                   status=requests_lib.RequestStatus.CANCELLED,
+                                   created_at=0.0,
+                                   user_id='user-123',
+                                   should_retry=True)
+    request.set_error(
+        exceptions.RequestInterruptedError(
+            'Request was interrupted by an API server restart.'))
+
+    with mock.patch('sky.server.common.make_authenticated_request'
+                   ) as mock_make_request:
+        mock_response = mock.Mock()
+        mock_response.status_code = 500
+        mock_response.json.return_value = {
+            'detail': request.encode().model_dump()
+        }
+        mock_make_request.return_value = mock_response
+
+        with pytest.raises(exceptions.RequestInterruptedError):
+            client_sdk.get('interrupted-req')

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -915,13 +915,20 @@ def test_api_get_interrupted_request_returns_terminal_error(monkeypatch):
     assert isinstance(error['object'], exceptions.RequestInterruptedError)
 
 
-def test_api_get_interrupted_request_without_error_returns_503(monkeypatch):
-    """Interrupted rows without a stored error keep the retryable 503.
+def test_api_get_interrupted_request_without_error_synthesizes_error(
+        monkeypatch):
+    """Interrupted rows without a stored error get a synthesized one.
 
-    Requests interrupted by legacy server versions carry no error object;
-    /api/get preserves the previous behavior for them.
+    Rows written by servers that predate the stored-error behavior —
+    including the draining side of the rolling update that ships it — carry
+    bare should_retry. /api/get synthesizes the same terminal error at read
+    time so those rows stop 503ing immediately on deploy.
     """
     from fastapi.testclient import TestClient
+
+    from sky import exceptions
+    from sky.server.requests import payloads
+    from sky.server.requests import requests as requests_lib
 
     request = _make_interrupted_request(with_error=False)
     _mount_api_get_request(monkeypatch, request)
@@ -929,8 +936,12 @@ def test_api_get_interrupted_request_without_error_returns_503(monkeypatch):
     client = TestClient(server.app)
     response = client.get('/api/get', params={'request_id': 'interrupted-req'})
 
-    assert response.status_code == 503
-    assert 'should be retried' in response.json()['detail']
+    assert response.status_code == 500
+    payload = payloads.RequestPayload(**response.json()['detail'])
+    decoded = requests_lib.Request.decode(payload)
+    error = decoded.get_error()
+    assert error is not None
+    assert isinstance(error['object'], exceptions.RequestInterruptedError)
 
 
 def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -845,6 +845,94 @@ def test_api_get_endpoint_serializes_request_payload(monkeypatch):
     assert data['user_id'] == 'user-123'
 
 
+def _make_interrupted_request(with_error: bool):
+    from sky import exceptions
+    from sky.server.requests import payloads
+    from sky.server.requests import requests as requests_lib
+
+    request = requests_lib.Request(
+        request_id='interrupted-req',
+        name='test-request',
+        entrypoint=_api_get_dummy_entrypoint,
+        request_body=payloads.RequestBody(),
+        status=requests_lib.RequestStatus.CANCELLED,
+        created_at=1234567890.0,
+        user_id='user-123',
+        should_retry=True,
+    )
+    if with_error:
+        request.set_error(
+            exceptions.RequestInterruptedError(
+                'Request was interrupted by an API server restart.'))
+    return request
+
+
+def _mount_api_get_request(monkeypatch, request):
+    from sky.server.requests import requests as requests_lib
+
+    async def fake_expand(request_id):
+        return request_id
+
+    async def fake_status(request_id, include_msg=False):
+        return requests_lib.StatusWithMsg(
+            status=requests_lib.RequestStatus.CANCELLED)
+
+    async def fake_get_request(request_id):
+        return request
+
+    monkeypatch.setattr(server, 'get_expanded_request_id', fake_expand)
+    monkeypatch.setattr(requests_lib, 'get_request_status_async', fake_status)
+    monkeypatch.setattr(requests_lib, 'get_request_async', fake_get_request)
+
+
+def test_api_get_interrupted_request_returns_terminal_error(monkeypatch):
+    """/api/get surfaces the stored error of an interrupted request.
+
+    Interrupted requests are terminal (the server does not re-execute them
+    after a restart), so /api/get must return the stored error instead of a
+    retryable 503 -- otherwise clients keep polling /api/get forever while
+    the request will never produce a result.
+    """
+    from fastapi.testclient import TestClient
+
+    from sky import exceptions
+    from sky.server.requests import payloads
+    from sky.server.requests import requests as requests_lib
+
+    request = _make_interrupted_request(with_error=True)
+    _mount_api_get_request(monkeypatch, request)
+
+    client = TestClient(server.app)
+    response = client.get('/api/get', params={'request_id': 'interrupted-req'})
+
+    assert response.status_code == 500
+    # The client SDK decodes the detail payload and raises the error object;
+    # verify it round-trips to RequestInterruptedError.
+    payload = payloads.RequestPayload(**response.json()['detail'])
+    decoded = requests_lib.Request.decode(payload)
+    error = decoded.get_error()
+    assert error is not None
+    assert isinstance(error['object'], exceptions.RequestInterruptedError)
+
+
+def test_api_get_interrupted_request_without_error_returns_503(monkeypatch):
+    """Interrupted rows without a stored error keep the retryable 503.
+
+    Requests interrupted by legacy server versions carry no error object;
+    /api/get preserves the previous behavior for them.
+    """
+    from fastapi.testclient import TestClient
+
+    request = _make_interrupted_request(with_error=False)
+    _mount_api_get_request(monkeypatch, request)
+
+    client = TestClient(server.app)
+    response = client.get('/api/get', params={'request_id': 'interrupted-req'})
+
+    assert response.status_code == 503
+    assert 'should be retried' in response.json()['detail']
+
+
 def test_dashboard_config_endpoint_serializes_external_links(monkeypatch):
     """/dashboard_config returns JSON-serialized dashboard settings.
 


### PR DESCRIPTION
When the API server shuts down (e.g. a rolling update), ongoing requests that cannot finish within the grace period are interrupted and marked `CANCELLED` + `should_retry`. `/api/get` returns a retryable 503 for such requests — but the server never re-executes them after the restart, so the 503 is permanent: a client polling `/api/get` for an interrupted request retries forever and never gets an answer. Every server restart can seed such a poll loop (we observed a single stuck `request_id` producing thousands of 503s over many hours), and the 503s also pollute availability metrics while the server is perfectly healthy.

This PR makes the interrupted state terminal and observable:

- `interrupt_request_for_retry()` now also records a `RequestInterruptedError` on the request, stating that it will not be resumed and the original request must be re-submitted.
- `/api/get` checks the stored error before `should_retry`, so interrupted requests surface the error through the existing 500 + serialized-exception path instead of a retryable 503. This also resolves the existing `TODO(aylei)` at this call site: it is the original request that should be retried, not `/api/get`.
- Client behavior: SDK functions wrapped in `rest.retry_transient_errors()` already treat `RequestInterruptedError` as an immediate re-submit signal, so they now transparently re-submit the original request. Bare `sdk.get()` callers get a clear terminal error instead of retrying a dead request id.
- The `/api/stream` path is unchanged: `Control.RETRY` is still emitted for `CANCELLED` + `should_retry` requests.
- Rows written by older server versions carry `should_retry` without a stored error; `/api/get` keeps the retryable 503 for them.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `tests/unit_tests/test_sky/server/requests/test_requests.py::test_interrupt_request_for_retry_records_terminal_error`
  - `tests/unit_tests/test_sky/server/test_server.py::test_api_get_interrupted_request_returns_terminal_error`
  - `tests/unit_tests/test_sky/server/test_server.py::test_api_get_interrupted_request_without_error_returns_503`
  - Full `tests/unit_tests/test_sky/server/test_server.py` and `test_requests.py`: 100 passed
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)