### PR TITLE
[Test] Pin stale-pod-cleanup kubectl to the cluster's landed context

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3143,26 +3143,33 @@ def test_kubernetes_stale_pod_cleanup():
         'kubernetes_stale_pod_cleanup',
         [
             # Launch a cluster with memory limits (2GB is enough to boot
-            # but tight enough to OOM on a large allocation).
+            # but tight enough to OOM on a large allocation). It may land on
+            # any context.
             f'sky launch -y -c {name} --infra kubernetes --cpus 1 --memory 2 '
             f'--config kubernetes.set_pod_resource_limits=true',
+            # Pin the cloud-cmd helper to the context the target landed on so
+            # its in-cluster kubectl can see the target's pod.
+            smoke_tests_utils.resolve_k8s_context_cmd(name),
+            smoke_tests_utils.launch_cloud_cmd_on_landed_context(name),
             # OOM the pod by writing 4GB to tmpfs, exceeding the 2GB limit.
             f'sky exec {name} -- dd if=/dev/zero of=/dev/shm/oom bs=1M count=4096 || true',
             # Wait for the pod to enter Failed phase.
-            f'for i in $(seq 1 30); do '
-            f'phase=$(kubectl get pod {head_pod} '
-            f'-o jsonpath=\'{{.status.phase}}\'); '
-            f'echo "attempt $i: phase=$phase"; '
-            f'if [ "$phase" = "Failed" ]; then break; fi; '
-            f'sleep 2; done && '
-            f'test "$phase" = "Failed"',
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name, f'for i in $(seq 1 30); do '
+                f'phase=$(kubectl get pod {head_pod} '
+                f'-o jsonpath=\'{{.status.phase}}\'); '
+                f'echo "attempt $i: phase=$phase"; '
+                f'if [ "$phase" = "Failed" ]; then break; fi; '
+                f'sleep 2; done && '
+                f'test "$phase" = "Failed"'),
             # Refresh state and assert INIT before restart.
             f'sky status {name} -r | grep INIT',
             # sky start should clean up the Failed pod and succeed.
             f'sky start -y {name}',
         ],
-        f'sky down -y {name}',
-        timeout=10 * 60,
+        f'sky down -y {name}; '
+        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
+        timeout=15 * 60,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Problem

`test_kubernetes_stale_pod_cleanup` waits for the OOMKilled head pod to reach the
`Failed` phase using a **bare `kubectl get pod`**:

```python
phase=$(kubectl get pod {head_pod} -o jsonpath='{.status.phase}')
```

A bare `kubectl` resolves against the test driver's `current-context`. On a
multi-context API server the cluster can land on **any** context, and the
driver's `current-context` is not guaranteed to be the one the cluster landed
on. When it isn't, the poll queries the wrong cluster and every attempt returns:

```
Error from server (NotFound): pods "<cluster>-head" not found
```

The test then fails the final `test "$phase" = "Failed"` after the full
30-attempt wait — even though provisioning and the OOMKill both worked exactly as
intended (the launch logs `Pod is up.` and the `dd` is SIGKILLed with exit 137).

Because the driver's context is fixed for a given test runner, this is
**deterministic, not flaky** — retrying the job reproduces the identical failure.

## Fix

Route the poll through the `cloud-cmd` helper pinned to the context the cluster
landed on, reusing the existing helpers:

- `resolve_k8s_context_cmd(name)` — resolve + persist the landed context
- `launch_cloud_cmd_on_landed_context(name)` — pin the helper to that context
- `run_cloud_cmd_on_cluster(name, ...)` — run the poll with the helper's
  in-cluster `kubectl`

This is the same pattern the surrounding Kubernetes tests in this file already
use (e.g. `test_kubernetes_sigterm_keepalive`,
`test_kubernetes_service_cleanup_on_down`); this test was simply never converted.

The `cloud-cmd` cluster is now torn down as well, and the timeout goes from 10 →
15 min to cover the extra helper launch.

## Single-context lane is unchanged

`run_cloud_cmd_on_cluster` returns the command **verbatim** when the API server
is local, and `launch_cluster_for_cloud_cmd` / `down_cluster_for_cloud_cmd` are
no-ops there. I verified this by rendering the generated command list under both
lanes:

| step | local API server | multi-context / remote API server |
|---|---|---|
| pod poll | bare `kubectl …` (identical to today) | `sky exec <cluster>-cloud-cmd …` after wait-for-`UP`, exit status checked |
| helper launch | `true` | `sky launch … --infra kubernetes/$(cat <landed-context-file>) --async` |
| teardown | `sky down -y <cluster>; true` | also `sky down -y <cluster>-cloud-cmd` |

So the behaviour of the existing single-context run is preserved byte-for-byte,
and only the multi-context case changes.

## Tests

- `yapf`, `isort`, `mypy`, `pylint` clean (pre-commit hooks pass).
- `pytest tests/smoke_tests/test_cluster_job.py::test_kubernetes_stale_pod_cleanup
  --collect-only --kubernetes` collects as
  `test_kubernetes_stale_pod_cleanup@serial_kubernetes`.
- Full e2e run on a multi-context API server: see the smoke-test run linked in a
  comment below.
