### PR TITLE
[Slurm] Submit jobs as authenticated users

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -139,6 +139,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`allowed_clusters <config-yaml-slurm-allowed-clusters>`:
       - mycluster1
       - mycluster2
+    :ref:`submit_as_user <config-yaml-slurm-submit-as-user>`: false
     :ref:`provision_timeout <config-yaml-slurm-provision-timeout>`: 120
     :ref:`pricing <config-yaml-slurm-pricing>`:
       cpu: 0.04        # $/vCPU/hr
@@ -150,6 +151,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`cpu_partition <config-yaml-slurm-cpu-partition>`: cpu-batch
     :ref:`cluster_configs <config-yaml-slurm-cluster-configs>`:
       mycluster1:
+        submit_as_user: true
         workdir: /mnt/lustre/$USER
         tmpdir: /local_scratch/sky
         pricing:
@@ -2173,6 +2175,43 @@ If you want all available clusters to be allowed, set it to ``all`` like this:
   slurm:
     allowed_clusters: all
 
+.. _config-yaml-slurm-submit-as-user:
+
+``slurm.submit_as_user``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run Slurm operations as the Unix account matching the authenticated SkyPilot
+user (optional).
+
+SkyPilot maps the username to the portion before ``@``. For example,
+``alice@example.com`` maps to ``alice``. The resulting username must start with
+a lowercase letter or ``_`` and contain only lowercase letters, digits, ``_``,
+``.``, or ``-``. The account must already exist on the Slurm cluster.
+
+When enabled, the ``User`` in ``~/.slurm/config`` must be ``root`` or have
+passwordless ``sudo`` permission to run ``su``. SkyPilot connects as that SSH
+user, then runs job lifecycle commands and file transfers as the mapped Unix
+user. A missing account or insufficient privilege causes the operation to fail
+without falling back to the SSH user.
+
+Cluster-wide inventory commands run as the SSH user so monitoring and capacity
+views do not depend on the user requesting them. The SSH user must have
+permission to view the required Slurm node, partition, and job information.
+
+Default: ``false``. This is an API server setting and cannot be overridden by
+client, project, or task configuration.
+
+Example:
+
+.. code-block:: yaml
+
+  slurm:
+    submit_as_user: true
+
+``submit_as_user`` can also be set per cluster using
+:ref:`cluster_configs <config-yaml-slurm-cluster-configs>`. The per-cluster
+value overrides the global value.
+
 .. _config-yaml-slurm-provision-timeout:
 
 ``slurm.provision_timeout``
@@ -2330,6 +2369,10 @@ global values.
 Per-cluster and per-partition configuration for Slurm (optional).
 
 Supported fields:
+
+- ``submit_as_user``:
+  :ref:`Submit as user <config-yaml-slurm-submit-as-user>` override for the
+  cluster.
 
 - ``workdir``: Base directory on a **shared filesystem** for SkyPilot
   cluster files (provision scripts, cluster home directories, sbatch logs, etc).

--- a/docs/source/reference/slurm/slurm-getting-started.rst
+++ b/docs/source/reference/slurm/slurm-getting-started.rst
@@ -263,6 +263,59 @@ To restrict which clusters SkyPilot can use, add the following to your ``~/.sky/
         - mycluster2
 
 
+.. _slurm-submit-as-user:
+
+Submitting as authenticated users
+---------------------------------
+
+A shared SkyPilot API server can connect to Slurm with one privileged SSH
+credential while owning each job under the authenticated user's Unix account.
+Enable this behavior in the API server's configuration:
+
+.. code-block:: yaml
+
+    slurm:
+      submit_as_user: true
+
+Configure each Slurm host entry with the shared SSH user and private key. The
+SSH user must be ``root`` or have passwordless ``sudo`` permission to run
+``su``:
+
+.. code-block:: text
+
+    Host mycluster
+        HostName login.mycluster.myorg.com
+        User slurm-admin
+        IdentityFile ~/.ssh/slurm_admin
+
+SkyPilot maps the authenticated username to the portion before ``@``. For
+example, ``alice@example.com`` maps to the Unix account ``alice``. The account
+must already exist on the Slurm login and compute nodes. SkyPilot submits,
+queries, and cancels the user's allocations, runs host commands, transfers
+files, and starts host SSH sessions as that user. Container commands and SSH
+sessions run as root inside the container, while the Slurm allocation remains
+owned by the mapped user. An invalid or missing account, a sudo password
+prompt, or denied sudo permission causes the operation to fail instead of
+falling back to the SSH user.
+
+Cluster-wide inventory and observability run as the shared SSH user configured
+in ``~/.slurm/config``. That user must have permission to view the required
+Slurm node, partition, and job information.
+
+To enable the behavior for one cluster, set it under ``cluster_configs``:
+
+.. code-block:: yaml
+
+    slurm:
+      cluster_configs:
+        mycluster:
+          submit_as_user: true
+
+The per-cluster value overrides the global value. See
+:ref:`slurm.submit_as_user <config-yaml-slurm-submit-as-user>` for the full
+configuration reference.
+
+
 .. _slurm-pricing:
 
 Configuring pricing
@@ -494,9 +547,11 @@ FAQs
 
 * **Which user are jobs submitted as?**
 
-  Jobs are submitted using your own Slurm username (the ``User`` specified in your ``~/.slurm/config``).
-  This means your jobs appear under your username in ``squeue``, count against your quotas, and respect
-  your existing permissions.
+  By default, jobs are submitted as the ``User`` in ``~/.slurm/config``. With
+  :ref:`submit as user <slurm-submit-as-user>` enabled, SkyPilot instead uses
+  the Unix account mapped from the authenticated username. Jobs appear under
+  that account in ``squeue``, count against its quotas, and use its
+  permissions.
 
 * **Can I use multiple Slurm clusters?**
 

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -129,6 +129,7 @@ class SlurmClient:
         ssh_proxy_jump: Optional[str] = None,
         is_inside_slurm_cluster: bool = False,
         identities_only: Optional[bool] = None,
+        slurm_user: Optional[str] = None,
     ):
         """Initialize SlurmClient.
 
@@ -144,6 +145,8 @@ class SlurmClient:
             identities_only: If True, only use the specified identity file and
                 don't try ssh-agent keys. If None, defaults to False (allows
                 ssh-agent fallback for backward compatibility).
+            slurm_user: Unix user to run remote Slurm commands as. None runs
+                commands as the SSH user.
         """
         self.ssh_host = ssh_host
         self.ssh_port = ssh_port
@@ -165,7 +168,7 @@ class SlurmClient:
             assert ssh_user is not None
             # If user has IdentitiesOnly=yes in their config, respect it by
             # NOT disabling IdentitiesOnly. Otherwise, allow ssh-agent fallback.
-            self._runner = command_runner.SSHCommandRunner(
+            self._runner = command_runner.SlurmLoginNodeCommandRunner(
                 (ssh_host, ssh_port),
                 ssh_user,
                 ssh_key,
@@ -173,6 +176,7 @@ class SlurmClient:
                 ssh_proxy_jump=ssh_proxy_jump,
                 enable_interactive_auth=True,
                 disable_identities_only=not identities_only,
+                slurm_user=slurm_user,
             )
 
     def _run_slurm_cmd(self, cmd: str) -> Tuple[int, str, str]:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -293,16 +293,11 @@ def _caller_is_viewer() -> bool:
             rbac_mod.RoleName.ADMIN.value not in roles)
 
 
-def is_command_length_over_limit(command: str) -> bool:
-    """Check if the length of the command exceeds the limit.
-
-    We calculate the length of the command after quoting the command twice as
-    when it is executed by the CommandRunner, the command will be quoted twice
-    to ensure the correctness, which will add significant length to the command.
-    """
-
-    quoted_length = len(shlex.quote(shlex.quote(command)))
-    return quoted_length > _MAX_INLINE_SCRIPT_LENGTH
+def is_command_length_over_limit(command: str, quote_levels: int = 2) -> bool:
+    """Check if the quoted command exceeds the inline command limit."""
+    for _ in range(quote_levels):
+        command = shlex.quote(command)
+    return len(command) > _MAX_INLINE_SCRIPT_LENGTH
 
 
 def is_ip(s: str) -> bool:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3139,6 +3139,21 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # a job (detach_setup, default).
         self._setup_cmd = None
 
+    @staticmethod
+    def _inline_command_quote_levels(handle: CloudVmRayResourceHandle) -> int:
+        # SSHCommandRunner quotes for the remote login shell and local shell.
+        quote_levels = 2
+        if isinstance(handle.launched_resources.cloud, clouds.Slurm):
+            # SlurmCommandRunner adds an srun bash -c shell.
+            quote_levels += 1
+            cluster_info = handle.cached_cluster_info
+            if (cluster_info is not None and
+                    cluster_info.provider_config is not None and
+                    cluster_info.provider_config.get('slurm_user') is not None):
+                # SlurmLoginNodeCommandRunner adds the su --command shell.
+                quote_levels += 1
+        return quote_levels
+
     # --- Implementation of Backend APIs ---
 
     def register_info(self, **kwargs) -> None:
@@ -4061,8 +4076,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 _dump_final_script(setup_script,
                                    constants.PERSISTENT_SETUP_SCRIPT_PATH)
 
-            if (detach_setup or
-                    backend_utils.is_command_length_over_limit(encoded_script)):
+            if (detach_setup or backend_utils.is_command_length_over_limit(
+                    encoded_script,
+                    quote_levels=self._inline_command_quote_levels(handle))):
                 _dump_final_script(setup_script)
                 create_script_code = 'true'
             else:
@@ -4281,7 +4297,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         user_id=managed_job_user_id,
                         execution=execution)
 
