### PR TITLE
[Server] Validate and parameterize request-status queries

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -164,6 +164,37 @@ REQUEST_COLUMNS = [
 ]
 
 
+def validate_fields(fields: Optional[List[str]]) -> None:
+    """Validates a caller-supplied column list for a request query.
+
+    `fields` reaches the SQL SELECT list by string interpolation (the column
+    list cannot be a bound parameter), and some callers pass it straight from
+    a client query param. Anything not an exact known column name is rejected
+    so the interpolation can only ever emit column names.
+
+    Raises:
+        ValueError: if any field is not a known request column.
+    """
+    if not fields:
+        return
+    unknown = [field for field in fields if field not in REQUEST_COLUMNS]
+    if unknown:
+        raise ValueError(f'Unknown request field(s): {unknown}. '
+                         f'Valid fields: {REQUEST_COLUMNS}')
+
+
+def _columns_str(fields: Optional[List[str]]) -> str:
+    """Returns the validated SELECT column list for a request query.
+
+    Raises:
+        ValueError: if any field is not a known request column.
+    """
+    if not fields:
+        return ', '.join(REQUEST_COLUMNS)
+    validate_fields(fields)
+    return ', '.join(fields)
+
+
 class ScheduleType(enum.Enum):
     """The schedule type for the requests."""
     LONG = 'long'
@@ -812,9 +843,7 @@ def _get_request_no_lock(
         fields: Optional[List[str]] = None) -> Optional[Request]:
     """Get a SkyPilot API request."""
     assert _DB is not None
-    columns_str = ', '.join(REQUEST_COLUMNS)
-    if fields:
-        columns_str = ', '.join(fields)
+    columns_str = _columns_str(fields)
     where, params = _request_id_where(request_id)
     with _DB.conn:
         cursor = _DB.conn.cursor()
@@ -833,9 +862,7 @@ async def _get_request_no_lock_async(
         fields: Optional[List[str]] = None) -> Optional[Request]:
     """Async version of _get_request_no_lock."""
     assert _DB is not None
