### PR TITLE
[Slurm] Use `--json` output in `get_job_nodes()`

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -1,10 +1,11 @@
 """Slurm adaptor for SkyPilot."""
 
 import ipaddress
+import json
 import logging
 import re
 import shlex
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from sky.adaptors import common
 from sky.utils import command_runner
@@ -36,6 +37,20 @@ hostlist = common.LazyImport('hostlist',
                              import_error_message=_IMPORT_ERROR_MESSAGE)
 
 _UNRESOLVED_HOSTNAME_MARKER = 'UNRESOLVED'
+
+# getopt marker in stderr when the Slurm CLI does not know an option, e.g. on
+# versions predating `--json` output.
+_UNRECOGNIZED_OPTION_MARKER = 'unrecognized option'
+
+# squeue marker in stderr when slurmctld no longer knows the job ID.
+_INVALID_JOB_ID_MARKER = 'invalid job id'
+
+# How much of a malformed JSON payload to include in error messages.
+_JSON_SNIPPET_LEN = 500
+
+
+class _JsonOutputUnsupportedError(Exception):
+    """The Slurm CLI does not support `--json` output."""
 
 
 class SlurmPartition(NamedTuple):
@@ -165,6 +180,10 @@ class SlurmClient:
         self.ssh_key = ssh_key
         self.ssh_proxy_command = ssh_proxy_command
         self.ssh_proxy_jump = ssh_proxy_jump
+
+        # Whether the cluster's Slurm CLI supports `--json` output. None until
+        # the first command that tries it.
+        self._json_output_supported: Optional[bool] = None
 
         self._runner: command_runner.CommandRunner
 
@@ -549,25 +568,183 @@ class SlurmClient:
             return False
         return bool(stdout.strip())
 
-    @timeline.event
-    def get_job_nodes(self, job_id: str) -> Tuple[List[str], List[str]]:
-        """Get the list of nodes and their IPs for a given job ID.
+    def _resolve_hostnames(
+            self, nodes_to_resolve: List[Tuple[str, str]]) -> Dict[str, str]:
+        """Resolve node addresses that are hostnames into IPs.
 
-        The ordering is guaranteed to be stable for the lifetime of the job.
+        The resolution runs on the login node, where the cluster-internal DNS
+        is reachable.
 
         Args:
-            job_id: The Slurm job ID.
+            nodes_to_resolve: List of (node name, hostname) pairs.
 
         Returns:
