### PR TITLE
[Slurm] Add SlurmClient.get_all_jobs_info() for per-node job attribution

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -68,6 +68,8 @@ class JobGresInfo(NamedTuple):
     """Per-node GRES allocation of a running job from squeue."""
     job_id: str
     job_name: str
+    # The user who submitted the job (squeue %u).
+    user: str
     # The job's per-node GRES request (squeue %b, TRES_PER_NODE), e.g.
     # 'gres/gpu:h100:4'.
     gres_str: str
@@ -402,7 +404,7 @@ class SlurmClient:
         return nodes_to_gres
 
     def get_all_jobs_info(self) -> Dict[str, List[JobGresInfo]]:
-        """Get id, name and GRES of all running jobs, grouped by node.
+        """Get id, name, user and GRES of all running jobs, grouped by node.
 
         Like ``get_all_jobs_gres`` but keeps the job identity, so callers can
         attribute per-node GPU allocations to specific jobs. A multi-node job
@@ -415,7 +417,7 @@ class SlurmClient:
             node.
         """
         cmd = (f'squeue -h --states=running,completing '
-               f'-o "%i{SEP}%j{SEP}%N{SEP}%b"')
+               f'-o "%i{SEP}%j{SEP}%u{SEP}%N{SEP}%b"')
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(rc,
                                            cmd,
@@ -429,15 +431,16 @@ class SlurmClient:
             if not line:
                 continue
             parts = line.split(SEP)
-            if len(parts) != 4:
+            if len(parts) != 5:
                 # We should never reach here, but just in case.
                 continue
-            job_id, job_name, nodelist_str, gres_str = parts
+            job_id, job_name, user, nodelist_str, gres_str = parts
             if not gres_str or gres_str == 'N/A':
                 continue
 
             job_info = JobGresInfo(job_id=job_id,
                                    job_name=job_name,
+                                   user=user,
                                    gres_str=gres_str)
             for node in hostlist.expand_hostlist(nodelist_str):
                 nodes_to_jobs.setdefault(node, []).append(job_info)

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -64,6 +64,15 @@ class NodeInfo(NamedTuple):
     partition: str
 
 
+class JobGresInfo(NamedTuple):
+    """Per-node GRES allocation of a running job from squeue."""
+    job_id: str
+    job_name: str
+    # The job's per-node GRES request (squeue %b, TRES_PER_NODE), e.g.
+    # 'gres/gpu:h100:4'.
+    gres_str: str
+
+
 def _parse_maxtime(line: str) -> Optional[int]:
     """Parse the maximum time a job can run from the scontrol output."""
     maxtime_match = _MAXTIME_REGEX.search(line)
@@ -391,6 +400,49 @@ class SlurmClient:
                 nodes_to_gres.setdefault(node, []).append(gres_str)
 
         return nodes_to_gres
+
+    def get_all_jobs_info(self) -> Dict[str, List[JobGresInfo]]:
+        """Get id, name and GRES of all running jobs, grouped by node.
+
+        Like ``get_all_jobs_gres`` but keeps the job identity, so callers can
+        attribute per-node GPU allocations to specific jobs. A multi-node job
+        appears in the list of every node it runs on, each time with its
+        per-node GRES request (squeue's ``%b``, TRES_PER_NODE). Jobs without
+        GRES (``%b`` empty or ``N/A``) are skipped.
+
+        Returns:
+            Dict mapping node_name -> list of JobGresInfo for jobs on that
+            node.
+        """
+        cmd = (f'squeue -h --states=running,completing '
+               f'-o "%i{SEP}%j{SEP}%N{SEP}%b"')
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        subprocess_utils.handle_returncode(rc,
+                                           cmd,
+                                           'Failed to get all jobs info.',
+                                           stderr=f'{stdout}\n{stderr}',
+                                           stream_logs=False)
+
+        nodes_to_jobs: Dict[str, List[JobGresInfo]] = {}
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(SEP)
+            if len(parts) != 4:
+                # We should never reach here, but just in case.
+                continue
+            job_id, job_name, nodelist_str, gres_str = parts
+            if not gres_str or gres_str == 'N/A':
+                continue
+
+            job_info = JobGresInfo(job_id=job_id,
+                                   job_name=job_name,
+                                   gres_str=gres_str)
+            for node in hostlist.expand_hostlist(nodelist_str):
+                nodes_to_jobs.setdefault(node, []).append(job_info)
+
+        return nodes_to_jobs
 
     def get_job_state(self, job_id: str) -> Optional[str]:
         """Get the state of a Slurm job.

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -397,9 +397,12 @@ class TestGetAllJobsInfo:
         )
 
         squeue_output = (
-            f'101{slurm.SEP}train a{slurm.SEP}node01{slurm.SEP}gpu:h100:4\n'
-            f'102{slurm.SEP}cpu-only{slurm.SEP}node01{slurm.SEP}N/A\n'
-            f'103{slurm.SEP}pretrain{slurm.SEP}node[02-03]{slurm.SEP}gpu:h100:2\n'
+            f'101{slurm.SEP}train a{slurm.SEP}alice{slurm.SEP}node01'
+            f'{slurm.SEP}gpu:h100:4\n'
+            f'102{slurm.SEP}cpu-only{slurm.SEP}bob{slurm.SEP}node01'
+            f'{slurm.SEP}N/A\n'
+            f'103{slurm.SEP}pretrain{slurm.SEP}bob{slurm.SEP}node[02-03]'
+            f'{slurm.SEP}gpu:h100:2\n'
             f'malformed line without separators\n')
 
         with mock.patch.object(client._runner, 'run') as mock_run:
