### PR TITLE
[Test] Raise sky jobs queue limit in the managed job status wait helper

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -326,13 +326,20 @@ def get_cmd_wait_until_job_status_contains_matching_job_name(
 # than a fixed column index. This keeps the wait robust regardless of which
 # columns the server renders (e.g. on a shared server where jobs from
 # multiple workspaces are listed and the WORKSPACE column appears).
+#
+# `sky jobs queue` defaults to showing only the latest 50 jobs. On a shared
+# server, a job that stays queued for a while can be pushed out of that window
+# by unrelated jobs submitted after it; the awk below then matches nothing and
+# the wait spins on an empty status until it times out, even though the job did
+# reach the expected state. Pass an explicit high --limit so the row stays
+# visible for the whole wait.
 _WAIT_UNTIL_MANAGED_JOB_STATUS_CONTAINS_MATCHING_JOB_NAME = (
     'start_time=$SECONDS; '
     'while true; do '
     'if (( $SECONDS - $start_time > {timeout} )); then '
     '  echo "Timeout after {timeout} seconds waiting for job status \'{job_status}\'"; exit 1; '
     'fi; '
-    'current_queue=$(sky jobs queue); '
+    'current_queue=$(sky jobs queue --limit 1000); '
     'current_status=$(echo "$current_queue" | '
     r'awk "{{name_found=0; '
     r'for (i=1; i<=NF; i++) if (\$i == \"{job_name}\") name_found=1; '


### PR DESCRIPTION
## Summary

- `get_cmd_wait_until_managed_job_status_contains_matching_job_name` polls a bare `sky jobs queue`, which shows only the latest 50 managed jobs by default (`_NUM_MANAGED_JOBS_TO_SHOW`).
- On a busy shared API server, a job that stays queued for several minutes gets pushed out of that window by unrelated jobs submitted after it. The awk filter then matches no row and reports an empty status, so the wait spins until it times out — even though the job did reach the expected state.
- Pass an explicit `--limit 1000` so the target row stays visible for the whole wait.

This turns a listing-visibility issue into an opaque `Timeout after N seconds waiting for job status '...'`, which is easy to misread as a real product regression. Tests that keep a job queued for a while (e.g. behind a long-running blocker) are the ones exposed; fast-moving tests never sit still long enough to age out.

Observed instance: a test waiting for a job to reach `RUNNING` logged `current status: PENDING` normally, then abruptly switched to an empty `current status:` and stayed there for the remaining ~13 minutes. The poll where the job vanished had an oldest visible row exactly one job ID above the target — the target had just fallen off the top-50. A wider listing after the timeout confirmed the job had gone `RUNNING` ~3 minutes after it disappeared and finished `SUCCEEDED`, well inside the wait budget.

Note that `--output-format json` would not help here: that path consumes the same `limit=max_num_jobs_to_show` request, so it truncates identically. A per-job filter would be the tightest fix, but `sky jobs queue` exposes no `--job-id`/name flag today (the `job_ids` argument exists on `queue_v2` but the CLI never passes it), and this helper matches by name without ever capturing the numeric ID.

## Test plan

- Rendered the command template and confirmed it emits `sky jobs queue --limit 1000` with no `.format()` brace-escaping breakage (the template embeds a literal awk block using `{{`/`}}`).
- Confirmed `-l/--limit INTEGER` is a valid `sky jobs queue` flag via the CLI's own `--help` (default 50).
- Ran `bash format.sh --files tests/smoke_tests/smoke_tests_utils.py`; no reformatting of the changed lines, and all remaining pylint warnings are pre-existing on untouched lines.
- Comment-and-flag-only change to a test helper; no product code paths touched. Behavior is unchanged for any wait where the job was already inside the default window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)