-                if backend_utils.is_command_length_over_limit(codegen):
+                if backend_utils.is_command_length_over_limit(
+                        codegen,
+                        quote_levels=self._inline_command_quote_levels(handle)):
                     _dump_code_to_file(codegen)
                     queue_job_request = jobsv1_pb2.QueueJobRequest(
                         job_id=job_id,
@@ -4304,7 +4322,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 use_legacy = True
 
         if use_legacy:
-            if backend_utils.is_command_length_over_limit(job_submit_cmd):
+            if backend_utils.is_command_length_over_limit(
+                    job_submit_cmd,
+                    quote_levels=self._inline_command_quote_levels(handle)):
                 _dump_code_to_file(codegen)
                 job_submit_cmd = f'{mkdir_code} && {code}'
 

--- a/sky/check.py
+++ b/sky/check.py
@@ -387,7 +387,7 @@ def check_capabilities(
         # re-running cloud probes. Full-workspace runs replace the row;
         # scoped runs (clouds is not None) merge at cloud granularity.
         # Wrapped in try/except: this row is a cache, and the
-        # source-of-truth enabled_clouds_<workspace>_<cap> rows have
+        # source-of-truth enabled_clouds_<workspace>_<cap>[_<user>] rows have
         # already been written above. A transient DB failure or
         # unsupported dialect must not fail the user-visible
         # `sky check` command.

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -496,6 +496,7 @@ class Slurm(clouds.Cloud):
         # cluster is our target slurmctld host.
         ssh_config = slurm_utils.get_slurm_ssh_config()
         ssh_config_dict = ssh_config.lookup(cluster)
+        slurm_user = slurm_utils.get_submit_user(cluster)
 
         resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
@@ -596,6 +597,7 @@ class Slurm(clouds.Cloud):
             'ssh_hostname': ssh_config_dict['hostname'],
             'ssh_port': str(ssh_config_dict.get('port', 22)),
             'ssh_user': ssh_config_dict['user'],
+            'slurm_user': slurm_user,
             'slurm_proxy_command': ssh_config_dict.get('proxycommand', None),
             'slurm_proxy_jump': ssh_config_dict.get('proxyjump', None),
             'slurm_identities_only':
@@ -795,6 +797,7 @@ class Slurm(clouds.Cloud):
                     ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
                     identities_only=slurm_utils.get_identities_only(
                         ssh_config_dict),
+                    slurm_user=slurm_utils.get_submit_user(cluster),
                 )
                 info = client.info()
                 logger.debug(f'Slurm cluster {cluster} sinfo: {info}')

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2616,22 +2616,43 @@ def set_enabled_clouds(enabled_clouds: List[str],
         session.commit()
 
 
+def _slurm_submit_as_user_enabled() -> bool:
+    slurm_config = skypilot_config.get_nested(('slurm',), default_value={})
+    if slurm_config.get('submit_as_user', False):
+        return True
+    cluster_configs = slurm_config.get('cluster_configs', {})
+    return any(
+        config.get('submit_as_user', False)
+        for config in cluster_configs.values())
+
+
+def _scope_config_key_to_user(key: str) -> str:
+    if not _slurm_submit_as_user_enabled():
+        return key
+    user_id = common_utils.get_current_user().id
+    return f'{key}_{user_id}'
+
+
 def _get_enabled_clouds_key(cloud_capability: 'cloud.CloudCapability',
                             workspace: str) -> str:
-    return _ENABLED_CLOUDS_KEY_PREFIX + workspace + '_' + cloud_capability.value
+    key = (_ENABLED_CLOUDS_KEY_PREFIX + workspace + '_' +
+           cloud_capability.value)
+    return _scope_config_key_to_user(key)
 
 
 _CHECK_RESULTS_KEY_PREFIX = 'check_results_'
 
 
 def _get_check_results_key(workspace: str) -> str:
-    return f'{_CHECK_RESULTS_KEY_PREFIX}{workspace}'
+    return _scope_config_key_to_user(f'{_CHECK_RESULTS_KEY_PREFIX}{workspace}')
 
 
 @metrics_lib.time_me
 def get_cached_check_results(
         workspace: str) -> Dict[str, Dict[str, Dict[str, Any]]]:
-    """Return the persisted check_results dict for a workspace, or {}.
+    """Return persisted check results for a workspace, or {}.
+
+    With Slurm submit-as-user enabled, results are scoped to the current user.
 
     Shape:
         {cloud_repr: {context_or_empty_str: {"enabled": bool, "reason": str}}}.
@@ -2660,6 +2681,8 @@ def set_check_results(
 ) -> None:
     """Persist `results` for `workspace`.
 
+    With Slurm submit-as-user enabled, results are scoped to the current user.
+
     `is_full_workspace_run=True` replaces the entire row (drops clouds /
     contexts not present in `results`).  `False` merges at *context*
     granularity within a cloud: read the existing row, update only the
@@ -2687,7 +2710,7 @@ def set_check_results(
         else:
             # Read-modify-write under the default session isolation. This
             # is NOT race-safe against concurrent scoped writes for
-            # different clouds in the same workspace: SQLAlchemy
+            # different clouds for the same cache scope: SQLAlchemy
             # `orm.Session` does not acquire row locks, and under the
             # default isolation (READ COMMITTED on Postgres, deferred on
             # SQLite) two interleaved RMW cycles can clobber each
@@ -2695,7 +2718,7 @@ def set_check_results(
             # (one scoped run's leaves get overwritten until the next
             # write rewrites the row) and the source-of-truth
             # enabled_clouds_* rows are unaffected, so we accept the
-            # race here rather than serialize through a per-workspace
+            # race here rather than serialize through a per-key
             # advisory lock. If this row ever becomes load-bearing for
             # correctness, switch to `with_for_update()` (postgres) and
             # an explicit BEGIN IMMEDIATE (sqlite).

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -325,6 +325,7 @@ def _create_virtual_instance(
     identities_only = ssh_config_dict.get('identities_only', False)
     partition = slurm_utils.get_partition_from_config(provider_config)
 
+    slurm_user = provider_config.get('slurm_user')
     client = slurm.SlurmClient(
         ssh_host,
         ssh_port,
@@ -333,6 +334,7 @@ def _create_virtual_instance(
         ssh_proxy_command=ssh_proxy_command,
         ssh_proxy_jump=ssh_proxy_jump,
         identities_only=identities_only,
+        slurm_user=slurm_user,
     )
 
     slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
@@ -460,7 +462,7 @@ def _create_virtual_instance(
 
     # To bootstrap things, we need to do it with SSHCommandRunner first.
     # SlurmCommandRunner is for after the virtual instances are created.
-    login_node_runner = command_runner.SSHCommandRunner(
+    login_node_runner = command_runner.SlurmLoginNodeCommandRunner(
         (ssh_host, ssh_port),
         ssh_user,
         ssh_key,
@@ -468,6 +470,7 @@ def _create_virtual_instance(
         ssh_proxy_jump=ssh_proxy_jump,
         enable_interactive_auth=True,
         disable_identities_only=not identities_only,
+        slurm_user=slurm_user,
     )
     remote_home_dir = login_node_runner.get_remote_home_dir()
 
@@ -797,6 +800,7 @@ def query_instances(
         ssh_proxy_command=ssh_proxy_command,
         ssh_proxy_jump=ssh_proxy_jump,
         identities_only=identities_only,
+        slurm_user=provider_config.get('slurm_user'),
     )
 
     # Map Slurm job states to SkyPilot ClusterStatus
@@ -895,6 +899,7 @@ def get_cluster_info(
         ssh_proxy_command=ssh_proxy_command,
         ssh_proxy_jump=ssh_proxy_jump,
         identities_only=identities_only,
+        slurm_user=provider_config.get('slurm_user'),
     )
 
     # Find running job for this cluster
@@ -992,6 +997,7 @@ def terminate_instances(
             ssh_proxy_command=ssh_proxy_command,
             ssh_proxy_jump=ssh_proxy_jump,
             identities_only=identities_only,
+            slurm_user=provider_config.get('slurm_user'),
         )
     jobs_state = client.get_jobs_state_by_name(cluster_name_on_cloud)
     if not jobs_state:
@@ -1109,6 +1115,7 @@ def get_command_runners(
     # collisions between different Slurm clusters.
     ssh_control_name = command_runner.DEFAULT_SSH_CONTROL_NAME
 
+    slurm_user = provider_config.get('slurm_user')
     client = slurm.SlurmClient(
         login_node_ssh_hostname,
         login_node_ssh_port,
@@ -1117,6 +1124,7 @@ def get_command_runners(
         ssh_proxy_command=login_node_ssh_proxy_command,
         ssh_proxy_jump=login_node_ssh_proxy_jump,
         identities_only=login_node_identities_only,
+        slurm_user=slurm_user,
     )
     remote_home_dir = client.get_remote_home_dir()
 
@@ -1165,6 +1173,7 @@ def get_command_runners(
             ssh_proxy_command=login_node_ssh_proxy_command,
             ssh_control_name=ssh_control_name,
             container_args=container_args,
+            slurm_user=slurm_user,
             enable_interactive_auth=True,
             # Allow ssh-agent and default key fallback for Slurm.
             disable_identities_only=True) for instance_info in instances

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -26,6 +26,7 @@ logger = sky_logging.init_logger(__name__)
 DEFAULT_SLURM_PATH = '~/.slurm/config'
 
 _VAR_PATTERN = re.compile(r'\$(\w+|\{[^}]*\})')
+_SLURM_USER_PATTERN = re.compile(r'^[a-z_][a-z0-9_.-]*$')
 
 SLURM_MARKER_FILE = '.sky_slurm_cluster'
 SLURM_CONTAINER_MARKER_FILE = '.sky_slurm_container'
@@ -91,6 +92,27 @@ def get_slurm_ssh_config() -> SSHConfig:
     return slurm_config
 
 
+def get_submit_user(cluster_name: str) -> Optional[str]:
+    """Return the current SkyPilot user's Unix account for Slurm submission."""
+    enabled = skypilot_config.get_effective_region_config(
+        cloud='slurm',
+        region=cluster_name,
+        keys=('submit_as_user',),
+        default_value=False)
+    if not enabled:
+        return None
+
+    user_name = common_utils.get_current_user_name()
+    submit_user = user_name.split('@', 1)[0]
+    if _SLURM_USER_PATTERN.fullmatch(submit_user) is None:
+        raise ValueError(
+            'Cannot derive a valid Unix user from SkyPilot user '
+            f'{user_name!r}. Slurm submit users must start with a lowercase '
+            'letter or "_" '
+            'and contain only lowercase letters, digits, "_", ".", or "-".')
+    return submit_user
+
+
 def get_identity_file(ssh_config_dict: Dict[str, Any]) -> Optional[str]:
     """Get the first identity file from SSH config, or None if not specified."""
     identity_files = ssh_config_dict.get('identityfile')
@@ -110,14 +132,16 @@ def get_identities_only(ssh_config_dict: Dict[str, Any]) -> bool:
 
 @annotations.lru_cache(scope='request')
 def get_slurm_nodes_info(cluster: str) -> List[slurm.NodeInfo]:
-    cache_key = f'slurm:nodes_info:{cluster}'
+    ssh_config = get_slurm_ssh_config()
+    ssh_config_dict = ssh_config.lookup(cluster)
+    slurm_user = get_submit_user(cluster)
+    command_user = slurm_user or ssh_config_dict['user']
+    cache_key = f'slurm:nodes_info:{cluster}:{command_user}'
     cached = kv_cache.get_cache_entry(cache_key)
     if cached is not None:
         logger.debug(f'Slurm nodes info found in cache ({cache_key})')
         return [slurm.NodeInfo(**item) for item in json.loads(cached)]
 
-    ssh_config = get_slurm_ssh_config()
-    ssh_config_dict = ssh_config.lookup(cluster)
     client = slurm.SlurmClient(
         ssh_config_dict['hostname'],
         int(ssh_config_dict.get('port', 22)),
@@ -126,6 +150,7 @@ def get_slurm_nodes_info(cluster: str) -> List[slurm.NodeInfo]:
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
+        slurm_user=slurm_user,
     )
     nodes_info = client.info_nodes()
 
@@ -163,6 +188,7 @@ def get_proctrack_type(cluster: str) -> Optional[str]:
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
+        slurm_user=get_submit_user(cluster),
     )
     proctrack_type = client.get_proctrack_type()
 
@@ -184,7 +210,7 @@ def _check_cluster_feature(
     check_fn: Callable[[slurm.SlurmClient], bool],
     cache_ttl: int,
 ) -> bool:
-    """Check if a feature is available on a Slurm cluster, with caching.
+    """Check if a feature is available to a Slurm user, with caching.
 
     Args:
         cluster: Name of the Slurm cluster.
@@ -193,15 +219,17 @@ def _check_cluster_feature(
             the feature is available.
         cache_ttl: Time-to-live for the cache entry in seconds.
     """
-    cache_key = f'slurm:{feature_name}_enabled:{cluster}'
+    ssh_config = get_slurm_ssh_config()
+    ssh_config_dict = ssh_config.lookup(cluster)
+    slurm_user = get_submit_user(cluster)
+    command_user = slurm_user or ssh_config_dict['user']
+    cache_key = f'slurm:{feature_name}_enabled:{cluster}:{command_user}'
     cached = kv_cache.get_cache_entry(cache_key)
     if cached is not None:
         logger.debug(f'Slurm {feature_name} check found in cache '
                      f'({cache_key})')
         return cached == 'true'
 
-    ssh_config = get_slurm_ssh_config()
-    ssh_config_dict = ssh_config.lookup(cluster)
     client = slurm.SlurmClient(
         ssh_config_dict['hostname'],
         int(ssh_config_dict.get('port', 22)),
@@ -210,6 +238,7 @@ def _check_cluster_feature(
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
+        slurm_user=slurm_user,
     )
     enabled = check_fn(client)
 
@@ -228,8 +257,8 @@ def check_pyxis_enabled(cluster: str) -> bool:
     """Check if the Pyxis SPANK plugin is installed on a Slurm cluster.
 
     Pyxis is required for Docker container support on Slurm. This function
-    caches the result per cluster since the plugin availability is unlikely
-    to change frequently.
+    caches the result per cluster and command user since the plugin
+    availability is unlikely to change frequently.
     """
     return _check_cluster_feature(cluster, 'pyxis',
                                   lambda c: c.check_pyxis_enabled(),
@@ -240,8 +269,8 @@ def check_fuse_enabled(cluster: str) -> bool:
     """Check if FUSE is available on a Slurm cluster.
 
     FUSE is required for storage mounting (MOUNT/MOUNT_CACHED modes) via
-    tools like goofys and rclone. This function caches the result per
-    cluster since FUSE availability is unlikely to change frequently.
+    tools like goofys and rclone. This function caches the result per cluster
+    and command user since FUSE availability is unlikely to change frequently.
     """
     return _check_cluster_feature(cluster, 'fuse',
                                   lambda c: c.check_fuse_enabled(),
@@ -269,6 +298,7 @@ def get_select_type_parameters(cluster: str) -> Optional[str]:
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
+        slurm_user=get_submit_user(cluster),
     )
     value = client.get_select_type_parameters()
 
@@ -485,6 +515,7 @@ def get_cluster_default_partition(cluster_name: str) -> Optional[str]:
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
+        slurm_user=get_submit_user(cluster_name),
     )
 
     return client.get_default_partition()
@@ -984,6 +1015,9 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         ssh_proxy_command=slurm_config_dict.get('proxycommand', None),
         ssh_proxy_jump=slurm_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(slurm_config_dict),
+        # The SSH transport identity gives cluster-wide inventory callers one
+        # consistent view of monitoring and capacity data.
+        slurm_user=None,
     )
     node_infos = slurm_client.info_nodes()
 
@@ -1176,18 +1210,19 @@ def get_partition_info(cluster_name: str,
     return get_partition_infos(cluster_name=cluster_name).get(partition_name)
 
 
-# Cache the partitions for 1 hour, we do not expect the
-# partitions to change frequently.
-@annotations.ttl_cache(scope='global', timer=time.time, maxsize=10, ttl=60 * 60)
 def get_partition_infos(cluster_name: str) -> Dict[str, slurm.SlurmPartition]:
-    """Get the partition information for a Slurm cluster.
+    """Get the partition information visible to the current Slurm user."""
+    return _get_partition_infos(cluster_name, get_submit_user(cluster_name))
 
-    Args:
-        cluster_name: Name of the Slurm cluster.
 
-    Returns:
-        List of partition information.
-    """
+# Cache the partitions for 1 hour, we do not expect them to change frequently.
+@annotations.ttl_cache(scope='global',
+                       timer=time.time,
+                       maxsize=128,
+                       ttl=60 * 60)
+def _get_partition_infos(
+        cluster_name: str,
+        slurm_user: Optional[str]) -> Dict[str, slurm.SlurmPartition]:
     try:
         slurm_config = SSHConfig.from_path(
             os.path.expanduser(DEFAULT_SLURM_PATH))
@@ -1201,6 +1236,7 @@ def get_partition_infos(cluster_name: str) -> Dict[str, slurm.SlurmPartition]:
             ssh_proxy_command=slurm_config_dict.get('proxycommand', None),
             ssh_proxy_jump=slurm_config_dict.get('proxyjump', None),
             identities_only=get_identities_only(slurm_config_dict),
+            slurm_user=slurm_user,
         )
 
         partitions_info = client.get_partitions_info()

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3158,6 +3158,31 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
             await loop.run_in_executor(None, proc.wait)
 
 
+def _build_slurm_job_ssh_command(
+    provider_config: Dict[str, Any],
+    job_id: str,
+    target_node: str,
+    cluster_name_on_cloud: str,
+    is_container_image: bool,
+) -> str:
+    login_node_user = provider_config['ssh']['user']
+    slurm_user = provider_config.get('slurm_user')
+    sshd_user = slurm_user if slurm_user is not None else login_node_user
+    if is_container_image:
+        sshd_user = 'root'
+    command = slurm_utils.srun_sshd_command(
+        job_id,
+        target_node,
+        sshd_user,
+        cluster_name_on_cloud,
+        is_container_image,
+    )
+    if slurm_user is not None:
+        command = command_runner.wrap_command_as_user(
+            command, slurm_user, use_sudo=login_node_user != 'root')
+    return command
+
+
 @app.websocket('/slurm-job-ssh-proxy')
 async def slurm_job_ssh_proxy(websocket: fastapi.WebSocket,
                               cluster_name: str,
@@ -3222,10 +3247,10 @@ async def slurm_job_ssh_proxy(websocket: fastapi.WebSocket,
     ) is not None
     ssh_cmd += [
         shlex.quote(
-            slurm_utils.srun_sshd_command(
+            _build_slurm_job_ssh_command(
+                provider_config,
                 job_id,
                 target_node,
-                login_node_user,
                 handle.cluster_name_on_cloud,
                 is_container_image,
             ))

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -612,9 +612,9 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     ('serve', 'controller', 'consolidation_mode'),
     ('jobs', 'controller', 'controller_logs_gc_retention_hours'),
     ('jobs', 'controller', 'task_logs_gc_retention_hours'),
-    # Slurm cluster configs (workdir, tmpdir, etc.) are admin-managed
-    # server-side settings and should not be overridden by clients.
+    # Slurm submit identity and cluster settings are managed server-side.
     ('slurm', 'cluster_configs'),
+    ('slurm', 'submit_as_user'),
 ]
 
 # Constants for Azure blob storage

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -1,4 +1,5 @@
-{% set user = ssh_user if image_id is none else 'root' %}
+{% set host_user = slurm_user | default(ssh_user, true) %}
+{% set user = host_user if image_id is none else 'root' %}
 {% set has_image = image_id is not none %}
 cluster_name: {{cluster_name_on_cloud}}
 
@@ -14,6 +15,9 @@ provider:
   cluster: "{{slurm_cluster}}"
   partition: "{{slurm_partition}}"
   provision_timeout: {{provision_timeout}}
+{% if slurm_user is defined and slurm_user is not none %}
+  slurm_user: {{slurm_user | tojson}}
+{% endif %}
 
   ssh:
     hostname: {{ssh_hostname}}

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -82,6 +82,22 @@ _SSH_AUTH_FAILURE_PATTERNS = [
 ]
 
 
+def wrap_command_as_user(command: str,
+                         user: str,
+                         shell_argv0: Optional[str] = None,
+                         use_sudo: bool = False) -> str:
+    """Build a command that a privileged SSH user runs as a Unix user."""
+    argv = [
+        'su', '--login', '--shell', '/bin/bash', '--command', command, '--',
+        user
+    ]
+    if shell_argv0 is not None:
+        argv.append(shell_argv0)
+    if use_sudo:
+        argv = ['sudo', '--non-interactive', '--'] + argv
+    return shlex.join(argv)
+
+
 def _ssh_control_path(ssh_control_filename: Optional[str]) -> Optional[str]:
     """Returns a temporary path to be used as the ssh control path."""
     if ssh_control_filename is None:
@@ -462,7 +478,8 @@ class CommandRunner:
             max_retry: int = 1,
             prefix_command: Optional[str] = None,
             get_remote_home_dir: Callable[[], str] = lambda: '~',
-            timeout: Optional[int] = None) -> None:
+            timeout: Optional[int] = None,
+            remote_rsync_command: Optional[str] = None) -> None:
         """Builds the rsync command."""
         # Build command.
         rsync_command = []
@@ -492,6 +509,9 @@ class CommandRunner:
 
         if rsh_option is not None:
             rsync_command.append(f'-e {shlex.quote(rsh_option)}')
+        if remote_rsync_command is not None:
+            rsync_command.append(
+                f'--rsync-path={shlex.quote(remote_rsync_command)}')
         maybe_dest_prefix = ('' if node_destination is None else
                              f'{node_destination}:')
 
@@ -1433,6 +1453,7 @@ class SSHCommandRunner(CommandRunner):
         max_retry: int = 1,
         get_remote_home_dir: Callable[[], str] = lambda: '~',
         timeout: Optional[int] = None,
+        remote_rsync_command: Optional[str] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -1449,6 +1470,7 @@ class SSHCommandRunner(CommandRunner):
               directory. Defaults to '~'.
             timeout: Optional total timeout in seconds for the rsync, including
               all retries and backoff waits. None means no timeout (default).
+            remote_rsync_command: Command used to start rsync on the remote.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -1477,7 +1499,8 @@ class SSHCommandRunner(CommandRunner):
                     stream_logs=stream_logs,
                     max_retry=max_retry,
                     get_remote_home_dir=get_remote_home_dir,
-                    timeout=timeout)
+                    timeout=timeout,
+                    remote_rsync_command=remote_rsync_command)
 
 
 class KubernetesCommandRunner(CommandRunner):
@@ -1929,7 +1952,64 @@ class LocalProcessCommandRunner(CommandRunner):
                     timeout=timeout)
 
 
-class SlurmCommandRunner(SSHCommandRunner):
+class SlurmLoginNodeCommandRunner(SSHCommandRunner):
+    """SSH runner that can execute login-node commands as a Unix user."""
+
+    def __init__(
+        self,
+        node: Tuple[str, int],
+        ssh_user: str,
+        ssh_private_key: Optional[str],
+        *,
+        slurm_user: Optional[str],
+        **kwargs,
+    ):
+        super().__init__(node, ssh_user, ssh_private_key, **kwargs)
+        self.slurm_user = slurm_user
+        self._use_sudo = ssh_user != 'root'
+
+    def run(
+        self,
+        cmd: Union[str, List[str]],
+        **kwargs,
+    ) -> Union[int, Tuple[int, str, str]]:
+        if self.slurm_user is not None:
+            if isinstance(cmd, list):
+                cmd = ' '.join(cmd)
+            cmd = wrap_command_as_user(cmd,
+                                       self.slurm_user,
+                                       use_sudo=self._use_sudo)
+        return super().run(cmd, **kwargs)
+
+    def rsync(
+        self,
+        source: str,
+        target: str,
+        *,
+        up: bool,
+        log_path: str = os.devnull,
+        stream_logs: bool = True,
+        max_retry: int = 1,
+        timeout: Optional[int] = None,
+    ) -> None:
+        remote_rsync_command = None
+        if self.slurm_user is not None:
+            remote_rsync_command = wrap_command_as_user('exec rsync "$@"',
+                                                        self.slurm_user,
+                                                        shell_argv0='rsync',
+                                                        use_sudo=self._use_sudo)
+        super().rsync(source,
+                      target,
+                      up=up,
+                      log_path=log_path,
+                      stream_logs=stream_logs,
+                      max_retry=max_retry,
+                      get_remote_home_dir=self.get_remote_home_dir,
+                      timeout=timeout,
+                      remote_rsync_command=remote_rsync_command)
+
+
+class SlurmCommandRunner(SlurmLoginNodeCommandRunner):
     """Runner for Slurm commands.
 
     SlurmCommandRunner sends commands over an SSH connection through the Slurm
@@ -1953,6 +2033,7 @@ class SlurmCommandRunner(SSHCommandRunner):
         job_id: str,
         slurm_node: str,
         container_args: Optional[str],
+        slurm_user: Optional[str] = None,
         **kwargs,
     ):
         """Initialize SlurmCommandRunner.
@@ -1981,10 +2062,16 @@ class SlurmCommandRunner(SSHCommandRunner):
             job_id: The Slurm job ID for this instance.
             slurm_node: The Slurm node hostname for this instance
               (compute node).
+            slurm_user: Unix user that owns the Slurm allocation. None runs
+              login-node commands as the SSH user.
             **kwargs: Additional arguments forwarded to SSHCommandRunner
               (e.g., ssh_proxy_command).
         """
-        super().__init__(node, ssh_user, ssh_private_key, **kwargs)
+        super().__init__(node,
+                         ssh_user,
+                         ssh_private_key,
+                         slurm_user=slurm_user,
+                         **kwargs)
         self.sky_dir = sky_dir
         self.skypilot_runtime_dir = skypilot_runtime_dir
         self.job_id = job_id
@@ -2017,11 +2104,6 @@ class SlurmCommandRunner(SSHCommandRunner):
             timeout: Optional total timeout in seconds for the rsync, including
                 all retries and backoff waits. None means no timeout (default).
         """
-        ssh_command = ' '.join(
-            self.ssh_base_command(ssh_mode=SshMode.NON_INTERACTIVE,
-                                  port_forward=None,
-                                  connect_timeout=None))
-
         extra_srun_args = (f'{self.container_args} '
                            if in_container and self.container_args else '')
         if in_container:
@@ -2031,37 +2113,64 @@ class SlurmCommandRunner(SSHCommandRunner):
         else:
             remote_home_dir = self.sky_dir
 
-        script_content = f"""#!/bin/bash
+        if self.slurm_user is None:
+            ssh_command = ' '.join(
+                self.ssh_base_command(ssh_mode=SshMode.NON_INTERACTIVE,
+                                      port_forward=None,
+                                      connect_timeout=None))
+            script_content = f"""#!/bin/bash
 job_id=$(echo "$1" | cut -d+ -f1)
 node_list=$(echo "$1" | cut -d+ -f2)
 shift
 exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
     --jobid="$job_id" --nodelist="$node_list" --nodes=1 --ntasks=1 "$@"
 """
-        encoded_info = f'{self.job_id}+{self.slurm_node}'
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.sh',
-                                         delete=False) as f:
-            f.write(script_content)
-            rsh_script_path = f.name
-        try:
-            os.chmod(rsh_script_path, 0o755)
-            self._rsync(source,
-                        target,
-                        node_destination=encoded_info,
-                        up=up,
-                        rsh_option=rsh_script_path,
-                        log_path=log_path,
-                        stream_logs=stream_logs,
-                        max_retry=max_retry,
-                        get_remote_home_dir=lambda: remote_home_dir,
-                        timeout=timeout)
-        finally:
+            encoded_info = f'{self.job_id}+{self.slurm_node}'
+            with tempfile.NamedTemporaryFile(mode='w',
+                                             suffix='.sh',
+                                             delete=False) as f:
+                f.write(script_content)
+                rsh_script_path = f.name
             try:
