### PR TITLE
[API] Redact basic-auth password when printing the API server URL

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -8209,7 +8209,10 @@ def api_info(output_format: str):
                        'server: sky api start')
         else:
             click.echo(
-                f'Could not connect to SkyPilot API server at {url}\n'
+                'Could not connect to SkyPilot API server at '
+                f'{server_common.redact_url_password(url)}\n'
+                # The hint below is meant to be copy-pasted, so it keeps the
+                # real URL -- redacting it would hand the user a broken command.
                 f'{ux_utils.INDENT_SYMBOL}To re-login to the API server: '
                 f'sky api login --relogin -e {url}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}To logout the server: '

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4059,8 +4059,10 @@ def check(infra_list: Tuple[str],
         api_server_url = server_common.get_server_url()
         click.echo()
         click.echo(
-            click.style(f'Using SkyPilot API server: {api_server_url}',
-                        fg='green'))
+            click.style(
+                'Using SkyPilot API server: '
+                f'{server_common.redact_url_password(api_server_url)}',
+                fg='green'))
 
 
 @cli.command()
@@ -8256,7 +8258,8 @@ def api_info(output_format: str):
             location = f'Endpoint set via {config_path}'
     else:
         location = 'Endpoint set to default local API server.'
-    click.echo(f'Using SkyPilot API server and dashboard: {url}\n'
+    click.echo(f'Using SkyPilot API server and dashboard: '
+               f'{server_common.redact_url_password(url)}\n'
                f'{ux_utils.INDENT_SYMBOL}Status: {api_server_info.status}, '
                f'commit: {api_server_info.commit}, '
                f'version: {api_server_info.version}\n'

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -18,6 +18,7 @@ import time
 import typing
 from typing import (Any, Callable, cast, Dict, Generic, List, Literal, Optional,
                     Tuple, TypeVar, Union)
+import urllib.parse
 from urllib.request import Request
 import uuid
 
@@ -499,6 +500,47 @@ def get_server_url(host: Optional[str] = None) -> str:
         constants.SKY_API_SERVER_URL_ENV_VAR,
         skypilot_config.get_nested(('api_server', 'endpoint'), endpoint))
     return url.rstrip('/')
+
+
+# Shown in place of a basic-auth password when a server URL is printed for
+# humans to read (banners, status lines). Chosen to be obviously not a real
+# password so nobody mistakes it for one.
+_REDACTED_PASSWORD = '<redacted>'
+
+
+def redact_url_password(url: str) -> str:
+    """Masks the basic-auth password embedded in a server URL, if any.
+
+    An API server endpoint can be configured with inline basic-auth
+    credentials, e.g. ``http://user:password@host:8080``. Echoing that URL
+    verbatim leaks the password into the terminal, logs, and -- when sky is
+    driven by an agent -- the agent's transcript. Use this only for the
+    human-readable places that display the URL; keep the real URL for anything
+    that has to connect or that the user needs to copy back into a command.
+
+    The username, scheme, host, port and path are preserved so the output is
+    still useful; only the password is replaced. Strings that are not URLs, or
+    URLs without a password, are returned unchanged.
+    """
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        # Not something urlsplit can make sense of; leave it untouched rather
+        # than risk mangling it.
+        return url
+    if not parsed.password:
+        return url
+
+    # urlsplit strips the brackets off an IPv6 literal, so add them back when
+    # rebuilding the authority or the ':port' becomes ambiguous.
+    host = parsed.hostname or ''
+    if is_ipv6_host(host):
+        host = f'[{host}]'
+    netloc = f'{parsed.username or ""}:{_REDACTED_PASSWORD}@{host}'
+    if parsed.port is not None:
+        netloc += f':{parsed.port}'
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
 
 
 # Wildcard bind addresses (0.0.0.0 / ::) are valid to *bind* but are not

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -524,11 +524,14 @@ def redact_url_password(url: str) -> str:
     """
     try:
         parsed = urllib.parse.urlsplit(url)
+        if not parsed.password:
+            return url
+        # urlsplit does not validate the port; SplitResult.port only raises
+        # when it is read, so keep that read inside the guard too.
+        port = parsed.port
     except ValueError:
         # Not something urlsplit can make sense of; leave it untouched rather
         # than risk mangling it.
-        return url
-    if not parsed.password:
         return url
 
     # urlsplit strips the brackets off an IPv6 literal, so add them back when
@@ -537,8 +540,8 @@ def redact_url_password(url: str) -> str:
     if is_ipv6_host(host):
         host = f'[{host}]'
     netloc = f'{parsed.username or ""}:{_REDACTED_PASSWORD}@{host}'
-    if parsed.port is not None:
-        netloc += f':{parsed.port}'
+    if port is not None:
+        netloc += f':{port}'
     return urllib.parse.urlunsplit(
         (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
 

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -780,3 +780,41 @@ def test_handle_request_error_5xx_stays_httperror():
     resp = _fake_response(500, {'detail': 'server boom'})
     with pytest.raises(requests.exceptions.HTTPError):
         common.handle_request_error(resp)
+
+
+def test_redact_url_password_masks_password():
+    """The password is masked while the rest of the URL is preserved."""
+    redacted = common.redact_url_password(
+        'http://alice:s3cr3t@example.com:8080')
+    assert redacted == 'http://alice:<redacted>@example.com:8080'
+    # The real password must not survive anywhere in the output.
+    assert 's3cr3t' not in redacted
+
+
+def test_redact_url_password_preserves_path_and_query():
+    """Scheme, host, port, path and query are all kept intact."""
+    url = 'https://user:hunter2@host:443/api/v1?token=abc'
+    redacted = common.redact_url_password(url)
+    assert redacted == 'https://user:<redacted>@host:443/api/v1?token=abc'
+    assert 'hunter2' not in redacted
+
+
+def test_redact_url_password_without_password_is_unchanged():
+    # No credentials at all.
+    assert common.redact_url_password(
+        'http://example.com:46580') == 'http://example.com:46580'
+    # A username but no password should be left alone.
+    assert common.redact_url_password(
+        'http://alice@example.com') == 'http://alice@example.com'
+
+
+def test_redact_url_password_ipv6_keeps_brackets():
+    """IPv6 hosts must stay bracketed so the ':port' is unambiguous."""
+    redacted = common.redact_url_password('http://user:pw@[::1]:8080')
+    assert redacted == 'http://user:<redacted>@[::1]:8080'
+
+
+def test_redact_url_password_non_url_is_unchanged():
+    # Something that isn't a URL should pass through untouched.
+    assert common.redact_url_password('not-a-url') == 'not-a-url'
+    assert common.redact_url_password('') == ''

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -818,3 +818,14 @@ def test_redact_url_password_non_url_is_unchanged():
     # Something that isn't a URL should pass through untouched.
     assert common.redact_url_password('not-a-url') == 'not-a-url'
     assert common.redact_url_password('') == ''
+
+
+def test_redact_url_password_bad_port_is_returned_unchanged():
+    """A malformed port must not raise, even with a password present.
+
+    urlsplit() accepts these, but SplitResult.port only validates when read,
+    so the read has to happen inside the guard. Otherwise `sky check` and
+    `sky api info` would abort instead of printing their summary line.
+    """
+    for url in ('http://user:pw@host:notaport', 'http://user:pw@host:99999'):
+        assert common.redact_url_password(url) == url


### PR DESCRIPTION
An API server endpoint can have basic-auth credentials baked into the URL, like `http://user:password@host:port`. That setup is pretty common with Helm/ingress deployments. Right now `sky check` and `sky api info` print the URL exactly as-is, so the password ends up in the terminal, in logs, and in an agent's transcript when sky is running under one. Closes #9529.

What changed:

I added a helper `redact_url_password()` in `sky/server/common.py`. It parses the URL and swaps just the password for `<redacted>`, keeping the scheme, username, host, port, and path so you can still tell which server the line is talking about. IPv6 hosts keep their brackets. If there's no password, or the string isn't a URL, it comes back untouched.

Then I called it in the two places that print the URL for a person to read: the "Using SkyPilot API server: ..." line in `sky check`, and the "Using SkyPilot API server and dashboard: ..." line in `sky api info`.

I left the real password in place everywhere it's actually needed:

- The SSH ProxyCommand that connects through the server.
- The `--format json` output of `sky api info`, since that output is meant to be parsed.
- The `sky api login --relogin -e <url>` hint in the "could not connect" path, since you have to copy that command and run it.

I kept the change small for now. If you'd rather redact more of the display spots, like the summary printed at the end of `sky launch`, I'm glad to do that too, just say the word.

Testing:

- [x] Code formatting: yapf, isort, mypy, and pylint all pass (pylint 10.00/10).
- [x] Unit tests: `pytest tests/unit_tests/test_sky/server/test_common.py -k redact`. Five cases: password masked, path and query preserved, no-password left alone, IPv6 brackets kept, non-URL left alone.
- [ ] Smoke tests: not applicable, this is just output formatting.
