### PR TITLE
[Dashboard] Infra table: unify data cell color across columns

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -628,14 +628,14 @@ export function InfrastructureSection({
                           )}
                         </td>
                         <td
-                          className={`${sharedCellClass} text-gray-700 tabular-nums whitespace-nowrap`}
+                          className={`${sharedCellClass} text-gray-500 tabular-nums whitespace-nowrap`}
                           rowSpan={subRowCount}
                         >
                           {!hasNodeData ? <SkeletonBadge /> : nodes.length}
                         </td>
                         {!isSlurm && (
                           <td
-                            className={`${sharedCellClass} text-gray-700 tabular-nums whitespace-nowrap`}
+                            className={`${sharedCellClass} text-gray-500 tabular-nums whitespace-nowrap`}
                             rowSpan={subRowCount}
                           >
                             {!hasNodeData ? (
@@ -647,7 +647,7 @@ export function InfrastructureSection({
                         )}
                         {!isSlurm && (
                           <td
-                            className={`${sharedCellClass} text-gray-700 tabular-nums whitespace-nowrap`}
+                            className={`${sharedCellClass} text-gray-500 tabular-nums whitespace-nowrap`}
                             rowSpan={subRowCount}
                           >
                             {!hasNodeData ? (
@@ -774,7 +774,7 @@ export function InfrastructureSection({
                         {s.loading ? (
                           <SkeletonBadge />
                         ) : (
-                          <span className="text-sm text-gray-700">
+                          <span className="text-sm text-gray-500">
                             {s.value}
                           </span>
                         )}

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -534,7 +534,7 @@ export function InfrastructureSection({
                             </span>
                           </NonCapitalizedTooltip>
                         </td>
-                        <td className="p-3 text-gray-600 tabular-nums whitespace-nowrap">
+                        <td className="p-3 text-gray-500 tabular-nums whitespace-nowrap">
                           <span
                             className={`font-semibold ${
                               typeEntry.gpu_free > 0

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -219,12 +219,8 @@ const GpuTypeSummaryStrip = ({ gpus }) => {
                 <span className="text-[13px] font-medium text-gray-800 truncate">
                   {canonicalizeGpuName(gpu.gpu_name)}
                 </span>
-                <span className="text-xs text-gray-600 whitespace-nowrap tabular-nums">
-                  <span
-                    className={`font-semibold ${
-                      free > 0 ? 'text-gray-900' : 'text-gray-500'
-                    }`}
-                  >
+                <span className="text-xs text-gray-500 whitespace-nowrap tabular-nums">
+                  <span className="font-semibold text-gray-600">
                     {free.toLocaleString()}
                   </span>
                   {' of '}
@@ -535,13 +531,7 @@ export function InfrastructureSection({
                           </NonCapitalizedTooltip>
                         </td>
                         <td className="p-3 text-gray-500 tabular-nums whitespace-nowrap">
-                          <span
-                            className={`font-semibold ${
-                              typeEntry.gpu_free > 0
-                                ? 'text-gray-900'
-                                : 'text-gray-500'
-                            }`}
-                          >
+                          <span className="font-semibold text-gray-600">
                             {typeEntry.gpu_free.toLocaleString()}
                           </span>
                           {' of '}

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -220,7 +220,11 @@ const GpuTypeSummaryStrip = ({ gpus }) => {
                   {canonicalizeGpuName(gpu.gpu_name)}
                 </span>
                 <span className="text-xs text-gray-500 whitespace-nowrap tabular-nums">
-                  <span className="font-semibold text-gray-600">
+                  <span
+                    className={
+                      free > 0 ? 'font-semibold text-gray-600' : 'text-gray-500'
+                    }
+                  >
                     {free.toLocaleString()}
                   </span>
                   {' of '}
@@ -531,7 +535,13 @@ export function InfrastructureSection({
                           </NonCapitalizedTooltip>
                         </td>
                         <td className="p-3 text-gray-500 tabular-nums whitespace-nowrap">
-                          <span className="font-semibold text-gray-600">
+                          <span
+                            className={
+                              typeEntry.gpu_free > 0
+                                ? 'font-semibold text-gray-600'
+                                : 'text-gray-500'
+                            }
+                          >
                             {typeEntry.gpu_free.toLocaleString()}
                           </span>
                           {' of '}

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -219,11 +219,11 @@ const GpuTypeSummaryStrip = ({ gpus }) => {
                 <span className="text-[13px] font-medium text-gray-800 truncate">
                   {canonicalizeGpuName(gpu.gpu_name)}
                 </span>
-                <span className="text-xs text-gray-500 whitespace-nowrap tabular-nums">
+                <span className="text-xs text-gray-600 whitespace-nowrap tabular-nums">
                   <span
-                    className={
-                      free > 0 ? 'font-semibold text-gray-600' : 'text-gray-500'
-                    }
+                    className={`font-semibold ${
+                      free > 0 ? 'text-gray-900' : 'text-gray-500'
+                    }`}
                   >
                     {free.toLocaleString()}
                   </span>
@@ -536,11 +536,11 @@ export function InfrastructureSection({
                         </td>
                         <td className="p-3 text-gray-500 tabular-nums whitespace-nowrap">
                           <span
-                            className={
+                            className={`font-semibold ${
                               typeEntry.gpu_free > 0
-                                ? 'font-semibold text-gray-600'
+                                ? 'text-gray-600'
                                 : 'text-gray-500'
-                            }
+                            }`}
                           >
                             {typeEntry.gpu_free.toLocaleString()}
                           </span>


### PR DESCRIPTION
Follow-up polish to #10067.

The infra table mixed three greys for what is all body text, so values read as
different font weights when only the colour differed — `H100` looked lighter
than `7048 GB` beside it, though both are weight 400 at 14px.

Body text is now one tone, and the free count keeps emphasis:

- Nodes, CPU, Memory, GPU Type, `of N free`, mobile stats → `text-gray-500`
- free count → `font-semibold`, `text-gray-600` when something is free and
  `text-gray-500` when nothing is

The weight on the count is unconditional; only its colour varies, so a `0`
never looks like a different size or weight from a `14` — it is just quieter.
The accent moves from `gray-900` to `gray-600` so it sits closer to the body
text it labels. Summary strip is unchanged.

`gray-500` on white is ~4.8:1, still AA.

## Test

Built and rendered `/dashboard/infra` against a local API server, then read
computed styles off the DOM to confirm the greys and weights land as intended.
Checked the mobile card layout and the multi-GPU `rowSpan` path. `next lint` and
`prettier --check` pass.