### PR TITLE
[Core] Optionally route the state DB through a transaction pooler

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -673,6 +673,21 @@ ENV_VAR_SERVER_AUTH_USER_HEADER = f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_USER_HEADER'
 # skypilot server.
 ENV_VAR_DB_CONNECTION_URI = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_CONNECTION_URI')
 
+# Optional: route the state DB through a transaction-mode connection pooler
+# (e.g. PgBouncer). When set, regular state-DB engines connect through the
+# pooler while session-scoped advisory locks keep a direct connection (see
+# `sky.utils.db.db_utils.get_engine`). Both are unset by default, in which
+# case the state DB is reached directly via ENV_VAR_DB_CONNECTION_URI.
+#
+# ENV_VAR_DB_POOL_CONNECTION_URI: a full replacement connection URI for the
+# pooled engines (escape hatch, e.g. an entirely separate pooler endpoint).
+# ENV_VAR_DB_POOL_HOSTPORT: a `host:port` that replaces just the host:port of
+# ENV_VAR_DB_CONNECTION_URI, preserving user/password/dbname/query — so no DB
+# credentials need re-plumbing when the pooler runs as a local sidecar.
+ENV_VAR_DB_POOL_CONNECTION_URI = (
+    f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_CONNECTION_URI')
+ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')
+
 # Environment variable that is set to 'true' if basic
 # authentication is enabled in the API server.
 ENV_VAR_ENABLE_BASIC_AUTH = 'ENABLE_BASIC_AUTH'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -8,6 +8,7 @@ import sqlite3
 import threading
 import typing
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
+import urllib.parse
 
 import aiosqlite
 import aiosqlite.context
@@ -448,7 +449,15 @@ class DatabaseManager:
             if self._engine is not None:
                 return self._engine
             engine = get_engine(self._db_name)
-            self._create_table_fn(engine)
+            # Run schema creation / migrations on a direct (unpooled)
+            # connection: Alembic's autocommit_block DDL relies on
+            # session-scoped COMMIT/BEGIN control that a transaction-mode
+            # pooler does not preserve, whereas the runtime engine returned to
+            # callers may be pooled. Tables live in the same physical database
+            # either way, so the pooled runtime engine sees them. When no
+            # pooler is configured, direct == pooled (same cached engine), so
+            # this is a no-op.
+            self._create_table_fn(get_engine(self._db_name, direct=True))
             # Set _engine before post_init_fn so that post_init_fn
             # can access self.engine (e.g. _sqlite_supports_returning).
             self._engine = engine
@@ -519,27 +528,85 @@ def _make_asyncpg_creator(dsn: str) -> Callable[[], Any]:
     import asyncpg
 
     async def _connect() -> Any:
-        return await asyncpg.connect(dsn, timeout=15)
+        # statement_cache_size=0 disables asyncpg's per-connection
+        # prepared-statement cache so the connection is safe behind a
+        # transaction-mode pooler (e.g. PgBouncer), where a statement prepared
+        # on one backend connection may not exist on the next. Harmless (a
+        # small perf trade-off) on a direct connection, so set unconditionally.
+        return await asyncpg.connect(dsn, timeout=15, statement_cache_size=0)
 
     return _connect
 
 
+def _rewrite_hostport(uri: str, hostport: str) -> str:
+    """Return *uri* with its netloc host:port replaced by *hostport*.
+
+    Userinfo (``user:password@``) is preserved verbatim so an already
+    percent-encoded password is not re-encoded. Non-PostgreSQL URIs are
+    returned unchanged (only PostgreSQL URIs have a rewritable host:port
+    netloc).
+    """
+    parts = urllib.parse.urlsplit(uri)
+    if not parts.scheme.startswith('postgres'):
+        return uri
+    at = parts.netloc.rfind('@')
+    userinfo = parts.netloc[:at + 1] if at != -1 else ''
+    return urllib.parse.urlunsplit((parts.scheme, userinfo + hostport,
+                                    parts.path, parts.query, parts.fragment))
+
+
+def _resolve_conn_string(direct: bool) -> Optional[str]:
+    """Resolve the Postgres connection string for a state-DB engine.
+
+    Returns None when the server is not configured for Postgres, so the caller
+    falls back to SQLite.
+
+    When ``direct`` is True, always returns the unpooled
+    ``ENV_VAR_DB_CONNECTION_URI`` so session-scoped advisory locks keep a
+    direct, session-pinned connection. When False, routes through a pooler if
+    one is configured (``ENV_VAR_DB_POOL_CONNECTION_URI`` wins, else a
+    host:port rewrite via ``ENV_VAR_DB_POOL_HOSTPORT``); otherwise returns the
+    direct URI unchanged, so deployments without a pooler are unaffected.
+    """
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
+        return None
+    base = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
+    if not base or direct:
+        return base
+    override = os.environ.get(constants.ENV_VAR_DB_POOL_CONNECTION_URI)
+    if override:
+        return override
+    hostport = os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT)
+    if hostport:
+        return _rewrite_hostport(base, hostport)
+    return base
+
+
+def _pooler_configured() -> bool:
+    """Whether a connection pooler is configured for non-direct engines."""
+    return bool(
+        os.environ.get(constants.ENV_VAR_DB_POOL_CONNECTION_URI) or
+        os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
+
+
 @typing.overload
-def get_engine(
-        db_name: Optional[str],
-        async_engine: Literal[False] = False) -> sqlalchemy.engine.Engine:
+def get_engine(db_name: Optional[str],
+               async_engine: Literal[False] = False,
+               direct: bool = False) -> sqlalchemy.engine.Engine:
     ...
 
 
 @typing.overload
 def get_engine(db_name: Optional[str],
-               async_engine: Literal[True]) -> sqlalchemy_async.AsyncEngine:
+               async_engine: Literal[True],
+               direct: bool = False) -> sqlalchemy_async.AsyncEngine:
     ...
 
 
 def get_engine(
     db_name: Optional[str],
-    async_engine: bool = False
+    async_engine: bool = False,
+    direct: bool = False,
 ) -> Union[sqlalchemy.engine.Engine, sqlalchemy_async.AsyncEngine]:
     """Get the engine for the given database name.
 
@@ -547,10 +614,14 @@ def get_engine(
         db_name: The name of the database. ONLY used for SQLite. On Postgres,
         we use a single database, which we get from the connection string.
         async_engine: Whether to return an async engine.
+        direct: When True, bypass any configured connection pooler and connect
+        directly to ``ENV_VAR_DB_CONNECTION_URI``. Used for session-scoped
+        advisory locks and schema migrations, which are unsafe through a
+        transaction-mode pooler. When no pooler is configured (the default),
+        direct and non-direct resolve to the same connection string and thus
+        the same cached engine.
     """
