### PR TITLE
[LLM] slime example: offload optimizer state to host RAM by default

### DIFF
--- a/llm/slime/coding-agent-2engine.yaml
+++ b/llm/slime/coding-agent-2engine.yaml
@@ -44,6 +44,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engines — jobs co-schedule on one cluster
   accelerators: H100:4
+  memory: 256+   # host RAM for offloaded optimizer state (see run-slime.sh OPTIMIZER_OFFLOAD)
   image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:

--- a/llm/slime/coding-agent-3engine.yaml
+++ b/llm/slime/coding-agent-3engine.yaml
@@ -57,6 +57,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engines — jobs co-schedule on one cluster
   accelerators: H100:4
+  memory: 256+   # host RAM for offloaded optimizer state (see run-slime.sh OPTIMIZER_OFFLOAD)
   image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:

--- a/llm/slime/coding-agent.yaml
+++ b/llm/slime/coding-agent.yaml
@@ -35,6 +35,7 @@ name: trainer
 resources:
   infra: kubernetes          # SAME context as the engine — jobs co-schedule on one cluster
   accelerators: H100:4
+  memory: 256+   # host RAM for offloaded optimizer state (see run-slime.sh OPTIMIZER_OFFLOAD)
   image_id: docker:slimerl/slime:nightly-dev-20260707a
 workdir: .
 volumes:

--- a/llm/slime/run-slime.sh
+++ b/llm/slime/run-slime.sh
@@ -139,6 +139,18 @@ OPTIMIZER_ARGS=(
    --adam-beta1 0.9
    --adam-beta2 0.98
 )
+# Keep optimizer state (Adam moments + fp32 master weights, ~12 of the trainer's
+# ~16 bytes/param) in host RAM instead of GPU memory. Long multi-turn rollouts
+# can spike activation memory past the headroom a 4-GPU trainer has left with
+# optimizer state on-device; offloading roughly halves per-GPU static memory and
+# keeps long runs comfortably inside the ceiling. Requires the large `memory:`
+# request on the trainer task (the states live on the host). Set
+# OPTIMIZER_OFFLOAD=0 to keep optimizer state on-GPU.
+[ "${OPTIMIZER_OFFLOAD:-1}" = "1" ] && OPTIMIZER_ARGS+=(
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
 
 # wandb is OPT-IN via WANDB_API_KEY: unset => empty WANDB_ARGS => run stays
 # fully disabled (never breaks a run for a missing key). slime derives the


### PR DESCRIPTION
## Problem

Long multi-turn RL rollouts can spike the trainer's activation memory past what a 4-GPU (TP4) 14B trainer has left once optimizer state sits on-device. The trainer's per-GPU statics are ~16 bytes/param (bf16 weights + fp32 grads + fp32 master weights + Adam moments) ≈ 56 GB at 14B/TP4 on an 80 GB H100 — leaving only a few GB of headroom. Long trajectories can produce a single packed sample tens of thousands of tokens long, whose fp32 `[T, vocab/TP]` log-prob computation transiently needs several contiguous GiB; runs then fail with CUDA OOMs a few GiB short after several steps, depending on how long a batch's trajectories happen to be:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 3.84 GiB.
GPU 0 has a total capacity of 79.19 GiB of which 3.79 GiB is free.
  ...
  File "slime/utils/ppo_utils.py", line 219, in vocab_parallel_softmax
    normalized_logits = logits.sub_(logits_max) if inplace else logits - logits_max
```

## Fix

Offload optimizer state (Adam moments + fp32 master weights, ~12 of the ~16 bytes/param) to pinned host RAM — the same flag trio slime's own large-model scripts use:

- `--optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d --use-precision-aware-optimizer` on by default in `run-slime.sh` (`OPTIMIZER_OFFLOAD=0` opts out)
- `memory: 256+` on the trainer task (the offloaded states live on the host)

Measured effect at 14B/TP4: per-GPU statics drop **~56 GB → ~22 GB**, so the transient spike lands in ~38 GB of slack instead of ~4. Optimizer-step overhead is hidden behind rollout time for this workload (the D2H/H2D transfers overlap with compute).

## Tested

- 3-step smoke at TP4 with offload: clean; flags verified in the launched command; 27.5 GB allocated after model load (vs ~56 GB without).
- **50-step training run at TP4 with offload on the full SWE-smith dataset: SUCCEEDED, 50/50 steps, zero recoveries.** GPU memory flat across the whole run (20.6–27.5 GB allocated at the per-step checkpoints — never approached the ceiling). Mean step time 859 s vs ~950 s for a matched 50-step no-offload TP8 baseline — offload overhead is not measurable above rollout variance for this workload.
- Previous behavior for comparison: TP4 without offload failed with the OOM above at steps 2–7 across three separate runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)