### PR TITLE
[Nebius] Route every SDK call through the adaptor's event loop

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -67,6 +67,16 @@ def sync_call(awaitable: Awaitable[Any]) -> Any:
 
     Uses a dedicated background event loop to avoid conflicts
     with existing asyncio contexts and prevent BlockingIOError.
+
+    Every nebius SDK call must go through this helper, so that all requests
+    run on this single event loop. The SDK caches grpc.aio channels per
+    address and hands them to whichever loop asks next, while grpc.aio binds
+    a channel to the loop that created it ("gRPC Async API objects must be
+    used exclusively on the thread where they were created"). Driving the SDK
+    from a second loop - via the blocking Request.wait() helper, or an
+    asyncio.run() of our own - therefore fails with "RuntimeError: ... got
+    Future ... attached to a different loop". See
+    https://github.com/nebius/pysdk/issues/178
     """
     loop = _get_event_loop()
     future = asyncio.run_coroutine_threadsafe(_coro(awaitable), loop)

--- a/sky/catalog/data_fetchers/fetch_nebius.py
+++ b/sky/catalog/data_fetchers/fetch_nebius.py
@@ -102,7 +102,7 @@ def estimate_platforms(
         List[PresetInfo]: A list of PresetInfo objects containing details and
         estimated prices for each preset.
     """
-    return asyncio.run(
+    return nebius.sync_call(
         _estimate_platforms_async(platforms, parent_id, region, offer_types))
 
 
@@ -264,8 +264,8 @@ def fetch_platforms_for_project(project_id: str) -> List[Any]:
 
     platform_request = compute().ListPlatformsRequest(page_size=999,
                                                       parent_id=project_id)
-    platform_response = platform_service.list(platform_request,
-                                              timeout=TIMEOUT).wait()
+    platform_response = nebius.sync_call(
+        platform_service.list(platform_request, timeout=TIMEOUT))
 
     return platform_response.items
 
@@ -279,13 +279,14 @@ def _get_regions_map() -> Dict[str, str]:
                         and values are full region names (e.g., "eu-north1").
     """
     result = {}
-    response = iam().TenantServiceClient(nebius.sdk()).list(
-        iam().ListTenantsRequest(), timeout=TIMEOUT).wait()
+    response = nebius.sync_call(iam().TenantServiceClient(nebius.sdk()).list(
+        iam().ListTenantsRequest(), timeout=TIMEOUT))
 
     for tenant in response.items:
-        projects = (iam().ProjectServiceClient(nebius.sdk()).list(
-            iam().ListProjectsRequest(parent_id=tenant.metadata.id),
-            timeout=TIMEOUT).wait())
+        projects = nebius.sync_call(iam().ProjectServiceClient(
+            nebius.sdk()).list(
+                iam().ListProjectsRequest(parent_id=tenant.metadata.id),
+                timeout=TIMEOUT))
 
         for project in projects.items:
             match = re.match(r'^project-([a-z0-9]{3})', project.metadata.id)

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -523,8 +523,9 @@ class Nebius(clouds.Cloud):
         sdk = nebius.sdk()
         try:
             service = nebius.iam().ProjectServiceClient(sdk)
-            service.list(
-                nebius.iam().ListProjectsRequest(parent_id=tenant_id)).wait()
+            nebius.sync_call(
+                service.list(
+                    nebius.iam().ListProjectsRequest(parent_id=tenant_id)))
         except nebius.request_error() as e:
             return False, (
                 f'{e.status} \n'  # First line is indented by 4 spaces
@@ -657,8 +658,8 @@ class Nebius(clouds.Cloud):
         image_client = compute.ImageServiceClient(sdk)
         if image_id.startswith('computeimage-'):
             try:
-                image = image_client.get(
-                    compute.GetImageRequest(id=image_id)).wait()
+                image = nebius.sync_call(
+                    image_client.get(compute.GetImageRequest(id=image_id)))
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
                     raise ValueError(f'Image {image_id} does not exist') from e
@@ -670,7 +671,8 @@ class Nebius(clouds.Cloud):
             request = compute.GetImageLatestByFamilyRequest(
                 image_family=image_id, parent_id=parent_id)
             try:
-                image = image_client.get_latest_by_family(request).wait()
+                image = nebius.sync_call(
+                    image_client.get_latest_by_family(request))
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
                     raise ValueError(


### PR DESCRIPTION
Draft — opening for review. Follow-up to #10280 (which pins `nebius<0.4` as the tactical unblock); this removes the underlying fragility on our side.

## Problem

`sky/adaptors/nebius.py` runs nebius SDK coroutines on one dedicated background event loop, so synchronous call sites keep working (a workaround for nebius/pysdk#76). Not every call site used it:

- `Request.wait()`, the SDK's blocking helper, drives the request on a loop the **SDK** creates and owns — `sky/clouds/nebius.py` (3 sites), `sky/catalog/data_fetchers/fetch_nebius.py` (3 sites)
- `fetch_nebius.estimate_platforms()` wrapped its coroutine in `asyncio.run()`, creating (and then closing) a loop of its own

So one process could talk to the same SDK object from three different event loops. That is unsafe: the SDK caches `grpc.aio` channels per address and hands them to whichever loop asks next, while gRPC requires that

> gRPC Async API objects must be used exclusively on the thread where they were created.
> — `grpc/doc/python/sphinx/grpc_asyncio.md`

Once a channel created under one loop is reused from another:

```
RuntimeError: Task <... Request._request_with_authorization_loop ...> got Future
<... InterceptedUnaryUnaryCall._invoke ...> attached to a different loop
```

Both `0.4.1` and `0.4.2` (the latest at the time of writing) are affected. With `nebius<0.4` this stayed invisible: that release built a fresh channel per RPC and never repopulated the pool, so every loop happened to get its own channel. `nebius==0.4.1` does pool them, turning the latent bug into a hard failure — on a fresh install, `sky launch` on Nebius aborts right after the optimizer output, in `sky/provision/nebius/utils.py::get_project_by_region`.

Smallest repro, on `master` with `nebius==0.4.1` and Nebius credentials — no API server needed:

```python
from sky.catalog.data_fetchers import fetch_nebius
from sky.provision.nebius import utils

utils.get_project_by_region('eu-north1')   # sync_call -> adaptor loop, pools the iam channel
fetch_nebius._get_regions_map()            # Request.wait() -> SDK loop, takes that channel
# RuntimeError: ... got Future ... attached to a different loop
```

It only breaks when the two loops want the *same* service address: in the same script `fetch_platforms_for_project()` (the `compute` address) succeeds, because it builds its own channel.

## Change

Route the remaining seven call sites through `nebius.sync_call()`, so every channel is created and used on the adaptor's loop, and document the invariant in `sync_call()`'s docstring. Blocking semantics are unchanged — `asyncio.run(coro)` and `sync_call(coro)` both block the caller until the coroutine completes; only the executing loop moves. Concurrency inside `_estimate_platforms_async` is untouched (it still gathers all price requests).

## Verification

**CI.** `/smoke-test --aws -k test_api_server_start_stop` on this branch: [passed](https://buildkite.com/skypilot-1/smoke-tests/builds/12078) first attempt, no retries, `1 passed in 967.57s`. The agent installed `nebius==0.4.2` (unpinned), so the test ran against an affected SDK. The same test fails 4/4 on `master`.

**Local, unpinned SDK**, Linux (`python:3.10-slim`), clean `~/.sky` each cycle:

| code | nebius | `api start` → `api status` → `sky launch --dryrun` | `api start` → `sky check nebius` → `sky launch --dryrun` |
|---|---|---|---|
| `master` | 0.4.1 | exit 1, 3× "attached to a different loop" (5/5 cycles) | exit 0 |
| `master` | 0.4.2 | exit 1, 3× "attached to a different loop" (2/2 cycles) | — |
| this branch | 0.4.1 | **exit 0, 0 errors (2/2)** | **exit 0, 0 errors (2/2)** |

**Latency.** 12 sequential calls per cell against a real tenant (`eu-north1`), median of calls 2..n so the first call's TLS handshake and token exchange are excluded; macOS, Python 3.11:

| code | nebius | `ListPlatforms` (1 RPC) | regions map (n RPCs) |
|---|---|---|---|
| `master` | 0.3.101 | 1116 ms | 2214 ms |
| this branch | 0.3.101 | 1140 ms | 2137 ms |
| `master` | 0.4.1 | 404 ms | fails (cross-loop) |
| this branch | 0.4.1 | **393 ms** | **635 ms** |

Two things follow. On the currently pinned `0.3.101` the change is **latency-neutral** (differences are within run-to-run noise). The ~3x improvement is `0.4.1`'s channel pooling actually working — `0.3.101` pays a fresh handshake per RPC — which is only reachable once the SDK is driven from a single loop, i.e. with this PR the `<0.4` cap in #10280 can be lifted when nebius/pysdk#178 is resolved or sooner.

Question for reviewers: worth adding a guard test (e.g. asserting no `.wait()` / `asyncio.run` on nebius clients) so this cannot regress silently? Happy to add one.

## Tested (run the relevant ones):

- [x] Code formatting: `pre-commit` (all hooks pass)
- [x] Any manual or new tests for this PR (please specify below) — tables above
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test --aws -k test_api_server_start_stop`
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167mdJ9BaUqWgP4ZDZJzY38
