### PR TITLE
[Slurm] Unset step-scoped SLURM_* env before running user scripts

### DIFF
--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -18,6 +18,24 @@ import hostlist
 from sky.skylet import constants
 from sky.skylet.log_lib import run_bash_command_with_log
 
+# Slurm populates step- and task-scoped SLURM_* variables for the executor's
+# own job step (e.g. SLURM_CPU_BIND, SLURM_CPUS_PER_TASK=1,
+# SLURM_NTASKS_PER_NODE=1). srun treats many of these as input defaults, so a
+# nested srun in the user script gets silently constrained to the executor
+# step's shape (1 CPU per task, the executor's CPU binding) instead of the
+# full job allocation. Unset them for the user script, keeping job-scoped
+# variables (SLURM_JOB_ID, SLURM_JOB_NODELIST, SLURM_GPUS_ON_NODE, ...) so
+# patterns like `srun --overlap --jobid=$SLURM_JOB_ID` keep working against
+# the full allocation.
+# See https://support.schedmd.com/show_bug.cgi?id=14298
+UNSET_STEP_SCOPED_SLURM_ENV = (
+    'unset "${!SLURM_STEP_@}" "${!SLURM_CPU_BIND@}" "${!SLURM_MEM_BIND@}" '
+    'SLURM_CPUS_PER_TASK SLURM_TRES_PER_TASK SLURM_CPUS_ON_NODE '
+    'SLURM_NTASKS SLURM_NPROCS SLURM_NTASKS_PER_NODE SLURM_TASKS_PER_NODE '
+    'SLURM_DISTRIBUTION SLURM_SRUN_COMM_HOST SLURM_SRUN_COMM_PORT '
+    'SLURM_LAUNCH_NODE_IPADDR SLURM_TASK_PID '
+    'SLURM_PROCID SLURM_LOCALID SLURM_NODEID SLURM_GTIDS SLURM_STEPID')
+
 
 def _is_proctrack_cgroup_enabled(shared_home_dir: str) -> bool:
     """Check if Slurm uses proctrack/cgroup.
@@ -145,6 +163,7 @@ def main():
             script = f.read()
     else:
         script = args.script
+    script = UNSET_STEP_SCOPED_SLURM_ENV + '\n' + script
 
     # Parse env vars and add SKYPILOT environment variables
     env_vars = json.loads(args.env_vars)

--- a/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
+++ b/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
@@ -1,0 +1,70 @@
+"""Tests for the Slurm task executor."""
+import subprocess
+
+from sky.skylet.executor import slurm
+
+# Step/task-scoped variables Slurm sets for the executor's own job step. A
+# nested srun in the user script reads several of these as input defaults, so
+# they must not leak into the user script's environment.
+_STEP_SCOPED_VARS = {
+    'SLURM_CPU_BIND': 'quiet,mask_cpu:0x3',
+    'SLURM_CPU_BIND_LIST': '0x3',
+    'SLURM_CPU_BIND_TYPE': 'mask_cpu:',
+    'SLURM_CPU_BIND_VERBOSE': 'quiet',
+    'SLURM_CPUS_PER_TASK': '1',
+    'SLURM_TRES_PER_TASK': 'cpu=1',
+    'SLURM_CPUS_ON_NODE': '2',
+    'SLURM_NTASKS': '2',
+    'SLURM_NPROCS': '2',
+    'SLURM_NTASKS_PER_NODE': '1',
+    'SLURM_TASKS_PER_NODE': '1(x2)',
+    'SLURM_STEP_ID': '12',
+    'SLURM_STEPID': '12',
+    'SLURM_STEP_NUM_TASKS': '2',
+    'SLURM_STEP_NODELIST': 'node[1-2]',
+    'SLURM_SRUN_COMM_HOST': '10.0.0.1',
+    'SLURM_SRUN_COMM_PORT': '33809',
+    'SLURM_LAUNCH_NODE_IPADDR': '10.0.0.1',
+    'SLURM_TASK_PID': '4242',
+    'SLURM_PROCID': '0',
+    'SLURM_LOCALID': '0',
+    'SLURM_NODEID': '0',
+    'SLURM_GTIDS': '0',
+}
+
+# Job-scoped variables that user scripts legitimately rely on (e.g.
+# `srun --overlap --jobid=$SLURM_JOB_ID`) and must survive the unset.
+_JOB_SCOPED_VARS = {
+    'SLURM_JOB_ID': '18',
+    'SLURM_JOBID': '18',
+    'SLURM_JOB_NODELIST': 'node[1-2]',
+    'SLURM_NODELIST': 'node[1-2]',
+    'SLURM_JOB_NUM_NODES': '2',
+    'SLURM_NNODES': '2',
+    'SLURM_JOB_CPUS_PER_NODE': '48(x2)',
+    'SLURM_GPUS_ON_NODE': '4',
+    'SLURM_GPUS_PER_NODE': '4',
+    'SLURM_MEM_PER_NODE': '409600',
+    'SLURM_JOB_PARTITION': 'all',
+    'SLURM_CONF': '/etc/slurm/slurm.conf',
+}
+
+
+def test_unset_step_scoped_slurm_env():
+    """Run the unset snippet in bash and check what survives."""
+    probe = '\n'.join(f'echo "{name}=${{{name}:-UNSET}}"'
+                      for name in list(_STEP_SCOPED_VARS) +
+                      list(_JOB_SCOPED_VARS))
+    script = slurm.UNSET_STEP_SCOPED_SLURM_ENV + '\n' + probe
+    env = {**_STEP_SCOPED_VARS, **_JOB_SCOPED_VARS, 'PATH': '/usr/bin:/bin'}
+    out = subprocess.run(['/bin/bash', '-c', script],
+                         env=env,
+                         capture_output=True,
+                         text=True,
+                         check=True).stdout
+    result = dict(
+        line.split('=', maxsplit=1) for line in out.strip().splitlines())
+    for name in _STEP_SCOPED_VARS:
+        assert result[name] == 'UNSET', f'{name} leaked into user script env'
+    for name, value in _JOB_SCOPED_VARS.items():
+        assert result[name] == value, f'{name} was wrongly unset'


### PR DESCRIPTION
## Summary

- A user `srun` in a task's `run` section gets silently constrained to the SkyPilot executor's own job step instead of the full allocation, because Slurm populates step/task-scoped `SLURM_*` variables (`SLURM_CPU_BIND`, `SLURM_CPUS_PER_TASK=1`, `SLURM_NTASKS_PER_NODE=1`, ...) for the executor's step, and `srun` treats many of them as input defaults.
- Fix: prepend an `unset` of the step/task-scoped variables to the user script in the Slurm executor, mirroring the existing unset in `task_codegen.py` (see https://support.schedmd.com/show_bug.cgi?id=14298) one nesting level deeper. Job-scoped variables (`SLURM_JOB_ID`, `SLURM_JOB_NODELIST`, `SLURM_GPUS_ON_NODE`, `SLURM_CONF*`, ...) are kept so patterns like `srun --overlap --jobid=$SLURM_JOB_ID` keep working against the full allocation.

## Observed impact

2-node x 4x A100 (PCIe, TCP interconnect) Slurm cluster, `all_reduce_perf` launched from a task `run` section via `srun --mpi=pmix --overlap -N 2 --ntasks=8 --ntasks-per-node=4`. (Log prefixes trimmed; numbers verbatim.)

The `run` section's environment before this fix — step-scoped variables leaked from the executor's own 1-task-per-node step:

```
SLURM_CPUS_PER_TASK=1
SLURM_TRES_PER_TASK=cpu=1
SLURM_CPU_BIND=quiet,mask_cpu:0x000000000003
SLURM_CPUS_ON_NODE=2
SLURM_NTASKS=2
SLURM_TASKS_PER_NODE=1(x2)
```

Before — full 48-CPU/node allocation, `--cpu-bind=none` even passed explicitly; the leaked step env still pins all ranks to the executor step's task shape:

```
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
     8388608       2097152     float     sum      -1    11830    0.71    1.24      0    12074    0.69    1.22      0
    16777216       4194304     float     sum      -1    23948    0.70    1.23      0    24942    0.67    1.18      0
    33554432       8388608     float     sum      -1    43860    0.77    1.34      0    43447    0.77    1.35      0
    67108864      16777216     float     sum      -1    88128    0.76    1.33      0    88946    0.75    1.32      0
   134217728      33554432     float     sum      -1   171000    0.78    1.37      0   181570    0.74    1.29      0
   268435456      67108864     float     sum      -1   375920    0.71    1.25      0   347609    0.77    1.35      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 1.28928
```

(With SkyPilot's default resource request instead of a whole-node one, the same job bottoms out at 0.83 GB/s.)

After this fix — same command, same allocation, no workaround flags; the probe at the top of the run section confirms the leak is gone:

```
leak check: CPUS_PER_TASK=gone CPU_BIND=gone NTASKS=gone
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
     8388608       2097152     float     sum      -1   5996.7    1.40    2.45      0   6267.3    1.34    2.34      0
    16777216       4194304     float     sum      -1    12036    1.39    2.44      0    11778    1.42    2.49      0
    33554432       8388608     float     sum      -1    23691    1.42    2.48      0    21138    1.59    2.78      0
    67108864      16777216     float     sum      -1    43093    1.56    2.73      0    44344    1.51    2.65      0
   134217728      33554432     float     sum      -1    87786    1.53    2.68      0    84328    1.59    2.79      0
   268435456      67108864     float     sum      -1   168476    1.59    2.79      0   165803    1.62    2.83      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 2.61961
```

Native sbatch baseline on the same nodes: 2.64-2.68 GB/s avg busbw — i.e. this restores full parity.

**Allocation ceiling check** — the unset does NOT let user steps escape the job allocation (it only removes env-var defaults; the nested step is still scheduled under `--jobid` and capped by slurmctld + job cgroups). Same task with SkyPilot's default resource request instead of a whole-node one, after this fix:

```
allocation: SLURM_JOB_ID=24 cpus/node=16(x2) mem/node=65536MB
leak check: CPUS_PER_TASK=gone CPU_BIND=gone NTASKS=gone
task 0 on np-0a498180-1: nproc=1     # x8 tasks, all nproc=1 —
task 4 on np-0a498180-2: nproc=1     # srun's own default cpus-per-task=1,
...                                  # not the node's 48 CPUs
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 2.56952
```

Tasks stay bound within the 16-CPU job allocation, and bandwidth still reaches ~parity — confirming the earlier 0.83-1.29 GB/s runs were caused by the leaked `SLURM_CPU_BIND` mask stacking every rank onto the same 2 hyperthreads, not by the allocation size.

Pushing further, with a deliberately tiny allocation (`cpus: 1` -> 1 core = 2 CPUs/node), the ceiling rejects an oversized step outright, and forcing it through degrades as expected:

```
srun: error: Unable to create step for job 25: More processors requested than permitted
# (with --overcommit, 8 ranks on 2 CPUs/node:)
# Avg bus bandwidth    : 0.802068
```

## Test plan

- New unit test `tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py` executes the unset snippet in bash with a realistic step env and asserts every step-scoped variable is removed while every job-scoped variable survives.
- `pytest tests/unit_tests/test_sky/backends/test_task_codegen.py tests/unit_tests/test_sky/skylet/executor/ tests/unit_tests/test_sky/provision/slurm/` passes.
- Live verification: the before/after runs above, via `sky launch` of the same 2-node task against a patched API server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
