### PR TITLE
[Server] Return the executor slot when the monitor thread fails to start

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -267,9 +267,16 @@ class RequestWorker:
                 elif self.schedule_type == api_requests.ScheduleType.SHORT:
                     metrics_utils.SKY_APISERVER_SHORT_EXECUTORS.dec()
             # Monitor the result of the request execution.
-            threading.Thread(target=self.handle_task_result,
-                             args=(fut, request_element),
-                             daemon=True).start()
+            try:
+                threading.Thread(target=self.handle_task_result,
+                                 args=(fut, request_element),
+                                 daemon=True).start()
+            except Exception:  # pylint: disable=broad-except
+                # handle_task_result owns the matching increment, so a thread
+                # that never starts would leak the slot for the lifetime of
+                # the process.
+                self._mark_executor_free()
+                raise
 
             logger.info(f'[{self}] Submitted request: {request_id}')
         except (Exception, SystemExit) as e:  # pylint: disable=broad-except

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -906,6 +906,64 @@ def test_pause_marks_executor_free_before_wait(pause_harness, monkeypatch):
     assert pause_harness.queue_items == [request_element]
 
 
+def test_monitor_thread_start_failure_returns_the_slot(pause_harness,
+                                                       monkeypatch):
+    """A monitor thread that never starts must not leak a free-executor slot.
+
+    handle_task_result, which runs in that thread, owns the increment matching
+    process_request()'s decrement. If the thread never starts the slot is gone
+    for the lifetime of the process, and enough of these drive the gauge
+    negative - indistinguishable from a genuine request backlog.
+    """
+    gauge = mock.Mock()
+    monkeypatch.setattr(executor.metrics_utils, 'METRICS_ENABLED', True)
+    monkeypatch.setattr(executor.metrics_utils, 'SKY_APISERVER_LONG_EXECUTORS',
+                        gauge)
+
+    class _UnstartableThread:
+
+        def start(self):
+            raise RuntimeError("can't start new thread")
+
+    real_thread = executor.threading.Thread
+
+    def _thread_factory(*args, **kwargs):
+        # Only the monitor thread is made unstartable; anything else the
+        # request path spawns must keep working.
+        if kwargs.get('target') == pause_harness.worker.handle_task_result:
+            return _UnstartableThread()
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(executor.threading, 'Thread', _thread_factory)
+
+    class _MockExecutor:
+
+        def submit_until_success(self, fn, *args, **kwargs):
+            del fn, args, kwargs
+            fut = concurrent.futures.Future()
+            fut.set_result(None)
+            return fut
+
+    class _OneShotQueue:
+
+        def __init__(self, item):
+            self._item = item
+
+        def get(self):
+            item, self._item = self._item, None
+            return item
+
+    request_queue = _OneShotQueue((pause_harness.request_id, False, True))
+
+    # The thread failure is still swallowed by process_request's handler, so
+    # the dispatcher loop survives it - only the accounting must be repaired.
+    pause_harness.worker.process_request(_MockExecutor(), request_queue)
+
+    # Assert the invariant, not where the decrement sits: a failed monitor
+    # thread must leave the gauge net-zero either way.
+    assert gauge.dec.call_count == gauge.inc.call_count
+
+
 def test_resolve_blob_valid(tmp_path, monkeypatch):
     """Test that resolve_blob_dir returns the shared extraction dir."""
     blob_id = 'a' * 64


### PR DESCRIPTION
## Summary

`RequestWorker.process_request()` decrements the free-executor gauge as soon as a request is submitted, and `handle_task_result` — which runs in the monitor thread — owns the matching increment. If starting that thread raises (e.g. the process is out of threads), the broad handler at the end of `process_request` swallows the failure and that slot is gone for the lifetime of the process.

That matters more than a lost metric sample, because the gauge is not a pool-size reading: it is `pool total − in-flight submissions`. The decrement happens even when no worker is idle, since `submit_until_success()` falls through to the guaranteed pool, whose internal queue never applies backpressure. So the gauge legitimately goes negative under load, and its magnitude is the backlog depth — a leaked slot is indistinguishable from a genuine backlog, and never recovers short of a process restart.

The fix gives the slot back before re-raising into the existing handler. The decrement is deliberately left where it is (paired with the submit, not with the thread start) so the gauge never transiently reads above the pool total, which is what `max_over_time()` is used to infer pool size from.

## Test plan

- New unit test `test_monitor_thread_start_failure_returns_the_slot`: makes only the monitor thread unstartable (any other thread the request path spawns keeps working) and asserts the gauge is left net-zero.
  ```
  pytest tests/unit_tests/test_sky/server/requests/test_executor.py
  ```
  Whole file passes.
- Revert check: with the `try`/`except` removed, the new test fails on `assert 1 == 0` — one decrement, zero increments — i.e. it reproduces the leak rather than passing vacuously.
- The assertion is written as `dec.call_count == inc.call_count` rather than pinning exact counts, so it holds regardless of where the decrement sits and still catches the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)