### PR TITLE
[Server] Make debug dump creation admin-only

### DIFF
--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -293,13 +293,6 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'path': '/upload_v2/blob',
         'method': 'GET'
     },
-    # NOTE: /debug/dump_create is intentionally NOT allowlisted for viewers.
-    # A debug dump collects other users' request records and log files into a
-    # downloadable archive, and is a `long`-scheduled, side-effecting
-    # operation; the strictly-read-only viewer role must not trigger it. It is
-    # admin-only: the regular `user` role already blocks it via
-    # `_DEFAULT_USER_BLOCKLIST`, and the diagnose/support flow schedules the
-    # dump directly (not through this endpoint).
     # --- Dashboard / static / auth-flow surface ---
     {
         'path': '/dashboard/*',

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -293,11 +293,13 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'path': '/upload_v2/blob',
         'method': 'GET'
     },
-    # /debug/dump_create for diagnose
-    {
-        'path': '/debug/dump_create',
-        'method': 'POST'
-    },
+    # NOTE: /debug/dump_create is intentionally NOT allowlisted for viewers.
+    # A debug dump collects other users' request records and log files into a
+    # downloadable archive, and is a `long`-scheduled, side-effecting
+    # operation; the strictly-read-only viewer role must not trigger it. It is
+    # admin-only: the regular `user` role already blocks it via
+    # `_DEFAULT_USER_BLOCKLIST`, and the diagnose/support flow schedules the
+    # dump directly (not through this endpoint).
     # --- Dashboard / static / auth-flow surface ---
     {
         'path': '/dashboard/*',

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -123,10 +123,12 @@ _KNOWN_VIEWER_DENIED: set = {
     ('/ssh_node_pools/{pool_name}/down', 'POST'),
     ('/ssh_node_pools/down', 'POST'),
     # --- Debug ---
-    # /debug/dump_create is intentionally on the viewer allowlist (see
-    # _DEFAULT_VIEWER_ALLOWLIST) so viewers can capture support diagnostics;
-    # only the download endpoint stays admin-only because the dump file
-    # itself may contain sensitive state.
+    # Both debug-dump endpoints are denied to viewers. A dump collects other
+    # users' request records and log files into a downloadable archive and is
+    # a side-effecting, long-scheduled operation, so the strictly-read-only
+    # viewer role must not trigger it; it is admin-only (the diagnose/support
+    # flow schedules the dump directly, not via this endpoint).
+    ('/debug/dump_create', 'POST'),
     ('/debug/dump_download/{dump_filename}', 'GET'),
     # --- /api/* paths: RBAC-skipped at middleware level, not on
     # viewer allowlist; explicitly enumerated here for documentation.
@@ -306,3 +308,20 @@ def test_allowlist_entries_match_real_routes():
         'Viewer allowlist entries that do not match any registered '
         f'route: {unknown!r}.  If the endpoint was renamed, update '
         'rbac._DEFAULT_VIEWER_ALLOWLIST.')
+
+
+def test_debug_dump_endpoints_denied_to_viewer():
+    """Both /debug/dump endpoints must be off the viewer allowlist.
+
+    A debug dump collects other users' request records and log files into a
+    downloadable archive, so the strictly-read-only viewer role must not be
+    able to trigger or fetch one. This guards against re-adding
+    /debug/dump_create to rbac._DEFAULT_VIEWER_ALLOWLIST.
+    """
+    allowlist = rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+    assert not _matches_any('/debug/dump_create', 'POST', allowlist)
+    assert not _matches_any('/debug/dump_download/{dump_filename}', 'GET',
+                            allowlist)
+    # Sanity: a genuinely-allowlisted read is still matched, so the matcher
+    # isn't just returning False for everything.
+    assert _matches_any('/users', 'GET', allowlist)

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -123,11 +123,6 @@ _KNOWN_VIEWER_DENIED: set = {
     ('/ssh_node_pools/{pool_name}/down', 'POST'),
     ('/ssh_node_pools/down', 'POST'),
     # --- Debug ---
-    # Both debug-dump endpoints are denied to viewers. A dump collects other
-    # users' request records and log files into a downloadable archive and is
-    # a side-effecting, long-scheduled operation, so the strictly-read-only
-    # viewer role must not trigger it; it is admin-only (the diagnose/support
-    # flow schedules the dump directly, not via this endpoint).
     ('/debug/dump_create', 'POST'),
     ('/debug/dump_download/{dump_filename}', 'GET'),
     # --- /api/* paths: RBAC-skipped at middleware level, not on


### PR DESCRIPTION
## Summary

`/debug/dump_create` was on the viewer-role allowlist, so the strictly read-only viewer role could trigger it — even though the regular `user` role could not (it is in the user blocklist). A debug dump collects other users' request records and log files into a downloadable archive and is a side-effecting, `long`-scheduled operation, so it should be admin-only.

Remove `/debug/dump_create` from `_DEFAULT_VIEWER_ALLOWLIST`. Both debug-dump endpoints are already blocked for the `user` role via the user blocklist, and the diagnose/support flow schedules the dump directly (not through this endpoint), so admin-only is the intended reach.

## Test plan

- `pytest tests/unit_tests/test_sky/users/test_viewer_route_coverage.py` — updated the deny classification; added `test_debug_dump_endpoints_denied_to_viewer` asserting both dump endpoints are off the real viewer allowlist while a known read stays allowed. Revert-checked: re-adding the allowlist entry fails both the coverage test and the new test.
- Manual: on a local server, `POST /debug/dump_create` still returns `200` for a legitimate (admin / no-auth) caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)