### PR TITLE
[Server] Park jobs-controller launches on cluster lock contention too

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3364,6 +3364,18 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # same mechanism. Only callers with no request context (no
                 # scheduler to hand the pause to) keep the blocking behavior
                 # below.
+                #
+                # Note on expected impact: in a healthy system controller
+                # launches should rarely contend on their own cluster lock at
+                # all -- the controller runs one launch attempt per job and
+                # reattaches to an in-flight or parked request on restart
+                # rather than submitting a duplicate, and a holder whose
+                # process died releases the lock (advisory locks are
+                # session-scoped). Parking here is consistency and defense in
+                # depth: when a bug does produce concurrent launches for one
+                # cluster (observed in practice), the losers release their
+                # workers instead of blocking one worker each for the
+                # duration of the holder's operation.
                 if common_utils.is_in_request_context():
                     raise exceptions.ExecutionPausedError(
                         f'Cluster {cluster_name!r} is locked by another '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3344,11 +3344,27 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # resume, release the worker instead of holding it blocked on
                 # the cluster lock: raising ExecutionPausedError marks the
                 # request WAITING and re-enqueues it once the attached
-                # condition observes the lock to be acquirable. Launches issued
-                # by the jobs controller in-process do not go through the
-                # request scheduler, so they keep the blocking behavior.
-                if (common_utils.is_in_request_context() and
-                        not self._is_launched_by_jobs_controller):
+                # condition observes the lock to be acquirable.
+                #
+                # The request context is the sole gate on purpose: it is
+                # exactly "a scheduler manages this request and can park and
+                # resume it". Launches issued by the jobs controller park too.
+                # The controller always launches through the SDK
+                # (recovery_strategy), so its launches run as scheduler-managed
+                # requests on whichever API server serves them: under
+                # consolidation that is the shared API server, where blocking
+                # on the lock pins one executor worker per contender (e.g.
+                # duplicate launch requests for the same cluster after
+                # controller retries) and starves the worker pool at scale;
+                # on a dedicated controller, it is the controller's local API
+                # server, where parking is equally safe -- the controller
+                # explicitly supports parked launch requests (see
+                # _wait_for_parked_request in recovery_strategy), since
+                # admission-wait pauses already park its launches via this
+                # same mechanism. Only callers with no request context (no
+                # scheduler to hand the pause to) keep the blocking behavior
+                # below.
+                if common_utils.is_in_request_context():
                     raise exceptions.ExecutionPausedError(
                         f'Cluster {cluster_name!r} is locked by another '
                         'operation (e.g. launch, start, stop, autostop or '

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -688,13 +688,34 @@ class TestProvisionClusterLockParking:
         assert result is sentinel
         assert locked_provision.call_count == 2
 
-    def test_blocks_for_jobs_controller_launch_even_in_request_context(
+    def test_parks_for_jobs_controller_launch_in_request_context(
             self, monkeypatch):
+        # A jobs-controller launch running as a scheduler-managed request
+        # (consolidation mode submits launches via the SDK like any other
+        # request) must park like any other request: blocking instead would
+        # pin one executor worker per lock contender (e.g. duplicate launch
+        # requests for the same cluster after controller retries), starving
+        # the worker pool at scale.
+        locked_provision = MagicMock(side_effect=locks.LockTimeout('locked'))
+        with pytest.raises(exceptions.ExecutionPausedError) as exc_info:
+            self._run_provision(monkeypatch,
+                                in_request_context=True,
+                                locked_provision_mock=locked_provision,
+                                is_launched_by_jobs_controller=True)
+        condition = exc_info.value.continue_condition
+        assert isinstance(condition, locks.LockAcquirableCondition)
+        assert locked_provision.call_count == 1
+
+    def test_blocks_for_jobs_controller_launch_outside_request_context(
+            self, monkeypatch):
+        # Without a request context there is no scheduler to park/resume the
+        # request, so the blocking behavior is kept regardless of the
+        # jobs-controller flag.
         sentinel = (MagicMock(), False)
         locked_provision = MagicMock(
             side_effect=[locks.LockTimeout('locked'), sentinel])
         result = self._run_provision(monkeypatch,
-                                     in_request_context=True,
+                                     in_request_context=False,
                                      locked_provision_mock=locked_provision,
                                      is_launched_by_jobs_controller=True)
         assert result is sentinel


### PR DESCRIPTION
#10210 parks a launch as WAITING (releasing its executor worker) when it cannot acquire the cluster lock, but excluded launches flagged `_is_launched_by_jobs_controller`, on the rationale that controller launches run in-process and have no request scheduler to park them.

That in-process path no longer exists. Auditing master:

- The jobs controller always launches through the SDK: `recovery_strategy.py` calls `sdk.launch(..., _is_launched_by_jobs_controller=True)` unconditionally, so its launches execute as scheduler-managed requests (`reload_for_new_request` sets the request context on every executor run) on whichever API server serves them.
- The controller explicitly supports parked launch requests: `_LaunchRequestParked`, `_wait_for_parked_request`, and stream reattach across parks exist precisely because admission-wait pauses already park controller launches via this same `ExecutionPausedError` + continue-condition mechanism. Excluding only lock contention from parking is inconsistent with that.

Where the exclusion bites hardest is **consolidation mode**: those launch requests share the main API server's executor pool, and under lock contention (e.g. duplicate launch requests for the same cluster after controller retries or a restart requeueing in-flight launches) each contender blocked on the lock while holding a worker instead of parking. With a large managed-jobs batch this multiplies into significant executor-pool pressure exactly when the queue is already saturated.

On a **dedicated controller**, the same change applies to the controller's local API server. This is a real (if low-stakes) behavior change: previously such launches blocked, which was cheap there thanks to local mode's burstable workers; now they park, which is equally safe given the controller's parked-request support and the lock-probe condition working on the filelock backend (covered by #10210's `test_locks.py` tests).

**Alternative considered**: gating on `is_consolidation_mode()` (i.e. keep blocking for controller launches outside consolidation) would confine the behavior change to where the pain is proven. Rejected because the request context already expresses the exact invariant ("a scheduler manages this request and can park/resume it"), a jobs-layer config read inside `_provision` adds unwanted coupling, and it would make lock contention behave differently from admission waits on the very same launch. Happy to switch to that if reviewers prefer the conservative scope.

This PR drops the flag from the condition so that any launch running in a request context parks on lock contention, and any launch outside one keeps blocking.

## Tested

- `pytest tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py` (45 passed), including:
  - flipped `test_blocks_for_jobs_controller_launch_even_in_request_context` to `test_parks_for_jobs_controller_launch_in_request_context`, pinning that a controller launch in a request context parks with a `LockAcquirableCondition` without retrying the blocking path;
  - new `test_blocks_for_jobs_controller_launch_outside_request_context`, pinning that the flag does not affect the no-request-context blocking behavior.
- `bash format.sh --files` on both files: yapf/isort clean, mypy clean, pylint 10.00/10 on the backend file (the test file carries pre-existing `protected-access` warnings, unchanged from master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)