### PR TITLE
[Serve] Start the autoscaler at the running version on controller restart

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -230,19 +230,42 @@ class Autoscaler:
                                           target_num_replicas))
 
     @classmethod
-    def from_spec(cls, service_name: str,
-                  spec: 'service_spec.SkyServiceSpec') -> 'Autoscaler':
+    def from_spec(cls,
+                  service_name: str,
+                  spec: 'service_spec.SkyServiceSpec',
+                  version: int = constants.INITIAL_VERSION) -> 'Autoscaler':
+        """Builds an autoscaler for a service, starting at ``version``.
+
+        ``version`` should be the service's currently running version. It
+        defaults to ``INITIAL_VERSION`` for a brand-new service. On a controller
+        restart or after an update the service is already past the initial
+        version, and the autoscaler must be told so: otherwise it keeps
+        ``latest_version`` at the initial value while the replica manager
+        launches replicas at the real (higher) version. The autoscaler then
+        never recognizes those replicas as current and churns them -- scaling
+        the "latest" version up and the freshly launched replicas straight back
+        down, even at 0 RPS. See issue #8562.
+        """
         # TODO(MaoZiming): use NAME to get the class.
         if spec.pool:
-            return QueueLengthAutoscaler(service_name, spec)
+            autoscaler: 'Autoscaler' = QueueLengthAutoscaler(service_name, spec)
         elif spec.use_ondemand_fallback:
-            return FallbackRequestRateAutoscaler(service_name, spec)
+            autoscaler = FallbackRequestRateAutoscaler(service_name, spec)
         elif isinstance(spec.target_qps_per_replica, dict):
             # Use instance-aware autoscaler
             # when target_qps_per_replica is a dict
-            return InstanceAwareRequestRateAutoscaler(service_name, spec)
+            autoscaler = InstanceAwareRequestRateAutoscaler(service_name, spec)
         else:
-            return RequestRateAutoscaler(service_name, spec)
+            autoscaler = RequestRateAutoscaler(service_name, spec)
+
+        # Align the version bookkeeping with the running version. The
+        # concrete autoscalers above are always constructed at
+        # INITIAL_VERSION (see Autoscaler.__init__), so mirror the invariant
+        # that latest_version_ever_ready is one below latest_version; the
+        # autoscaler re-observes actual readiness on its next loop.
+        autoscaler.latest_version = version
+        autoscaler.latest_version_ever_ready = version - 1
+        return autoscaler
 
     def get_decision_interval(self) -> int:
         """Get the decision interval for the autoscaler.

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -52,8 +52,14 @@ class SkyServeController:
             replica_managers.SkyPilotReplicaManager(service_name=service_name,
                                                     spec=service_spec,
                                                     version=version))
+        # Pass the running version so the autoscaler starts aligned with the
+        # replica manager. On a fresh service this is INITIAL_VERSION; on a
+        # controller restart or after an update it is the current version, and
+        # skipping it makes the autoscaler churn the live replicas (#8562).
         self._autoscaler: autoscalers.Autoscaler = (
-            autoscalers.Autoscaler.from_spec(service_name, service_spec))
+            autoscalers.Autoscaler.from_spec(service_name,
+                                             service_spec,
+                                             version=version))
         self._host = host
         self._port = port
         self._app = fastapi.FastAPI(lifespan=self.lifespan)

--- a/tests/unit_tests/test_serve_autoscaler.py
+++ b/tests/unit_tests/test_serve_autoscaler.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 from sky.serve import autoscalers
+from sky.serve import constants
 from sky.serve import replica_managers
 from sky.serve import serve_state
 
@@ -151,6 +152,45 @@ class TestSelectNonterminalReplicasToScaleDown(unittest.TestCase):
         # Should select old version replica first despite having more jobs
         self.assertEqual(len(result), 1)
         self.assertEqual(result, [1])
+
+
+class TestFromSpecVersion(unittest.TestCase):
+    """Autoscaler.from_spec should start at the running service version."""
+
+    def _make_spec(self):
+        """A minimal spec that resolves to a plain RequestRateAutoscaler."""
+        spec = mock.Mock()
+        spec.pool = False
+        spec.use_ondemand_fallback = False
+        spec.target_qps_per_replica = 2.0  # float -> RequestRateAutoscaler
+        spec.min_replicas = 2
+        spec.max_replicas = 5
+        spec.num_overprovision = None
+        spec.upscale_delay_seconds = None
+        spec.downscale_delay_seconds = None
+        return spec
+
+    def test_defaults_to_initial_version(self):
+        """A brand-new service starts at INITIAL_VERSION (unchanged behavior)."""
+        autoscaler = autoscalers.Autoscaler.from_spec('svc', self._make_spec())
+        self.assertEqual(autoscaler.latest_version, constants.INITIAL_VERSION)
+        self.assertEqual(autoscaler.latest_version_ever_ready,
+                         constants.INITIAL_VERSION - 1)
+
+    def test_starts_at_running_version(self):
+        """After a restart/update, the autoscaler adopts the running version.
+
+        Regression test for #8562: previously latest_version stayed at
+        INITIAL_VERSION while replicas ran at a higher version, causing the
+        autoscaler to repeatedly scale the live replicas up and back down.
+        """
+        autoscaler = autoscalers.Autoscaler.from_spec('svc',
+                                                      self._make_spec(),
+                                                      version=3)
+        self.assertEqual(autoscaler.latest_version, 3)
+        # Invariant preserved: ever_ready is one below latest_version and is
+        # re-derived from real replica readiness on the next autoscaler loop.
+        self.assertEqual(autoscaler.latest_version_ever_ready, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the SkyServe controller restarts (for example a Kubernetes reschedule), or after `sky serve update`, the service is already past its initial version. The problem is that `Autoscaler.from_spec` always built the autoscaler at `INITIAL_VERSION`, and nothing on the restart path corrected it. `load_dynamic_states` only restores `latest_version_ever_ready`, and `update_version` only runs when a new version is actually deployed.

Meanwhile the replica manager gets constructed with the real running version, so it launches replicas at (say) version 3 while the autoscaler still thinks the latest version is 1. Once that happens the autoscaler never counts the live replicas as current, and it starts churning: it keeps asking to scale the "latest" version up, then scales the replicas it just launched right back down, even at 0 RPS. That lines up with the DB state and logs in the issue, where `active_versions` is `[3]` but the autoscaler sits at version 1. Closes #8562.

What changed:

`Autoscaler.from_spec` now takes an optional `version` (defaulting to `INITIAL_VERSION`) and sets `latest_version` from it after building the concrete autoscaler. `SkyServeController.__init__` passes the running version it already has.

The default keeps every existing caller the same. A brand new service still starts at `INITIAL_VERSION`, and the in-process update path is untouched since it calls `update_version` right after `from_spec` anyway.

One thing to flag honestly: I verified the version bookkeeping with unit tests, but I have not reproduced the full scale up/down churn end to end, since that needs a live service and a controller restart. If there's a serve update or recovery smoke test you'd like me to run, point me at it and I'll do that.

Testing:

- [x] Code formatting: yapf, isort, mypy, and pylint all pass (pylint 10.00/10).
- [x] Unit tests: `pytest tests/unit_tests/test_serve_autoscaler.py`. The new `TestFromSpecVersion` covers the default (INITIAL_VERSION) and the restart case (version=3 gives latest_version 3).
- [ ] Smoke tests: not run locally (needs a cloud or K8s cluster).
