### PR TITLE
[Slurm] Use `--json` output in `get_all_node_details()`

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -5,7 +5,8 @@ import json
 import logging
 import re
 import shlex
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import (Any, Callable, Dict, List, NamedTuple, Optional, Tuple,
+                    TypeVar)
 
 from sky.adaptors import common
 from sky.utils import command_runner
@@ -42,11 +43,23 @@ _UNRESOLVED_HOSTNAME_MARKER = 'UNRESOLVED'
 # versions predating `--json` output.
 _UNRECOGNIZED_OPTION_MARKER = 'unrecognized option'
 
+_JSON_OPTION = '--json'
+
 # squeue marker in stderr when slurmctld no longer knows the job ID.
 _INVALID_JOB_ID_MARKER = 'invalid job id'
 
 # How much of a malformed JSON payload to include in error messages.
 _JSON_SNIPPET_LEN = 500
+
+_T = TypeVar('_T')
+
+# Slurm's sentinel for an unset uint32, e.g. a CPU load slurmd has not
+# reported yet. Fields typed as a plain number in the JSON schema carry it
+# through verbatim.
+_NO_VAL32 = 0xfffffffe
+
+# Slurm reports CPULoad as the load average scaled by this factor.
+_CPU_LOAD_SCALE = 100.0
 
 
 class _JsonOutputUnsupportedError(Exception):
@@ -64,6 +77,24 @@ class SlurmPartition(NamedTuple):
     # (e.g. '01:00:00', '2-00:00:00'). None if the partition has no
     # DefaultTime configured (NONE/UNLIMITED).
     default_time: Optional[str]
+
+
+class NodeDetails(NamedTuple):
+    """Per-node counters that sinfo's format codes cannot express.
+
+    Every field is None when Slurm does not report the counter, e.g. on a node
+    slurmd has not reported in for.
+    """
+    # CPUs allocated to jobs by the scheduler, and the node's total.
+    alloc_cpus: Optional[int]
+    total_cpus: Optional[int]
+    # Memory in MB: allocated to jobs by the scheduler, the node's total, and
+    # the free memory slurmd last sampled from the OS.
+    alloc_memory_mb: Optional[int]
+    real_memory_mb: Optional[int]
+    free_memory_mb: Optional[int]
+    # Load average slurmd last sampled from the OS.
+    cpu_load: Optional[float]
 
 
 # TODO(kevin): Add more API types for other client functions.
@@ -127,6 +158,37 @@ def _parse_default_time(line: str) -> Optional[str]:
     return raw
 
 
+def _parse_optional_number(value: Optional[str]) -> Optional[float]:
+    """Parse a number from an scontrol attribute value; None on N/A."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _parse_optional_int(value: Optional[str]) -> Optional[int]:
+    """Parse an int from an scontrol attribute value; None on N/A."""
+    number = _parse_optional_number(value)
+    return None if number is None else int(number)
+
+
+def _json_optional_int(value: Any) -> Optional[int]:
+    """Read a Slurm JSON number, which is optional-typed or plain.
+
+    Optional numbers are wrapped as ``{'set': bool, 'infinite': bool,
+    'number': N}``; plain ones carry ``_NO_VAL32`` when unset.
+    """
+    if isinstance(value, dict):
+        if not value.get('set') or value.get('infinite'):
+            return None
+        value = value.get('number')
+    if not isinstance(value, int) or value == _NO_VAL32:
+        return None
+    return value
+
+
 def _parse_scontrol_node_output(output: str) -> Dict[str, str]:
     """Parses the key=value output of 'scontrol show node'."""
     node_info = {}
@@ -181,9 +243,12 @@ class SlurmClient:
         self.ssh_proxy_command = ssh_proxy_command
         self.ssh_proxy_jump = ssh_proxy_jump
 
-        # Whether the cluster's Slurm CLI supports `--json` output. None until
-        # the first command that tries it.
-        self._json_output_supported: Optional[bool] = None
+        # Whether the cluster's Slurm CLI supports `--json` output, keyed by
+        # program name. `--json` ships in a different release per program
+        # (squeue since 21.08, scontrol since 23.02), so the verdict is probed
+        # and cached per program. A program is absent until the first command
+        # that tries it.
+        self._json_output_supported: Dict[str, bool] = {}
 
         self._runner: command_runner.CommandRunner
 
@@ -329,34 +394,38 @@ class SlurmClient:
 
         return nodes
 
-    def node_details(self, node_name: str) -> Dict[str, str]:
-        """Get detailed Slurm node information.
+    def _get_all_node_details_json(self) -> Dict[str, NodeDetails]:
+        """get_all_node_details() using Slurm's `--json` output.
 
-        Returns:
-            A dictionary of node attributes.
+        `scontrol --json` ships since Slurm 23.02. Older versions reject the
+        option, and get_all_node_details() falls back to the text output.
         """