-            A tuple of (nodes, node_ips) where nodes is a list of node names
-            and node_ips is a list of corresponding IP addresses.
+            A dictionary mapping node name to the resolved IP.
         """
+        hostnames = [h for _, h in nodes_to_resolve]
+        # The output of `getent ahostsv4` is as follows:
+        # 10.0.0.0     STREAM worker-0
+        # 10.0.0.0     DGRAM
+        # 10.0.0.0     RAW
+        resolve_ip_cmd = (
+            f'for h in {" ".join(hostnames)}; do '
+            f'ip=$(getent ahostsv4 "$h" | head -1 | awk \'{{print $1}}\'); '
+            f'if [ -n "$ip" ]; then echo "$h $ip"; '
+            f'else echo "$h {_UNRESOLVED_HOSTNAME_MARKER}"; fi; '
+            f'done')
+        rc, resolve_stdout, stderr = self._run_slurm_cmd(resolve_ip_cmd)
+        subprocess_utils.handle_returncode(
+            rc,
+            resolve_ip_cmd,
+            f'Failed to resolve hostnames for: {hostnames}',
+            stderr=f'{resolve_stdout}\n{stderr}',
+            stream_logs=False)
 
+        hostname_to_ip = {}
+        unresolved = []
+        for line in resolve_stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                hostname = parts[0]
+                ip = parts[1]
+                if ip == _UNRESOLVED_HOSTNAME_MARKER:
+                    unresolved.append(hostname)
+                else:
+                    hostname_to_ip[hostname] = ip
+
+        if unresolved:
+            raise RuntimeError(f'Failed to resolve hostnames for: {unresolved}')
+
+        node_to_ip = {}
+        for node_name, hostname in nodes_to_resolve:
+            if hostname not in hostname_to_ip:
+                raise RuntimeError(
+                    f'Failed to resolve {hostname} for node {node_name}')
+            node_to_ip[node_name] = hostname_to_ip[hostname]
+        return node_to_ip
+
+    def _run_slurm_json_cmd(self, cmd: str) -> Tuple[int, str, str]:
+        """Run a Slurm command with `--json`.
+
+        Raises:
+            _JsonOutputUnsupportedError: The Slurm CLI does not know the
+                `--json` option.
+        """
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        if rc != 0 and _UNRECOGNIZED_OPTION_MARKER in stderr:
+            raise _JsonOutputUnsupportedError(
+                f'{cmd!r} failed: {stderr.strip()}')
+        return rc, stdout, stderr
+
+    def _load_slurm_json(self, cmd: str, stdout: str) -> Dict[str, Any]:
+        """Parse the JSON payload of a Slurm `--json` command."""
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f'Failed to parse the JSON output of {cmd!r}: {e}. '
+                f'Output: {stdout[:_JSON_SNIPPET_LEN]!r}') from e
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f'Unexpected JSON output of {cmd!r}: expected an object, got '
+                f'{type(payload).__name__}. '
+                f'Output: {stdout[:_JSON_SNIPPET_LEN]!r}')
+        return payload
+
+    def _get_json_field(self, cmd: str, payload: Dict[str, Any],
+                        field: str) -> Any:
+        """Read a field of a Slurm JSON payload, raising if it is absent."""
+        if field not in payload:
+            raise RuntimeError(
+                f'Unexpected JSON output of {cmd!r}: no {field!r} field. '
+                f'Output: {json.dumps(payload)[:_JSON_SNIPPET_LEN]!r}')
+        return payload[field]
+
+    def _get_job_nodes_json(self, job_id: str) -> Tuple[List[str], List[str]]:
+        """get_job_nodes() implementation using Slurm's `--json` output.
+
+        `squeue --json` ships since Slurm 21.08 and `scontrol --json` since
+        23.02, so 23.02 is the floor for this path. Older versions reject the
+        option, and get_job_nodes() falls back to parsing the text output.
+        """
+        no_nodes_error = (
+            f'No nodes found for job {job_id}. '
+            f'The job may have terminated or the output was empty.')
+
+        squeue_cmd = f'squeue --jobs {job_id} --json'
+        rc, stdout, stderr = self._run_slurm_json_cmd(squeue_cmd)
+        if rc != 0 and _INVALID_JOB_ID_MARKER in stderr.lower():
+            # slurmctld no longer knows about the job.
+            raise RuntimeError(no_nodes_error)
+        subprocess_utils.handle_returncode(
+            rc,
+            squeue_cmd,
+            f'Failed to get nodes for job {job_id}.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+
+        payload = self._load_slurm_json(squeue_cmd, stdout)
+        jobs = self._get_json_field(squeue_cmd, payload, 'jobs')
+        if not jobs:
+            raise RuntimeError(no_nodes_error)
+        # A compact Slurm hostlist expression, e.g. 'ml-16-node-[001-002]'.
+        # Empty while the job is still pending.
+        nodelist = self._get_json_field(squeue_cmd, jobs[0], 'nodes')
+        if not nodelist:
+            raise RuntimeError(no_nodes_error)
+
+        # Expand client-side so the ordering is ours, independent of the order
+        # scontrol returns the nodes in.
+        nodes = hostlist.expand_hostlist(nodelist)
+
+        # scontrol takes the hostlist expression directly, so no per-node
+        # round-trip is needed.
+        scontrol_cmd = f'scontrol show node {shlex.quote(nodelist)} --json'
+        rc, stdout, stderr = self._run_slurm_json_cmd(scontrol_cmd)
+        subprocess_utils.handle_returncode(
+            rc,
+            scontrol_cmd,
+            f'Failed to get node addresses for job {job_id}.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+
+        payload = self._load_slurm_json(scontrol_cmd, stdout)
+        node_addrs: Dict[str, str] = {}
+        for node in self._get_json_field(scontrol_cmd, payload, 'nodes'):
+            name = self._get_json_field(scontrol_cmd, node, 'name')
+            node_addrs[name] = self._get_json_field(scontrol_cmd, node,
+                                                    'address')
+
+        # scontrol silently omits nodes it does not know, so a node that was
+        # removed from the cluster would otherwise disappear from the result.
+        missing = [node for node in nodes if node not in node_addrs]
+        if missing:
+            raise RuntimeError(
+                f'Slurm did not report an address for the following nodes of '
+                f'job {job_id}: {missing}')
+
+        node_info: Dict[str, str] = {}
+        nodes_to_resolve: List[Tuple[str, str]] = []
+        for node in nodes:
+            address = node_addrs[node]
+            try:
+                ipaddress.ip_address(address)
+                node_info[node] = address  # Already an IP
+            except ValueError:
+                nodes_to_resolve.append((node, address))
+
+        if nodes_to_resolve:
+            node_info.update(self._resolve_hostnames(nodes_to_resolve))
+
+        return nodes, [node_info[node] for node in nodes]
+
+    def _get_job_nodes_text(self, job_id: str) -> Tuple[List[str], List[str]]:
+        """get_job_nodes() implementation for Slurm versions without `--json`.
+        """
         cmd = (
             # Use scontrol show hostnames to expand both compact Slurm
             # hostlist notation (e.g. ml-16-node-[001-002]) and
             # comma-separated nodes into individual node names.
-            # TODO(kevin): Use json output for more robust parsing.
             f'nodelist=$(squeue -h --jobs {job_id} -o "%N"); '
             f'scontrol show hostnames $nodelist | while read -r node; do '
             f'node_addr=$(scontrol show node=$node | grep NodeAddr= | '
@@ -600,46 +777,7 @@ class SlurmClient:
                         nodes_to_resolve.append((node_name, node_addr))
 
         if nodes_to_resolve:
-            hostnames = [h for _, h in nodes_to_resolve]
-            # The output of `getent ahostsv4` is as follows:
-            # 10.0.0.0     STREAM worker-0
-            # 10.0.0.0     DGRAM
-            # 10.0.0.0     RAW
-            resolve_ip_cmd = (
-                f'for h in {" ".join(hostnames)}; do '
-                f'ip=$(getent ahostsv4 "$h" | head -1 | awk \'{{print $1}}\'); '
-                f'if [ -n "$ip" ]; then echo "$h $ip"; '
-                f'else echo "$h {_UNRESOLVED_HOSTNAME_MARKER}"; fi; '
-                f'done')
-            rc, resolve_stdout, stderr = self._run_slurm_cmd(resolve_ip_cmd)
-            subprocess_utils.handle_returncode(
-                rc,
-                resolve_ip_cmd,
-                f'Failed to resolve hostnames for: {hostnames}',
-                stderr=f'{resolve_stdout}\n{stderr}',
-                stream_logs=False)
-
-            hostname_to_ip = {}
-            unresolved = []
-            for line in resolve_stdout.strip().splitlines():
-                parts = line.split()
-                if len(parts) >= 2:
-                    hostname = parts[0]
-                    ip = parts[1]
-                    if ip == _UNRESOLVED_HOSTNAME_MARKER:
-                        unresolved.append(hostname)
-                    else:
-                        hostname_to_ip[hostname] = ip
-
-            if unresolved:
-                raise RuntimeError(
-                    f'Failed to resolve hostnames for: {unresolved}')
-
-            for node_name, hostname in nodes_to_resolve:
-                if hostname not in hostname_to_ip:
-                    raise RuntimeError(
-                        f'Failed to resolve {hostname} for node {node_name}')
-                node_info[node_name] = hostname_to_ip[hostname]
+            node_info.update(self._resolve_hostnames(nodes_to_resolve))
 
         nodes = list(node_info.keys())
         node_ips = [node_info[node] for node in nodes]
@@ -651,6 +789,30 @@ class SlurmClient:
                ), f'Number of nodes and IPs do not match: {nodes} != {node_ips}'
 
         return nodes, node_ips
+
+    @timeline.event
+    def get_job_nodes(self, job_id: str) -> Tuple[List[str], List[str]]:
+        """Get the list of nodes and their IPs for a given job ID.
+
+        The ordering is guaranteed to be stable for the lifetime of the job.
+
+        Args:
+            job_id: The Slurm job ID.
+
+        Returns:
+            A tuple of (nodes, node_ips) where nodes is a list of node names
+            and node_ips is a list of corresponding IP addresses.
+        """
+        if self._json_output_supported is not False:
+            try:
+                nodes, node_ips = self._get_job_nodes_json(job_id)
+                self._json_output_supported = True
+                return nodes, node_ips
+            except _JsonOutputUnsupportedError as e:
+                logger.debug(f'Slurm does not support --json output ({e}), '
+                             'falling back to parsing the text output.')
+                self._json_output_supported = False
+        return self._get_job_nodes_text(job_id)
 
     def submit_job(
         self,

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -1,10 +1,42 @@
 """Unit tests for Slurm adaptor."""
 
+import json
+import os
 import unittest.mock as mock
 
 import pytest
 
 from sky.adaptors import slurm
+
+# Payloads captured from `squeue --jobs <id> --json` and
+# `scontrol show node <hostlist> --json` on a Slurm 25.05.3 cluster
+# (data_parser/v0.0.43), for a running 2-node job. Node names, addresses and
+# user identities are anonymized, and the (unparsed) per-node core allocation
+# of the squeue payload is elided.
+_TESTDATA_DIR = os.path.join(os.path.dirname(__file__), 'testdata', 'slurm')
+
+
+def _load_fixture(name: str):
+    with open(os.path.join(_TESTDATA_DIR, name), 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def _squeue_json(**overrides) -> str:
+    """The squeue fixture, with fields of the single job overridden."""
+    payload = _load_fixture('squeue_jobs.json')
+    payload['jobs'][0].update(overrides)
+    return json.dumps(payload)
+
+
+def _scontrol_json(addresses=None, names=None) -> str:
+    """The scontrol fixture, with node addresses/names optionally replaced."""
+    payload = _load_fixture('scontrol_nodes.json')
+    for i, node in enumerate(payload['nodes']):
+        if addresses is not None:
+            node['address'] = addresses[i]
+        if names is not None:
+            node['name'] = names[i]
+    return json.dumps(payload)
 
 
 class TestGetPartitions:
@@ -270,17 +302,211 @@ class TestSlurmClientInit:
         assert isinstance(client._runner, command_runner.SSHCommandRunner)
 
 
-class TestGetJobNodes:
-    """Test SlurmClient.get_job_nodes()."""
+def _make_client() -> slurm.SlurmClient:
+    return slurm.SlurmClient(
+        ssh_host='localhost',
+        ssh_port=22,
+        ssh_user='root',
+        ssh_key=None,
+    )
+
+
+class TestGetJobNodesJson:
+    """Test SlurmClient.get_job_nodes() on the `--json` path."""
 
     def test_get_job_nodes_returns_nodes_and_ips(self):
         """Test that get_job_nodes returns parsed nodes and IPs."""
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _squeue_json(), ''),
+                (0, _scontrol_json(), ''),
+            ]
+
+            nodes, node_ips = client.get_job_nodes('935')
+
+            assert nodes == ['node-001', 'node-002']
+            assert node_ips == ['10.0.0.1', '10.0.0.2']
+            assert mock_run.call_count == 2
+            commands = [call[0][0] for call in mock_run.call_args_list]
+            assert commands[0] == 'squeue --jobs 935 --json'
+            # The compact hostlist expression is passed to scontrol as is.
+            assert commands[1] == "scontrol show node 'node-[001-002]' --json"
+            assert client._json_output_supported is True
+
+    def test_get_job_nodes_ordering_independent_of_scontrol(self):
+        """Test that the ordering follows the job's hostlist expansion."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _squeue_json(), ''),
+                # scontrol returns the nodes in the opposite order.
+                (0,
+                 _scontrol_json(names=['node-002', 'node-001'],
+                                addresses=['10.0.0.2', '10.0.0.1']), ''),
+            ]
+
+            nodes, node_ips = client.get_job_nodes('935')
+
+            assert nodes == ['node-001', 'node-002']
+            assert node_ips == ['10.0.0.1', '10.0.0.2']
+
+    def test_get_job_nodes_resolves_hostnames_via_login_node(self):
+        """Test hostnames are resolved via getent ahostsv4 on the login node."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _squeue_json(), ''),
+                # NodeAddr is a hostname instead of an IP.
+                (0, _scontrol_json(addresses=['worker-1', 'worker-10']), ''),
+                # Resolve loop output (hostname ip per line).
+                (0, 'worker-1 10.20.30.1\nworker-10 10.20.30.10', ''),
+            ]
+
+            nodes, node_ips = client.get_job_nodes('935')
+
+            assert nodes == ['node-001', 'node-002']
+            assert node_ips == ['10.20.30.1', '10.20.30.10']
+
+            # Verify a single resolution call was made (not 1 per node).
+            assert mock_run.call_count == 3
+            resolve_call = mock_run.call_args_list[2][0][0]
+            assert 'for h in worker-1 worker-10' in resolve_call
+            assert 'getent ahostsv4' in resolve_call
+
+    def test_get_job_nodes_hostname_resolution_failure(self):
+        """Test error handling when hostname resolution fails."""
+        client = _make_client()
+
+        # One hostname resolves, one fails (getent returns empty)
+        resolve_output = (f'worker-1 10.20.30.1\n'
+                          f'worker-10 {slurm._UNRESOLVED_HOSTNAME_MARKER}')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _squeue_json(), ''),
+                (0, _scontrol_json(addresses=['worker-1', 'worker-10']), ''),
+                (0, resolve_output, ''),
+            ]
+
+            with pytest.raises(RuntimeError,
+                               match='Failed to resolve hostnames'):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_job_terminated(self):
+        """Test that a job that squeue no longer lists raises."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, json.dumps({'jobs': []}), '')
+
+            with pytest.raises(RuntimeError, match='No nodes found for job'):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_invalid_job_id(self):
+        """Test that a job ID slurmctld no longer knows about raises."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (
+                1, '', 'slurm_load_jobs error: Invalid job id specified')
+
+            with pytest.raises(RuntimeError, match='No nodes found for job'):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_pending_job(self):
+        """Test that a pending job (no nodes allocated yet) raises."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0,
+                                     _squeue_json(nodes='',
+                                                  job_state=['PENDING']), '')
+
+            with pytest.raises(RuntimeError, match='No nodes found for job'):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_missing_node_address(self):
+        """Test that a node scontrol does not report raises."""
+        client = _make_client()
+
+        payload = _load_fixture('scontrol_nodes.json')
+        # scontrol silently omits nodes it does not know about.
+        payload['nodes'] = payload['nodes'][:1]
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _squeue_json(), ''),
+                (0, json.dumps(payload), ''),
+            ]
+
+            with pytest.raises(RuntimeError,
+                               match=r'did not report an address.*node-002'):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_malformed_json_does_not_fall_back(self):
+        """Test that malformed JSON raises instead of using the text path."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, 'not json', '')
+
+            with pytest.raises(RuntimeError,
+                               match='Failed to parse the JSON output'):
+                client.get_job_nodes('935')
+
+            assert mock_run.call_count == 1
+            assert client._json_output_supported is None
+
+    def test_get_job_nodes_missing_nodes_field(self):
+        """Test that an unexpected squeue schema raises."""
+        client = _make_client()
+
+        payload = _load_fixture('squeue_jobs.json')
+        del payload['jobs'][0]['nodes']
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, json.dumps(payload), '')
+
+            with pytest.raises(RuntimeError, match="no 'nodes' field"):
+                client.get_job_nodes('935')
+
+    def test_get_job_nodes_falls_back_when_json_unsupported(self):
+        """Test the fallback to the text path on Slurm versions w/o --json."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (1, '', "squeue: unrecognized option '--json'"),
+                (0, 'node1 10.0.0.1\nnode2 10.0.0.2', ''),
+            ]
+
+            nodes, node_ips = client.get_job_nodes('935')
+
+            assert nodes == ['node1', 'node2']
+            assert node_ips == ['10.0.0.1', '10.0.0.2']
+            assert client._json_output_supported is False
+
+        # The verdict is cached: the next call goes straight to the text path.
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, 'node1 10.0.0.1\nnode2 10.0.0.2', '')
+
+            client.get_job_nodes('935')
+
+            assert mock_run.call_count == 1
+            assert '--json' not in mock_run.call_args_list[0][0][0]
+
+
+class TestGetJobNodesText:
+    """Test SlurmClient.get_job_nodes() on the text-parsing fallback path."""
+
+    def test_get_job_nodes_returns_nodes_and_ips(self):
+        """Test that get_job_nodes returns parsed nodes and IPs."""
+        client = _make_client()
+        client._json_output_supported = False
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.return_value = (0, 'node1 10.0.0.1\nnode2 10.0.0.2', '')
@@ -293,12 +519,8 @@ class TestGetJobNodes:
 
     def test_get_job_nodes_resolves_hostnames_via_login_node(self):
         """Test hostnames are resolved via getent ahostsv4 on the login node."""
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+        client = _make_client()
+        client._json_output_supported = False
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.side_effect = [
@@ -322,13 +544,8 @@ class TestGetJobNodes:
 
     def test_get_job_nodes_hostname_resolution_failure(self):
         """Test error handling when hostname resolution fails."""
-
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+        client = _make_client()
+        client._json_output_supported = False
 
         # One hostname resolves, one fails (getent returns empty)
         resolve_output = (f'worker-1 10.20.30.1\n'
@@ -344,6 +561,17 @@ class TestGetJobNodes:
 
             with pytest.raises(RuntimeError,
                                match='Failed to resolve hostnames'):
+                client.get_job_nodes('12345')
+
+    def test_get_job_nodes_no_nodes(self):
+        """Test that empty output raises."""
+        client = _make_client()
+        client._json_output_supported = False
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, '', '')
+
+            with pytest.raises(RuntimeError, match='No nodes found for job'):
                 client.get_job_nodes('12345')
 
 

--- a/tests/unit_tests/test_sky/adaptors/testdata/slurm/scontrol_nodes.json
+++ b/tests/unit_tests/test_sky/adaptors/testdata/slurm/scontrol_nodes.json
@@ -1,0 +1,275 @@
+{
+  "nodes": [
+    {
+      "architecture": "aarch64",
+      "burstbuffer_network_address": "",
+      "boards": 1,
+      "boot_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1777315521
+      },
+      "tls_cert_last_renewal": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "cert_flags": [],
+      "cluster_name": "",
+      "cores": 72,
+      "specialized_cores": 0,
+      "cpu_binding": 0,
+      "cpu_load": 93,
+      "free_mem": {
+        "set": true,
+        "infinite": false,
+        "number": 436979
+      },
+      "cpus": 72,
+      "effective_cpus": 72,
+      "specialized_cpus": "",
+      "energy": {
+        "average_watts": 0,
+        "base_consumed_energy": 0,
+        "consumed_energy": 0,
+        "current_watts": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "previous_consumed_energy": 0,
+        "last_collected": 0
+      },
+      "external_sensors": {},
+      "extra": "",
+      "power": {},
+      "features": [
+        "cu130",
+        "driver-580.126.20",
+        "gh200",
+        "gpu"
+      ],
+      "active_features": [
+        "cu130",
+        "driver-580.126.20",
+        "gh200",
+        "gpu"
+      ],
+      "gpu_spec": "",
+      "gres": "gpu:gh200:1(S:0)",
+      "gres_drained": "N/A",
+      "gres_used": "gpu:gh200:0(IDX:N/A)",
+      "instance_id": "",
+      "instance_type": "",
+      "last_busy": {
+        "set": true,
+        "infinite": false,
+        "number": 1785387712
+      },
+      "mcs_label": "",
+      "specialized_memory": 0,
+      "name": "node-001",
+      "next_state_after_reboot": [
+        "INVALID"
+      ],
+      "address": "10.0.0.1",
+      "hostname": "node-001",
+      "state": [
+        "MIXED",
+        "DYNAMIC_NORM"
+      ],
+      "operating_system": "Linux 6.8.0-1029-nvidia-64k #32-Ubuntu SMP PREEMPT_DYNAMIC Fri May 23 23:55:03 UTC 2025",
+      "owner": "",
+      "partitions": [
+        "all",
+        "gh200"
+      ],
+      "port": 6818,
+      "real_memory": 430080,
+      "res_cores_per_gpu": 0,
+      "comment": "",
+      "reason": "",
+      "reason_changed_at": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "reason_set_by_user": "",
+      "resume_after": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "reservation": "",
+      "alloc_memory": 4096,
+      "alloc_cpus": 1,
+      "alloc_idle_cpus": 71,
+      "tres_used": "cpu=1,mem=4G",
+      "tres_weighted": 0.0,
+      "slurmd_start_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785388382
+      },
+      "sockets": 1,
+      "threads": 1,
+      "temporary_disk": 0,
+      "weight": 1,
+      "topology": "",
+      "tres": "cpu=72,mem=420G,billing=72,gres/gpu=1",
+      "version": "25.05.3"
+    },
+    {
+      "architecture": "aarch64",
+      "burstbuffer_network_address": "",
+      "boards": 1,
+      "boot_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1777315498
+      },
+      "tls_cert_last_renewal": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "cert_flags": [],
+      "cluster_name": "",
+      "cores": 72,
+      "specialized_cores": 0,
+      "cpu_binding": 0,
+      "cpu_load": 83,
+      "free_mem": {
+        "set": true,
+        "infinite": false,
+        "number": 416651
+      },
+      "cpus": 72,
+      "effective_cpus": 72,
+      "specialized_cpus": "",
+      "energy": {
+        "average_watts": 0,
+        "base_consumed_energy": 0,
+        "consumed_energy": 0,
+        "current_watts": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "previous_consumed_energy": 0,
+        "last_collected": 0
+      },
+      "external_sensors": {},
+      "extra": "",
+      "power": {},
+      "features": [
+        "cu130",
+        "driver-580.126.20",
+        "gh200",
+        "gpu"
+      ],
+      "active_features": [
+        "cu130",
+        "driver-580.126.20",
+        "gh200",
+        "gpu"
+      ],
+      "gpu_spec": "",
+      "gres": "gpu:gh200:1(S:0)",
+      "gres_drained": "N/A",
+      "gres_used": "gpu:gh200:0(IDX:N/A)",
+      "instance_id": "",
+      "instance_type": "",
+      "last_busy": {
+        "set": true,
+        "infinite": false,
+        "number": 1785387712
+      },
+      "mcs_label": "",
+      "specialized_memory": 0,
+      "name": "node-002",
+      "next_state_after_reboot": [
+        "INVALID"
+      ],
+      "address": "10.0.0.2",
+      "hostname": "node-002",
+      "state": [
+        "MIXED",
+        "DYNAMIC_NORM"
+      ],
+      "operating_system": "Linux 6.8.0-1029-nvidia-64k #32-Ubuntu SMP PREEMPT_DYNAMIC Fri May 23 23:55:03 UTC 2025",
+      "owner": "",
+      "partitions": [
+        "all",
+        "gh200"
+      ],
+      "port": 6818,
+      "real_memory": 430080,
+      "res_cores_per_gpu": 0,
+      "comment": "",
+      "reason": "",
+      "reason_changed_at": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "reason_set_by_user": "",
+      "resume_after": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "reservation": "",
+      "alloc_memory": 4096,
+      "alloc_cpus": 1,
+      "alloc_idle_cpus": 71,
+      "tres_used": "cpu=1,mem=4G",
+      "tres_weighted": 0.0,
+      "slurmd_start_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785388382
+      },
+      "sockets": 1,
+      "threads": 1,
+      "temporary_disk": 0,
+      "weight": 1,
+      "topology": "",
+      "tres": "cpu=72,mem=420G,billing=72,gres/gpu=1",
+      "version": "25.05.3"
+    }
+  ],
+  "last_update": {
+    "set": true,
+    "infinite": false,
+    "number": 1785439304
+  },
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser/v0.0.43",
+      "accounting_storage": "accounting_storage/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "skypilot",
+      "group": "skypilot"
+    },
+    "command": [
+      "show",
+      "node"
+    ],
+    "slurm": {
+      "version": {
+        "major": "25",
+        "micro": "3",
+        "minor": "05"
+      },
+      "release": "25.05.3",
+      "cluster": "slurm"
+    }
+  },
+  "errors": [],
+  "warnings": []
+}