@@ -409,7 +412,7 @@ class TestGetAllJobsInfo:
 
             mock_run.assert_called_once_with(
                 f'squeue -h --states=running,completing '
-                f'-o "%i{slurm.SEP}%j{slurm.SEP}%N{slurm.SEP}%b"',
+                f'-o "%i{slurm.SEP}%j{slurm.SEP}%u{slurm.SEP}%N{slurm.SEP}%b"',
                 require_outputs=True,
                 separate_stderr=True,
                 stream_logs=False,
@@ -420,6 +423,7 @@ class TestGetAllJobsInfo:
             assert result['node01'] == [
                 slurm.JobGresInfo(job_id='101',
                                   job_name='train a',
+                                  user='alice',
                                   gres_str='gpu:h100:4')
             ]
             # Multi-node job 103 appears on both nodes with the same
@@ -428,6 +432,7 @@ class TestGetAllJobsInfo:
                 assert result[node] == [
                     slurm.JobGresInfo(job_id='103',
                                       job_name='pretrain',
+                                      user='bob',
                                       gres_str='gpu:h100:2')
                 ]
 

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -384,6 +384,68 @@ class TestGetAllJobsGres:
             assert result['node06'] == ['gpu:h100:2']
 
 
+class TestGetAllJobsInfo:
+    """Test SlurmClient.get_all_jobs_info()."""
+
+    def test_get_all_jobs_info_expansion(self):
+        """Multi-node jobs fan out to every node, keeping job identity."""
+        client = slurm.SlurmClient(
+            ssh_host='localhost',
+            ssh_port=22,
+            ssh_user='root',
+            ssh_key=None,
+        )
+
+        squeue_output = (
+            f'101{slurm.SEP}train a{slurm.SEP}node01{slurm.SEP}gpu:h100:4\n'
+            f'102{slurm.SEP}cpu-only{slurm.SEP}node01{slurm.SEP}N/A\n'
+            f'103{slurm.SEP}pretrain{slurm.SEP}node[02-03]{slurm.SEP}gpu:h100:2\n'
+            f'malformed line without separators\n')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, squeue_output, '')
+
+            result = client.get_all_jobs_info()
+
+            mock_run.assert_called_once_with(
+                f'squeue -h --states=running,completing '
+                f'-o "%i{slurm.SEP}%j{slurm.SEP}%N{slurm.SEP}%b"',
+                require_outputs=True,
+                separate_stderr=True,
+                stream_logs=False,
+            )
+
+            # Job 102 (no GRES) and the malformed line are skipped.
+            assert set(result.keys()) == {'node01', 'node02', 'node03'}
+            assert result['node01'] == [
+                slurm.JobGresInfo(job_id='101',
+                                  job_name='train a',
+                                  gres_str='gpu:h100:4')
+            ]
+            # Multi-node job 103 appears on both nodes with the same
+            # per-node GRES.
+            for node in ('node02', 'node03'):
+                assert result[node] == [
+                    slurm.JobGresInfo(job_id='103',
+                                      job_name='pretrain',
+                                      gres_str='gpu:h100:2')
+                ]
+
+    def test_get_all_jobs_info_empty_queue(self):
+        """Empty squeue output yields an empty mapping."""
+        client = slurm.SlurmClient(
+            ssh_host='localhost',
+            ssh_port=22,
+            ssh_user='root',
+            ssh_key=None,
+        )
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, '', '')
+
+            assert client.get_all_jobs_info() == {}
+
+
 class TestParseMaxtime:
     """Test _parse_maxtime()."""
 


### PR DESCRIPTION
Adds a public `SlurmClient.get_all_jobs_info()` next to `get_all_jobs_gres()`. Same single `squeue -h --states=running,completing` call for the whole cluster, but keeps the job identity (`%i` job id, `%j` job name, `%u` submitting user) alongside the nodelist (`%N`) and per-node GRES (`%b`) instead of discarding it:

```python
{
  'node01': [JobGresInfo(job_id='101', job_name='train a', user='alice', gres_str='gpu:h100:4')],
  'node02': [JobGresInfo(job_id='103', job_name='pretrain', user='bob', gres_str='gpu:h100:2')],
  'node03': [JobGresInfo(job_id='103', job_name='pretrain', user='bob', gres_str='gpu:h100:2')],
}
```

This lets callers attribute per-node GPU allocations to specific jobs (e.g. showing which job occupies how many GPUs on each node). Multi-node jobs fan out to every node in their expanded nodelist with the per-node GRES request; jobs without GRES (`%b` empty/`N/A`) are skipped — both behaviors matching `get_all_jobs_gres`.

Note: like `get_all_jobs_gres`, this inherits `%b` (TRES_PER_NODE) semantics — accurate for `--gres`/`--gpus-per-node` style requests; jobs submitted with a job-total `--gpus=N` report no `%b` and are skipped. Consolidating on `scontrol` (per the TODO discussed in #10293) would lift that later.

## Tests

- `TestGetAllJobsInfo` in `tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py`: multi-node fan-out with identity preserved, N/A-GRES and malformed-line skipping, job names with spaces, empty queue.
- `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py` → 41 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
