### PR TITLE
[AWS] Add a SkyPilot user-agent suffix to boto3 clients

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -73,6 +73,27 @@ def _assert_kwargs_builtin_type(kwargs):
         f'kwargs should not contain none built-in types: {kwargs}')
 
 
+def _user_agent_extra() -> str:
+    """Return SkyPilot's user-agent suffix for boto3 clients."""
+    from sky import __version__
+    return f'skypilot/{__version__}'
+
+
+def _add_user_agent(kwargs: Dict[str, Any]) -> None:
+    """Append SkyPilot's user agent to the botocore config in kwargs.
+
+    The suffix is added to (not replacing) the default boto3 user agent so
+    that any S3-compatible endpoint can identify the client. Existing config
+    options are preserved, and the endpoint_url kwarg is left untouched.
+    """
+    ua_config = botocore_config().Config(user_agent_extra=_user_agent_extra())
+    existing = kwargs.get('config')
+    if existing is not None:
+        kwargs['config'] = existing.merge(ua_config)
+    else:
+        kwargs['config'] = ua_config
+
+
 def _create_aws_object(creation_fn_or_cls: Callable[[], T],
                        object_name: str) -> T:
     """Create an AWS object.
@@ -185,6 +206,8 @@ def resource(service_name: str, **kwargs):
     check_credentials = kwargs.pop('check_credentials', True)
     profile = get_workspace_profile()
 
+    _add_user_agent(kwargs)
+
     # Need to use the client retrieved from the per-thread session to avoid
     # thread-safety issues (Directly creating the client with boto3.resource()
     # is not thread-safe). Reference: https://stackoverflow.com/a/59635814
@@ -240,6 +263,8 @@ def client(service_name: str, **kwargs):
         kwargs['config'] = botocore_config().Config(**config_kwargs)
 
     profile = get_workspace_profile()
+
+    _add_user_agent(kwargs)
 
     # Need to use the client retrieved from the per-thread session to avoid
     # thread-safety issues (Directly creating the client with boto3.client() is


### PR DESCRIPTION
## Summary

`sky/adaptors/aws.py` creates every boto3 client and resource SkyPilot uses, and none of them identify SkyPilot in the HTTP `User-Agent`. Server-side request logs (Amazon S3 server access logs, CloudTrail) therefore show generic boto3 traffic, so an operator debugging a bucket or API issue cannot tell which requests came from SkyPilot, and there is no SkyPilot version to reference in a support thread.

This sets botocore's `user_agent_extra` to `skypilot/<version>` for clients and resources created through the adaptor.

- New `_add_user_agent()` builds a `botocore.config.Config` carrying the suffix and merges it into whatever config the caller already asked for (`max_attempts` in `resource()`, and `connect_timeout` / `read_timeout` / `total_max_attempts` in `client()`), so existing options are preserved. `Config.merge()` returns a new object, so no caller-owned config is mutated.
- `user_agent_extra` appends to boto3's default user agent rather than replacing it, so the boto3, botocore and Python identifiers stay intact and only gain a trailing `skypilot/<version>`.
- The call sits after `_assert_kwargs_builtin_type(kwargs)` in both functions, since that assert only permits int/float/str kwargs and would reject a `Config` object.
- The version is read from `sky.__version__` through a function-local import, matching the file's existing `import-outside-toplevel` convention.
- Nothing changes for callers: `endpoint_url` and all other kwargs are untouched, and no new configuration is introduced. The suffix applies to every service created through the AWS adaptor (`s3`, `ec2`, `sts`, `iam`, `service-quotas`), not only S3.

The other boto3-based adaptors (`cloudflare.py`, `nebius.py`, `oci_s3.py`) construct their own clients and are unchanged here. They could take the same suffix in a follow-up.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Draft, since the checks above are still outstanding. So far only `yapf` has been run on the changed file (no changes reported, with a newer yapf than the pinned 0.32.0). The full `format.sh` (pylint, mypy, isort), a unit test asserting the merged config and the emitted user agent, and a live AWS run are all still to do.
