### PR TITLE
[Dashboard] Show CPU-only Slurm clusters on the Infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -3263,16 +3263,28 @@ export function GPUs() {
     return allGPUs.filter((gpu) => kubeGpuNames.has(gpu.gpu_name));
   }, [allGPUs, perContextGPUs]);
 
-  // Extract Slurm cluster names from perClusterSlurmGPUs
+  // Extract Slurm cluster names. Union the cluster names from both the
+  // GPU-availability data (perClusterSlurmGPUs) and the per-node data
+  // (perNodeSlurmGPUs). GPU availability only reports clusters that have
+  // GPUs, so a CPU-only cluster would otherwise never appear here and the
+  // Slurm section would render "not configured" even though the cluster is
+  // reachable. Node info lists every node regardless of GPUs, so unioning
+  // it in keeps parity with the Kubernetes section, which always lists a
+  // context whether or not it has GPUs (GPU counts are just extra columns).
   const slurmClusters = React.useMemo(() => {
-    if (!perClusterSlurmGPUs || !Array.isArray(perClusterSlurmGPUs)) {
-      return [];
+    const clusterSet = new Set();
+    if (Array.isArray(perClusterSlurmGPUs)) {
+      perClusterSlurmGPUs.forEach((gpu) => {
+        if (gpu.cluster) clusterSet.add(gpu.cluster);
+      });
     }
-    const clusters = [
-      ...new Set(perClusterSlurmGPUs.map((gpu) => gpu.cluster)),
-    ];
-    return clusters.sort();
-  }, [perClusterSlurmGPUs]);
+    if (Array.isArray(perNodeSlurmGPUs)) {
+      perNodeSlurmGPUs.forEach((node) => {
+        if (node.cluster) clusterSet.add(node.cluster);
+      });
+    }
+    return [...clusterSet].sort();
+  }, [perClusterSlurmGPUs, perNodeSlurmGPUs]);
 
   // Group perClusterSlurmGPUs by cluster
   const groupedPerClusterSlurmGPUs = React.useMemo(() => {


### PR DESCRIPTION
## Summary

The Infra page derives the Slurm cluster list solely from the GPU-availability data (`/slurm_gpu_availability`), which only reports clusters that have GPUs. A reachable **CPU-only** Slurm cluster therefore never appears, and the Slurm section renders "No Slurm found or Slurm is not configured" even though the cluster is connected and usable.

This unions in the cluster names from the per-node data (`/slurm_node_info`), which lists every node regardless of whether it has GPUs. This matches the Kubernetes section, which always lists a context whether or not it has GPUs (GPU counts are just extra columns).

## Test

- `npm --prefix sky/dashboard run build` passes.
- Manually: against an API server with a CPU-only Slurm cluster in `~/.slurm/config`, the Infra page now lists the cluster (previously "No Slurm found or Slurm is not configured"); `/slurm_node_info` returns the nodes with no GPU while `/slurm_gpu_availability` returns empty.
