### PR TITLE
[Server] Scope request-tracking endpoints to the calling user

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1587,6 +1587,12 @@ class SqliteRequestBackend(request_storage.RequestBackend):
                 if not _should_kill_request(request_id, request_record):
                     continue
                 assert request_record is not None
+                # When a user_id scope is given, only cancel requests owned by
+                # that user. Without this, an explicit request_ids list would
+                # bypass the scope entirely and let a caller cancel another
+                # user's request.
+                if (user_id is not None and request_record.user_id != user_id):
+                    continue
                 if request_record.pid is not None:
                     logger.debug(
                         f'Killing request process {request_record.pid}')

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -21,12 +21,71 @@ than a middleware so it can mutate the parsed pydantic body
 in-place; standard Starlette middlewares run before body parsing.
 """
 
+from typing import Optional
+
 import fastapi
 
 from sky.server.requests import payloads
 from sky.users import permission
 from sky.users import rbac
 from sky.utils import common as common_lib
+
+
+def _is_admin(request: fastapi.Request) -> bool:
+    """Return True if the authenticated caller has the admin role.
+
+    Uses the in-memory Casbin enforcer state (no DB roundtrip), matching
+    `_is_viewer` and `PermissionService.check_endpoint_permission`.
+    """
+    auth_user = getattr(request.state, 'auth_user', None)
+    if auth_user is None:
+        return False
+    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
+    roles = enforcer.get_roles_for_user(auth_user.id)
+    return rbac.RoleName.ADMIN.value in roles
+
+
+def request_owner_scope(request: fastapi.Request) -> Optional[str]:
+    """The user_id that request-tracking queries must be scoped to.
+
+    Returns ``None`` (meaning "no scope — see every user's requests") when:
+      * no authentication is configured (``auth_user`` is unset), i.e. a
+        single-user/local server where ownership is not enforceable; or
+      * the caller is an admin.
+    Otherwise returns the caller's own user id, so a non-admin only ever
+    sees or acts on their own requests.
+
+    This is the single place that decides request-object visibility; every
+    ``/api/{get,stream,status,cancel,completion}`` handler routes its scope
+    through here.
+    """
+    auth_user = getattr(request.state, 'auth_user', None)
+    if auth_user is None:
+        return None
+    if _is_admin(request):
+        return None
+    return auth_user.id
+
+
+def force_caller_scope_cancel_body(
+    request: fastapi.Request,
+    request_cancel_body: payloads.RequestCancelBody,
+) -> payloads.RequestCancelBody:
+    """Bind `POST /api/cancel` to the caller unless they are an admin.
+
+    A non-admin caller may only cancel their own requests, regardless of the
+    ``user_id`` they put in the body. Admins (and no-auth servers) keep the
+    client-supplied value, so ``--all-users`` (``user_id=None`` => every
+    request) still works for them. The strictly-read-only viewer role may not
+    cancel anything at all.
+    """
+    if _is_viewer(request):
+        raise fastapi.HTTPException(
+            status_code=403, detail='The viewer role cannot cancel requests.')
+    scope = request_owner_scope(request)
+    if scope is not None:
+        request_cancel_body.user_id = scope
+    return request_cancel_body
 
 
 def _is_viewer(request: fastapi.Request) -> bool:

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -31,26 +31,14 @@ from sky.users import rbac
 from sky.utils import common as common_lib
 
 
-def _is_admin(request: fastapi.Request) -> bool:
-    """Return True if the authenticated caller has the admin role.
-
-    Uses the in-memory Casbin enforcer state (no DB roundtrip), matching
-    `_is_viewer` and `PermissionService.check_endpoint_permission`.
-    """
-    auth_user = getattr(request.state, 'auth_user', None)
-    if auth_user is None:
-        return False
-    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
-    roles = enforcer.get_roles_for_user(auth_user.id)
-    return rbac.RoleName.ADMIN.value in roles
-
-
 def request_owner_scope(request: fastapi.Request) -> Optional[str]:
     """The user_id that request-tracking queries must be scoped to.
 
     Returns ``None`` (meaning "no scope — see every user's requests") when:
-      * no authentication is configured (``auth_user`` is unset), i.e. a
-        single-user/local server where ownership is not enforceable; or
+      * the API server has no per-user identity for the caller
+        (``auth_user`` is unset) — either a single-user/local server, or a
+        deployment where auth is terminated upstream (e.g. basic auth at the
+        ingress) so no RBAC applies; or
       * the caller is an admin.
     Otherwise returns the caller's own user id, so a non-admin only ever
     sees or acts on their own requests.
@@ -62,7 +50,10 @@ def request_owner_scope(request: fastapi.Request) -> Optional[str]:
     auth_user = getattr(request.state, 'auth_user', None)
     if auth_user is None:
         return None
-    if _is_admin(request):
+    # In-memory Casbin lookup (no DB roundtrip), matching `_is_viewer`.
+    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
+    roles = enforcer.get_roles_for_user(auth_user.id)
+    if rbac.RoleName.ADMIN.value in roles:
         return None
     return auth_user.id
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3586,15 +3586,20 @@ async def complete_api_request(request: fastapi.Request,
     scope_user_id = role_filter.request_owner_scope(request)
     if scope_user_id is None:
         return await requests_lib.get_api_request_ids_start_with(incomplete)
-    # Non-admin: only complete the caller's own request IDs.
-    request_tasks = await requests_lib.get_requests_async_with_prefix(
-        incomplete, fields=['request_id', 'user_id'])
-    if request_tasks is None:
-        return []
+    # Non-admin: complete only the caller's own request IDs. Fetch their recent
+    # requests with the user_id filter, ordering, and 1000-row cap applied in
+    # SQL (via RequestTaskFilter), then prefix-match in memory. This keeps the
+    # bounded, recency-ordered behavior of the admin path instead of an
+    # unbounded full-table scan (an empty prefix would otherwise load every
+    # user's requests into memory).
+    request_tasks = await requests_lib.get_request_tasks_async(
+        req_filter=requests_lib.RequestTaskFilter(
+            user_id=scope_user_id, fields=['request_id'], sort=True, limit=1000)
+    )
     return [
         task.request_id
         for task in request_tasks
-        if task.user_id == scope_user_id
+        if task.request_id.startswith(incomplete)
     ]
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2375,11 +2375,24 @@ async def local_down(request: fastapi.Request,
     )
 
 
-async def get_expanded_request_id(request_id: str) -> str:
-    """Gets the expanded request ID for a given request ID prefix."""
+async def get_expanded_request_id(request_id: str,
+                                  scope_user_id: Optional[str] = None) -> str:
+    """Gets the expanded request ID for a given request ID prefix.
+
+    When ``scope_user_id`` is set, only requests owned by that user are
+    considered candidates. This both hides other users' requests (a
+    non-owned prefix resolves to a 404, identical to a genuine miss) and
+    closes an existence oracle: uniqueness is decided over the caller's own
+    requests only, so another user's request can never turn the response
+    into the distinguishable "multiple requests found" 400.
+    """
     request_tasks = await requests_lib.get_requests_async_with_prefix(
-        request_id, fields=['request_id'])
-    if request_tasks is None:
+        request_id, fields=['request_id', 'user_id'])
+    if request_tasks is not None and scope_user_id is not None:
+        request_tasks = [
+            task for task in request_tasks if task.user_id == scope_user_id
+        ]
+    if not request_tasks:
         raise fastapi.HTTPException(status_code=404,
                                     detail=f'Request {request_id!r} not found')
     if len(request_tasks) > 1:
@@ -2391,10 +2404,13 @@ async def get_expanded_request_id(request_id: str) -> str:
 
 # === API server related APIs ===
 @app.get('/api/get')
