### PR TITLE
[Slurm] Use `--json` output in `get_partitions_info()`

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -73,10 +73,9 @@ class SlurmPartition(NamedTuple):
     # The maximum time a job can run in seconds.
     # None if the maximum time is unlimited.
     maxtime: Optional[int]
-    # The raw Slurm time string the partition assigns when --time is omitted
-    # (e.g. '01:00:00', '2-00:00:00'). None if the partition has no
-    # DefaultTime configured (NONE/UNLIMITED).
-    default_time: Optional[str]
+    # The time in seconds the partition assigns when --time is omitted.
+    # None if the partition has no DefaultTime configured (NONE/UNLIMITED).
+    default_time: Optional[int]
 
 
 class NodeDetails(NamedTuple):
@@ -121,41 +120,39 @@ class JobGresInfo(NamedTuple):
     gres_str: str
 
 
-def _parse_maxtime(line: str) -> Optional[int]:
-    """Parse the maximum time a job can run from the scontrol output."""
-    maxtime_match = _MAXTIME_REGEX.search(line)
-    if not maxtime_match:
-        return None
-    maxtime_str = maxtime_match.group(1).strip()
-    if maxtime_str == 'UNLIMITED':
+def _parse_duration(raw: str) -> Optional[int]:
+    """Convert a Slurm '[days-]hours:minutes:seconds' duration into seconds.
+
+    Example: '2-12:30:05' => (2*86400) + (12*3600) + (30*60) + 5. Returns None
+    for the durations Slurm spells out (``UNLIMITED``/``NONE``).
+    """
+    if raw in ('NONE', 'UNLIMITED'):
         return None
 
-    # Convert maxTime from '[days-]hours:minutes:seconds' to seconds.
-    # Example: "2-12:30:05" => (2*86400) + (12*3600) + (30*60) + 5
     days = 0
-    time_part = maxtime_str
-    if '-' in maxtime_str:
-        days_part, time_part = maxtime_str.split('-', 1)
+    time_part = raw
+    if '-' in raw:
+        days_part, time_part = raw.split('-', 1)
         days = int(days_part)
 
     h, m, s = map(int, time_part.split(':'))
     return days * 86400 + h * 3600 + m * 60 + s
 
 
-def _parse_default_time(line: str) -> Optional[str]:
-    """Parse the DefaultTime a partition uses from the scontrol output.
+def _parse_maxtime(line: str) -> Optional[int]:
+    """Parse the maximum time a job can run from the scontrol output."""
+    maxtime_match = _MAXTIME_REGEX.search(line)
+    if not maxtime_match:
+        return None
+    return _parse_duration(maxtime_match.group(1).strip())
 
-    Returns the raw Slurm time string (e.g. '01:00:00', '2-00:00:00') so it
-    can be passed straight through to ``--time``. Returns None when the
-    partition has no DefaultTime configured (``NONE``/``UNLIMITED``).
-    """
+
+def _parse_default_time(line: str) -> Optional[int]:
+    """Parse the DefaultTime a partition uses from the scontrol output."""
     match = _DEFAULT_TIME_REGEX.search(line)
     if not match:
         return None
-    raw = match.group(1)
-    if raw in ('NONE', 'UNLIMITED'):
-        return None
-    return raw
+    return _parse_duration(match.group(1))
 
 
 def _parse_optional_number(value: Optional[str]) -> Optional[float]:
@@ -957,12 +954,72 @@ class SlurmClient:
 
         return job_id
 
-    def get_partitions_info(self) -> List[SlurmPartition]:
-        """Get the partitions information for the Slurm cluster.
+    def _get_default_partition_name(self, names: List[str]) -> Optional[str]:
+        """Ask sinfo which partition is the default, marked with a '*'.
 
