### PR TITLE
[k8s] Keep the spinner updating while pods await queue admission

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -797,6 +797,18 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
                     nop_if_duplicate=True,
                 )
             last_gated_pod_names = gated_pod_names
+            # Keep refreshing the spinner while gated. The message set above
+            # is written once, on entering the gated state; the admission
+            # wait that follows can last hours, and it is exactly the phase
+            # where live feedback (e.g. the workload's position in the
+            # queue) is most useful. Skipping the per-poll update would
+            # freeze the spinner on that static message for the whole wait.
+            _update_spinner_message(iteration=iteration,
+                                    pods=pods,
+                                    context=context,
+                                    namespace=namespace,
+                                    cluster_name_on_cloud=cluster_name_on_cloud,
+                                    cluster_name=cluster_name)
             iteration += 1
             time.sleep(1)
             continue

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1834,6 +1834,41 @@ class TestWaitForPodsToScheduleQueueGating:
         ]
         assert len(queue_events) == 1
 
+    def test_spinner_message_updates_while_gated(self, monkeypatch):
+        """The per-poll spinner update must keep running while pods are
+        gated. The gated branch sets a status message once, on entry; the
+        admission wait after it can last hours, so skipping the per-poll
+        update would freeze the spinner on that static message for the
+        whole queue wait."""
+        cluster = 'my-cluster'
+        gated = self._add_gate(self._make_pending_pod('pod-0', cluster))
+        scheduled = self._make_pending_pod('pod-0', cluster)
+        scheduled.status.phase = 'Running'
+        clock, _, _ = self._setup(monkeypatch,
+                                  pod_timeline=[(0.0, gated),
+                                                (30.0, scheduled)])
+        update_spinner = mock.MagicMock()
+        monkeypatch.setattr(instance, '_update_spinner_message', update_spinner)
+
+        node = self._make_node('pod-0', cluster)
+        import datetime  # pylint: disable=import-outside-toplevel
+
+        instance._wait_for_pods_to_schedule(
+            namespace='ns',
+            context='test-context',
+            new_nodes=[node],
+            timeout=5,
+            cluster_name='cn',
+            create_pods_start=datetime.datetime.now(datetime.timezone.utc))
+
+        assert clock.now >= 30.0
+        # Any call at all can only have come from the gated phase: the pod
+        # is Running (hence scheduled) from t=30 on, so the loop returns on
+        # that poll without reaching the post-gate spinner update.
+        assert update_spinner.call_count > 0, (
+            'Expected the spinner to keep updating during the 30s gated '
+            'phase, but _update_spinner_message was never called.')
+
     def test_provision_clock_starts_at_admission(self, monkeypatch):
         """Once pods are admitted (gates removed), provision_timeout applies
         from the admission moment — an unschedulable pod then times out at


### PR DESCRIPTION
## Problem

`_wait_for_pods_to_schedule` gained a scheduling-gate fast-path in #10252: while any expected pod is held by a gate (e.g. Kueue's `kueue.x-k8s.io/admission`), the loop skips scheduling checks and autoscaler detection and `continue`s early.

That `continue` sits ahead of the `_update_spinner_message(...)` call at the bottom of the loop body, so **the per-poll status update is skipped for the entire queue-admission phase**.

The gated branch sets a message exactly once, on entry:

```python
rich_utils.force_update_status(
    ux_utils.spinner_message('Launching (waiting for queue admission)',
                             cluster_name=cluster_name))
```

and the wait that follows can be long — it is bounded by `kubernetes.kueue.admission_timeout`, which defaults to 24h. So the spinner freezes on that static line for the whole wait, precisely during the phase where live feedback (e.g. the workload's position in the queue) is most useful to a user staring at a launch that is not progressing.

## Fix

Call `_update_spinner_message` from the gated branch too.

Scheduling checks and autoscaler detection stay skipped — those are genuinely meaningless for a gated pod, which is invisible to `kube-scheduler` — but the per-poll status update is not.

The upstream `_update_spinner_message` is a no-op `pass`, so this is behaviour-neutral for a stock launch; it restores the per-poll update point that the rest of the wait loop already relies on.

## Test

Adds `test_spinner_message_updates_while_gated` to the existing `TestWaitForPodsToScheduleQueueGating` class: a pod gated for 30s, then admitted and Running. Asserts the hook is called during the gated phase.

Because the pod is scheduled from `t=30` on, the loop returns on that poll without reaching the post-gate spinner update — so any call at all can only have come from the gated phase.

Verified it catches the regression:

```
# without the fix
E   AssertionError: Expected the spinner to keep updating during the 30s gated
    phase, but _update_spinner_message was never called.
1 failed, 3 passed

# with the fix
4 passed
```

## Checks

- `pytest tests/unit_tests/kubernetes/test_provision.py::TestWaitForPodsToScheduleQueueGating` — 4 passed
- `yapf` clean, `pylint` 10.00/10, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
