### PR TITLE
[Jobs] Add inter_connection knob for JobGroups: require or skip in-group networking

### DIFF
--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -107,6 +107,15 @@ The header document supports the following fields:
        allowing them to finish pending work (e.g., flushing data). Can be a
        string (e.g., ``"30s"``, ``"5m"``) or a dict with per-task delays
        (e.g., ``{"default": "30s", "replay-buffer": "1m"}``).
+   * - ``inter_connection``
+     - ``true``
+     - Whether tasks need to reach each other by hostname (in-group
+       networking). When ``true`` (the default), all tasks are placed
+       together on one Kubernetes cluster and the job fails if networking
+       cannot be set up. Set to ``false`` for tasks that coordinate
+       externally: no in-group networking is set up, tasks start without
+       waiting for peers, and tasks may be placed across different clusters.
+       See :ref:`job-groups-inter-connection`.
 
 Each task document after the header follows the standard :ref:`SkyPilot task YAML format <yaml-spec>`.
 
@@ -162,6 +171,49 @@ Example usage in a task:
 
     # Access the trainer task from the evaluator using the hostname
     curl http://trainer-0.${SKYPILOT_JOBGROUP_NAME}:8000/status
+
+.. _job-groups-inter-connection:
+
+Requiring or skipping in-group networking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In-group service discovery is supported on Kubernetes. By default
+(``inter_connection: true``), SkyPilot places all tasks in a job group on a
+single Kubernetes cluster, and tasks wait for peer hostnames to become
+resolvable before running. If networking cannot be initialized, the job
+fails with a clear error rather than running without connectivity.
+
+Set ``inter_connection: false`` in the header for tasks that do not need to
+reach each other by hostname (e.g., components that coordinate through an
+external endpoint or a shared object store):
+
+.. code-block:: yaml
+
+    name: my-job-group
+    execution: parallel
+    inter_connection: false
+    ---
+    # ... task documents ...
+
+With ``inter_connection: false``:
+
+- No in-group networking is set up, and tasks start immediately without
+  waiting for peers.
+- Tasks may be placed on **different Kubernetes clusters** when no single
+  cluster can host the whole group (e.g., the required GPU types live in
+  different clusters), or on non-Kubernetes infrastructure.
+- Tasks can also pin different clusters explicitly, via per-task
+  ``infra: k8s/<context>``.
+
+.. note::
+
+   Hostname-based service discovery across clusters is not supported:
+   tasks placed on different clusters cannot reach each other via in-group
+   hostnames. ``inter_connection: true`` (the default) therefore requires
+   placing the whole group on a single Kubernetes cluster — a job group
+   that cannot be co-located fails at submission with instructions, and
+   pinning non-Kubernetes or conflicting infras together with
+   ``inter_connection: true`` is rejected when the YAML is loaded.
 
 
 Viewing logs

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -108,17 +108,15 @@ The header document supports the following fields:
        string (e.g., ``"30s"``, ``"5m"``) or a dict with per-task delays
        (e.g., ``{"default": "30s", "replay-buffer": "1m"}``).
    * - ``inter_connection``
-     - enabled
-     - Whether tasks need to reach each other by hostname (in-group
-       networking). When enabled, all tasks are placed together on one
-       Kubernetes cluster and the job fails if networking cannot be set
-       up. Unset (the default) enables networking wherever it is
-       supported; explicitly setting ``true`` is stricter — placements
-       that cannot support in-group networking (non-Kubernetes or
-       conflicting infra pins) become errors instead of warnings. Set to
-       ``false`` for tasks that coordinate externally: no in-group
-       networking is set up, tasks start without waiting for peers, and
-       tasks may be placed across different clusters.
+     - ``None``
+     - Whether tasks need to reach each other by hostname.
+       ``true``: place all tasks on a single Kubernetes cluster and set
+       up hostname connectivity between them; hard-fail if either is not
+       possible. ``false``: deliberately skip all networking setup; tasks
+       still prefer co-location but may land on separate clusters (via
+       per-task infra pins, or when no single cluster has the required
+       resource types). Unset: behaves like ``true`` where supported,
+       like ``false`` (with a warning) where not.
        See :ref:`job-groups-inter-connection`.
 
 Each task document after the header follows the standard :ref:`SkyPilot task YAML format <yaml-spec>`.

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -108,13 +108,17 @@ The header document supports the following fields:
        string (e.g., ``"30s"``, ``"5m"``) or a dict with per-task delays
        (e.g., ``{"default": "30s", "replay-buffer": "1m"}``).
    * - ``inter_connection``
-     - ``true``
+     - enabled
      - Whether tasks need to reach each other by hostname (in-group
-       networking). When ``true`` (the default), all tasks are placed
-       together on one Kubernetes cluster and the job fails if networking
-       cannot be set up. Set to ``false`` for tasks that coordinate
-       externally: no in-group networking is set up, tasks start without
-       waiting for peers, and tasks may be placed across different clusters.
+       networking). When enabled, all tasks are placed together on one
+       Kubernetes cluster and the job fails if networking cannot be set
+       up. Unset (the default) enables networking wherever it is
+       supported; explicitly setting ``true`` is stricter — placements
+       that cannot support in-group networking (non-Kubernetes or
+       conflicting infra pins) become errors instead of warnings. Set to
+       ``false`` for tasks that coordinate externally: no in-group
+       networking is set up, tasks start without waiting for peers, and
+       tasks may be placed across different clusters.
        See :ref:`job-groups-inter-connection`.
 
 Each task document after the header follows the standard :ref:`SkyPilot task YAML format <yaml-spec>`.
@@ -177,11 +181,18 @@ Example usage in a task:
 Requiring or skipping in-group networking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In-group service discovery is supported on Kubernetes. By default