-        Returns:
-            List of SlurmPartition objects.
+        `scontrol show partitions --json` does not serialize the partition
+        flags, so `Default=YES` is not available there on any Slurm version
+        released so far.
+
+        Args:
+            names: The cluster's partition names, used to tell a default
+                marker apart from a name that ends with a '*' itself.
         """
+        # --all so that a hidden partition is listed too.
+        cmd = 'sinfo -h -a -o "%P"'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            'Failed to get the default Slurm partition.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+
+        known = set(names)
+        for line in stdout.splitlines():
+            name = line.strip()
+            if name.endswith('*') and name not in known and name[:-1] in known:
+                return name[:-1]
+        return None
+
+    def _get_partitions_info_json(self) -> List[SlurmPartition]:
+        """get_partitions_info() using Slurm's `--json` output.
+
+        `scontrol --json` ships since Slurm 23.02. Older versions reject the
+        option, and get_partitions_info() falls back to the text output.
+        """
+        cmd = 'scontrol show partitions --json'
+        rc, stdout, stderr = self._run_slurm_json_cmd(cmd)
+        subprocess_utils.handle_returncode(rc,
+                                           cmd,
+                                           'Failed to get Slurm partitions.',
+                                           stderr=f'{stdout}\n{stderr}',
+                                           stream_logs=False)
+
+        payload = self._load_slurm_json(cmd, stdout)
+        names: List[str] = []
+        # Slurm reports both times in minutes.
+        times: List[Tuple[Optional[int], Optional[int]]] = []
+        for partition in self._get_json_field(cmd, payload, 'partitions'):
+            names.append(self._get_json_field(cmd, partition, 'name'))
+            maximums = self._get_json_field(cmd, partition, 'maximums')
+            defaults = self._get_json_field(cmd, partition, 'defaults')
+            times.append((_json_optional_int(maximums.get('time')),
+                          _json_optional_int(defaults.get('time'))))
+
+        default_partition = self._get_default_partition_name(names)
+        return [
+            SlurmPartition(
+                name=name,
+                is_default=name == default_partition,
+                maxtime=None if maxtime is None else maxtime * 60,
+                default_time=None if default_time is None else default_time *
+                60,
+            ) for name, (maxtime, default_time) in zip(names, times)
+        ]
+
+    def _get_partitions_info_text(self) -> List[SlurmPartition]:
+        """get_partitions_info() for Slurm versions without `--json`."""
         cmd = 'scontrol show partitions -o'
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(rc,
@@ -988,6 +1045,16 @@ class SlurmClient:
                                        maxtime=maxtime,
                                        default_time=default_time))
         return partitions
+
+    def get_partitions_info(self) -> List[SlurmPartition]:
+        """Get the partitions information for the Slurm cluster.
+
+        Returns:
+            List of SlurmPartition objects.
+        """
+        return self._with_json_output(['scontrol'],
+                                      self._get_partitions_info_json,
+                                      self._get_partitions_info_text)
 
     def get_default_partition(self) -> Optional[str]:
         """Get the default partition name for the Slurm cluster.

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -50,6 +50,7 @@ class TestGetPartitions:
             ssh_user='root',
             ssh_key=None,
         )
