### PR TITLE
[Kubernetes] Bound pod wait-loop polls with a request timeout

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -441,6 +441,19 @@ def max_retry_error():
     return urllib3.exceptions.MaxRetryError
 
 
+def urllib3_http_error():
+    """Base class of urllib3 transport errors.
+
+    Covers read timeouts, dropped/reset connections and exhausted connect
+    retries -- i.e. failures of the HTTP transport itself, as opposed to
+    HTTP error responses from the API server (``api_exception``). Note
+    that the kubernetes client re-wraps ``urllib3.exceptions.SSLError``
+    into an ``ApiException`` with ``status=0``, so TLS failures do NOT
+    surface as this type.
+    """
+    return urllib3.exceptions.HTTPError
+
+
 def stream():
     return kubernetes.stream.stream
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -72,6 +72,22 @@ _AUTOSCALE_INITIAL_MIN_TIMEOUT_SECONDS = 60
 # knob's default (matching the default provision_timeout applied when a
 # Kueue local queue is configured); -1 waits indefinitely.
 _QUEUE_ADMISSION_TIMEOUT_SECONDS = 24 * 60 * 60  # 24 hours
+# Request timeout for the pod polling loops (_wait_for_pods_to_schedule /
+# _wait_for_pods_to_run): (connect, read) seconds. Without a request timeout,
+# a connection that stops receiving data without being closed (e.g. silently
+# dropped by a NAT/LB after an idle or lifetime limit) blocks the poll
+# forever: the loop stops iterating and the launch hangs until
+# provision_timeout, which can be hours in autoscaling/queueing setups. The
+# read timeout bounds each socket read (idle time), not the whole response,
+# so large pod lists that stream slowly are unaffected.
+_POD_POLL_REQUEST_TIMEOUT = (5, 30)
+# How long a continuous streak of pod-poll transport errors may last before
+# it surfaces as an error. A transient failure (timeout, dropped connection)
+# is treated as a missed poll and retried, but a persistently unreachable API
+# server should still surface instead of retrying silently forever. The
+# budget is wall-clock rather than attempt-based so that fast-failing errors
+# (e.g. connection refused) get the same tolerance as slow read timeouts.
+_POD_POLL_TRANSPORT_ERROR_GRACE_SECONDS = 180
 _NUM_THREADS = subprocess_utils.get_parallel_threads('kubernetes')
 
 # Normal-type pod events that represent slow, legitimately-in-flight steps
@@ -339,7 +355,9 @@ def _raise_pod_scheduling_errors(namespace, context, new_nodes):
                        'may be too slow to autoscale.')
     for new_node in new_nodes:
         pod = kubernetes.core_api(context).read_namespaced_pod(
-            new_node.metadata.name, namespace)
+            new_node.metadata.name,
+            namespace,
+            _request_timeout=_POD_POLL_REQUEST_TIMEOUT)
         pod_status = pod.status.phase
         # When there are multiple pods involved while launching instance,
         # there may be a single pod causing issue while others are
@@ -351,7 +369,8 @@ def _raise_pod_scheduling_errors(namespace, context, new_nodes):
         events = kubernetes.core_api(context).list_namespaced_event(
             namespace,
             field_selector=(f'involvedObject.name={pod_name},'
-                            'involvedObject.kind=Pod'))
+                            'involvedObject.kind=Pod'),
+            _request_timeout=_POD_POLL_REQUEST_TIMEOUT)
         # Events created in the past hours are kept by
         # Kubernetes python client and we want to surface
         # the latest event message
@@ -505,7 +524,9 @@ def _detect_cluster_event_reason_occurred(namespace, context, search_start,
         return None
 
     events = kubernetes.core_api(context).list_namespaced_event(
-        namespace=namespace, field_selector=f'reason={reason}')
+        namespace=namespace,
+        field_selector=f'reason={reason}',
+        _request_timeout=_POD_POLL_REQUEST_TIMEOUT)
     for event in events.items:
         ts = _get_event_timestamp(event)
         if ts and _convert_to_utc(ts) > search_start:
@@ -578,6 +599,44 @@ def _update_spinner_message(*, iteration: int, pods: List[Any],
 
 
 @timeline.event
+def _is_transport_error(e: Exception) -> bool:
+    """Whether ``e`` is a failure of the HTTP transport to the API server.
+
+    urllib3 transport errors propagate raw out of the kubernetes client,
+    with one exception: the client wraps ``urllib3.exceptions.SSLError``
+    into an ``ApiException`` with ``status=0`` (no HTTP response was
+    received). An ``ApiException`` with a real HTTP status is an API error
+    response, not a transport failure.
+    """
+    if isinstance(e, kubernetes.api_exception()):
+        return e.status == 0
+    return isinstance(e, kubernetes.urllib3_http_error())
+
+
+def _count_transport_error(e: Exception, first_error_time: Optional[float],
+                           cluster_name: str) -> float:
+    """Account a pod-poll transport error; raise once the streak persists.
+
+    Treats the error as a missed poll: debug-log, sleep out the tick, and
+    return the start time of the current failure streak (callers pass the
+    returned value back in, and reset it to None on the next success). Once
+    a streak lasts _POD_POLL_TRANSPORT_ERROR_GRACE_SECONDS, raise
+    KubernetesError instead.
+    """
+    now = time.time()
+    if first_error_time is None:
+        first_error_time = now
+    if now - first_error_time >= _POD_POLL_TRANSPORT_ERROR_GRACE_SECONDS:
+        raise config_lib.KubernetesError(
+            'Lost connectivity to the Kubernetes API server while waiting '
+            f'for the pods of {cluster_name}: '
+            f'{common_utils.format_exception(e)}') from e
+    logger.debug(f'Transient error polling the pods of {cluster_name}: '
+                 f'{common_utils.format_exception(e)}. Retrying.')
+    time.sleep(1)
+    return first_error_time
+
+
 def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
                                cluster_name: str,
                                create_pods_start: datetime.datetime):
@@ -674,16 +733,29 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
         return time.time() < deadline
 
     iteration = 0
+    transport_error_since: Optional[float] = None
     while _evaluate_timeout():
         # Get all pods in a single API call using the cluster name label
         # which all pods in new_nodes should share
         cluster_name_on_cloud = new_nodes[0].metadata.labels[
             constants.TAG_SKYPILOT_CLUSTER_NAME]
-        pods = kubernetes.core_api(context).list_namespaced_pod(
-            namespace,
-            label_selector=
-            f'{constants.TAG_SKYPILOT_CLUSTER_NAME}={cluster_name_on_cloud}'
-        ).items
+        try:
+            pods = kubernetes.core_api(context).list_namespaced_pod(
+                namespace,
+                label_selector=(f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                                f'{cluster_name_on_cloud}'),
+                _request_timeout=_POD_POLL_REQUEST_TIMEOUT).items
+            transport_error_since = None
+        except (kubernetes.api_exception(),
+                kubernetes.urllib3_http_error()) as e:
+            # Treat a transport failure as a missed poll and retry within
+            # the deadline above; see _POD_POLL_REQUEST_TIMEOUT for why the
+            # call must be bounded rather than left to block indefinitely.
+            if not _is_transport_error(e):
+                raise
+            transport_error_since = _count_transport_error(
+                e, transport_error_since, cluster_name)
+            continue
 
         # Get the set of found pod names and check if we have all expected pods
         found_pod_names = {pod.metadata.name for pod in pods}
@@ -983,16 +1055,30 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             f'{reason}{detail}')
 
     missing_pods_retry = 0
+    transport_error_since: Optional[float] = None
     last_status_msg: Optional[str] = None
     while True:
         # Get all pods in a single API call
         cluster_name_on_cloud = new_pods[0].metadata.labels[
             constants.TAG_SKYPILOT_CLUSTER_NAME]
-        all_pods = kubernetes.core_api(context).list_namespaced_pod(
-            namespace,
-            label_selector=
-            f'{constants.TAG_SKYPILOT_CLUSTER_NAME}={cluster_name_on_cloud}'
-        ).items
+        try:
+            all_pods = kubernetes.core_api(context).list_namespaced_pod(
+                namespace,
+                label_selector=(f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                                f'{cluster_name_on_cloud}'),
+                _request_timeout=_POD_POLL_REQUEST_TIMEOUT).items
+            transport_error_since = None
+        except (kubernetes.api_exception(),
+                kubernetes.urllib3_http_error()) as e:
+            # Same missed-poll treatment as in _wait_for_pods_to_schedule.
+            # This loop has no deadline, so the transport-error grace window
+            # is what keeps a persistently unreachable API server from
+            # turning into an endless silent retry loop.
+            if not _is_transport_error(e):
+                raise
+            transport_error_since = _count_transport_error(
+                e, transport_error_since, cluster_name)
+            continue
 
         # Get the set of found pod names and check if we have all expected pods
         found_pod_names = {pod.metadata.name for pod in all_pods}

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1,9 +1,11 @@
 """Tests for Kubernetes provision."""
 
+import datetime
 import re
 from unittest import mock
 
 import pytest
+import urllib3
 
 from sky import clouds
 from sky import exceptions as sky_exceptions