-                os.unlink(rsh_script_path)
-            except OSError as e:
-                logger.warning('Failed to remove temporary rsh script '
-                               f'{rsh_script_path}: '
-                               f'{common_utils.exception_to_string(e)}')
+                os.chmod(rsh_script_path, 0o755)
+                self._rsync(source,
+                            target,
+                            node_destination=encoded_info,
+                            up=up,
+                            rsh_option=rsh_script_path,
+                            log_path=log_path,
+                            stream_logs=stream_logs,
+                            max_retry=max_retry,
+                            get_remote_home_dir=lambda: remote_home_dir,
+                            timeout=timeout)
+            finally:
+                try:
+                    os.unlink(rsh_script_path)
+                except OSError as e:
+                    logger.warning('Failed to remove temporary rsh script '
+                                   f'{rsh_script_path}: '
+                                   f'{common_utils.exception_to_string(e)}')
+            return
+
+        rsync_command = (
+            f'exec srun --unbuffered --quiet --overlap {extra_srun_args}'
+            f'--jobid={shlex.quote(self.job_id)} '
+            f'--nodelist={shlex.quote(self.slurm_node)} '
+            f'--nodes=1 --ntasks=1 rsync "$@"')
+        remote_rsync_command = wrap_command_as_user(rsync_command,
+                                                    self.slurm_user,
+                                                    shell_argv0='rsync',
+                                                    use_sudo=self._use_sudo)
+        SSHCommandRunner.rsync(self,
+                               source,
+                               target,
+                               up=up,
+                               log_path=log_path,
+                               stream_logs=stream_logs,
+                               max_retry=max_retry,
+                               get_remote_home_dir=lambda: remote_home_dir,
+                               timeout=timeout,
+                               remote_rsync_command=remote_rsync_command)
 
     def _run_via_srun(
         self,
@@ -2101,7 +2210,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
             f'--nodes=1 --ntasks=1 {extra_srun_args}'
             f'bash -c {shlex.quote(inner_cmd)}')
 