-    columns_str = ', '.join(REQUEST_COLUMNS)
-    if fields:
-        columns_str = ', '.join(fields)
+    columns_str = _columns_str(fields)
     where, params = _request_id_where(request_id)
     async with _DB.execute_fetchall_async(
             f'SELECT {columns_str} FROM {REQUEST_TABLE} WHERE {where}',
@@ -1012,6 +1039,10 @@ class RequestTaskFilter:
             raise ValueError(
                 'Only one of exclude_request_names or include_request_names '
                 'can be provided, not both.')
+        # `fields` becomes the SELECT list by interpolation, and some callers
+        # pass it through from a client query param. Validate here so every
+        # caller of this filter is covered, not just the ones that remember to.
+        validate_fields(self.fields)
 
     def build_query(self) -> Tuple[str, List[Any]]:
         """Build the SQL query and filter parameters.
@@ -1022,26 +1053,29 @@ class RequestTaskFilter:
         filters = []
         filter_params: List[Any] = []
         if self.status is not None:
-            status_list_str = ','.join(
-                repr(status.value) for status in self.status)
-            filters.append(f'status IN ({status_list_str})')
+            status_placeholders = ','.join(['?'] * len(self.status))
+            filters.append(f'status IN ({status_placeholders})')
+            filter_params.extend(status.value for status in self.status)
         if self.include_request_names is not None:
-            request_names_str = ','.join(
-                repr(name) for name in self.include_request_names)
-            filters.append(f'name IN ({request_names_str})')
+            name_placeholders = ','.join(['?'] *
+                                         len(self.include_request_names))
+            filters.append(f'name IN ({name_placeholders})')
+            filter_params.extend(self.include_request_names)
         if self.exclude_request_names is not None:
-            exclude_request_names_str = ','.join(
-                repr(name) for name in self.exclude_request_names)
-            filters.append(f'name NOT IN ({exclude_request_names_str})')
+            exclude_placeholders = ','.join(['?'] *
+                                            len(self.exclude_request_names))
+            filters.append(f'name NOT IN ({exclude_placeholders})')
+            filter_params.extend(self.exclude_request_names)
         if self.cluster_names is not None:
             if len(self.cluster_names) == 0:
                 # Empty IN () is invalid SQL in PostgreSQL.
                 # An empty list means "match nothing".
                 filters.append('1=0')
             else:
-                cluster_names_str = ','.join(
-                    repr(name) for name in self.cluster_names)
-                filters.append(f'{COL_CLUSTER_NAME} IN ({cluster_names_str})')
+                cluster_placeholders = ','.join(['?'] * len(self.cluster_names))
+                filters.append(
+                    f'{COL_CLUSTER_NAME} IN ({cluster_placeholders})')
+                filter_params.extend(self.cluster_names)
         if self.user_id is not None:
             filters.append(f'{COL_USER_ID} = ?')
             filter_params.append(self.user_id)
@@ -1434,10 +1468,10 @@ class SqliteRequestBackend(request_storage.RequestBackend):
         stale_ids = [rid for rid in existing if rid not in keep_ids]
         if not stale_ids:
             return
-        id_list_str = ','.join(repr(rid) for rid in stale_ids)
+        placeholders = ','.join(['?'] * len(stale_ids))
         await _DB.execute_and_commit_async(
             f'DELETE FROM {REQUEST_TABLE} '
-            f'WHERE request_id IN ({id_list_str})')
+            f'WHERE request_id IN ({placeholders})', tuple(stale_ids))
         logger.info(f'Deleted orphan internal daemon rows: {stale_ids}')
 
     @init_db
@@ -1477,13 +1511,13 @@ class SqliteRequestBackend(request_storage.RequestBackend):
         if not request_ids:
             return
         assert _DB is not None
-        id_list_str = ','.join(repr(rid) for rid in request_ids)
+        placeholders = ','.join(['?'] * len(request_ids))
         if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
             logger.debug(f'Start deleting requests {request_ids}')
         try:
             await _DB.execute_and_commit_async(
                 f'DELETE FROM {REQUEST_TABLE} '
-                f'WHERE request_id IN ({id_list_str})')
+                f'WHERE request_id IN ({placeholders})', tuple(request_ids))
         finally:
             if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
                 logger.debug(f'End deleting requests {request_ids}')
@@ -1570,10 +1604,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             request_id_prefix: str,
             fields: Optional[List[str]] = None) -> Optional[List[Request]]:
         assert _DB is not None
-        if fields:
-            columns_str = ', '.join(fields)
-        else:
-            columns_str = ', '.join(REQUEST_COLUMNS)
+        columns_str = _columns_str(fields)
         clause, params = _request_id_prefix_clause(request_id_prefix)
         with _DB.conn:
             cursor = _DB.conn.cursor()
@@ -1593,10 +1624,7 @@ class SqliteRequestBackend(request_storage.RequestBackend):
             request_id_prefix: str,
             fields: Optional[List[str]] = None) -> Optional[List[Request]]:
         assert _DB is not None
-        if fields:
-            columns_str = ', '.join(fields)
-        else:
-            columns_str = ', '.join(REQUEST_COLUMNS)
+        columns_str = _columns_str(fields)
         clause, params = _request_id_prefix_clause(request_id_prefix)
         async with _DB.execute_fetchall_async(
                 f'SELECT {columns_str} FROM {REQUEST_TABLE} {clause}',

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2682,6 +2682,13 @@ async def api_status(
         None, description='Filter requests by cluster name.'),
 ) -> List[payloads.RequestPayload]:
     """Gets the list of requests."""
+    # `fields` is caller-supplied and ends up in the SQL column list. Reject an
+    # unknown column here so the client gets a 400 instead of a 500 from the
+    # query layer.
+    try:
+        requests_lib.validate_fields(fields)
+    except ValueError as e:
+        raise fastapi.HTTPException(status_code=400, detail=str(e)) from e
     if request_ids is None:
         statuses = None
         if not all_status:

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1274,20 +1274,20 @@ def test_requests_filter():
         status=[RequestStatus.PENDING, RequestStatus.RUNNING], sort=True)
     sql, params = filter_status.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE status IN (\'PENDING\',\'RUNNING\') '
+                    'WHERE status IN (?,?) '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == []
+    assert params == ['PENDING', 'RUNNING']
 
     # Test cluster_names filter
     filter_clusters = requests.RequestTaskFilter(
         cluster_names=['cluster1', 'cluster2'], sort=True)
     sql, params = filter_clusters.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE cluster_name IN (\'cluster1\',\'cluster2\') '
+                    'WHERE cluster_name IN (?,?) '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == []
+    assert params == ['cluster1', 'cluster2']
 
     # Test user_id filter (uses parameterized query)
     filter_user = requests.RequestTaskFilter(user_id='test-user-123', sort=True)
@@ -1302,20 +1302,20 @@ def test_requests_filter():
         exclude_request_names=['request1', 'request2'], sort=True)
     sql, params = filter_exclude.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE name NOT IN (\'request1\',\'request2\') '
+                    'WHERE name NOT IN (?,?) '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == []
+    assert params == ['request1', 'request2']
 
     # Test include_request_names filter
     filter_include = requests.RequestTaskFilter(
         include_request_names=['request3', 'request4'], sort=True)
     sql, params = filter_include.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE name IN (\'request3\',\'request4\') '
+                    'WHERE name IN (?,?) '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == []
+    assert params == ['request3', 'request4']
 
     # Test finished_before filter (uses parameterized query)
     timestamp = 1234567890.0
@@ -1337,13 +1337,17 @@ def test_requests_filter():
         sort=True)
     sql, params = filter_combined.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE status IN (\'SUCCEEDED\',\'FAILED\') AND '
-                    'name NOT IN (\'internal-task\') AND '
-                    'cluster_name IN (\'prod-cluster\') AND '
+                    'WHERE status IN (?,?) AND '
+                    'name NOT IN (?) AND '
+                    'cluster_name IN (?) AND '
                     'user_id = ? AND finished_at < ? '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == ['admin-user', 9876543210.0]
+    # Parameter order must match placeholder order in the SQL above.
+    assert params == [
+        'SUCCEEDED', 'FAILED', 'internal-task', 'prod-cluster', 'admin-user',
+        9876543210.0
+    ]
 
     # Test mutually exclusive filters raise ValueError
     with pytest.raises(ValueError, match='Only one of exclude_request_names'):
@@ -1351,17 +1355,55 @@ def test_requests_filter():
                                    include_request_names=['req2'],
                                    sort=True)
 
-    # Test special characters in names are properly escaped with repr()
+    # Names with quotes are bound as parameters, never interpolated. repr()
+    # was previously used here, which emitted a double-quoted value -- a
+    # SQL *identifier*, not a string literal.
     filter_special_chars = requests.RequestTaskFilter(
         cluster_names=['cluster\'with\'quotes', 'cluster\"with\"double'],
         sort=True)
     sql, params = filter_special_chars.build_query()
-    # repr() should properly escape the quotes
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE cluster_name IN (\"cluster\'with\'quotes\",'
-                    '\'cluster\"with\"double\') ORDER BY created_at DESC')
+                    'WHERE cluster_name IN (?,?) ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == []
+    assert params == ['cluster\'with\'quotes', 'cluster\"with\"double']
+    # The values themselves must not appear in the SQL text at all.
+    assert 'with\'quotes' not in sql
+    assert 'with\"double' not in sql
+
+
+def test_validate_fields_rejects_injection():
+    """`fields` reaches the SELECT list by interpolation -- allowlist it."""
+    # Every known column is accepted.
+    requests.validate_fields(requests.REQUEST_COLUMNS)
+    requests.validate_fields(['request_id', 'status'])
+    # None/empty mean "all columns".
+    requests.validate_fields(None)
+    requests.validate_fields([])
+
+    injections = [
+        'request_id) FROM requests--',
+        '(SELECT 1)',
+        'request_id, (SELECT user_id FROM requests LIMIT 1)',
+        '*',
+        'request_id;DROP TABLE requests',
+        'rowid',
+    ]
+    for payload in injections:
+        with pytest.raises(ValueError, match='Unknown request field'):
+            requests.validate_fields([payload])
+        # Also rejected when smuggled alongside a valid column.
+        with pytest.raises(ValueError, match='Unknown request field'):
+            requests.validate_fields(['request_id', payload])
+
+
+def test_requests_filter_rejects_bad_fields():
+    """RequestTaskFilter validates `fields` for every caller, at construction."""
+    filter_ok = requests.RequestTaskFilter(fields=['request_id', 'status'])
+    sql, _ = filter_ok.build_query()
+    assert sql.startswith('SELECT request_id, status FROM')
+
+    with pytest.raises(ValueError, match='Unknown request field'):
+        requests.RequestTaskFilter(fields=['request_id) FROM requests--'])
 
 
 def test_encode_requests_empty_list():


### PR DESCRIPTION
## Summary

- The `GET /api/status` `fields` query parameter was interpolated directly into the SQL `SELECT` list. Validate `fields` against `REQUEST_COLUMNS` in one place (`RequestTaskFilter` / the shared column-list helper) and return `400` for any unknown column.
- Bind the previously `repr()`-interpolated list filters (`status`, `include`/`exclude_request_names`, `cluster_names`) and both `DELETE ... IN (...)` sites as SQL parameters instead of interpolating them.

Hardening of the request-tracking query layer; no user-facing behavior change for valid inputs.

## Test plan

- `pytest tests/unit_tests/test_sky/server/requests/test_requests.py` (64 passed). Added `test_validate_fields_rejects_injection` and `test_requests_filter_rejects_bad_fields`; updated `test_requests_filter` to the bound-parameter contract.
- Revert-checked: disabling the validator fails the new tests; restoring `repr()` fails the filter test.
- Manual: on a local server, `GET /api/status?fields=<known column>` and `sky api status` / `-v` behave as before; unknown/expression `fields` values return `400`; a quoted `cluster_name` filter returns `200` (bound, not interpolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)