### PR TITLE
[Dashboard] Persist rows-per-page for the cluster jobs and pools tables

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -93,6 +93,14 @@ import { trackJobAction, trackFilterUsed } from '@/lib/analytics';
 const JOBS_PAGE_SIZE_OPTIONS = [10, 30, 50, 100, 200];
 const JOBS_PAGE_SIZE_STORAGE_KEY = 'skypilot-jobs-page-size';
 
+// Same for the per-cluster jobs table and the pools table. Both keep their own
+// option lists (smaller tables, so smaller steps) and their own storage key, so
+// changing rows-per-page on one table never moves another.
+const CLUSTER_JOBS_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
+const CLUSTER_JOBS_PAGE_SIZE_STORAGE_KEY = 'skypilot-cluster-jobs-page-size';
+const POOLS_PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
+const POOLS_PAGE_SIZE_STORAGE_KEY = 'skypilot-pools-page-size';
+
 // Define status groups for active and finished jobs
 export const statusGroups = {
   active: [
@@ -2702,7 +2710,15 @@ export function ClusterJobs({
     direction: 'ascending',
   });
   const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+  // Restore the last "rows per page" choice from localStorage so it survives
+  // reloads. Lazy initializer keeps the read out of the render path.
+  const [pageSize, setPageSize] = useState(() =>
+    getPersistedPageSize(
+      CLUSTER_JOBS_PAGE_SIZE_STORAGE_KEY,
+      CLUSTER_JOBS_PAGE_SIZE_OPTIONS,
+      10
+    )
+  );
   const expandedRowRef = useRef(null);
   const [prevClusterJobData, setPrevClusterJobData] = useState(null);
 
@@ -2794,6 +2810,8 @@ export function ClusterJobs({
     const newSize = parseInt(e.target.value, 10);
     setPageSize(newSize);
     setCurrentPage(1); // Reset to first page when changing page size
+    // Remember the choice so it sticks across reloads.
+    persistPageSize(CLUSTER_JOBS_PAGE_SIZE_STORAGE_KEY, newSize);
   };
 
   return (
@@ -2960,7 +2978,7 @@ export function ClusterJobs({
           isNextDisabled={currentPage === totalPages || totalPages === 0}
           pageSize={pageSize}
           onPageSizeChange={handlePageSizeChange}
-          pageSizeOptions={[5, 10, 20, 50]}
+          pageSizeOptions={CLUSTER_JOBS_PAGE_SIZE_OPTIONS}
         />
       )}
     </div>
@@ -3033,7 +3051,15 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
   const [loading, setLocalLoading] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+  // Restore the last "rows per page" choice from localStorage so it survives
+  // reloads. Lazy initializer keeps the read out of the render path.
+  const [pageSize, setPageSize] = useState(() =>
+    getPersistedPageSize(
+      POOLS_PAGE_SIZE_STORAGE_KEY,
+      POOLS_PAGE_SIZE_OPTIONS,
+      10
+    )
+  );
 
   const fetchData = React.useCallback(async () => {
     setLocalLoading(true);
@@ -3127,6 +3153,8 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
     const newSize = parseInt(e.target.value, 10);
     setPageSize(newSize);
     setCurrentPage(1);
+    // Remember the choice so it sticks across reloads.
+    persistPageSize(POOLS_PAGE_SIZE_STORAGE_KEY, newSize);
   };
 
   const getWorkersCount = (pool) => {
@@ -3244,8 +3272,10 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
         </Table>
       </div>
 
-      {/* Pagination */}
-      {paginatedData.length > 0 && totalPages > 1 && (
+      {/* Pagination. Shown whenever there is at least one row — matching the
+          other tables — so the rows-per-page selector stays reachable even when
+          everything fits on a single page. */}
+      {paginatedData.length > 0 && (
         <PaginationControls
           currentPage={currentPage}
           totalPages={totalPages}
@@ -3259,7 +3289,7 @@ function PoolsTable({ refreshInterval, setLoading, refreshDataRef }) {
           isNextDisabled={currentPage === totalPages}
           pageSize={pageSize}
           onPageSizeChange={handlePageSizeChange}
-          pageSizeOptions={[5, 10, 25, 50]}
+          pageSizeOptions={POOLS_PAGE_SIZE_OPTIONS}
         />
       )}
     </Card>


### PR DESCRIPTION
`#10044` added localStorage persistence for the "Rows per page" selector across the dashboard's tables, but two tables were missed and still reset to 10 on every reload.

## Changes

| Page to visit | Table | Before this PR | After this PR |
|---|---|---|---|
| `/dashboard/clusters/<cluster>` | Per-cluster jobs table | `useState(10)` — hardcoded; change to 5, reload, back to 10 | Restored from `skypilot-cluster-jobs-page-size`; reload keeps 5 |
| `/dashboard/jobs` (Pools section) | Pools table | `useState(10)` — hardcoded; change to 25, reload, back to 10 | Restored from `skypilot-pools-page-size`; reload keeps 25 |
| `/dashboard/jobs` (Pools section) | Pools table pagination row | Gated on `totalPages > 1` — the whole row, selector included, vanished when the rows fit one page | Gated on `length > 0`, matching every other table — selector always reachable |

Each table gets its own storage key following the existing `skypilot-<table>-page-size` convention, and validates the stored value against **its own** option list. Both tables offer smaller steps than the rest of the dashboard (`[5, 10, 20, 50]` and `[5, 10, 25, 50]`), so validating against the wider list would reject a stored `5` and silently snap back to 10.

The two inline option arrays are also lifted into named constants next to the existing `JOBS_PAGE_SIZE_*` pair, so the option list and the validation list cannot drift apart.

## Test plan

Verified in a browser against a local API server with a cluster carrying 6 jobs and one pool:

**Per-cluster jobs table** — `/dashboard/clusters/<cluster>`
1. Set "Rows per page" to 5 → table shows `1 – 5 of 6`.
2. Reload.
   - Before: selector back to 10, nothing in localStorage.
   - After: selector still 5, `skypilot-cluster-jobs-page-size=5`.

**Pools table** — `/dashboard/jobs`
1. With a single pool, confirm the pagination row renders at all.
   - Before: not rendered (`totalPages === 1`).
   - After: rendered.
2. Set "Rows per page" to 25, reload.
   - Before: back to 10.
   - After: still 25, `skypilot-pools-page-size=25`.

<img width="3786" height="1773" alt="8751f6efc566129d6e597f817a557008" src="https://github.com/user-attachments/assets/1b431b0f-2669-4724-b726-f906559f4425" />


<img width="3722" height="1182" alt="0b595f6940e08ca537cd2b36135c8c2a" src="https://github.com/user-attachments/assets/65392bc7-fb3f-4ccf-aebf-ce02b0a1e23c" />


**Key isolation** — changing the pools table leaves the managed jobs table at 10, and `/dashboard/clusters` keeps its own `skypilot-clusters-page-size`. Each table stores independently.

**Formatting** — `prettier --check src/components/jobs.jsx` clean; `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->