+        client._json_output_supported['scontrol'] = False
 
         mock_output = """PartitionName=dev AllowGroups=ALL AllowAccounts=ALL AllowQos=ALL AllocNodes=ALL Default=YES QoS=N/A DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO ExclusiveTopo=NO GraceTime=0 Hidden=NO MaxNodes=UNLIMITED MaxTime=UNLIMITED MinNodes=0 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED NodeSets=ALL Nodes=ip-10-3-0-193,ip-10-3-68-50,ip-10-3-200-46,ip-10-3-201-35,ip-10-3-215-227,ip-10-3-225-110 PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=NO OverTimeLimit=NONE PreemptMode=OFF State=UP TotalCPUs=248 TotalNodes=6 SelectTypeParameters=NONE JobDefaults=(null) DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED TRES=cpu=248,mem=1216G,node=6,billing=248,gres/gpu=12
 PartitionName=CPU nodes (amd) AllowGroups=ALL AllowAccounts=ALL AllowQos=ALL AllocNodes=ALL Default=NO QoS=N/A DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO ExclusiveTopo=NO GraceTime=0 Hidden=NO MaxNodes=UNLIMITED MaxTime=UNLIMITED MinNodes=0 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED Nodes=ip-10-3-0-193,ip-10-3-215-227 PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=NO OverTimeLimit=NONE PreemptMode=OFF State=UP TotalCPUs=4 TotalNodes=2 SelectTypeParameters=NONE JobDefaults=(null) DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED TRES=cpu=4,mem=32G,node=2,billing=4
@@ -766,15 +767,14 @@ class TestParseDefaultTime:
         assert result is None
 
     def test_parse_default_time_hms(self):
-        """Returns the raw hh:mm:ss string verbatim."""
         line = 'PartitionName=dev DefaultTime=01:00:00 MaxTime=12:00:00'
         result = slurm._parse_default_time(line)
-        assert result == '01:00:00'
+        assert result == 3600
 
     def test_parse_default_time_with_days(self):
         line = 'PartitionName=dev DefaultTime=2-00:00:00 MaxTime=7-00:00:00'
         result = slurm._parse_default_time(line)
-        assert result == '2-00:00:00'
+        assert result == 2 * 86400
 
     def test_parse_default_time_no_match(self):
         line = 'PartitionName=dev MaxTime=12:00:00'
@@ -782,16 +782,125 @@ class TestParseDefaultTime:
         assert result is None
 
 
-class TestGetPartitionsInfoDefaultTime:
-    """Verify get_partitions_info() populates the default_time field."""
+def _partitions_json(times=None) -> str:
+    """The partitions fixture, with the two time fields optionally replaced.
 