-(``inter_connection: true``), SkyPilot places all tasks in a job group on a
-single Kubernetes cluster, and tasks wait for peer hostnames to become
-resolvable before running. If networking cannot be initialized, the job
-fails with a clear error rather than running without connectivity.
+In-group service discovery is supported on Kubernetes. By default,
+in-group networking is enabled: SkyPilot places all tasks in a job group
+on a single Kubernetes cluster, and tasks wait for peer hostnames to
+become resolvable before running. If networking cannot be initialized,
+the job fails with a clear error rather than running without
+connectivity.
+
+Explicitly setting ``inter_connection: true`` is stricter than leaving it
+unset: placements where in-group networking cannot exist (non-Kubernetes
+infra, or infra pins with no common option) are rejected with an error,
+whereas with the field unset such placements proceed without networking
+and emit a warning.
 
 Set ``inter_connection: false`` in the header for tasks that do not need to
 reach each other by hostname (e.g., components that coordinate through an
@@ -209,11 +220,12 @@ With ``inter_connection: false``:
 
    Hostname-based service discovery across clusters is not supported:
    tasks placed on different clusters cannot reach each other via in-group
-   hostnames. ``inter_connection: true`` (the default) therefore requires
-   placing the whole group on a single Kubernetes cluster — a job group
-   that cannot be co-located fails at submission with instructions, and
-   pinning non-Kubernetes or conflicting infras together with
-   ``inter_connection: true`` is rejected when the YAML is loaded.
+   hostnames. In-group networking therefore requires placing the whole
+   group on a single Kubernetes cluster — a job group with networking
+   enabled that cannot be co-located fails at submission with
+   instructions, and pinning non-Kubernetes or conflicting infras
+   together with an explicit ``inter_connection: true`` is rejected when
+   the YAML is loaded.
 
 
 Viewing logs

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -113,9 +113,8 @@ The header document supports the following fields:
        ``true``: place all tasks on a single Kubernetes cluster and set
        up hostname connectivity between them; hard-fail if either is not
        possible. ``false``: deliberately skip all networking setup; tasks
-       still prefer co-location but may land on separate clusters (via
-       per-task infra pins, or when no single cluster has the required
-       resource types). Unset: behaves like ``true`` where supported,
+       still prefer co-location but may land on separate clusters.
+       Unset: behaves like ``true`` where supported,
        like ``false`` (with a warning) where not.
        See :ref:`job-groups-inter-connection`.
 
@@ -216,14 +215,9 @@ With ``inter_connection: false``:
 
 .. note::
 
-   Hostname-based service discovery across clusters is not supported:
-   tasks placed on different clusters cannot reach each other via in-group
-   hostnames. In-group networking therefore requires placing the whole
-   group on a single Kubernetes cluster — a job group with networking
-   enabled that cannot be co-located fails at submission with
-   instructions, and pinning non-Kubernetes or conflicting infras
-   together with an explicit ``inter_connection: true`` is rejected when
-   the YAML is loaded.
+   Hostname-based service discovery across clusters is not yet
+   supported: tasks placed on different clusters cannot reach each other
+   via in-group hostnames.
 
 
 Viewing logs

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -57,6 +57,14 @@ class Dag:
         # Can be a string like "30s" (applies to all auxiliary tasks) or
         # a dict like {"default": "30s", "replay-buffer": "1m"}.
         self.termination_delay: Optional[Union[str, Dict[str, str]]] = None
+        # Whether tasks in a job group need to reach each other by hostname.
+        # When enabled (the default), all tasks must be placed on a single
+        # infrastructure where in-group service discovery works, and failure
+        # to set up networking fails the job. When disabled, no in-group
+        # networking is set up and tasks may be placed on different
+        # infrastructures (e.g. different Kubernetes clusters).
+        # None means unset (treated as enabled).
+        self.inter_connection: Optional[bool] = None
 
     def add(self, task: 'task.Task') -> None:
         self.graph.add_node(task)
@@ -99,6 +107,16 @@ class Dag:
     def set_execution(self, execution: 'DagExecution') -> None:
         """Configure this DAG with the given execution mode."""
         self.execution = execution
+
+    def inter_connection_enabled(self) -> bool:
+        """Whether in-group networking is required for this job group.
+
+        Defaults to True when inter_connection is unset. Consumers should
+        use this instead of reading the raw tri-state attribute; the raw
+        attribute exists so that only user-specified values round-trip
+        through YAML serialization.
+        """
+        return self.inter_connection is not False
 
     def get_termination_delay_secs(self, task_name: str) -> int:
         """Get termination delay in seconds for a specific task.

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -152,6 +152,20 @@ def _add_k8s_annotations(task: 'sky.Task', job_id: int) -> None:
     task.set_resources(new_resources_list)
 
 
+def _task_uses_kubernetes(task: 'sky.Task') -> bool:
+    """Whether any of the task's resources target Kubernetes.
+
+    JobGroup tasks are pinned to a single cloud by the optimizer before
+    reaching the controller, so checking all resource candidates is
+    equivalent to checking the pinned cloud. In-group networking (hostname
+    discovery) is only supported on Kubernetes.
+    """
+    for res in task.resources:
+        if res.cloud is not None and str(res.cloud).lower() == 'kubernetes':
+            return True
+    return False
+
+
 def _build_task_specs(
     executor: 'recovery_strategy.StrategyExecutor',) -> Dict[str, Any]:
     """Merge base and strategy-specific task specs with collision detection."""
@@ -1667,26 +1681,36 @@ class JobController:
         task_name = task.name
         assert task_name is not None, f'Task {task_id} must have a name'
 
-        # Inject wait script to ensure networking is ready before task runs.
-        # We inject this into task.run (not task.setup) because:
-        # - setup runs during cluster provisioning (Phase 1)
-        # - DNS mappings file is written in Phase 3 (after clusters are UP)
-        # - If we block in setup, it times out before Phase 3 can run
-        wait_script = job_group_networking.generate_wait_for_networking_script(
-            job_group_name, other_job_names)
-        # When non-empty, this prelude is prepended to the task's run
-        # section to start the JobGroup DNS updater from there. Phase 3
-        # below does the same delivery via SSH for tasks not covered here.
-        inline_networking_setup_script = (
-            job_group_networking.generate_inline_networking_setup_script(
-                job_group_name, self._dag.tasks, self._job_id))
-        run_prefixes = [
-            script for script in (inline_networking_setup_script, wait_script)
-            if script
-        ]
-        if run_prefixes:
-            current_run = task.run or ''
-            task.run = '\n\n'.join(run_prefixes + [current_run])
+        # In-group networking machinery is only set up when the group
+        # requires it (inter_connection enabled, the default) and the task
+        # runs on Kubernetes — the only infra with in-group networking
+        # support. Otherwise no wait/updater is injected: the task starts
+        # immediately and peers are not reachable by hostname.
+        if (self._dag.inter_connection_enabled() and
+                _task_uses_kubernetes(task)):
+            # Inject wait script to ensure networking is ready before task
+            # runs. We inject this into task.run (not task.setup) because:
+            # - setup runs during cluster provisioning (Phase 1)
+            # - DNS mappings file is written in Phase 3 (after clusters are
+            #   UP)
+            # - If we block in setup, it times out before Phase 3 can run
+            wait_script = (
+                job_group_networking.generate_wait_for_networking_script(
+                    job_group_name, other_job_names))
+            # When non-empty, this prelude is prepended to the task's run
+            # section to start the JobGroup DNS updater from there. Phase 3
+            # below does the same delivery via SSH for tasks not covered
+            # here.
+            inline_networking_setup_script = (
+                job_group_networking.generate_inline_networking_setup_script(
+                    job_group_name, self._dag.tasks, self._job_id))
+            run_prefixes = [
+                script for script in (inline_networking_setup_script,
+                                      wait_script) if script
+            ]
+            if run_prefixes:
+                current_run = task.run or ''
+                task.run = '\n\n'.join(run_prefixes + [current_run])
 
         # JobGroups don't support pools, so cluster name is always deterministic
         cluster_name = managed_job_utils.generate_managed_job_cluster_name(
@@ -1762,6 +1786,8 @@ class JobController:
             mapping — a recovered peer may have a new IP, so every
             task's /etc/hosts needs refreshing.
             """
+            if not self._dag.inter_connection_enabled():
+                return
             updated_handles = []
             for t, _ in all_tasks_handles:
                 t_name = t.name
@@ -2018,28 +2044,48 @@ class JobController:
             handles[task_id] = handle
 
         # Phase 3: Set up networking
-        logger.info('Phase 3: Setting up JobGroup networking...')
-        # Build list of (task, handle) for non-terminal tasks with valid
-        # handles. Skip tasks that inline the DNS mapping — they already
-        # start the DNS updater from task.run.
-        tasks_handles: List[Tuple[
-            'sky.Task', 'cloud_vm_ray_backend.CloudVmRayResourceHandle']] = []
-        for tid, task in enumerate(tasks):
-            task_handle = handles[tid]
-            if task_handle is None:
-                continue
-            if (job_group_networking.dns_addresses_for_task(task, self._job_id)
-                    is not None):
-                continue
-            tasks_handles.append((task, task_handle))
+        if not self._dag.inter_connection_enabled():
+            logger.info('Phase 3: Skipping JobGroup networking setup '
+                        '(inter_connection disabled).')
+        else:
+            logger.info('Phase 3: Setting up JobGroup networking...')
+            # Build list of (task, handle) for non-terminal tasks with valid
+            # handles. Skip tasks that inline the DNS mapping — they already
+            # start the DNS updater from task.run.
+            tasks_handles: List[
+                Tuple['sky.Task',
+                      'cloud_vm_ray_backend.CloudVmRayResourceHandle']] = []
+            for tid, task in enumerate(tasks):
+                task_handle = handles[tid]
+                if task_handle is None:
+                    continue
+                if (job_group_networking.dns_addresses_for_task(
+                        task, self._job_id) is not None):
+                    continue
+                tasks_handles.append((task, task_handle))
 
-        if tasks_handles:
-            networking_success = await (
-                job_group_networking.setup_job_group_networking(
-                    job_group_name, tasks_handles))
-            if not networking_success:
-                logger.warning(
-                    'Some networking setup failed, continuing anyway')
+            if tasks_handles:
+                networking_success = await (
+                    job_group_networking.setup_job_group_networking(
+                        job_group_name, tasks_handles))
+                if not networking_success:
+                    # This group requires in-group networking
+                    # (inter_connection enabled): without it, every task
+                    # would stall at its networking wait and fail anyway.
+                    # Fail fast and clean up instead. Phase 2/3 run outside
+                    # the Phase 1 and Phase 4 try blocks, so clean up here
+                    # before raising to avoid leaking clusters.
+                    logger.error('JobGroup networking setup failed and '
+                                 'inter_connection is enabled; failing the '
+                                 'job group.')
+                    await self._cleanup_job_group_clusters(cluster_names)
+                    raise RuntimeError(
+                        f'Failed to set up in-group networking for JobGroup '
+                        f'{job_group_name!r}, which requires inter-task '
+                        'connectivity (inter_connection is enabled). If '
+                        'tasks in this job group do not need to reach each '
+                        'other by hostname, set \'inter_connection: false\' '
+                        'in the job group header.')
 
         logger.info('JobGroup setup complete, all jobs are running')
 

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2044,26 +2044,27 @@ class JobController:
             handles[task_id] = handle
 
         # Phase 3: Set up networking
+        # Build list of (task, handle) for non-terminal tasks with valid
+        # handles. Skip tasks that inline the DNS mapping — they already
+        # start the DNS updater from task.run. Built unconditionally: the
+        # per-task monitors take this list for their on-recovery
+        # networking refresh (which itself no-ops when networking is off).
+        tasks_handles: List[Tuple[
+            'sky.Task', 'cloud_vm_ray_backend.CloudVmRayResourceHandle']] = []
+        for tid, task in enumerate(tasks):
+            task_handle = handles[tid]
+            if task_handle is None:
+                continue
+            if (job_group_networking.dns_addresses_for_task(task, self._job_id)
+                    is not None):
+                continue
+            tasks_handles.append((task, task_handle))
+
         if not self._dag.inter_connection_enabled():
             logger.info('Phase 3: Skipping JobGroup networking setup '
                         '(inter_connection disabled).')
         else:
             logger.info('Phase 3: Setting up JobGroup networking...')
-            # Build list of (task, handle) for non-terminal tasks with valid
-            # handles. Skip tasks that inline the DNS mapping — they already
-            # start the DNS updater from task.run.
-            tasks_handles: List[
-                Tuple['sky.Task',
-                      'cloud_vm_ray_backend.CloudVmRayResourceHandle']] = []
-            for tid, task in enumerate(tasks):
-                task_handle = handles[tid]
-                if task_handle is None:
-                    continue
-                if (job_group_networking.dns_addresses_for_task(
-                        task, self._job_id) is not None):
-                    continue
-                tasks_handles.append((task, task_handle))
-
             if tasks_handles:
                 networking_success = await (
                     job_group_networking.setup_job_group_networking(

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -658,6 +658,11 @@ def generate_wait_for_networking_script(job_group_name: str,
     1. Wait for the networking ready marker file (created by Phase 3)
     2. Wait for all hostnames to be resolvable
 
+    If networking is not ready after the wait, the script fails the job
+    (exit 1). It is only injected when the job group requires in-group
+    networking (``inter_connection`` enabled, the default), so continuing
+    without networking is never correct here.
+
     Args:
         job_group_name: Name of the JobGroup.
         other_job_names: List of other task names in the group to wait for.
@@ -680,14 +685,10 @@ def generate_wait_for_networking_script(job_group_name: str,
                    f'{job_group_name}.log')
     updater_process = f'skypilot-jobgroup-dns-updater-{job_group_name}'
 
-    # TODO(zhwu): The current handling is not robust against the case where
-    # network setup fails. The job will continue but may get stuck if it
-    # depends on networking. We should make the job group automatically
-    # recover (e.g., re-trigger network setup or restart the job) if the
-    # network fails to initialize properly.
     wait_script = textwrap.dedent(f"""
-        # Wait for JobGroup networking to be ready (best-effort, non-blocking)
-        # If networking fails, we continue anyway to allow job group recovery
+        # Wait for JobGroup networking to be ready. This job group requires
+        # in-group networking (inter_connection), so failure to initialize
+        # networking fails the job.
         echo "[SkyPilot] Waiting for network setup..."
         NETWORK_READY=true
 
@@ -699,8 +700,7 @@ def generate_wait_for_networking_script(job_group_name: str,
         echo "[SkyPilot] Waiting for networking initialization marker..."
         while [ ! -f "$MARKER_FILE" ]; do
           if [ $MARKER_ELAPSED -ge $MARKER_WAIT ]; then
-            echo "[SkyPilot] Warning: Networking setup not initiated after ${{MARKER_ELAPSED}}s"
-            echo "[SkyPilot] Continuing without full network setup (job group may recover later)"
+            echo "[SkyPilot] Error: Networking setup not initiated after ${{MARKER_ELAPSED}}s"
             NETWORK_READY=false
             break
           fi
@@ -724,9 +724,8 @@ def generate_wait_for_networking_script(job_group_name: str,
           for hostname in $HOSTNAMES; do
             while ! getent hosts "$hostname" >/dev/null 2>&1; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
-                echo "[SkyPilot] Warning: Network setup timed out for \\"$hostname\\" after ${{ELAPSED}}s"
+                echo "[SkyPilot] Error: Network setup timed out for \\"$hostname\\" after ${{ELAPSED}}s"
                 echo "[SkyPilot] DNS updater running: $(pgrep -f "$UPDATER_PROCESS" > /dev/null && echo 'yes' || echo 'no')"
-                echo "[SkyPilot] Continuing without full network setup (job group may recover later)"
                 NETWORK_READY=false
                 break 2  # Break out of both loops
               fi
@@ -744,6 +743,10 @@ def generate_wait_for_networking_script(job_group_name: str,
 
         if [ "$NETWORK_READY" = "true" ]; then
           echo "[SkyPilot] Network is ready!"
+        else
+          echo "[SkyPilot] Error: this job group requires in-group networking (inter_connection is enabled) but networking failed to initialize; failing the job."
+          echo "[SkyPilot] If tasks in this job group do not need to reach each other by hostname, set 'inter_connection: false' in the job group header."
+          exit 1
         fi
     """)
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -731,34 +731,28 @@ def launch(
                         override_params['region'] = best_region
                     task_.set_resources_override(override_params)
 
-        # In-group networking (hostname-based service discovery) is only
-        # supported on Kubernetes. Explicit `inter_connection: true` groups
-        # never get placed elsewhere (the optimizer constrains their
-        # candidates to Kubernetes); for unset (default) groups placed on
-        # other clouds, networking degrades to off with a warning, and no
-        # networking machinery is set up on the controller.
-        first_task = dag.tasks[0]
-        if first_task.best_resources is not None:
-            best_cloud = first_task.best_resources.cloud
-            if best_cloud is not None and str(
-                    best_cloud).lower() != 'kubernetes':
-                # Load-time validation and the optimizer's candidate
-                # filtering guarantee explicit `inter_connection: true`
-                # groups are never placed off Kubernetes.
-                assert dag.inter_connection is not True, (
-                    f'JobGroup {dag.name!r} requires inter_connection but '
-                    f'was placed on {best_cloud}')
-                logger.warning(
-                    f'{colorama.Fore.YELLOW}Job group service discovery '
-                    f'(hostname-based networking) is only supported on '
-                    f'Kubernetes. Tasks will run on {best_cloud} but cannot '
-                    f'communicate with each other using hostnames.'
-                    f'{colorama.Style.RESET_ALL}')
-                # Persist the degradation so the controller skips all
-                # networking machinery (Phase 3 setup would fail and, with
-                # networking required, fail the group) for a placement
-                # where in-group networking cannot exist.
-                dag.inter_connection = False
+        # Post-optimization invariant: a group that still has in-group
+        # networking enabled (inter_connection unset or true) was placed
+        # by the same-infra path, which pins every job to one cloud (and
+        # to Kubernetes: unset degrades to False in the optimizer when
+        # placed elsewhere, and explicit true only ever gets Kubernetes
+        # candidates). Heterogeneous placements only arise via
+        # independent placement, which always carries
+        # inter_connection == False.
+        if dag.inter_connection is not False:
+            best_clouds = {
+                str(task_.best_resources.cloud)
+                for task_ in dag.tasks
+                if task_.best_resources is not None and
+                task_.best_resources.cloud is not None
+            }
+            assert len(best_clouds) <= 1, (
+                f'JobGroup {dag.name!r} has in-group networking enabled '
+                f'but was placed on multiple clouds: {sorted(best_clouds)}')
+            assert all(
+                cloud.lower() == 'kubernetes' for cloud in best_clouds), (
+                    f'JobGroup {dag.name!r} has in-group networking '
+                    f'enabled but was placed on {sorted(best_clouds)}')
 
     # If there is a local postgres db, when the api server tries launching on
     # the remote jobs controller it will fail. therefore, we should remove this

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -731,12 +731,23 @@ def launch(
                         override_params['region'] = best_region
                     task_.set_resources_override(override_params)
 
-        # Warn if job group is not running on Kubernetes (networking won't work)
+        # In-group networking (hostname-based service discovery) is only
+        # supported on Kubernetes. Explicit `inter_connection: true` groups
+        # never get placed elsewhere (the optimizer constrains their
+        # candidates to Kubernetes); for unset (default) groups placed on
+        # other clouds, networking degrades to off with a warning, and no
+        # networking machinery is set up on the controller.
         first_task = dag.tasks[0]
         if first_task.best_resources is not None:
             best_cloud = first_task.best_resources.cloud
             if best_cloud is not None and str(
                     best_cloud).lower() != 'kubernetes':
+                # Load-time validation and the optimizer's candidate
+                # filtering guarantee explicit `inter_connection: true`
+                # groups are never placed off Kubernetes.
+                assert dag.inter_connection is not True, (
+                    f'JobGroup {dag.name!r} requires inter_connection but '
+                    f'was placed on {best_cloud}')
                 logger.warning(
                     f'{colorama.Fore.YELLOW}Job group service discovery '
                     f'(hostname-based networking) is only supported on '

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -754,6 +754,11 @@ def launch(
                     f'Kubernetes. Tasks will run on {best_cloud} but cannot '
                     f'communicate with each other using hostnames.'
                     f'{colorama.Style.RESET_ALL}')
+                # Persist the degradation so the controller skips all
+                # networking machinery (Phase 3 setup would fail and, with
+                # networking required, fail the group) for a placement
+                # where in-group networking cannot exist.
+                dag.inter_connection = False
 
     # If there is a local postgres db, when the api server tries launching on
     # the remote jobs controller it will fail. therefore, we should remove this

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1193,15 +1193,17 @@ class Optimizer:
 
             if dag.inter_connection is True:
                 # In-group networking is only supported on Kubernetes, so
-                # explicitly requiring it constrains placement to
-                # Kubernetes candidates.
-                cloud_launchables = collections.defaultdict(
-                    list, {
-                        cloud: res_list
-                        for cloud, res_list in cloud_launchables.items()
-                        if str(cloud).lower() == 'kubernetes'
-                    })
-                if not any(cloud_launchables.values()):
+                # explicitly requiring it constrains this task's
+                # candidates to Kubernetes before the common-infra
+                # intersection below ever sees other clouds.
+                kubernetes_launchables: _PerCloudCandidates = (
+                    collections.defaultdict(
+                        list, {
+                            cloud: res_list
+                            for cloud, res_list in cloud_launchables.items()
+                            if str(cloud).lower() == 'kubernetes'
+                        }))
+                if not any(kubernetes_launchables.values()):
                     # Distinguish a user contradiction (the job pins only
                     # non-Kubernetes infra) from a feasibility problem.
                     cloud_pins, _ = _get_task_pin_sets(task)
@@ -1222,6 +1224,7 @@ class Optimizer:
                             '`inter_connection: true`, which requires '
                             'in-group networking, only supported on '
                             f'Kubernetes, but {reason}')
+                cloud_launchables = kubernetes_launchables
 
             task_launchables[task] = cloud_launchables
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1068,68 +1068,10 @@ class Optimizer:
             logger.info(
                 f'Optimizing JobGroup "{dag.name}" with {len(tasks)} jobs')
 
-        # Detect deliberately cross-infra pins from the user's spec alone,
-        # at two levels of granularity:
-        # - cloud-pinned: every resource option of a job pins a cloud
-        #   (region optional, e.g. `infra: k8s`). Jobs whose cloud pin
-        #   sets share no cloud can never be co-located.
-        # - fully-pinned: every option pins cloud+region (e.g.
-        #   `infra: k8s/ctx`). Jobs whose pin sets share no infra can
-        #   never be co-located, even within one cloud.
-        # Either way the common-infra search below can never succeed.
-        # Whether that is allowed depends on inter_connection (in-group
-        # networking does not work across infras today):
-        # - explicitly required (true): error;
-        # - unset (default): allowed, networking degrades to off with a
-        #   warning;
-        # - false: allowed silently.
-        pinned_task_clouds: Dict[str, Set[str]] = {}
-        pinned_task_infras: Dict[str, Set[str]] = {}
-        for task in tasks:
-            cloud_pins, infra_pins = _get_task_pin_sets(task)
-            if cloud_pins is not None:
-                pinned_task_clouds[str(task.name)] = cloud_pins
-            if infra_pins is not None:
-                pinned_task_infras[str(task.name)] = infra_pins
-        clouds_conflict = (len(pinned_task_clouds) > 1 and
-                           not set.intersection(*pinned_task_clouds.values()))
-        infras_conflict = (len(pinned_task_infras) > 1 and
-                           not set.intersection(*pinned_task_infras.values()))
-        pins_conflict = clouds_conflict or infras_conflict
-        if pins_conflict:
-            # Show each job's own pins so the user can see exactly which
-            # jobs disagree, at the granularity that conflicted.
-            conflicting_pins = (pinned_task_infras
-                                if infras_conflict else pinned_task_clouds)
-            pins_desc = '; '.join(f'{name}: {sorted(pins)}'
-                                  for name, pins in conflicting_pins.items())
-            if dag.inter_connection is True:
-                with ux_utils.print_exception_no_traceback():
-                    raise exceptions.ResourcesUnavailableError(
-                        f'Jobs in JobGroup "{dag.name}" pin infrastructures '
-                        f'with no common option ({pins_desc}), but '
-                        '`inter_connection: true` requires in-group '
-                        'networking, which does not work across '
-                        'infrastructures. Unify the infra pins, or set '
-                        '`inter_connection: false` if the jobs do not need '
-                        'to reach each other by hostname.')
-            if dag.inter_connection is None:
-                logger.warning(
-                    f'Jobs in JobGroup "{dag.name}" pin infrastructures '
-                    f'with no common option ({pins_desc}); in-group '
-                    'networking will not be set up and jobs cannot reach '
-                    'each other by hostname. Set `inter_connection: false` '
-                    'to silence this warning.')
-                # Persist the degradation so downstream consumers (the
-                # jobs controller) skip all networking machinery: without
-                # this, the controller would inject the (fatal)
-                # networking wait for a placement where hostnames can
-                # never resolve.
-                dag.inter_connection = False
-            elif not quiet:
-                logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
-                            'infrastructures; optimizing each job '
-                            'independently.')
+        # Spec-level validation of the user's infra pins against
+        # inter_connection (no catalog lookups). May persist an
+        # unset -> off networking degradation on the dag.
+        if _validate_inter_connection_pins(dag, quiet):
             return Optimizer._optimize_independent(dag, minimize,
                                                    blocked_resources, quiet)
 
@@ -1204,26 +1146,16 @@ class Optimizer:
                             if str(cloud).lower() == 'kubernetes'
                         }))
                 if not any(kubernetes_launchables.values()):
-                    # Distinguish a user contradiction (the job pins only
-                    # non-Kubernetes infra) from a feasibility problem.
-                    cloud_pins, _ = _get_task_pin_sets(task)
-                    if cloud_pins and not any(cloud.lower() == 'kubernetes'
-                                              for cloud in cloud_pins):
-                        reason = (f'job "{task.name}" pins non-Kubernetes '
-                                  f'infra ({sorted(cloud_pins)}). Remove '
-                                  'the non-Kubernetes infra pins, or set '
-                                  '`inter_connection: false` if the jobs '
-                                  'do not need to reach each other by '
-                                  'hostname.')
-                    else:
-                        reason = (f'job "{task.name}" has no feasible '
-                                  'Kubernetes placement.')
+                    # Pure feasibility: user-ask contradictions (pins
+                    # excluding Kubernetes) were already rejected by
+                    # _validate_inter_connection_pins before placement.
                     with ux_utils.print_exception_no_traceback():
                         raise exceptions.ResourcesUnavailableError(
                             f'JobGroup "{dag.name}" sets '
                             '`inter_connection: true`, which requires '
                             'in-group networking, only supported on '
-                            f'Kubernetes, but {reason}')
+                            f'Kubernetes, but job "{task.name}" has no '
+                            'feasible Kubernetes placement.')
                 cloud_launchables = kubernetes_launchables
 
             task_launchables[task] = cloud_launchables
@@ -1848,6 +1780,91 @@ def _get_task_pin_sets(
         # No resource options at all: no constraints expressed.
         return None, None
     return cloud_pins, infra_pins
+
+
+def _validate_inter_connection_pins(dag: 'dag_lib.Dag', quiet: bool) -> bool:
+    """Validate a JobGroup's infra pins against its inter_connection.
+
+    Spec-level validation only: reads the pins the user wrote and the
+    inter_connection setting, no catalog lookups. Feasibility (whether a
+    pinned infra actually exists and fits each job) is checked later by
+    the common-infra search.
+
+    Checks, in order:
+    - `inter_connection: true` + a job whose options pin only
+      non-Kubernetes clouds: contradiction (in-group networking is only
+      supported on Kubernetes) -> error.
+    - Pinned jobs share no common infra option, at cloud or cloud/region
+      granularity: the placement is deliberately cross-infra, so the
+      common-infra search can never succeed. Error when networking is
+      explicitly required; degrade networking to off (persisted on the
+      dag) with a warning when unset; allowed silently when false.
+
+    Returns:
+        True when the group's pins are deliberately cross-infra and each
+        job must be placed independently; False when the common-infra
+        search should run.
+    """
+    pinned_task_clouds: Dict[str, Set[str]] = {}
+    pinned_task_infras: Dict[str, Set[str]] = {}
+    for task in dag.tasks:
+        cloud_pins, infra_pins = _get_task_pin_sets(task)
+        if cloud_pins is not None:
+            pinned_task_clouds[str(task.name)] = cloud_pins
+        if infra_pins is not None:
+            pinned_task_infras[str(task.name)] = infra_pins
+
+    if dag.inter_connection is True:
+        for task_name, cloud_pins in pinned_task_clouds.items():
+            if not any(cloud.lower() == 'kubernetes' for cloud in cloud_pins):
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.ResourcesUnavailableError(
+                        f'JobGroup "{dag.name}" sets '
+                        '`inter_connection: true`, which requires '
+                        'in-group networking, only supported on '
+                        f'Kubernetes, but job "{task_name}" pins '
+                        f'non-Kubernetes infra ({sorted(cloud_pins)}). '
+                        'Remove the non-Kubernetes infra pins, or set '
+                        '`inter_connection: false` if the jobs do not '
+                        'need to reach each other by hostname.')
+
+    clouds_conflict = (len(pinned_task_clouds) > 1 and
+                       not set.intersection(*pinned_task_clouds.values()))
+    infras_conflict = (len(pinned_task_infras) > 1 and
+                       not set.intersection(*pinned_task_infras.values()))
+    if not (clouds_conflict or infras_conflict):
+        return False
+
+    # Show each job's own pins so the user can see exactly which jobs
+    # disagree, at the granularity that conflicted.
+    conflicting_pins = (pinned_task_infras
+                        if infras_conflict else pinned_task_clouds)
+    pins_desc = '; '.join(
+        f'{name}: {sorted(pins)}' for name, pins in conflicting_pins.items())
+    if dag.inter_connection is True:
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.ResourcesUnavailableError(
+                f'Jobs in JobGroup "{dag.name}" pin infrastructures with '
+                f'no common option ({pins_desc}), but '
+                '`inter_connection: true` requires in-group networking, '
+                'which does not work across infrastructures. Unify the '
+                'infra pins, or set `inter_connection: false` if the jobs '
+                'do not need to reach each other by hostname.')
+    if dag.inter_connection is None:
+        logger.warning(
+            f'Jobs in JobGroup "{dag.name}" pin infrastructures with no '
+            f'common option ({pins_desc}); in-group networking will not '
+            'be set up and jobs cannot reach each other by hostname. Set '
+            '`inter_connection: false` to silence this warning.')
+        # Persist the degradation so downstream consumers (the jobs
+        # controller) skip all networking machinery: without this, the
+        # controller would inject the (fatal) networking wait for a
+        # placement where hostnames can never resolve.
+        dag.inter_connection = False
+    elif not quiet:
+        logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
+                    'infrastructures; optimizing each job independently.')
+    return True
 
 
 def _fill_in_launchable_resources(

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1202,13 +1202,26 @@ class Optimizer:
                         if str(cloud).lower() == 'kubernetes'
                     })
                 if not any(cloud_launchables.values()):