-async def api_get(request_id: str) -> payloads.RequestPayload:
+async def api_get(request: fastapi.Request,
+                  request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
-    # Validate request_id prefix matches a single request.
-    request_id = await get_expanded_request_id(request_id)
+    # Validate request_id prefix matches a single request, scoped to the
+    # caller so a non-admin cannot read another user's request.
+    request_id = await get_expanded_request_id(
+        request_id, scope_user_id=role_filter.request_owner_scope(request))
 
     # Exponential backoff: start fast (10ms) for short requests like
     # status/queue, then back off to 100ms for long requests like
@@ -2492,11 +2508,32 @@ async def stream(
             status_code=400,
             detail='Only one of request_id and log_path can be provided')
 
+    scope_user_id = role_filter.request_owner_scope(request)
+
+    if log_path is not None and scope_user_id is not None:
+        # log_path streaming targets arbitrary files under the shared
+        # ~/sky_logs tree and the multi-tenant API server log. A non-admin
+        # has no supported use for it, so gate it to admins/no-auth.
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Streaming logs by log_path is restricted to admins.')
+
     if request_id is not None:
-        request_id = await get_expanded_request_id(request_id)
+        request_id = await get_expanded_request_id(request_id,
+                                                   scope_user_id=scope_user_id)
 
     if request_id is None and log_path is None:
-        request_id = await requests_lib.get_latest_request_id_async()
+        if scope_user_id is None:
+            request_id = await requests_lib.get_latest_request_id_async()
+        else:
+            # Scope "latest request" to the caller instead of leaking the
+            # server-wide most-recent request from any user.
+            latest = await requests_lib.get_request_tasks_async(
+                req_filter=requests_lib.RequestTaskFilter(user_id=scope_user_id,
+                                                          fields=['request_id'],
+                                                          sort=True,
+                                                          limit=1))
+            request_id = latest[0].request_id if latest else None
         if request_id is None:
             raise fastapi.HTTPException(status_code=404,
                                         detail='No request found')
@@ -2676,8 +2713,11 @@ async def stream(
 
 
 @app.post('/api/cancel')
-async def api_cancel(request: fastapi.Request,
-                     request_cancel_body: payloads.RequestCancelBody) -> None:
+async def api_cancel(
+    request: fastapi.Request,
+    request_cancel_body: payloads.RequestCancelBody = fastapi.Depends(
+        role_filter.force_caller_scope_cancel_body),
+) -> None:
     """Cancels requests."""
     await executor.schedule_request_async(
         request_id=request.state.request_id,
@@ -2715,6 +2755,9 @@ async def api_status(
         requests_lib.validate_fields(fields)
     except ValueError as e:
         raise fastapi.HTTPException(status_code=400, detail=str(e)) from e
+    # Scope to the caller so a non-admin only sees their own requests. None
+    # (admin / no-auth) means unscoped, i.e. every user's requests.
+    scope_user_id = role_filter.request_owner_scope(request)
     if request_ids is None:
         statuses = None
         if not all_status:
@@ -2723,6 +2766,7 @@ async def api_status(
             req_filter=requests_lib.RequestTaskFilter(
                 status=statuses,
                 cluster_names=[cluster_name] if cluster_name else None,
+                user_id=scope_user_id,
                 exclude_request_names=[
                     server_constants.REQUEST_NAME_PREFIX + d.value
                     for d in daemons.HIDDEN_REQUEST_NAMES
@@ -2741,6 +2785,10 @@ async def api_status(
             if request_tasks is None:
                 continue
             for request_task in request_tasks:
+                # Drop requests the caller does not own (non-admin scope).
+                if (scope_user_id is not None and
+                        request_task.user_id != scope_user_id):
+                    continue
                 encoded_request_tasks.append(
                     request_task.readable_encode(caller_user_id=caller_user_id))
         return encoded_request_tasks
@@ -3533,8 +3581,21 @@ async def complete_volume_name(incomplete: str,) -> List[str]:
 
 
 @app.get('/api/completion/api_request')
-async def complete_api_request(incomplete: str,) -> List[str]:
-    return await requests_lib.get_api_request_ids_start_with(incomplete)
+async def complete_api_request(request: fastapi.Request,
+                               incomplete: str) -> List[str]:
+    scope_user_id = role_filter.request_owner_scope(request)
+    if scope_user_id is None:
+        return await requests_lib.get_api_request_ids_start_with(incomplete)
+    # Non-admin: only complete the caller's own request IDs.
+    request_tasks = await requests_lib.get_requests_async_with_prefix(
+        incomplete, fields=['request_id', 'user_id'])
+    if request_tasks is None:
+        return []
+    return [
+        task.request_id
+        for task in request_tasks
+        if task.user_id == scope_user_id
+    ]
 
 
 def _load_dynamic_routes() -> List[Tuple['re.Pattern[str]', str]]:

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2306,3 +2306,54 @@ def test_encode_requests_omits_body_when_owner_unknown():
     with mock.patch('sky.global_user_state.get_all_users', return_value=[]):
         payload = requests.encode_requests([request], caller_user_id='bob')[0]
     assert payload.request_body == json.dumps(None)
+
+
+@pytest.mark.asyncio
+async def test_kill_requests_scoped_by_user(isolated_database):
+    """kill_requests with an explicit request_ids list must still honor the
+    user_id scope, so a caller cannot cancel another user's request."""
+    alice = requests.Request(request_id='kill-alice-1',
+                             name='sky.launch',
+                             entrypoint=dummy,
+                             request_body=payloads.RequestBody(),
+                             status=RequestStatus.RUNNING,
+                             created_at=0.0,
+                             pid=None,
+                             user_id='alice')
+    bob = requests.Request(request_id='kill-bob-1',
+                           name='sky.launch',
+                           entrypoint=dummy,
+                           request_body=payloads.RequestBody(),
+                           status=RequestStatus.RUNNING,
+                           created_at=0.0,
+                           pid=None,
+                           user_id='bob')
+    await requests.create_if_not_exists_async(alice)
+    await requests.create_if_not_exists_async(bob)
+
+    # Alice tries to cancel both by explicit id; only her own is cancelled.
+    cancelled = requests.kill_requests(
+        request_ids=['kill-alice-1', 'kill-bob-1'], user_id='alice')
+    assert cancelled == ['kill-alice-1']
+    assert requests.get_request(
+        'kill-alice-1').status == RequestStatus.CANCELLED
+    # Bob's request is untouched.
+    assert requests.get_request('kill-bob-1').status == RequestStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_kill_requests_unscoped_cancels_all(isolated_database):
+    """user_id=None stays privileged (internal shutdown path): cancels all."""
+    for rid, uid in [('shutdown-a', 'alice'), ('shutdown-b', 'bob')]:
+        await requests.create_if_not_exists_async(
+            requests.Request(request_id=rid,
+                             name='sky.launch',
+                             entrypoint=dummy,
+                             request_body=payloads.RequestBody(),
+                             status=RequestStatus.RUNNING,
+                             created_at=0.0,
+                             pid=None,
+                             user_id=uid))
+    cancelled = requests.kill_requests(request_ids=['shutdown-a', 'shutdown-b'],
+                                       user_id=None)
+    assert set(cancelled) == {'shutdown-a', 'shutdown-b'}

--- a/tests/unit_tests/test_sky/server/test_role_filter.py
+++ b/tests/unit_tests/test_sky/server/test_role_filter.py
@@ -4,6 +4,7 @@ for the viewer role."""
 from unittest import mock
 
 import fastapi
+import pytest
 
 from sky.server.requests import payloads
 from sky.server.requests import role_filter
@@ -142,3 +143,72 @@ def test_force_viewer_volume_refresh_user_unchanged(mock_svc):
     out = role_filter.force_viewer_volume_refresh(_user_request(), refresh=True)
     # Non-viewer is unaffected.
     assert out is True
+
+
+def _admin_request():
+    request = mock.Mock(spec=fastapi.Request)
+    auth_user = mock.Mock()
+    auth_user.id = 'admin-carol'
+    request.state.auth_user = auth_user
+    return request
+
+
+def _enforcer_returning(mock_svc, roles):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = roles
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_request_owner_scope_user_scopes_to_self(mock_svc):
+    _enforcer_returning(mock_svc, [rbac.RoleName.USER.value])
+    assert role_filter.request_owner_scope(_user_request()) == 'user-alice'
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_request_owner_scope_viewer_scopes_to_self(mock_svc):
+    _enforcer_returning(mock_svc, [rbac.RoleName.VIEWER.value])
+    # A viewer is still a non-admin: reads are scoped to their own requests.
+    assert role_filter.request_owner_scope(_viewer_request()) == 'viewer-bob'
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_request_owner_scope_admin_unscoped(mock_svc):
+    _enforcer_returning(mock_svc,
+                        [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
+    # Admin sees every user's requests.
+    assert role_filter.request_owner_scope(_admin_request()) is None
+
+
+def test_request_owner_scope_no_auth_unscoped():
+    # No authentication configured -> ownership is unenforceable, unscoped.
+    assert role_filter.request_owner_scope(_anonymous_request()) is None
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_caller_scope_cancel_body_user_forced(mock_svc):
+    _enforcer_returning(mock_svc, [rbac.RoleName.USER.value])
+    # A non-admin cannot cancel on behalf of another user, even by asking.
+    body = payloads.RequestCancelBody(request_ids=['abc'],
+                                      user_id='someone-else')
+    out = role_filter.force_caller_scope_cancel_body(_user_request(), body)
+    assert out.user_id == 'user-alice'
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_caller_scope_cancel_body_admin_preserved(mock_svc):
+    _enforcer_returning(mock_svc,
+                        [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
+    # Admin keeps the client-supplied scope, incl. user_id=None (all users).
+    body = payloads.RequestCancelBody(request_ids=None, user_id=None)
+    out = role_filter.force_caller_scope_cancel_body(_admin_request(), body)
+    assert out.user_id is None
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_caller_scope_cancel_body_viewer_forbidden(mock_svc):
+    _enforcer_returning(mock_svc, [rbac.RoleName.VIEWER.value])
+    body = payloads.RequestCancelBody(request_ids=['abc'])
+    with pytest.raises(fastapi.HTTPException) as exc:
+        role_filter.force_caller_scope_cancel_body(_viewer_request(), body)
+    assert exc.value.status_code == 403

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -819,7 +819,7 @@ def test_api_get_endpoint_serializes_request_payload(monkeypatch):
         user_id='user-123',
     )
 
-    async def fake_expand(request_id):
+    async def fake_expand(request_id, scope_user_id=None):
         return request_id
 
     async def fake_status(request_id, include_msg=False):
@@ -870,7 +870,7 @@ def _make_interrupted_request(with_error: bool):
 def _mount_api_get_request(monkeypatch, request):
     from sky.server.requests import requests as requests_lib
 
-    async def fake_expand(request_id):
+    async def fake_expand(request_id, scope_user_id=None):
         return request_id
 
     async def fake_status(request_id, include_msg=False):
@@ -1148,3 +1148,187 @@ def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY',
                         str(tmp_path / 'does-not-exist'))
     assert server._prune_sky_logs(cutoff=1_000_000.0) == 0
+
+
+class _FakeTask:
+    """Minimal stand-in for a Request row (only the fields get_expanded uses)."""
+
+    def __init__(self, request_id, user_id):
+        self.request_id = request_id
+        self.user_id = user_id
+
+
+@pytest.mark.asyncio
+async def test_get_expanded_request_id_scopes_to_owner(monkeypatch):
+    all_tasks = [_FakeTask('abc-alice', 'alice'), _FakeTask('abc-bob', 'bob')]
+
+    async def fake_prefix(prefix, fields=None):
+        matched = [t for t in all_tasks if t.request_id.startswith(prefix)]
+        return matched or None
+
+    monkeypatch.setattr(server.requests_lib, 'get_requests_async_with_prefix',
+                        fake_prefix)
+
+    # Alice: uniqueness is decided over her own requests only -> resolves to
+    # hers, NOT a 400 "multiple found" (which would be an existence oracle).
+    assert await server.get_expanded_request_id(
+        'abc', scope_user_id='alice') == 'abc-alice'
+
+    # A prefix that only matches bob's request is a 404 for alice, identical
+    # to a genuine miss (no 400 that would confirm the row exists).
+    with pytest.raises(fastapi.HTTPException) as exc:
+        await server.get_expanded_request_id('abc-bob', scope_user_id='alice')
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_expanded_request_id_admin_unscoped(monkeypatch):
+    both = [_FakeTask('abc-alice', 'alice'), _FakeTask('abc-bob', 'bob')]
+
+    async def fake_prefix(prefix, fields=None):
+        return list(both)
+
+    monkeypatch.setattr(server.requests_lib, 'get_requests_async_with_prefix',
+                        fake_prefix)
+
+    # Unscoped (admin / no-auth): the ambiguous prefix is a 400 as before.
+    with pytest.raises(fastapi.HTTPException) as exc:
+        await server.get_expanded_request_id('abc', scope_user_id=None)
+    assert exc.value.status_code == 400
+
+
+# --- SKY-6429: cross-user request-API access control (integration) ----------
+
+
+def _seed_request(rid, user_id, status=None):
+    from sky.server.requests import payloads
+    from sky.server.requests import requests as requests_lib
+    return requests_lib.Request(request_id=rid,
+                                name='sky.launch',
+                                entrypoint=_api_get_dummy_entrypoint,
+                                request_body=payloads.RequestBody(),
+                                status=status or
+                                requests_lib.RequestStatus.SUCCEEDED,
+                                created_at=1234567890.0,
+                                pid=None,
+                                user_id=user_id)
+
+
+@pytest.fixture()
+def _request_authz_env(tmp_path, monkeypatch):
+    """Isolated request DB seeded with alice's and bob's requests."""
+    import asyncio
+
+    from sky.server.requests import requests as requests_lib
+
+    logs = tmp_path / 'logs'
+    logs.mkdir()
+    monkeypatch.setattr('sky.server.constants.API_SERVER_REQUEST_DB_PATH',
+                        str(tmp_path / 'requests.db'))
+    monkeypatch.setattr('sky.server.constants.REQUEST_LOG_PATH_PREFIX',
+                        str(logs))
+    requests_lib._DB = None
+
+    async def _seed():
+        await requests_lib.create_if_not_exists_async(
+            _seed_request('alice-req-1', 'alice'))
+        await requests_lib.create_if_not_exists_async(
+            _seed_request('bob-req-1', 'bob'))
+
+    asyncio.new_event_loop().run_until_complete(_seed())
+    yield
+    requests_lib._DB = None
+
+
+def _scope_as(monkeypatch, scope):
+    """Force request_owner_scope (the single chokepoint) to a given value."""
+    monkeypatch.setattr(server.role_filter, 'request_owner_scope',
+                        lambda request: scope)
+
+
+def test_api_get_blocks_other_users_request(_request_authz_env, monkeypatch):
+    from fastapi.testclient import TestClient
+    client = TestClient(server.app)
+
+    # Alice can read her own request.
+    _scope_as(monkeypatch, 'alice')
+    assert client.get('/api/get', params={
+        'request_id': 'alice-req-1'
+    }).status_code == 200
+    # Alice cannot read bob's — 404, identical to a genuine miss.
+    assert client.get('/api/get', params={
+        'request_id': 'bob-req-1'
+    }).status_code == 404
+    # Admin (unscoped) can read bob's.
+    _scope_as(monkeypatch, None)
+    assert client.get('/api/get', params={
+        'request_id': 'bob-req-1'
+    }).status_code == 200
+
+
+def test_api_status_scopes_to_caller(_request_authz_env, monkeypatch):
+    from fastapi.testclient import TestClient
+    client = TestClient(server.app)
+
+    _scope_as(monkeypatch, 'alice')
+    ids = {
+        r['request_id']
+        for r in client.get('/api/status', params={
+            'all_status': True
+        }).json()
+    }
+    assert 'alice-req-1' in ids
+    assert 'bob-req-1' not in ids
+
+    # The request_ids (prefix) branch also drops non-owned rows.
+    body = client.get('/api/status',
+                      params={
+                          'request_ids': ['bob-req-1'],
+                          'all_status': True
+                      }).json()
+    assert body == []
+
+    # Admin sees everyone.
+    _scope_as(monkeypatch, None)
+    ids = {
+        r['request_id']
+        for r in client.get('/api/status', params={
+            'all_status': True
+        }).json()
+    }
+    assert {'alice-req-1', 'bob-req-1'} <= ids
+
+
+def test_api_completion_scopes_to_caller(_request_authz_env, monkeypatch):
+    from fastapi.testclient import TestClient
+    client = TestClient(server.app)
+
+    _scope_as(monkeypatch, 'alice')
+    ids = client.get('/api/completion/api_request', params={
+        'incomplete': ''
+    }).json()
+    assert 'alice-req-1' in ids
+    assert 'bob-req-1' not in ids
+
+
+def test_api_stream_log_path_admin_only(_request_authz_env, monkeypatch):
+    from fastapi.testclient import TestClient
+    client = TestClient(server.app)
+
+    # Non-admin: log_path streaming is forbidden.
+    _scope_as(monkeypatch, 'alice')
+    assert client.get('/api/stream',
+                      params={
+                          'log_path': 'api_server/foo.log'
+                      },
+                      headers={
+                          'user-agent': 'curl'
+                      }).status_code == 403
+    # Non-admin cannot stream another user's request either.
+    assert client.get('/api/stream',
+                      params={
+                          'request_id': 'bob-req-1'
+                      },
+                      headers={
+                          'user-agent': 'curl'
+                      }).status_code == 404


### PR DESCRIPTION
## Summary

The request-tracking endpoints (`/api/get`, `/api/stream`, `/api/status`, `/api/cancel`, `/api/completion/api_request`) did not scope results by the calling user. This adds a single visibility helper, `role_filter.request_owner_scope()`, that returns `None` (unscoped) for admins and for servers with no auth configured, and otherwise the caller's own user id; every request endpoint routes through it.

- `get_expanded_request_id()` filters prefix candidates to the caller and decides uniqueness over that owned set, so a request id the caller does not own resolves to `404` (identical to a genuine miss) rather than a distinguishable `400`.
- `/api/status` scopes the no-ids query and drops non-owned rows in the request-ids branch.
- `/api/stream` with no `request_id` returns the caller's own latest request; streaming by `log_path` is restricted to admins.
- `/api/cancel` binds the body `user_id` to the caller (admins keep `--all-users`) and rejects the read-only viewer role; `kill_requests()` enforces the `user_id` scope per request even when an explicit `request_ids` list is passed.
- `/api/completion/api_request` returns only the caller's own request ids.

Admins and no-auth (single-user) servers are unscoped, so their behavior is unchanged. The two visible changes are for non-admins only: `sky api status` shows their own requests, and `sky api logs`/stream with no id returns their own latest.

> Note: stacked on #10273 — review/merge that first; this PR's base will move to `master` once it lands.

## Test plan

- `pytest tests/unit_tests/test_sky/server/test_role_filter.py tests/unit_tests/test_sky/server/requests/test_requests.py tests/unit_tests/test_sky/server/test_server.py` (123 passed). New coverage: `request_owner_scope` per role (user/viewer/admin/no-auth); cancel-body scope forcing + viewer `403`; `kill_requests` owner enforcement with an explicit id list; the `get_expanded_request_id` uniqueness/oracle behavior; and `TestClient` integration tests that `/api/get`, `/api/status` (both branches), `/api/completion/api_request` and `/api/stream` (`log_path` admin-only + non-owned id `404`) block cross-user access against a real request DB while admins pass.
- Revert-checked: dropping the scope makes the cross-user tests fail.
- Manual: live no-auth local server confirms normal single-user usage (status / get by full id and prefix / completion / stream / cancel) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)