### PR TITLE
[Slurm] Enrich node info with CPU/memory allocation and sampled usage

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -101,6 +101,21 @@ def _parse_default_time(line: str) -> Optional[str]:
     return raw
 
 
+def _parse_scontrol_node_output(output: str) -> Dict[str, str]:
+    """Parses the key=value output of 'scontrol show node'."""
+    node_info = {}
+    # Split by space, handling values that might have spaces
+    # if quoted. This is simplified; scontrol can be complex.
+    parts = output.split()
+    for part in parts:
+        if '=' in part:
+            key, value = part.split('=', 1)
+            # Simple quote removal, might need refinement
+            value = value.strip('\'"')
+            node_info[key] = value
+    return node_info
+
+
 class SlurmClient:
     """Client for Slurm control plane operations."""
 
@@ -286,21 +301,6 @@ class SlurmClient:
         Returns:
             A dictionary of node attributes.
         """
-
-        def _parse_scontrol_node_output(output: str) -> Dict[str, str]:
-            """Parses the key=value output of 'scontrol show node'."""
-            node_info = {}
-            # Split by space, handling values that might have spaces
-            # if quoted. This is simplified; scontrol can be complex.
-            parts = output.split()
-            for part in parts:
-                if '=' in part:
-                    key, value = part.split('=', 1)
-                    # Simple quote removal, might need refinement
-                    value = value.strip('\'"')
-                    node_info[key] = value
-            return node_info
-
         cmd = f'scontrol show node {node_name}'
         rc, node_details, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(
@@ -311,6 +311,36 @@ class SlurmClient:
             stream_logs=False)
         node_info = _parse_scontrol_node_output(node_details)
         return node_info
+
+    def get_all_node_details(self) -> Dict[str, Dict[str, str]]:
+        """Get detailed attributes for every node in a single scontrol call.
+
+        Uses ``scontrol show node -o`` (one line per node) so per-node
+        attributes that sinfo's format codes cannot express (CPUAlloc,
+        AllocMem, FreeMem, CPULoad, GresUsed, ...) are available without a
+        round-trip per node.
+
+        Returns:
+            A dictionary mapping node name to its attribute dictionary.
+        """
+        cmd = 'scontrol show node -o'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            'Failed to get detailed node information.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+        details: Dict[str, Dict[str, str]] = {}
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            node_info = _parse_scontrol_node_output(line)
+            node_name = node_info.get('NodeName')
+            if node_name:
+                details[node_name] = node_info
+        return details
 
     def get_jobs_gres(self, node_name: str) -> List[str]:
         """Get the list of jobs GRES for a given node name.

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -942,6 +942,26 @@ def resolve_gres_gpu_type(
     return chosen
 
 
+def _parse_int_or_none(value: Optional[str]) -> Optional[int]:
+    """Parse an int from an scontrol attribute value; None on N/A/garbage."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _parse_float_or_none(value: Optional[str]) -> Optional[float]:
+    """Parse a float from an scontrol attribute value; None on N/A/garbage."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     """Gathers detailed information about each node in the Slurm cluster.
 
@@ -972,6 +992,17 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
             f'`sinfo -N` returned no output on cluster {slurm_cluster_name}. '
             f'No nodes found?')
         return []
+
+    # Best-effort enrichment with per-node scontrol attributes (CPU/memory
+    # allocation from the scheduler plus actual load/free-memory sampled
+    # by slurmd) — sinfo's format codes cannot express these. A failure
+    # here must not break basic node info.
+    try:
+        node_details_by_name = slurm_client.get_all_node_details()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not fetch scontrol node details on cluster '
+                     f'{slurm_cluster_name}: {e}')
+        node_details_by_name = {}
 
     # 2. Process each node, aggregating partitions per node
     slurm_nodes_info: Dict[str, Dict[str, Any]] = {}
@@ -1018,6 +1049,27 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
                                                                  'maint') else 0
         free_gpus = max(0, free_gpus)
 