-    def test_populates_default_time(self):
-        client = slurm.SlurmClient(
-            ssh_host='localhost',
-            ssh_port=22,
-            ssh_user='root',
-            ssh_key=None,
-        )
+    Args:
+        times: Per partition, a (MaxTime, DefaultTime) pair of minutes, or
+            None for the unlimited/unset encoding the fixture was captured
+            with.
+    """
+    payload = _load_fixture('scontrol_partitions.json')
+    for i, partition in enumerate(payload['partitions']):
+        if times is None or times[i] is None:
+            continue
+        maxtime, default_time = times[i]
+        partition['maximums']['time'] = {
+            'set': True,
+            'infinite': False,
+            'number': maxtime
+        }
+        partition['defaults']['time'] = {
+            'set': True,
+            'infinite': False,
+            'number': default_time
+        }
+    return json.dumps(payload)
+
+
+class TestGetPartitionsInfoJson:
+    """Test SlurmClient.get_partitions_info() on the `--json` path."""
+
+    # sinfo marks the default partition with a trailing '*'.
+    _SINFO_OUTPUT = 'default-partition*\ngpu\ncpu\n'
+
+    def test_returns_partitions_with_default_and_times(self):
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _partitions_json(times=[(120, 60), None, None]), ''),
+                (0, self._SINFO_OUTPUT, ''),
+            ]
+
+            result = client.get_partitions_info()
+
+            commands = [call[0][0] for call in mock_run.call_args_list]
+            assert commands == [
+                'scontrol show partitions --json', 'sinfo -h -a -o "%P"'
+            ]
+
+        assert [p.name for p in result] == ['default-partition', 'gpu', 'cpu']
+        assert [p.is_default for p in result] == [True, False, False]
+        # Slurm reports both times in minutes.
+        assert result[0].maxtime == 7200
+        assert result[0].default_time == 3600
+        # MaxTime=UNLIMITED and DefaultTime=NONE, as captured.
+        assert result[1].maxtime is None
+        assert result[1].default_time is None
+
+    def test_no_default_partition(self):
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, _partitions_json(), ''),
+                (0, 'default-partition\ngpu\ncpu\n', ''),
+            ]
+            result = client.get_partitions_info()
+
+        assert not any(p.is_default for p in result)
+
+    def test_star_in_partition_name_is_not_the_default_marker(self):
+        """A partition may be named with a trailing '*' itself."""
+        client = _make_client()
+        payload = _load_fixture('scontrol_partitions.json')
+        payload['partitions'][1]['name'] = 'gpu*'
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (0, json.dumps(payload), ''),
+                (0, 'default-partition\ngpu*\ncpu\n', ''),
+            ]
+            result = client.get_partitions_info()
+
+        assert not any(p.is_default for p in result)
+
+    def test_falls_back_when_json_unsupported(self):
+        client = _make_client()
+        text_output = ('PartitionName=cpu Default=YES DefaultTime=01:00:00 '
+                       'MaxTime=UNLIMITED')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.side_effect = [
+                (1, '', "scontrol: unrecognized option '--json'"),
+                (0, text_output, ''),
+            ]
+            result = client.get_partitions_info()
+
+            assert mock_run.call_count == 2
+            assert (mock_run.call_args_list[1][0][0] ==
+                    'scontrol show partitions -o')
+
+        assert result[0].name == 'cpu'
+        assert result[0].is_default is True
+        assert result[0].default_time == 3600
+
+    def test_missing_partitions_field(self):
+        client = _make_client()
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, json.dumps({'meta': {}}), '')
+            with pytest.raises(RuntimeError, match="no 'partitions' field"):
+                client.get_partitions_info()
+
+
+class TestGetPartitionsInfoText:
+    """Test SlurmClient.get_partitions_info() on the text path."""
+
+    def test_populates_times_and_default(self):
+        client = _make_client()
+        client._json_output_supported['scontrol'] = False
 
         mock_output = ('PartitionName=cpu Default=YES DefaultTime=01:00:00 '
                        'MaxTime=UNLIMITED\n'
@@ -806,7 +915,7 @@ class TestGetPartitionsInfoDefaultTime:
         assert result[0].name == 'cpu'
         assert result[0].is_default is True
         assert result[0].maxtime is None  # UNLIMITED
-        assert result[0].default_time == '01:00:00'
+        assert result[0].default_time == 3600
         assert result[1].name == 'gpu'
         assert result[1].is_default is False
         assert result[1].maxtime == 7200

--- a/tests/unit_tests/test_sky/adaptors/testdata/slurm/scontrol_partitions.json
+++ b/tests/unit_tests/test_sky/adaptors/testdata/slurm/scontrol_partitions.json
@@ -1,0 +1,411 @@
+{
+  "partitions": [
+    {
+      "nodes": {
+        "allowed_allocation": "",
+        "configured": "node-[001-002]",
+        "total": 2
+      },
+      "accounts": {
+        "allowed": "",
+        "deny": ""
+      },
+      "groups": {
+        "allowed": ""
+      },
+      "qos": {
+        "allowed": "",
+        "deny": "",
+        "assigned": ""
+      },
+      "alternate": "",
+      "tres": {
+        "billing_weights": "",
+        "configured": "cpu=144,mem=840G,node=2,billing=144,gres/gpu=2"
+      },
+      "cluster": "",
+      "select_type": [],
+      "cpus": {
+        "task_binding": 0,
+        "total": 144
+      },
+      "defaults": {
+        "memory_per_cpu": 0,
+        "partition_memory_per_cpu": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "partition_memory_per_node": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "time": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "job": ""
+      },
+      "grace_time": 0,
+      "maximums": {
+        "cpus_per_node": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "cpus_per_socket": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "memory_per_cpu": 0,
+        "partition_memory_per_cpu": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "partition_memory_per_node": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "nodes": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "shares": 1,
+        "oversubscribe": {
+          "jobs": 1,
+          "flags": []
+        },
+        "time": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "over_time_limit": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "minimums": {
+        "nodes": 0
+      },
+      "name": "default-partition",
+      "node_sets": "ALL",
+      "priority": {
+        "job_factor": 1,
+        "tier": 1
+      },
+      "timeouts": {
+        "resume": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "suspend": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "topology": "",
+      "partition": {
+        "state": [
+          "UP"
+        ]
+      },
+      "suspend_time": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      }
+    },
+    {
+      "nodes": {
+        "allowed_allocation": "",
+        "configured": "node-[001-002]",
+        "total": 2
+      },
+      "accounts": {
+        "allowed": "",
+        "deny": ""
+      },
+      "groups": {
+        "allowed": ""
+      },
+      "qos": {
+        "allowed": "",
+        "deny": "",
+        "assigned": ""
+      },
+      "alternate": "",
+      "tres": {
+        "billing_weights": "",
+        "configured": "cpu=144,mem=840G,node=2,billing=144,gres/gpu=2"
+      },
+      "cluster": "",
+      "select_type": [],
+      "cpus": {
+        "task_binding": 0,
+        "total": 144
+      },
+      "defaults": {
+        "memory_per_cpu": -9223372036854739968,
+        "partition_memory_per_cpu": {
+          "set": true,
+          "infinite": false,
+          "number": 35840
+        },
+        "partition_memory_per_node": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "time": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "job": ""
+      },
+      "grace_time": 0,
+      "maximums": {
+        "cpus_per_node": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "cpus_per_socket": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "memory_per_cpu": 0,
+        "partition_memory_per_cpu": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "partition_memory_per_node": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "nodes": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "shares": 1,
+        "oversubscribe": {
+          "jobs": 1,
+          "flags": []
+        },
+        "time": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "over_time_limit": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "minimums": {
+        "nodes": 0
+      },
+      "name": "gpu",
+      "node_sets": "gh200",
+      "priority": {
+        "job_factor": 1,
+        "tier": 1
+      },
+      "timeouts": {
+        "resume": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "suspend": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "topology": "",
+      "partition": {
+        "state": [
+          "UP"
+        ]
+      },
+      "suspend_time": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      }
+    },
+    {
+      "nodes": {
+        "allowed_allocation": "",
+        "configured": "",
+        "total": 0
+      },
+      "accounts": {
+        "allowed": "",
+        "deny": ""
+      },
+      "groups": {
+        "allowed": ""
+      },
+      "qos": {
+        "allowed": "",
+        "deny": "",
+        "assigned": ""
+      },
+      "alternate": "",
+      "tres": {
+        "billing_weights": "",
+        "configured": ""
+      },
+      "cluster": "",
+      "select_type": [],
+      "cpus": {
+        "task_binding": 0,
+        "total": 0
+      },
+      "defaults": {
+        "memory_per_cpu": -9223372036854771295,
+        "partition_memory_per_cpu": {
+          "set": true,
+          "infinite": false,
+          "number": 4513
+        },
+        "partition_memory_per_node": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "time": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "job": ""
+      },
+      "grace_time": 0,
+      "maximums": {
+        "cpus_per_node": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "cpus_per_socket": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "memory_per_cpu": 0,
+        "partition_memory_per_cpu": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "partition_memory_per_node": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "nodes": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "shares": 1,
+        "oversubscribe": {
+          "jobs": 1,
+          "flags": []
+        },
+        "time": {
+          "set": false,
+          "infinite": true,
+          "number": 0
+        },
+        "over_time_limit": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "minimums": {
+        "nodes": 0
+      },
+      "name": "cpu",
+      "node_sets": "slurm-cpu",
+      "priority": {
+        "job_factor": 1,
+        "tier": 1
+      },
+      "timeouts": {
+        "resume": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "suspend": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "topology": "",
+      "partition": {
+        "state": [
+          "UP"
+        ]
+      },
+      "suspend_time": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      }
+    }
+  ],
+  "last_update": {
+    "set": true,
+    "infinite": false,
+    "number": 1785451276
+  },
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser/v0.0.43",
+      "accounting_storage": "accounting_storage/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "skypilot",
+      "group": "skypilot"
+    },
+    "command": [
+      "show"
+    ],
+    "slurm": {
+      "version": {
+        "major": "25",
+        "micro": "3",
+        "minor": "05"
+      },
+      "release": "25.05.3",
+      "cluster": "slurm"
+    }
+  },
+  "errors": [],
+  "warnings": []
+}


### PR DESCRIPTION
Third of a series replacing fragile text parsing in the Slurm adaptor with typed `--json` output (follows #10307 and #10310).

## Why

`get_partitions_info()` ran three regexes over the free-form output of `scontrol show partitions -o`. The name pattern has to guess where the name ends, because partition names may contain spaces:

```python
_PARTITION_NAME_REGEX = re.compile(r'PartitionName=(.+?)(?:\s+\w+=|$)')
```

The other two hand-roll `[days-]HH:MM:SS` parsing for `MaxTime` and `DefaultTime`.

## What

* `get_partitions_info()` queries `scontrol show partitions --json`, which reports the name as a field and both limits as optional-typed numbers of **minutes** — `src/api/partition_info.c` multiplies both by 60 before printing them as `[days-]HH:MM:SS`. The text parser stays as a fallback for Slurm versions before `scontrol --json` (23.02).
* The default partition needs a second command. The partition `flags` field is `add_skip(flags), //FIXME` in the data_parser (`PARSER_ARRAY(PARTITION_INFO)` in `src/plugins/data_parser/v0.0.44/parsers.c`), so `Default=YES` is absent from the JSON on Slurm master too, not just on older releases. `sinfo -h -a -o "%P"` supplies it as a single field, marking the default with a trailing `*`. Because the JSON gives the exact set of partition names, a partition whose name ends with a `*` itself is no longer ambiguous — the previous inline `endswith('*')` checks in `sky/provision/slurm/utils.py` had to guess. `-a` so a hidden default partition is still listed.
* Both calls sit behind the existing one-hour TTL cache in `get_partition_infos()`, so the extra round-trip is once per cluster per hour.
* `SlurmPartition.default_time` becomes seconds instead of a raw Slurm time string, matching `maxtime` and keeping the two paths in agreement. Its only consumer (`_compute_time_directive`) tests it for `None`.

## Tested

* `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/ tests/unit_tests/test_sky/clouds/test_slurm.py tests/unit_tests/slurm/` — 370 passed. New cases cover the JSON path, a cluster with no default partition, a partition named with a trailing `*`, the fallback on an unrecognized `--json`, and a missing `partitions` field raising.
* The unit-test fixture is a real `scontrol show partitions --json` payload from a Slurm 25.05.3 cluster (`data_parser/v0.0.43`), anonymized. That cluster has `MaxTime=UNLIMITED` and `DefaultTime=NONE` on every partition, so the finite-duration conversion is exercised by setting those two fields to Slurm's set encoding — the minutes-to-seconds factor itself comes from `partition_info.c` above, not from a live finite value.
* Live, against a Slurm 25.05.3 cluster over SSH: `get_partitions_info()` took the JSON path and returned a list identical to the text path's, default flag included:

  ```
  SlurmPartition(name='all',   is_default=True,  maxtime=None, default_time=None)
  SlurmPartition(name='gpu',   is_default=False, maxtime=None, default_time=None)
  SlurmPartition(name='cpu',   is_default=False, maxtime=None, default_time=None)
  ```

  `get_default_partition()` returned `all`, matching `Default=YES` in the text output.
* Not exercised live: the pre-23.02 fallback path, and a partition with a finite `MaxTime`/`DefaultTime` — both covered by unit tests only.