-        cmd = f'scontrol show node {node_name}'
-        rc, node_details, stderr = self._run_slurm_cmd(cmd)
+        cmd = 'scontrol show node --json'
+        rc, stdout, stderr = self._run_slurm_json_cmd(cmd)
         subprocess_utils.handle_returncode(
             rc,
             cmd,
-            f'Failed to get detailed node information for {node_name}.',
-            stderr=f'{node_details}\n{stderr}',
+            'Failed to get detailed node information.',
+            stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
-        node_info = _parse_scontrol_node_output(node_details)
-        return node_info
 
-    def get_all_node_details(self) -> Dict[str, Dict[str, str]]:
-        """Get detailed attributes for every node in a single scontrol call.
+        payload = self._load_slurm_json(cmd, stdout)
+        details: Dict[str, NodeDetails] = {}
+        for node in self._get_json_field(cmd, payload, 'nodes'):
+            cpu_load = _json_optional_int(node.get('cpu_load'))
+            details[self._get_json_field(cmd, node, 'name')] = NodeDetails(
+                alloc_cpus=_json_optional_int(node.get('alloc_cpus')),
+                total_cpus=_json_optional_int(node.get('cpus')),
+                alloc_memory_mb=_json_optional_int(node.get('alloc_memory')),
+                real_memory_mb=_json_optional_int(node.get('real_memory')),
+                free_memory_mb=_json_optional_int(node.get('free_mem')),
+                cpu_load=(None if cpu_load is None else cpu_load /
+                          _CPU_LOAD_SCALE),
+            )
+        return details
 
-        Uses ``scontrol show node -o`` (one line per node) so per-node
-        attributes that sinfo's format codes cannot express (CPUAlloc,
-        AllocMem, FreeMem, CPULoad, GresUsed, ...) are available without a
-        round-trip per node.
-
-        Returns:
-            A dictionary mapping node name to its attribute dictionary.
-        """
+    def _get_all_node_details_text(self) -> Dict[str, NodeDetails]:
+        """get_all_node_details() for Slurm versions without `--json`."""
         cmd = 'scontrol show node -o'
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(
@@ -365,7 +434,7 @@ class SlurmClient:
             'Failed to get detailed node information.',
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
-        details: Dict[str, Dict[str, str]] = {}
+        details: Dict[str, NodeDetails] = {}
         for line in stdout.splitlines():
             line = line.strip()
             if not line:
@@ -373,25 +442,31 @@ class SlurmClient:
             node_info = _parse_scontrol_node_output(line)
             node_name = node_info.get('NodeName')
             if node_name:
-                details[node_name] = node_info
+                details[node_name] = NodeDetails(
+                    alloc_cpus=_parse_optional_int(node_info.get('CPUAlloc')),
+                    total_cpus=_parse_optional_int(node_info.get('CPUTot')),
+                    alloc_memory_mb=_parse_optional_int(
+                        node_info.get('AllocMem')),
+                    real_memory_mb=_parse_optional_int(
+                        node_info.get('RealMemory')),
+                    free_memory_mb=_parse_optional_int(
+                        node_info.get('FreeMem')),
+                    cpu_load=_parse_optional_number(node_info.get('CPULoad')),
+                )
         return details
 
-    def get_jobs_gres(self, node_name: str) -> List[str]:
-        """Get the list of jobs GRES for a given node name.
+    def get_all_node_details(self) -> Dict[str, NodeDetails]:
+        """Get per-node counters for every node in a single scontrol call.
+
+        These are the counters sinfo's format codes cannot express, fetched
+        without a round-trip per node.
 
         Returns:
-            A list of GRES specs (e.g., 'gres/gpu:h100:4')
-            for jobs on the node.
+            A dictionary mapping node name to its counters.
         """
-        cmd = f'squeue -h --nodelist {node_name} -o "%b"'
-        rc, stdout, stderr = self._run_slurm_cmd(cmd)
-        subprocess_utils.handle_returncode(
-            rc,
-            cmd,
-            f'Failed to get jobs for node {node_name}.',
-            stderr=f'{stdout}\n{stderr}',
-            stream_logs=False)
-        return stdout.splitlines()
+        return self._with_json_output(['scontrol'],
+                                      self._get_all_node_details_json,
+                                      self._get_all_node_details_text)
 
     def get_all_jobs_gres(self) -> Dict[str, List[str]]:
         """Get GRES allocation for all running jobs, grouped by node.
@@ -623,24 +698,62 @@ class SlurmClient:
             node_to_ip[node_name] = hostname_to_ip[hostname]
         return node_to_ip
 
+    def _with_json_output(self, programs: List[str], json_impl: Callable[[],
+                                                                         _T],
+                          text_impl: Callable[[], _T]) -> _T:
+        """Run a `--json` implementation, falling back to the text one.
+
+        Args:
+            programs: The Slurm programs that `json_impl` runs with `--json`.
+            json_impl: The implementation parsing `--json` output.
+            text_impl: The implementation parsing the text output, used when
+                the cluster's Slurm is too old for `--json`.
+        """
+        if all(self._json_output_supported.get(p, True) for p in programs):
+            try:
+                return json_impl()
+            except _JsonOutputUnsupportedError as e:
+                logger.debug(f'Falling back to parsing the text output: {e}')
+        return text_impl()
+
     def _run_slurm_json_cmd(self, cmd: str) -> Tuple[int, str, str]:
         """Run a Slurm command with `--json`.
 
         Raises:
-            _JsonOutputUnsupportedError: The Slurm CLI does not know the
-                `--json` option.
+            _JsonOutputUnsupportedError: The Slurm CLI does not know one of the
+                command's options, so the caller has to use the text output.
         """
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         if rc != 0 and _UNRECOGNIZED_OPTION_MARKER in stderr:
+            if _JSON_OPTION in stderr:
+                # Any other option is specific to this command, so it must not
+                # disqualify the program's `--json` support as a whole.
+                self._json_output_supported[shlex.split(cmd)[0]] = False
             raise _JsonOutputUnsupportedError(
                 f'{cmd!r} failed: {stderr.strip()}')
         return rc, stdout, stderr
 
     def _load_slurm_json(self, cmd: str, stdout: str) -> Dict[str, Any]:
-        """Parse the JSON payload of a Slurm `--json` command."""
+        """Parse the JSON payload of a Slurm `--json` command.
+
+        Raises:
+            _JsonOutputUnsupportedError: The command exited successfully but
+                printed its text output, i.e. it ignored `--json`, and it has
+                never produced JSON before.
+            RuntimeError: The payload is not a JSON object.
+        """
+        program = shlex.split(cmd)[0]
         try:
             payload = json.loads(stdout)
         except json.JSONDecodeError as e:
+            if not self._json_output_supported.get(program):
+                # Some subcommands (e.g. `scontrol show config`) ignore
+                # `--json` and exit 0, so a successful exit is not proof that
+                # the output is JSON.
+                self._json_output_supported[program] = False
+                raise _JsonOutputUnsupportedError(
+                    f'{cmd!r} did not return JSON output: '
+                    f'{stdout[:_JSON_SNIPPET_LEN]!r}') from e
             raise RuntimeError(
                 f'Failed to parse the JSON output of {cmd!r}: {e}. '
                 f'Output: {stdout[:_JSON_SNIPPET_LEN]!r}') from e
@@ -649,6 +762,7 @@ class SlurmClient:
                 f'Unexpected JSON output of {cmd!r}: expected an object, got '
                 f'{type(payload).__name__}. '
                 f'Output: {stdout[:_JSON_SNIPPET_LEN]!r}')
+        self._json_output_supported[program] = True
         return payload
 
     def _get_json_field(self, cmd: str, payload: Dict[str, Any],
@@ -803,16 +917,9 @@ class SlurmClient:
             A tuple of (nodes, node_ips) where nodes is a list of node names
             and node_ips is a list of corresponding IP addresses.
         """
-        if self._json_output_supported is not False:
-            try:
-                nodes, node_ips = self._get_job_nodes_json(job_id)
-                self._json_output_supported = True
-                return nodes, node_ips
-            except _JsonOutputUnsupportedError as e:
-                logger.debug(f'Slurm does not support --json output ({e}), '
-                             'falling back to parsing the text output.')
-                self._json_output_supported = False
-        return self._get_job_nodes_text(job_id)
+        return self._with_json_output(['squeue', 'scontrol'],
+                                      lambda: self._get_job_nodes_json(job_id),
+                                      lambda: self._get_job_nodes_text(job_id))
 
     def submit_job(
         self,

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -973,24 +973,12 @@ def resolve_gres_gpu_type(
     return chosen
 
 
-def _parse_int_or_none(value: Optional[str]) -> Optional[int]:
-    """Parse an int from an scontrol attribute value; None on N/A/garbage."""
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _parse_float_or_none(value: Optional[str]) -> Optional[float]:
-    """Parse a float from an scontrol attribute value; None on N/A/garbage."""
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
+_EMPTY_NODE_DETAILS = slurm.NodeDetails(alloc_cpus=None,
+                                        total_cpus=None,
+                                        alloc_memory_mb=None,
+                                        real_memory_mb=None,
+                                        free_memory_mb=None,
+                                        cpu_load=None)
 
 
 def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
@@ -1086,23 +1074,19 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         # CPU/memory allocation + sampled usage from scontrol. All of
         # these are None when scontrol was unavailable or reported N/A
         # (e.g. on down nodes).
-        details = node_details_by_name.get(node_name, {})
-        cpu_alloc = _parse_int_or_none(details.get('CPUAlloc'))
-        cpu_tot = _parse_int_or_none(details.get('CPUTot'))
+        details = node_details_by_name.get(node_name, _EMPTY_NODE_DETAILS)
         free_vcpus = None
-        if cpu_alloc is not None and cpu_tot is not None:
-            free_vcpus = max(0, cpu_tot - cpu_alloc)
-        # scontrol reports memory in MB.
-        alloc_mem_mb = _parse_int_or_none(details.get('AllocMem'))
-        real_mem_mb = _parse_int_or_none(details.get('RealMemory'))
+        if details.alloc_cpus is not None and details.total_cpus is not None:
+            free_vcpus = max(0, details.total_cpus - details.alloc_cpus)
         free_alloc_memory_gb = None
-        if alloc_mem_mb is not None and real_mem_mb is not None:
+        if (details.alloc_memory_mb is not None and
+                details.real_memory_mb is not None):
             free_alloc_memory_gb = round(
-                max(0, real_mem_mb - alloc_mem_mb) / 1024.0, 2)
-        free_mem_mb = _parse_int_or_none(details.get('FreeMem'))
-        free_memory_gb = (round(free_mem_mb /
-                                1024.0, 2) if free_mem_mb is not None else None)
-        cpu_load = _parse_float_or_none(details.get('CPULoad'))
+                max(0, details.real_memory_mb - details.alloc_memory_mb) /
+                1024.0, 2)
+        free_memory_gb = (round(details.free_memory_mb / 1024.0, 2)
+                          if details.free_memory_mb is not None else None)
+        cpu_load = details.cpu_load
 
         slurm_nodes_info[node_name] = {
             'node_name': node_name,

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -333,7 +333,10 @@ class TestGetJobNodesJson:
             assert commands[0] == 'squeue --jobs 935 --json'
             # The compact hostlist expression is passed to scontrol as is.
             assert commands[1] == "scontrol show node 'node-[001-002]' --json"
-            assert client._json_output_supported is True
+            assert client._json_output_supported == {
+                'squeue': True,
+                'scontrol': True
+            }
 
     def test_get_job_nodes_ordering_independent_of_scontrol(self):
         """Test that the ordering follows the job's hostlist expansion."""
@@ -448,8 +451,9 @@ class TestGetJobNodesJson:
                 client.get_job_nodes('935')
 
     def test_get_job_nodes_malformed_json_does_not_fall_back(self):
-        """Test that malformed JSON raises instead of using the text path."""
+        """Test that malformed JSON raises once squeue has produced JSON."""
         client = _make_client()
+        client._json_output_supported['squeue'] = True
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.return_value = (0, 'not json', '')
@@ -459,7 +463,6 @@ class TestGetJobNodesJson:
                 client.get_job_nodes('935')
 
             assert mock_run.call_count == 1
-            assert client._json_output_supported is None
 
     def test_get_job_nodes_missing_nodes_field(self):
         """Test that an unexpected squeue schema raises."""
@@ -488,7 +491,7 @@ class TestGetJobNodesJson:
 
             assert nodes == ['node1', 'node2']
             assert node_ips == ['10.0.0.1', '10.0.0.2']
-            assert client._json_output_supported is False
+            assert client._json_output_supported['squeue'] is False
 
         # The verdict is cached: the next call goes straight to the text path.
         with mock.patch.object(client._runner, 'run') as mock_run:
@@ -506,7 +509,7 @@ class TestGetJobNodesText:
     def test_get_job_nodes_returns_nodes_and_ips(self):
         """Test that get_job_nodes returns parsed nodes and IPs."""
         client = _make_client()
-        client._json_output_supported = False
+        client._json_output_supported['squeue'] = False
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.return_value = (0, 'node1 10.0.0.1\nnode2 10.0.0.2', '')
@@ -520,7 +523,7 @@ class TestGetJobNodesText:
     def test_get_job_nodes_resolves_hostnames_via_login_node(self):
         """Test hostnames are resolved via getent ahostsv4 on the login node."""
         client = _make_client()
-        client._json_output_supported = False
+        client._json_output_supported['squeue'] = False
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.side_effect = [
@@ -545,7 +548,7 @@ class TestGetJobNodesText:
     def test_get_job_nodes_hostname_resolution_failure(self):
         """Test error handling when hostname resolution fails."""
         client = _make_client()
-        client._json_output_supported = False
+        client._json_output_supported['squeue'] = False
 
         # One hostname resolves, one fails (getent returns empty)
         resolve_output = (f'worker-1 10.20.30.1\n'
@@ -566,7 +569,7 @@ class TestGetJobNodesText:
     def test_get_job_nodes_no_nodes(self):
         """Test that empty output raises."""
         client = _make_client()
-        client._json_output_supported = False
+        client._json_output_supported['squeue'] = False
 
         with mock.patch.object(client._runner, 'run') as mock_run:
             mock_run.return_value = (0, '', '')
@@ -865,16 +868,119 @@ class TestGetProctrackType:
             assert result is None
 
 
-class TestGetAllNodeDetails:
-    """Test SlurmClient.get_all_node_details()."""
+class TestGetAllNodeDetailsJson:
+    """Test SlurmClient.get_all_node_details() on the `--json` path."""
+
+    def test_returns_counters_for_every_node(self):
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, _scontrol_json(), '')
+
+            result = client.get_all_node_details()
+            mock_run.assert_called_once_with(
+                'scontrol show node --json',
+                require_outputs=True,
+                separate_stderr=True,
+                stream_logs=False,
+            )
+
+        assert set(result.keys()) == {'node-001', 'node-002'}
+        node = result['node-001']
+        assert node.alloc_cpus == 1
+        assert node.total_cpus == 72
+        assert node.alloc_memory_mb == 4096
+        assert node.real_memory_mb == 430080
+        assert node.free_memory_mb == 436979
+        # Slurm reports the load average scaled by 100.
+        assert node.cpu_load == 0.93
+        assert result['node-002'].cpu_load == 0.83
+
+    def test_unreported_counters_are_none(self):
+        """Counters slurmd has not reported carry Slurm's unset sentinels."""
+        client = _make_client()
+        payload = _load_fixture('scontrol_nodes.json')
+        payload['nodes'][0]['cpu_load'] = 0xfffffffe
+        payload['nodes'][0]['free_mem'] = {
+            'set': False,
+            'infinite': False,
+            'number': 0
+        }
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, json.dumps(payload), '')
+            result = client.get_all_node_details()
+
+        assert result['node-001'].cpu_load is None
+        assert result['node-001'].free_memory_mb is None
+        # The other counters are still reported.
+        assert result['node-001'].total_cpus == 72
+
+    def test_falls_back_when_json_unsupported(self):
+        client = _make_client()
+        text_output = ('NodeName=node1 CPUAlloc=8 CPUTot=72 CPULoad=3.50 '
+                       'RealMemory=430080 AllocMem=102400 FreeMem=421339\n')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (1, '', "scontrol: unrecognized option '--json'"),
+                (0, text_output, ''),
+            ]
+            result = client.get_all_node_details()
+
+            assert mock_run.call_count == 2
+            assert mock_run.call_args_list[1][0][0] == 'scontrol show node -o'
+
+        assert result['node1'].cpu_load == 3.5
+        # The verdict is cached, so the next call skips the `--json` probe.
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, text_output, '')
+            client.get_all_node_details()
+            assert mock_run.call_args_list[0][0][0] == 'scontrol show node -o'
+
+    def test_falls_back_when_json_is_ignored(self):
+        """A subcommand may exit 0 and print its text output regardless."""
+        client = _make_client()
+        text_output = 'NodeName=node1 CPUAlloc=8 CPUTot=72 CPULoad=3.50\n'
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [(0, text_output, ''), (0, text_output, '')]
+            result = client.get_all_node_details()
+
+            assert mock_run.call_count == 2
+            assert mock_run.call_args_list[1][0][0] == 'scontrol show node -o'
+
+        assert result['node1'].total_cpus == 72
+
+    def test_malformed_json_does_not_fall_back(self):
+        """Garbage after a successful probe is a bug, not an old Slurm."""
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, _scontrol_json(), '')
+            client.get_all_node_details()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, 'not json', '')
+            with pytest.raises(RuntimeError, match='Failed to parse'):
+                client.get_all_node_details()
+            assert mock_run.call_count == 1
+
+    def test_missing_nodes_field(self):
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, json.dumps({'meta': {}}), '')
+            with pytest.raises(RuntimeError, match="no 'nodes' field"):
+                client.get_all_node_details()
+
+
+class TestGetAllNodeDetailsText:
+    """Test SlurmClient.get_all_node_details() on the text path."""
 
     def test_parses_one_line_per_node(self):
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+        client = _make_client()
+        client._json_output_supported['scontrol'] = False
 
         mock_output = (
             'NodeName=node1 Arch=x86_64 CPUAlloc=8 CPUEfctv=72 CPUTot=72 '
@@ -896,22 +1002,19 @@ class TestGetAllNodeDetails:
             )
 
         assert set(result.keys()) == {'node1', 'node2'}
