### PR TITLE
[Dashboard] Add filtering to the volumes page

### DIFF
--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -800,7 +800,7 @@ function VolumesTable({
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-2">
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
@@ -811,11 +811,15 @@ function VolumesTable({
           />
         </div>
       </div>
-      <Filters
-        filters={filters}
-        setFilters={setFilters}
-        updateURLParams={noopUpdateURLParams}
-      />
+      {filters.length > 0 && (
+        <div className="mb-2">
+          <Filters
+            filters={filters}
+            setFilters={setFilters}
+            updateURLParams={noopUpdateURLParams}
+          />
+        </div>
+      )}
 
       <Card>
         <div className="overflow-x-auto rounded-lg">

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -44,6 +44,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { TimestampWithTooltip, LastUpdatedTimestamp } from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
+import {
+  FilterDropdown,
+  Filters,
+  filterData,
+} from '@/components/shared/FilterSystem';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents, useTableColumns } from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
@@ -54,6 +59,20 @@ const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 
 const VOLUMES_PAGE_SIZE_OPTIONS = [10, 30, 50, 100, 200];
 const VOLUMES_PAGE_SIZE_STORAGE_KEY = 'skypilot-volumes-page-size';
+
+// Properties offered by the filter dropdown. `value` keys into `valueList` for
+// the typeahead; `label` is what lands in `filter.property`, which
+// `evaluateCondition` lowercases to look up the field on each volume.
+const PROPERTY_OPTIONS = [
+  { label: 'Name', value: 'name' },
+  { label: 'Status', value: 'status' },
+  { label: 'Infra', value: 'infra' },
+  { label: 'Type', value: 'type' },
+  { label: 'User', value: 'user' },
+];
+
+// Filters are kept in local state only, so there is nothing to sync to the URL.
+const noopUpdateURLParams = () => {};
 
 export function Volumes() {
   const router = useRouter();
@@ -471,6 +490,7 @@ function VolumesTable({
   preloadingComplete,
 }) {
   const [data, setData] = useState([]);
+  const [filters, setFilters] = useState([]);
   const [sortConfig, setSortConfig] = useState({
     key: null,
     direction: 'ascending',
@@ -510,10 +530,36 @@ function VolumesTable({
     }
   }, [setLoading, onDataChange]);
 
+  // Suggestions shown in the filter dropdown, keyed by PROPERTY_OPTIONS value.
+  const valueList = useMemo(() => {
+    const uniq = (getValue) => [
+      ...new Set(data.map(getValue).filter((value) => value && value !== '-')),
+    ];
+    return {
+      name: uniq((volume) => volume.name),
+      status: uniq((volume) => volume.status),
+      infra: uniq((volume) => volume.infra),
+      type: uniq((volume) => volume.type),
+      user: uniq((volume) => volume.user_name),
+    };
+  }, [data]);
+
+  const filteredData = useMemo(() => {
+    if (filters.length === 0) {
+      return data;
+    }
+    // `User` filters against `user_name`; alias it so the shared filter can
+    // resolve the property name to a field.
+    return filterData(
+      data.map((volume) => ({ ...volume, user: volume.user_name })),
+      filters
+    );
+  }, [data, filters]);
+
   // Use useMemo to compute sorted data
   const sortedData = useMemo(() => {
-    return sortData(data, sortConfig.key, sortConfig.direction);
-  }, [data, sortConfig]);
+    return sortData(filteredData, sortConfig.key, sortConfig.direction);
+  }, [filteredData, sortConfig]);
 
   // Expose fetchData to parent component
   useEffect(() => {
@@ -547,10 +593,10 @@ function VolumesTable({
     };
   }, [refreshInterval, fetchData, preloadingComplete]);
 
-  // Reset to first page when data changes
+  // Reset to first page when the data or the active filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [data.length]);
+  }, [data.length, filters]);
 
   const requestSort = (key) => {
     let direction = 'ascending';
@@ -754,6 +800,23 @@ function VolumesTable({
 
   return (
     <div>
+      <div className="flex items-center justify-between mb-4">
+        <div className="w-full sm:w-auto max-w-xl">
+          <FilterDropdown
+            propertyList={PROPERTY_OPTIONS}
+            valueList={valueList}
+            setFilters={setFilters}
+            updateURLParams={noopUpdateURLParams}
+            placeholder="Filter volumes"
+          />
+        </div>
+      </div>
+      <Filters
+        filters={filters}
+        setFilters={setFilters}
+        updateURLParams={noopUpdateURLParams}
+      />
+
       <Card>
         <div className="overflow-x-auto rounded-lg">
           <Table className="min-w-full">
@@ -791,8 +854,16 @@ function VolumesTable({
                 <EmptyTableState
                   colSpan={totalColSpan}
                   icon={<VolumeIcon className="w-5 h-5" />}
-                  title="No volumes found"
-                  description="Create a volume to mount storage in your clusters and jobs"
+                  title={
+                    filters.length > 0
+                      ? 'No matching volumes'
+                      : 'No volumes found'
+                  }
+                  description={
+                    filters.length > 0
+                      ? 'Try removing or loosening a filter'
+                      : 'Create a volume to mount storage in your clusters and jobs'
+                  }
                 />
               )}
             </TableBody>
@@ -801,7 +872,7 @@ function VolumesTable({
       </Card>
 
       {/* Pagination controls */}
-      {data.length > 0 && (
+      {sortedData.length > 0 && (
         <div className="flex justify-end items-center py-2 px-4 text-sm text-gray-700">
           <div className="flex items-center space-x-4">
             <div className="flex items-center">
@@ -836,8 +907,8 @@ function VolumesTable({
               </div>
             </div>
             <div>
-              {startIndex + 1} – {Math.min(endIndex, data.length)} of{' '}
-              {data.length}
+              {startIndex + 1} – {Math.min(endIndex, sortedData.length)} of{' '}
+              {sortedData.length}
             </div>
             <div className="flex items-center space-x-2">
               <Button


### PR DESCRIPTION
## Summary

The volumes page is the only list page in the dashboard without filtering — clusters, jobs, users and workspaces all have one.

- Add a filter bar above the volumes table, reusing the shared `FilterDropdown` / `Filters` / `filterData` from `components/shared/FilterSystem.jsx` so it behaves like the other list pages. Filters by name, status, infra, type and user.
- Filter before sorting/paginating; reset to page 1 when filters change.
- Fix the pagination footer, which reported the unfiltered row count.
- With filters active, the empty table says "No matching volumes" rather than prompting the user to create their first volume.

Filtering is client-side, like the other pages using this component — `getVolumes()` already fetches the full list.

Note for review: `evaluateCondition` looks up `filter.property.toLowerCase()` on the item, but the volume field is `user_name`, so the `User` option aliases it before calling `filterData` — same as `users.jsx` does for `user id`.

## Tested

No automated tests added — presentational wiring over the already-tested shared `filterData` / `sortData`, no new matching logic.

Manual, on `/dashboard/volumes` with several volumes:

1. Typeahead suggests real values per property; selecting one, or typing + Enter, commits a chip and narrows the table.
2. Each property filters correctly — especially `User` (aliased) and `Infra` (special-cased in the shared filter).
3. Chips AND together; "Clear filters" restores the full list.
4. Pagination footer shows the filtered count and returns to page 1 on filter change; sorting still works with filters applied.
5. Zero matches shows "No matching volumes"; with no filters, the original create-a-volume empty state is unchanged.