### PR TITLE
[API] Export metrics for the on-demand request thread executor

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -272,24 +272,31 @@ SKY_APISERVER_SHORT_EXECUTORS = prom.Gauge(
 )
 
 # Active threads in on-demand thread executors. Each process has its own
-# executor with a per-process max_workers limit, so the pid label is kept:
+# executor with a per-process max_workers limit, so per-pid series are kept:
 # exhaustion is a per-process condition and a fleet-wide sum can exceed the
 # limit while no single executor is full. Compare against
 # sky_apiserver_threads_max with the same labels.
+#
+# multiprocess_mode must be 'liveall': for the aggregating modes (livesum
+# etc.) the multiprocess collector strips any label named 'pid' — including
+# this user-defined one — and merges all processes into a single series,
+# which hides per-process exhaustion.
 SKY_APISERVER_THREADS_ACTIVE = prom.Gauge(
     'sky_apiserver_threads_active',
     'Number of active threads in on-demand thread executors, per process',
     ['pid', 'name'],
-    multiprocess_mode='livesum',
+    multiprocess_mode='liveall',
 )
 
 # The max_workers limit of each on-demand thread executor, exported so
 # dashboards and alerts can compute utilization without hardcoding the limit.
+# 'liveall' for the same reason as sky_apiserver_threads_active: any other
+# mode would sum the limits across processes.
 SKY_APISERVER_THREADS_MAX = prom.Gauge(
     'sky_apiserver_threads_max',
     'Max workers of on-demand thread executors, per process',
     ['pid', 'name'],
-    multiprocess_mode='livesum',
+    multiprocess_mode='liveall',
 )
 
 # A gauge scraped every N seconds can miss short bursts that hit the limit;

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -271,6 +271,35 @@ SKY_APISERVER_SHORT_EXECUTORS = prom.Gauge(
     'Total number of short-running request executors in the API server',
 )
 