-    conn_string = None
-    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
+    conn_string = _resolve_conn_string(direct)
     if conn_string:
         # We use the same cache for both sync and async engines
         # because we prefix the cache key in the async case,
@@ -577,7 +648,17 @@ def get_engine(
                             'postgresql+asyncpg://',
                             poolclass=sqlalchemy.NullPool,
                             async_creator=_make_asyncpg_creator(conn_string)))
-                elif _max_connections == 0:
+                elif _max_connections == 0 or (direct and _pooler_configured()):
+                    # NullPool: no persistent connections. Used when no pool
+                    # size is configured, and — crucially — for the direct
+                    # engine when a pooler IS configured. The direct engine
+                    # then only serves brief advisory-lock holds and one-time
+                    # startup migrations; a reuse pool (QueuePool) would pin
+                    # one idle direct backend per process for the process's
+                    # whole life, defeating the pooling (each process would
+                    # keep a direct connection on top of its pooled one). With
+                    # NullPool the direct path opens a connection only while a
+                    # lock or migration actively needs it and closes it after.
                     _postgres_engine_cache[cache_key] = (
                         sqlalchemy.create_engine(conn_string,
                                                  poolclass=sqlalchemy.NullPool))

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -206,7 +206,12 @@ class PostgresLock(DistributedLock):
     @db_retries.retry
     def _get_connection(self) -> sqlalchemy.pool.PoolProxiedConnection:
         """Get database connection."""