+                    # Distinguish a user contradiction (the job pins only
+                    # non-Kubernetes infra) from a feasibility problem.
+                    cloud_pins, _ = _get_task_pin_sets(task)
+                    if cloud_pins and not any(cloud.lower() == 'kubernetes'
+                                              for cloud in cloud_pins):
+                        reason = (f'job "{task.name}" pins non-Kubernetes '
+                                  f'infra ({sorted(cloud_pins)}). Remove '
+                                  'the non-Kubernetes infra pins, or set '
+                                  '`inter_connection: false` if the jobs '
+                                  'do not need to reach each other by '
+                                  'hostname.')
+                    else:
+                        reason = (f'job "{task.name}" has no feasible '
+                                  'Kubernetes placement.')
                     with ux_utils.print_exception_no_traceback():
                         raise exceptions.ResourcesUnavailableError(
-                            f'Job "{task.name}" in JobGroup "{dag.name}" '
-                            'has no feasible Kubernetes placement, but '
-                            '`inter_connection: true` requires in-group '
-                            'networking, which is only supported on '
-                            'Kubernetes.')
+                            f'JobGroup "{dag.name}" sets '
+                            '`inter_connection: true`, which requires '
+                            'in-group networking, only supported on '
+                            f'Kubernetes, but {reason}')
 
             task_launchables[task] = cloud_launchables
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1068,6 +1068,54 @@ class Optimizer:
             logger.info(
                 f'Optimizing JobGroup "{dag.name}" with {len(tasks)} jobs')
 
+        # A job is "pinned" when every one of its resource options
+        # specifies a concrete infra (cloud+region). If the pinned jobs
+        # share no common infra option, the common-infra search below can
+        # never succeed: the placement is deliberately cross-infra.
+        # Whether that is allowed depends on inter_connection (in-group
+        # networking does not work across infras today):
+        # - explicitly required (true): error;
+        # - unset (default): allowed, networking degrades to off with a
+        #   warning;
+        # - false: allowed silently.
+        pinned_task_infras: List[Set[Tuple[str, str]]] = []
+        for task in tasks:
+            resource_infras: Set[Tuple[str, str]] = set()
+            fully_pinned = True
+            for resource in task.resources:
+                if resource.cloud is None or resource.region is None:
+                    fully_pinned = False
+                    break
+                resource_infras.add((str(resource.cloud), resource.region))
+            if fully_pinned and resource_infras:
+                pinned_task_infras.append(resource_infras)
+        pins_conflict = (len(pinned_task_infras) > 1 and
+                         not set.intersection(*pinned_task_infras))
+        if pins_conflict:
+            pinned_infras = set.union(*pinned_task_infras)
+            if dag.inter_connection is True:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.ResourcesUnavailableError(
+                        f'Jobs in JobGroup "{dag.name}" pin different '
+                        f'infrastructures ({sorted(pinned_infras)}), but '
+                        '`inter_connection: true` requires in-group '
+                        'networking, which does not work across '
+                        'infrastructures. Unify the infra pins, or set '
+                        '`inter_connection: false` if the jobs do not need '
+                        'to reach each other by hostname.')
+            if dag.inter_connection is None:
+                logger.warning(
+                    f'Jobs in JobGroup "{dag.name}" pin different '
+                    'infrastructures; in-group networking will not be set '
+                    'up and jobs cannot reach each other by hostname. Set '
+                    '`inter_connection: false` to silence this warning.')
+            elif not quiet:
+                logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
+                            'infrastructures; optimizing each job '
+                            'independently.')
+            return Optimizer._optimize_independent(dag, minimize,
+                                                   blocked_resources, quiet)
+
         # Find common infrastructure for all tasks in the JobGroup
         return Optimizer._optimize_same_infra(dag, minimize, blocked_resources,
                                               quiet)
@@ -1125,16 +1173,53 @@ class Optimizer:
                 for res in launchable_list:
                     if res.cloud is not None:
                         cloud_launchables[res.cloud].append(res)
+
+            if dag.inter_connection is True:
+                # In-group networking is only supported on Kubernetes, so
+                # explicitly requiring it constrains placement to
+                # Kubernetes candidates.
+                cloud_launchables = collections.defaultdict(
+                    list, {
+                        cloud: res_list
+                        for cloud, res_list in cloud_launchables.items()
+                        if str(cloud).lower() == 'kubernetes'
+                    })
+                if not any(cloud_launchables.values()):
+                    with ux_utils.print_exception_no_traceback():
+                        raise exceptions.ResourcesUnavailableError(
+                            f'Job "{task.name}" in JobGroup "{dag.name}" '
+                            'has no feasible Kubernetes placement, but '
+                            '`inter_connection: true` requires in-group '
+                            'networking, which is only supported on '
+                            'Kubernetes.')
+
             task_launchables[task] = cloud_launchables
 
         # Step 2: Find common cloud+region combinations
         common_infras = Optimizer._find_common_infras(task_launchables)
 
         if not common_infras:
-            # If no common infra, fallback to independent optimization
+            if dag.inter_connection_enabled():
+                # The group requires in-group networking (the default),
+                # which needs all jobs co-located on one infrastructure.
+                # No single infrastructure can host every job, so fail
+                # fast instead of silently spreading the group.
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.ResourcesUnavailableError(
+                        f'No single infrastructure can host all jobs in '
+                        f'JobGroup "{dag.name}", and in-group networking '
+                        '(inter_connection, enabled by default) requires '
+                        'all jobs to be co-located. Set '
+                        '`inter_connection: false` to allow jobs to be '
+                        'placed on different infrastructures without '
+                        'hostname connectivity, or pin each job\'s infra '
+                        'explicitly.')
+            # inter_connection: false — cross-infra placement is allowed;
+            # place each job independently.
             if not quiet:
-                logger.warning('No common infrastructure found for all jobs. '
-                               'Falling back to independent optimization.')
+                logger.info(f'No common infrastructure for all jobs in '
+                            f'JobGroup "{dag.name}"; placing jobs '
+                            'independently (inter_connection: false).')
             return Optimizer._optimize_independent(dag, minimize,
                                                    blocked_resources, quiet)
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1245,6 +1245,22 @@ class Optimizer:
             common_infras, task_launchables, tasks,
             minimize == common.OptimizeTarget.COST)
 
+        if (dag.inter_connection is None and
+                str(best_infra[0]).lower() != 'kubernetes'):
+            # In-group networking is only supported on Kubernetes, and the
+            # group is placed elsewhere. Explicit `inter_connection: true`
+            # can never get here (its candidates are filtered to
+            # Kubernetes above); unset degrades to no networking, with a
+            # warning. Persist the degradation so downstream consumers
+            # (the jobs controller) skip all networking machinery.
+            logger.warning(
+                f'Job group "{dag.name}" is placed on {best_infra[0]}; '
+                'in-group service discovery (hostname-based networking) '
+                'is only supported on Kubernetes, so tasks cannot reach '
+                'each other by hostname. Set `inter_connection: false` '
+                'to silence this warning.')
+            dag.inter_connection = False
+
         if not quiet:
             cloud, region = best_infra
             # Format infra as lowercase cloud/region
@@ -1274,26 +1290,37 @@ class Optimizer:
                 if str(cand_cloud) == cloud_name:
                     matching_cloud = cand_cloud
                     break
-            if matching_cloud is None:
-                continue
+            # best_infra came from the intersection of every task's
+            # candidates, so every task must have a matching candidate. A
+            # silently unpinned task would be re-optimized independently
+            # on the controller and could land on a different infra.
+            assert matching_cloud is not None, (
+                f'Job {task.name!r} has no candidates in the selected '
+                f'cloud {cloud_name!r}')
 
             # Find resources in this cloud+region
+            matched_resources = None
             for resources in candidates[matching_cloud]:
                 if resources.region == region:
