### PR TITLE
[Examples] Serve CIFAR-10 from a SkyPilot-maintained GCS mirror

### DIFF
--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -21,15 +21,19 @@ setup: |
         exit 0
     fi
     cd data && \
-    # `--timeout=30` is wget's inactivity (read) timeout: catches stalls.
-    # `timeout 90s` is a hard wallclock cap: catches slow-but-steady mirrors
-    # (the toronto host has dipped to ~350 KB/s, which would never trip
-    # --timeout but would blow the 360s SETTING_UP budget). Together they
-    # ensure `||` actually fires and the wayback fallback gets used.
-    (timeout 90s wget -c --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
-        || timeout 120s wget --quiet --timeout=30 --tries=2 -O cifar-10-python.tar.gz \
-            "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz")
-    tar -xvzf cifar-10-python.tar.gz
+    # CIFAR-10 is served from a SkyPilot-maintained GCS mirror because the
+    # upstream host (cs.toronto.edu) is often slow or unavailable. The md5
+    # check guards against truncated downloads (a truncated file can leave
+    # wget exiting 0, which would otherwise skip the fallback and fail in tar).
+    CIFAR_MD5=c58f30108f718f92721af3b95e74349a
+    cifar_ok() { echo "${CIFAR_MD5}  cifar-10-python.tar.gz" | md5sum -c --status; }
+    timeout 90s wget -c --quiet --timeout=30 --tries=2 https://storage.googleapis.com/skypilot-example-data/datasets/cifar-10-python.tar.gz || true
+    if ! cifar_ok; then
+        rm -f cifar-10-python.tar.gz
+        timeout 120s wget --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+        cifar_ok
+    fi
+    tar -xzf cifar-10-python.tar.gz
 
 run: |
     source .venv/bin/activate

--- a/examples/resnet_distributed_torch_scripts/setup.sh
+++ b/examples/resnet_distributed_torch_scripts/setup.sh
@@ -16,7 +16,16 @@ pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://do
 mkdir -p data
 mkdir -p saved_models
 cd data
-wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
-    || wget --quiet -O cifar-10-python.tar.gz \
-        "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
-tar -xvzf cifar-10-python.tar.gz
+# CIFAR-10 is served from a SkyPilot-maintained GCS mirror because the
+# upstream host (cs.toronto.edu) is often slow or unavailable. The md5
+# check guards against truncated downloads (a truncated file can leave
+# wget exiting 0, which would otherwise skip the fallback and fail in tar).
+CIFAR_MD5=c58f30108f718f92721af3b95e74349a
+cifar_ok() { echo "${CIFAR_MD5}  cifar-10-python.tar.gz" | md5sum -c --status; }
+timeout 90s wget -c --quiet --timeout=30 --tries=2 https://storage.googleapis.com/skypilot-example-data/datasets/cifar-10-python.tar.gz || true
+if ! cifar_ok; then
+    rm -f cifar-10-python.tar.gz
+    timeout 120s wget --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+    cifar_ok
+fi
+tar -xzf cifar-10-python.tar.gz

--- a/examples/spot/resnet.yaml
+++ b/examples/spot/resnet.yaml
@@ -34,7 +34,7 @@ setup: |
     pip3 install --upgrade pip
     cd ~/resnet_ddp && pip3 install -r requirements.txt
     mkdir -p data  && mkdir -p saved_models && cd data && \
-    wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+    wget -c --quiet https://storage.googleapis.com/skypilot-example-data/datasets/cifar-10-python.tar.gz || wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
     tar -xvzf cifar-10-python.tar.gz
 
     mkdir -p /checkpoint/torch_ddp_resnet/

--- a/examples/storage/checkpointed_training.yaml
+++ b/examples/storage/checkpointed_training.yaml
@@ -35,7 +35,7 @@ setup: |
     git clone https://github.com/romilbhardwaj/pytorch-distributed-resnet.git
     cd pytorch-distributed-resnet && pip3 install -r requirements.txt
     mkdir -p data  && mkdir -p saved_models && cd data && \
-    wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+    wget -c --quiet https://storage.googleapis.com/skypilot-example-data/datasets/cifar-10-python.tar.gz || wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
     tar -xvzf cifar-10-python.tar.gz
     mkdir -p /checkpoints/torch_ddp_resnet/
 


### PR DESCRIPTION
## Summary

Several examples download CIFAR-10 from the upstream host `cs.toronto.edu`, which is frequently slow (sustained ~350 KB/s dips) or unavailable (503s). This has caused recurring `test_cancel_pytorch` smoke-test flakes, previously mitigated by bumping the wait budget (#9496), adding a Wayback Machine fallback (#9512), and adding timeout scaffolding (#9572) — but a slow or truncated download can still blow the `SETTING_UP` budget or fail in `tar`.

This PR:
- Serves the tarball from a SkyPilot-maintained public GCS mirror first — `https://storage.googleapis.com/skypilot-example-data/datasets/cifar-10-python.tar.gz` — with the upstream host as fallback, replacing the Wayback URL.
- Verifies the archive md5 before extraction in `resnet_distributed_torch.yaml` / `resnet_distributed_torch_scripts/setup.sh`. A truncated download can leave `wget -c` exiting 0, which previously skipped the `||` fallback entirely and surfaced as an opaque `FAILED_SETUP` in `tar`; now it triggers the fallback.
- Gives `examples/spot/resnet.yaml` and `examples/storage/checkpointed_training.yaml` — which had no fallback at all — the same mirror-first treatment (minimal one-line change).

Mirror object: 170,498,071 bytes, md5 `c58f30108f718f92721af3b95e74349a` (matches the canonical CIFAR-10 hash that torchvision also pins). Bucket is public-read with uniform bucket-level access.

## Tested

- `yaml.safe_load` on all modified yamls; `bash -n` on the modified setup sections.
- Control-flow test of the download logic: mirror-success, mirror-truncated→fallback, and mirror-timeout→fallback paths all behave under `set -e`.
- Anonymous end-to-end fetch of the mirror object from a cred-less environment: 200 OK, full download in 0.6s, md5 exact match.
- Smoke test: `test_cancel_pytorch` run to be linked below.

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191jrHLP3ZRfubpLi9THbqP