@@ -1768,8 +1770,8 @@ class TestWaitForPodsToScheduleQueueGating:
         monkeypatch.setattr(instance.time, 'time', clock.time)
         monkeypatch.setattr(instance.time, 'sleep', clock.sleep)
 
-        def list_pods(namespace, label_selector=None):
-            del namespace, label_selector  # unused
+        def list_pods(namespace, label_selector=None, **kwargs):
+            del namespace, label_selector, kwargs  # unused
             current = pod_timeline[0][1]
             for since, pod in pod_timeline:
                 if clock.now >= since:
@@ -1891,6 +1893,138 @@ class TestWaitForPodsToScheduleQueueGating:
         # The queue-specific error path is taken, not the generic
         # scheduling-error path (gated pods have no scheduler events).
         assert not raise_errors.called
+
+
+class TestWaitForPodsToScheduleTransportErrors:
+    """Transport failures of the pod poll must not wedge or kill the wait.
+
+    The production bug: the poll's list_namespaced_pod call had no request
+    timeout, so a connection silently dropped mid-response (e.g. by a NAT/LB
+    idle limit) blocked the call — and with it the whole launch — forever.
+    The poll is now bounded by _POD_POLL_REQUEST_TIMEOUT; a transport error
+    is treated as a missed tick and retried, and only a failure streak
+    lasting _POD_POLL_TRANSPORT_ERROR_GRACE_SECONDS surfaces as an error.
+    """
+
+    _FakeClock = TestWaitForPodsToScheduleAutoscaleTimeout._FakeClock
+    _make_node = staticmethod(
+        TestWaitForPodsToScheduleAutoscaleTimeout._make_node)
+    _make_pending_pod = staticmethod(
+        TestWaitForPodsToScheduleAutoscaleTimeout._make_pending_pod)
+
+    def _setup(self, monkeypatch, list_side_effect):
+
+        def mock_config(cloud, region, keys, default_value=None, **kwargs):
+            del cloud, region, keys, kwargs  # unused; no autoscaler
+            return default_value
+
+        monkeypatch.setattr('sky.skypilot_config.get_effective_region_config',
+                            mock_config)
+
+        clock = self._FakeClock()
+        monkeypatch.setattr(instance.time, 'time', clock.time)
+        monkeypatch.setattr(instance.time, 'sleep', clock.sleep)
+
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.side_effect = list_side_effect
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+        monkeypatch.setattr(
+            instance, '_raise_pod_scheduling_errors',
+            mock.MagicMock(
+                side_effect=config_lib.KubernetesError('sched-errors')))
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+        return clock, core_api
+
+    @staticmethod
+    def _read_timeout():
+        return urllib3.exceptions.ReadTimeoutError(None, 'url',
+                                                   'Read timed out.')
+
+    def _wait(self, timeout=60):
+        node = self._make_node('pod-0', 'my-cluster')
+        instance._wait_for_pods_to_schedule(
+            namespace='ns',
+            context='test-context',
+            new_nodes=[node],
+            timeout=timeout,
+            cluster_name='cn',
+            create_pods_start=datetime.datetime.now(datetime.timezone.utc))
+
+    def _scheduled_pod(self):
+        pod = self._make_pending_pod('pod-0', 'my-cluster')
+        pod.status.phase = 'Running'
+        return pod
+
+    def _flaky_list(self, failures, error_factory):
+        """A list mock failing ``failures`` times, then serving a scheduled
+        pod. Asserts every poll is bounded by _POD_POLL_REQUEST_TIMEOUT."""
+        scheduled = self._scheduled_pod()
+        state = {'n': 0}
+
+        def list_pods(namespace, label_selector=None, **kwargs):
+            del namespace, label_selector  # unused
+            assert kwargs.get('_request_timeout') == (
+                instance._POD_POLL_REQUEST_TIMEOUT)
+            state['n'] += 1
+            if state['n'] <= failures:
+                raise error_factory()
+            result = mock.MagicMock()
+            result.items = [scheduled]
+            return result
+
+        return list_pods
+
+    def test_transient_transport_error_is_retried(self, monkeypatch):
+        """A couple of timed-out polls are missed ticks, not a failure."""
+        _, core_api = self._setup(monkeypatch,
+                                  self._flaky_list(2, self._read_timeout))
+        self._wait()
+        assert core_api.list_namespaced_pod.call_count == 3
+
+    def test_wrapped_ssl_error_is_retried(self, monkeypatch):
+        """The kubernetes client wraps urllib3 SSLError into
+        ApiException(status=0); it must be retried like any other transport
+        error, while ApiExceptions with a real HTTP status still raise."""
+        _, core_api = self._setup(
+            monkeypatch,
+            self._flaky_list(
+                2, lambda: kubernetes.api_exception()
+                (status=0, reason='TLS blip')))
+        self._wait()
+        assert core_api.list_namespaced_pod.call_count == 3
+
+    def test_api_error_response_is_not_retried(self, monkeypatch):
+        """An HTTP error response (e.g. 403) is not a transport failure and
+        must fail fast, unchanged."""
+        self._setup(
+            monkeypatch,
+            self._flaky_list(
+                1, lambda: kubernetes.api_exception()
+                (status=403, reason='Forbidden')))
+        with pytest.raises(kubernetes.api_exception()):
+            self._wait()
+
+    def test_persistent_transport_errors_raise(self, monkeypatch):
+        """A persistently unreachable API server surfaces as an error once
+        the failure streak outlasts the grace window, instead of retrying
+        silently forever."""
+        clock, core_api = self._setup(
+            monkeypatch, self._flaky_list(10**9, self._read_timeout))
+
+        with pytest.raises(config_lib.KubernetesError,
+                           match='Lost connectivity'):
+            # Timeout far larger than the grace window, so the raise comes
+            # from the transport-error budget, not the deadline.
+            self._wait(timeout=10**6)
+
+        assert clock.now >= instance._POD_POLL_TRANSPORT_ERROR_GRACE_SECONDS
+        # Each missed poll costs ~1s of (fake) sleep, so the streak is
+        # roughly one attempt per second of the grace window.
+        assert core_api.list_namespaced_pod.call_count > 2
 
 
 class TestWaitForPodsToScheduleBoundPod:


