### PR TITLE
[Slurm] Use node AllocTRES for GPU availability accounting

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -33,8 +33,18 @@ SLURM_CONTAINER_MARKER_FILE = '.sky_slurm_container'
 # Regex pattern for parsing GPU GRES strings.
 # Format: 'gpu[:acc_type]:acc_count(optional_extra_info)'
 # Examples: 'gpu:8', 'gpu:H100:8', 'gpu:nvidia_h100_80gb_hbm3:8(S:0-1)'
-_GRES_GPU_PATTERN = re.compile(r'\bgpu:(?:(?P<type>[^:(]+):)?(?P<count>\d+)',
-                               re.IGNORECASE)
+# Also accepts '=' as the count separator to handle TRES-style strings
+# that appear in some Slurm outputs (e.g. squeue %b can return
+# 'gres/gpu=1' or 'gres/gpu:h100=2').
+_GRES_GPU_PATTERN = re.compile(
+    r'\bgpu[:=](?:(?P<type>[^:=(,]+)[:=])?(?P<count>\d+)', re.IGNORECASE)
+
+# Regex pattern for parsing GPU entries in TRES strings from
+# `scontrol show node` (CfgTRES/AllocTRES), e.g.
+# 'cpu=64,mem=800G,billing=64,gres/gpu=8' or typed entries such as
+# 'gres/gpu=8,gres/gpu:h100=8'.
+_TRES_GPU_PATTERN = re.compile(
+    r'(?:^|,)gres/gpu(?::(?P<type>[^=,]+))?=(?P<count>\d+)', re.IGNORECASE)
 
 _SLURM_NODES_INFO_CACHE_TTL = 30 * 60
 # Proctrack type is highly unlikely to change.
@@ -73,6 +83,24 @@ def get_gpu_type_and_count(gres_str: str) -> Tuple[Optional[str], int]:
     if not match:
         return None, 0
     return match.group('type'), int(match.group('count'))
+
+
+def get_gpu_count_from_tres(tres_str: str) -> int:
+    """Parses the GPU count from a TRES string (CfgTRES/AllocTRES).
+
+    A TRES string may contain both an untyped total (``gres/gpu=8``) and
+    typed entries (``gres/gpu:h100=8``). The untyped total is preferred;
+    if only typed entries are present, their counts are summed.
+
+    Returns:
+        The GPU count. If no GPU entry is found, returns 0.
+    """
+    typed_total = 0
+    for match in _TRES_GPU_PATTERN.finditer(tres_str):
+        if match.group('type') is None:
+            return int(match.group('count'))
+        typed_total += int(match.group('count'))
+    return typed_total
 
 
 def pyxis_container_name(cluster_name_on_cloud: str) -> str:
