### PR TITLE
[Vast] fix wrong instance type provisioned

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -111,23 +111,9 @@ def launch(name: str,
     # `ports` is currently unused. Keep it in the signature for caller
     # compatibility and future use (port-forwarding is handled separately).
     del ports
-    cpu_ram = float(instance_type.split('-')[-1]) / 1024
-    gpu_name = instance_type.split('-')[1].replace('_', ' ')
-    num_gpus = int(instance_type.split('-')[0].replace('x', ''))
 
-    query = [
-        'chunked=true',
-        'georegion=true',
-        f'geolocation="{region[-2:]}"',
-        f'disk_space>={disk_size}',
-        f'num_gpus={num_gpus}',
-        f'gpu_name="{gpu_name}"',
-        f'cpu_ram>="{cpu_ram}"',
-    ]
-    if secure_only:
-        query.append('datacenter=true')
-        query.append('hosting_type>=1')
-    query_str = ' '.join(query)
+    query_str = _create_search_offers_query(instance_type, region, disk_size,
+                                            secure_only)
 
     instance_list = vast.vast().search_offers(query=query_str)
 
@@ -242,6 +228,29 @@ def launch(name: str,
         id=new_instance_contract['new_contract'])
 
     return new_instance['id']
+
+
+def _create_search_offers_query(instance_type: str, region: str, disk_size: int,
+                                secure_only: bool) -> str:
+    # ref: https://docs.vast.ai/api-reference/search/search-offers
+
+    cpu_ram = float(instance_type.split('-')[-1]) / 1024
+    gpu_name = instance_type.split('-')[1]
+    num_gpus = int(instance_type.split('-')[0].replace('x', ''))
+
+    query = [
+        'chunked=true',
+        'georegion=true',
+        f'geolocation={region[-2:]}',
+        f'disk_space>={disk_size}',
+        f'num_gpus={num_gpus}',
+        f'gpu_name={gpu_name}',
+        f'cpu_ram>={cpu_ram}',
+    ]
+    if secure_only:
+        query.append('datacenter=true')
+
+    return ' '.join(query)
 
 
 def start(instance_id: str) -> None:

--- a/tests/unit_tests/test_vast.py
+++ b/tests/unit_tests/test_vast.py
@@ -1,0 +1,14 @@
+"""Tests for Vast.ai Cloud provider."""
+
+from sky.provision.vast.utils import _create_search_offers_query
+
+
+def test_search_offers_valid_query():
+    got = _create_search_offers_query(instance_type='1x-RTX_5090-32-65536',
+                                      region=', CA, NA',
+                                      disk_size=32,
+                                      secure_only=True)
+
+    assert got == ('chunked=true georegion=true geolocation=NA '
+                   'disk_space>=32 num_gpus=1 gpu_name=RTX_5090 '
+                   'cpu_ram>=64.0 datacenter=true')


### PR DESCRIPTION
Root cause is a format mismatch between the search_offers string that skypilot produces and the string format the string parser in vastai sdk expects.

Fixes #9733

<!-- Describe the changes in this PR -->

Fixes wrong instance being provisioned using compared to what was shown in the preview before the [Y/n] confirmation prompt for the vastai provisioner.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

`pytest --noconftest --override-ini='addopts=' --disable-warnings tests/unit_tests/test_vast.py`

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
  `tests/unit_tests/test_vast.py`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