-        engine = global_user_state.initialize_and_get_db()
+        # Session-scoped advisory locks hold one connection across their whole
+        # lifetime, which is unsafe through a transaction-mode pooler (the
+        # backend can change between statements). Use a direct engine so the
+        # lock connection bypasses any configured pooler; when none is
+        # configured this is the same engine global_user_state uses.
+        engine = db_utils.get_engine(None, direct=True)
         if engine.dialect.name != db_utils.SQLAlchemyDialect.POSTGRESQL.value:
             raise ValueError('PostgresLock requires PostgreSQL database. '
                              f'Current dialect: {engine.dialect.name}')

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -109,6 +109,8 @@ class TestGetEngine:
         # Ensure we're not in server mode by default
         monkeypatch.delenv('IS_SKYPILOT_SERVER', raising=False)
         monkeypatch.delenv('SKYPILOT_DB_CONNECTION_URI', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_CONNECTION_URI', raising=False)
 
     def test_sqlite_sync_engine_creation(self, tmp_path, monkeypatch):
         """Test SQLite sync engine is created correctly."""
@@ -428,3 +430,171 @@ class TestGetEngine:
             # Parent directory should be created
             expected_dir = runtime_dir / '.sky'
             assert expected_dir.exists()
+
+    def test_pool_hostport_rewrites_default_engine(self, monkeypatch):
+        """With a pooler configured, the default engine uses the pooled URI."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(1)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.return_value = mock.MagicMock()
+            db_utils.get_engine(db_name='ignored')
+
+            assert mock_create.call_args[0][0] == (
+                'postgresql://user:pass@127.0.0.1:6432/db')
+
+    def test_direct_bypasses_pooler(self, monkeypatch):
+        """direct=True keeps the raw URI even when a pooler is configured."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(1)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.return_value = mock.MagicMock()
+            db_utils.get_engine(db_name='ignored', direct=True)
+
+            assert mock_create.call_args[0][0] == (
+                'postgresql://user:pass@10.0.0.5:5432/db')
+
+    def test_pooled_and_direct_engines_cached_separately(self, monkeypatch):
+        """Pooled and direct engines are distinct entries in the cache."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(1)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.side_effect = lambda *a, **k: mock.MagicMock()
+            pooled = db_utils.get_engine(db_name='ignored')
+            direct = db_utils.get_engine(db_name='ignored', direct=True)
+
+            # Two distinct conn strings -> two engines, two create calls.
+            assert mock_create.call_count == 2
+            assert pooled is not direct
+
+    def test_no_pooler_direct_equals_pooled(self, monkeypatch):
+        """Without a pooler, direct and default resolve to the same engine."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        db_utils.set_max_connections(1)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.side_effect = lambda *a, **k: mock.MagicMock()
+            default = db_utils.get_engine(db_name='ignored')
+            direct = db_utils.get_engine(db_name='ignored', direct=True)
+
+            assert mock_create.call_count == 1
+            assert default is direct
+
+    def test_direct_engine_uses_nullpool_when_pooler_configured(
+            self, monkeypatch):
+        """With a pooler, the direct engine is NullPool (no idle backend);
+        the pooled engine stays QueuePool."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(1)
+
+        pools = {}
+
+        def rec(conn, **kw):
+            pools[conn] = kw.get('poolclass')
+            return mock.MagicMock()
+
+        with mock.patch('sqlalchemy.create_engine', side_effect=rec):
+            db_utils.get_engine(db_name='ignored')  # pooled
+            db_utils.get_engine(db_name='ignored', direct=True)  # direct
+
+        assert pools['postgresql://user:pass@127.0.0.1:6432/db'] == (
+            sqlalchemy.pool.QueuePool)
+        assert pools['postgresql://user:pass@10.0.0.5:5432/db'] == (
+            sqlalchemy.NullPool)
+
+    def test_direct_engine_uses_queuepool_when_no_pooler(self, monkeypatch):
+        """Without a pooler, direct=True keeps QueuePool (no separate engine);
+        order-independent — creating the direct one first must not force
+        NullPool onto the shared engine."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        db_utils.set_max_connections(1)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.side_effect = lambda *a, **k: mock.MagicMock()
+            db_utils.get_engine(db_name='ignored', direct=True)
+            assert mock_create.call_args[1]['poolclass'] == (
+                sqlalchemy.pool.QueuePool)
+
+
+class TestConnStringResolution:
+    """Tests for _rewrite_hostport and _resolve_conn_string."""
+
+    @pytest.fixture(autouse=True)
+    def clear_env(self, monkeypatch):
+        monkeypatch.delenv('IS_SKYPILOT_SERVER', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_CONNECTION_URI', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_CONNECTION_URI', raising=False)
+
+    def test_rewrite_preserves_userinfo_dbname_query(self):
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p%40ss@10.0.0.5:5432/staging-db?sslmode=require',
+            '127.0.0.1:6432')
+        assert out == (
+            'postgresql://u:p%40ss@127.0.0.1:6432/staging-db?sslmode=require')
+
+    def test_rewrite_no_userinfo(self):
+        out = db_utils._rewrite_hostport('postgresql://10.0.0.5:5432/db',
+                                         '127.0.0.1:6432')
+        assert out == 'postgresql://127.0.0.1:6432/db'
+
+    def test_rewrite_no_explicit_port(self):
+        out = db_utils._rewrite_hostport('postgresql://u:p@host/db',
+                                         '127.0.0.1:6432')
+        assert out == 'postgresql://u:p@127.0.0.1:6432/db'
+
+    def test_rewrite_non_postgres_is_noop(self):
+        uri = 'sqlite:////var/lib/sky/state.db'
+        assert db_utils._rewrite_hostport(uri, '127.0.0.1:6432') == uri
+
+    def test_resolve_none_when_not_server(self, monkeypatch):
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        assert db_utils._resolve_conn_string(direct=False) is None
+        assert db_utils._resolve_conn_string(direct=True) is None
+
+    def test_resolve_direct_when_no_pooler(self, monkeypatch):
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        assert db_utils._resolve_conn_string(
+            direct=False) == 'postgresql://u:p@h:5432/db'
+
+    def test_resolve_rewrites_hostport(self, monkeypatch):
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        assert db_utils._resolve_conn_string(
+            direct=False) == 'postgresql://u:p@127.0.0.1:6432/db'
+        # direct always bypasses the pooler.
+        assert db_utils._resolve_conn_string(
+            direct=True) == 'postgresql://u:p@h:5432/db'
+
+    def test_resolve_full_override_wins(self, monkeypatch):
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_CONNECTION_URI',
+                           'postgresql://u:p@pooler:6432/db')
+        assert db_utils._resolve_conn_string(
+            direct=False) == 'postgresql://u:p@pooler:6432/db'