--- a/tests/unit_tests/test_sky/adaptors/testdata/slurm/squeue_jobs.json
+++ b/tests/unit_tests/test_sky/adaptors/testdata/slurm/squeue_jobs.json
@@ -1,0 +1,416 @@
+{
+  "jobs": [
+    {
+      "account": "default",
+      "accrue_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439204
+      },
+      "admin_comment": "",
+      "allocating_node": "10-0-0-9",
+      "array_job_id": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "array_task_id": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "array_max_tasks": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "array_task_string": "",
+      "association_id": 10,
+      "batch_features": "",
+      "batch_flag": true,
+      "batch_host": "node-001",
+      "flags": [
+        "ACCRUE_COUNT_CLEARED",
+        "JOB_WAS_RUNNING",
+        "USING_DEFAULT_ACCOUNT",
+        "USING_DEFAULT_PARTITION",
+        "USING_DEFAULT_QOS",
+        "USING_DEFAULT_WCKEY",
+        "PARTITION_ASSIGNED"
+      ],
+      "burst_buffer": "",
+      "burst_buffer_state": "",
+      "cluster": "slurm",
+      "cluster_features": "",
+      "command": "",
+      "comment": "",
+      "container": "",
+      "container_id": "",
+      "contiguous": false,
+      "core_spec": 0,
+      "thread_spec": 32766,
+      "cores_per_socket": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "billable_tres": {
+        "set": true,
+        "infinite": false,
+        "number": 2.0
+      },
+      "cpus_per_task": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "cpu_frequency_minimum": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpu_frequency_maximum": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpu_frequency_governor": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpus_per_tres": "",
+      "cron": "",
+      "deadline": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "delay_boot": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "dependency": "",
+      "derived_exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "eligible_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439204
+      },
+      "end_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1816975205
+      },
+      "excluded_nodes": "",
+      "exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "extra": "",
+      "failed_node": "",
+      "features": "",
+      "federation_origin": "",
+      "federation_siblings_active": "",
+      "federation_siblings_viable": "",
+      "gres_detail": [],
+      "group_id": 100006,
+      "group_name": "skypilot",
+      "het_job_id": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "het_job_id_set": "",
+      "het_job_offset": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "job_id": 935,
+      "job_resources": {
+        "select_type": [
+          "CPU"
+        ],
+        "nodes": {
+          "count": 2,
+          "select_type": [
+            "ONE_ROW"
+          ],
+          "list": "node-001,node-002",
+          "whole": false
+        },
+        "cpus": 2,
+        "threads_per_core": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "job_size_str": [],
+      "job_state": [
+        "RUNNING"
+      ],
+      "last_sched_evaluation": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439205
+      },
+      "licenses": "",
+      "licenses_allocated": "",
+      "mail_type": [],
+      "mail_user": "skypilot",
+      "max_cpus": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "max_nodes": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "mcs_label": "",
+      "memory_per_tres": "",
+      "name": "sky-cluster-1234",
+      "network": "",
+      "nodes": "node-[001-002]",
+      "nice": 0,
+      "tasks_per_core": {
+        "set": false,
+        "infinite": true,
+        "number": 0
+      },
+      "tasks_per_tres": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "tasks_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "tasks_per_socket": {
+        "set": false,
+        "infinite": true,
+        "number": 0
+      },
+      "tasks_per_board": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "cpus": {
+        "set": true,
+        "infinite": false,
+        "number": 2
+      },
+      "node_count": {
+        "set": true,
+        "infinite": false,
+        "number": 2
+      },
+      "tasks": {
+        "set": true,
+        "infinite": false,
+        "number": 2
+      },
+      "partition": "all",
+      "prefer": "",
+      "memory_per_cpu": {
+        "set": true,
+        "infinite": false,
+        "number": 4096
+      },
+      "memory_per_node": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "minimum_cpus_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "minimum_tmp_disk_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "power": {
+        "flags": []
+      },
+      "preempt_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "preemptable_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439205
+      },
+      "pre_sus_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "hold": false,
+      "priority": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "priority_by_partition": [],
+      "profile": [
+        "NOT_SET"
+      ],
+      "qos": "normal",
+      "reboot": false,
+      "required_nodes": "",
+      "required_switches": 0,
+      "requeue": true,
+      "resize_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "restart_cnt": 0,
+      "resv_name": "",
+      "scheduled_nodes": "",
+      "segment_size": 0,
+      "selinux_context": "",
+      "shared": [],
+      "sockets_per_board": 0,
+      "sockets_per_node": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "start_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439205
+      },
+      "state_description": "",
+      "state_reason": "Prolog",
+      "standard_input": "/dev/null",
+      "standard_output": "",
+      "standard_error": "",
+      "stdin_expanded": "/dev/null",
+      "stdout_expanded": "",
+      "stderr_expanded": "",
+      "submit_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1785439204
+      },
+      "suspend_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "system_comment": "",
+      "time_limit": {
+        "set": false,
+        "infinite": true,
+        "number": 0
+      },
+      "time_minimum": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "threads_per_core": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "tres_bind": "",
+      "tres_freq": "",
+      "tres_per_job": "",
+      "tres_per_node": "",
+      "tres_per_socket": "",
+      "tres_per_task": "",
+      "tres_req_str": "cpu=2,mem=8G,node=2,billing=2",
+      "tres_alloc_str": "cpu=2,mem=8G,node=2,billing=2",
+      "user_id": 100006,
+      "user_name": "skypilot",
+      "maximum_switch_wait_time": 0,
+      "wckey": "",
+      "current_working_directory": "/home/skypilot"
+    }
+  ],
+  "last_backfill": {
+    "set": true,
+    "infinite": false,
+    "number": 1772058792
+  },
+  "last_update": {
+    "set": true,
+    "infinite": false,
+    "number": 1785439209
+  },
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser/v0.0.43",
+      "accounting_storage": "accounting_storage/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "skypilot",
+      "group": "skypilot"
+    },
+    "command": [
+      "squeue",
+      "--jobs",
+      "--json"
+    ],
+    "slurm": {
+      "version": {
+        "major": "25",
+        "micro": "3",
+        "minor": "05"
+      },
+      "release": "25.05.3",
+      "cluster": "slurm"
+    }
+  },
+  "errors": [],
+  "warnings": []
+}