+        # CPU/memory allocation + sampled usage from scontrol. All of
+        # these are None when scontrol was unavailable or reported N/A
+        # (e.g. on down nodes).
+        details = node_details_by_name.get(node_name, {})
+        cpu_alloc = _parse_int_or_none(details.get('CPUAlloc'))
+        cpu_tot = _parse_int_or_none(details.get('CPUTot'))
+        free_vcpus = None
+        if cpu_alloc is not None and cpu_tot is not None:
+            free_vcpus = max(0, cpu_tot - cpu_alloc)
+        # scontrol reports memory in MB.
+        alloc_mem_mb = _parse_int_or_none(details.get('AllocMem'))
+        real_mem_mb = _parse_int_or_none(details.get('RealMemory'))
+        free_alloc_memory_gb = None
+        if alloc_mem_mb is not None and real_mem_mb is not None:
+            free_alloc_memory_gb = round(
+                max(0, real_mem_mb - alloc_mem_mb) / 1024.0, 2)
+        free_mem_mb = _parse_int_or_none(details.get('FreeMem'))
+        free_memory_gb = (round(free_mem_mb /
+                                1024.0, 2) if free_mem_mb is not None else None)
+        cpu_load = _parse_float_or_none(details.get('CPULoad'))
+
         slurm_nodes_info[node_name] = {
             'node_name': node_name,
             'slurm_cluster_name': slurm_cluster_name,
@@ -1028,6 +1080,14 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
             'free_gpus': free_gpus,
             'vcpu_count': node_info.cpus,
             'memory_gb': round(node_info.memory_gb, 2),
+            # Scheduler-allocation view: CPUs / memory not reserved by
+            # jobs on this node.
+            'free_vcpus': free_vcpus,
+            'free_alloc_memory_gb': free_alloc_memory_gb,
+            # Sampled-usage view: slurmd-reported load average and free
+            # OS memory.
+            'cpu_load': cpu_load,
+            'free_memory_gb': free_memory_gb,
         }
 
     for node_info in slurm_nodes_info.values():