--- a/tests/unit_tests/test_sky/utils/test_locks.py
+++ b/tests/unit_tests/test_sky/utils/test_locks.py
@@ -429,28 +429,30 @@ class TestPostgresLock:
         connection.commit.assert_not_called()
         connection.close.assert_called_once()
 
-    @mock.patch.object(global_user_state, 'initialize_and_get_db')
-    def test_postgres_lock_get_connection_success(self, mock_init_db):
-        """Test successful database connection."""
+    @mock.patch.object(db_utils, 'get_engine')
+    def test_postgres_lock_get_connection_success(self, mock_get_engine):
+        """Test successful database connection via a direct engine."""
         mock_engine = mock.Mock()
         mock_engine.dialect.name = db_utils.SQLAlchemyDialect.POSTGRESQL.value
         mock_connection = mock.Mock()
         mock_engine.raw_connection.return_value = mock_connection
-        mock_init_db.return_value = mock_engine
+        mock_get_engine.return_value = mock_engine
 
         lock = locks.PostgresLock('test_lock')
         result = lock._get_connection()
 
         assert result is mock_connection
-        mock_init_db.assert_called_once()
+        mock_get_engine.assert_called_once()
+        # The lock must bypass any configured pooler.
+        assert mock_get_engine.call_args.kwargs.get('direct') is True
         mock_engine.raw_connection.assert_called_once()
 