-                    # Set best_resources on the task
-                    task.best_resources = resources
-                    # Also set resources override to ensure the constraint
-                    # persists through YAML serialization to the controller.
-                    # Without this, the controller would re-optimize each
-                    # task independently, placing them on different infras.
-                    override_params: Dict[str, Any] = {}
-                    if resources.cloud is not None:
-                        override_params['cloud'] = resources.cloud
-                    if resources.region is not None:
-                        override_params['region'] = resources.region
-                    if override_params:
-                        task.set_resources_override(override_params)
+                    matched_resources = resources
                     break
+            assert matched_resources is not None, (
+                f'Job {task.name!r} has no candidates in the selected '
+                f'infra {cloud_name}/{region}')
+
+            # Set best_resources on the task
+            task.best_resources = matched_resources
+            # Also set resources override to ensure the constraint
+            # persists through YAML serialization to the controller.
+            # Without this, the controller would re-optimize each
+            # task independently, placing them on different infras.
+            override_params: Dict[str, Any] = {}
+            if matched_resources.cloud is not None:
+                override_params['cloud'] = matched_resources.cloud
+            if matched_resources.region is not None:
+                override_params['region'] = matched_resources.region
+            if override_params:
+                task.set_resources_override(override_params)
 
         # Step 5: Print optimizer table for job groups
         if not quiet and len(tasks) > 1:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1068,36 +1068,65 @@ class Optimizer:
             logger.info(
                 f'Optimizing JobGroup "{dag.name}" with {len(tasks)} jobs')
 
-        # A job is "pinned" when every one of its resource options
-        # specifies a concrete infra (cloud+region). If the pinned jobs
-        # share no common infra option, the common-infra search below can
-        # never succeed: the placement is deliberately cross-infra.
+        # Detect deliberately cross-infra pins from the user's spec alone,
+        # at two levels of granularity:
+        # - cloud-pinned: every resource option of a job pins a cloud
+        #   (region optional, e.g. `infra: k8s`). Jobs whose cloud pin
+        #   sets share no cloud can never be co-located.
+        # - fully-pinned: every option pins cloud+region (e.g.
+        #   `infra: k8s/ctx`). Jobs whose pin sets share no infra can
+        #   never be co-located, even within one cloud.
+        # Either way the common-infra search below can never succeed.
         # Whether that is allowed depends on inter_connection (in-group
         # networking does not work across infras today):
         # - explicitly required (true): error;
         # - unset (default): allowed, networking degrades to off with a
         #   warning;
         # - false: allowed silently.
-        pinned_task_infras: List[Set[Tuple[str, str]]] = []
+        pinned_task_clouds: Dict[str, Set[str]] = {}
+        pinned_task_infras: Dict[str, Set[str]] = {}
         for task in tasks:
-            resource_infras: Set[Tuple[str, str]] = set()
+            cloud_pins: Set[str] = set()
+            infra_pins: Set[str] = set()
             fully_pinned = True
             for resource in task.resources:
-                if resource.cloud is None or resource.region is None:
-                    fully_pinned = False
+                if resource.cloud is None:
+                    # An option with no cloud can land anywhere: the job
+                    # is flexible and cannot cause a provable conflict.
                     break
-                resource_infras.add((str(resource.cloud), resource.region))
-            if fully_pinned and resource_infras:
-                pinned_task_infras.append(resource_infras)
-        pins_conflict = (len(pinned_task_infras) > 1 and
-                         not set.intersection(*pinned_task_infras))
+                cloud_pins.add(str(resource.cloud))
+                if resource.region is None:
+                    fully_pinned = False
+                else:
+                    infra_pins.add(f'{resource.cloud}/{resource.region}')
+            else:
+                task_name = str(task.name)
+                if cloud_pins:
+                    pinned_task_clouds[task_name] = cloud_pins
+                # A job only participates in infra-level conflict checks
+                # when EVERY option pins a region: a job with a mix of
+                # region-pinned and cloud-only options (e.g.
+                # any_of: [k8s/ctxA, k8s]) is still flexible within the
+                # cloud and cannot cause a provable infra conflict.
+                if fully_pinned and infra_pins:
+                    pinned_task_infras[task_name] = infra_pins
+        clouds_conflict = (len(pinned_task_clouds) > 1 and
+                           not set.intersection(*pinned_task_clouds.values()))
+        infras_conflict = (len(pinned_task_infras) > 1 and
+                           not set.intersection(*pinned_task_infras.values()))
+        pins_conflict = clouds_conflict or infras_conflict
         if pins_conflict:
-            pinned_infras = set.union(*pinned_task_infras)
+            # Show each job's own pins so the user can see exactly which
+            # jobs disagree, at the granularity that conflicted.
+            conflicting_pins = (pinned_task_infras
+                                if infras_conflict else pinned_task_clouds)
+            pins_desc = '; '.join(f'{name}: {sorted(pins)}'
+                                  for name, pins in conflicting_pins.items())
             if dag.inter_connection is True:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.ResourcesUnavailableError(
-                        f'Jobs in JobGroup "{dag.name}" pin different '
-                        f'infrastructures ({sorted(pinned_infras)}), but '
+                        f'Jobs in JobGroup "{dag.name}" pin infrastructures '
+                        f'with no common option ({pins_desc}), but '
                         '`inter_connection: true` requires in-group '
                         'networking, which does not work across '
                         'infrastructures. Unify the infra pins, or set '
@@ -1105,10 +1134,17 @@ class Optimizer:
                         'to reach each other by hostname.')
             if dag.inter_connection is None:
                 logger.warning(
-                    f'Jobs in JobGroup "{dag.name}" pin different '
-                    'infrastructures; in-group networking will not be set '
-                    'up and jobs cannot reach each other by hostname. Set '
-                    '`inter_connection: false` to silence this warning.')
+                    f'Jobs in JobGroup "{dag.name}" pin infrastructures '
+                    f'with no common option ({pins_desc}); in-group '
+                    'networking will not be set up and jobs cannot reach '
+                    'each other by hostname. Set `inter_connection: false` '
+                    'to silence this warning.')
+                # Persist the degradation so downstream consumers (the
+                # jobs controller) skip all networking machinery: without
+                # this, the controller would inject the (fatal)
+                # networking wait for a placement where hostnames can
+                # never resolve.
+                dag.inter_connection = False
             elif not quiet:
                 logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
                             'infrastructures; optimizing each job '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1086,30 +1086,11 @@ class Optimizer:
         pinned_task_clouds: Dict[str, Set[str]] = {}
         pinned_task_infras: Dict[str, Set[str]] = {}
         for task in tasks:
-            cloud_pins: Set[str] = set()
-            infra_pins: Set[str] = set()
-            fully_pinned = True
-            for resource in task.resources:
-                if resource.cloud is None:
-                    # An option with no cloud can land anywhere: the job
-                    # is flexible and cannot cause a provable conflict.
-                    break
-                cloud_pins.add(str(resource.cloud))
-                if resource.region is None:
-                    fully_pinned = False
-                else:
-                    infra_pins.add(f'{resource.cloud}/{resource.region}')
-            else:
-                task_name = str(task.name)
-                if cloud_pins:
-                    pinned_task_clouds[task_name] = cloud_pins
-                # A job only participates in infra-level conflict checks
-                # when EVERY option pins a region: a job with a mix of
-                # region-pinned and cloud-only options (e.g.
-                # any_of: [k8s/ctxA, k8s]) is still flexible within the
-                # cloud and cannot cause a provable infra conflict.
-                if fully_pinned and infra_pins:
-                    pinned_task_infras[task_name] = infra_pins
+            cloud_pins, infra_pins = _get_task_pin_sets(task)
+            if cloud_pins is not None:
+                pinned_task_clouds[str(task.name)] = cloud_pins
+            if infra_pins is not None:
+                pinned_task_infras[str(task.name)] = infra_pins
         clouds_conflict = (len(pinned_task_clouds) > 1 and
                            not set.intersection(*pinned_task_clouds.values()))
         infras_conflict = (len(pinned_task_infras) > 1 and
@@ -1787,6 +1768,43 @@ def _check_specified_regions(task: task_lib.Task) -> None:
                 f'to ensure the infra is enabled.')
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(msg)
+
+
+def _get_task_pin_sets(
+        task: task_lib.Task) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    """Return the exact placement constraint sets a task's pins express.
+
+    A task's resource options are alternatives (OR semantics): the task
+    can run anywhere any option allows. A task therefore only has an
+    exactly-enumerable constraint set at a given granularity when EVERY
+    option is pinned at that granularity; one flexible option means the
+    task can escape any conflict at that granularity.
+
+    Returns:
+        (cloud_pins, infra_pins):
+        cloud_pins: the exact set of cloud names the task can run on, or
+            None if any option leaves the cloud unspecified (or the task
+            has no resource options) - the task is flexible across
+            clouds.
+        infra_pins: the exact set of 'cloud/region' infras the task can
+            run on, or None if any option leaves cloud or region
+            unspecified - the task is flexible at least within a cloud
+            (e.g. any_of: [k8s/ctxA, k8s]).
+    """
+    cloud_pins: Set[str] = set()
+    infra_pins: Optional[Set[str]] = set()
+    for resource in task.resources:
+        if resource.cloud is None:
+            return None, None
+        cloud_pins.add(str(resource.cloud))
+        if resource.region is None:
+            infra_pins = None
+        elif infra_pins is not None:
+            infra_pins.add(f'{resource.cloud}/{resource.region}')
+    if not cloud_pins:
+        # No resource options at all: no constraints expressed.
+        return None, None
+    return cloud_pins, infra_pins
 
 
 def _fill_in_launchable_resources(

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -645,7 +645,9 @@ def _load_job_group(
                     f'termination_delay must be a string, int, or dict, '
                     f'got {type(termination_delay).__name__}')
 
-    # Parse and validate inter_connection
+    # Parse and validate inter_connection. Semantic validation (e.g.
+    # non-Kubernetes pins contradicting `inter_connection: true`) lives in
+    # the optimizer, the choke point every launch passes through.
     inter_connection = header.get('inter_connection')
     if inter_connection is not None:
         if not isinstance(inter_connection, bool):
@@ -654,28 +656,6 @@ def _load_job_group(
                                  f'got {type(inter_connection).__name__}: '
                                  f'{inter_connection!r}')
         dag.inter_connection = inter_connection
-
-    if dag.inter_connection is True:
-        # In-group networking is only supported on Kubernetes. Explicitly
-        # requiring it while pinning a job to a non-Kubernetes cloud is a
-        # contradiction; fail at load time rather than at placement.
-        conflicting_jobs = []
-        for task in dag.tasks:
-            clouds = [res.cloud for res in task.resources]
-            if clouds and all(
-                    cloud is not None and str(cloud).lower() != 'kubernetes'
-                    for cloud in clouds):
-                conflicting_jobs.append(task.name)
-        if conflicting_jobs:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'This job group sets `inter_connection: true`, but '
-                    'in-group networking (hostname-based service '
-                    'discovery) is only supported on Kubernetes, and the '
-                    f'following jobs pin non-Kubernetes infra: '
-                    f'{conflicting_jobs}. Remove the non-Kubernetes infra '
-                    'pins, or set `inter_connection: false` if the jobs do '
-                    'not need to reach each other by hostname.')
 
     logger.info(f'Loaded JobGroup "{group_name}" with {len(dag.tasks)} jobs: '
                 f'{[t.name for t in dag.tasks]}')

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -18,7 +18,8 @@ logger = sky_logging.init_logger(__name__)
 
 # JobGroup header fields
 _JOB_GROUP_HEADER_FIELDS = {
-    'name', 'execution', 'primary_tasks', 'termination_delay'
+    'name', 'execution', 'primary_tasks', 'termination_delay',
+    'inter_connection'
 }
 _JOB_GROUP_REQUIRED_HEADER_FIELDS = {'name'}
 
@@ -644,6 +645,17 @@ def _load_job_group(
                     f'termination_delay must be a string, int, or dict, '
                     f'got {type(termination_delay).__name__}')
 
+    # Parse and validate inter_connection
+    inter_connection = header.get('inter_connection')
+    if inter_connection is not None:
+        if not isinstance(inter_connection, bool):
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'inter_connection must be a boolean, '
+                    f'got {type(inter_connection).__name__}: '
+                    f'{inter_connection!r}')
+        dag.inter_connection = inter_connection
+
     logger.info(f'Loaded JobGroup "{group_name}" with {len(dag.tasks)} jobs: '
                 f'{[t.name for t in dag.tasks]}')
 
@@ -692,6 +704,8 @@ def dump_job_group_to_yaml_str(dag: dag_lib.Dag,
         header['primary_tasks'] = dag.primary_tasks
     if dag.termination_delay is not None:
         header['termination_delay'] = dag.termination_delay
+    if dag.inter_connection is not None:
+        header['inter_connection'] = dag.inter_connection
 
     # Build job configs
     configs: List[Dict[str, Any]] = [header]

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -650,11 +650,32 @@ def _load_job_group(
     if inter_connection is not None:
         if not isinstance(inter_connection, bool):
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    f'inter_connection must be a boolean, '
-                    f'got {type(inter_connection).__name__}: '
-                    f'{inter_connection!r}')
+                raise ValueError(f'inter_connection must be a boolean, '
+                                 f'got {type(inter_connection).__name__}: '
+                                 f'{inter_connection!r}')
         dag.inter_connection = inter_connection
+
+    if dag.inter_connection is True:
+        # In-group networking is only supported on Kubernetes. Explicitly
+        # requiring it while pinning a job to a non-Kubernetes cloud is a
+        # contradiction; fail at load time rather than at placement.
+        conflicting_jobs = []
+        for task in dag.tasks:
+            clouds = [res.cloud for res in task.resources]
+            if clouds and all(
+                    cloud is not None and str(cloud).lower() != 'kubernetes'
+                    for cloud in clouds):
+                conflicting_jobs.append(task.name)
+        if conflicting_jobs:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'This job group sets `inter_connection: true`, but '
+                    'in-group networking (hostname-based service '
+                    'discovery) is only supported on Kubernetes, and the '
+                    f'following jobs pin non-Kubernetes infra: '
+                    f'{conflicting_jobs}. Remove the non-Kubernetes infra '
+                    'pins, or set `inter_connection: false` if the jobs do '
+                    'not need to reach each other by hostname.')
 
     logger.info(f'Loaded JobGroup "{group_name}" with {len(dag.tasks)} jobs: '
                 f'{[t.name for t in dag.tasks]}')

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2950,6 +2950,69 @@ def test_job_group_basic(generic_cloud: str):
 
 @pytest.mark.managed_jobs
 @pytest.mark.kubernetes
