### PR TITLE
[API] Give auth its own thread executor so streams cannot starve it

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -92,6 +92,15 @@ multiprocessing.set_start_method('spawn', force=True)
 # server process become overloaded.
 _REQUEST_THREADS_LIMIT = 128
 
+# Limit for the auth executor. Sized against the sync DB connection pool, not
+# against a request rate: these threads do DB lookups, so a worker cannot have
+# more of them doing useful work than it has connections, and the rest would
+# just queue inside the pool. The ceiling is single-digit per worker today, so
+# this leaves several times the headroom needed while staying far below the
+# point where the sheer number of threads in one process starts slowing its
+# request handling down.
+_AUTH_THREADS_LIMIT = 32
+
 # Max length of the retry reason in a request's backoff status message; the
 # reason comes from the exception message, so truncate to keep it readable.
 _RETRY_STATUS_MSG_REASON_MAX_LEN = 200
@@ -115,6 +124,37 @@ def get_request_thread_executor() -> threads.OnDemandThreadExecutor:
                 name='request_thread_executor',
                 max_workers=_REQUEST_THREADS_LIMIT)
         return _REQUEST_THREAD_EXECUTOR
+
+
+_AUTH_THREAD_EXECUTOR_LOCK = threading.Lock()
+# A separate pool for the short DB lookups that authentication middleware runs
+# on every request. Kept apart from _REQUEST_THREAD_EXECUTOR because the two
+# have very different lifetimes: a worker in the request executor can be held
+# for the whole life of a streaming request (e.g. `sky jobs logs` on a queued
+# job runs for as long as the job does), while these lookups take under a
+# millisecond. Sharing one pool means enough concurrent streams starve
+# authentication, and every request fails with 503 -- including requests that
+# have nothing to do with streaming. Separate pools keep that failure confined
+# to the streaming endpoints.
+_AUTH_THREAD_EXECUTOR: Optional[threads.OnDemandThreadExecutor] = None
+
+
+def get_auth_thread_executor() -> threads.OnDemandThreadExecutor:
+    """Lazy init and return the auth thread executor for current process.
+
+    For short, latency-sensitive work on the request hot path -- primarily the
+    DB lookups done by authentication middleware. Do not submit long-running or
+    streaming work here; that belongs in ``get_request_thread_executor()``,
+    whose exhaustion must not be able to lock users out.
+    """
+    global _AUTH_THREAD_EXECUTOR
+    if _AUTH_THREAD_EXECUTOR is not None:
+        return _AUTH_THREAD_EXECUTOR
+    with _AUTH_THREAD_EXECUTOR_LOCK:
+        if _AUTH_THREAD_EXECUTOR is None:
+            _AUTH_THREAD_EXECUTOR = threads.OnDemandThreadExecutor(
+                name='auth_thread_executor', max_workers=_AUTH_THREADS_LIMIT)
+        return _AUTH_THREAD_EXECUTOR
 
 
 class RequestQueue:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -489,17 +489,19 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # JWT carries a freshly-generated token_id; only the hash is
             # consistent between the live JWT and the live DB row.
             incoming_hash = hashlib.sha256(sa_token.encode()).hexdigest()
-            # Offload the sync DB lookups to the bounded request thread executor
-            # so a slow/locked DB cannot stall the request event loop (this runs
-            # on the loop for every service-account-authenticated request).
-            # Using the dedicated executor (not asyncio's shared default thread
+            # Offload the sync DB lookups to the bounded auth thread executor so
+            # a slow/locked DB cannot stall the request event loop (this runs on
+            # the loop for every service-account-authenticated request).
+            # Using a dedicated executor (not asyncio's shared default thread
             # pool) avoids saturating that pool under DB slowness; when it is
             # exhausted it raises ConcurrentWorkerExhaustedError, which the
-            # app-level handler turns into a 503 so the client retries.
+            # app-level handler turns into a 503 so the client retries. The auth
+            # executor is kept separate from the request executor so long-lived
+            # streaming requests cannot starve authentication.
             loop = asyncio.get_running_loop()
-            request_executor = executor.get_request_thread_executor()
+            auth_executor = executor.get_auth_thread_executor()
             token_row = await loop.run_in_executor(
-                request_executor,
+                auth_executor,
                 global_user_state.get_service_account_token_by_hash,
                 incoming_hash)
             if token_row is None:
@@ -516,7 +518,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     {'detail': 'Service account token has expired'})
 
             # Verify user still exists in database
