### PR TITLE
[Kubernetes] Add read-side DRA GPU support

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -565,6 +565,12 @@ rbac:
     - apiGroups: [ "node.k8s.io" ]
       resources: [ "runtimeclasses" ]
       verbs: [ "get", "list", "watch" ]
+    # Required for discovering GPUs advertised via DRA (Dynamic Resource
+    # Allocation) and accounting their allocations. Read-only; harmless on
+    # clusters without the resource.k8s.io API group.
+    - apiGroups: [ "resource.k8s.io" ]
+      resources: [ "deviceclasses", "resourceslices", "resourceclaims" ]
+      verbs: [ "get", "list", "watch" ]
     # Required for exposing services.
     - apiGroups: [ "networking.k8s.io" ]
       resources: [ "ingressclasses" ]

--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -16,6 +16,7 @@ from sky.adaptors import kubernetes
 from sky.catalog import CloudFilter
 from sky.catalog import common
 from sky.clouds import cloud
+from sky.provision.kubernetes import dra_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 
 if typing.TYPE_CHECKING:
@@ -154,27 +155,35 @@ def _list_accelerators(
     if not kubernetes_utils.check_credentials(context, cloud='kubernetes')[0]:
         return {}, {}, {}
 
-    has_gpu = kubernetes_utils.detect_accelerator_resource(context)
+    has_gpu, _ = kubernetes_utils.detect_accelerator_resource(context)
     if not has_gpu:
         return {}, {}, {}
 
     lf, _ = kubernetes_utils.detect_gpu_label_formatter(context)
-    if not lf:
+    # Per-node GPU capacity advertised via DRA ResourceSlices (empty on
+    # device-plugin-only clusters). Best-effort: failure to read
+    # resource.k8s.io must not break device-plugin listing.
+    try:
+        dra_capacity = dra_utils.get_dra_node_capacity(context)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to get DRA node capacity: {e}')
+        dra_capacity = {}
+    if not lf and not dra_capacity:
         return {}, {}, {}
 
     accelerators_qtys: Set[Tuple[str, int]] = set()
-    keys = lf.get_label_keys()
+    keys = lf.get_label_keys() if lf else []
     nodes = kubernetes_utils.get_kubernetes_nodes(context=context)
 
     # Check if any nodes have accelerators before fetching pods
-    has_accelerator_nodes = False
+    has_accelerator_nodes = bool(dra_capacity)
     for node in nodes:
+        if has_accelerator_nodes:
+            break
         for key in keys:
             if key in node.metadata.labels:
                 has_accelerator_nodes = True
                 break
-        if has_accelerator_nodes:
-            break
 
     # Only fetch pods if we have accelerator nodes and realtime is requested
     allocated_qty_by_node: Dict[str, int] = collections.defaultdict(int)
@@ -203,6 +212,85 @@ def _list_accelerators(
     configured_tolerations = kubernetes_utils.get_configured_tolerations(
         context)
 
+    # Per-node allocation not yet attributed to an accelerator row, so a
+    # node accounted through both node labels and DRA does not have its
+    # allocated GPUs subtracted twice. Note allocated_qty_by_node already
+    # includes GPUs allocated via DRA ResourceClaims.
+    remaining_allocated: Dict[str, int] = dict(allocated_qty_by_node)
+    # DRA capacity not yet accounted through the label-driven pass.
+    remaining_dra: Dict[str, Dict[str, int]] = {
+        node_name: dict(accs) for node_name, accs in dra_capacity.items()
+    }
+
+    def _account_accelerator(node, accelerator_name: str,
+                             accelerator_count: int, node_is_ready: bool,
+                             node_is_cordoned: bool,
+                             node_is_tainted: bool) -> None:
+        """Accumulates one (node, accelerator) row into the result dicts."""
+        # Check if name_filter regex matches the accelerator_name
+        regex_flags = 0 if case_sensitive else re.IGNORECASE
+        if name_filter and not re.match(
+                name_filter, accelerator_name, flags=regex_flags):
+            return
+
+        if accelerator_count > 0:
+            # TPUs are counted in a different way compared to GPUs.
+            # Multi-node GPUs can be split into smaller units and be
+            # provisioned, but TPUs are considered as an atomic unit.
+            if kubernetes_utils.is_tpu_on_gke(accelerator_name):
+                accelerators_qtys.add((accelerator_name, accelerator_count))
+            else:
+                count = 1
+                while count <= accelerator_count:
+                    accelerators_qtys.add((accelerator_name, count))
+                    count *= 2
+                # Add the accelerator count if it's not already in the
+                # set (e.g., if there's 12 GPUs, we should have qtys 1,
+                # 2, 4, 8, 12)
+                if accelerator_count not in accelerators_qtys:
+                    accelerators_qtys.add((accelerator_name, accelerator_count))
+
+        if accelerator_count >= min_quantity_filter:
+            quantized_count = (min_quantity_filter *
+                               (accelerator_count // min_quantity_filter))
+            if accelerator_name not in total_accelerators_capacity:
+                total_accelerators_capacity[accelerator_name] = quantized_count
+            else:
+                total_accelerators_capacity[accelerator_name] += quantized_count
+
+        # Initialize the total_accelerators_available to make sure the
+        # key exists in the dictionary.
+        total_accelerators_available[accelerator_name] = (
+            total_accelerators_available.get(accelerator_name, 0))
+
+        # Skip availability counting for not-ready, cordoned,
+        # or tainted nodes
+        if not node_is_ready or node_is_cordoned or node_is_tainted:
+            return
+
+        if error_on_get_allocated_gpu_qty_by_node:
+            # If we can't get the allocated GPU quantity by each node,
+            # we can't get the GPU usage.
+            total_accelerators_available[accelerator_name] = -1
+            return
+
+        allocated_qty = min(remaining_allocated.get(node.metadata.name, 0),
+                            accelerator_count)
+        remaining_allocated[node.metadata.name] = (
+            remaining_allocated.get(node.metadata.name, 0) - allocated_qty)
+        accelerators_available = accelerator_count - allocated_qty
+
+        if accelerators_available >= min_quantity_filter:
+            quantized_availability = min_quantity_filter * (
+                accelerators_available // min_quantity_filter)
+            if quantized_availability > 0:
+                # only increment when quantized availability is positive
+                # to avoid assertion errors checking keyset sizes in
+                # core.py _realtime_kubernetes_gpu_availability_single
+                total_accelerators_available[accelerator_name] = (
+                    total_accelerators_available.get(accelerator_name, 0) +
+                    quantized_availability)
+
     for node in nodes:
         # Check if node is ready
         node_is_ready = node.is_ready()
@@ -221,6 +309,7 @@ def _list_accelerators(
 
         for key in keys:
             if key in node.metadata.labels:
+                assert lf is not None
                 accelerator_name = lf.get_accelerator_from_label_value(
                     node.metadata.labels.get(key))
 
@@ -234,76 +323,36 @@ def _list_accelerators(
                 if kubernetes_utils.is_multi_host_tpu(node.metadata.labels):
                     continue
 
-                # Check if name_filter regex matches the accelerator_name
-                regex_flags = 0 if case_sensitive else re.IGNORECASE
-                if name_filter and not re.match(
-                        name_filter, accelerator_name, flags=regex_flags):
-                    continue
+                # Generate the accelerator quantities. DRA nodes (appearing
+                # in GPU ResourceSlices) are counted from their
+                # DRA-advertised devices, which do not appear in
+                # allocatable; all other nodes from allocatable. Using a
+                # single per-node mechanism avoids double counting if a
+                # misconfigured node advertises the same GPUs through both.
+                # The DRA entry is consumed so the DRA-only pass below does
+                # not account this row again.
+                dra_count = remaining_dra.get(node.metadata.name,
+                                              {}).pop(accelerator_name, 0)
+                if node.metadata.name in dra_capacity:
+                    accelerator_count = dra_count
+                else:
+                    accelerator_count = (
+                        kubernetes_utils.get_node_accelerator_count(
+                            context, node.status.allocatable))
 
-                # Generate the accelerator quantities
-                accelerator_count = (
-                    kubernetes_utils.get_node_accelerator_count(
-                        context, node.status.allocatable))
+                _account_accelerator(node, accelerator_name, accelerator_count,
+                                     node_is_ready, node_is_cordoned,
+                                     node_is_tainted)
 
-                if accelerator_count > 0:
-                    # TPUs are counted in a different way compared to GPUs.
-                    # Multi-node GPUs can be split into smaller units and be
-                    # provisioned, but TPUs are considered as an atomic unit.
-                    if kubernetes_utils.is_tpu_on_gke(accelerator_name):
-                        accelerators_qtys.add(
-                            (accelerator_name, accelerator_count))
-                    else:
-                        count = 1
-                        while count <= accelerator_count:
-                            accelerators_qtys.add((accelerator_name, count))
-                            count *= 2
-                        # Add the accelerator count if it's not already in the
-                        # set (e.g., if there's 12 GPUs, we should have qtys 1,
-                        # 2, 4, 8, 12)
-                        if accelerator_count not in accelerators_qtys:
-                            accelerators_qtys.add(
-                                (accelerator_name, accelerator_count))
-
-                if accelerator_count >= min_quantity_filter:
-                    quantized_count = (
-                        min_quantity_filter *
-                        (accelerator_count // min_quantity_filter))
-                    if accelerator_name not in total_accelerators_capacity:
-                        total_accelerators_capacity[
-                            accelerator_name] = quantized_count
-                    else:
-                        total_accelerators_capacity[
-                            accelerator_name] += quantized_count
-
-                # Initialize the total_accelerators_available to make sure the
-                # key exists in the dictionary.
-                total_accelerators_available[accelerator_name] = (
-                    total_accelerators_available.get(accelerator_name, 0))
-
-                # Skip availability counting for not-ready, cordoned,
-                # or tainted nodes
-                if not node_is_ready or node_is_cordoned or node_is_tainted:
-                    continue
-
-                if error_on_get_allocated_gpu_qty_by_node:
-                    # If we can't get the allocated GPU quantity by each node,
-                    # we can't get the GPU usage.
-                    total_accelerators_available[accelerator_name] = -1
-                    continue
-
-                allocated_qty = allocated_qty_by_node[node.metadata.name]
-                accelerators_available = accelerator_count - allocated_qty
-
-                if accelerators_available >= min_quantity_filter:
-                    quantized_availability = min_quantity_filter * (
-                        accelerators_available // min_quantity_filter)
-                    if quantized_availability > 0:
-                        # only increment when quantized availability is positive
-                        # to avoid assertion errors checking keyset sizes in
-                        # core.py _realtime_kubernetes_gpu_availability_single
-                        total_accelerators_available[accelerator_name] = (
-                            total_accelerators_available.get(
-                                accelerator_name, 0) + quantized_availability)
+        # Account DRA-advertised accelerators not covered by the label pass
+        # (e.g. DRA-only nodes without GPU Feature Discovery labels).
+        node_dra_capacity = remaining_dra.get(node.metadata.name)
+        if node_dra_capacity:
+            for accelerator_name in list(node_dra_capacity.keys()):
+                accelerator_count = node_dra_capacity.pop(accelerator_name)
+                _account_accelerator(node, accelerator_name, accelerator_count,
+                                     node_is_ready, node_is_cordoned,
+                                     node_is_tainted)
 
     pricing = _get_pricing(context)
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -21,6 +21,7 @@ from sky.adaptors import kubernetes
 from sky.clouds.utils import gcp_utils
 from sky.provision import instance_setup
 from sky.provision.gcp import constants as gcp_constants
+from sky.provision.kubernetes import dra_utils
 from sky.provision.kubernetes import fuse as kubernetes_fuse
 from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import network_utils
@@ -804,6 +805,14 @@ class Kubernetes(clouds.Cloud):
             else:
                 k8s_resource_key = kubernetes_utils.get_gpu_resource_key(
                     context)
+                # On clusters that advertise GPUs via DRA, verify the
+                # extended resource request is schedulable (KEP-5004
+                # DeviceClass mapping) and remap the key to the
+                # DeviceClass-declared name if needed. Raises with
+                # actionable guidance on DRA-only clusters without the
+                # mapping.
+                k8s_resource_key = dra_utils.maybe_remap_resource_key_for_dra(
+                    context, k8s_resource_key)
         else:
             # If no GPUs are requested, we set NVIDIA_VISIBLE_DEVICES=none to
             # maintain GPU isolation. This is to override the default behavior

--- a/sky/provision/kubernetes/dra_utils.py
+++ b/sky/provision/kubernetes/dra_utils.py
@@ -1,0 +1,342 @@
+"""Kubernetes DRA (Dynamic Resource Allocation) utilities.
+
+Read-side support for clusters that advertise GPUs via DRA
+(``resource.k8s.io``: DeviceClass / ResourceSlice / ResourceClaim) instead
+of (or in addition to) the device plugin's extended resources
+(e.g. ``nvidia.com/gpu``).
+
+The write side is unchanged: SkyPilot pods keep requesting the extended
+resource key and rely on KEP-5004 (DRA extended resource mapping, i.e.
+``DeviceClass.spec.extendedResourceName``) for the kube-scheduler to
+translate those requests into ResourceClaims. See ``DRA_SUPPORT_DESIGN.md``
+at the repository root for the full design.
+
+All functions in this module are best-effort and read-only: if the
+``resource.k8s.io`` API group is unavailable (older clusters, missing RBAC),
+they degrade to empty results rather than raising, so device-plugin-only
+clusters are unaffected.
+"""
+import collections
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from sky import exceptions
+from sky import sky_logging
+from sky.adaptors import kubernetes
+from sky.utils import annotations
+from sky.utils import ux_utils
+
+logger = sky_logging.init_logger(__name__)
+
+# Only the GA API (Kubernetes >= 1.34) is supported.
+_DRA_API_GROUP = 'resource.k8s.io'
+_DRA_API_VERSION = 'v1'
+
+# Known DRA drivers that advertise GPU devices, mapping the driver name to
+# the device attribute holding the (human-readable) GPU product name.
+# https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu
+_GPU_DRIVER_PRODUCT_ATTRIBUTES: Dict[str, str] = {
+    'gpu.nvidia.com': 'productName',
+}
+
+
+def _list_dra_objects(context: Optional[str], plural: str) -> Dict[str, Any]:
+    """Lists cluster-scoped resource.k8s.io/v1 objects, returning a dict.
+
+    Uses a raw REST call instead of the typed client so we do not depend on
+    the installed ``kubernetes`` python client shipping the (still moving)
+    ``resource.k8s.io`` models. Raises ApiException on HTTP errors.
+    """
+    api = kubernetes.api_client(context)
+    return api.call_api(
+        f'/apis/{_DRA_API_GROUP}/{_DRA_API_VERSION}/{plural}',
+        'GET',
+        auth_settings=['BearerToken'],
+        response_type='object',
+        _return_http_data_only=True,
+        _request_timeout=kubernetes.API_TIMEOUT,
+    )
+
+
+@annotations.lru_cache(scope='request', maxsize=10)
+def _dra_api_available(context: Optional[str] = None) -> bool:
+    """Returns True if the resource.k8s.io/v1 API is readable.
+
+    Returns False if the API group is unavailable (pre-1.34 or pre-GA
+    cluster) or unreadable (missing RBAC) — callers then fall back to
+    device-plugin-only behavior.
+    """
+    try:
+        _list_dra_objects(context, 'deviceclasses')
+        return True
+    except kubernetes.api_exception() as e:
+        if e.status != 404:
+            logger.debug(f'DRA API unreadable in context {context!r} '
+                         f'(status {e.status}); DRA support disabled for '
+                         'this context.')
+        return False
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to probe DRA API in context {context!r}: {e}')
+        return False
+
+
+@annotations.lru_cache(scope='request', maxsize=10)
+def get_extended_resource_mapping(
+        context: Optional[str] = None) -> Dict[str, str]:
+    """Returns {extendedResourceName: deviceClassName} from DeviceClasses.
+
+    A non-empty mapping means KEP-5004 is configured on the cluster: pods may
+    keep requesting the extended resource (e.g. ``nvidia.com/gpu``) and the
+    scheduler will translate the request into a ResourceClaim.
+    """
+    if not _dra_api_available(context):
+        return {}
+    mapping: Dict[str, str] = {}
+    try:
+        device_classes = _list_dra_objects(context, 'deviceclasses')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to list DeviceClasses: {e}')
+        return {}
+    for item in device_classes.get('items', []) or []:
+        extended_resource_name = item.get('spec',
+                                          {}).get('extendedResourceName')
+        if extended_resource_name:
+            mapping[extended_resource_name] = item['metadata']['name']
+    return mapping
+
+
+def _get_device_attributes(device: Dict[str, Any]) -> Dict[str, Any]:
+    """Extracts the attributes dict from a ResourceSlice device."""
+    return device.get('attributes') or {}
+
+
+def _get_accelerator_from_device(driver: str,
+                                 device: Dict[str, Any]) -> Optional[str]:
+    """Maps a DRA device to a canonical SkyPilot accelerator name.
+
+    Returns None if the driver is not a known GPU driver or the device does
+    not carry a recognizable product name.
+    """
+    product_attribute = _GPU_DRIVER_PRODUCT_ATTRIBUTES.get(driver)
+    if product_attribute is None:
+        return None
+    attributes = _get_device_attributes(device)
+    attribute_value = attributes.get(product_attribute, {})
+    if not isinstance(attribute_value, dict):
+        return None
+    product_name = attribute_value.get('string')
+    if not product_name:
+        return None
+    # DRA product names are human readable (e.g. 'NVIDIA H100 80GB HBM3')
+    # while GFD label values are dash-separated
+    # (e.g. 'NVIDIA-H100-80GB-HBM3'). Normalize and reuse the GFD
+    # canonicalization so both allocation modes yield identical accelerator
+    # names.
+    # pylint: disable-next=import-outside-toplevel
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    return kubernetes_utils.GFDLabelFormatter.get_accelerator_from_label_value(
+        product_name.replace(' ', '-'))
+
+
+@annotations.lru_cache(scope='request', maxsize=10)
+def _get_device_index(
+    context: Optional[str] = None
+) -> Dict[Tuple[str, str, str], Tuple[str, str]]:
+    """Indexes DRA GPU devices from ResourceSlices.
+
+    Returns {(driver, pool, device_name): (node_name, accelerator_name)}.
+    Only devices from known GPU drivers that map to a node and a
+    recognizable accelerator name are included.
+    """
+    if not _dra_api_available(context):
+        return {}
+    try:
+        slices = _list_dra_objects(context, 'resourceslices')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to list ResourceSlices: {e}')
+        return {}
+    index: Dict[Tuple[str, str, str], Tuple[str, str]] = {}
+    for item in slices.get('items', []) or []:
+        spec = item.get('spec', {})
+        driver = spec.get('driver', '')
+        if driver not in _GPU_DRIVER_PRODUCT_ATTRIBUTES:
+            continue
+        node_name = spec.get('nodeName')
+        if not node_name:
+            # Network-attached or multi-node pools cannot be attributed to a
+            # single node; skip (not expected for GPU drivers today).
+            logger.debug(f'Skipping non-node-local ResourceSlice '
+                         f'{item.get("metadata", {}).get("name")!r} from '
+                         f'driver {driver!r}.')
+            continue
+        pool_name = spec.get('pool', {}).get('name', '')
+        for device in spec.get('devices', []) or []:
+            accelerator = _get_accelerator_from_device(driver, device)
+            if accelerator is None:
+                continue
+            device_name = device.get('name', '')
+            index[(driver, pool_name, device_name)] = (node_name, accelerator)
+    return index
+
+
+def detect_dra(context: Optional[str] = None) -> bool:
+    """Returns True if the cluster advertises GPU devices via DRA."""
+    return bool(_get_device_index(context))
+
+
+def get_dra_node_capacity(
+        context: Optional[str] = None) -> Dict[str, Dict[str, int]]:
+    """Returns per-node DRA GPU capacity.
+
+    Returns {node_name: {accelerator_name: count}}. Empty if the cluster has
+    no (readable) DRA GPU devices.
+    """
+    capacity: Dict[str, Dict[str, int]] = collections.defaultdict(
+        lambda: collections.defaultdict(int))
+    for (node_name, accelerator) in _get_device_index(context).values():
+        capacity[node_name][accelerator] += 1
+    return {node: dict(accs) for node, accs in capacity.items()}
+
+
+def get_dra_node_count_for_acc(context: Optional[str], node_name: str,
+                               acc_type: str) -> int:
+    """Returns the DRA GPU count on a node matching the accelerator type."""
+    node_capacity = get_dra_node_capacity(context).get(node_name, {})
+    # pylint: disable-next=import-outside-toplevel
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    count = 0
+    for accelerator, acc_count in node_capacity.items():
+        # pylint: disable-next=protected-access
+        if kubernetes_utils._accelerator_name_matches(acc_type, [accelerator]):
+            count += acc_count
+    return count
+
+
+def get_dra_gpu_node_names(context: Optional[str] = None) -> Set[str]:
+    """Returns the names of nodes whose GPUs are managed via DRA.
+
+    A node is a "DRA node" when it appears in a GPU driver's
+    ResourceSlices. This is the single source of truth for choosing a
+    node's accounting mechanism: DRA nodes are accounted from
+    ResourceSlices/ResourceClaims, all other nodes from
+    allocatable/pod requests. If a node (mis)advertises the same GPUs
+    through both the device plugin and DRA, the DRA side wins.
+    """
+    return set(get_dra_node_capacity(context))
+
+
+def is_dra_node(context: Optional[str], node_name: str) -> bool:
+    """Returns True if the node's GPUs are managed via DRA.
+
+    See ``get_dra_gpu_node_names`` for the definition.
+    """
+    return node_name in get_dra_gpu_node_names(context)
+
+
+def get_dra_allocated_by_node(
+        context: Optional[str] = None) -> Dict[str, Dict[str, int]]:
+    """Returns per-node GPU devices currently allocated via ResourceClaims.
+
+    Returns {node_name: {accelerator_name: count}}. Includes claims created
+    by the scheduler for KEP-5004 extended-resource requests, so callers that
+    also sum container requests must exclude those pods (see
+    ``V1Pod.status.has_extended_resource_claims`` handling in
+    ``get_allocated_resources_by_node``) to avoid double counting.
+    """
+    device_index = _get_device_index(context)
+    if not device_index:
+        return {}
+    try:
+        claims = _list_dra_objects(context, 'resourceclaims')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to list ResourceClaims: {e}')
+        return {}
+    allocated: Dict[str, Dict[str, int]] = collections.defaultdict(
+        lambda: collections.defaultdict(int))
+    for claim in claims.get('items', []) or []:
+        allocation = claim.get('status', {}).get('allocation')
+        if not allocation:
+            continue
+        results = allocation.get('devices', {}).get('results', []) or []
+        for result in results:
+            if result.get('adminAccess'):
+                # Admin-access allocations (monitoring etc.) do not consume
+                # the device.
+                continue
+            key = (result.get('driver',
+                              ''), result.get('pool',
+                                              ''), result.get('device', ''))
+            device_info = device_index.get(key)
+            if device_info is None:
+                continue
+            node_name, accelerator = device_info
+            allocated[node_name][accelerator] += 1
+    return {node: dict(accs) for node, accs in allocated.items()}
+
+
+def has_dra_accelerator(context: Optional[str], acc_type: str,
+                        acc_count: int) -> bool:
+    """Returns True if some node advertises >= acc_count matching DRA GPUs."""
+    for node_name in get_dra_node_capacity(context):
+        if get_dra_node_count_for_acc(context, node_name,
+                                      acc_type) >= acc_count:
+            return True
+    return False
+
+
+def list_dra_accelerators(context: Optional[str] = None) -> List[str]:
+    """Returns the distinct DRA-advertised accelerator names."""
+    accelerators: Set[str] = set()
+    for accs in get_dra_node_capacity(context).values():
+        accelerators.update(accs.keys())
+    return sorted(accelerators)
+
+
+def maybe_remap_resource_key_for_dra(context: Optional[str],
+                                     resource_key: str) -> str:
+    """Validates/remaps the pod resource key for DRA-only clusters.
+
+    SkyPilot's write side always requests an extended resource key (e.g.
+    ``nvidia.com/gpu``). On a cluster where GPUs are advertised only via DRA
+    (no device plugin), such a request is only schedulable if KEP-5004 is
+    configured, i.e. some DeviceClass sets ``spec.extendedResourceName``.
+
+    Returns the resource key to request (possibly remapped to the
+    DeviceClass-declared name). Raises ResourcesUnavailableError with
+    actionable guidance if the cluster is DRA-only and no mapping exists.
+    """
+    if not detect_dra(context):
+        return resource_key
+    # pylint: disable-next=import-outside-toplevel
+    from sky.provision.kubernetes import utils as kubernetes_utils
+
+    # If any node still advertises the key via the device plugin, the
+    # request is schedulable without KEP-5004.
+    for node in kubernetes_utils.get_kubernetes_nodes(context=context):
+        try:
+            if int(node.status.allocatable.get(resource_key, 0)) > 0:
+                return resource_key
+        except (TypeError, ValueError):
+            continue
+    mapping = get_extended_resource_mapping(context)
+    if resource_key in mapping:
+        return resource_key
+    if mapping:
+        # KEP-5004 is configured under a different extended resource name;
+        # request that name instead.
+        remapped_key = sorted(mapping.keys())[0]
+        logger.info(f'Cluster advertises GPUs via DRA; requesting extended '
+                    f'resource {remapped_key!r} (mapped to DeviceClass '
+                    f'{mapping[remapped_key]!r}) instead of {resource_key!r}.')
+        return remapped_key
+    with ux_utils.print_exception_no_traceback():
+        raise exceptions.ResourcesUnavailableError(
+            'This Kubernetes cluster advertises GPUs via DRA (Dynamic '
+            'Resource Allocation) only, and no DeviceClass has '
+            '`spec.extendedResourceName` set, so SkyPilot pods requesting '
+            f'{resource_key!r} cannot be scheduled. To use this cluster '
+            'with SkyPilot, enable the `DRAExtendedResource` feature gate '
+            '(Kubernetes >= 1.34; beta in 1.35) on the kube-apiserver and '
+            'kube-scheduler, and set `spec.extendedResourceName: '
+            f'{resource_key}` on the GPU DeviceClass. See '
+            'https://kubernetes.io/docs/concepts/scheduling-eviction/'
+            'dynamic-resource-allocation/ for details.')

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -30,6 +30,7 @@ from sky.adaptors import gcp
 from sky.adaptors import kubernetes
 from sky.provision import constants as provision_constants
 from sky.provision.kubernetes import constants as kubernetes_constants
+from sky.provision.kubernetes import dra_utils
 from sky.provision.kubernetes import network_utils
 from sky.skylet import constants
 from sky.utils import annotations
@@ -1510,6 +1511,15 @@ def detect_accelerator_resource(
                        TPU_RESOURCE_KEY in cluster_resources or
                        NEURON_RESOURCE_KEY in cluster_resources)
 
+    if not has_accelerator and dra_utils.detect_dra(context):
+        # GPUs advertised via DRA (resource.k8s.io) do not appear in
+        # node.status.allocatable. Surface the extended resource names
+        # declared on DeviceClasses (KEP-5004) so error messages and
+        # downstream checks reflect the DRA-advertised resources.
+        has_accelerator = True
+        cluster_resources.update(
+            dra_utils.get_extended_resource_mapping(context).keys())
+
     return has_accelerator, cluster_resources
 
 
@@ -2222,6 +2232,10 @@ def diagnose_terminated_pod(context: Optional[str], namespace: str,
 @dataclasses.dataclass
 class V1PodStatus:
     phase: str
+    # True when the scheduler translated the pod's extended resource
+    # requests (e.g. nvidia.com/gpu) into a DRA ResourceClaim (KEP-5004).
+    # Such GPUs are accounted via ResourceClaims, not container requests.
+    has_extended_resource_claims: bool = False
 
 
 @dataclasses.dataclass
@@ -2254,7 +2268,11 @@ class V1Pod:
             labels=data['metadata'].get('labels', {}),
             namespace=data['metadata'].get('namespace'),
         ),
-                   status=V1PodStatus(phase=data['status'].get('phase'),),
+                   status=V1PodStatus(
+                       phase=data['status'].get('phase'),
+                       has_extended_resource_claims=bool(
+                           data['status'].get('extendedResourceClaimStatus')),
+                   ),
                    spec=V1PodSpec(
                        node_name=data['spec'].get('nodeName'),
                        containers=[
@@ -2300,6 +2318,15 @@ def get_allocated_resources_by_node(
         allocated_qty_by_node: Dict[str, int] = collections.defaultdict(int)
         allocated_cpu_memory_by_node: Dict[str, Tuple[
             float, float]] = collections.defaultdict(lambda: (0.0, 0.0))
+        # Nodes whose GPUs are managed via DRA: their GPU allocations are
+        # accounted from ResourceClaims below, not from container requests.
+        # Best-effort: a failure to read resource.k8s.io must not break
+        # device-plugin accounting.
+        try:
+            dra_node_names = dra_utils.get_dra_gpu_node_names(context)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to get DRA node names: {e}')
+            dra_node_names = set()
         for item_dict in ijson.items(response,
                                      'items.item',
                                      buf_size=IJSON_BUFFER_SIZE):
@@ -2319,9 +2346,16 @@ def get_allocated_resources_by_node(
             for container in pod.spec.containers:
                 if container.resources.requests:
                     requests = container.resources.requests
-                    # Parse GPU
-                    pod_allocated_qty += get_node_accelerator_count(
-                        context, requests)
+                    # Parse GPU. On DRA nodes GPU allocations are accounted
+                    # from ResourceClaims, so skip container requests there
+                    # (KEP-5004-translated pods carry both a request and a
+                    # claim; counting both would double count). The
+                    # extendedResourceClaimStatus check is kept as defense
+                    # for pods not attributable to a DRA node.
+                    if (pod.spec.node_name not in dra_node_names and
+                            not pod.status.has_extended_resource_claims):
+                        pod_allocated_qty += get_node_accelerator_count(
+                            context, requests)
                     # Parse CPU
                     if 'cpu' in requests:
                         pod_allocated_cpu += parse_cpu_or_gpu_resource_to_float(
@@ -2339,6 +2373,20 @@ def get_allocated_resources_by_node(
                 allocated_cpu_memory_by_node[pod.spec.node_name] = (
                     current_cpu + pod_allocated_cpu,
                     current_memory + pod_allocated_memory_gb)
+        # Merge in GPUs allocated via DRA ResourceClaims (including claims
+        # the scheduler created for KEP-5004 extended resource requests) on
+        # DRA nodes. Claims on non-DRA nodes are ignored: those nodes'
+        # capacity is accounted from allocatable, so their allocations must
+        # come from pod requests to stay consistent.
+        if dra_node_names:
+            try:
+                dra_allocated = dra_utils.get_dra_allocated_by_node(context)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Failed to get DRA allocations: {e}')
+                dra_allocated = {}
+            for node_name, acc_counts in dra_allocated.items():
+                if node_name in dra_node_names:
+                    allocated_qty_by_node[node_name] += sum(acc_counts.values())
         return allocated_qty_by_node, allocated_cpu_memory_by_node
     finally:
         response.release_conn()
@@ -2547,12 +2595,22 @@ def check_instance_fits(
         except exceptions.ResourcesUnavailableError as e:
             # If GPU not found, return empty list and error message.
             return False, str(e)
-        # Get the set of nodes that have the GPU type
-        gpu_nodes = [
-            node for node in nodes
-            if node.is_ready() and gpu_label_key in node.metadata.labels and
-            node.metadata.labels[gpu_label_key] in gpu_label_values
-        ]
+        if gpu_label_key is None:
+            # DRA fallback: GPUs are advertised via ResourceSlices and the
+            # nodes carry no recognizable accelerator label. Select nodes by
+            # their DRA-advertised capacity instead.
+            gpu_nodes = [
+                node for node in nodes
+                if node.is_ready() and dra_utils.get_dra_node_count_for_acc(
+                    context, node.metadata.name, acc_type) > 0
+            ]
+        else:
+            # Get the set of nodes that have the GPU type
+            gpu_nodes = [
+                node for node in nodes
+                if node.is_ready() and gpu_label_key in node.metadata.labels and
+                node.metadata.labels[gpu_label_key] in gpu_label_values
+            ]
         if not gpu_nodes:
             return False, f'No ready GPU nodes found with {acc_type} on the cluster'
         if is_tpu_on_gke(acc_type):
@@ -2563,10 +2621,23 @@ def check_instance_fits(
             if reason is not None:
                 return fits, reason
         else:
+
+            def _node_gpu_capacity(node) -> int:
+                # DRA nodes (appearing in GPU ResourceSlices) are counted
+                # from their DRA-advertised devices; all other nodes from
+                # allocatable. Using a single per-node mechanism avoids
+                # double counting if a misconfigured node advertises the
+                # same GPUs through both.
+                if dra_utils.is_dra_node(context, node.metadata.name):
+                    return dra_utils.get_dra_node_count_for_acc(
+                        context, node.metadata.name, acc_type)
+                return get_node_accelerator_count(context,
+                                                  node.status.allocatable)
+
             # Check if any of the GPU nodes have sufficient number of GPUs.
             gpu_nodes = [
-                node for node in gpu_nodes if get_node_accelerator_count(
-                    context, node.status.allocatable) >= acc_count
+                node for node in gpu_nodes
+                if _node_gpu_capacity(node) >= acc_count
             ]
             if not gpu_nodes:
                 return False, (
@@ -2740,6 +2811,16 @@ def get_accelerator_label_key_values(
         label_formatter, node_labels = \
             detect_gpu_label_formatter(context)
         if label_formatter is None:
+            # DRA fallback: the cluster advertises GPUs via ResourceSlices
+            # but its nodes carry no recognizable accelerator label. Pod
+            # placement is then delegated to the kube-scheduler (via
+            # KEP-5004 extended resource translation), so no node label
+            # key/values are needed.
+            if check_mode and dra_utils.detect_dra(context):
+                return None, None, None, None
+            if not check_mode and dra_utils.has_dra_accelerator(
+                    context, acc_type, acc_count):
+                return None, None, None, None
             # If none of the GPU labels from LABEL_FORMATTER_REGISTRY are
             # detected, raise error
             with ux_utils.print_exception_no_traceback():
@@ -2826,6 +2907,14 @@ def get_accelerator_label_key_values(
                                     continue
                         else:
                             return label, [value], None, None
+
+            # DRA fallback: no labeled node carries the requested
+            # accelerator, but a node may still advertise it via DRA
+            # ResourceSlices (e.g. a mixed cluster where only some nodes
+            # run GPU Feature Discovery). Delegate placement to the
+            # kube-scheduler in that case.
+            if dra_utils.has_dra_accelerator(context, acc_type, acc_count):
+                return None, None, None, None
 
             # If no node is found with the requested acc_type, raise error
             with ux_utils.print_exception_no_traceback():
@@ -4503,12 +4592,21 @@ def get_kubernetes_node_info(
     else:
         label_keys = lf.get_label_keys()
 
+    # Per-node GPU capacity advertised via DRA ResourceSlices (empty on
+    # device-plugin-only clusters). Best-effort: a failure to read
+    # resource.k8s.io must not break node info for device-plugin clusters.
+    try:
+        dra_capacity = dra_utils.get_dra_node_capacity(context)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to get DRA node capacity: {e}')
+        dra_capacity = {}
+
     # Check if all nodes have no accelerators to avoid fetching pods
     has_accelerator_nodes = False
     for node in nodes:
         accelerator_count = get_node_accelerator_count(context,
                                                        node.status.allocatable)
-        if accelerator_count > 0:
+        if accelerator_count > 0 or dra_capacity.get(node.metadata.name):
             has_accelerator_nodes = True
             break
 
@@ -4571,8 +4669,21 @@ def get_kubernetes_node_info(
                         node_ip = address.address
                         break
 
-        accelerator_count = get_node_accelerator_count(context,
-                                                       node.status.allocatable)
+        node_dra_capacity = dra_capacity.get(node.metadata.name)
+        if node_dra_capacity:
+            # DRA node: count the DRA-advertised devices (which do not
+            # appear in allocatable). Using a single per-node mechanism
+            # avoids double counting if a misconfigured node advertises
+            # the same GPUs through both the device plugin and DRA.
+            accelerator_count = sum(node_dra_capacity.values())
+            if accelerator_name is None:
+                # No recognizable node label; use the (most numerous)
+                # DRA-advertised accelerator name.
+                accelerator_name = max(node_dra_capacity.items(),
+                                       key=lambda item: item[1])[0]
+        else:
+            accelerator_count = get_node_accelerator_count(
+                context, node.status.allocatable)
 
         # Parse CPU and memory from node capacity
         cpu_count = None

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -191,6 +191,9 @@ provider:
         - apiGroups: [ "networking.k8s.io" ]   # Required for exposing services.
           resources: [ "ingressclasses" ]
           verbs: [ "get", "list", "watch" ]
+        - apiGroups: [ "resource.k8s.io" ]   # Required for discovering GPUs advertised via DRA.
+          resources: [ "deviceclasses", "resourceslices", "resourceclaims" ]
+          verbs: [ "get", "list", "watch" ]
 
     # Bind cluster role to the service account
     autoscaler_cluster_role_binding:

--- a/tests/unit_tests/kubernetes/test_dra_utils.py
+++ b/tests/unit_tests/kubernetes/test_dra_utils.py
@@ -1,0 +1,385 @@
+"""Unit tests for sky.provision.kubernetes.dra_utils."""
+from typing import Any, Dict
+from unittest import mock
+
+import pytest
+
+from sky import exceptions
+from sky.provision.kubernetes import dra_utils
+from sky.provision.kubernetes import utils as kubernetes_utils
+
+
+def _api_exception(status: int):
+    # pylint: disable=import-outside-toplevel
+    from kubernetes.client.rest import ApiException
+    return ApiException(status=status, reason='test')
+
+
+DEVICE_CLASSES = {
+    'items': [{
+        'metadata': {
+            'name': 'gpu.nvidia.com'
+        },
+        'spec': {
+            'extendedResourceName': 'nvidia.com/gpu'
+        },
+    }, {
+        'metadata': {
+            'name': 'compute-domain.nvidia.com'
+        },
+        'spec': {},
+    }]
+}
+
+DEVICE_CLASSES_NO_MAPPING = {
+    'items': [{
+        'metadata': {
+            'name': 'gpu.nvidia.com'
+        },
+        'spec': {},
+    }]
+}
+
+_H100_PRODUCT = 'NVIDIA H100 80GB HBM3'
+_H100_CANONICAL = (
+    kubernetes_utils.GFDLabelFormatter.get_accelerator_from_label_value(
+        _H100_PRODUCT.replace(' ', '-')))
+
+
+def _gpu_device(name: str, product: str = _H100_PRODUCT) -> Dict[str, Any]:
+    return {'name': name, 'attributes': {'productName': {'string': product}}}
+
+
+RESOURCE_SLICES = {
+    'items': [
+        # Node-local GPU slice: 2 H100s on node1.
+        {
+            'metadata': {
+                'name': 'node1-slice'
+            },
+            'spec': {
+                'driver': 'gpu.nvidia.com',
+                'nodeName': 'node1',
+                'pool': {
+                    'name': 'node1'
+                },
+                'devices': [_gpu_device('gpu-0'),
+                            _gpu_device('gpu-1')],
+            },
+        },
+        # Unknown (non-GPU) driver: ignored.
+        {
+            'metadata': {
+                'name': 'dranet-slice'
+            },
+            'spec': {
+                'driver': 'dra.net',
+                'nodeName': 'node1',
+                'pool': {
+                    'name': 'node1'
+                },
+                'devices': [{
+                    'name': 'nic-0'
+                }],
+            },
+        },
+        # Non-node-local slice: ignored.
+        {
+            'metadata': {
+                'name': 'clusterwide-slice'
+            },
+            'spec': {
+                'driver': 'gpu.nvidia.com',
+                'allNodes': True,
+                'pool': {
+                    'name': 'shared'
+                },
+                'devices': [_gpu_device('gpu-x')],
+            },
+        },
+    ]
+}
+
+RESOURCE_CLAIMS = {
+    'items': [
+        # Allocated claim consuming gpu-0 on node1.
+        {
+            'metadata': {
+                'name': 'claim-1',
+                'namespace': 'default'
+            },
+            'status': {
+                'allocation': {
+                    'devices': {
+                        'results': [{
+                            'driver': 'gpu.nvidia.com',
+                            'pool': 'node1',
+                            'device': 'gpu-0',
+                        }]
+                    }
+                }
+            },
+        },
+        # Pending claim: no allocation, ignored.
+        {
+            'metadata': {
+                'name': 'claim-2',
+                'namespace': 'default'
+            },
+            'status': {},
+        },
+        # Admin-access allocation: does not consume the device.
+        {
+            'metadata': {
+                'name': 'claim-3',
+                'namespace': 'monitoring'
+            },
+            'status': {
+                'allocation': {
+                    'devices': {
+                        'results': [{
+                            'driver': 'gpu.nvidia.com',
+                            'pool': 'node1',
+                            'device': 'gpu-1',
+                            'adminAccess': True,
+                        }]
+                    }
+                }
+            },
+        },
+        # Allocation of a device we did not index: ignored.
+        {
+            'metadata': {
+                'name': 'claim-4',
+                'namespace': 'default'
+            },
+            'status': {
+                'allocation': {
+                    'devices': {
+                        'results': [{
+                            'driver': 'dra.net',
+                            'pool': 'node1',
+                            'device': 'nic-0',
+                        }]
+                    }
+                }
+            },
+        },
+    ]
+}
+
+
+def _clear_all_dra_caches():
+    dra_utils.get_extended_resource_mapping.cache_clear()
+    # pylint: disable=protected-access
+    dra_utils._dra_api_available.cache_clear()
+    dra_utils._get_device_index.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_dra_caches():
+    _clear_all_dra_caches()
+    yield
+    _clear_all_dra_caches()
+
+
+def _make_lister(objects_by_plural: Dict[str, Any]):
+    """Returns a fake _list_dra_objects serving the given fixtures.
+
+    Missing plurals raise 404, mimicking an API server without the
+    resource.k8s.io/v1 API (or resource).
+    """
+
+    def _fake(context, plural):
+        del context  # Unused.
+        objects = objects_by_plural.get(plural)
+        if objects is None:
+            raise _api_exception(404)
+        return objects
+
+    return _fake
+
+
+_V1_CLUSTER = {
+    'deviceclasses': DEVICE_CLASSES,
+    'resourceslices': RESOURCE_SLICES,
+    'resourceclaims': RESOURCE_CLAIMS,
+}
+
+
+class TestDRAApiProbe:
+    """Tests for resource.k8s.io/v1 API availability probing."""
+
+    def test_v1_available(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            # pylint: disable=protected-access
+            assert dra_utils._dra_api_available('ctx')
+
+    def test_api_group_absent(self):
+        # Covers both pre-DRA clusters and pre-GA (beta-only) clusters:
+        # the v1 endpoint returns 404 in either case.
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister({})):
+            # pylint: disable=protected-access
+            assert not dra_utils._dra_api_available('ctx')
+            assert not dra_utils.detect_dra('ctx')
+            assert not dra_utils.get_dra_node_capacity('ctx')
+            assert not dra_utils.get_dra_allocated_by_node('ctx')
+            assert not dra_utils.get_extended_resource_mapping('ctx')
+
+    def test_forbidden_disables_dra(self):
+
+        def _forbidden(context, plural):
+            del context, plural  # Unused.
+            raise _api_exception(403)
+
+        with mock.patch.object(dra_utils, '_list_dra_objects', _forbidden):
+            # pylint: disable=protected-access
+            assert not dra_utils._dra_api_available('ctx')
+            assert not dra_utils.detect_dra('ctx')
+
+
+class TestDRADiscovery:
+    """Tests for DRA capacity discovery from ResourceSlices."""
+
+    def test_extended_resource_mapping(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            assert dra_utils.get_extended_resource_mapping('ctx') == {
+                'nvidia.com/gpu': 'gpu.nvidia.com'
+            }
+
+    def test_node_capacity(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            capacity = dra_utils.get_dra_node_capacity('ctx')
+            # Non-GPU drivers and non-node-local slices are excluded.
+            assert capacity == {'node1': {_H100_CANONICAL: 2}}
+            assert dra_utils.detect_dra('ctx')
+            assert dra_utils.list_dra_accelerators('ctx') == [_H100_CANONICAL]
+
+    def test_count_for_acc_matches_type(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            assert dra_utils.get_dra_node_count_for_acc('ctx', 'node1',
+                                                        _H100_CANONICAL) == 2
+            assert dra_utils.get_dra_node_count_for_acc('ctx', 'node1',
+                                                        'A100') == 0
+            assert dra_utils.get_dra_node_count_for_acc('ctx', 'unknown-node',
+                                                        _H100_CANONICAL) == 0
+            assert dra_utils.has_dra_accelerator('ctx', _H100_CANONICAL, 2)
+            assert not dra_utils.has_dra_accelerator('ctx', _H100_CANONICAL, 3)
+
+
+class TestDRAAllocation:
+    """Tests for DRA allocation accounting from ResourceClaims."""
+
+    def test_allocated_by_node(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            allocated = dra_utils.get_dra_allocated_by_node('ctx')
+            # claim-1 consumes one GPU; claim-3 is admin access (skipped);
+            # claim-2 is pending; claim-4 targets an unindexed device.
+            assert allocated == {'node1': {_H100_CANONICAL: 1}}
+
+
+class TestWriteSideRemap:
+    """Tests for KEP-5004 write-side resource key validation/remapping."""
+
+    def _mock_nodes(self, allocatable: Dict[str, str]):
+        node = mock.MagicMock()
+        node.status.allocatable = allocatable
+        return [node]
+
+    def test_no_dra_returns_key_unchanged(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister({})):
+            assert dra_utils.maybe_remap_resource_key_for_dra(
+                'ctx', 'nvidia.com/gpu') == 'nvidia.com/gpu'
+
+    def test_device_plugin_still_present_returns_key(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)), \
+             mock.patch.object(kubernetes_utils, 'get_kubernetes_nodes',
+                               return_value=self._mock_nodes(
+                                   {'nvidia.com/gpu': '8'})):
+            assert dra_utils.maybe_remap_resource_key_for_dra(
+                'ctx', 'nvidia.com/gpu') == 'nvidia.com/gpu'
+
+    def test_dra_only_with_mapping_returns_mapped_key(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)), \
+             mock.patch.object(kubernetes_utils, 'get_kubernetes_nodes',
+                               return_value=self._mock_nodes({})):
+            assert dra_utils.maybe_remap_resource_key_for_dra(
+                'ctx', 'nvidia.com/gpu') == 'nvidia.com/gpu'
+
+    def test_dra_only_without_mapping_raises(self):
+        cluster = {
+            'deviceclasses': DEVICE_CLASSES_NO_MAPPING,
+            'resourceslices': RESOURCE_SLICES,
+            'resourceclaims': RESOURCE_CLAIMS,
+        }
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(cluster)), \
+             mock.patch.object(kubernetes_utils, 'get_kubernetes_nodes',
+                               return_value=self._mock_nodes({})):
+            with pytest.raises(exceptions.ResourcesUnavailableError,
+                               match='DRAExtendedResource'):
+                dra_utils.maybe_remap_resource_key_for_dra(
+                    'ctx', 'nvidia.com/gpu')
+
+
+class TestIsDRANode:
+    """Tests for the per-node DRA vs device-plugin classification."""
+
+    def test_classification(self):
+        # A node is a DRA node iff it appears in a GPU driver's
+        # ResourceSlices: node1 does (fixtures), node2 does not (device
+        # plugin only), and a node appearing only in a non-GPU driver's
+        # slices does not count.
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister(_V1_CLUSTER)):
+            assert dra_utils.get_dra_gpu_node_names('ctx') == {'node1'}
+            assert dra_utils.is_dra_node('ctx', 'node1')
+            assert not dra_utils.is_dra_node('ctx', 'node2')
+
+    def test_no_dra_cluster(self):
+        with mock.patch.object(dra_utils, '_list_dra_objects',
+                               _make_lister({})):
+            assert dra_utils.get_dra_gpu_node_names('ctx') == set()
+            assert not dra_utils.is_dra_node('ctx', 'node1')
+
+
+class TestPodExtendedResourceClaimStatus:
+    """Tests for parsing pod.status.extendedResourceClaimStatus."""
+
+    def test_pod_flag_parsed_from_status(self):
+        pod_dict = {
+            'metadata': {
+                'name': 'p1'
+            },
+            'status': {
+                'phase': 'Running',
+                'extendedResourceClaimStatus': {
+                    'resourceClaimName': 'p1-extended-resources'
+                },
+            },
+            'spec': {
+                'nodeName': 'node1',
+                'containers': [{
+                    'resources': {
+                        'requests': {
+                            'nvidia.com/gpu': '1'
+                        }
+                    }
+                }],
+            },
+        }
+        pod = kubernetes_utils.V1Pod.from_dict(pod_dict)
+        assert pod.status.has_extended_resource_claims
+
+        pod_dict['status'].pop('extendedResourceClaimStatus')
+        pod = kubernetes_utils.V1Pod.from_dict(pod_dict)
+        assert not pod.status.has_extended_resource_claims

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -732,7 +732,7 @@ def test_heterogenous_gpu_detection():
     with mock.patch('sky.clouds.cloud_in_iterable', return_value=True), \
          mock.patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name', return_value='doesntexist'), \
          mock.patch('sky.provision.kubernetes.utils.check_credentials', return_value=[True]), \
-         mock.patch('sky.provision.kubernetes.utils.detect_accelerator_resource', return_value=True), \
+         mock.patch('sky.provision.kubernetes.utils.detect_accelerator_resource', return_value=(True, set())), \
          mock.patch('sky.provision.kubernetes.utils.detect_gpu_label_formatter', return_value=[utils.GKELabelFormatter(), None]), \
          mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes', return_value=[mock_node1, mock_node2]), \
          mock.patch('sky.provision.kubernetes.utils.get_allocated_resources_by_node', return_value=({mock_node1.metadata.name: 1, mock_node2.metadata.name: 0}, {})), \

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/base_cpu.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/base_cpu.json
@@ -209,6 +209,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/cpu_avoid_label_keys.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/cpu_avoid_label_keys.json
@@ -230,6 +230,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/custom_service_account.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/custom_service_account.json
@@ -209,6 +209,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_all.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_all.json
@@ -241,6 +241,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_build.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/docker_build.json
@@ -242,6 +242,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/efa_same_az_multinode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/efa_same_az_multinode.json
@@ -262,6 +262,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/ephemeral_storage.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/ephemeral_storage.json
@@ -210,6 +210,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_gpu_singlenode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_gpu_singlenode.json
@@ -364,6 +364,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
@@ -457,6 +457,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/flex_start_priority_preemption.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/flex_start_priority_preemption.json
@@ -220,6 +220,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/fuse_enabled.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/fuse_enabled.json
@@ -224,6 +224,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_multiple_label_values.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_multiple_label_values.json
@@ -252,6 +252,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_single_label_value.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpu_single_label_value.json
@@ -250,6 +250,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpudirect_tcpx.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gpudirect_tcpx.json
@@ -426,6 +426,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/high_availability.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/high_availability.json
@@ -277,6 +277,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
@@ -235,6 +235,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/kueue.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/kueue.json
@@ -215,6 +215,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/multinode.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/multinode.json
@@ -209,6 +209,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/oci_roce.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/oci_roce.json
@@ -282,6 +282,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/pod_resource_limits.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/pod_resource_limits.json
@@ -214,6 +214,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/spot.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/spot.json
@@ -220,6 +220,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/tpu.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/tpu.json
@@ -253,6 +253,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/user_labels.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/user_labels.json
@@ -212,6 +212,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/volume_mounts.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/volume_mounts.json
@@ -235,6 +235,21 @@
             "list",
             "watch"
           ]
+        },
+        {
+          "apiGroups": [
+            "resource.k8s.io"
+          ],
+          "resources": [
+            "deviceclasses",
+            "resourceslices",
+            "resourceclaims"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Addresses #10275.
- Adds read-side Kubernetes DRA GPU discovery and allocation accounting through `resource.k8s.io/v1` `ResourceSlice`, `ResourceClaim`, and `DeviceClass`.
- Keeps the SkyPilot write path unchanged: pods still request extended resources such as `nvidia.com/gpu`, relying on KEP-5004 `DeviceClass.spec.extendedResourceName` mapping on DRA clusters.
- Supports mixed DRA/device-plugin clusters by accounting DRA nodes from ResourceSlices/Claims and traditional nodes from allocatable/pod requests.
- Adds read-only `resource.k8s.io` RBAC and unit coverage for DRA capacity/accounting helpers.

## Details

This PR introduces `sky/provision/kubernetes/dra_utils.py` as a best-effort read-side data source. It uses raw Kubernetes REST calls for GA `resource.k8s.io/v1` objects so SkyPilot does not depend on typed DRA models being present in the installed Kubernetes Python client.

The implementation wires DRA-derived capacity and allocations into:

- accelerator resource detection
- Kubernetes scheduling feasibility checks
- label-less DRA fallback for accelerator matching
- allocated-resource accounting
- `sky show-gpus`
- Kubernetes node info
- launch-time preflight for DRA-only clusters without extended resource mapping

Clusters without the DRA API group or without readable DRA RBAC fall back to the existing device-plugin behavior.

## Test Plan

- `pytest tests/unit_tests/kubernetes/test_dra_utils.py`
- Existing Kubernetes template snapshots were updated for the added read-only RBAC.

Manual validation to run on a DRA-capable Kubernetes cluster:

- Configure a GPU DRA driver and a `DeviceClass` with `spec.extendedResourceName: nvidia.com/gpu`.
- Run `sky show-gpus --cloud kubernetes` and verify GPU capacity is discovered from ResourceSlices.
- Launch a GPU task with SkyPilot and verify kube-scheduler translates the extended resource request into a ResourceClaim.
- Re-run `sky show-gpus` and verify free GPU accounting reflects the allocated claim.
- Verify a DRA-only cluster without the mapping fails with actionable preflight guidance.
