### PR TITLE
[Nebius] Pin nebius SDK below 0.4

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -269,7 +269,8 @@ cloud_dependencies: Dict[str, List[str]] = {
     'nebius': [
         # Nebius requires grpcio and protobuf, so we need to include
         # our constraints here.
-        'nebius>=0.3.59',
+        # 0.4.1 fails with "attached to a different loop".
+        'nebius>=0.3.59,<0.4',
         GRPC,
         PROTOBUF,
     ] + aws_dependencies,


### PR DESCRIPTION
`nebius` 0.4.1 (released 2026-07-28) breaks every SkyPilot code path that talks to Nebius from more than one asyncio event loop.

Starting with 0.4.1 the SDK returns finished `grpc.aio` channels to an internal per-address free pool (`Channel._free_channels`), and that pool has no event loop affinity. A channel created while one loop was running gets handed to a caller running on a different loop, and the request fails with:

```
RuntimeError: Task <... Request._request_with_authorization_loop ...> got Future
<... InterceptedUnaryUnaryCall._invoke ...> attached to a different loop
```

SkyPilot drives the SDK from more than one loop by design:

- `sky/adaptors/nebius.py::sync_call` — a dedicated background loop, so synchronous call sites keep working
- `Request.wait()` — the SDK's own loop (`sky/clouds/nebius.py`, `sky/catalog/data_fetchers/fetch_nebius.py`)
- `asyncio.run()` in the Nebius catalog fetcher (`fetch_nebius.estimate_platforms`)

So whichever of those runs second can inherit a pooled channel from the first and abort. On a fresh install this makes `sky launch` on Nebius fail right after the optimizer output, in `sky/provision/nebius/utils.py::get_project_by_region`:

```console
$ pip install 'skypilot-nightly[nebius]'   # resolves nebius 0.4.1
$ rm -rf ~/.sky                            # no cached Nebius catalog yet
$ sky api start && sky launch --dryrun -y
 INFRA                INSTANCE           vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN
 Nebius (eu-north1)   cpu-e2_2vcpu-8gb   2       8         -      0.05          ✔
RuntimeError: Task <...> got Future <...> attached to a different loop
```

`nebius` 0.3.101 never reaches `return_channel` on this path, so each loop creates its own channel and the same code works — the pooling functions themselves are byte-identical between the two releases, and both attach the same single `IdempotencyKeyInterceptor`.

`0.4.2` (published a day later) has the same defect: `master` + `nebius==0.4.2` fails 2/2 cold cycles with the same error, so this is not specific to `0.4.1`.

This PR caps the requirement at `<0.4` (newest satisfying release: 0.3.101) while the pool is not loop-aware. Reported upstream: https://github.com/nebius/pysdk/issues/178

A follow-up can route all Nebius calls through the single dedicated loop (replacing the `Request.wait()` call sites and the fetcher's `asyncio.run`), which also fixes it with 0.4.1 installed; keeping this PR to the minimal unblock.

## Tested (run the relevant ones):

- [x] Code formatting: `pre-commit` (all hooks pass)
- [x] Any manual or new tests for this PR (please specify below)
  - Verified the constraint resolves to `nebius==0.3.101`.
  - Reproduced on Linux (`python:3.10-slim`) and macOS (3.11): with 0.4.1, `sky api start` → `sky launch --dryrun -y` from a clean `~/.sky` failed 5/5; with 0.3.101 the same sequence passed 4/4.
  - Minimal, SkyPilot-free reproducer (one SDK, two long-lived loops, same unary RPC) passes on 0.3.101 and raises on 0.4.1 — included in the upstream issue.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167mdJ9BaUqWgP4ZDZJzY38
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