@@ -942,6 +970,18 @@ def resolve_gres_gpu_type(
     return chosen
 
 
+@annotations.lru_cache(scope='request')
+def _get_all_jobs_gres(
+        slurm_client: 'slurm.SlurmClient') -> Dict[str, List[str]]:
+    """Request-scoped cached wrapper around SlurmClient.get_all_jobs_gres().
+
+    Fetched lazily: `squeue` is only queried when at least one node falls
+    back to job-level GPU accounting (see _get_slurm_node_info_list), and
+    at most once per client instance.
+    """
+    return slurm_client.get_all_jobs_gres()
+
+
 def _parse_int_or_none(value: Optional[str]) -> Optional[int]:
     """Parse an int from an scontrol attribute value; None on N/A/garbage."""
     if value is None:
@@ -1007,7 +1047,6 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     # 2. Process each node, aggregating partitions per node
     slurm_nodes_info: Dict[str, Dict[str, Any]] = {}
 
-    nodes_to_jobs_gres = slurm_client.get_all_jobs_gres()
     for node_info in node_infos:
         node_name = node_info.node
         state = node_info.state
@@ -1026,22 +1065,47 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
             else:
                 node_gpu_type = 'GPU'
 
-        # Get allocated GPUs
+        # Per-node scontrol attributes (fetched once above); empty when
+        # scontrol was unavailable.
+        details = node_details_by_name.get(node_name, {})
+
+        # Get allocated GPUs.
+        # Node-level TRES accounting (AllocTRES from `scontrol show node`)
+        # is the preferred source for allocated GPUs: job-level
+        # `squeue -o "%b"` can be `N/A` even when the job has allocated
+        # GPUs (e.g. jobs requesting GPUs via --tres-per-task), or can use
+        # GRES formats the parser does not recognize, causing free GPUs to
+        # be overestimated.
+        # See https://github.com/skypilot-org/skypilot/issues/10283.
         allocated_gpus = 0
-        # TODO(zhwu): move to enum
-        if state in ('alloc', 'mix', 'drain', 'drng', 'drained', 'resv',
-                     'comp'):
-            jobs_gres = nodes_to_jobs_gres.get(node_name, [])
-            if jobs_gres:
-                for job_line in jobs_gres:
-                    _, job_gpu_count = get_gpu_type_and_count(job_line)
-                    allocated_gpus += job_gpu_count
-            elif state == 'alloc':
-                # If no GRES info found but node is fully allocated,
-                # assume all GPUs are in use.
-                allocated_gpus = total_gpus
-        elif state == 'idle':
-            allocated_gpus = 0
+        use_tres = False
+        if details and total_gpus > 0:
+            # Only trust AllocTRES if the cluster actually tracks
+            # gres/gpu in TRES: on clusters that do not project GRES
+            # into TRES, CfgTRES reports 0 GPUs while sinfo %G reports
+            # the real count, and AllocTRES would silently under-report
+            # the allocation.
+            cfg_tres = details.get('CfgTRES', '')
+            alloc_tres = details.get('AllocTRES', '')
+            if get_gpu_count_from_tres(cfg_tres) >= total_gpus:
+                allocated_gpus = get_gpu_count_from_tres(alloc_tres)
+                use_tres = True
+        if not use_tres and total_gpus > 0:
+            # Fall back to job-level accounting via squeue.
+            # TODO(zhwu): move to enum
+            if state in ('alloc', 'mix', 'drain', 'drng', 'drained', 'resv',
+                         'comp'):
+                jobs_gres = _get_all_jobs_gres(slurm_client).get(node_name, [])
+                if jobs_gres:
+                    for job_line in jobs_gres:
+                        _, job_gpu_count = get_gpu_type_and_count(job_line)
+                        allocated_gpus += job_gpu_count
+                elif state == 'alloc':
+                    # If no GRES info found but node is fully allocated,
+                    # assume all GPUs are in use.
+                    allocated_gpus = total_gpus
+            elif state == 'idle':
+                allocated_gpus = 0
 
         free_gpus = total_gpus - allocated_gpus if state not in ('down',
                                                                  'drain',
@@ -1052,7 +1116,6 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         # CPU/memory allocation + sampled usage from scontrol. All of
         # these are None when scontrol was unavailable or reported N/A
         # (e.g. on down nodes).
-        details = node_details_by_name.get(node_name, {})
         cpu_alloc = _parse_int_or_none(details.get('CPUAlloc'))
         cpu_tot = _parse_int_or_none(details.get('CPUTot'))
         free_vcpus = None

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from sky import exceptions
+from sky.adaptors import slurm as slurm_adaptor
 from sky.provision.slurm import utils
 
 
@@ -175,6 +176,247 @@ class TestSlurmNodeInfo:
             utils, '_get_slurm_node_info_list',
             mock.Mock(side_effect=exceptions.NotSupportedError('nope')))
         assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')
+
+
+class TestGetGpuTypeAndCount:
+    """Test get_gpu_type_and_count() GRES parsing."""
+
+    @pytest.mark.parametrize(
+        'gres_str,expected',
+        [
+            # Colon-style GRES from sinfo %G / squeue %b.
+            ('gpu:8', (None, 8)),
+            ('gpu:H100:8', ('H100', 8)),
+            ('gpu:nvidia_h100_80gb_hbm3:8(S:0-1)',
+             ('nvidia_h100_80gb_hbm3', 8)),
+            # TRES/equals-style GRES that some Slurm versions return for
+            # squeue %b. See #10283.
+            ('gres/gpu=1', (None, 1)),
+            ('gres/gpu:8', (None, 8)),
+            ('gres/gpu:h100=2', ('h100', 2)),
+            ('gres/gpu:h100:4', ('h100', 4)),
+            # No GPU allocation.
+            ('N/A', (None, 0)),
+            ('(null)', (None, 0)),
+            ('', (None, 0)),
+            ('cpu=8,mem=32G', (None, 0)),
+        ])
+    def test_get_gpu_type_and_count(self, gres_str, expected):
+        assert utils.get_gpu_type_and_count(gres_str) == expected
+
+
+class TestGetGpuCountFromTres:
+    """Test get_gpu_count_from_tres() TRES parsing."""
+
+    @pytest.mark.parametrize(
+        'tres_str,expected',
+        [
+            ('cpu=64,mem=800G,node=1,billing=64,gres/gpu=8', 8),
+            # Untyped total is preferred over typed entries.
+            ('cpu=64,mem=800G,gres/gpu=8,gres/gpu:h100=8', 8),
+            ('gres/gpu:h100=8,gres/gpu=8', 8),
+            # Only typed entries: counts are summed.
+            ('cpu=8,gres/gpu:h100=4,gres/gpu:a100=2', 6),
+            # No GPU entries.
+            ('cpu=64,mem=400G', 0),
+            ('', 0),
+            # 'gres/gpu' should not match other gres types.
+            ('cpu=8,gres/shard=32', 0),
+        ])
+    def test_get_gpu_count_from_tres(self, tres_str, expected):
+        assert utils.get_gpu_count_from_tres(tres_str) == expected
+
+
+class _FakeSlurmClient:
+    """Fake SlurmClient for _get_slurm_node_info_list tests."""
+
+    def __init__(self,
+                 node_infos,
+                 node_details=None,
+                 jobs_gres=None,
+                 details_error=None):
+        self._node_infos = node_infos
+        self._node_details = node_details or {}
+        self._jobs_gres = jobs_gres or {}
+        self._details_error = details_error
+        self.jobs_gres_calls = 0
+
+    def info_nodes(self):
+        return self._node_infos
+
+    def get_all_node_details(self):
+        if self._details_error is not None:
+            raise self._details_error
+        return self._node_details
+
+    def get_all_jobs_gres(self):
+        self.jobs_gres_calls += 1
+        return self._jobs_gres
+
+
+class TestGetSlurmNodeInfoList:
+    """Test _get_slurm_node_info_list() GPU accounting."""
+
+    def _patch(self, monkeypatch, fake_client):
+        ssh_config = mock.Mock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'host',
+            'user': 'user',
+        }
+        monkeypatch.setattr(utils, 'get_slurm_ssh_config', lambda: ssh_config)
+        monkeypatch.setattr(utils.slurm, 'SlurmClient',
+                            lambda *args, **kwargs: fake_client)
+
+    def _make_sinfo_node(self, state) -> slurm_adaptor.NodeInfo:
+        return slurm_adaptor.NodeInfo(node='node1',
+                                      state=state,
+                                      gres='gpu:h100:8',
+                                      cpus=192,
+                                      memory_gb=800.0,
+                                      partition='main')
+
+    def test_alloc_tres_used_when_squeue_gres_is_na(self, monkeypatch):
+        """Node-level AllocTRES should be used even if squeue %b is N/A.
+
+        Regression test for #10283: jobs requesting GPUs via
+        --tres-per-task report %b as N/A, so squeue-based accounting
+        counts 0 allocated GPUs.
+        """
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192,gres/gpu=8',
+                    'AllocTRES': 'cpu=64,mem=400G,gres/gpu=8',
+                },
+            },
+            # squeue %b returned N/A for the job, so no GRES was recorded.
+            jobs_gres={})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['total_gpus'] == 8
+        assert result[0]['free_gpus'] == 0
+
+    def test_alloc_tres_empty_on_idle_node(self, monkeypatch):
+        """An idle node with empty AllocTRES should have all GPUs free."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('idle')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192,gres/gpu=8',
+                    'AllocTRES': '',
+                },
+            })
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 8
+
+    def test_fallback_when_tres_lacks_gpu(self, monkeypatch):
+        """Fall back to squeue if the cluster does not track gres/gpu in TRES.
+
+        scontrol succeeds, but CfgTRES reports no GPUs while sinfo %G
+        reports 8: AllocTRES cannot be trusted for GPU accounting, so the
+        squeue-based path must be used.
+        """
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('alloc')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192',
+                    'AllocTRES': 'cpu=192,mem=800G,billing=192',
+                },
+            },
+            jobs_gres={'node1': ['gpu:h100:8']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 0
+
+    def test_fallback_when_node_missing_from_details(self, monkeypatch):
+        """A sinfo node absent from scontrol output uses squeue accounting."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            # scontrol succeeded but did not report this node (e.g. node
+            # added between the two calls).
+            node_details={},
+            jobs_gres={'node1': ['gres/gpu=1']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 7
+
+    def test_fallback_to_squeue_when_scontrol_fails(self, monkeypatch):
+        """If scontrol fails, fall back to squeue-based accounting."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            details_error=RuntimeError('scontrol failed'),
+            # Equals-style GRES string (see #10283 example 2).
+            jobs_gres={'node1': ['gres/gpu=1']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 7
+
+    def test_fallback_fully_allocated_node_without_gres(self, monkeypatch):
+        """Fallback: alloc node with no job GRES info counts 0 free GPUs."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('alloc')],
+            details_error=RuntimeError('scontrol failed'),
+            jobs_gres={})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 0
+
+    def test_squeue_not_queried_on_cpu_only_cluster(self, monkeypatch):
+        """CPU-only clusters never pay the squeue round-trip."""
+        cpu_node = slurm_adaptor.NodeInfo(node='node1',
+                                          state='alloc',
+                                          gres='(null)',
+                                          cpus=8,
+                                          memory_gb=32.0,
+                                          partition='main')
+        fake_client = _FakeSlurmClient(node_infos=[cpu_node])
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['total_gpus'] == 0
+        assert result[0]['free_gpus'] == 0
+        assert fake_client.jobs_gres_calls == 0
+
+    def test_squeue_not_queried_when_tres_covers_all_nodes(self, monkeypatch):
+        """squeue is not queried when AllocTRES covers every GPU node."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192,gres/gpu=8',
+                    'AllocTRES': 'cpu=64,mem=400G,gres/gpu=4',
+                },
+            })
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 4
+        assert fake_client.jobs_gres_calls == 0
 
 
 class TestGetSlurmNodeInfoListEnrichment:


### PR DESCRIPTION
## Summary

This PR improves Slurm GPU availability accounting by preferring node-level TRES allocation data from `scontrol show nodes -o`.

The previous path relied on job-level `squeue -o "%b"` GRES output. In some Slurm setups, `%b` may be `N/A` even when the job has allocated GPUs in `AllocTRES`, or may use equals-style GRES strings such as `gres/gpu=1`. That can cause SkyPilot to overestimate free GPUs.

Fixes #10283.

## Changes

- Add `SlurmClient.get_all_nodes_tres()` to parse `CfgTRES` and `AllocTRES` from `scontrol show nodes -o`.
- Add TRES GPU count parsing for `gres/gpu=...` and typed GPU entries such as `gres/gpu:h100=...`.
- Update Slurm node info accounting to prefer node-level `AllocTRES` GPU allocation and fall back to the existing `squeue`-based path if `scontrol` fails.
- Extend GRES parsing to handle equals-style strings returned by some Slurm versions.

## Test Plan

- Added unit coverage for:
  - parsing `CfgTRES`/`AllocTRES` from `scontrol show nodes -o`
  - parsing colon-style and equals-style GRES strings
  - parsing untyped and typed GPU TRES entries
  - using `AllocTRES` when `squeue %b` is unavailable
  - falling back to `squeue`-based accounting when `scontrol` fails

- Local review validation:
  - `PYTHONPYCACHEPREFIX=/private/tmp/skypilot-review-gpu-pycache python3 -m compileall -q sky/adaptors/slurm.py sky/provision/slurm/utils.py tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py`

Note: I could not run pytest locally because this environment does not have `pytest` installed.
