### PR TITLE
[Jobs] Add index on job_info.schedule_state for scheduler queries

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -138,7 +138,10 @@ job_info_table = sqlalchemy.Table(
                       primary_key=True,
                       autoincrement=True),
     sqlalchemy.Column('name', sqlalchemy.Text),
-    sqlalchemy.Column('schedule_state', sqlalchemy.Text),
+    # Indexed: every scheduling attempt filters on schedule_state (e.g.
+    # get_waiting_job_async, get_num_launching_jobs, get_num_alive_jobs),
+    # and active-state rows are a tiny fraction of the table.
+    sqlalchemy.Column('schedule_state', sqlalchemy.Text, index=True),
     sqlalchemy.Column('controller_pid', sqlalchemy.Integer,
                       server_default=None),
     sqlalchemy.Column('controller_pid_started_at',

--- a/sky/schemas/db/spot_jobs/024_add_job_info_schedule_state_index.py
+++ b/sky/schemas/db/spot_jobs/024_add_job_info_schedule_state_index.py
@@ -1,0 +1,48 @@
+"""Add index on job_info.schedule_state for scheduler queries.
+
+The job scheduler filters on ``schedule_state`` on every scheduling
+attempt: ``get_waiting_job_async`` (outer query and the busy-batch-pools
+subquery), ``get_num_launching_jobs``, ``get_num_alive_jobs``, and
+``get_managed_jobs_highest_priority`` in ``sky/jobs/state.py``. Since
+``maybe_schedule_next_jobs`` runs on every job state transition, these
+queries are the hottest path in the spot DB. Without an index each one
+is a full scan of ``job_info``; on a deployment with tens of thousands
+of finished jobs this is ~10ms per call and dominates DB time during
+bursts of concurrent job submissions. Active-state rows are always a
+tiny fraction of the table, so an index on ``schedule_state`` is highly
+selective for these queries.
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-07-28
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '024'
+down_revision: Union[str, Sequence[str], None] = '023'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_job_info_schedule_state'
+
+
+def upgrade():
+    """Create the schedule_state index if it doesn't already exist."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = {ix['name'] for ix in inspector.get_indexes('job_info')}
+    if _INDEX_NAME in existing:
+        return
+    with op.get_context().autocommit_block():
+        op.create_index(_INDEX_NAME, 'job_info', ['schedule_state'])
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,7 @@ GLOBAL_USER_STATE_VERSION = '020'  # add is_managed column to cluster_history
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
-SPOT_JOBS_VERSION = '022'  # add emergency recovery columns
+SPOT_JOBS_VERSION = '024'  # add job_info.schedule_state index
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'


### PR DESCRIPTION
The managed-job scheduler filters `job_info` on `schedule_state` on every scheduling attempt: `get_waiting_job_async` (both the outer WAITING scan and the busy-batch-pools subquery), `get_num_launching_jobs`, `get_num_alive_jobs`, and `get_managed_jobs_highest_priority`. Since `maybe_schedule_next_jobs()` is invoked on every job state transition, these are the hottest queries in the spot DB — and none of them can use an index today, so each call is a full scan of `job_info`.

Benchmark:

PostgreSQL 16 micro-benchmark, single-connection `pgbench -T 10` on a synthetic `job_info` populated to match a busy deployment: 15,000 rows (14,850 finished, 60 WAITING, 90 in other active states, yaml content columns filled), schema created by the real migration chain (023 = before, 024 = after).

`get_waiting_job_async` query shape (`WHERE schedule_state IN ('WAITING') AND (is_batch IS NOT TRUE OR pool NOT IN (subquery)) ORDER BY priority DESC, spot_job_id ASC LIMIT 1 FOR UPDATE`):

| | before (023) | after (024) |
|---|---|---|
| plan | Seq Scan, 2,267 shared buffers | Index Scan on `ix_job_info_schedule_state`, 17 buffers |
| `EXPLAIN ANALYZE` execution time | 11.4 ms | 0.33 ms |
| pgbench avg latency | 8.75 ms | 1.21 ms |
| pgbench tps (1 conn) | 114 | 827 |

`get_num_alive_jobs` count shape: 4.03 ms / 248 tps → 0.28 ms / 3,543 tps.

The busy-batch-pools subquery also picks up the new index. Absolute numbers scale with table width/size — deployments with larger yaml payloads in `job_info` see a bigger gap, since the before-plan reads the whole heap on every scheduling attempt.

## Migration note

This PR adds migration 024 creating `ix_job_info_schedule_state` (same idempotent pattern as 020) and bumps `SPOT_JOBS_VERSION` to `'024'`.

Note: `SPOT_JOBS_VERSION` was still `'022'` — migration 023 (`ix_job_events_new_status_recovery_index`, added in #10186) was never applied because the constant wasn't bumped. Bumping to `'024'` also activates 023 on existing deployments.

## Tests

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual test: created a fresh SQLite spot DB via `sky.jobs.state` engine init — alembic upgrades to 024, `ix_job_info_schedule_state` exists, 023's `ix_job_events_new_status_recovery_source` is now applied as well, and `EXPLAIN QUERY PLAN` shows the scheduler's `schedule_state IN (...)` filter served by the new index. Also verified a pre-existing DB at revision 022 upgrades cleanly.