### PR DESCRIPTION
## Summary

`_wait_for_pods_to_schedule` / `_wait_for_pods_to_run` poll `list_namespaced_pod` with no `_request_timeout`. A connection that stops receiving data without being closed (e.g. silently dropped by a NAT/LB idle limit, or packet loss on a long-haul path to the apiserver) blocks the poll forever: the wait loop stops iterating and the launch hangs until `provision_timeout` — hours in autoscaling/queueing setups — while pinning an API server executor worker for the whole time. Observed in production; py-spy of a launch worker wedged for ~1h (all further loop work, including spinner/status updates, never ran again):

```
Thread (active): "MainThread"
    read (ssl.py:1163)
    ...
    _read_chunked (http/client.py:592)
    ...
    list_namespaced_pod (kubernetes/client/api/core_v1_api.py:15968)
    with_refresh (sky/adaptors/kubernetes.py:320)
    _wait_for_pods_to_schedule (sky/provision/kubernetes/instance.py:648)
    _create_pods (sky/provision/kubernetes/instance.py:1815)
    ...
```

Changes:

- Bound each poll with `_request_timeout=(5, 30)` (connect, per-read idle). The read timeout bounds socket idle time, not the whole response, so large pod lists that stream slowly are unaffected. The same timeout is applied to the other unbounded calls reachable from the wait loops — the per-tick autoscale-event lists (`_detect_cluster_event_reason_occurred`) and the post-deadline error reporting (`_raise_pod_scheduling_errors`) — which would otherwise reproduce the same wedge one call later, exactly when the network is already broken.
- Treat a transport error as a missed tick: debug-log, sleep 1s, retry. A failure streak lasting 180s (wall-clock, so fast connection-refused failures get the same tolerance as slow read timeouts) surfaces as `KubernetesError('Lost connectivity ...')` — `_wait_for_pods_to_run` has no deadline, so this is what keeps a persistently unreachable apiserver from becoming a silent endless retry loop, while a single blip no longer fails the launch.
- Transport errors are matched via a new adaptor helper `kubernetes.urllib3_http_error()` plus `ApiException(status=0)`: the kubernetes client re-wraps `urllib3.exceptions.SSLError` into an `ApiException` with no HTTP status, so TLS-level blips are retried too, while genuine API error responses (4xx/5xx) fail fast unchanged.

## Tested

- New unit tests (`TestWaitForPodsToScheduleTransportErrors`): transient read timeouts and wrapped SSL errors are retried and the wait succeeds; an HTTP 403 still fails fast; a persistent outage raises `KubernetesError` after the grace window; every poll is asserted to carry `_request_timeout`.
- `pytest tests/unit_tests/kubernetes/test_provision.py` — 145 passed.
- yapf 0.32.0 / isort 5.12.0 (CI-pinned versions) clean on changed files.
- `/quicktest-core --kubernetes` and `/smoke-test --kubernetes -k basic` (47 jobs) passed on the previous revision of this change; re-triggering on the current revision.