### PR TITLE
[Server] Scope request-listing body to the request owner

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -164,6 +164,20 @@ REQUEST_COLUMNS = [
 ]
 
 
+def _request_body_for_display(body: 'payloads.RequestBody', owner_user_id: str,
+                              caller_user_id: Optional[str]) -> str:
+    """Serialize a request body for a listing, scoped to the caller.
+
+    Returns the full body to the owner (and when ``caller_user_id`` is
+    ``None``); any other caller gets no body (``null``), so one user's body is
+    never exposed to another. The owner can still fetch the full body via
+    ``/api/get`` (``Request.encode()``).
+    """
+    if caller_user_id is None or owner_user_id == caller_user_id:
+        return body.model_dump_json()
+    return orjson.dumps(None).decode('utf-8')
+
+
 def validate_fields(fields: Optional[List[str]]) -> None:
     """Validates a caller-supplied column list for a request query.
 
@@ -299,7 +313,9 @@ class Request:
             row.append(getattr(payload, k))
         return tuple(row)
 
-    def readable_encode(self) -> payloads.RequestPayload:
+    def readable_encode(
+            self,
+            caller_user_id: Optional[str] = None) -> payloads.RequestPayload:
         """Serialize the SkyPilot API request for display purposes.
 
         This function should be called on the server side to serialize the
@@ -312,6 +328,9 @@ class Request:
         We do not use `encode` for display to avoid a large amount of data being
         sent to the client side, especially for the request table could include
         all the requests.
+
+        ``caller_user_id`` scopes the request body; see
+        ``_request_body_for_display``.
         """
         assert isinstance(self.request_body,
                           payloads.RequestBody), (self.name, self.request_body)
@@ -321,7 +340,9 @@ class Request:
             request_id=self.request_id,
             name=self.name,
             entrypoint=self.entrypoint.__name__,
-            request_body=self.request_body.model_dump_json(),
+            request_body=_request_body_for_display(self.request_body,
+                                                   self.user_id,
+                                                   caller_user_id),
             status=_status_value_for_client(self.status.value),
             return_value=orjson.dumps(None).decode('utf-8'),
             error=orjson.dumps(None).decode('utf-8'),
@@ -436,7 +457,9 @@ def get_new_request_id() -> str:
     return str(uuid.uuid4())
 
 
-def encode_requests(requests: List[Request]) -> List[payloads.RequestPayload]:
+def encode_requests(
+        requests: List[Request],
+        caller_user_id: Optional[str] = None) -> List[payloads.RequestPayload]:
     """Serialize the SkyPilot API request for display purposes.
 
         This function should be called on the server side to serialize the
@@ -464,7 +487,8 @@ def encode_requests(requests: List[Request]) -> List[payloads.RequestPayload]:
             name=request.name,
             entrypoint=request.entrypoint.__name__
             if request.entrypoint is not None else '',
