### PR TITLE
[Test] Fix test_minimal job numbering on Slurm

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -63,7 +63,9 @@ def test_minimal(generic_cloud: str):
     # Ensure the raylet process has the correct file descriptor limit.
     check_raylet_cmd = smoke_tests_utils.get_check_raylet_nofile_limit_cmd(name)
     if generic_cloud == 'slurm':
-        check_raylet_cmd = 'true'
+        # No raylet on Slurm, but keep the `sky exec` so this step still
+        # creates a job and the job IDs asserted below stay in sync.
+        check_raylet_cmd = f'sky exec {name} true'
     test = smoke_tests_utils.Test(
         'minimal',
         [


### PR DESCRIPTION
Fixes `test_minimal --slurm`, which is currently failing on master (e.g. the nightly `test_minimal --slurm` build) with:

```
Job 3: None
Job 3 not found
Failed (returned 102).
Reason: sky logs <name> 3 --status
```

[#10263](https://github.com/skypilot-org/skypilot/pull/10263) moved the raylet nofile check's `sky exec` inside `get_check_raylet_nofile_limit_cmd()`. Before that, the check ran as `sky exec {name} {check_raylet_cmd}`, so the Slurm stub (`true`) still executed through `sky exec` and created job 3. Now the stub is a bare local `true`, job 3 is never created, and the next assertion `sky logs {name} 3 --status` fails — along with every job ID after it being off by one.

Keep the Slurm stub as a `sky exec` no-op (`sky exec {name} true`) so the job numbering the test asserts stays in sync.

## Tested

- Root cause verified against build history: the same failure reproduces on master's nightly (`test_minimal --slurm`, post-#10263, failing at `sky logs <name> 3 --status`) and does not occur on a branch based on master from before #10263.
- To verify on this PR: `/smoke-test --slurm -k test_minimal` (not yet triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