+# Active threads in on-demand thread executors. Each process has its own
+# executor with a per-process max_workers limit, so the pid label is kept:
+# exhaustion is a per-process condition and a fleet-wide sum can exceed the
+# limit while no single executor is full. Compare against
+# sky_apiserver_threads_max with the same labels.
+SKY_APISERVER_THREADS_ACTIVE = prom.Gauge(
+    'sky_apiserver_threads_active',
+    'Number of active threads in on-demand thread executors, per process',
+    ['pid', 'name'],
+    multiprocess_mode='livesum',
+)
+
+# The max_workers limit of each on-demand thread executor, exported so
+# dashboards and alerts can compute utilization without hardcoding the limit.
+SKY_APISERVER_THREADS_MAX = prom.Gauge(
+    'sky_apiserver_threads_max',
+    'Max workers of on-demand thread executors, per process',
+    ['pid', 'name'],
+    multiprocess_mode='livesum',
+)
+
+# A gauge scraped every N seconds can miss short bursts that hit the limit;
+# this counter is the reliable signal that exhaustion actually happened.
+SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
+    'sky_apiserver_threads_exhausted_total',
+    'Number of tasks rejected because an on-demand thread executor was full',
+    ['name'],
+)
+
 # Time a request spends waiting in the task queue (from creation to dequeue).
 SKY_APISERVER_QUEUE_WAIT_SECONDS = prom.Histogram(
     'sky_apiserver_queue_wait_seconds',

--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -2,12 +2,16 @@
 
 import asyncio
 import concurrent.futures
+import os
 import sys
 import threading
-from typing import Callable, Set, TypeVar
+from typing import Callable, Optional, Set, TypeVar
+
+import prometheus_client as prom
 
 from sky import exceptions
 from sky import sky_logging
+from sky.metrics import utils as metrics_utils
 from sky.utils import atomic
 
 # pylint: disable=ungrouped-imports
@@ -46,6 +50,20 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         self._shutdown_lock: threading.Lock = threading.Lock()
         self._threads: Set[threading.Thread] = set()
         self._threads_lock: threading.Lock = threading.Lock()
+        # Cache the labeled metric children to avoid the label lookup on
+        # every submit/complete.
+        self._active_gauge: Optional[prom.Gauge] = None
+        self._exhausted_counter: Optional[prom.Counter] = None
+        if metrics_utils.METRICS_ENABLED:
+            pid = os.getpid()
+            self._active_gauge = (
+                metrics_utils.SKY_APISERVER_THREADS_ACTIVE.labels(pid=pid,
+                                                                  name=name))
+            self._exhausted_counter = (
+                metrics_utils.SKY_APISERVER_THREADS_EXHAUSTED_TOTAL.labels(
+                    name=name))
+            metrics_utils.SKY_APISERVER_THREADS_MAX.labels(
+                pid=pid, name=name).set(max_workers)
 
     def _cleanup_thread(self, thread: threading.Thread):
         with self._threads_lock:
@@ -85,6 +103,8 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                 fut.set_exception(e)
         finally:
             self.running.decrement()
+            if self._active_gauge is not None:
+                self._active_gauge.dec()
             self._cleanup_thread(threading.current_thread())
 
     def check_available(self, borrow: bool = False) -> int:
@@ -98,6 +118,8 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         count = self.running.increment()
         if count > self.max_workers:
             self.running.decrement()
+            if self._exhausted_counter is not None:
+                self._exhausted_counter.inc()
             raise exceptions.ConcurrentWorkerExhaustedError(
                 f'Maximum concurrent workers {self.max_workers} of threads '
                 f'executor [{self.name}] reached')
@@ -112,6 +134,8 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                 raise RuntimeError(
                     'Cannot submit task after executor is shutdown')
             count = self.check_available(borrow=True)
+            if self._active_gauge is not None:
+                self._active_gauge.inc()
             fut: concurrent.futures.Future = concurrent.futures.Future()
             # Name is assigned for debugging purpose, duplication is fine
             thread = threading.Thread(target=self._task_wrapper,
@@ -125,6 +149,8 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                 thread.start()
             except Exception as e:
                 self.running.decrement()
+                if self._active_gauge is not None:
+                    self._active_gauge.dec()
                 self._cleanup_thread(thread)
                 fut.set_exception(e)
                 raise

--- a/tests/unit_tests/test_sky/server/requests/test_threads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_threads.py
@@ -151,6 +151,19 @@ def test_on_demand_executor_metrics(monkeypatch):
     executor = OnDemandThreadExecutor(name=name, max_workers=2)
     release_event = threading.Event()
     try:
+        # The gauges must use 'liveall': the multiprocess collector strips
+        # any label named 'pid' for the aggregating modes (livesum etc.) and
+        # merges all processes into one series, hiding per-process
+        # exhaustion. This registry-level test cannot catch that (the
+        # multiprocess merge only runs when PROMETHEUS_MULTIPROC_DIR is
+        # set), so pin the mode directly.
+        # pylint: disable=protected-access
+        assert (metrics_utils.SKY_APISERVER_THREADS_ACTIVE._multiprocess_mode ==
+                'liveall')
+        assert (metrics_utils.SKY_APISERVER_THREADS_MAX._multiprocess_mode ==
+                'liveall')
+        # pylint: enable=protected-access
+
         assert _gauge_value('sky_apiserver_threads_max', name) == 2
         assert _gauge_value('sky_apiserver_threads_active', name) == 0
 

--- a/tests/unit_tests/test_sky/server/requests/test_threads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_threads.py
@@ -1,13 +1,16 @@
 """Unit tests for sky/server/requests/threads.py."""
 
 import concurrent.futures
+import os
 import queue
 import threading
 import time
 
+import prometheus_client
 import pytest
 
 from sky import exceptions
+from sky.metrics import utils as metrics_utils
 from sky.server.requests.threads import OnDemandThreadExecutor
 
 
@@ -129,5 +132,50 @@ def test_on_demand_executor_threads_dict_cleanup():
         assert fut.result(timeout=5) is True
         assert len(executor._threads) == 0
         assert executor.running.get() == 0
+    finally:
+        executor.shutdown()
+
+
+def _gauge_value(name: str, executor_name: str) -> float:
+    value = prometheus_client.REGISTRY.get_sample_value(name, {
+        'pid': str(os.getpid()),
+        'name': executor_name
+    })
+    assert value is not None
+    return value
+
+
+def test_on_demand_executor_metrics(monkeypatch):
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    name = 'metrics_test'
+    executor = OnDemandThreadExecutor(name=name, max_workers=2)
+    release_event = threading.Event()
+    try:
+        assert _gauge_value('sky_apiserver_threads_max', name) == 2
+        assert _gauge_value('sky_apiserver_threads_active', name) == 0
+
+        f1 = executor.submit(blocking_task, release_event)
+        f2 = executor.submit(blocking_task, release_event)
+        assert _gauge_value('sky_apiserver_threads_active', name) == 2
+
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(blocking_task, release_event)
+        assert prometheus_client.REGISTRY.get_sample_value(
+            'sky_apiserver_threads_exhausted_total', {'name': name}) == 1
+        # The rejected submit must not leak into the active gauge.
+        assert _gauge_value('sky_apiserver_threads_active', name) == 2
+
+        release_event.set()
+        concurrent.futures.wait([f1, f2], timeout=5)
+        assert f1.result() is True
+        assert f2.result() is True
+        # The gauge is decremented in the worker thread after the future
+        # resolves; poll briefly to avoid racing that final decrement.
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if _gauge_value('sky_apiserver_threads_active', name) == 0:
+                break
+            time.sleep(0.01)
+        assert _gauge_value('sky_apiserver_threads_active', name) == 0
     finally:
         executor.shutdown()


### PR DESCRIPTION
## Summary

The request thread executor caps concurrent threads per process (`_REQUEST_THREADS_LIMIT = 128`) and rejects submissions with `ConcurrentWorkerExhaustedError` once the cap is hit, but there is currently no visibility into how close a process is to the cap or how often exhaustion actually happens — the resulting 503 is indistinguishable from other 5xx in `sky_apiserver_requests_total`.

This PR adds three metrics, instrumented inside `OnDemandThreadExecutor` (gated on `METRICS_ENABLED` like the other server metrics):

- `sky_apiserver_threads_active{pid, name}` — active threads in the executor, per process. Uses `multiprocess_mode='liveall'` (same pattern as `sky_apiserver_event_loop_lag_max_seconds`) so each process keeps its own series through the multiprocess collector.
- `sky_apiserver_threads_max{pid, name}` — the executor's `max_workers` limit, so dashboards and alerts can compute utilization (`active / max`) without hardcoding the limit.
- `sky_apiserver_threads_exhausted_total{name}` — submissions rejected because the executor was full. A gauge sampled at scrape interval can miss short bursts that hit the limit; this counter is the reliable signal that exhaustion happened.

Per-pid series are load-bearing here, not cosmetic: each process has its own executor and limit, so exhaustion is a per-process condition — a fleet-wide sum can exceed the limit while no single executor is full. This is also why the gauges must use `liveall` rather than an aggregating mode: for `livesum`/`livemax`/etc., `MultiProcessCollector` strips any label named `pid` (including a user-defined one) before merging, which would collapse all processes into one summed series (`threads_max` = N×128 for N workers) and hide a single fully-exhausted worker. The unit test pins the mode since the registry-level test cannot exercise the multiprocess merge path.

Other design notes:
- The gauge mirrors the executor's existing `running` counter at its durable transitions only (successful submit, task completion, thread-start failure); the transient probe in `check_available(borrow=False)` is not instrumented.
- Labeled metric children are cached in `__init__` to avoid the label lookup on every submit/complete.
- A scrape-time custom collector would not work here: the executor is per-process and `/metrics` is served by a separate process via `MultiProcessCollector`, so the value must be written from the owning process.

## Test plan

- Added `test_on_demand_executor_metrics` to `tests/unit_tests/test_sky/server/requests/test_threads.py`, covering: max gauge set on init, active gauge tracking submit/complete, rejected submissions incrementing the exhausted counter without leaking into the active gauge, the gauge returning to 0 after tasks finish, and pinning `multiprocess_mode='liveall'` on both gauges.
- `pytest tests/unit_tests/test_sky/server/requests/test_threads.py` — all 8 tests pass.
- `bash format.sh --files sky/server/requests/threads.py sky/metrics/utils.py tests/unit_tests/test_sky/server/requests/test_threads.py` — yapf/isort/mypy clean (one pre-existing pylint `protected-access` warning in the untouched `test_on_demand_executor_threads_dict_cleanup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)