-        return SSHCommandRunner.run(self, srun_cmd, **kwargs)
+        return SlurmLoginNodeCommandRunner.run(self, srun_cmd, **kwargs)
 
     def rsync(
         self,

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -23,6 +23,13 @@ ALIAS_SUDO_TO_EMPTY_FOR_ROOT_CMD: str
 DEFAULT_SSH_CONTROL_NAME: str
 
 
+def wrap_command_as_user(command: str,
+                         user: str,
+                         shell_argv0: Optional[str] = ...,
+                         use_sudo: bool = ...) -> str:
+    ...
+
+
 def ssh_options_list(
     ssh_private_key: Optional[str],
     ssh_control_name: Optional[str],
@@ -304,6 +311,8 @@ class SSHCommandRunner(CommandRunner):
         stream_logs: bool = ...,
         max_retry: int = ...,
         get_remote_home_dir: Callable[[], str] = ...,
+        timeout: Optional[int] = ...,
+        remote_rsync_command: Optional[str] = ...,
     ) -> None:
         ...
 
@@ -400,7 +409,23 @@ class KubernetesCommandRunner(CommandRunner):
         ...
 
 
-class SlurmCommandRunner(SSHCommandRunner):
+class SlurmLoginNodeCommandRunner(SSHCommandRunner):
+    """SSH runner that can execute login-node commands as a Unix user."""
+    slurm_user: Optional[str]
+
+    def __init__(
+        self,
+        node: Tuple[str, int],
+        ssh_user: str,
+        ssh_private_key: Optional[str],
+        *,
+        slurm_user: Optional[str],
+        **kwargs,
+    ) -> None:
+        ...
+
+
+class SlurmCommandRunner(SlurmLoginNodeCommandRunner):
     """Runner for Slurm commands."""
     sky_dir: str
     skypilot_runtime_dir: str
@@ -419,6 +444,7 @@ class SlurmCommandRunner(SSHCommandRunner):
         job_id: str,
         slurm_node: str,
         container_args: Optional[str] = ...,
+        slurm_user: Optional[str] = ...,
         **kwargs,
     ) -> None:
         ...

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2070,6 +2070,9 @@ def get_config_schema():
                 'provision_timeout': {
                     'type': 'integer',
                 },