### PR DESCRIPTION
`SlurmClient.get_job_nodes()` maps a job's nodes to the IPs that become the SSH
targets for everything SkyPilot does on that cluster afterwards. It built that
mapping out of a remote shell pipeline:

```bash
nodelist=$(squeue -h --jobs <id> -o "%N")
scontrol show hostnames $nodelist | while read -r node; do
  node_addr=$(scontrol show node=$node | grep NodeAddr= | awk -F= '{print $2}' | awk '{print $1}')
  echo "$node $node_addr"
done
```

Format drift, or any value containing a space, silently yields a wrong mapping
instead of an error, and the resulting breakage surfaces far from its cause. It
also costs one `scontrol` invocation per node on the login node.

This replaces it with two typed calls:

```bash
squeue --jobs <id> --json                 # -> .jobs[0].nodes   (compact hostlist)
scontrol show node '<hostlist>' --json    # -> .nodes[] | {name, address}
```

`scontrol` accepts the compact hostlist expression directly, so the per-node
loop disappears. The hostlist is expanded client-side (`hostlist.expand_hostlist`,
already a dependency) and the `scontrol` payload is indexed by node name, so the
documented "stable ordering for the lifetime of the job" holds regardless of the
order `scontrol` returns nodes in.

**Version support and fallback.** `squeue --json` ships since Slurm 21.08
([21.08 NEWS](https://github.com/SchedMD/slurm/blob/slurm-21-08-0-1/NEWS#L65):
"squeue - Add --json and --yaml arguments") and `scontrol --json` since 23.02
([23.02 RELEASE_NOTES](https://github.com/SchedMD/slurm/blob/slurm-23-02-0-1/RELEASE_NOTES#L209):
"Partial support for '--json' and '--yaml' formated outputs have been implemented
for sacctmgr, sdiag, sinfo, squeue, and scontrol"), making 23.02 the floor for
this path. Confirmed against the sources: `OPT_LONG_JSON` is absent from
`src/squeue/opts.c` at `slurm-20-11-0-1` and present at `slurm-21-08-0-1`; absent
from `src/scontrol/scontrol.c` at `slurm-22-05-0-1` and present at
`slurm-23-02-0-1`. Rather than hardcoding a version, an older Slurm is detected
at runtime from the `unrecognized option` error, cached per client, and the
previous text parsing is used instead — the same pattern as the existing
`--only-job-state` fallback in `get_job_state()`.

**Failing loudly.** Malformed JSON, a payload missing an expected field, or a
node `scontrol` does not report all raise with a snippet of the payload, rather
than falling back to the text path. The last one matters: `scontrol show node`
silently omits nodes it does not know and still exits 0, so without the check a
removed node would just disappear from the result.

The `getent ahostsv4` resolution step for clusters whose `NodeAddr` is a hostname
is unchanged, and is now shared by both paths.

Two SSH execs replace what was one on the happy path. With ControlMaster
(~100 ms/exec) that is noise against the 1–2 s poll cadence, and each exec is
independently attributable on failure. `--json` serialization measured ~15 ms per
call on the test cluster.

## Tested

- `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py` — 51 passed.
  New JSON-path cases (happy path, ordering independent of `scontrol`'s order,
  hostname-resolution branch, resolution failure, terminated job, invalid job id,
  pending job, node missing from `scontrol`, malformed JSON, missing schema
  field, fallback to text + cached verdict); the pre-existing tests are kept,
  pinned to the text path. Fixtures under
  `tests/unit_tests/test_sky/adaptors/testdata/slurm/` are payloads captured from
  a live Slurm 25.05.3 cluster (`data_parser/v0.0.43`), anonymized.
- `pytest tests/unit_tests/test_sky/clouds/test_slurm.py tests/unit_tests/test_sky/provision` — 303 passed.
- Live on a 2-node Slurm 25.05.3 cluster: `sky launch --num-nodes 2` end to end,
  `sky exec --num-nodes 2`, `sky status --refresh`, `sky down`. Head and worker
  resolved to the same addresses `scontrol show node --json` reports.
- Live check that the JSON path is actually taken (not silently falling back):
  called `get_job_nodes()` against the running job and confirmed the returned
  names/IPs plus the cached "supports JSON" verdict. Also confirmed a job
  slurmctld no longer knows raises the same `No nodes found for job …` error as
  before.
- The old-Slurm fallback is covered by unit tests only — no pre-23.02 cluster was
  available to exercise it live.