-            request_body=request.request_body.model_dump_json()
+            request_body=_request_body_for_display(
+                request.request_body, request.user_id, caller_user_id)
             if request.request_body is not None else
             orjson.dumps(None).decode('utf-8'),
             status=_status_value_for_client(request.status.value),

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2670,6 +2670,7 @@ async def api_cancel(request: fastapi.Request,
 
 @app.get('/api/status')
 async def api_status(
+    request: fastapi.Request,
     request_ids: Optional[List[str]] = fastapi.Query(
         None, description='Request ID prefixes to get status for.'),
     all_status: bool = fastapi.Query(
@@ -2682,6 +2683,10 @@ async def api_status(
         None, description='Filter requests by cluster name.'),
 ) -> List[payloads.RequestPayload]:
     """Gets the list of requests."""
+    # Scope the request body to the caller: the owner sees it, others get null
+    # (see _request_body_for_display).
+    auth_user = request.state.auth_user
+    caller_user_id = auth_user.id if auth_user is not None else None
     # `fields` is caller-supplied and ends up in the SQL column list. Reject an
     # unknown column here so the client gets a 400 instead of a 500 from the
     # query layer.
@@ -2705,7 +2710,8 @@ async def api_status(
                 fields=fields,
                 sort=True,
             ))
-        return requests_lib.encode_requests(request_tasks)
+        return requests_lib.encode_requests(request_tasks,
+                                            caller_user_id=caller_user_id)
     else:
         encoded_request_tasks = []
         for request_id in request_ids:
@@ -2714,7 +2720,8 @@ async def api_status(
             if request_tasks is None:
                 continue
             for request_task in request_tasks:
-                encoded_request_tasks.append(request_task.readable_encode())
+                encoded_request_tasks.append(
+                    request_task.readable_encode(caller_user_id=caller_user_id))
         return encoded_request_tasks
 
 

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1,5 +1,6 @@
 """Unit tests for sky.server.requests.requests module."""
 import asyncio
+import json
 import logging
 import pathlib
 import time
@@ -15,6 +16,7 @@ from sky.server.requests import payloads
 from sky.server.requests import requests
 from sky.server.requests.requests import RequestStatus
 from sky.server.requests.requests import ScheduleType
+from sky.server.requests.serializers import decoders
 from sky.server.requests.serializers import encoders
 
 
@@ -2217,3 +2219,90 @@ async def test_interrupt_request_without_retry_records_plain_cancellation(
     error = interrupted.get_error()
     assert error is not None
     assert isinstance(error['object'], exceptions.RequestInterruptedError)
+
+
+# --- Display serializers: request body scoped to the caller -----------------
+
+_SECRET_TASK_YAML = """name: t
+resources:
+  cloud: aws
+envs:
+  HF_TOKEN: env-marker-secret
+secrets:
+  WANDB_API_KEY: secret-marker-value
+run: echo hi
+"""
+
+
+def _launch_body_with_secrets():
+    return payloads.LaunchBody(
+        task=_SECRET_TASK_YAML,
+        cluster_name='c',
+        env_vars={'MY_TOKEN': 'env-var-marker'},
+        override_skypilot_config={'aws': {
+            'token': 'CONFIG-MARKER'
+        }})
+
+
+def _make_request(request_id: str, body) -> requests.Request:
+    return requests.Request(request_id=request_id,
+                            name='sky.launch',
+                            entrypoint=dummy,
+                            request_body=body,
+                            status=RequestStatus.SUCCEEDED,
+                            created_at=0.0,
+                            user_id='alice')
+
+
+def _assert_full(request_body: str):
+    for marker in ('env-marker-secret', 'secret-marker-value', 'CONFIG-MARKER',
+                   'env-var-marker'):
+        assert marker in request_body, f'{marker!r} missing from owner body'
+
+
+def test_encode_owner_path_keeps_real_values():
+    """Request.encode() (the /api/get owner path) is never scoped/dropped."""
+    request = _make_request('display-owner-1', _launch_body_with_secrets())
+    encoded = request.encode()
+    decoded_body = decoders.decode_and_unpickle(encoded.request_body)
+    assert 'env-marker-secret' in decoded_body.task
+    assert 'secret-marker-value' in decoded_body.task
+    assert decoded_body.override_skypilot_config == {
+        'aws': {
+            'token': 'CONFIG-MARKER'
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_readable_encode_scopes_to_caller(isolated_database):
+    request = _make_request('display-readable-1', _launch_body_with_secrets())
+    await requests.create_if_not_exists_async(request)
+    row = requests.get_request('display-readable-1')
+    # Owner (caller == owner) and no-auth (caller None) get the full body.
+    _assert_full(row.readable_encode(caller_user_id='alice').request_body)
+    _assert_full(row.readable_encode(caller_user_id=None).request_body)
+    # Any other caller (e.g. an admin listing everyone) gets no body at all.
+    other = row.readable_encode(caller_user_id='some-admin')
+    assert other.request_body == json.dumps(None)
+
+
+def test_encode_requests_scopes_to_caller():
+    """The other listing serializer (GET /api/status without request_ids)."""
+    request = _make_request('display-listing-1', _launch_body_with_secrets())
+    with mock.patch('sky.global_user_state.get_all_users', return_value=[]):
+        _assert_full(
+            requests.encode_requests([request],
+                                     caller_user_id='alice')[0].request_body)
+        other = requests.encode_requests([request],
+                                         caller_user_id='some-admin')[0]
+        assert other.request_body == json.dumps(None)
+
+
+def test_encode_requests_omits_body_when_owner_unknown():
+    """Fail-safe: an unknown (blanked) owner is not the caller, so no body."""
+    request = _make_request('display-listing-2', _launch_body_with_secrets())
+    request.user_id = ''  # user_id excluded from the fetched fields
+    with mock.patch('sky.global_user_state.get_all_users', return_value=[]):
+        payload = requests.encode_requests([request], caller_user_id='bob')[0]
+    assert payload.request_body == json.dumps(None)


### PR DESCRIPTION
## Summary

`GET /api/status` serializes each request's `request_body` for display (`readable_encode` / `encode_requests`). Returning it verbatim exposes one user's task YAML (with `envs:`/`secrets:`), `override_skypilot_config`, etc. to any other caller listing requests — e.g. an admin.

Scope the body to the caller: the **owner** (and a no-auth server, where the caller id is `None`) gets the full body; **any other caller gets no body** (`null`).

We omit rather than redact: nothing consumes `request_body` from `/api/status` programmatically (it is display-only), and the owner can still fetch the full body via `/api/get` (`Request.encode()`, unchanged). An admin who needs another user's body can use `/api/get`. This avoids parsing every task YAML and is leak-proof by construction.

> Supersedes the earlier field-by-field redaction approach in this PR's history.

## Test plan

- `pytest tests/unit_tests/test_sky/server/requests/test_requests.py`: the owner and a no-auth caller (`None`) get the full body; any other caller gets `null`; fail-safe when the owner id wasn't fetched. `encode()` (the `/api/get` owner path) is unchanged.
- Manual: local auth server, `sky api status` with all flags as a `user` and an `admin` — see PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)