-    @mock.patch.object(global_user_state, 'initialize_and_get_db')
-    def test_postgres_lock_get_connection_wrong_dialect(self, mock_init_db):
+    @mock.patch.object(db_utils, 'get_engine')
+    def test_postgres_lock_get_connection_wrong_dialect(self, mock_get_engine):
         """Test database connection with wrong dialect."""
         mock_engine = mock.Mock()
         mock_engine.dialect.name = 'sqlite'
-        mock_init_db.return_value = mock_engine
+        mock_get_engine.return_value = mock_engine
 
         lock = locks.PostgresLock('test_lock')
 
@@ -610,14 +612,14 @@ class TestPostgresLockAutocommit:
     for the whole lock hold, leaving the session 'idle in transaction'.
     """
 
-    @mock.patch.object(global_user_state, 'initialize_and_get_db')
-    def test_get_connection_enables_autocommit(self, mock_init_db):
+    @mock.patch.object(db_utils, 'get_engine')
+    def test_get_connection_enables_autocommit(self, mock_get_engine):
         """_get_connection puts the borrowed connection in autocommit."""
         mock_engine = mock.Mock()
         mock_engine.dialect.name = db_utils.SQLAlchemyDialect.POSTGRESQL.value
         mock_connection = mock.Mock()
         mock_engine.raw_connection.return_value = mock_connection
-        mock_init_db.return_value = mock_engine
+        mock_get_engine.return_value = mock_engine
 
         lock = locks.PostgresLock('test_lock')
         result = lock._get_connection()


### PR DESCRIPTION
## Summary

Adds **opt-in** support for reaching the server state database through a transaction-mode connection pooler (e.g. PgBouncer). On Postgres, every long-lived server process holds a resident `QueuePool` connection to the state DB; behind a pooler these many per-process connections collapse onto a small shared backend pool.

Two new env vars, both **unset by default** (no behavior change):

- `SKYPILOT_DB_POOL_HOSTPORT` — rewrite only the `host:port` of `SKYPILOT_DB_CONNECTION_URI`, preserving `user`/`password`/`dbname`/query params. Intended for an in-pod pooler sidecar so no DB credentials need re-plumbing.
- `SKYPILOT_DB_POOL_CONNECTION_URI` — a full replacement URI (escape hatch); wins over the host:port rewrite.

What stays on a **direct** connection (unsafe through a transaction-mode pooler):

- **Session-scoped advisory locks** (`PostgresLock`): they hold one connection across the whole lock lifetime, so the backend must not change between statements. `PostgresLock` now borrows from `get_engine(..., direct=True)`.
- **Schema creation / migrations**: Alembic's `autocommit_block` relies on session-scoped `COMMIT`/`BEGIN` control. `DatabaseManager` runs `create_table_fn` on the direct engine and returns the (possibly pooled) engine for runtime queries. Tables live in the same physical DB, so the pooled runtime engine sees them.

Also disables asyncpg's prepared-statement cache (`statement_cache_size=0`) so the async engine is safe behind a transaction-mode pooler, where a statement prepared on one backend connection may not exist on the next. Harmless on a direct connection.

When no pooler is configured, `direct` and non-direct resolve to the same connection string and thus the same cached engine, so existing deployments are unaffected.

## Tested

- Unit tests for `_rewrite_hostport` / `_resolve_conn_string` precedence, `get_engine(direct=...)` engine separation and caching, and `PostgresLock` using a direct engine.
- `pytest tests/unit_tests/test_sky/utils/test_db_utils.py tests/unit_tests/test_sky/utils/test_locks.py` — all pass.