### PR TITLE
[Jobs] Release log-tail threads when the client disconnects

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -54,6 +54,7 @@ from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common as common_lib
 from sky.utils import common_utils
+from sky.utils import context as context_lib
 from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import debug_dump_helpers
@@ -1792,8 +1793,14 @@ def stream_logs_by_id(
                 os.kill(os.getpid(), signal.SIGTERM)
                 return
 
-    watchdog = threading.Thread(target=_orphan_watchdog, daemon=True)
-    watchdog.start()
+    # The watchdog detects a dropped `kubectl exec` connection, which only
+    # happens when this runs as a subprocess on the controller. Inside a
+    # context we are in the API server, where a client disconnect arrives as
+    # ctx.cancel() instead, and this thread's own loop has no exit condition:
+    # it would outlive the request and accumulate one thread per tail call.
+    if context_lib.get() is None:
+        watchdog = threading.Thread(target=_orphan_watchdog, daemon=True)
+        watchdog.start()
 
     def should_keep_logging(status: managed_job_state.ManagedJobStatus) -> bool:
         # If we see CANCELLING, just exit - we could miss some job logs but the

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -54,6 +54,7 @@ from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common as common_lib
 from sky.utils import common_utils
+from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import debug_dump_helpers
 from sky.utils import infra_utils
@@ -1859,6 +1860,7 @@ def stream_logs_by_id(
         prev_msg = msg
         while (managed_job_status :=
                managed_job_state.get_status(job_id)) is None:
+            context_utils.raise_if_canceled()
             time.sleep(1)
 
         # Show hint about per-task filtering when there are multiple tasks
@@ -2068,6 +2070,7 @@ def stream_logs_by_id(
         task_id = latest_task_id
 
         while should_keep_logging(managed_job_status):
+            context_utils.raise_if_canceled()
             handle = None
             job_id_to_tail = None
             if task_id is not None:
@@ -2101,6 +2104,7 @@ def stream_logs_by_id(
                 # status every JOB_STATUS_CHECK_GAP_SECONDS.
                 waited = 0.0
                 while True:
+                    context_utils.raise_if_canceled()
                     # Keep the "Waiting for task to start" context and append
                     # the live cluster-launch status, so it's clear the job is
                     # waiting on its cluster to be provisioned.
@@ -2219,6 +2223,7 @@ def stream_logs_by_id(
                         while not is_managed_job_status_updated(
                                 managed_job_status :=
                                 managed_job_state.get_status(job_id)):
+                            context_utils.raise_if_canceled()
                             time.sleep(JOB_STATUS_CHECK_GAP_SECONDS)
                         assert managed_job_status is not None, (
                             job_id, managed_job_status)
@@ -2247,6 +2252,7 @@ def stream_logs_by_id(
                     status_display.start()
                     original_task_id = task_id
                     while True:
+                        context_utils.raise_if_canceled()
                         latest_task_id, managed_job_status = (
                             managed_job_state.get_latest_task_id_status(job_id))
                         if original_task_id != latest_task_id:
@@ -2285,6 +2291,7 @@ def stream_logs_by_id(
             # controller, and check the managed job queue again.
             # Wait a bit longer than the controller, so as to make sure the
             # managed job state is updated.
+            context_utils.raise_if_canceled()
             time.sleep(3 * JOB_STATUS_CHECK_GAP_SECONDS)
             managed_job_status = managed_job_state.get_status(job_id)
             assert managed_job_status is not None, (job_id, managed_job_status)
@@ -2297,6 +2304,7 @@ def stream_logs_by_id(
     assert managed_job_status is not None, job_id
     while (should_keep_logging(managed_job_status) and follow and
            wait_seconds < _FINAL_JOB_STATUS_WAIT_TIMEOUT_SECONDS):
+        context_utils.raise_if_canceled()
         time.sleep(1)
         wait_seconds += 1
         managed_job_status = managed_job_state.get_status(job_id)
@@ -2374,6 +2382,7 @@ def stream_logs(job_id: Optional[int],
 
         # Wait for the log file to be written
         while not os.path.exists(controller_log_path):
+            context_utils.raise_if_canceled()
             if not follow:
                 # Assume that the log file hasn't been written yet. Since we
                 # aren't following, just return.
@@ -2430,6 +2439,7 @@ def stream_logs(job_id: Optional[int],
                       encoding='utf-8') as f:
                 f.seek(end_pos)
                 while True:
+                    context_utils.raise_if_canceled()
                     # Print all new lines, if there are any.
                     line = f.readline()
                     while line is not None and line != '':

--- a/sky/utils/context_utils.py
+++ b/sky/utils/context_utils.py
@@ -180,6 +180,21 @@ def wait_process(ctx: context.SkyPilotContext,
             break
 
 
+def raise_if_canceled() -> None:
+    """Raise asyncio.CancelledError if the current context is cancelled.
+
+    For polling loops that run in a worker thread: ``time.sleep()`` cannot
+    observe ``ctx.cancel()``, so a loop that only exits on its own condition
+    keeps its thread long after the client that asked for the work went away.
+    Calling this once per iteration bounds that to one iteration.
+
+    No-op outside a context (the CLI, or code running on a cluster).
+    """
+    ctx = context.get()
+    if ctx is not None and ctx.is_canceled():
+        raise asyncio.CancelledError()
+
+
 F = TypeVar('F', bound=Callable[..., Any])
 
 

--- a/tests/unit_tests/test_sky/utils/test_context_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_context_utils.py
@@ -1,12 +1,47 @@
 """Unit tests for sky.utils.context_utils module."""
+import asyncio
+import threading
 from typing import Optional, Union
 
+import pytest
+
+from sky.utils import context
 from sky.utils import context_utils
 
 
 @context_utils.cancellation_guard
 def original_function(arg1: int, arg2: str) -> Optional[Union[int, str]]:
     return None
+
+
+def _run_in_fresh_thread(func):
+    """Run func in a new thread, which starts with no context set.
+
+    Contextvars are per-thread, so a context initialized (and cancelled) inside
+    func stays there: leaking a cancelled context into the test process would
+    make cancellation_guard raise in every later test.
+    """
+    box = {}
+
+    def target():
+        # SkyPilotContext holds an asyncio.Event, whose constructor looks up the
+        # thread's event loop on Python 3.9, so give the thread one to find.
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            box['value'] = func()
+        except Exception as e:  # pylint: disable=broad-except
+            box['error'] = e
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+    if 'error' in box:
+        raise box['error']
+    return box.get('value')
 
 
 def test_cancellation_guard_perserves_typecheck():
@@ -20,3 +55,56 @@ def test_cancellation_guard_perserves_typecheck():
 
     # Verify that the decorated function can be called with the same signature
     assert original_function(1, 'test') is None
+
+
+def test_raise_if_canceled_without_context():
+    """Outside a context there is nothing to cancel, so this is a no-op."""
+
+    def body():
+        assert context.get() is None
+        context_utils.raise_if_canceled()
+
+    _run_in_fresh_thread(body)
+
+
+def test_raise_if_canceled_with_live_context():
+
+    def body():
+        context.initialize()
+        assert context.get() is not None
+        context_utils.raise_if_canceled()
+
+    _run_in_fresh_thread(body)
+
+
+def test_raise_if_canceled_after_cancel():
+
+    def body():
+        context.initialize()
+        ctx = context.get()
+        assert ctx is not None
+        ctx.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            context_utils.raise_if_canceled()
+
+    _run_in_fresh_thread(body)
+
+
+def test_raise_if_canceled_breaks_polling_loop():
+    """A sleep-based polling loop exits within one iteration of a cancel."""
+
+    def body():
+        context.initialize()
+        ctx = context.get()
+        assert ctx is not None
+        threading.Timer(0.1, ctx.cancel).start()
+        iterations = 0
+        with pytest.raises(asyncio.CancelledError):
+            while True:
+                context_utils.raise_if_canceled()
+                iterations += 1
+                assert iterations < 1000, 'loop did not observe cancellation'
+                # Stand-in for the real loops' time.sleep(...).
+                threading.Event().wait(0.05)
+
+    _run_in_fresh_thread(body)


### PR DESCRIPTION
Two thread leaks in the managed-job log-tail path, as separate commits.

## 1. The tail worker thread is not released on client disconnect

`sky jobs logs` for a managed job is executed as a coroutine on the API server and runs `core.tail_logs` on the bounded request thread executor (`OnDemandThreadExecutor`) for the whole life of the stream. When the client disconnects, the serving coroutine cancels the request context — but the tail loops in `stream_logs_by_id` / `stream_logs` only slept in `time.sleep()`, which cannot observe `ctx.cancel()`.

So the worker thread stayed parked in the "Waiting for task to start" branch and the follow-wait loops until the **job** reached a terminal state. Tailing a queued job held a thread for as long as the job stayed queued, however quickly the client went away.

Consequences:

1. The executor is shared, so once enough abandoned tails accumulate, any request needing a worker fails with `ConcurrentWorkerExhaustedError` (a 503). Because abandoned tails are only freed when their jobs end, the server does not recover on its own.
2. Each abandoned tail keeps polling the managed-job state DB on its interval, so the accumulated pollers add DB connection pressure on top of holding threads.

Fix: add `context_utils.raise_if_canceled()` and call it once per iteration in those loops, following the pattern already used in `backend_utils` (`_raise_if_ctx_canceled`, and the poll loop in `refresh_cluster_record`) and in `log_lib._handle_io_stream`. A cancelled tail exits within one poll interval instead of holding its thread until the job finishes. `OnDemandThreadExecutor._task_wrapper` already turns `asyncio.CancelledError` into a cancelled future, so the thread returns to the pool through the existing path, and the helper is a no-op outside a context, so the CLI and on-cluster callers are unaffected.

## 2. The orphan watchdog thread outlives its request on the API server

`stream_logs_by_id` starts a watchdog thread per call to notice a dropped `kubectl exec` connection. That only applies when it runs as a subprocess on the controller: there stdin is a live pipe and the parent pid can change. On the API server neither signal can fire — stdin is already at EOF so the stdin check is skipped, and the parent pid is stable — and the watchdog loop has no exit condition, so it outlives its request and the process accumulates one idle thread per tail call, independently of leak 1.

Fix: start it only outside a request context.

## Tested

- New unit tests for `raise_if_canceled`: no-op with no context, no-op with a live context, raises once cancelled, and a polling loop exits within one iteration of a cancel.
- Existing context and jobs-utils unit tests pass; `mypy` clean; `pylint` 10.00 on the changed files.
- On a deployed API server with a managed job that had not started yet, using `sky_apiserver_threads_active` to watch the executor: three waves of 40 follow-tails whose clients disconnected after 60s produced a staircase of 40 -> 80 -> 120 active threads that stayed flat at 120 for 4.5 minutes with no clients attached, and only unwound when the job itself began running. With the change, the same workload showed threads active 1:1 while clients were attached and back to 0 once they disconnected.
- For leak 2, ~1200 tail requests left 1038 threads parked in `_orphan_watchdog`'s sleep, including for streams that had already finished.