### PR TITLE
[Core] Compute Kubernetes node selector in Python

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1052,6 +1052,9 @@ class Kubernetes(clouds.Cloud):
             'tpu_requested': tpu_requested,
             'k8s_topology_label_key': k8s_topology_label_key,
             'k8s_topology_label_value': k8s_topology_label_value,
+            'k8s_node_selector': kubernetes_utils.get_node_selector(
+                k8s_topology_label_key, k8s_topology_label_value,
+                spot_label_key, spot_label_value, enable_flex_start),
             'k8s_resource_key': k8s_resource_key,
             'k8s_env_vars': k8s_env_vars,
             'image_id': image_id,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2719,6 +2719,49 @@ def get_pod_affinity(
     return pod_affinity
 
 
+def get_node_selector(
+    topology_label_key: Optional[str],
+    topology_label_value: Optional[str],
+    spot_label_key: Optional[str],
+    spot_label_value: Optional[str],
+    enable_flex_start: bool,
+) -> Optional[Dict[str, str]]:
+    """Builds the pod ``nodeSelector``.
+
+    Three independent entries, any of which may be absent:
+
+    * An accelerator topology label, pinning the pod to nodes belonging to a
+      slice of the requested shape (e.g.
+      ``cloud.google.com/gke-tpu-topology: 2x2``).
+    * A spot label, pinning the pod to preemptible nodes. The pod also carries
+      a matching toleration, rendered separately from the same key/value.
+    * ``cloud.google.com/gke-flex-start``, which selects GKE nodes provisioned
+      through flex-start (Dynamic Workload Scheduler).
+
+    Args:
+        topology_label_key: Node label key identifying the accelerator slice
+            topology, or None.
+        topology_label_value: Requested value for ``topology_label_key``, or
+            None.
+        spot_label_key: Node label key identifying preemptible nodes, or None.
+        spot_label_value: Value ``spot_label_key`` carries on preemptible
+            nodes, or None.
+        enable_flex_start: Whether the pod should schedule onto flex-start
+            nodes.
+
+    Returns:
+        A ``nodeSelector`` dict, or None when no entry applies.
+    """
+    node_selector: Dict[str, str] = {}
+    if topology_label_key is not None and topology_label_value is not None:
+        node_selector[topology_label_key] = topology_label_value
+    if spot_label_key is not None and spot_label_value is not None:
+        node_selector[spot_label_key] = spot_label_value
+    if enable_flex_start:
+        node_selector['cloud.google.com/gke-flex-start'] = 'true'
+    return node_selector or None
+
+
 def get_accelerator_label_keys(context: Optional[str],) -> List[str]:
     """Returns the label keys that should be avoided for scheduling
     CPU-only tasks.

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -423,18 +423,8 @@ available_node_types:
           fsGroupChangePolicy: OnRootMismatch
         {% endif %}
 
-        # Add node selector if GPU/TPUs are requested:
-        {% if (k8s_topology_label_key is not none and k8s_topology_label_value is not none) or (k8s_spot_label_key is not none) or (k8s_enable_flex_start) %}
-        nodeSelector:
-            {% if k8s_topology_label_key is not none and k8s_topology_label_value is not none %}
-            {{k8s_topology_label_key}}: {{k8s_topology_label_value}}
-            {% endif %}
-            {% if k8s_spot_label_key is not none %}
-            {{k8s_spot_label_key}}: {{k8s_spot_label_value|tojson}}
-            {% endif %}
-            {% if k8s_enable_flex_start %}
-            cloud.google.com/gke-flex-start: "true"
-            {% endif %}
+        {% if k8s_node_selector %}
+        nodeSelector: {{k8s_node_selector | tojson}}
         {% endif %}
         {% if k8s_node_affinity or k8s_pod_affinity or k8s_host_network %}
         affinity:

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5609,3 +5609,50 @@ class TestGetPodAffinity:
                 'topologyKey': 'topology.kubernetes.io/zone',
             }],
         }
+
+
+class TestGetNodeSelector:
+    """Tests for utils.get_node_selector."""
+
+    def test_none_when_no_entries(self):
+        assert utils.get_node_selector(None, None, None, None, False) is None
+
+    def test_none_when_key_without_value(self):
+        """A key with a None value does not produce an entry."""
+        assert utils.get_node_selector('cloud.google.com/gke-tpu-topology',
+                                       None, 'cloud.google.com/gke-spot', None,
+                                       False) is None
+
+    def test_topology_only(self):
+        assert utils.get_node_selector(
+            'cloud.google.com/gke-tpu-topology', '2x2', None, None, False) == {
+                'cloud.google.com/gke-tpu-topology': '2x2',
+            }
+
+    def test_spot_only(self):
+        assert utils.get_node_selector(None, None, 'cloud.google.com/gke-spot',
+                                       'true', False) == {
+                                           'cloud.google.com/gke-spot': 'true',
+                                       }
+
+    def test_flex_start_only(self):
+        assert utils.get_node_selector(None, None, None, None, True) == {
+            'cloud.google.com/gke-flex-start': 'true',
+        }
+
+    def test_topology_and_spot(self):
+        assert utils.get_node_selector(
+            'cloud.google.com/gke-tpu-topology', '2x4',
+            'cloud.google.com/gke-spot', 'true', False) == {
+                'cloud.google.com/gke-tpu-topology': '2x4',
+                'cloud.google.com/gke-spot': 'true',
+            }
+
+    def test_all_entries(self):
+        assert utils.get_node_selector(
+            'cloud.google.com/gke-tpu-topology', '2x2',
+            'cloud.google.com/gke-spot', 'true', True) == {
+                'cloud.google.com/gke-tpu-topology': '2x2',
+                'cloud.google.com/gke-spot': 'true',
+                'cloud.google.com/gke-flex-start': 'true',
+            }

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -438,13 +438,13 @@ CASES: Dict[str, Dict[str, Any]] = {
 def _build_variables(case_name: str) -> Dict[str, Any]:
     """Merges a case onto the base and derives the computed template vars.
 
-    ``k8s_node_affinity`` / ``k8s_pod_affinity`` and the binpack-label vars are
-    built by calling the same production helpers and constants
-    (``kubernetes_utils.get_node_affinity`` / ``get_pod_affinity`` /
-    ``GPU_BINPACK_LABEL_*``) that ``make_deploy_resources_variables`` uses, from
-    the raw vars the case carries. Deriving them here rather than hard-coding
-    them is what makes the goldens a semantic-identity proof for the Python
-    lift.
+    ``k8s_node_affinity`` / ``k8s_pod_affinity`` / ``k8s_node_selector`` and
+    the binpack-label vars are built by calling the same production helpers and
+    constants (``kubernetes_utils.get_node_affinity`` / ``get_pod_affinity`` /
+    ``get_node_selector`` / ``GPU_BINPACK_LABEL_*``) that
+    ``make_deploy_resources_variables`` uses, from the raw vars the case
+    carries. Deriving them here rather than hard-coding them is what makes the
+    goldens a semantic-identity proof for the Python lift.
     """
     variables = base_variables()
     variables.update(CASES[case_name])
@@ -458,6 +458,13 @@ def _build_variables(case_name: str) -> Dict[str, Any]:
         variables['k8s_acc_label_values'],
         variables['k8s_efa_same_az'],
         variables['cluster_name_on_cloud'],
+    )
+    variables['k8s_node_selector'] = kubernetes_utils.get_node_selector(
+        variables['k8s_topology_label_key'],
+        variables['k8s_topology_label_value'],
+        variables['k8s_spot_label_key'],
+        variables['k8s_spot_label_value'],
+        variables['k8s_enable_flex_start'],
     )
     variables['k8s_binpack_label_key'] = kubernetes_utils.GPU_BINPACK_LABEL_KEY
     variables['k8s_binpack_label_value'] = (


### PR DESCRIPTION
## Summary

Continues moving hand-written YAML out of `kubernetes-ray.yml.j2` into tested Python. This one lifts the pod `nodeSelector`.

The block rendered three independent entries, each behind its own Jinja conditional, with the whole block behind a fourth conditional repeating the union of the three:

- an accelerator topology label (e.g. `cloud.google.com/gke-tpu-topology: 2x2`),
- a spot label pinning the pod to preemptible nodes,
- `cloud.google.com/gke-flex-start` when flex-start is enabled.

They now come from one pure helper, `kubernetes_utils.get_node_selector`, which returns the `nodeSelector` dict or `None` when no entry applies. `make_deploy_resources_variables` calls it and exposes a single structured template var, `k8s_node_selector`; the template renders `nodeSelector: {{k8s_node_selector | tojson}}` gated on truthiness.

The raw `k8s_spot_label_key` / `k8s_spot_label_value` vars stay exposed — the spot **toleration**, a separate section of the pod spec, still renders from them.

One condition tightened: the spot entry now requires both the key and the value to be set, matching how the topology pair is gated. `get_spot_label` returns the pair together, so this is the same condition for every value the plumbing can actually produce.

## Evidence: goldens unchanged

The snapshot fixture derives `k8s_node_selector` by calling the same helper production calls, so **zero golden files changed** — the rendered manifest is byte-for-byte the same structure for every covered permutation. No new cases and no golden regeneration; the existing matrix already flips all three gates.

The coverage is not vacuous: the `spot`, `tpu`, `flex_start_priority_preemption` and `everything_on_gpu_singlenode` goldens each still carry their `nodeSelector` entries.

Based on #10239.

## Tested

- `tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py` — 48 passed, run twice (the suite includes a per-case determinism test); `git status` clean under `testdata/` after both runs.
- `tests/unit_tests/kubernetes/test_kubernetes_utils.py` — new `TestGetNodeSelector` (7 exact-dict cases: none, key-without-value, each single dimension, topology+spot, all three) plus the existing `TestGetNodeAffinity` / `TestGetPodAffinity` classes, all green.
- `tests/unit_tests/test_sky/clouds/test_kubernetes.py` — full file green.
- `bash format.sh --files ...` — yapf/isort clean, `mypy: Success: no issues found in 586 source files`. Pylint reports only pre-existing findings in `test_kubernetes_utils.py` (verified by running it against the file at HEAD: same exit code, score 9.02 → 9.64 with these additions).
- Not exercised against a live cluster; the goldens are the identity argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
