### PR TITLE
[Slurm] Fix node info aggregation for multi-cluster setups

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -18,6 +18,7 @@ from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import gpu_names
+from sky.utils import subprocess_utils
 from sky.utils.db import kv_cache
 
 logger = sky_logging.init_logger(__name__)
@@ -941,8 +942,7 @@ def resolve_gres_gpu_type(
     return chosen
 
 
-def _get_slurm_node_info_list(
-        slurm_cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
+def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     """Gathers detailed information about each node in the Slurm cluster.
 
     Raises:
@@ -954,11 +954,6 @@ def _get_slurm_node_info_list(
 
     # can raise FileNotFoundError if config file does not exist.
     slurm_config = get_slurm_ssh_config()
-    if slurm_cluster_name is None:
-        slurm_cluster_names = clouds.Slurm.existing_allowed_clusters()
-        if not slurm_cluster_names:
-            return []
-        slurm_cluster_name = slurm_cluster_names[0]
     slurm_config_dict = slurm_config.lookup(slurm_cluster_name)
     logger.debug(f'Slurm config dict: {slurm_config_dict}')
     slurm_client = slurm.SlurmClient(
@@ -1044,18 +1039,39 @@ def _get_slurm_node_info_list(
 
 def slurm_node_info(
         slurm_cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Gets detailed information for each node in the Slurm cluster.
+    """Gets detailed information for each node in the Slurm cluster(s).
+
+    Args:
+        slurm_cluster_name: The Slurm cluster to query. If None, node info
+            is aggregated across all existing allowed Slurm clusters.
 
     Returns:
         List[Dict[str, Any]]: A list of dictionaries, each containing node info.
     """
-    try:
-        node_list = _get_slurm_node_info_list(
-            slurm_cluster_name=slurm_cluster_name)
-    except (FileNotFoundError, RuntimeError, exceptions.NotSupportedError) as e:
-        logger.debug(f'Could not retrieve Slurm node info: {e}')
-        return []
-    return node_list
+    if slurm_cluster_name is not None:
+        clusters_to_query = [slurm_cluster_name]
+    else:
+        clusters_to_query = clouds.Slurm.existing_allowed_clusters()
+        if not clusters_to_query:
+            return []
+
+    def _query_cluster(cluster_name: str) -> List[Dict[str, Any]]:
+        try:
+            return _get_slurm_node_info_list(slurm_cluster_name=cluster_name)
+        except (FileNotFoundError, RuntimeError,
+                exceptions.NotSupportedError) as e:
+            logger.debug('Could not retrieve Slurm node info for cluster '
+                         f'{cluster_name!r}: {e}')
+            return []
+
+    if len(clusters_to_query) == 1:
+        return _query_cluster(clusters_to_query[0])
+    node_info_lists = subprocess_utils.run_in_parallel(_query_cluster,
+                                                       clusters_to_query)
+    return [
+        node_info for node_info_list in node_info_lists
+        for node_info in node_info_list
+    ]
 
 
 def is_inside_slurm_cluster() -> bool:

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -1,7 +1,9 @@
 """Unit tests for sky.provision.slurm.utils."""
+from unittest import mock
 
 import pytest
 
+from sky import exceptions
 from sky.provision.slurm import utils
 
 
@@ -90,3 +92,86 @@ class TestGetIdentityFile:
         """Test get_identity_file with various SSH config inputs."""
         result = utils.get_identity_file(ssh_config_dict)
         assert result == expected
+
+
+def _make_node_info(node_name: str, cluster_name: str) -> dict:
+    return {
+        'node_name': node_name,
+        'slurm_cluster_name': cluster_name,
+        'partition': 'main',
+        'node_state': 'idle',
+        'gpu_type': 'H100',
+        'total_gpus': 8,
+        'free_gpus': 8,
+        'vcpu_count': 96,
+        'memory_gb': 1024.0,
+    }
+
+
+class TestSlurmNodeInfo:
+    """Test slurm_node_info() multi-cluster aggregation."""
+
+    def test_aggregates_all_clusters_when_no_name_given(self, monkeypatch):
+        """slurm_node_info(None) should return nodes from all clusters."""
+        clusters = ['cluster-a', 'cluster-b', 'cluster-c']
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=clusters))
+        monkeypatch.setattr(
+            utils, '_get_slurm_node_info_list', lambda slurm_cluster_name: [
+                _make_node_info(f'{slurm_cluster_name}-node-0',
+                                slurm_cluster_name)
+            ])
+
+        result = utils.slurm_node_info()
+
+        assert len(result) == 3
+        assert {info['slurm_cluster_name'] for info in result} == set(clusters)
+
+    def test_queries_only_specified_cluster(self, monkeypatch):
+        """slurm_node_info with a name should query only that cluster."""
+        existing_allowed_clusters = mock.Mock(
+            return_value=['cluster-a', 'cluster-b'])
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            existing_allowed_clusters)
+        get_node_info_list = mock.Mock(
+            return_value=[_make_node_info('node-0', 'cluster-b')])
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            get_node_info_list)
+
+        result = utils.slurm_node_info(slurm_cluster_name='cluster-b')
+
+        assert len(result) == 1
+        assert result[0]['slurm_cluster_name'] == 'cluster-b'
+        get_node_info_list.assert_called_once_with(
+            slurm_cluster_name='cluster-b')
+        existing_allowed_clusters.assert_not_called()
+
+    def test_returns_empty_list_when_no_clusters(self, monkeypatch):
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=[]))
+        assert not utils.slurm_node_info()
+
+    def test_unreachable_cluster_does_not_break_others(self, monkeypatch):
+        """A failure on one cluster should not drop nodes of other clusters."""
+        clusters = ['cluster-a', 'cluster-b']
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=clusters))
+
+        def _fake_get_node_info_list(slurm_cluster_name):
+            if slurm_cluster_name == 'cluster-a':
+                raise RuntimeError('SSH connection failed')
+            return [_make_node_info('node-0', slurm_cluster_name)]
+
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            _fake_get_node_info_list)
+
+        result = utils.slurm_node_info()
+
+        assert len(result) == 1
+        assert result[0]['slurm_cluster_name'] == 'cluster-b'
+
+    def test_single_cluster_error_returns_empty_list(self, monkeypatch):
+        monkeypatch.setattr(
+            utils, '_get_slurm_node_info_list',
+            mock.Mock(side_effect=exceptions.NotSupportedError('nope')))
+        assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')


### PR DESCRIPTION
## Summary

This PR fixes the Slurm infrastructure dashboard node info path for multi-cluster setups.

When `slurm_cluster_name` is not specified, `slurm_node_info()` now queries all existing allowed Slurm clusters and aggregates the returned node info instead of implicitly falling back to only the first configured cluster.

## Context

Previously, the dashboard could show aggregate GPU totals across all Slurm clusters while `/slurm_node_info` returned nodes from only one configured cluster. This made the infrastructure page inconsistent for multi-cluster Slurm deployments.

Fixes #10282.

## Test Plan

- Added unit coverage for:
  - aggregating all allowed Slurm clusters when no cluster name is provided
  - querying only the requested cluster when `slurm_cluster_name` is specified
  - returning an empty list when no Slurm clusters are configured
  - preserving best-effort behavior when one configured Slurm cluster fails
  - returning an empty list for a single-cluster query failure

- Local review validation:
  - `PYTHONPYCACHEPREFIX=/private/tmp/skypilot-review-pycache python3 -m compileall -q sky/provision/slurm/utils.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py`