-        assert result['node1']['CPUAlloc'] == '8'
-        assert result['node1']['CPUTot'] == '72'
-        assert result['node1']['CPULoad'] == '3.50'
-        assert result['node1']['AllocMem'] == '102400'
-        assert result['node1']['FreeMem'] == '421339'
-        assert result['node1']['State'] == 'MIXED'
-        assert result['node2']['CPULoad'] == 'N/A'
-        assert result['node2']['FreeMem'] == 'N/A'
+        assert result['node1'].alloc_cpus == 8
+        assert result['node1'].total_cpus == 72
+        assert result['node1'].cpu_load == 3.5
+        assert result['node1'].alloc_memory_mb == 102400
+        assert result['node1'].real_memory_mb == 430080
+        assert result['node1'].free_memory_mb == 421339
+        assert result['node2'].cpu_load is None
+        assert result['node2'].free_memory_mb is None
+        assert result['node2'].alloc_cpus == 0
 
     def test_skips_blank_lines_and_lines_without_node_name(self):
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+        client = _make_client()
+        client._json_output_supported['scontrol'] = False
 
         mock_output = ('\n'
                        'NodeName=node1 CPUTot=8\n'

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -328,16 +328,16 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert slurm_client_cls.call_args.kwargs['slurm_user'] is None
 
     def test_enriches_from_scontrol(self, monkeypatch):
+        from sky.adaptors import slurm as slurm_adaptor
+
         result, _ = self._run(
             monkeypatch, {
-                'node1': {
-                    'CPUAlloc': '8',
-                    'CPUTot': '72',
-                    'CPULoad': '3.50',
-                    'RealMemory': '430080',
-                    'AllocMem': '102400',
-                    'FreeMem': '421339',
-                },
+                'node1': slurm_adaptor.NodeDetails(alloc_cpus=8,
+                                                   total_cpus=72,
+                                                   alloc_memory_mb=102400,
+                                                   real_memory_mb=430080,
+                                                   free_memory_mb=421339,
+                                                   cpu_load=3.5),
             })
         assert len(result) == 1
         node = result[0]
@@ -347,17 +347,17 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert node['cpu_load'] == 3.5
         assert node['free_memory_gb'] == round(421339 / 1024.0, 2)
 
-    def test_na_values_become_none(self, monkeypatch):
+    def test_unreported_counters_become_none(self, monkeypatch):
+        from sky.adaptors import slurm as slurm_adaptor
+
         result, _ = self._run(
             monkeypatch, {
-                'node1': {
-                    'CPUAlloc': '0',
-                    'CPUTot': '72',
-                    'CPULoad': 'N/A',
-                    'RealMemory': '430080',
-                    'AllocMem': '0',
-                    'FreeMem': 'N/A',
-                },
+                'node1': slurm_adaptor.NodeDetails(alloc_cpus=0,
+                                                   total_cpus=72,
+                                                   alloc_memory_mb=0,
+                                                   real_memory_mb=430080,
+                                                   free_memory_mb=None,
+                                                   cpu_load=None),
             })
         node = result[0]
         assert node['free_vcpus'] == 72


### PR DESCRIPTION
Second of a series replacing fragile text parsing in the Slurm adaptor with typed `--json` output (follows #10307).

## Why

`scontrol show node -o` is the one node query with no format-string option, so `get_all_node_details()` had to split its free-form `key=value` output on whitespace. Any value containing a space breaks that splitter — `Reason=Not responding [slurm@...]`, `OS=Linux ... SMP ...`, `Extra={"a": "b c"}` all end up truncated at the first space, with the remaining tokens silently dropped. It also hands callers raw strings to reparse, so `sky/provision/slurm/utils.py` reimplements int/float coercion for six attribute names.

## What

* `get_all_node_details()` queries `scontrol show node --json` and returns a typed `NodeDetails` per node. The text parser stays as a fallback for Slurm versions before `scontrol --json` (23.02).
* Two details the JSON schema forces, both verified against `data_parser/v0.0.44` in `src/plugins/data_parser/v0.0.44/parsers.c`:
  * `cpu_load` is `add_parse(UINT32, ...)` — the load average scaled by 100, as a plain integer — so an unreported value arrives as Slurm's `NO_VAL` sentinel rather than as null.
  * `free_mem` is `UINT64_NO_VAL`, i.e. wrapped as `{set, infinite, number}`.
* `--json` support is now probed per Slurm program instead of per client: `squeue --json` ships since 21.08 but `scontrol --json` only since 23.02, so one verdict for both is wrong on 22.x. An unrecognized option other than `--json` no longer disqualifies a program either, and a subcommand that ignores `--json` and prints its text output regardless (as `scontrol show config` does) is detected and falls back.
* Drops `node_details()` and `get_jobs_gres()`, which have no callers.

## Tested

* `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/ tests/unit_tests/test_sky/clouds/test_slurm.py tests/unit_tests/slurm/` — 365 passed. New cases cover the JSON path, the unset-sentinel encodings, the fallback on an unrecognized `--json`, the fallback when `--json` is ignored, cached verdicts, and malformed JSON after a successful probe raising instead of falling back.
* Unit-test fixtures are real payloads captured from a Slurm 25.05.3 cluster (`data_parser/v0.0.43`), anonymized. The unset-sentinel case is the captured payload with those two fields replaced by Slurm's unset encodings — no cluster with an unreported counter was available.
* Live, against a Slurm 25.05.3 cluster over SSH: `get_all_node_details()` took the JSON path (probe cached as `{'scontrol': True}`) and returned exactly the same `NodeDetails` as the text path for both nodes, `cpu_load` included:

  ```
  slurm-node-a  NodeDetails(alloc_cpus=1, total_cpus=72, alloc_memory_mb=4096,
                            real_memory_mb=430080, free_memory_mb=447029, cpu_load=0.01)
  slurm-node-b  NodeDetails(alloc_cpus=1, total_cpus=72, alloc_memory_mb=4096,
                            real_memory_mb=430080, free_memory_mb=446765, cpu_load=0.6)
  ```

  matching `CPULoad=0.01` / `CPULoad=0.60` from `scontrol show node -o` sampled at the same moment.
* Not exercised live: the pre-23.02 fallback path (no such cluster available) — it is covered by unit tests only.