@@ -1046,7 +1106,14 @@ def slurm_node_info(
             is aggregated across all existing allowed Slurm clusters.
 
     Returns:
-        List[Dict[str, Any]]: A list of dictionaries, each containing node info.
+        List[Dict[str, Any]]: One dictionary per node with keys:
+            node_name, slurm_cluster_name, partition (comma-joined),
+            node_state, gpu_type, total_gpus, free_gpus, vcpu_count,
+            memory_gb, and the scontrol-derived enrichment fields
+            free_vcpus / free_alloc_memory_gb (scheduler allocation) and
+            cpu_load / free_memory_gb (slurmd-sampled usage) — the
+            enrichment fields are None when scontrol is unavailable or
+            reports N/A.
     """
     if slurm_cluster_name is not None:
         clusters_to_query = [slurm_cluster_name]

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -568,3 +568,63 @@ class TestGetProctrackType:
             result = client.get_proctrack_type()
 
             assert result is None
+
+
+class TestGetAllNodeDetails:
+    """Test SlurmClient.get_all_node_details()."""
+
+    def test_parses_one_line_per_node(self):
+        client = slurm.SlurmClient(
+            ssh_host='localhost',
+            ssh_port=22,
+            ssh_user='root',
+            ssh_key=None,
+        )
+
+        mock_output = (
+            'NodeName=node1 Arch=x86_64 CPUAlloc=8 CPUEfctv=72 CPUTot=72 '
+            'CPULoad=3.50 Gres=gpu:gh200:1 RealMemory=430080 AllocMem=102400 '
+            'FreeMem=421339 State=MIXED Partitions=all,gh200\n'
+            'NodeName=node2 Arch=x86_64 CPUAlloc=0 CPUEfctv=2 CPUTot=2 '
+            'CPULoad=N/A Gres=(null) RealMemory=14000 AllocMem=0 FreeMem=N/A '
+            'State=DOWN* Partitions=dev\n')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, mock_output, '')
+
+            result = client.get_all_node_details()
+            mock_run.assert_called_once_with(
+                'scontrol show node -o',
+                require_outputs=True,
+                separate_stderr=True,
+                stream_logs=False,
+            )
+
+        assert set(result.keys()) == {'node1', 'node2'}
+        assert result['node1']['CPUAlloc'] == '8'
+        assert result['node1']['CPUTot'] == '72'
+        assert result['node1']['CPULoad'] == '3.50'
+        assert result['node1']['AllocMem'] == '102400'
+        assert result['node1']['FreeMem'] == '421339'
+        assert result['node1']['State'] == 'MIXED'
+        assert result['node2']['CPULoad'] == 'N/A'
+        assert result['node2']['FreeMem'] == 'N/A'
+
+    def test_skips_blank_lines_and_lines_without_node_name(self):
+        client = slurm.SlurmClient(
+            ssh_host='localhost',
+            ssh_port=22,
+            ssh_user='root',
+            ssh_key=None,
+        )
+
+        mock_output = ('\n'
+                       'NodeName=node1 CPUTot=8\n'
+                       '   \n'
+                       'Arch=x86_64 CPUTot=4\n')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, mock_output, '')
+            result = client.get_all_node_details()
+
+        assert list(result.keys()) == ['node1']

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -175,3 +175,89 @@ class TestSlurmNodeInfo:
             utils, '_get_slurm_node_info_list',
             mock.Mock(side_effect=exceptions.NotSupportedError('nope')))
         assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')
+
+
+class TestGetSlurmNodeInfoListEnrichment:
+    """Test scontrol-based CPU/memory enrichment in _get_slurm_node_info_list."""
+
+    def _run(self, monkeypatch, node_details_result):
+        from sky.adaptors import slurm as slurm_adaptor
+
+        client = mock.Mock()
+        client.info_nodes.return_value = [
+            slurm_adaptor.NodeInfo(node='node1',
+                                   state='mix',
+                                   gres='gpu:gh200:1',
+                                   cpus=72,
+                                   memory_gb=420.0,
+                                   partition='all*'),
+        ]
+        client.get_all_jobs_gres.return_value = {}
+        if isinstance(node_details_result, Exception):
+            client.get_all_node_details.side_effect = node_details_result
+        else:
+            client.get_all_node_details.return_value = node_details_result
+
+        ssh_config = mock.Mock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'user': 'me',
+        }
+        monkeypatch.setattr(utils, 'get_slurm_ssh_config', lambda: ssh_config)
+        monkeypatch.setattr(utils.slurm, 'SlurmClient',
+                            mock.Mock(return_value=client))
+        return utils._get_slurm_node_info_list('cluster-a')
+
+    def test_enriches_from_scontrol(self, monkeypatch):
+        result = self._run(
+            monkeypatch, {
+                'node1': {
+                    'CPUAlloc': '8',
+                    'CPUTot': '72',
+                    'CPULoad': '3.50',
+                    'RealMemory': '430080',
+                    'AllocMem': '102400',
+                    'FreeMem': '421339',
+                },
+            })
+        assert len(result) == 1
+        node = result[0]
+        assert node['free_vcpus'] == 64
+        assert node['free_alloc_memory_gb'] == round((430080 - 102400) / 1024.0,
+                                                     2)
+        assert node['cpu_load'] == 3.5
+        assert node['free_memory_gb'] == round(421339 / 1024.0, 2)
+
+    def test_na_values_become_none(self, monkeypatch):
+        result = self._run(
+            monkeypatch, {
+                'node1': {
+                    'CPUAlloc': '0',
+                    'CPUTot': '72',
+                    'CPULoad': 'N/A',
+                    'RealMemory': '430080',
+                    'AllocMem': '0',
+                    'FreeMem': 'N/A',
+                },
+            })
+        node = result[0]
+        assert node['free_vcpus'] == 72
+        assert node['free_alloc_memory_gb'] == round(430080 / 1024.0, 2)
+        assert node['cpu_load'] is None
+        assert node['free_memory_gb'] is None
+
+    def test_missing_node_details_yields_none_fields(self, monkeypatch):
+        result = self._run(monkeypatch, {})
+        node = result[0]
+        assert node['free_vcpus'] is None
+        assert node['free_alloc_memory_gb'] is None
+        assert node['cpu_load'] is None
+        assert node['free_memory_gb'] is None
+
+    def test_scontrol_failure_does_not_break_node_info(self, monkeypatch):
+        result = self._run(monkeypatch, RuntimeError('scontrol failed'))
+        assert len(result) == 1
+        node = result[0]
+        assert node['node_name'] == 'node1'
+        assert node['free_vcpus'] is None
+        assert node['cpu_load'] is None


### PR DESCRIPTION
## Summary

`slurm_node_info()` (behind the `/slurm_node_info` endpoint used by the dashboard's infrastructure views) reports GPU allocation plus static CPU/memory totals, but nothing about how busy a node's CPUs or memory actually are. sinfo's `-o` format codes cannot express CPU/memory allocation (`CPUAlloc`, `AllocMem` have no format code), so this PR sources them from scontrol:

- **`SlurmClient.get_all_node_details()`** — a single `scontrol show node -o` round-trip (one line per node), parsed with the existing key=value parser factored out of `node_details()`. Same SSH session as the sinfo call via ControlMaster, so the added latency is minimal.
- **`_get_slurm_node_info_list`** joins the details by node name and emits four new per-node fields:

| Field | Source | Meaning |
|---|---|---|
| `free_vcpus` | `CPUTot − CPUAlloc` | CPUs not reserved by jobs (scheduler-allocation view) |
| `free_alloc_memory_gb` | `RealMemory − AllocMem` | Memory not reserved by jobs |
| `cpu_load` | `CPULoad` | slurmd-sampled load average |
| `free_memory_gb` | `FreeMem` | slurmd-sampled free OS memory |

The enrichment is best-effort: an scontrol failure or `N/A` values (common on down nodes) yield `None` for these fields without breaking basic node info. Existing fields and consumers are unchanged.

## Testing

- New unit tests: `TestGetAllNodeDetails` (adaptor parse, incl. N/A and malformed lines) and `TestGetSlurmNodeInfoListEnrichment` (join, N/A → None, missing node, scontrol failure fallback).
- `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py`: 77 passed.
- Live verification against a real 2-cluster Slurm deployment (GH200 + CPU-only nodes) in progress; will report results in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
