### PR TITLE
[Dashboard] Break Slurm clusters down by partition on the Infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -754,13 +754,13 @@ export function InfrastructureSection({
                             }
                             onClick={() => toggleExpanded(context)}
                           >
-                            {partitions.length} partition
-                            {partitions.length === 1 ? '' : 's'}
                             {isExpanded ? (
                               <ChevronDownIcon className="w-4 h-4" />
                             ) : (
                               <ChevronRightIcon className="w-4 h-4" />
                             )}
+                            {partitions.length} partition
+                            {partitions.length === 1 ? '' : 's'}
                           </button>
                         )}
                       </td>

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -10,6 +10,8 @@ import {
   EditIcon,
   TrashIcon,
   PlayIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
 } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
 import {
@@ -240,6 +242,93 @@ const GpuTypeSummaryStrip = ({ gpus }) => {
   );
 };
 
+// Slurm reports every partition a node belongs to in one comma-joined field,
+// with sinfo's trailing '*' marking the cluster's default partition.
+const parseSlurmPartitions = (partitionField) =>
+  String(partitionField ?? '')
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((name) => ({
+      name: name.replace(/\*$/, ''),
+      isDefault: name.endsWith('*'),
+    }));
+
+const formatSlurmPartitions = (partitionField) => {
+  const partitions = parseSlurmPartitions(partitionField);
+  return partitions.length > 0 ? partitions.map((p) => p.name).join(', ') : '-';
+};
+
+// The GPU quantities a Slurm node can be asked for, mirroring what
+// `slurm_catalog.list_accelerators_realtime` derives per node: powers of two up
+// to the node's GPU count, plus the count itself when it is not a power of two.
+// Partition rows compute this client-side because the catalog aggregates per
+// cluster, and a partition may hold only some of the cluster's node shapes.
+export const slurmRequestableCounts = (gpusPerNode) => {
+  const counts = [];
+  for (let count = 1; count <= gpusPerNode; count *= 2) {
+    counts.push(count);
+  }
+  if (counts.length > 0 && counts[counts.length - 1] !== gpusPerNode) {
+    counts.push(gpusPerNode);
+  }
+  return counts;
+};
+
+// Group a Slurm cluster's nodes into the partitions they belong to, each
+// partition split by GPU type. Jobs are submitted to a partition, so what is
+// free *in a partition* is the number that decides whether a job can run.
+// A node can belong to several partitions, so its capacity is counted once per
+// partition it is reachable from: partition rows overlap and do not sum to the
+// cluster totals.
+const aggregateSlurmPartitions = (nodes) => {
+  const byPartition = new Map();
+  nodes.forEach((node) => {
+    parseSlurmPartitions(node.partition).forEach(({ name, isDefault }) => {
+      let partition = byPartition.get(name);
+      if (!partition) {
+        partition = { name, isDefault: false, byType: new Map() };
+        byPartition.set(name, partition);
+      }
+      partition.isDefault = partition.isDefault || isDefault;
+      const gpuName = canonicalizeGpuName(node.gpu_name);
+      const type = partition.byType.get(gpuName) || {
+        gpu_name: gpuName,
+        gpu_total: 0,
+        gpu_free: 0,
+        requestableQtys: new Set(),
+      };
+      type.gpu_total += node.gpu_total || 0;
+      type.gpu_free += node.gpu_free || 0;
+      slurmRequestableCounts(node.gpu_total || 0).forEach((count) =>
+        type.requestableQtys.add(count)
+      );
+      partition.byType.set(gpuName, type);
+    });
+  });
+  return Array.from(byPartition.values())
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+    .map((partition) => {
+      const types = Array.from(partition.byType.values())
+        .filter((type) => type.gpu_total > 0)
+        .map((type) => ({
+          ...type,
+          // Ascending, so the tooltip reads "1, 2, 4, 8" whatever order the
+          // partition's node shapes were seen in.
+          requestableQtys: Array.from(type.requestableQtys).sort(
+            (a, b) => a - b
+          ),
+        }))
+        .sort((a, b) => b.gpu_total - a.gpu_total);
+      return {
+        ...partition,
+        // A CPU-only partition still gets a row; the null type renders as
+        // dashes in the GPU columns.
+        types: types.length > 0 ? types : [null],
+      };
+    });
+};
+
 // Reusable component for infrastructure sections (SSH Node Pool or Kubernetes)
 export function InfrastructureSection({
   title,
@@ -275,6 +364,19 @@ export function InfrastructureSection({
 
   const contextNoun = isSSH ? 'pool' : isSlurm ? 'cluster' : 'context';
 
+  // Slurm clusters with more than one partition start collapsed on their
+  // cluster-wide totals; expanding swaps in the per-partition rows.
+  const [expandedContexts, setExpandedContexts] = useState(() => new Set());
+  const toggleExpanded = useCallback((context) => {
+    setExpandedContexts((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(context)) {
+        next.add(context);
+      }
+      return next;
+    });
+  }, []);
+
   // Per-context derived data, shared by the desktop table and the mobile cards
   // so both render identical numbers from one computation.
   const deriveContextData = (context) => {
@@ -303,6 +405,29 @@ export function InfrastructureSection({
     });
     const typeAgg = Array.from(byType.values());
 
+    // Collapsed: one row per GPU type, from the cluster-wide totals, so the
+    // rows add up to the cluster's capacity.
+    const typeRows = typeAgg.map((type) => ({
+      key: type.gpu_name,
+      label: type.gpu_name,
+      type,
+    }));
+
+    // Expanded (Slurm only): one row per partition, split by GPU type, since a
+    // partition is what a job is submitted to. A node can be in several
+    // partitions, so these rows overlap — which is why they are behind a
+    // toggle rather than the default view. The partition cell spans its own
+    // type rows.
+    const partitions = isSlurm ? aggregateSlurmPartitions(nodes) : [];
+    const partitionRows = partitions.flatMap((partition) =>
+      partition.types.map((type, index) => ({
+        key: `${partition.name}/${type ? type.gpu_name : 'none'}`,
+        type,
+        partition,
+        partitionRowSpan: index === 0 ? partition.types.length : 0,
+      }))
+    );
+
     const contextStatsKey = buildContextStatsKey(context, { isSSH, isSlurm });
     const stats = contextStats[contextStatsKey] || { clusters: 0, jobs: 0 };
 
@@ -329,7 +454,9 @@ export function InfrastructureSection({
     return {
       gpuList,
       nodes,
-      typeAgg,
+      typeRows,
+      partitionRows,
+      partitions,
       contextStatsKey,
       stats,
       hasGpuData,
@@ -439,6 +566,11 @@ export function InfrastructureSection({
                   <th className="p-3 text-left font-medium text-gray-600 whitespace-nowrap">
                     Nodes
                   </th>
+                  {isSlurm && (
+                    <th className="p-3 text-left font-medium text-gray-600 whitespace-nowrap">
+                      Partition
+                    </th>
+                  )}
                   {!isSlurm && (
                     <th className="p-3 text-left font-medium text-gray-600 whitespace-nowrap">
                       CPU
@@ -469,7 +601,9 @@ export function InfrastructureSection({
                 {safeContexts.map((context) => {
                   const {
                     nodes,
-                    typeAgg,
+                    typeRows,
+                    partitionRows,
+                    partitions,
                     contextStatsKey,
                     stats,
                     hasGpuData,
@@ -482,10 +616,17 @@ export function InfrastructureSection({
                     workspaces,
                   } = deriveContextData(context);
 
-                  // One sub-row per GPU type; CPU-only contexts and contexts
-                  // still loading GPU data render a single row.
+                  // A single-partition cluster has nothing to expand into: its
+                  // one partition already is the cluster.
+                  const isExpandable = partitions.length > 1;
+                  const isExpanded =
+                    isExpandable && expandedContexts.has(context);
+                  const subRows = isExpanded ? partitionRows : typeRows;
+
+                  // CPU-only contexts and contexts still loading GPU data
+                  // render a single row.
                   const subRowCount = hasGpuData
-                    ? Math.max(1, typeAgg.length)
+                    ? Math.max(1, subRows.length)
                     : 1;
                   const sharedCellClass =
                     subRowCount > 1 ? 'p-3 align-top' : 'p-3';
@@ -516,7 +657,7 @@ export function InfrastructureSection({
                       );
                     }
                     const requestable = Array.from(
-                      typeEntry.requestableQtys
+                      typeEntry.requestableQtys || []
                     ).filter((qty) => qty !== undefined && qty !== null);
                     return (
                       <>
@@ -557,6 +698,69 @@ export function InfrastructureSection({
                     );
                   };
 
+                  const partitionName = (partition) => (
+                    <>
+                      {partition.name}
+                      {partition.isDefault && (
+                        <span className="ml-1.5 text-xs text-gray-400">
+                          (default)
+                        </span>
+                      )}
+                    </>
+                  );
+
+                  // Slurm only. Expanded, each partition's cell spans its own
+                  // GPU-type rows; collapsed, one cell spans the whole cluster
+                  // and names what expanding would reveal.
+                  const renderPartitionCell = (subRow, index) => {
+                    if (!hasGpuData) {
+                      return (
+                        <td className="p-3">
+                          <SkeletonBadge />
+                        </td>
+                      );
+                    }
+                    if (!isExpanded) {
+                      if (index > 0) {
+                        return null;
+                      }
+                      return (
+                        <td
+                          className="p-3 align-top text-gray-700 whitespace-nowrap"
+                          rowSpan={subRowCount}
+                        >
+                          {partitions.length === 0 ? (
+                            <span className="text-gray-400">-</span>
+                          ) : partitions.length === 1 ? (
+                            partitionName(partitions[0])
+                          ) : (
+                            <span className="text-gray-500">
+                              {partitions.length} partitions
+                            </span>
+                          )}
+                        </td>
+                      );
+                    }
+                    if (!subRow || !subRow.partitionRowSpan) {
+                      return null;
+                    }
+                    return (
+                      <td
+                        className="p-3 align-top text-gray-700 whitespace-nowrap"
+                        rowSpan={subRow.partitionRowSpan}
+                      >
+                        {partitionName(subRow.partition)}
+                      </td>
+                    );
+                  };
+
+                  const renderSubRowCells = (subRow, index) => (
+                    <>
+                      {isSlurm && renderPartitionCell(subRow, index)}
+                      {renderGpuCells(subRow ? subRow.type : null)}
+                    </>
+                  );
+
                   return (
                     <React.Fragment key={context}>
                       <tr
@@ -590,6 +794,23 @@ export function InfrastructureSection({
                         </td>
                         <td className={sharedCellClass} rowSpan={subRowCount}>
                           <div className="flex items-center gap-2 flex-wrap">
+                            {isExpandable && (
+                              <button
+                                className="text-gray-400 hover:text-gray-600 -ml-1"
+                                title={
+                                  isExpanded
+                                    ? 'Hide partitions'
+                                    : 'Show partitions'
+                                }
+                                onClick={() => toggleExpanded(context)}
+                              >
+                                {isExpanded ? (
+                                  <ChevronDownIcon className="w-4 h-4" />
+                                ) : (
+                                  <ChevronRightIcon className="w-4 h-4" />
+                                )}
+                              </button>
+                            )}
                             <NonCapitalizedTooltip
                               content={displayName}
                               className="text-sm text-muted-foreground"
@@ -657,7 +878,7 @@ export function InfrastructureSection({
                             )}
                           </td>
                         )}
-                        {renderGpuCells(hasGpuData ? typeAgg[0] : null)}
+                        {renderSubRowCells(hasGpuData ? subRows[0] : null, 0)}
                         <td
                           className="w-0 p-0 whitespace-nowrap text-right align-top"
                           rowSpan={subRowCount}
@@ -669,11 +890,11 @@ export function InfrastructureSection({
                         </td>
                       </tr>
                       {hasGpuData &&
-                        typeAgg
+                        subRows
                           .slice(1)
-                          .map((typeEntry) => (
-                            <tr key={`${context}-${typeEntry.gpu_name}`}>
-                              {renderGpuCells(typeEntry)}
+                          .map((subRow, index) => (
+                            <tr key={`${context}-${subRow.key}`}>
+                              {renderSubRowCells(subRow, index + 1)}
                             </tr>
                           ))}
                     </React.Fragment>
@@ -688,7 +909,7 @@ export function InfrastructureSection({
             {safeContexts.map((context) => {
               const {
                 nodes,
-                typeAgg,
+                typeRows,
                 contextStatsKey,
                 stats,
                 hasGpuData,
@@ -700,6 +921,9 @@ export function InfrastructureSection({
                 rowKind,
                 workspaces,
               } = deriveContextData(context);
+              // Cards stay on the cluster-wide totals; partitions are a
+              // desktop-table affordance.
+              const gpuSubRows = typeRows.filter((subRow) => subRow.type);
               const mobileStats = [
                 {
                   label: 'Clusters',
@@ -781,22 +1005,22 @@ export function InfrastructureSection({
                       </div>
                     ))}
                   </div>
-                  {hasGpuData && typeAgg.length > 0 && (
+                  {hasGpuData && gpuSubRows.length > 0 && (
                     <div className="border-t border-gray-100 pt-3 space-y-2">
-                      {typeAgg.map((t) => (
+                      {gpuSubRows.map((subRow) => (
                         <div
-                          key={t.gpu_name}
+                          key={subRow.key}
                           className="flex items-center gap-2"
                         >
                           <span className="text-xs font-medium text-gray-700 w-20 truncate shrink-0">
-                            {t.gpu_name}
+                            {subRow.label}
                           </span>
                           <CleanUtilizationBar
-                            gpu={t}
+                            gpu={subRow.type}
                             className="flex-1 min-w-0"
                           />
                           <span className="text-xs text-gray-500 whitespace-nowrap shrink-0 w-14 text-right">
-                            {t.gpu_free.toLocaleString()} free
+                            {subRow.type.gpu_free.toLocaleString()} free
                           </span>
                         </div>
                       ))}
@@ -1048,6 +1272,11 @@ export function ContextDetails({
                         </th>
                       </>
                     )}
+                    {isSlurm && (
+                      <th className="p-3 text-left font-medium text-gray-600">
+                        Partitions
+                      </th>
+                    )}
                     <th className="p-3 text-left font-medium text-gray-600">
                       GPU
                     </th>
@@ -1169,6 +1398,11 @@ export function ContextDetails({
                               {memoryDisplay}
                             </td>
                           </>
+                        )}
+                        {isSlurm && (
+                          <td className="p-3 whitespace-nowrap text-gray-700">
+                            {formatSlurmPartitions(node.partition)}
+                          </td>
                         )}
                         <td className="p-3 whitespace-nowrap text-gray-700">
                           {canonicalizeGpuName(node.gpu_name)}

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -405,23 +405,24 @@ export function InfrastructureSection({
     });
     const typeAgg = Array.from(byType.values());
 
-    // Collapsed: one row per GPU type, from the cluster-wide totals, so the
-    // rows add up to the cluster's capacity.
+    // One row per GPU type, from the cluster-wide totals, so the rows add up to
+    // the cluster's capacity. Always shown; for Slurm they are what the
+    // partition breakdown hangs off.
     const typeRows = typeAgg.map((type) => ({
       key: type.gpu_name,
       label: type.gpu_name,
       type,
     }));
 
-    // Expanded (Slurm only): one row per partition, split by GPU type, since a
-    // partition is what a job is submitted to. A node can be in several
-    // partitions, so these rows overlap — which is why they are behind a
-    // toggle rather than the default view. The partition cell spans its own
-    // type rows.
+    // Slurm only, appended when the cluster is expanded: one row per partition,
+    // split by GPU type, since a partition is what a job is submitted to. A
+    // node can be in several partitions, so these rows overlap — which is why
+    // they are behind a toggle rather than shown by default. The partition cell
+    // spans its own type rows.
     const partitions = isSlurm ? aggregateSlurmPartitions(nodes) : [];
     const partitionRows = partitions.flatMap((partition) =>
       partition.types.map((type, index) => ({
-        key: `${partition.name}/${type ? type.gpu_name : 'none'}`,
+        key: `partition/${partition.name}/${type ? type.gpu_name : 'none'}`,
         type,
         partition,
         partitionRowSpan: index === 0 ? partition.types.length : 0,
@@ -616,12 +617,16 @@ export function InfrastructureSection({
                     workspaces,
                   } = deriveContextData(context);
 
-                  // A single-partition cluster has nothing to expand into: its
-                  // one partition already is the cluster.
-                  const isExpandable = partitions.length > 1;
+                  const isExpandable = partitions.length > 0;
                   const isExpanded =
                     isExpandable && expandedContexts.has(context);
-                  const subRows = isExpanded ? partitionRows : typeRows;
+                  // Expanding appends the partition breakdown under the
+                  // cluster's own totals, so the aggregate stays on screen and
+                  // the toggle keeps its place.
+                  const subRows = isExpanded
+                    ? [...typeRows, ...partitionRows]
+                    : typeRows;
+                  const summaryRowCount = Math.max(1, typeRows.length);
 
                   // CPU-only contexts and contexts still loading GPU data
                   // render a single row.
@@ -709,9 +714,10 @@ export function InfrastructureSection({
                     </>
                   );
 
-                  // Slurm only. Expanded, each partition's cell spans its own
-                  // GPU-type rows; collapsed, one cell spans the whole cluster
-                  // and names what expanding would reveal.
+                  // Slurm only. The cluster's own rows carry one cell counting
+                  // its partitions and toggling them; each partition row below
+                  // names its partition, spanning that partition's GPU-type
+                  // rows.
                   const renderPartitionCell = (subRow, index) => {
                     if (!hasGpuData) {
                       return (
@@ -720,36 +726,43 @@ export function InfrastructureSection({
                         </td>
                       );
                     }
-                    if (!isExpanded) {
-                      if (index > 0) {
-                        return null;
-                      }
-                      return (
+                    if (subRow && subRow.partition) {
+                      return subRow.partitionRowSpan ? (
                         <td
-                          className="p-3 align-top text-gray-700 whitespace-nowrap"
-                          rowSpan={subRowCount}
+                          className="p-3 pl-6 align-top text-gray-700 whitespace-nowrap"
+                          rowSpan={subRow.partitionRowSpan}
                         >
-                          {partitions.length === 0 ? (
-                            <span className="text-gray-400">-</span>
-                          ) : partitions.length === 1 ? (
-                            partitionName(partitions[0])
-                          ) : (
-                            <span className="text-gray-500">
-                              {partitions.length} partitions
-                            </span>
-                          )}
+                          {partitionName(subRow.partition)}
                         </td>
-                      );
+                      ) : null;
                     }
-                    if (!subRow || !subRow.partitionRowSpan) {
+                    if (index > 0) {
                       return null;
                     }
                     return (
                       <td
-                        className="p-3 align-top text-gray-700 whitespace-nowrap"
-                        rowSpan={subRow.partitionRowSpan}
+                        className="p-3 align-top whitespace-nowrap"
+                        rowSpan={summaryRowCount}
                       >
-                        {partitionName(subRow.partition)}
+                        {!isExpandable ? (
+                          <span className="text-gray-400">-</span>
+                        ) : (
+                          <button
+                            className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-700"
+                            title={
+                              isExpanded ? 'Hide partitions' : 'Show partitions'
+                            }
+                            onClick={() => toggleExpanded(context)}
+                          >
+                            {partitions.length} partition
+                            {partitions.length === 1 ? '' : 's'}
+                            {isExpanded ? (
+                              <ChevronDownIcon className="w-4 h-4" />
+                            ) : (
+                              <ChevronRightIcon className="w-4 h-4" />
+                            )}
+                          </button>
+                        )}
                       </td>
                     );
                   };
@@ -794,23 +807,6 @@ export function InfrastructureSection({
                         </td>
                         <td className={sharedCellClass} rowSpan={subRowCount}>
                           <div className="flex items-center gap-2 flex-wrap">
-                            {isExpandable && (
-                              <button
-                                className="text-gray-400 hover:text-gray-600 -ml-1"
-                                title={
-                                  isExpanded
-                                    ? 'Hide partitions'
-                                    : 'Show partitions'
-                                }
-                                onClick={() => toggleExpanded(context)}
-                              >
-                                {isExpanded ? (
-                                  <ChevronDownIcon className="w-4 h-4" />
-                                ) : (
-                                  <ChevronRightIcon className="w-4 h-4" />
-                                )}
-                              </button>
-                            )}
                             <NonCapitalizedTooltip
                               content={displayName}
                               className="text-sm text-muted-foreground"

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -74,7 +74,7 @@ describe('InfrastructureSection Slurm partition rows', () => {
       groupedPerNodeGPUs: { 'nebius-slinky': nodes },
     });
 
-  it('collapses to the cluster totals, naming what expanding reveals', () => {
+  it('collapses to the cluster totals, counting what expanding reveals', () => {
     const { container } = renderSlurm();
     const rows = tableRows(container);
     // One row for the cluster's single GPU type, not one per partition.
@@ -89,19 +89,23 @@ describe('InfrastructureSection Slurm partition rows', () => {
     );
   });
 
-  it('renders one row per partition and GPU type once expanded', () => {
+  it('appends the partition rows under the cluster totals when expanded', () => {
     const { container } = renderSlurm();
     expandPartitions();
     const rows = tableRows(container);
-    expect(rows).toHaveLength(4);
-    expect(cellTexts(rows[0])).toContain('fabric-a');
-    expect(cellTexts(rows[1])).toContain('mock');
+    // The cluster's own row stays on top, keeping the aggregate on screen.
+    expect(rows).toHaveLength(5);
+    expect(cellTexts(rows[0])).toEqual(
+      expect.arrayContaining(['3 partitions', 'H100', '12 of 32 free'])
+    );
+    expect(cellTexts(rows[1])).toContain('fabric-a');
+    expect(cellTexts(rows[2])).toContain('mock');
     // The cluster's node count stays deduplicated: 5 nodes, not one per
     // partition membership.
     expect(normalize(rows[0])).toMatch(/nebius-slinky\s*5/);
   });
 
-  it('does not offer a toggle for a single-partition cluster', () => {
+  it('counts a single-partition cluster the same way', () => {
     renderSection({
       isSlurm: true,
       contexts: ['crusoe-slurm-use1'],
@@ -121,8 +125,8 @@ describe('InfrastructureSection Slurm partition rows', () => {
         ],
       },
     });
-    expect(screen.queryByTitle('Show partitions')).toBeNull();
-    // With nothing to expand into, the partition is named outright.
+    expect(screen.getAllByText(/1 partition$/)[0]).toBeTruthy();
+    expandPartitions();
     expect(screen.getAllByText('all')[0]).toBeTruthy();
   });
 
@@ -132,16 +136,16 @@ describe('InfrastructureSection Slurm partition rows', () => {
     const rows = tableRows(container);
     // fabric-a and mock both count n3 + n4's 16 H100s: shared capacity is
     // reachable from either partition, so it is not split between them.
-    expect(cellTexts(rows[0])).toEqual(
-      expect.arrayContaining(['H100', '8 of 16 free'])
-    );
     expect(cellTexts(rows[1])).toEqual(
       expect.arrayContaining(['H100', '8 of 16 free'])
     );
     expect(cellTexts(rows[2])).toEqual(
-      expect.arrayContaining(['A100', '4 of 4 free'])
+      expect.arrayContaining(['H100', '8 of 16 free'])
     );
     expect(cellTexts(rows[3])).toEqual(
+      expect.arrayContaining(['A100', '4 of 4 free'])
+    );
+    expect(cellTexts(rows[4])).toEqual(
       expect.arrayContaining(['H100', '4 of 16 free'])
     );
   });
@@ -151,23 +155,28 @@ describe('InfrastructureSection Slurm partition rows', () => {
     expandPartitions();
     const rows = tableRows(container);
     // The gap before the tag is a margin, not whitespace in the text.
-    expect(cellTexts(rows[3])).toContain('real(default)');
+    expect(cellTexts(rows[4])).toContain('real(default)');
     // 'mock' has H100 and A100 rows, so its cell spans both; the second row
     // carries only the GPU cells.
-    const mockCell = Array.from(rows[1].querySelectorAll('td')).find((td) =>
+    const mockCell = Array.from(rows[2].querySelectorAll('td')).find((td) =>
       td.textContent.includes('mock')
     );
     expect(mockCell.getAttribute('rowspan')).toBe('2');
-    expect(rows[2].querySelectorAll('td')).toHaveLength(3);
+    expect(rows[3].querySelectorAll('td')).toHaveLength(3);
   });
 
-  it('gives the cluster cells a rowSpan covering every partition row', () => {
+  it('gives the cluster cells a rowSpan covering totals and partitions', () => {
     const { container } = renderSlurm();
     expandPartitions();
     const nameCell = Array.from(
       container.querySelectorAll('table tbody td')
     ).find((td) => td.textContent.includes('nebius-slinky'));
-    expect(nameCell.getAttribute('rowspan')).toBe('4');
+    expect(nameCell.getAttribute('rowspan')).toBe('5');
+    // The partition count spans only the cluster's own rows.
+    const summaryCell = Array.from(
+      container.querySelectorAll('table tbody td')
+    ).find((td) => td.textContent.includes('3 partitions'));
+    expect(summaryCell.getAttribute('rowspan')).toBe('1');
   });
 });
 

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -1,0 +1,221 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  InfrastructureSection,
+  slurmRequestableCounts,
+} from '@/components/infra';
+
+// The infrastructure table renders one sub-row per GPU type. A Slurm cluster
+// can additionally be expanded into its partitions, which is where the
+// overlap lives: a node in several partitions is counted in each, so the
+// partition rows do not add up to the collapsed cluster totals.
+const normalize = (el) => el.textContent.replace(/\s+/g, ' ').trim();
+
+const renderSection = (props) =>
+  render(
+    <InfrastructureSection
+      title="Slurm"
+      isLoading={false}
+      isDataLoaded={true}
+      handleContextClick={() => {}}
+      isInitialLoad={false}
+      groupedPerContextGPUs={{}}
+      groupedPerNodeGPUs={{}}
+      {...props}
+    />
+  );
+
+// Desktop table and mobile cards render the same data, so scope queries to the
+// table.
+const tableRows = (container) =>
+  Array.from(container.querySelectorAll('table tbody tr'));
+
+const cellTexts = (row) =>
+  Array.from(row.querySelectorAll('td')).map(normalize);
+
+const expandPartitions = () =>
+  fireEvent.click(screen.getAllByTitle('Show partitions')[0]);
+
+describe('InfrastructureSection Slurm partition rows', () => {
+  const slurmNode = (nodeName, partition, gpuName, total, free) => ({
+    node_name: nodeName,
+    partition,
+    gpu_name: gpuName,
+    gpu_total: total,
+    gpu_free: free,
+    cluster: 'nebius-slinky',
+  });
+
+  // 'real*' is the default partition (sinfo marks it with a trailing '*');
+  // n3/n4 sit in both fabric-a and mock, and mock also holds an A100 node so
+  // one partition spans two GPU types.
+  const nodes = [
+    slurmNode('n1', 'real*', 'H100', 8, 0),
+    slurmNode('n2', 'real*', 'H100', 8, 4),
+    slurmNode('n3', 'fabric-a,mock', 'H100', 8, 8),
+    slurmNode('n4', 'fabric-a,mock', 'H100', 8, 0),
+    slurmNode('n5', 'mock', 'A100', 4, 4),
+  ];
+
+  const renderSlurm = () =>
+    renderSection({
+      isSlurm: true,
+      contexts: ['nebius-slinky'],
+      gpus: [{ gpu_name: 'H100', gpu_total: 32, gpu_free: 12 }],
+      groupedPerContextGPUs: {
+        'nebius-slinky': [
+          {
+            gpu_name: 'H100',
+            gpu_total: 32,
+            gpu_free: 12,
+            cluster: 'nebius-slinky',
+          },
+        ],
+      },
+      groupedPerNodeGPUs: { 'nebius-slinky': nodes },
+    });
+
+  it('collapses to the cluster totals, naming what expanding reveals', () => {
+    const { container } = renderSlurm();
+    const rows = tableRows(container);
+    // One row for the cluster's single GPU type, not one per partition.
+    expect(rows).toHaveLength(1);
+    expect(cellTexts(rows[0])).toContain('3 partitions');
+    expect(cellTexts(rows[0])).toEqual(
+      expect.arrayContaining(['H100', '12 of 32 free'])
+    );
+    expect(normalize(rows[0])).toMatch(/nebius-slinky\s*5/);
+    expect(container.querySelector('table').textContent).not.toContain(
+      'fabric-a'
+    );
+  });
+
+  it('renders one row per partition and GPU type once expanded', () => {
+    const { container } = renderSlurm();
+    expandPartitions();
+    const rows = tableRows(container);
+    expect(rows).toHaveLength(4);
+    expect(cellTexts(rows[0])).toContain('fabric-a');
+    expect(cellTexts(rows[1])).toContain('mock');
+    // The cluster's node count stays deduplicated: 5 nodes, not one per
+    // partition membership.
+    expect(normalize(rows[0])).toMatch(/nebius-slinky\s*5/);
+  });
+
+  it('does not offer a toggle for a single-partition cluster', () => {
+    renderSection({
+      isSlurm: true,
+      contexts: ['crusoe-slurm-use1'],
+      gpus: [{ gpu_name: 'A100', gpu_total: 8, gpu_free: 8 }],
+      groupedPerContextGPUs: {
+        'crusoe-slurm-use1': [{ gpu_name: 'A100', gpu_total: 8, gpu_free: 8 }],
+      },
+      groupedPerNodeGPUs: {
+        'crusoe-slurm-use1': [
+          {
+            node_name: 'c1',
+            partition: 'all*',
+            gpu_name: 'A100',
+            gpu_total: 8,
+            gpu_free: 8,
+          },
+        ],
+      },
+    });
+    expect(screen.queryByTitle('Show partitions')).toBeNull();
+    // With nothing to expand into, the partition is named outright.
+    expect(screen.getAllByText('all')[0]).toBeTruthy();
+  });
+
+  it('sums GPU capacity per partition from its member nodes', () => {
+    const { container } = renderSlurm();
+    expandPartitions();
+    const rows = tableRows(container);
+    // fabric-a and mock both count n3 + n4's 16 H100s: shared capacity is
+    // reachable from either partition, so it is not split between them.
+    expect(cellTexts(rows[0])).toEqual(
+      expect.arrayContaining(['H100', '8 of 16 free'])
+    );
+    expect(cellTexts(rows[1])).toEqual(
+      expect.arrayContaining(['H100', '8 of 16 free'])
+    );
+    expect(cellTexts(rows[2])).toEqual(
+      expect.arrayContaining(['A100', '4 of 4 free'])
+    );
+    expect(cellTexts(rows[3])).toEqual(
+      expect.arrayContaining(['H100', '4 of 16 free'])
+    );
+  });
+
+  it('marks the default partition and spans multi-GPU-type partitions', () => {
+    const { container } = renderSlurm();
+    expandPartitions();
+    const rows = tableRows(container);
+    // The gap before the tag is a margin, not whitespace in the text.
+    expect(cellTexts(rows[3])).toContain('real(default)');
+    // 'mock' has H100 and A100 rows, so its cell spans both; the second row
+    // carries only the GPU cells.
+    const mockCell = Array.from(rows[1].querySelectorAll('td')).find((td) =>
+      td.textContent.includes('mock')
+    );
+    expect(mockCell.getAttribute('rowspan')).toBe('2');
+    expect(rows[2].querySelectorAll('td')).toHaveLength(3);
+  });
+
+  it('gives the cluster cells a rowSpan covering every partition row', () => {
+    const { container } = renderSlurm();
+    expandPartitions();
+    const nameCell = Array.from(
+      container.querySelectorAll('table tbody td')
+    ).find((td) => td.textContent.includes('nebius-slinky'));
+    expect(nameCell.getAttribute('rowspan')).toBe('4');
+  });
+});
+
+// Mirrors slurm_catalog.list_accelerators_realtime, which feeds the
+// "Requestable: N / node" tooltip. If the backend rule changes, this is the
+// copy that has to move with it.
+describe('slurmRequestableCounts', () => {
+  it('returns powers of two up to a power-of-two node size', () => {
+    expect(slurmRequestableCounts(8)).toEqual([1, 2, 4, 8]);
+  });
+
+  it('appends the node size when it is not a power of two', () => {
+    expect(slurmRequestableCounts(6)).toEqual([1, 2, 4, 6]);
+  });
+
+  it('returns nothing for a CPU-only node', () => {
+    expect(slurmRequestableCounts(0)).toEqual([]);
+  });
+});
+
+describe('InfrastructureSection Kubernetes GPU-type rows', () => {
+  it('still renders one row per GPU type with no partition column', () => {
+    const { container } = renderSection({
+      title: 'Kubernetes',
+      contexts: ['usw9b'],
+      gpus: [
+        { gpu_name: 'H100', gpu_total: 256, gpu_free: 67 },
+        { gpu_name: 'B200', gpu_total: 256, gpu_free: 88 },
+      ],
+      groupedPerContextGPUs: {
+        usw9b: [
+          { gpu_name: 'H100', gpu_total: 256, gpu_free: 67, context: 'usw9b' },
+          { gpu_name: 'B200', gpu_total: 256, gpu_free: 88, context: 'usw9b' },
+        ],
+      },
+      groupedPerNodeGPUs: { usw9b: [] },
+      loadedContexts: new Set(['usw9b']),
+    });
+    const rows = tableRows(container);
+    expect(rows).toHaveLength(2);
+    expect(cellTexts(rows[0])).toEqual(
+      expect.arrayContaining(['H100', '67 of 256 free'])
+    );
+    expect(cellTexts(rows[1])).toEqual(
+      expect.arrayContaining(['B200', '88 of 256 free'])
+    );
+    expect(container.querySelector('table').textContent).not.toContain(
+      'Partition'
+    );
+  });
+});


### PR DESCRIPTION
A Slurm job is submitted to a partition, so what is free *in a partition* is the
number that decides whether it can run. The Infra page only showed cluster-wide
totals, which say nothing about where the free GPUs are reachable from.

This adds a **Partition** column to the Slurm section:

- **Collapsed by default** on the cluster-wide totals, with the cell counting what
  expanding reveals (`4 partitions`). These rows add up to the cluster's capacity.
- **Expanding** appends one row per partition underneath, split by GPU type, each
  with its own free/total and utilization bar. The cluster's own totals stay on
  screen above them. The partition cell spans its GPU-type rows, reusing the
  `rowSpan` grouping the table already uses.
- A node can belong to several partitions, so its capacity is counted once per
  partition it is reachable from. **The partition rows overlap and do not add up to
  the cluster totals** — that is why they sit behind a toggle instead of being the
  default view.
- Every cluster reports its partition count the same way, single-partition ones
  included, with the disclosure chevron next to the count.
- The Slurm node table on the cluster detail page gains a `Partitions` column; the
  field was already in its row data.

```
collapsed                                        expanded
Name      Nodes  Partition       GPU   GPUs      Name      Nodes  Partition        GPU   GPUs
slurm-a   202    > 4 partitions  H100  425/1600  slurm-a   202    v 4 partitions   H100  425/1600
                                                                    fabric-a       H100  138/800
                                                                    fabric-b       H100  287/800
                                                                    mock           H100  425/1600
                                                                    real (default) -     -
```

No backend change is needed: `slurm_node_info` already returns one row per node with
its partition memberships comma-joined, and sinfo's trailing `*` marks the default
partition (stripped for display, shown as a `(default)` tag).

The quantities behind the `Requestable: N / node` tooltip are computed per partition,
mirroring the rule in `slurm_catalog.list_accelerators_realtime` (powers of two up to
a node's GPU count, plus the count itself when it is not one). The catalog aggregates
per cluster, and a partition may hold only some of the cluster's node shapes, so a
partition of 4-GPU nodes correctly reads `1, 2, 4` even where the cluster has 8s. The
duplicated rule is called out in a comment on both sides.

Kubernetes and SSH sections are unchanged — same GPU-type rows, no Partition column.
Mobile cards stay on cluster totals; partitions are a desktop-table affordance.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New jest tests in `sky/dashboard/src/components/infra.test.jsx` (10, all passing) render
`InfrastructureSection` and cover: the collapsed default (one row per GPU type, no
partition names in the DOM), the expanded rows appended under the cluster totals, the
single-partition cluster counting the same way, per-partition GPU sums including shared
capacity counted in both partitions, the `(default)` tag and multi-GPU-type `rowSpan`,
the cluster and summary cell `rowSpan`s, the unchanged Kubernetes path, and the
requestable-quantity rule.

```
npm --prefix sky/dashboard run lint     # clean
npx jest src/components/infra.test.jsx  # 10 passed
npm --prefix sky/dashboard run build    # compiles
```

Manually verified against a live API server with five Slurm clusters, including one
with 202 nodes across four partitions where 200 nodes are members of two partitions
each, and a CPU-only partition that renders as dashes. Collapsed totals reconcile with
the GPU summary strip; expanded rows show the per-partition split; the requestable
tooltip reads `Requestable: 1, 2, 4, 8 / node`.