+def test_job_group_inter_connection_false(generic_cloud: str):
+    """JobGroup with inter_connection: false skips all networking machinery.
+
+    Tasks must start without the peer-hostname wait and succeed; the
+    networking wait banner must not appear in the task logs.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    yaml_path = _render_job_group_yaml(
+        'tests/test_job_groups/smoke_inter_connection_false.yaml', name,
+        generic_cloud)
+
+    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
+                      f'awk \'{{print $1}}\'')
+    test = smoke_tests_utils.Test(
+        'job_group_inter_connection_false',
+        [
+            f'sky jobs launch {yaml_path} -y -d',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                timeout=360),
+            f'sky jobs logs $({get_job_id_cmd}) --no-follow | '
+            f'grep "JOB-A-DONE"',
+            # No networking machinery: the wait banner must not appear.
+            f'! sky jobs logs $({get_job_id_cmd}) --no-follow | '
+            f'grep "Waiting for network setup"',
+        ],
+        f'sky jobs cancel -y -n {name}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=15 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.kubernetes
+def test_job_group_inter_connection_non_k8s_pin_error(generic_cloud: str):
+    """inter_connection: true + a non-Kubernetes infra pin fails at
+    submission with an error naming the contradicting job, without
+    launching anything."""
+    name = smoke_tests_utils.get_cluster_name()
+    yaml_path = _render_job_group_yaml(
+        'tests/test_job_groups/smoke_inter_connection_pin_error.yaml', name,
+        generic_cloud)
+
+    test = smoke_tests_utils.Test(
+        'job_group_inter_connection_non_k8s_pin_error',
+        [
+            f'sky jobs launch {yaml_path} -y 2>&1 | '
+            f'grep "pins non-Kubernetes infra"',
+            # Nothing was submitted.
+            f'! sky jobs queue | grep {name}',
+        ],
+        f'sky jobs cancel -y -n {name} || true',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=5 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.kubernetes
 def test_job_group_cancelled_logs(generic_cloud: str):
     """Test that logs are accessible for all tasks after a job group is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/test_job_groups/smoke_inter_connection_false.yaml
+++ b/tests/test_job_groups/smoke_inter_connection_false.yaml
@@ -1,0 +1,22 @@
+# JobGroup with inter_connection: false - no networking machinery is set
+# up, tasks start without waiting for peers.
+---
+name: {{name}}
+execution: parallel
+inter_connection: false
+---
+name: job-a
+resources:
+  cpus: 2
+  infra: {{cloud}}
+run: |
+  echo "Job A running without in-group networking"
+  echo "JOB-A-DONE"
+---
+name: job-b
+resources:
+  cpus: 2
+  infra: {{cloud}}
+run: |
+  echo "Job B running without in-group networking"
+  echo "JOB-B-DONE"

--- a/tests/test_job_groups/smoke_inter_connection_pin_error.yaml
+++ b/tests/test_job_groups/smoke_inter_connection_pin_error.yaml
@@ -1,0 +1,17 @@
+# JobGroup contradiction: inter_connection: true requires Kubernetes, but
+# a job pins non-Kubernetes infra. Submission must fail fast.
+---
+name: {{name}}
+execution: parallel
+inter_connection: true
+---
+name: pinned-aws
+resources:
+  cpus: 2
+  infra: aws
+run: echo hi
+---
+name: flexible
+resources:
+  cpus: 2
+run: echo hi

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -136,3 +136,66 @@ def test_jobs_recovery_fill_default_values():
     dag = dag_utils.convert_entrypoint_to_dag(task)
     with pytest.raises(ValueError):
         dag_utils.fill_default_config_in_dag_for_job_launch(dag)
+
+
+_JOB_GROUP_YAML_TEMPLATE = textwrap.dedent("""\
+    name: test-group
+    execution: parallel
+    {header_extra}---
+    name: job1
+    {job1_extra}run: echo hi
+    ---
+    name: job2
+    run: echo hi
+    """)
+
+
+def _load_job_group(header_extra: str = '', job1_extra: str = ''):
+    return dag_utils.load_job_group_from_yaml_str(
+        _JOB_GROUP_YAML_TEMPLATE.format(header_extra=header_extra,
+                                        job1_extra=job1_extra))
+
+
+def test_job_group_inter_connection_round_trip():
+    """inter_connection parses, dumps, and survives a YAML round-trip."""
+    dag = _load_job_group(header_extra='inter_connection: false\n')
+    assert dag.inter_connection is False
+    assert not dag.inter_connection_enabled()
+
+    dumped = dag_utils.dump_job_group_to_yaml_str(dag)
+    assert 'inter_connection: false' in dumped
+    redag = dag_utils.load_job_group_from_yaml_str(dumped)
+    assert redag.inter_connection is False
+
+    dag = _load_job_group(header_extra='inter_connection: true\n')
+    assert dag.inter_connection is True
+    assert dag.inter_connection_enabled()
+
+
+def test_job_group_inter_connection_unset_defaults_to_enabled():
+    """Unset inter_connection is enabled but not serialized."""
+    dag = _load_job_group()
+    assert dag.inter_connection is None
+    assert dag.inter_connection_enabled()
+    assert 'inter_connection' not in dag_utils.dump_job_group_to_yaml_str(dag)
+
+
+def test_job_group_inter_connection_invalid_type():
+    with pytest.raises(ValueError, match='inter_connection must be a boolean'):
+        _load_job_group(header_extra='inter_connection: "yes"\n')
+
+
+def test_job_group_inter_connection_non_k8s_pin_is_a_contradiction():
+    """Explicit true + a job pinned to a non-k8s cloud fails at load time."""
+    with pytest.raises(ValueError, match='non-Kubernetes'):
+        _load_job_group(header_extra='inter_connection: true\n',
+                        job1_extra='resources:\n  infra: aws\n')
+
+    # Unset degrades with a warning instead of failing.
+    dag = _load_job_group(job1_extra='resources:\n  infra: aws\n')
+    assert dag.inter_connection is None
+
+    # Kubernetes pins (with or without a context) are fine.
+    dag = _load_job_group(header_extra='inter_connection: true\n',
+                          job1_extra='resources:\n  infra: k8s/my-ctx\n')
+    assert dag.inter_connection is True

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -167,6 +167,12 @@ def test_job_group_inter_connection_round_trip():
     redag = dag_utils.load_job_group_from_yaml_str(dumped)
     assert redag.inter_connection is False
 
+    # The user-specified-yaml dump variant shares the header build and
+    # must also carry the field (the controller-bound serialization).
+    dumped_user = dag_utils.dump_job_group_to_yaml_str(
+        dag, use_user_specified_yaml=True)
+    assert 'inter_connection: false' in dumped_user
+
     dag = _load_job_group(header_extra='inter_connection: true\n')
     assert dag.inter_connection is True
     assert dag.inter_connection_enabled()

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -185,17 +185,19 @@ def test_job_group_inter_connection_invalid_type():
         _load_job_group(header_extra='inter_connection: "yes"\n')
 
 
-def test_job_group_inter_connection_non_k8s_pin_is_a_contradiction():
-    """Explicit true + a job pinned to a non-k8s cloud fails at load time."""
-    with pytest.raises(ValueError, match='non-Kubernetes'):
-        _load_job_group(header_extra='inter_connection: true\n',
-                        job1_extra='resources:\n  infra: aws\n')
+def test_job_group_inter_connection_pins_load_without_validation():
+    """Infra pins load fine regardless of inter_connection.
 
-    # Unset degrades with a warning instead of failing.
+    Semantic validation (e.g. non-Kubernetes pins contradicting
+    `inter_connection: true`) lives in the optimizer, not the loader.
+    """
+    dag = _load_job_group(header_extra='inter_connection: true\n',
+                          job1_extra='resources:\n  infra: aws\n')
+    assert dag.inter_connection is True
+
     dag = _load_job_group(job1_extra='resources:\n  infra: aws\n')
     assert dag.inter_connection is None
 
-    # Kubernetes pins (with or without a context) are fine.
     dag = _load_job_group(header_extra='inter_connection: true\n',
                           job1_extra='resources:\n  infra: k8s/my-ctx\n')
     assert dag.inter_connection is True

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -762,6 +762,32 @@ class TestInterConnectionPlacement:
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
             mock_same_infra.assert_called_once()
 
+    def test_unset_placed_off_kubernetes_degrades(self, mock_aws_cloud):
+        """Unset group whose best common infra is non-k8s: warn + degrade.
+
+        The degradation is persisted on the dag so the controller (which
+        reads the serialized dag) skips all networking machinery.
+        """
+        res = self._make_resources(mock_aws_cloud, 'us-east-1')
+        task1 = self._make_task('task-1')
+        task2 = self._make_task('task-2')
+        dag = self._make_dag([task1, task2], inter_connection=None)
+
+        def mock_fill(task, blocked_resources, quiet):
+            return ({'any': [res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            optimizer.Optimizer._optimize_same_infra(
+                dag,
+                minimize=common.OptimizeTarget.COST,
+                blocked_resources=None,
+                quiet=True)
+
+        assert dag.inter_connection is False
+        assert task1.best_resources == res
+        assert task2.best_resources == res
+
     def test_mixed_pin_narrows_group_to_pinned_context(self, mock_k8s_cloud):
         """k8s/blah + k8s + k8s: everyone lands on blah, hard-pinned."""
         res_blah = self._make_resources(mock_k8s_cloud, 'ctx-blah')

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -712,6 +712,56 @@ class TestInterConnectionPlacement:
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
             mock_same_infra.assert_called_once()
 
+    def test_disjoint_any_of_pin_sets_conflict(self, mock_k8s_cloud):
+        """any_of {A,B} vs any_of {C,D}: no common option -> conflict."""
+        task1 = self._make_task('task-1', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(mock_k8s_cloud, 'ctx-b'),
+        ])
+        task2 = self._make_task('task-2', [
+            self._make_resources(mock_k8s_cloud, 'ctx-c'),
+            self._make_resources(mock_k8s_cloud, 'ctx-d'),
+        ])
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+        assert 'no common option' in str(exc_info.value)
+
+    def test_cross_cloud_any_of_with_common_option_not_a_conflict(
+            self, mock_k8s_cloud, mock_aws_cloud):
+        """{k8s/ctxA, aws/use1} vs {aws/use1}: common option -> no conflict."""
+        task1 = self._make_task('task-1', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(mock_aws_cloud, 'us-east-1'),
+        ])
+        task2 = self._make_task(
+            'task-2', [self._make_resources(mock_aws_cloud, 'us-east-1')])
+        dag = self._make_dag([task1, task2], inter_connection=False)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_same_infra.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_same_infra.assert_called_once()
+
+    def test_unpinned_option_defuses_conflict(self, mock_k8s_cloud,
+                                              mock_aws_cloud):
+        """[k8s/ctxA, <unpinned>] vs aws pin: task1 is fully flexible."""
+        task1 = self._make_task('task-1', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(None, None),
+        ])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_aws_cloud, None)])
+        dag = self._make_dag([task1, task2], inter_connection=False)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_same_infra.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_same_infra.assert_called_once()
+
     def test_mixed_pin_narrows_group_to_pinned_context(self, mock_k8s_cloud):
         """k8s/blah + k8s + k8s: everyone lands on blah, hard-pinned."""
         res_blah = self._make_resources(mock_k8s_cloud, 'ctx-blah')
@@ -767,6 +817,70 @@ class TestInterConnectionPlacement:
                     blocked_resources=None,
                     quiet=True)
         assert 'No single infrastructure' in str(exc_info.value)
+
+
+class TestGetTaskPinSets:
+    """Direct tests for per-task pin-set extraction (OR semantics).
+
+    A task only has an exactly-enumerable constraint set at a granularity
+    when EVERY resource option is pinned at that granularity.
+    """
+
+    def _task(self, options):
+        task = MagicMock(spec=task_lib.Task)
+        task.name = 't'
+        task.resources = options
+        return task
+
+    def _res(self, cloud_str, region):
+        res = MagicMock(spec=resources_lib.Resources)
+        if cloud_str is None:
+            res.cloud = None
+        else:
+            cloud = MagicMock()
+            cloud.__str__ = MagicMock(return_value=cloud_str)
+            res.cloud = cloud
+        res.region = region
+        return res
+
+    def test_fully_pinned_single_option(self):
+        cloud_pins, infra_pins = optimizer._get_task_pin_sets(
+            self._task([self._res('Kubernetes', 'ctx-a')]))
+        assert cloud_pins == {'Kubernetes'}
+        assert infra_pins == {'Kubernetes/ctx-a'}
+
+    def test_any_of_fully_pinned_across_clouds(self):
+        cloud_pins, infra_pins = optimizer._get_task_pin_sets(
+            self._task([
+                self._res('Kubernetes', 'ctx-a'),
+                self._res('AWS', 'us-east-1'),
+            ]))
+        assert cloud_pins == {'Kubernetes', 'AWS'}
+        assert infra_pins == {'Kubernetes/ctx-a', 'AWS/us-east-1'}
+
+    def test_mixed_region_and_cloud_only_options(self):
+        cloud_pins, infra_pins = optimizer._get_task_pin_sets(
+            self._task([
+                self._res('Kubernetes', 'ctx-a'),
+                self._res('Kubernetes', None),
+            ]))
+        # Exactly enumerable at cloud granularity, flexible within it.
+        assert cloud_pins == {'Kubernetes'}
+        assert infra_pins is None
+
+    def test_option_without_cloud_makes_task_fully_flexible(self):
+        cloud_pins, infra_pins = optimizer._get_task_pin_sets(
+            self._task([
+                self._res('Kubernetes', 'ctx-a'),
+                self._res(None, None),
+            ]))
+        assert cloud_pins is None
+        assert infra_pins is None
+
+    def test_no_resource_options(self):
+        cloud_pins, infra_pins = optimizer._get_task_pin_sets(self._task([]))
+        assert cloud_pins is None
+        assert infra_pins is None
 
 
 class TestModuleLevelOptimizeJobGroup:

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -562,6 +562,28 @@ class TestInterConnectionPlacement:
                     quiet=True)
         assert 'no feasible Kubernetes placement' in str(exc_info.value)
 