+                'submit_as_user': {
+                    'type': 'boolean',
+                },
                 'pricing': _PRICING_SCHEMA,
                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
                 'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
@@ -2090,6 +2093,9 @@ def get_config_schema():
                             },
                             'tmpdir': {
                                 'type': 'string',
+                            },
+                            'submit_as_user': {
+                                'type': 'boolean',
                             },
                             'pricing': _PRICING_SCHEMA,
                             'sbatch_options': _SBATCH_OPTIONS_SCHEMA,

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -35,6 +35,7 @@ from smoke_tests import smoke_tests_utils
 
 import sky
 from sky import skypilot_config
+from sky.provision.slurm import utils as slurm_utils
 from sky.skylet import constants
 from sky.skylet import events
 from sky.utils import common_utils
@@ -3329,6 +3330,89 @@ def test_kubernetes_slurm_ssh_proxy_connection(generic_cloud: str,
         ],
         f'sky down -y {cluster_name}',
         timeout=15 * 60,  # 15 minutes timeout
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.slurm
+@pytest.mark.no_remote_server
+@pytest.mark.no_dependency
+def test_slurm_submit_as_authenticated_user():
+    """Submit a Slurm allocation as the authenticated user's Unix account."""
+    configured_cluster = os.environ.get('SLURM_CLUSTER')
+    cluster_names = slurm_utils.get_all_slurm_cluster_names()
+    if configured_cluster is None:
+        if len(cluster_names) != 1:
+            pytest.skip('Set SLURM_CLUSTER when multiple Slurm clusters are '
+                        'configured.')
+        slurm_cluster = cluster_names[0]
+    else:
+        matching_clusters = [
+            cluster for cluster in cluster_names
+            if cluster == configured_cluster or
+            cluster.endswith(f'-{configured_cluster}')
+        ]
+        if not matching_clusters:
+            pytest.skip(f'Slurm cluster {configured_cluster!r} is not '
+                        'configured in ~/.slurm/config.')
+        assert len(matching_clusters) == 1, matching_clusters
+        slurm_cluster = matching_clusters[0]
+
+    ssh_config = slurm_utils.get_slurm_ssh_config()
+    transport_user = ssh_config.lookup(slurm_cluster)['user']
+    assert transport_user != 'ci', (
+        'The test must use a distinct SSH transport user, but the configured '
+        f'user for {slurm_cluster!r} is already ci.')
+
+    slurm_config_path = os.path.expanduser(slurm_utils.DEFAULT_SLURM_PATH)
+    user_check = subprocess.run(
+        ['ssh', '-F', slurm_config_path, slurm_cluster, 'getent passwd ci'],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if user_check.returncode != 0:
+        pytest.skip(f'Unix user ci is not configured on {slurm_cluster!r}.')
+    print(f'Using Slurm cluster {slurm_cluster!r}: '
+          f'transport user={transport_user!r}, submit user=\'ci\'')
+
+    name = smoke_tests_utils.get_cluster_name()
+    user_id = 'ci-smoke-test'
+    name_on_cloud = f'{name}-{user_id}'
+    ssh_squeue = shlex.join([
+        'ssh', '-F', slurm_config_path, slurm_cluster,
+        f'squeue --noheader --name={name_on_cloud} --format=%u'
+    ])
+    test = smoke_tests_utils.Test(
+        'slurm_submit_as_authenticated_user',
+        [
+            smoke_tests_utils.SKY_API_RESTART,
+            'sky check slurm',
+            f'sky launch -y -c {name} --infra slurm/{slurm_cluster} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} -- '
+            "'test \"$(id -un)\" = ci && echo SLURM_SUBMIT_USER_OK'",
+            f'owner=$({ssh_squeue}); '
+            'echo "Slurm allocation owner: $owner"; test "$owner" = ci',
+            f'logs="$(sky logs {name} 1)"; printf "%s\\n" "$logs"; '
+            '[[ "$logs" == *SLURM_SUBMIT_USER_OK* ]]',
+        ],
+        teardown=(f'sky down -y {name} || true; '
+                  f'unset {constants.USER_ENV_VAR} '
+                  f'{constants.USER_ID_ENV_VAR}; '
+                  f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}= && '
+                  f'{smoke_tests_utils.SKY_API_RESTART}'),
+        timeout=smoke_tests_utils.get_timeout('slurm'),
+        env={
+            constants.USER_ENV_VAR: 'ci@example.com',
+            constants.USER_ID_ENV_VAR: user_id,
+        },
+        config_dict={
+            'slurm': {
+                'allowed_clusters': [slurm_cluster],
+                'submit_as_user': True,
+            },
+        },
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -8,14 +8,32 @@ from unittest.mock import patch
 
 import pytest
 
+from sky import clouds
 from sky import exceptions
 from sky import resources
 from sky import task
+from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.backends.cloud_vm_ray_backend import CloudVmRayResourceHandle
 from sky.backends.cloud_vm_ray_backend import SSHTunnelInfo
 from sky.utils import locks
 from sky.utils import status_lib
+
+
+def test_command_length_accounts_for_slurm_user_quoting():
+    command = "a'b" * 5000
+    assert not backend_utils.is_command_length_over_limit(command)
+    assert backend_utils.is_command_length_over_limit(command, quote_levels=4)
+
+    handle = MagicMock()
+    handle.launched_resources.cloud = clouds.Slurm()
+    handle.cached_cluster_info.provider_config = {'slurm_user': 'alice'}
+    assert cloud_vm_ray_backend.CloudVmRayBackend._inline_command_quote_levels(
+        handle) == 4
+
+    handle.cached_cluster_info.provider_config = {}
+    assert cloud_vm_ray_backend.CloudVmRayBackend._inline_command_quote_levels(
+        handle) == 3
 
 
 class TestCloudVmRayBackendTaskRedaction:

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -12,6 +12,203 @@ from sky.adaptors import slurm
 from sky.clouds import slurm as slurm_cloud
 from sky.provision.slurm import instance as slurm_instance
 from sky.provision.slurm import utils as slurm_utils
+from sky.skylet import constants
+
+
+class TestGetSubmitUser:
+
+    def test_config_is_server_managed(self):
+        key = ('slurm', 'submit_as_user')
+        assert key in constants.SKIPPED_CLIENT_OVERRIDE_KEYS
+
+    @pytest.mark.parametrize('user_name,expected', [
+        ('alice@example.com', 'alice'),
+        ('alice', 'alice'),
+        ('alice.ml@example.com', 'alice.ml'),
+    ])
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.skypilot_config.'
+           'get_effective_region_config')
+    def test_enabled(self, mock_get_config, mock_get_user_name, user_name,
+                     expected):
+        mock_get_config.return_value = True
+        mock_get_user_name.return_value = user_name
+
+        assert slurm_utils.get_submit_user('my-cluster') == expected
+        mock_get_config.assert_called_once_with(cloud='slurm',
+                                                region='my-cluster',
+                                                keys=('submit_as_user',),
+                                                default_value=False)
+
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.skypilot_config.'
+           'get_effective_region_config')
+    def test_disabled(self, mock_get_config, mock_get_user_name):
+        mock_get_config.return_value = False
+
+        assert slurm_utils.get_submit_user('my-cluster') is None
+        mock_get_user_name.assert_not_called()
+
+    @pytest.mark.parametrize('user_name', [
+        '@example.com',
+        'Alice@example.com',
+        'alice+ml@example.com',
+        '-alice@example.com',
+    ])
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.skypilot_config.'
+           'get_effective_region_config',
+           return_value=True)
+    def test_invalid_unix_user_rejected(self, _mock_get_config,
+                                        mock_get_user_name, user_name):
+        mock_get_user_name.return_value = user_name
+
+        with pytest.raises(ValueError, match='valid Unix user'):
+            slurm_utils.get_submit_user('my-cluster')
+
+
+class TestSlurmClientSubmitUser:
+
+    @patch('sky.adaptors.slurm.command_runner.SlurmLoginNodeCommandRunner')
+    def test_passes_submit_user_to_login_runner(self, mock_runner_class):
+        runner = mock_runner_class.return_value
+        runner.run.return_value = (0, '', '')
+        runner.get_remote_home_dir.return_value = '/home/alice'
+
+        client = slurm.SlurmClient(ssh_host='login.example.com',
+                                   ssh_port=22,
+                                   ssh_user='ubuntu',
+                                   ssh_key='/root/.ssh/key',
+                                   slurm_user='alice')
+
+        assert client.get_remote_home_dir() == '/home/alice'
+        mock_runner_class.assert_called_once_with(('login.example.com', 22),
+                                                  'ubuntu',
+                                                  '/root/.ssh/key',
+                                                  ssh_proxy_command=None,
+                                                  ssh_proxy_jump=None,
+                                                  enable_interactive_auth=True,
+                                                  disable_identities_only=True,
+                                                  slurm_user='alice')
+
+
+class TestSubmitUserDeployVariables:
+
+    @staticmethod
+    def _make_deploy_variables(submit_user, ssh_user='root'):
+        cloud = slurm_cloud.Slurm()
+        resources = mock.MagicMock(unsafe=True)
+        resources.zone = 'gpu'
+        resources.instance_type = '4CPU--16GB'
+        resources.assert_launchable.return_value = resources
+        resources.extract_docker_image.return_value = None
+        resources.cluster_config_overrides = {}
+
+        region = mock.MagicMock()
+        region.name = 'my-cluster'
+        zone = mock.MagicMock()
+        zone.name = 'gpu'
+        ssh_config = mock.MagicMock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'port': '22',
+            'user': ssh_user,
+            'identityfile': ['/root/.ssh/id_ed25519'],
+        }
+
+        with patch('sky.clouds.slurm.slurm_utils.get_slurm_ssh_config',
+                   return_value=ssh_config), \
+             patch('sky.clouds.slurm.slurm_utils.get_submit_user',
+                   return_value=submit_user), \
+             patch('sky.clouds.slurm.slurm_utils.get_partitions',
+                   return_value=['gpu']), \
+             patch('sky.clouds.slurm.skypilot_config.'
+                   'get_effective_region_config', return_value=None):
+            return cloud.make_deploy_resources_variables(
+                resources=resources,
+                cluster_name=mock.MagicMock(),
+                region=region,
+                zones=[zone],
+                num_nodes=1)
+
+    def test_submit_user_persisted(self):
+        deploy_vars = self._make_deploy_variables('alice')
+
+        assert deploy_vars['slurm_user'] == 'alice'
+
+    def test_disabled_keeps_default(self):
+        deploy_vars = self._make_deploy_variables(None, ssh_user='ubuntu')
+
+        assert deploy_vars['slurm_user'] is None
+
+    def test_submit_user_allows_passwordless_sudo_transport(self):
+        deploy_vars = self._make_deploy_variables('alice', ssh_user='ubuntu')
+
+        assert deploy_vars['ssh_user'] == 'ubuntu'
+        assert deploy_vars['slurm_user'] == 'alice'
+
+
+class TestSubmitUserTemplate:
+
+    @pytest.mark.parametrize(
+        'slurm_user,transport_user,image_id,expected_ssh_user', [
+            ('alice', 'root', None, 'alice'),
+            ('alice', 'root', 'ubuntu:22.04', 'root'),
+            (None, 'ubuntu', None, 'ubuntu'),
+        ])
+    def test_persists_submit_user(self, tmp_path, slurm_user, transport_user,
+                                  image_id, expected_ssh_user):
+        from sky.utils import common_utils
+        from sky.utils import yaml_utils
+
+        output_path = tmp_path / 'cluster.yaml'
+        common_utils.fill_template(
+            'slurm-ray.yml.j2', {
+                'slurm_user': slurm_user,
+                'ssh_user': transport_user,
+                'image_id': image_id,
+                'cluster_name_on_cloud': 'test-cluster',
+                'num_nodes': 1,
+                'slurm_cluster': 'my-cluster',
+                'slurm_partition': 'gpu',
+                'provision_timeout': 120,
+                'ssh_hostname': 'login.example.com',
+                'ssh_port': 22,
+                'slurm_private_key': '/root/.ssh/key',
+                'slurm_proxy_command': None,
+                'slurm_proxy_jump': None,
+                'slurm_identities_only': True,
+                'ssh_private_key': '/tmp/sky-key',
+                'instance_type': '4CPU--16GB',
+                'disk_size': 256,
+                'cpus': 4,
+                'memory': 16,
+                'accelerator_type': None,
+                'accelerator_count': 0,
+                'sbatch_options': {},
+                'sky_ray_yaml_remote_path': '/tmp/ray.yaml',
+                'sky_ray_yaml_local_path': '/tmp/ray.yaml',
+                'sky_remote_path': '/tmp/sky',
+                'sky_wheel_hash': 'wheel.whl',
+                'sky_local_path': '/tmp/sky.whl',
+                'credentials': {},
+                'initial_setup_commands': [],
+                'slurm_sshd_host_key_filename': 'skypilot_host_key',
+                'slurm_cluster_name_env_var': 'SKYPILOT_CLUSTER_NAME',
+                'setup_sky_dirs_commands': '',
+                'conda_installation_commands': '',
+                'uv_installation_commands': '',
+                'skypilot_wheel_installation_commands': '',
+                'copy_skypilot_templates_commands': '',
+            }, str(output_path))
+
+        config = yaml_utils.read_yaml(str(output_path))
+        if slurm_user is None:
+            assert 'slurm_user' not in config['provider']
+        else:
+            assert config['provider']['slurm_user'] == slurm_user
+        assert config['provider']['ssh']['user'] == transport_user
+        assert config['auth']['ssh_user'] == expected_ssh_user
 
 
 class TestCheckInstanceFits:
@@ -843,6 +1040,8 @@ class TestSlurmProvisionTimeout:
                    return_value=mock_ssh_config), \
              patch('sky.clouds.slurm.slurm_utils.get_partitions',
                    return_value=['default', 'gpu', 'cpu']), \
+             patch('sky.clouds.slurm.slurm_utils.get_submit_user',
+                   return_value=None), \
              patch('sky.clouds.slurm.slurm_utils.resolve_gres_gpu_type',
                    side_effect=lambda cluster, t, count=1, partition=None: t):
             deploy_vars = cloud.make_deploy_resources_variables(
@@ -878,7 +1077,8 @@ class TestProvisionTimeoutPassthrough:
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
     @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
     def test_default_timeout_passthrough(self, mock_ssh_runner,
                                          mock_slurm_client,
                                          mock_get_partition_info,
@@ -948,7 +1148,8 @@ class TestProvisionTimeoutPassthrough:
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
     @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
     def test_explicit_timeout_passthrough(self, mock_ssh_runner,
                                           mock_slurm_client,
                                           mock_get_partition_info,
@@ -1069,7 +1270,8 @@ class TestCreateVirtualInstance:
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
     @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
     def test_container_script_format(self, mock_ssh_runner, mock_slurm_client,
                                      mock_get_partition_info,
                                      mock_get_proctrack_type,
@@ -1115,7 +1317,8 @@ class TestCreateVirtualInstance:
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
     @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
     def test_non_container_script_format(self, mock_ssh_runner,
                                          mock_slurm_client,
                                          mock_get_partition_info,
@@ -1133,12 +1336,13 @@ class TestCreateVirtualInstance:
                 'ssh': {
                     'hostname': 'login.example.com',
                     'port': '22',
-                    'user': 'testuser',
+                    'user': 'root',
                     'private_key': '/path/to/key',
                 },
                 'cluster': 'test-slurm',
                 'partition': 'cpus',
                 'provision_timeout': 300,
+                'slurm_user': 'alice',
             },
             authentication_config={},
             docker_config={},
@@ -1155,6 +1359,8 @@ class TestCreateVirtualInstance:
         written_script = self._run_and_capture_script(
             'test-cluster-no-container', config)
         assert_sbatch_matches_snapshot('basic', written_script)
+        assert mock_slurm_client.call_args.kwargs['slurm_user'] == 'alice'
+        assert mock_ssh_runner.call_args.kwargs['slurm_user'] == 'alice'
 
     @pytest.mark.parametrize('memory_gb,expected_mem_mb', [
         (0.5, 512),
@@ -1167,7 +1373,8 @@ class TestCreateVirtualInstance:
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
     @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    @patch('sky.provision.slurm.instance.command_runner.SSHCommandRunner')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
     def test_fractional_memory_converted_to_mb(self, mock_ssh_runner,
                                                mock_slurm_client,
                                                mock_get_partition_info,

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -94,6 +94,115 @@ class TestGetIdentityFile:
         assert result == expected
 
 
+class TestGetSlurmNodesInfo:
+    """Test user-scoped Slurm node discovery."""
+
+    @pytest.mark.parametrize('slurm_user,expected_command_user',
+                             [('alice', 'alice'), ('bob', 'bob'),
+                              (None, 'transport-user')])
+    def test_cache_and_query_are_scoped_by_command_user(self, monkeypatch,
+                                                        slurm_user,
+                                                        expected_command_user):
+        ssh_config = mock.Mock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'user': 'transport-user',
+        }
+        monkeypatch.setattr(utils, 'get_slurm_ssh_config',
+                            mock.Mock(return_value=ssh_config))
+        monkeypatch.setattr(utils, 'get_submit_user',
+                            mock.Mock(return_value=slurm_user))
+        get_cache_entry = mock.Mock(return_value=None)
+        monkeypatch.setattr(utils.kv_cache, 'get_cache_entry', get_cache_entry)
+        monkeypatch.setattr(utils.kv_cache, 'add_or_update_cache_entry',
+                            mock.Mock())
+        client = mock.Mock()
+        client.info_nodes.return_value = []
+        slurm_client_cls = mock.Mock(return_value=client)
+        monkeypatch.setattr(utils.slurm, 'SlurmClient', slurm_client_cls)
+
+        assert utils.get_slurm_nodes_info('cluster-a') == []
+
+        get_cache_entry.assert_called_once_with(
+            f'slurm:nodes_info:cluster-a:{expected_command_user}')
+        assert slurm_client_cls.call_args.kwargs['slurm_user'] == slurm_user
+
+
+class TestClusterFeatureCache:
+    """Test user-scoped Slurm feature checks."""
+
+    @pytest.mark.parametrize('slurm_user,expected_command_user',
+                             [('alice', 'alice'), ('bob', 'bob'),
+                              (None, 'transport-user')])
+    def test_cache_and_query_are_scoped_by_command_user(self, monkeypatch,
+                                                        slurm_user,
+                                                        expected_command_user):
+        ssh_config = mock.Mock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'user': 'transport-user',
+        }
+        monkeypatch.setattr(utils, 'get_slurm_ssh_config',
+                            mock.Mock(return_value=ssh_config))
+        monkeypatch.setattr(utils, 'get_submit_user',
+                            mock.Mock(return_value=slurm_user))
+        get_cache_entry = mock.Mock(return_value=None)
+        monkeypatch.setattr(utils.kv_cache, 'get_cache_entry', get_cache_entry)
+        monkeypatch.setattr(utils.kv_cache, 'add_or_update_cache_entry',
+                            mock.Mock())
+        slurm_client_cls = mock.Mock(return_value=mock.Mock())
+        monkeypatch.setattr(utils.slurm, 'SlurmClient', slurm_client_cls)
+
+        assert utils._check_cluster_feature('cluster-a', 'fuse', lambda _: True,
+                                            60)
+
+        get_cache_entry.assert_called_once_with(
+            f'slurm:fuse_enabled:cluster-a:{expected_command_user}')
+        assert slurm_client_cls.call_args.kwargs['slurm_user'] == slurm_user
+
+
+class TestGetPartitionInfos:
+    """Test user-scoped Slurm partition caching."""
+
+    def test_cache_is_scoped_by_submit_user(self, monkeypatch):
+        utils._get_partition_infos.cache_clear()
+        ssh_config = mock.Mock()
+        ssh_config.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'user': 'transport-user',
+        }
+        monkeypatch.setattr(utils.SSHConfig, 'from_path',
+                            mock.Mock(return_value=ssh_config))
+        submit_users = iter(['alice', 'bob', 'alice'])
+        monkeypatch.setattr(utils, 'get_submit_user',
+                            mock.Mock(side_effect=lambda _: next(submit_users)))
+
+        def _make_client(*args, **kwargs):
+            del args
+            slurm_user = kwargs['slurm_user']
+            client = mock.Mock()
+            client.get_partitions_info.return_value = [
+                utils.slurm.SlurmPartition(f'{slurm_user}-partition', True,
+                                           None, None)
+            ]
+            return client
+
+        slurm_client_cls = mock.Mock(side_effect=_make_client)
+        monkeypatch.setattr(utils.slurm, 'SlurmClient', slurm_client_cls)
+
+        try:
+            alice = utils.get_partition_infos('cluster-a')
+            bob = utils.get_partition_infos('cluster-a')
+            alice_again = utils.get_partition_infos('cluster-a')
+
+            assert set(alice) == {'alice-partition'}
+            assert set(bob) == {'bob-partition'}
+            assert alice_again is alice
+            assert slurm_client_cls.call_count == 2
+        finally:
+            utils._get_partition_infos.cache_clear()
+
+
 def _make_node_info(node_name: str, cluster_name: str) -> dict:
     return {
         'node_name': node_name,
@@ -204,12 +313,22 @@ class TestGetSlurmNodeInfoListEnrichment:
             'user': 'me',
         }
         monkeypatch.setattr(utils, 'get_slurm_ssh_config', lambda: ssh_config)
-        monkeypatch.setattr(utils.slurm, 'SlurmClient',
-                            mock.Mock(return_value=client))
-        return utils._get_slurm_node_info_list('cluster-a')
+        slurm_client_cls = mock.Mock(return_value=client)
+        monkeypatch.setattr(utils.slurm, 'SlurmClient', slurm_client_cls)
+        result = utils._get_slurm_node_info_list('cluster-a')
+        return result, slurm_client_cls
+
+    def test_uses_transport_user(self, monkeypatch):
+        get_submit_user = mock.Mock(side_effect=AssertionError)
+        monkeypatch.setattr(utils, 'get_submit_user', get_submit_user)
+
+        _, slurm_client_cls = self._run(monkeypatch, {})
+
+        get_submit_user.assert_not_called()
+        assert slurm_client_cls.call_args.kwargs['slurm_user'] is None
 
     def test_enriches_from_scontrol(self, monkeypatch):
-        result = self._run(
+        result, _ = self._run(
             monkeypatch, {
                 'node1': {
                     'CPUAlloc': '8',
@@ -229,7 +348,7 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert node['free_memory_gb'] == round(421339 / 1024.0, 2)
 
     def test_na_values_become_none(self, monkeypatch):
-        result = self._run(
+        result, _ = self._run(
             monkeypatch, {
                 'node1': {
                     'CPUAlloc': '0',
@@ -247,7 +366,7 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert node['free_memory_gb'] is None
 
     def test_missing_node_details_yields_none_fields(self, monkeypatch):
-        result = self._run(monkeypatch, {})
+        result, _ = self._run(monkeypatch, {})
         node = result[0]
         assert node['free_vcpus'] is None
         assert node['free_alloc_memory_gb'] is None
@@ -255,7 +374,7 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert node['free_memory_gb'] is None
 
     def test_scontrol_failure_does_not_break_node_info(self, monkeypatch):
-        result = self._run(monkeypatch, RuntimeError('scontrol failed'))
+        result, _ = self._run(monkeypatch, RuntimeError('scontrol failed'))
         assert len(result) == 1
         node = result[0]
         assert node['node_name'] == 'node1'

--- a/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
+++ b/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
@@ -5,6 +5,7 @@ gracefully (rather than raising an HTTPException, which would surface as an
 unhandled RuntimeError traceback) when cluster validation fails.
 """
 
+import shlex
 from unittest import mock
 
 import fastapi
@@ -18,6 +19,67 @@ def _make_websocket():
     websocket = mock.MagicMock(spec=fastapi.WebSocket)
     websocket.close = mock.AsyncMock()
     return websocket
+
+
+def test_slurm_ssh_proxy_runs_as_submit_user():
+    command = server._build_slurm_job_ssh_command(
+        provider_config={
+            'ssh': {
+                'user': 'root'
+            },
+            'slurm_user': 'alice',
+        },
+        job_id='123',
+        target_node='node-1',
+        cluster_name_on_cloud='test-cluster',
+        is_container_image=False)
+
+    argv = shlex.split(command)
+    assert argv[:5] == ['su', '--login', '--shell', '/bin/bash', '--command']
+    assert argv[6:] == ['--', 'alice']
+    assert argv[5].startswith('srun ')
+    assert '~alice/.ssh/authorized_keys' in argv[5]
+
+
+def test_slurm_ssh_proxy_uses_sudo_for_non_root_transport():
+    command = server._build_slurm_job_ssh_command(
+        provider_config={
+            'ssh': {
+                'user': 'ubuntu'
+            },
+            'slurm_user': 'alice',
+        },
+        job_id='123',
+        target_node='node-1',
+        cluster_name_on_cloud='test-cluster',
+        is_container_image=False)
+
+    argv = shlex.split(command)
+    assert argv[:8] == [
+        'sudo', '--non-interactive', '--', 'su', '--login', '--shell',
+        '/bin/bash', '--command'
+    ]
+    assert argv[9:] == ['--', 'alice']
+    assert argv[8].startswith('srun ')
+
+
+def test_slurm_container_ssh_proxy_uses_root_in_container():
+    command = server._build_slurm_job_ssh_command(
+        provider_config={
+            'ssh': {
+                'user': 'root'
+            },
+            'slurm_user': 'alice',
+        },
+        job_id='123',
+        target_node='node-1',
+        cluster_name_on_cloud='test-cluster',
+        is_container_image=True)
+
+    argv = shlex.split(command)
+    assert argv[:5] == ['su', '--login', '--shell', '/bin/bash', '--command']
+    assert argv[6:] == ['--', 'alice']
+    assert '--container-remap-root' in argv[5]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_sky/test_global_user_state_check_results.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_check_results.py
@@ -1,5 +1,9 @@
 """Unit tests for check_results accessors in global_user_state."""
+import pytest
+
 from sky import global_user_state
+from sky import models
+from sky.clouds import cloud
 from sky.skylet import constants
 from sky.utils.db import db_utils
 
@@ -26,6 +30,35 @@ def _fresh_db(tmp_path, monkeypatch):
         ),
     )
     return tmp_path / '.sky' / 'state.db'
+
+
+@pytest.mark.parametrize(
+    'slurm_config,expected',
+    [
+        ({}, False),
+        ({
+            'submit_as_user': True
+        }, True),
+        ({
+            'cluster_configs': {
+                'cluster-a': {
+                    'submit_as_user': True
+                }
+            }
+        }, True),
+        ({
+            'cluster_configs': {
+                'cluster-a': {
+                    'submit_as_user': False
+                }
+            }
+        }, False),
+    ],
+)
+def test_detects_submit_as_user_config(monkeypatch, slurm_config, expected):
+    monkeypatch.setattr(global_user_state.skypilot_config, 'get_nested',
+                        lambda *args, **kwargs: slurm_config)
+    assert global_user_state._slurm_submit_as_user_enabled() is expected
 
 
 def test_get_returns_empty_when_no_row(tmp_path, monkeypatch):
@@ -56,6 +89,72 @@ def test_set_then_get_full_run(tmp_path, monkeypatch):
     global_user_state.set_check_results(results,
                                         workspace='default',
                                         is_full_workspace_run=True)
+    assert global_user_state.get_cached_check_results('default') == results
+
+
+def test_check_results_and_enabled_clouds_are_user_scoped(
+        tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    current_user = [models.User(id='alice-id', name='alice@example.com')]
+    monkeypatch.setattr(global_user_state, '_slurm_submit_as_user_enabled',
+                        lambda: True)
+    monkeypatch.setattr(global_user_state.common_utils, 'get_current_user',
+                        lambda: current_user[0])
+    alice_results = {
+        'Slurm': {
+            'cluster-a': {
+                'enabled': True,
+                'reason': 'alice home is shared'
+            }
+        }
+    }
+    global_user_state.set_check_results(alice_results,
+                                        workspace='default',
+                                        is_full_workspace_run=True)
+    global_user_state.set_enabled_clouds(['Slurm'],
+                                         cloud.CloudCapability.COMPUTE,
+                                         workspace='default')
+
+    current_user[0] = models.User(id='bob-id', name='bob@example.com')
+    assert global_user_state.get_cached_check_results('default') == {}
+    assert global_user_state.get_cached_enabled_clouds(
+        cloud.CloudCapability.COMPUTE, workspace='default') == []
+
+    bob_results = {
+        'Slurm': {
+            'cluster-a': {
+                'enabled': True,
+                'reason': 'bob home is not shared'
+            }
+        }
+    }
+    global_user_state.set_check_results(bob_results,
+                                        workspace='default',
+                                        is_full_workspace_run=True)
+
+    current_user[0] = models.User(id='alice-id', name='alice@example.com')
+    assert global_user_state.get_cached_check_results(
+        'default') == alice_results
+    assert [
+        repr(c) for c in global_user_state.get_cached_enabled_clouds(
+            cloud.CloudCapability.COMPUTE, workspace='default')
+    ] == ['Slurm']
+
+
+def test_check_results_remain_workspace_scoped_when_submit_user_disabled(
+        tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    current_user = [models.User(id='alice-id', name='alice@example.com')]
+    monkeypatch.setattr(global_user_state, '_slurm_submit_as_user_enabled',
+                        lambda: False)
+    monkeypatch.setattr(global_user_state.common_utils, 'get_current_user',
+                        lambda: current_user[0])
+    results = {'AWS': {'': {'enabled': True, 'reason': 'enabled'}}}
+    global_user_state.set_check_results(results,
+                                        workspace='default',
+                                        is_full_workspace_run=True)
+
+    current_user[0] = models.User(id='bob-id', name='bob@example.com')
     assert global_user_state.get_cached_check_results('default') == results
 
 

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -3,6 +3,7 @@
 from contextlib import suppress
 import os
 import select
+import shlex
 import socket
 import subprocess
 import tempfile
@@ -350,6 +351,138 @@ class TestSSHCommandRunnerInteractiveAuth:
             handler_thread.join(timeout=2)
             if os.path.exists(log_path):
                 os.unlink(log_path)
+
+
+class TestSlurmCommandRunnerUserImpersonation:
+
+    @staticmethod
+    def _login_runner(slurm_user, ssh_user='root'):
+        return command_runner.SlurmLoginNodeCommandRunner(
+            node=('login.example.com', 22),
+            ssh_user=ssh_user,
+            ssh_private_key=None,
+            slurm_user=slurm_user)
+
+    @staticmethod
+    def _slurm_runner(slurm_user, ssh_user='root'):
+        return command_runner.SlurmCommandRunner(
+            node=('login.example.com', 22),
+            ssh_user=ssh_user,
+            ssh_private_key=None,
+            sky_dir='/home/alice/.sky_clusters/test',
+            skypilot_runtime_dir='/tmp/test',
+            job_id='123',
+            slurm_node='node-1',
+            container_args=None,
+            slurm_user=slurm_user)
+
+    def test_wrap_command_as_user(self):
+        command = 'echo "$HOME" && printf %s "a b"'
+
+        wrapped = command_runner.wrap_command_as_user(command, 'alice')
+
+        assert shlex.split(wrapped) == [
+            'su', '--login', '--shell', '/bin/bash', '--command', command, '--',
+            'alice'
+        ]
+
+    def test_login_node_run_as_user(self):
+        runner = self._login_runner('alice')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'run',
+                               autospec=True,
+                               return_value=(0, '', '')) as mock_run:
+            runner.run('squeue --me', require_outputs=True)
+
+        remote_command = mock_run.call_args.args[1]
+        assert shlex.split(remote_command) == [
+            'su', '--login', '--shell', '/bin/bash', '--command', 'squeue --me',
+            '--', 'alice'
+        ]
+
+    def test_login_node_run_as_user_with_sudo(self):
+        runner = self._login_runner('alice', ssh_user='ubuntu')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'run',
+                               autospec=True,
+                               return_value=(0, '', '')) as mock_run:
+            runner.run('squeue --me', require_outputs=True)
+
+        remote_command = mock_run.call_args.args[1]
+        assert shlex.split(remote_command) == [
+            'sudo', '--non-interactive', '--', 'su', '--login', '--shell',
+            '/bin/bash', '--command', 'squeue --me', '--', 'alice'
+        ]
+
+    def test_login_node_sudo_failure_propagates(self):
+        runner = self._login_runner('alice', ssh_user='ubuntu')
+        with mock.patch.object(
+                command_runner.SSHCommandRunner,
+                'run',
+                autospec=True,
+                return_value=(1, '',
+                              'sudo: a password is required')) as mock_run:
+            result = runner.run('squeue --me', require_outputs=True)
+
+        assert result == (1, '', 'sudo: a password is required')
+        assert mock_run.call_count == 1
+
+    def test_login_node_run_unchanged_when_disabled(self):
+        runner = self._login_runner(None, ssh_user='ubuntu')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'run',
+                               autospec=True,
+                               return_value=(0, '', '')) as mock_run:
+            runner.run('squeue --me', require_outputs=True)
+
+        assert mock_run.call_args.args[1] == 'squeue --me'
+
+    def test_login_node_rsync_as_user(self):
+        runner = self._login_runner('alice', ssh_user='ubuntu')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'rsync',
+                               autospec=True) as mock_rsync:
+            runner.rsync('/tmp/source', '~/.sky/file', up=True)
+
+        remote_command = mock_rsync.call_args.kwargs['remote_rsync_command']
+        assert shlex.split(remote_command) == [
+            'sudo', '--non-interactive', '--', 'su', '--login', '--shell',
+            '/bin/bash', '--command', 'exec rsync "$@"', '--', 'alice', 'rsync'
+        ]
+
+    def test_srun_as_user(self):
+        runner = self._slurm_runner('alice', ssh_user='ubuntu')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'run',
+                               autospec=True,
+                               return_value=0) as mock_run:
+            runner.run('whoami')
+
+        remote_command = shlex.split(mock_run.call_args.args[1])
+        assert remote_command[:8] == [
+            'sudo', '--non-interactive', '--', 'su', '--login', '--shell',
+            '/bin/bash', '--command'
+        ]
+        assert remote_command[9:] == ['--', 'alice']
+        assert remote_command[8].startswith('srun --unbuffered')
+        assert 'whoami' in remote_command[8]
+
+    def test_srun_rsync_as_user(self):
+        runner = self._slurm_runner('alice', ssh_user='ubuntu')
+        with mock.patch.object(command_runner.SSHCommandRunner,
+                               'rsync',
+                               autospec=True) as mock_rsync:
+            runner.rsync('/tmp/source', '~/file', up=True)
+
+        remote_command = mock_rsync.call_args.kwargs['remote_rsync_command']
+        argv = shlex.split(remote_command)
+        assert argv[:8] == [
+            'sudo', '--non-interactive', '--', 'su', '--login', '--shell',
+            '/bin/bash', '--command'
+        ]
+        assert argv[8].startswith('exec srun --unbuffered')
+        assert argv[8].endswith('rsync "$@"')
+        assert argv[9:] == ['--', 'alice', 'rsync']
 
 
 def test_kubernetes_runner_adds_container_flag_to_kubectl_exec() -> None:


### PR DESCRIPTION
This adds opt-in `slurm.submit_as_user` support for shared API servers.

When enabled, SkyPilot derives the Unix account from the authenticated username (the portion before `@`) and runs user-owned Slurm operations under that account. The shared SSH transport may connect as root or as a user with passwordless sudo access to `su`.

- Persist the mapped user in cluster provider configuration.
- Apply impersonation to provisioning, job queries, `srun`, rsync, cancellation, recovery, teardown, and SSH proxying.
- Keep cluster-wide inventory on the SSH transport user.
- Keep Slurm allocations owned by the mapped user while allowing container commands and SSH sessions to run as root inside containers.
- Scope user-sensitive Slurm caches and persisted cloud-check results by the effective user, including shared-home, Pyxis, FUSE, partition, and launch-discovery results.
- Fail closed for invalid usernames, missing accounts, and insufficient privileges.
- Make the setting server-managed and support global or per-cluster configuration.
- Document the configuration, identity split, and privilege requirements.

Tested:

- [x] Code formatting and static checks
  - YAPF and isort
  - Mypy: 586 source files
  - Pylint: 10.00/10
- [x] Manual and selected tests
  - 621 selected unit tests
  - 80 isolated configuration tests
  - Ran the rebased commit through a local API server against a Slurm cluster using a non-root SSH transport with passwordless sudo
  - Verified allocations, bare tasks, SSH access, rsync, cancellation, and teardown use the mapped user
  - Verified container tasks run as root inside mapped-user-owned allocations
  - Verified managed-job recovery preserves the mapped user
  - Verified cluster inventory uses the SSH transport user
  - Verified a missing mapped account fails closed during `sky check slurm`
- [ ] All smoke tests
- [ ] Relevant individual smoke tests
- [ ] Backward compatibility tests

The Sphinx documentation build was not run because `sphinx-build` was unavailable locally.
