### PR TITLE
[Slurm] Make multi-cluster node info aggregation actually best-effort

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1036,10 +1036,16 @@ def _parse_float_or_none(value: Optional[str]) -> Optional[float]:
 def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     """Gathers detailed information about each node in the Slurm cluster.
 
+    Args:
+        slurm_cluster_name: The Slurm cluster to query. Must be a host defined
+            in the Slurm SSH config (~/.slurm/config).
+
     Raises:
         FileNotFoundError: If the Slurm configuration file does not exist.
-        ValueError: If no Slurm cluster name is found in the Slurm
-                    configuration file.
+        KeyError: If the cluster's entry in the Slurm configuration file is
+            missing a required field, e.g. `User`.
+        exceptions.CommandError: If a Slurm command fails on the cluster, e.g.
+            because the login node is unreachable.
     """
     # 1. Get node state and GRES using sinfo
 
@@ -1211,25 +1217,44 @@ def slurm_node_info(
             cpu_load / free_memory_gb (slurmd-sampled usage) — the
             enrichment fields are None when scontrol is unavailable or
             reports N/A.
+
+    Raises:
+        exceptions.CommandError: If a single cluster is explicitly requested
+            and querying it fails. Failures are never raised when aggregating
+            across clusters, so that one unreachable cluster does not hide the
+            nodes of the reachable ones.
     """
     if slurm_cluster_name is not None:
-        clusters_to_query = [slurm_cluster_name]
-    else:
-        clusters_to_query = clouds.Slurm.existing_allowed_clusters()
-        if not clusters_to_query:
+        # An explicitly requested cluster propagates query failures, so that
+        # callers can tell an unreachable cluster apart from a cluster with no
+        # nodes. `sky show-gpus` and the dashboard's per-cluster GPU tile rely
+        # on this to report the cluster as failed instead of empty, see
+        # `core.realtime_slurm_gpu_availability`.
+        try:
+            return _get_slurm_node_info_list(
+                slurm_cluster_name=slurm_cluster_name)
+        except (FileNotFoundError, RuntimeError,
+                exceptions.NotSupportedError) as e:
+            logger.debug(f'Could not retrieve Slurm node info: {e}')
             return []
+
+    clusters_to_query = clouds.Slurm.existing_allowed_clusters()
+    if not clusters_to_query:
+        return []
 
     def _query_cluster(cluster_name: str) -> List[Dict[str, Any]]:
         try:
             return _get_slurm_node_info_list(slurm_cluster_name=cluster_name)
-        except (FileNotFoundError, RuntimeError,
-                exceptions.NotSupportedError) as e:
-            logger.debug('Could not retrieve Slurm node info for cluster '
-                         f'{cluster_name!r}: {e}')
+        except Exception as e:  # pylint: disable=broad-except
+            # Best-effort aggregation: an unreachable login node raises
+            # exceptions.CommandError and a malformed ~/.slurm/config entry
+            # raises KeyError. run_in_parallel re-raises the first exception,
+            # so anything escaping here would drop every cluster's nodes.
+            logger.warning(
+                f'Skipping Slurm cluster {cluster_name!r} while collecting '
+                f'node info: {common_utils.format_exception(e)}')
             return []
 
-    if len(clusters_to_query) == 1:
-        return _query_cluster(clusters_to_query[0])
     node_info_lists = subprocess_utils.run_in_parallel(_query_cluster,
                                                        clusters_to_query)
     return [

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -218,6 +218,14 @@ def _make_node_info(node_name: str, cluster_name: str) -> dict:
     }
 
 
+def _make_command_error() -> exceptions.CommandError:
+    """The error raised when a Slurm command fails, e.g. on an unreachable
+    login node: `sinfo` exits with 255 and `handle_returncode` raises."""
+    return exceptions.CommandError(
+        255, 'sinfo -h --Node', 'Failed to get Slurm node information.',
+        'ssh: connect to host slurm-login port 22: Connection timed out')
+
+
 class TestSlurmNodeInfo:
     """Test slurm_node_info() multi-cluster aggregation."""
 
@@ -261,7 +269,15 @@ class TestSlurmNodeInfo:
                             mock.Mock(return_value=[]))
         assert not utils.slurm_node_info()
 
-    def test_unreachable_cluster_does_not_break_others(self, monkeypatch):
+    @pytest.mark.parametrize('error', [
+        RuntimeError('sinfo returned unexpected output'),
+        _make_command_error(),
+        KeyError('user'),
+        exceptions.NotSupportedError('nope'),
+        FileNotFoundError('~/.slurm/config'),
+    ])
+    def test_unreachable_cluster_does_not_break_others(self, monkeypatch,
+                                                       error):
         """A failure on one cluster should not drop nodes of other clusters."""
         clusters = ['cluster-a', 'cluster-b']
         monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
@@ -269,7 +285,7 @@ class TestSlurmNodeInfo:
 
         def _fake_get_node_info_list(slurm_cluster_name):
             if slurm_cluster_name == 'cluster-a':
-                raise RuntimeError('SSH connection failed')
+                raise error
             return [_make_node_info('node-0', slurm_cluster_name)]
 
         monkeypatch.setattr(utils, '_get_slurm_node_info_list',
@@ -280,11 +296,31 @@ class TestSlurmNodeInfo:
         assert len(result) == 1
         assert result[0]['slurm_cluster_name'] == 'cluster-b'
 
+    def test_only_configured_cluster_failing_returns_empty_list(
+            self, monkeypatch):
+        """Aggregation is best-effort even with a single allowed cluster."""
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=['cluster-a']))
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            mock.Mock(side_effect=_make_command_error()))
+        assert not utils.slurm_node_info()
+
     def test_single_cluster_error_returns_empty_list(self, monkeypatch):
         monkeypatch.setattr(
             utils, '_get_slurm_node_info_list',
             mock.Mock(side_effect=exceptions.NotSupportedError('nope')))
         assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')
+
+    def test_single_cluster_command_error_propagates(self, monkeypatch):
+        """An explicitly requested cluster surfaces query failures.
+
+        Callers such as `core.realtime_slurm_gpu_availability` need to tell an
+        unreachable cluster apart from a cluster without nodes.
+        """
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            mock.Mock(side_effect=_make_command_error()))
+        with pytest.raises(exceptions.CommandError):
+            utils.slurm_node_info(slurm_cluster_name='cluster-a')
 
 
 class TestGetGpuTypeAndCount:


### PR DESCRIPTION
Follow-up to #10284 (multi-cluster `slurm_node_info` aggregation).

## Summary

- **One unreachable cluster no longer wipes out every cluster's nodes.** The per-cluster fan-out added in #10284 caught only `(FileNotFoundError, RuntimeError, exceptions.NotSupportedError)`, but the failure mode of an unreachable Slurm login node is `exceptions.CommandError`: `sinfo` exits 255 over SSH and `subprocess_utils.handle_returncode` raises (`sky/adaptors/slurm.py`). `CommandError` derives from `Exception`, not `RuntimeError`, so it escaped the handler, and `run_in_parallel` re-raises the first exception — the whole `/slurm_node_info` request failed and the dashboard rendered an empty per-node table for *all* clusters (it swallows the 500 and falls back to `[]`). A `~/.slurm/config` entry missing `User` raises `KeyError` and escaped the same way. The aggregation path now catches broad `Exception` per cluster, matching `core.realtime_slurm_gpu_availability`, which fans out over the same cluster set.
- **A skipped cluster is now logged at `warning`, not `debug`,** so a cluster silently missing from the dashboard is visible in the server log. The CLI path already surfaces this as `skipped unreachable clusters:`.
- **Kept the narrow handling for an explicitly requested cluster.** Callers need to tell an unreachable cluster apart from a cluster with no nodes: `slurm_catalog` raising through to `core.realtime_slurm_gpu_availability` is what makes `sky show-gpus` and the dashboard's per-cluster GPU tile report the cluster as failed rather than empty.
- **Dropped the redundant `len(clusters) == 1` short-circuit** — `subprocess_utils.run_in_parallel` already runs a single-item list inline without a thread pool.
- **Docs**: fixed the stale `Raises: ValueError` on `_get_slurm_node_info_list` (it can no longer be called without a cluster name) and documented its arg.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

### Test plan

Unit tests: `pytest tests/unit_tests/test_sky/provision/slurm/ tests/unit_tests/test_sky/test_cli_gpus_list.py` → 134 passed.

- `test_unreachable_cluster_does_not_break_others` is now parametrized over the errors that actually occur — `CommandError(255, 'sinfo ...')`, `KeyError('user')`, `RuntimeError`, `NotSupportedError`, `FileNotFoundError`. The `CommandError` and `KeyError` cases fail on `master` and pass here; the previous version of this test only used `RuntimeError`, which was already in the catch list.
- `test_only_configured_cluster_failing_returns_empty_list`: aggregation stays best-effort when only one cluster is allowed (covers the removed short-circuit).
- `test_single_cluster_command_error_propagates`: an explicitly requested cluster still surfaces the failure to its caller.

Formatting: `yapf`/`isort` clean, `pylint sky/provision/slurm/utils.py` → 10.00/10 (`sky/provision/slurm/utils.py` is not in `tests/mypy_files.txt`).

Manual verification with multiple Slurm clusters configured in `~/.slurm/config`, one of them unreachable (e.g. point `HostName` at a black-holed address):

```bash
sky api stop && sky api start
curl -X POST http://127.0.0.1:46580/slurm_node_info -H 'content-type: application/json' --data '{}'
```

Expected: request succeeds and returns nodes from the reachable clusters; the API server log contains `Skipping Slurm cluster '<name>' while collecting node info: ...`. On `master` the same request fails and `/dashboard/infra` shows an empty per-node GPU table for every cluster. Also check `sky show-gpus --infra slurm` still reports the unreachable cluster as failed (`skipped unreachable clusters: <name>`) rather than silently dropping it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7X56o6ESS3W26rx7zEo82)_