-            user_info = await loop.run_in_executor(request_executor,
+            user_info = await loop.run_in_executor(auth_executor,
                                                    global_user_state.get_user,
                                                    user_id)
             if user_info is None:
@@ -530,7 +532,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # carries a different token_id than the DB row.
             try:
                 await loop.run_in_executor(
-                    request_executor,
+                    auth_executor,
                     global_user_state.update_service_account_token_last_used,
                     token_row['token_id'])
             except Exception as e:  # pylint: disable=broad-except

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -5,6 +5,7 @@ import functools
 import os
 import pathlib
 import queue as queue_lib
+import threading
 import time
 from typing import List
 from unittest import mock
@@ -1385,3 +1386,61 @@ def test_resolution_log_silent_for_bare_launch_without_prefix(
     assert not [m for m in info_calls if 'Using workspace' in m], (
         f'bare `launch` (without prefix) must not match the whitelist; '
         f'got: {info_calls}')
+
+
+def _reset_thread_executors():
+    """Drop both cached per-process executors so each test starts clean."""
+    # pylint: disable=protected-access
+    executor._REQUEST_THREAD_EXECUTOR = None
+    executor._AUTH_THREAD_EXECUTOR = None
+
+
+def test_auth_and_request_executors_are_distinct():
+    _reset_thread_executors()
+    try:
+        request_executor = executor.get_request_thread_executor()
+        auth_executor = executor.get_auth_thread_executor()
+        assert request_executor is not auth_executor
+        assert request_executor.name != auth_executor.name
+        # Each getter still memoizes per process.
+        assert executor.get_request_thread_executor() is request_executor
+        assert executor.get_auth_thread_executor() is auth_executor
+    finally:
+        _reset_thread_executors()
+
+
+def test_saturating_request_executor_does_not_block_auth():
+    """The point of the split: streaming work filling the request executor
+    must not make authentication fail.
+
+    Before the split both shared one pool, so enough long-lived streams
+    starved the auth lookups that run on every request and the server
+    answered 503 to traffic that had nothing to do with streaming.
+    """
+    _reset_thread_executors()
+    try:
+        request_executor = executor.get_request_thread_executor()
+        auth_executor = executor.get_auth_thread_executor()
+
+        release = threading.Event()
+        futures = []
+        # Fill the request executor to its limit with tasks that do not finish,
+        # standing in for in-flight log streams.
+        for _ in range(request_executor.max_workers):
+            futures.append(request_executor.submit(release.wait, 10))
+
+        # It is now full: one more task is rejected.
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            request_executor.submit(release.wait, 10)
+
+        # Auth is unaffected and still serves requests.
+        assert auth_executor.submit(lambda: 'ok').result(timeout=5) == 'ok'
+        assert auth_executor.check_available() >= 0
+    finally:
+        release.set()
+        for fut in futures:
+            try:
+                fut.result(timeout=5)
+            except Exception:  # pylint: disable=broad-except
+                pass
+        _reset_thread_executors()


### PR DESCRIPTION
Draft — the mechanism is here and tested, but see "Open questions" before merging.

## Problem

`request_thread_executor` is a single per-process pool (128 workers) shared by two kinds of work with very different lifetimes:

| Work | Where | Duration |
|---|---|---|
| Auth DB lookups, on **every** request | `BearerTokenMiddleware` (`server.py`) | one DB round trip |
| Requests executed as coroutines | `/logs`, `/jobs/logs`, `jobs/wait`, serve logs | the life of the stream — for a tail of a queued job, as long as the job stays queued |

Because the pool is shared, enough concurrent streams fill it and then *every* request fails with `ConcurrentWorkerExhaustedError` → 503, including requests that have nothing to do with streaming.

This is not hypothetical, and the blast radius is counter-intuitive. On a deployed server I drove a burst of managed-job log tails: **all of the tail requests returned 200**, while the rejections landed on unrelated traffic — health checks, internal status polls, `sky jobs queue`. The clients that caused the saturation saw nothing wrong; everyone else was locked out.

Note this failure mode does not require a leak. #10290 fixed tails that were held after the client disconnected, but 128 *legitimate* concurrent tails saturate the pool just as effectively. That fixed a cheap way of reaching the state; this addresses the coupling that makes the state catastrophic.

## Change

Add a second `OnDemandThreadExecutor` (`auth_thread_executor`) and point the service-account auth middleware at it.

- Threads are created on demand and destroyed when their task finishes, so an unreached limit costs nothing; in steady state the auth pool holds ~0 threads.
- The new pool reports separately as `sky_apiserver_threads_{active,max}{name="auth_thread_executor"}` — those gauges are already labelled by executor name, so no metrics work was needed.

What this does **not** do: it does not stop streams from exhausting their own pool. It confines that failure to the streaming endpoints instead of turning it into a server-wide authentication outage.

## Sizing (32, not 128)

Sized against the **sync DB connection pool**, not a request rate. These threads do DB lookups, so a worker cannot have more of them doing useful work than it has connections — the rest queue inside the pool. The per-worker connection ceiling is single-digit today, so 32 is several times the headroom needed.

This matters beyond tidiness: when the shared pool saturated on the deployed server, **876 of 896 threads were blocked in `psycopg2.connect`**, i.e. queued behind a handful of connections rather than doing work. Sizing a large thread pool in front of a small connection pool manufactures exactly that pile-up, and the extra threads are pure scheduling overhead.

32 rather than something tighter because the connection pool is configurable, and the thread pool should not become the binding constraint if a deployment raises it.

## Tested

- `test_auth_and_request_executors_are_distinct` — separate instances, each still memoized per process.
- `test_saturating_request_executor_does_not_block_auth` — fills the request executor to its limit with tasks that do not finish (standing in for in-flight streams), asserts the next submit is rejected, then asserts auth still runs work.
- **Revert check**: making the auth getter return the request executor fails both tests, so they genuinely pin the behaviour.
- `mypy` and `pylint` clean on the changed files; `format.sh` applied.

I could not run the full `test_executor.py` locally — it hangs in my environment, and hangs identically on unmodified `master`, so it is unrelated to this change. Relying on CI for that suite.

## Open questions

1. **The request pool has the same mismatch.** Its 128 sits in front of the same single-digit connection pool, which is why saturation shows up as hundreds of threads stacked on `psycopg2.connect` rather than as useful concurrency. Worth revisiting separately — lowering it is a user-visible behaviour change (fewer concurrent tails before 503), so I have deliberately left it alone here.
2. **Other consumers.** `local_blob_storage.py` submits file-lock waits to the request executor. Those are neither auth nor streams, and are another source of long holds in the shared pool.
3. **Naming.** Every current consumer is authentication, hence `auth_thread_executor`. If the intent is "short hot-path work" generally, a broader name may age better.