+    def test_required_non_k8s_pin_error_names_pins(self, mock_aws_cloud):
+        """Explicit true + a job pinning only non-k8s infra: the error
+        names the contradicting pins instead of a generic feasibility
+        message."""
+        aws_res = self._make_resources(mock_aws_cloud, 'us-east-1')
+        task = self._make_task('task-1', [aws_res])
+        dag = self._make_dag([task], inter_connection=True)
+
+        def mock_fill(task, blocked_resources, quiet):
+            return ({'any': [aws_res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            with pytest.raises(
+                    exceptions.ResourcesUnavailableError) as exc_info:
+                optimizer.Optimizer._optimize_same_infra(
+                    dag,
+                    minimize=common.OptimizeTarget.COST,
+                    blocked_resources=None,
+                    quiet=True)
+        assert 'pins non-Kubernetes infra' in str(exc_info.value)
+
     def test_enabled_no_common_infra_raises(self, mock_k8s_cloud):
         """Default (unset) + empty intersection fails fast, never spreads."""
         res_a = self._make_resources(mock_k8s_cloud, 'ctx-a')

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -270,11 +270,15 @@ class TestOptimizeJobGroup:
         dag = MagicMock(spec=dag_lib.Dag)
         dag.is_job_group = MagicMock(return_value=True)
         dag.name = 'test-job-group'
+        dag.inter_connection = None
+        dag.inter_connection_enabled = MagicMock(return_value=True)
 
         task1 = MagicMock(spec=task_lib.Task)
         task1.name = 'task-1'
+        task1.resources = []
         task2 = MagicMock(spec=task_lib.Task)
         task2.name = 'task-2'
+        task2.resources = []
         dag.tasks = [task1, task2]
 
         return dag
@@ -354,6 +358,8 @@ class TestOptimizeSameInfra:
         """Test that missing resources raises ResourcesUnavailableError."""
         dag = MagicMock(spec=dag_lib.Dag)
         dag.name = 'test-job-group'
+        dag.inter_connection = None
+        dag.inter_connection_enabled = MagicMock(return_value=True)
         task = MagicMock(spec=task_lib.Task)
         task.name = 'task-1'
         dag.tasks = [task]
@@ -375,9 +381,15 @@ class TestOptimizeSameInfra:
 
     def test_optimize_same_infra_fallback_when_no_common_infra(
             self, mock_aws_cloud):
-        """Test fallback to independent optimization when no common infra."""
+        """No common infra + inter_connection: false -> independent placement.
+
+        With inter_connection enabled (the default) the same situation is an
+        error instead; see TestInterConnectionPlacement.
+        """
         dag = MagicMock(spec=dag_lib.Dag)
         dag.name = 'test-job-group'
+        dag.inter_connection = False
+        dag.inter_connection_enabled = MagicMock(return_value=False)
 
         task1 = MagicMock(spec=task_lib.Task)
         task1.name = 'task-1'
@@ -422,6 +434,8 @@ class TestOptimizeSameInfra:
         """Test that _optimize_same_infra sets best_resources on tasks."""
         dag = MagicMock(spec=dag_lib.Dag)
         dag.name = 'test-job-group'
+        dag.inter_connection = None
+        dag.inter_connection_enabled = MagicMock(return_value=True)
 
         task1 = MagicMock(spec=task_lib.Task)
         task1.name = 'task-1'
@@ -455,6 +469,182 @@ class TestOptimizeSameInfra:
             # Both tasks should have best_resources set
             assert task1.best_resources == resources
             assert task2.best_resources == resources
+
+
+class TestInterConnectionPlacement:
+    """Tests for inter_connection-aware JobGroup placement."""
+
+    @pytest.fixture
+    def mock_k8s_cloud(self):
+        cloud = MagicMock(spec=clouds.Kubernetes)
+        cloud.__str__ = MagicMock(return_value='Kubernetes')
+        cloud.__repr__ = MagicMock(return_value='Kubernetes')
+        cloud.__hash__ = MagicMock(return_value=hash('Kubernetes'))
+        cloud.__eq__ = lambda self, other: str(other) == 'Kubernetes'
+        return cloud
+
+    @pytest.fixture
+    def mock_aws_cloud(self):
+        cloud = MagicMock(spec=clouds.AWS)
+        cloud.__str__ = MagicMock(return_value='AWS')
+        cloud.__repr__ = MagicMock(return_value='AWS')
+        cloud.__hash__ = MagicMock(return_value=hash('AWS'))
+        cloud.__eq__ = lambda self, other: str(other) == 'AWS'
+        return cloud
+
+    def _make_resources(self, cloud, region, cost=1.0):
+        resources = MagicMock(spec=resources_lib.Resources)
+        resources.cloud = cloud
+        resources.region = region
+        resources.get_cost = MagicMock(return_value=cost)
+        return resources
+
+    def _make_dag(self, tasks, inter_connection):
+        dag = MagicMock(spec=dag_lib.Dag)
+        dag.is_job_group = MagicMock(return_value=True)
+        dag.name = 'test-job-group'
+        dag.inter_connection = inter_connection
+        dag.inter_connection_enabled = MagicMock(
+            return_value=inter_connection is not False)
+        dag.tasks = tasks
+        return dag
+
+    def _make_task(self, name, resources=None):
+        task = MagicMock(spec=task_lib.Task)
+        task.name = name
+        task.resources = resources if resources is not None else []
+        task.estimate_runtime = MagicMock(return_value=3600)
+        task.num_nodes = 1
+        return task
+
+    def test_required_filters_candidates_to_kubernetes(self, mock_k8s_cloud,
+                                                       mock_aws_cloud):
+        """inter_connection: true places on k8s even when AWS is cheaper."""
+        k8s_res = self._make_resources(mock_k8s_cloud, 'ctx-a', cost=5.0)
+        aws_res = self._make_resources(mock_aws_cloud, 'us-east-1', cost=1.0)
+
+        task1 = self._make_task('task-1')
+        task2 = self._make_task('task-2')
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        def mock_fill(task, blocked_resources, quiet):
+            return ({'any': [k8s_res, aws_res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            optimizer.Optimizer._optimize_same_infra(
+                dag,
+                minimize=common.OptimizeTarget.COST,
+                blocked_resources=None,
+                quiet=True)
+
+        # AWS is cheaper but must not be chosen: networking requires k8s.
+        assert task1.best_resources == k8s_res
+        assert task2.best_resources == k8s_res
+
+    def test_required_no_kubernetes_candidates_raises(self, mock_aws_cloud):
+        """inter_connection: true with no feasible k8s placement errors."""
+        aws_res = self._make_resources(mock_aws_cloud, 'us-east-1')
+        task = self._make_task('task-1')
+        dag = self._make_dag([task], inter_connection=True)
+
+        def mock_fill(task, blocked_resources, quiet):
+            return ({'any': [aws_res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            with pytest.raises(
+                    exceptions.ResourcesUnavailableError) as exc_info:
+                optimizer.Optimizer._optimize_same_infra(
+                    dag,
+                    minimize=common.OptimizeTarget.COST,
+                    blocked_resources=None,
+                    quiet=True)
+        assert 'no feasible Kubernetes placement' in str(exc_info.value)
+
+    def test_enabled_no_common_infra_raises(self, mock_k8s_cloud):
+        """Default (unset) + empty intersection fails fast, never spreads."""
+        res_a = self._make_resources(mock_k8s_cloud, 'ctx-a')
+        res_b = self._make_resources(mock_k8s_cloud, 'ctx-b')
+        task1 = self._make_task('task-1')
+        task2 = self._make_task('task-2')
+        dag = self._make_dag([task1, task2], inter_connection=None)
+
+        def mock_fill(task, blocked_resources, quiet):
+            res = res_a if task == task1 else res_b
+            return ({'any': [res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            with pytest.raises(
+                    exceptions.ResourcesUnavailableError) as exc_info:
+                optimizer.Optimizer._optimize_same_infra(
+                    dag,
+                    minimize=common.OptimizeTarget.COST,
+                    blocked_resources=None,
+                    quiet=True)
+        assert 'No single infrastructure' in str(exc_info.value)
+        assert 'inter_connection: false' in str(exc_info.value)
+
+    def test_pins_conflict_required_raises(self, mock_k8s_cloud):
+        """Explicit true + conflicting pins is a submission-time error."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+        assert 'pin different infrastructures' in str(exc_info.value)
+
+    def test_pins_conflict_unset_places_independently(self, mock_k8s_cloud):
+        """Unset + conflicting pins warns and places independently."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
+        dag = self._make_dag([task1, task2], inter_connection=None)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent:
+            mock_independent.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_independent.assert_called_once()
+
+    def test_pins_conflict_partial_pinning(self, mock_k8s_cloud):
+        """Conflict detection works when only some tasks are pinned."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
+        unpinned = self._make_task('task-3',
+                                   [self._make_resources(mock_k8s_cloud, None)])
+        dag = self._make_dag([task1, task2, unpinned], inter_connection=False)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent:
+            mock_independent.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_independent.assert_called_once()
+
+    def test_any_of_overlapping_pins_not_a_conflict(self, mock_k8s_cloud):
+        """Tasks whose pin sets overlap can still colocate: no conflict."""
+        task1 = self._make_task('task-1', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(mock_k8s_cloud, 'ctx-b'),
+        ])
+        task2 = self._make_task('task-2', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(mock_k8s_cloud, 'ctx-b'),
+        ])
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_same_infra.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_same_infra.assert_called_once()
 
 
 class TestModuleLevelOptimizeJobGroup:

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -627,6 +627,32 @@ class TestInterConnectionPlacement:
         assert task1.best_resources == res
         assert task2.best_resources == res
 
+    def test_false_still_prefers_colocation(self, mock_k8s_cloud):
+        """`inter_connection: false` permits spreading, it does not ask for
+        it: when a common context exists, the group is still co-located
+        there and independent placement is not used."""
+        shared = self._make_resources(mock_k8s_cloud, 'ctx-shared')
+        task1 = self._make_task('task-1')
+        task2 = self._make_task('task-2')
+        dag = self._make_dag([task1, task2], inter_connection=False)
+
+        def mock_fill(task, blocked_resources, quiet):
+            return ({'any': [shared]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            with patch.object(optimizer.Optimizer,
+                              '_optimize_independent') as mock_independent:
+                optimizer.Optimizer._optimize_same_infra(
+                    dag,
+                    minimize=common.OptimizeTarget.COST,
+                    blocked_resources=None,
+                    quiet=True)
+                mock_independent.assert_not_called()
+
+        assert task1.best_resources == shared
+        assert task2.best_resources == shared
+
     def test_mixed_pin_narrows_group_to_pinned_context(self, mock_k8s_cloud):
         """k8s/blah + k8s + k8s: everyone lands on blah, hard-pinned."""
         res_blah = self._make_resources(mock_k8s_cloud, 'ctx-blah')

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -563,26 +563,19 @@ class TestInterConnectionPlacement:
         assert 'no feasible Kubernetes placement' in str(exc_info.value)
 
     def test_required_non_k8s_pin_error_names_pins(self, mock_aws_cloud):
-        """Explicit true + a job pinning only non-k8s infra: the error
-        names the contradicting pins instead of a generic feasibility
-        message."""
+        """Explicit true + a job pinning only non-k8s infra: rejected by
+        the spec-level pin validation, before any catalog work, with an
+        error naming the contradicting pins."""
         aws_res = self._make_resources(mock_aws_cloud, 'us-east-1')
         task = self._make_task('task-1', [aws_res])
         dag = self._make_dag([task], inter_connection=True)
 
-        def mock_fill(task, blocked_resources, quiet):
-            return ({'any': [aws_res]}, None, None, None)
-
-        with patch('sky.optimizer._fill_in_launchable_resources',
-                   side_effect=mock_fill):
-            with pytest.raises(
-                    exceptions.ResourcesUnavailableError) as exc_info:
-                optimizer.Optimizer._optimize_same_infra(
-                    dag,
-                    minimize=common.OptimizeTarget.COST,
-                    blocked_resources=None,
-                    quiet=True)
+        # No catalog mocking: the contradiction is knowable from the
+        # spec alone and must be rejected before placement runs.
+        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
         assert 'pins non-Kubernetes infra' in str(exc_info.value)
+        assert 'task-1' in str(exc_info.value)
 
     def test_enabled_no_common_infra_raises(self, mock_k8s_cloud):
         """Default (unset) + empty intersection fails fast, never spreads."""
@@ -676,7 +669,8 @@ class TestInterConnectionPlacement:
 
     def test_cloud_level_pins_conflict_required_raises(self, mock_k8s_cloud,
                                                        mock_aws_cloud):
-        """Cloud-only pins to different clouds conflict (k8s vs aws)."""
+        """Cloud-only pins with explicit true: the non-k8s pin is the
+        contradiction (checked before the cross-job conflict)."""
         task1 = self._make_task('task-1',
                                 [self._make_resources(mock_k8s_cloud, None)])
         task2 = self._make_task('task-2',
@@ -685,7 +679,8 @@ class TestInterConnectionPlacement:
 
         with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-        assert 'no common option' in str(exc_info.value)
+        assert 'pins non-Kubernetes infra' in str(exc_info.value)
+        assert 'task-2' in str(exc_info.value)
 
     def test_cloud_level_pins_conflict_unset_degrades(self, mock_k8s_cloud,
                                                       mock_aws_cloud):

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -601,184 +601,6 @@ class TestInterConnectionPlacement:
         assert 'No single infrastructure' in str(exc_info.value)
         assert 'inter_connection: false' in str(exc_info.value)
 
-    def test_pins_conflict_required_raises(self, mock_k8s_cloud):
-        """Explicit true + conflicting pins is a submission-time error."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
-        dag = self._make_dag([task1, task2], inter_connection=True)
-
-        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-        assert 'no common option' in str(exc_info.value)
-        # The error names each conflicting job with its own pins.
-        assert 'task-1' in str(exc_info.value)
-        assert 'ctx-b' in str(exc_info.value)
-
-    def test_pins_conflict_unset_places_independently(self, mock_k8s_cloud):
-        """Unset + conflicting pins warns, degrades, places independently."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
-        dag = self._make_dag([task1, task2], inter_connection=None)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_independent') as mock_independent:
-            mock_independent.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_independent.assert_called_once()
-        # The degradation is persisted so the controller (which reads the
-        # serialized dag) skips all networking machinery.
-        assert dag.inter_connection is False
-
-    def test_pins_conflict_partial_pinning(self, mock_k8s_cloud):
-        """Conflict detection works when only some tasks are pinned."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
-        unpinned = self._make_task('task-3',
-                                   [self._make_resources(mock_k8s_cloud, None)])
-        dag = self._make_dag([task1, task2, unpinned], inter_connection=False)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_independent') as mock_independent:
-            mock_independent.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_independent.assert_called_once()
-
-    def test_any_of_overlapping_pins_not_a_conflict(self, mock_k8s_cloud):
-        """Tasks whose pin sets overlap can still colocate: no conflict."""
-        task1 = self._make_task('task-1', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(mock_k8s_cloud, 'ctx-b'),
-        ])
-        task2 = self._make_task('task-2', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(mock_k8s_cloud, 'ctx-b'),
-        ])
-        dag = self._make_dag([task1, task2], inter_connection=True)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_same_infra') as mock_same_infra:
-            mock_same_infra.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_same_infra.assert_called_once()
-
-    def test_cloud_level_pins_conflict_required_raises(self, mock_k8s_cloud,
-                                                       mock_aws_cloud):
-        """Cloud-only pins with explicit true: the non-k8s pin is the
-        contradiction (checked before the cross-job conflict)."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, None)])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_aws_cloud, None)])
-        dag = self._make_dag([task1, task2], inter_connection=True)
-
-        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-        assert 'pins non-Kubernetes infra' in str(exc_info.value)
-        assert 'task-2' in str(exc_info.value)
-
-    def test_cloud_level_pins_conflict_unset_degrades(self, mock_k8s_cloud,
-                                                      mock_aws_cloud):
-        """k8s/ctx pin vs aws pin with unset degrades instead of erroring."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_aws_cloud, None)])
-        dag = self._make_dag([task1, task2], inter_connection=None)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_independent') as mock_independent:
-            mock_independent.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_independent.assert_called_once()
-        assert dag.inter_connection is False
-
-    def test_cloud_pin_with_context_pin_same_cloud_no_conflict(
-            self, mock_k8s_cloud):
-        """`infra: k8s` + `infra: k8s/ctx` share a cloud: no conflict."""
-        task1 = self._make_task('task-1',
-                                [self._make_resources(mock_k8s_cloud, None)])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
-        dag = self._make_dag([task1, task2], inter_connection=True)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_same_infra') as mock_same_infra:
-            mock_same_infra.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_same_infra.assert_called_once()
-
-    def test_mixed_options_task_is_flexible(self, mock_k8s_cloud):
-        """any_of [k8s/ctxA, k8s] is flexible: no conflict with a ctxB pin."""
-        mixed = self._make_task('mixed', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(mock_k8s_cloud, None),
-        ])
-        pinned_b = self._make_task(
-            'pinned-b', [self._make_resources(mock_k8s_cloud, 'ctx-b')])
-        dag = self._make_dag([mixed, pinned_b], inter_connection=True)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_same_infra') as mock_same_infra:
-            mock_same_infra.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_same_infra.assert_called_once()
-
-    def test_disjoint_any_of_pin_sets_conflict(self, mock_k8s_cloud):
-        """any_of {A,B} vs any_of {C,D}: no common option -> conflict."""
-        task1 = self._make_task('task-1', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(mock_k8s_cloud, 'ctx-b'),
-        ])
-        task2 = self._make_task('task-2', [
-            self._make_resources(mock_k8s_cloud, 'ctx-c'),
-            self._make_resources(mock_k8s_cloud, 'ctx-d'),
-        ])
-        dag = self._make_dag([task1, task2], inter_connection=True)
-
-        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-        assert 'no common option' in str(exc_info.value)
-
-    def test_cross_cloud_any_of_with_common_option_not_a_conflict(
-            self, mock_k8s_cloud, mock_aws_cloud):
-        """{k8s/ctxA, aws/use1} vs {aws/use1}: common option -> no conflict."""
-        task1 = self._make_task('task-1', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(mock_aws_cloud, 'us-east-1'),
-        ])
-        task2 = self._make_task(
-            'task-2', [self._make_resources(mock_aws_cloud, 'us-east-1')])
-        dag = self._make_dag([task1, task2], inter_connection=False)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_same_infra') as mock_same_infra:
-            mock_same_infra.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_same_infra.assert_called_once()
-
-    def test_unpinned_option_defuses_conflict(self, mock_k8s_cloud,
-                                              mock_aws_cloud):
-        """[k8s/ctxA, <unpinned>] vs aws pin: task1 is fully flexible."""
-        task1 = self._make_task('task-1', [
-            self._make_resources(mock_k8s_cloud, 'ctx-a'),
-            self._make_resources(None, None),
-        ])
-        task2 = self._make_task('task-2',
-                                [self._make_resources(mock_aws_cloud, None)])
-        dag = self._make_dag([task1, task2], inter_connection=False)
-
-        with patch.object(optimizer.Optimizer,
-                          '_optimize_same_infra') as mock_same_infra:
-            mock_same_infra.return_value = dag
-            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-            mock_same_infra.assert_called_once()
-
     def test_unset_placed_off_kubernetes_degrades(self, mock_aws_cloud):
         """Unset group whose best common infra is non-k8s: warn + degrade.
 
@@ -860,6 +682,155 @@ class TestInterConnectionPlacement:
                     blocked_resources=None,
                     quiet=True)
         assert 'No single infrastructure' in str(exc_info.value)
+
+    def test_pins_conflict_routes_to_independent_placement(
+            self, mock_k8s_cloud):
+        """optimize_job_group consults the pin validation and routes a
+        cross-infra verdict to independent placement."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-b')])
+        dag = self._make_dag([task1, task2], inter_connection=False)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent, \
+             patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_independent.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_independent.assert_called_once()
+            mock_same_infra.assert_not_called()
+
+
+class TestValidateInterConnectionPins:
+    """Direct truth-table tests for _validate_inter_connection_pins.
+
+    Spec-level only: scenario (pins x inter_connection) -> verdict
+    (place independently?), error, or persisted degradation. No catalog
+    or placement machinery involved.
+    """
+
+    @pytest.fixture
+    def k8s(self):
+        cloud = MagicMock(spec=clouds.Kubernetes)
+        cloud.__str__ = MagicMock(return_value='Kubernetes')
+        return cloud
+
+    @pytest.fixture
+    def aws(self):
+        cloud = MagicMock(spec=clouds.AWS)
+        cloud.__str__ = MagicMock(return_value='AWS')
+        return cloud
+
+    def _res(self, cloud, region):
+        res = MagicMock(spec=resources_lib.Resources)
+        res.cloud = cloud
+        res.region = region
+        return res
+
+    def _dag(self, task_specs, inter_connection):
+        """task_specs: dict of task name -> list of (cloud, region)."""
+        dag = MagicMock(spec=dag_lib.Dag)
+        dag.name = 'g'
+        dag.inter_connection = inter_connection
+        tasks = []
+        for name, options in task_specs.items():
+            task = MagicMock(spec=task_lib.Task)
+            task.name = name
+            task.resources = [self._res(c, r) for c, r in options]
+            tasks.append(task)
+        dag.tasks = tasks
+        return dag
+
+    def _validate(self, dag):
+        return optimizer._validate_inter_connection_pins(dag, quiet=True)
+
+    def test_no_pins_no_verdict(self, k8s):
+        dag = self._dag({'a': [(None, None)], 'b': [(None, None)]}, None)
+        assert self._validate(dag) is False
+
+    def test_true_with_non_k8s_pin_raises(self, aws):
+        dag = self._dag({'a': [(aws, 'us-east-1')]}, True)
+        with pytest.raises(exceptions.ResourcesUnavailableError,
+                           match='pins non-Kubernetes infra'):
+            self._validate(dag)
+
+    def test_unset_with_non_k8s_pin_alone_is_fine(self, aws):
+        """A lone non-k8s pin with unset is not a conflict; degradation
+        (if the group lands off k8s) happens later, at placement."""
+        dag = self._dag({'a': [(aws, 'us-east-1')], 'b': [(None, None)]}, None)
+        assert self._validate(dag) is False
+        assert dag.inter_connection is None
+
+    def test_region_conflict_true_raises(self, k8s):
+        dag = self._dag({'a': [(k8s, 'ctx-a')], 'b': [(k8s, 'ctx-b')]}, True)
+        with pytest.raises(exceptions.ResourcesUnavailableError,
+                           match='no common option'):
+            self._validate(dag)
+
+    def test_region_conflict_unset_degrades(self, k8s):
+        dag = self._dag({'a': [(k8s, 'ctx-a')], 'b': [(k8s, 'ctx-b')]}, None)
+        assert self._validate(dag) is True
+        assert dag.inter_connection is False
+
+    def test_region_conflict_false_allowed(self, k8s):
+        dag = self._dag({'a': [(k8s, 'ctx-a')], 'b': [(k8s, 'ctx-b')]}, False)
+        assert self._validate(dag) is True
+        assert dag.inter_connection is False
+
+    def test_cloud_conflict_unset_degrades(self, k8s, aws):
+        dag = self._dag({'a': [(k8s, 'ctx-a')], 'b': [(aws, None)]}, None)
+        assert self._validate(dag) is True
+        assert dag.inter_connection is False
+
+    def test_partial_pinning_conflict(self, k8s):
+        """Conflict detection works when only some tasks are pinned."""
+        dag = self._dag(
+            {
+                'a': [(k8s, 'ctx-a')],
+                'b': [(k8s, 'ctx-b')],
+                'c': [(k8s, None)]
+            }, False)
+        assert self._validate(dag) is True
+
+    def test_overlapping_any_of_not_a_conflict(self, k8s):
+        dag = self._dag(
+            {
+                'a': [(k8s, 'ctx-a'), (k8s, 'ctx-b')],
+                'b': [(k8s, 'ctx-a'), (k8s, 'ctx-b')]
+            }, True)
+        assert self._validate(dag) is False
+
+    def test_disjoint_any_of_is_a_conflict(self, k8s):
+        dag = self._dag(
+            {
+                'a': [(k8s, 'ctx-a'), (k8s, 'ctx-b')],
+                'b': [(k8s, 'ctx-c'), (k8s, 'ctx-d')]
+            }, True)
+        with pytest.raises(exceptions.ResourcesUnavailableError,
+                           match='no common option'):
+            self._validate(dag)
+
+    def test_cross_cloud_any_of_with_common_option(self, k8s, aws):
+        dag = self._dag(
+            {
+                'a': [(k8s, 'ctx-a'), (aws, 'us-east-1')],
+                'b': [(aws, 'us-east-1')]
+            }, False)
+        assert self._validate(dag) is False
+
+    def test_unpinned_option_defuses_conflict(self, k8s, aws):
+        dag = self._dag(
+            {
+                'a': [(k8s, 'ctx-a'), (None, None)],
+                'b': [(aws, None)]
+            }, False)
+        assert self._validate(dag) is False
+
+    def test_cloud_pin_and_context_pin_same_cloud(self, k8s):
+        dag = self._dag({'a': [(k8s, None)], 'b': [(k8s, 'ctx-a')]}, True)
+        assert self._validate(dag) is False
 
 
 class TestGetTaskPinSets:

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -596,10 +596,13 @@ class TestInterConnectionPlacement:
 
         with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
-        assert 'pin different infrastructures' in str(exc_info.value)
+        assert 'no common option' in str(exc_info.value)
+        # The error names each conflicting job with its own pins.
+        assert 'task-1' in str(exc_info.value)
+        assert 'ctx-b' in str(exc_info.value)
 
     def test_pins_conflict_unset_places_independently(self, mock_k8s_cloud):
-        """Unset + conflicting pins warns and places independently."""
+        """Unset + conflicting pins warns, degrades, places independently."""
         task1 = self._make_task('task-1',
                                 [self._make_resources(mock_k8s_cloud, 'ctx-a')])
         task2 = self._make_task('task-2',
@@ -611,6 +614,9 @@ class TestInterConnectionPlacement:
             mock_independent.return_value = dag
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
             mock_independent.assert_called_once()
+        # The degradation is persisted so the controller (which reads the
+        # serialized dag) skips all networking machinery.
+        assert dag.inter_connection is False
 
     def test_pins_conflict_partial_pinning(self, mock_k8s_cloud):
         """Conflict detection works when only some tasks are pinned."""
@@ -645,6 +651,122 @@ class TestInterConnectionPlacement:
             mock_same_infra.return_value = dag
             optimizer.Optimizer.optimize_job_group(dag, quiet=True)
             mock_same_infra.assert_called_once()
+
+    def test_cloud_level_pins_conflict_required_raises(self, mock_k8s_cloud,
+                                                       mock_aws_cloud):
+        """Cloud-only pins to different clouds conflict (k8s vs aws)."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, None)])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_aws_cloud, None)])
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        with pytest.raises(exceptions.ResourcesUnavailableError) as exc_info:
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+        assert 'no common option' in str(exc_info.value)
+
+    def test_cloud_level_pins_conflict_unset_degrades(self, mock_k8s_cloud,
+                                                      mock_aws_cloud):
+        """k8s/ctx pin vs aws pin with unset degrades instead of erroring."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_aws_cloud, None)])
+        dag = self._make_dag([task1, task2], inter_connection=None)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_independent') as mock_independent:
+            mock_independent.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_independent.assert_called_once()
+        assert dag.inter_connection is False
+
+    def test_cloud_pin_with_context_pin_same_cloud_no_conflict(
+            self, mock_k8s_cloud):
+        """`infra: k8s` + `infra: k8s/ctx` share a cloud: no conflict."""
+        task1 = self._make_task('task-1',
+                                [self._make_resources(mock_k8s_cloud, None)])
+        task2 = self._make_task('task-2',
+                                [self._make_resources(mock_k8s_cloud, 'ctx-a')])
+        dag = self._make_dag([task1, task2], inter_connection=True)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_same_infra.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_same_infra.assert_called_once()
+
+    def test_mixed_options_task_is_flexible(self, mock_k8s_cloud):
+        """any_of [k8s/ctxA, k8s] is flexible: no conflict with a ctxB pin."""
+        mixed = self._make_task('mixed', [
+            self._make_resources(mock_k8s_cloud, 'ctx-a'),
+            self._make_resources(mock_k8s_cloud, None),
+        ])
+        pinned_b = self._make_task(
+            'pinned-b', [self._make_resources(mock_k8s_cloud, 'ctx-b')])
+        dag = self._make_dag([mixed, pinned_b], inter_connection=True)
+
+        with patch.object(optimizer.Optimizer,
+                          '_optimize_same_infra') as mock_same_infra:
+            mock_same_infra.return_value = dag
+            optimizer.Optimizer.optimize_job_group(dag, quiet=True)
+            mock_same_infra.assert_called_once()
+
+    def test_mixed_pin_narrows_group_to_pinned_context(self, mock_k8s_cloud):
+        """k8s/blah + k8s + k8s: everyone lands on blah, hard-pinned."""
+        res_blah = self._make_resources(mock_k8s_cloud, 'ctx-blah')
+        res_other = self._make_resources(mock_k8s_cloud, 'ctx-other', cost=0.1)
+
+        pinned = self._make_task('pinned', [res_blah])
+        flex1 = self._make_task('flex1')
+        flex2 = self._make_task('flex2')
+        dag = self._make_dag([pinned, flex1, flex2], inter_connection=True)
+
+        def mock_fill(task, blocked_resources, quiet):
+            if task == pinned:
+                # The region pin constrains candidate generation: no
+                # candidates outside ctx-blah exist for this task.
+                return ({'any': [res_blah]}, None, None, None)
+            return ({'any': [res_blah, res_other]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            optimizer.Optimizer._optimize_same_infra(
+                dag,
+                minimize=common.OptimizeTarget.COST,
+                blocked_resources=None,
+                quiet=True)
+
+        # ctx-other is cheaper, but the pin narrows the intersection to
+        # ctx-blah: every task must land there, hard-pinned.
+        for task in (pinned, flex1, flex2):
+            assert task.best_resources.region == 'ctx-blah'
+            task.set_resources_override.assert_called_once()
+
+    def test_mixed_pin_infeasible_fails_fast(self, mock_k8s_cloud):
+        """k8s/blah + a task infeasible on blah: error, no fallthrough."""
+        res_blah = self._make_resources(mock_k8s_cloud, 'ctx-blah')
+        res_other = self._make_resources(mock_k8s_cloud, 'ctx-other')
+
+        pinned = self._make_task('pinned', [res_blah])
+        other_only = self._make_task('other-only')
+        dag = self._make_dag([pinned, other_only], inter_connection=True)
+
+        def mock_fill(task, blocked_resources, quiet):
+            if task == pinned:
+                return ({'any': [res_blah]}, None, None, None)
+            return ({'any': [res_other]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            with pytest.raises(
+                    exceptions.ResourcesUnavailableError) as exc_info:
+                optimizer.Optimizer._optimize_same_infra(
+                    dag,
+                    minimize=common.OptimizeTarget.COST,
+                    blocked_resources=None,
+                    quiet=True)
+        assert 'No single infrastructure' in str(exc_info.value)
 
 
 class TestModuleLevelOptimizeJobGroup:

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1165,6 +1165,7 @@ class TestJobGroupResumeDoesNotReissueStarting:
         task.name = 'job-a'
         task.envs = {}
         task.run = 'echo hi'
+        task.resources = []
         controller._dag.tasks = [task]
         controller._backend = MagicMock()
         controller._backend.run_timestamp = 'run-ts'
@@ -1210,6 +1211,86 @@ class TestJobGroupResumeDoesNotReissueStarting:
                                                     task,
                                                     set_starting=True)
         set_starting_async.assert_awaited_once()
+
+
+class TestJobGroupNetworkingInjectionGate:
+    """Networking wait/updater scripts are only injected when the group
+    requires in-group networking (inter_connection enabled) and the task
+    runs on Kubernetes."""
+
+    def _make_task(self, cloud_str):
+        task = MagicMock()
+        task.name = 'job-a'
+        task.envs = {}
+        task.run = 'echo hi'
+        resource = MagicMock()
+        if cloud_str is None:
+            resource.cloud = None
+        else:
+            cloud = MagicMock()
+            cloud.__str__ = MagicMock(return_value=cloud_str)
+            resource.cloud = cloud
+        task.resources = [resource]
+        return task
+
+    def test_task_uses_kubernetes(self):
+        from sky.jobs import controller as controller_lib
+        assert controller_lib._task_uses_kubernetes(
+            self._make_task('Kubernetes'))
+        assert not controller_lib._task_uses_kubernetes(self._make_task('AWS'))
+        assert not controller_lib._task_uses_kubernetes(self._make_task(None))
+
+    async def _prepare(self, inter_connection_enabled, cloud_str):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._dag = MagicMock()
+        controller._dag.inter_connection_enabled = MagicMock(
+            return_value=inter_connection_enabled)
+        task = self._make_task(cloud_str)
+        controller._dag.tasks = [task]
+        controller._backend = MagicMock()
+        controller._backend.run_timestamp = 'run-ts'
+        controller.starting = set()
+        controller.starting_lock = MagicMock()
+        controller.starting_signal = MagicMock()
+
+        with patch('sky.jobs.controller.job_group_networking') as net, \
+             patch('sky.jobs.controller.managed_job_utils') as utils, \
+             patch('sky.jobs.controller.recovery_strategy') as recovery, \
+             patch('sky.jobs.controller.managed_job_state') as state, \
+             patch('sky.jobs.controller.backend_utils'), \
+             patch('sky.jobs.controller._build_task_specs', return_value={}):
+            net.generate_wait_for_networking_script.return_value = 'WAIT'
+            net.generate_inline_networking_setup_script.return_value = ''
+            utils.generate_managed_job_cluster_name.return_value = 'job-a-1'
+            recovery.StrategyExecutor.make.return_value = MagicMock()
+            state.get_file_mounts_blob_id.return_value = None
+            state.set_starting_async = AsyncMock()
+
+            await JobController._prepare_job_group_task_for_launch(
+                controller, task, 0, 'group', ['peer'], set_starting=False)
+            return task, net
+
+    @pytest.mark.asyncio
+    async def test_injects_wait_for_kubernetes_task(self):
+        task, net = await self._prepare(inter_connection_enabled=True,
+                                        cloud_str='Kubernetes')
+        assert task.run.startswith('WAIT')
+        net.generate_wait_for_networking_script.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_injection_when_inter_connection_disabled(self):
+        task, net = await self._prepare(inter_connection_enabled=False,
+                                        cloud_str='Kubernetes')
+        assert task.run == 'echo hi'
+        net.generate_wait_for_networking_script.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_injection_for_non_kubernetes_task(self):
+        task, net = await self._prepare(inter_connection_enabled=True,
+                                        cloud_str='AWS')
+        assert task.run == 'echo hi'
+        net.generate_wait_for_networking_script.assert_not_called()
 
 
 class TestUserJobStatusClassification:

--- a/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
+++ b/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
@@ -1,0 +1,27 @@
+"""Unit tests for JobGroup networking script generation."""
+from sky.jobs import job_group_networking
+
+
+class TestWaitForNetworkingScript:
+    """The wait script is only injected when in-group networking is
+    required (inter_connection enabled), so failure to initialize
+    networking must fail the job instead of silently continuing."""
+
+    def test_fails_job_when_networking_not_ready(self):
+        script = job_group_networking.generate_wait_for_networking_script(
+            'group', ['peer1', 'peer2'])
+        assert 'exit 1' in script
+        assert 'inter_connection' in script
+        # The old silent-fallthrough messaging must be gone.
+        assert 'Continuing without full network setup' not in script
+
+    def test_waits_for_all_peer_hostnames(self):
+        script = job_group_networking.generate_wait_for_networking_script(
+            'group', ['peer1', 'peer2'])
+        assert 'peer1-0.group' in script
+        assert 'peer2-0.group' in script
+
+    def test_empty_without_peers(self):
+        script = job_group_networking.generate_wait_for_networking_script(
+            'group', [])
+        assert script == ''

--- a/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
+++ b/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
@@ -25,3 +25,59 @@ class TestWaitForNetworkingScript:
         script = job_group_networking.generate_wait_for_networking_script(
             'group', [])
         assert script == ''
+
+
+class TestPhase3VariableScoping:
+    """Regression guard: names used after the Phase 3 networking block in
+    ``_run_job_group`` must be bound on both branches of the
+    inter_connection gate.
+
+    An e2e run caught ``tasks_handles`` being defined only when networking
+    was enabled, so every ``inter_connection: false`` group crashed the
+    controller loop with UnboundLocalError once Phase 4 referenced it.
+    """
+
+    def test_names_used_after_phase3_are_bound_on_both_branches(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from sky.jobs import controller as controller_lib
+
+        src = textwrap.dedent(
+            inspect.getsource(controller_lib.JobController._run_job_group))
+        tree = ast.parse(src)
+
+        # Find the `if not self._dag.inter_connection_enabled():` statement
+        # guarding Phase 3.
+        gate = None
+        for node in ast.walk(tree):
+            if isinstance(node,
+                          ast.If) and 'inter_connection_enabled' in ast.dump(
+                              node.test):
+                gate = node
+                break
+        assert gate is not None, 'Phase 3 inter_connection gate not found'
+
+        # Names assigned only inside the gate's branches.
+        assigned_in_gate = set()
+        for branch in (gate.body, gate.orelse):
+            for stmt in branch:
+                for node in ast.walk(stmt):
+                    if isinstance(node, ast.Name) and isinstance(
+                            node.ctx, ast.Store):
+                        assigned_in_gate.add(node.id)
+
+        # Names read after the gate.
+        gate_end = gate.end_lineno
+        read_after = set()
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Name) and
+                    isinstance(node.ctx, ast.Load) and node.lineno > gate_end):
+                read_after.add(node.id)
+
+        leaked = assigned_in_gate & read_after
+        assert not leaked, (
+            f'Names bound only inside the Phase 3 inter_connection gate but '
+            f'read afterwards: {sorted(leaked)}. Bind them before the gate '
+            'so both branches reach Phase 4.')


### PR DESCRIPTION
## Summary

- Adds a group-level `inter_connection: true | false` field to the JobGroup YAML header: whether tasks need to reach each other by in-group hostnames.
- Networking is enabled by default (unset behaves as `true` wherever supported; explicit `true` is stricter — placements that cannot support networking error instead of warn). Enabled networking is a real guarantee: placement is constrained to a single Kubernetes cluster, and networking failures fail the job loudly instead of today's silent best-effort fallthrough.
- `false` skips all networking machinery (no setup, no updater, no wait) and allows deliberate cross-cluster / cross-infra placement — for groups whose tasks coordinate externally.

## What this fixes

1. **Hostname-dependent groups no longer get silently spread.** A group whose jobs cannot share one cluster (e.g. plain `infra: kubernetes` with GPU types that live in different clusters) used to be scattered across clusters, where in-group hostnames do not resolve. The job launched, ran, and hung inside user code minutes later. It now fails at submission, naming the fix.
2. **Networking failures fail the job.** Setup that did not come up within the grace period previously logged a warning and ran the workload anyway, without connectivity. It is now a hard failure with an actionable message.
3. **Contradictory requests are rejected up front.** Requiring in-group networking while pinning non-Kubernetes infra, or while pinning jobs to clusters that cannot be co-located, is an error at submission instead of a broken run.
4. **Groups that cannot use in-group networking no longer wait for it.** Non-Kubernetes groups spent 10 minutes waiting on a marker that could never appear before starting. They now start immediately.

## Semantics

| `inter_connection` | Meaning |
|---|---|
| `true` | Networking required. Placement constrained to Kubernetes; non-Kubernetes or conflicting pins are errors; networking-wait timeout fails the job. |
| unset (default) | "Required where supported": identical to `true` on colocatable Kubernetes groups. Where the *user's pins* make networking impossible (conflicting pins) or the *optimizer* places the colocated group off Kubernetes, networking degrades to off with a warning — and the degradation is **persisted** (`inter_connection: false` written into the dag before serialization to the controller), so downstream never applies networking machinery to a placement where hostnames cannot resolve. An *unpinned* group that cannot be co-located fails fast instead of silently spreading (see judgment calls). |
| `false` | No networking machinery at all. Tasks start immediately; cross-infra placement allowed (deliberate pins, or feasibility-driven spread when no single cluster has the required hardware). |

## Architecture: one concern per layer

| Layer | Owns | Code |
|---|---|---|
| YAML loader | shape only (`inter_connection` must be a boolean) | `dag_utils._load_job_group` |
| Optimizer, pre-placement | **all ask-validation**: (1) explicit `true` + a job pinning only non-k8s clouds → error naming the job and its pins; (2) pinned jobs sharing no common infra option (cloud- or region-granularity, `any_of`-aware) → error / degrade+warn / allow for true / unset / false | `_validate_inter_connection_pins`, built on `_get_task_pin_sets` |
| Optimizer, placement | feasibility + choice: explicit `true` filters candidates to Kubernetes (k8s wins even when another cloud is cheaper; none feasible → pure-feasibility error); empty intersection → fail fast when networking enabled, independent placement when `false`; unset group whose *chosen* infra is non-k8s → degrade+warn (Step 3); every task hard-pinned to the chosen infra, silent pin-skips are now assertion failures (Step 4) | `_optimize_same_infra` |
| Server core | post-optimization invariant assert only: networking still enabled ⟹ placement is homogeneous and on Kubernetes | `jobs/server/core.py` |
| Controller | mechanics, zero placement reasoning: networking scripts injected only when enabled and the task targets Kubernetes; Phase 3 skipped when off; Phase 3 failure with networking required fails the group **with explicit cluster cleanup**; recovery networking refresh no-ops when off | `_run_job_group`, `_prepare_job_group_task_for_launch`, `on_recovery` |
| On-pod wait script | fails the job (`exit 1`) on marker/hostname timeout — only injected when networking is required, so continuing without networking is never correct | `generate_wait_for_networking_script` |

Placement scope-narrowing needs no new machinery: a pin (or a hardware requirement only one cluster satisfies) constrains that task's candidate set, the intersection narrows the whole group onto it, and the previously-silent independent-optimization fallback is now gated — `k8s/ctx` + unpinned siblings all land on `ctx` or the group fails, never a silent landing elsewhere.

## Behavior changes

- The ~15-minute best-effort networking wait no longer ends in "continue anyway": for networking-enabled k8s groups it is fatal (including after recovery re-setup); for non-k8s groups it is no longer injected at all (removes a dead 10-minute startup stall — hostnames never worked there).
- A JobGroup with no common infrastructure now fails at submission with remediation instructions instead of silently scattering tasks via per-task independent optimization (and the misleading "No common infrastructure found" warning is gone).
- Conflict errors name each job with its own pins (`task-1: ['Kubernetes/ctx-a']; task-2: ['Kubernetes/ctx-b']`) at the granularity that conflicted.

## Judgment calls (please review explicitly)

1. **A group with `inter_connection` unset, no infra pins, and no single cluster able to host all its jobs now fails at submission instead of being spread.** Unset still degrades to no-networking in the two cases where that is safe: when the user pinned jobs to clusters that cannot be co-located (they asked for the spread), and when the group is co-located but placed off Kubernetes (placement is unchanged, only the k8s-only feature is unavailable). It does not degrade here, because doing so means scattering a group that never asked to be scattered — and such a group is by construction one that expects hostnames to work. This is the one deliberate backward-compatibility break.
2. **Networking failure is fatal for groups that did not set the field**, not just for explicit `true`. Co-located Kubernetes groups still set up networking and wait for it as before; the change is that a wait that times out now fails the job instead of proceeding without connectivity.
3. Non-k8s groups lose the dead 10-minute wait entirely.
4. **When unset degrades to no-networking, the decision is written into the dag as `inter_connection: false` before it is serialized to the controller.** The controller re-parses the dag in a separate process with no placement context, so it cannot re-derive this; without it, the controller would inject the (now fatal) networking wait onto a placement where hostnames can never resolve. Side effect: a dumped YAML carries the explicit `false`, so resubmitting it keeps the degraded behavior.

## Case coverage (unit)

| # | Case | Test |
|---|---|---|
| 1 | parse/validate/round-trip; unset not serialized; both dump variants carry the field | `test_dag_utils.py::test_job_group_inter_connection_*` |
| 2 | per-task pin extraction truth table (single pin, cross-cloud `any_of`, mixed options, unpinned option, no options) | `TestGetTaskPinSets` |
| 3 | ask-validation truth table: non-k8s pin × true/unset; region- and cloud-level conflicts × true/unset/false (incl. persisted degradation); partial pinning; overlapping/disjoint `any_of`; unpinned option defusing; compatible cloud+context pins | `TestValidateInterConnectionPins` |
| 4 | `optimize_job_group` consults the validator and routes its verdict | `test_pins_conflict_routes_to_independent_placement` |
| 5 | `true` picks k8s over cheaper non-k8s; no feasible k8s errors; non-k8s-pin error propagates end-to-end | `test_required_*` |
| 6 | unset + empty intersection fail-fast; `false` + empty intersection → independent | `test_enabled_no_common_infra_raises`, `test_optimize_same_infra_fallback_when_no_common_infra` |
| 7 | unset group placed off-k8s → warn + persisted degradation (Step 3) | `test_unset_placed_off_kubernetes_degrades` |
| 8 | scope narrowing: pinned context + unpinned siblings all land on it (even when another context is cheaper); infeasible pin fails fast | `test_mixed_pin_*` |
| 9 | wait script fatal, no silent fallthrough; empty without peers | `test_job_group_networking.py` |
| 10 | controller injection gate: enabled+k8s / disabled / non-k8s | `TestJobGroupNetworkingInjectionGate` |

99 tests across the four affected suites; `bash format.sh` clean. (One pre-existing failure in `test_sky/jobs/test_utils.py` reproduces on clean master, unrelated.)

## E2E validation

In progress on a two-cluster kind rig (fake A100-only / H100-only clusters, local API server running this branch, consolidation-mode controller). Results will be posted as a PR comment: what was exercised end-to-end and what is deferred with reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
