### PR TITLE
[CLI] Respect enabled clouds in GPU listing

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4897,10 +4897,18 @@ def _show_gpus_impl(
         # common GPUs.
         clouds_to_list: Union[Optional[str], List[str]] = cloud_name
         if cloud_name is None:
-            clouds_to_list = [
+            cloud_catalogs = [
                 c for c in constants.ALL_CLOUDS
                 if c != 'kubernetes' and c != 'ssh' and c != 'slurm'
             ]
+            enabled_cloud_names = {c.lower() for c in enabled_clouds}
+            if enabled_cloud_names:
+                clouds_to_list = [
+                    c for c in cloud_catalogs
+                    if c.lower() in enabled_cloud_names
+                ]
+            else:
+                clouds_to_list = cloud_catalogs
 
         k8s_messages = ''
         slurm_messages = ''
@@ -4970,12 +4978,15 @@ def _show_gpus_impl(
                     yield slurm_messages
                 yield '\n\n'
 
-            list_accelerator_counts_result = sdk.stream_and_get(
-                sdk.list_accelerator_counts(
-                    gpus_only=True,
-                    clouds=clouds_to_list,
-                    region_filter=region,
-                ))
+            if clouds_to_list:
+                list_accelerator_counts_result = sdk.stream_and_get(
+                    sdk.list_accelerator_counts(
+                        gpus_only=True,
+                        clouds=clouds_to_list,
+                        region_filter=region,
+                    ))
+            else:
+                list_accelerator_counts_result = {}
             # TODO(zhwu): handle the case where no accelerators are found,
             # especially when --region specified a non-existent region.
 

--- a/tests/unit_tests/test_sky/test_cli_gpus_list.py
+++ b/tests/unit_tests/test_sky/test_cli_gpus_list.py
@@ -337,6 +337,34 @@ class TestGpusList:
 
         assert 'Slurm is not enabled' in result.output
 
+    def test_gpus_list_all_with_only_slurm_enabled_skips_cloud_catalogs(self):
+        """Test that allowed_clouds=[slurm] does not query cloud catalogs."""
+        self.cloud_registry_mock.return_value = None
+        self.sdk_get_mock.return_value = ['slurm']
+        gpu_availability = [
+            ('cluster1', [('A100', [1, 2, 4, 8], 24, 12)]),
+        ]
+        self.stream_and_get_mock.side_effect = [
+            gpu_availability,
+            [],
+        ]
+
+        with mock.patch.object(sdk,
+                               'realtime_slurm_gpu_availability',
+                               return_value=mock.MagicMock()), \
+             mock.patch.object(sdk,
+                               'slurm_node_info',
+                               return_value=mock.MagicMock()), \
+             mock.patch.object(sdk,
+                               'list_accelerator_counts',
+                               return_value=mock.MagicMock()) as mock_list:
+            result = self.runner.invoke(command.gpus_list, ['--all'])
+
+        assert result.exit_code == 0
+        assert 'Slurm GPUs' in result.output
+        assert 'A100' in result.output
+        mock_list.assert_not_called()
+
     def _invoke_slurm_gpus_list(self,
                                 gpu_availability,
                                 node_info,


### PR DESCRIPTION
## Summary
- Limit the default cloud catalog lookup in `sky gpus list` to currently enabled clouds.
- Skip the cloud catalog request entirely when only realtime infra such as Slurm is enabled.
- Add a regression test for the `allowed_clouds: [slurm]` case to ensure cloud catalogs are not queried.

## Root cause
`sky gpus list` printed realtime Slurm GPU availability, but then continued into the generic cloud catalog path with `constants.ALL_CLOUDS` when no explicit `--infra` was provided. That could trigger unrelated AWS catalog calls even when `allowed_clouds` only enabled Slurm.
