### PR TITLE
[Slurm] Use GresUsed for GPU accounting when TRES does not track GRES

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -86,6 +86,16 @@ def get_gpu_type_and_count(gres_str: str) -> Tuple[Optional[str], int]:
     return match.group('type'), int(match.group('count'))
 
 
+def has_gpu_gres(gres_str: str) -> bool:
+    """Whether a GRES string carries a GPU entry at all.
+
+    Distinguishes "no GPU information" (``(null)``, ``N/A``, empty) from
+    "zero GPUs allocated" (``gpu:0``, ``gpu:h100:0``), which
+    ``get_gpu_type_and_count`` reports identically as a count of 0.
+    """
+    return _GRES_GPU_PATTERN.search(gres_str) is not None
+
+
 def get_gpu_count_from_tres(tres_str: str) -> int:
     """Parses the GPU count from a TRES string (CfgTRES/AllocTRES).
 
@@ -1002,8 +1012,7 @@ def resolve_gres_gpu_type(
 
 
 @annotations.lru_cache(scope='request')
-def _get_all_jobs_gres(
-        slurm_client: 'slurm.SlurmClient') -> Dict[str, List[str]]:
+def _get_all_jobs_gres(slurm_client: slurm.SlurmClient) -> Dict[str, List[str]]:
     """Request-scoped cached wrapper around SlurmClient.get_all_jobs_gres().
 
     Fetched lazily: `squeue` is only queried when at least one node falls
@@ -1103,16 +1112,20 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         # scontrol was unavailable.
         details = node_details_by_name.get(node_name, {})
 
-        # Get allocated GPUs.
-        # Node-level TRES accounting (AllocTRES from `scontrol show node`)
-        # is the preferred source for allocated GPUs: job-level
-        # `squeue -o "%b"` can be `N/A` even when the job has allocated
-        # GPUs (e.g. jobs requesting GPUs via --tres-per-task), or can use
-        # GRES formats the parser does not recognize, causing free GPUs to
-        # be overestimated.
+        # Get allocated GPUs, in order of preference:
+        #   1. AllocTRES  - node-level TRES accounting from `scontrol show
+        #                   node`, when the cluster tracks gres/gpu in TRES.
+        #   2. GresUsed   - node-level GRES accounting from the same
+        #                   `scontrol` output, for clusters that do not.
+        #   3. squeue %b  - job-level GRES, aggregated per node.
+        # Both node-level sources reflect what the scheduler actually
+        # allocated. Job-level `squeue -o "%b"` can be `N/A` even when the
+        # job has allocated GPUs (e.g. jobs requesting GPUs via
+        # --tres-per-task), or can use GRES formats the parser does not
+        # recognize, causing free GPUs to be overestimated.
         # See https://github.com/skypilot-org/skypilot/issues/10283.
         allocated_gpus = 0
-        use_tres = False
+        accounted = False
         if details and total_gpus > 0:
             # Only trust AllocTRES if the cluster actually tracks
             # gres/gpu in TRES: on clusters that do not project GRES
@@ -1123,9 +1136,22 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
             alloc_tres = details.get('AllocTRES', '')
             if get_gpu_count_from_tres(cfg_tres) >= total_gpus:
                 allocated_gpus = get_gpu_count_from_tres(alloc_tres)
-                use_tres = True
-        if not use_tres and total_gpus > 0:
-            # Fall back to job-level accounting via squeue.
+                accounted = True
+            else:
+                # The cluster does not project GRES into TRES. GresUsed is
+                # the GRES-side equivalent of AllocTRES and is maintained by
+                # slurmctld regardless of AccountingStorageTRES, so it covers
+                # exactly the clusters the check above rejects — and, like
+                # AllocTRES, it is per-node and independent of how each job
+                # requested its GPUs.
+                gres_used = details.get('GresUsed', '')
+                if has_gpu_gres(gres_used):
+                    _, allocated_gpus = get_gpu_type_and_count(gres_used)
+                    accounted = True
+        if not accounted and total_gpus > 0:
+            # Last resort: job-level accounting via squeue. Only reached
+            # when scontrol is unavailable or reports neither gres/gpu in
+            # CfgTRES nor a GPU entry in GresUsed.
             # TODO(zhwu): move to enum
             if state in ('alloc', 'mix', 'drain', 'drng', 'drained', 'resv',
                          'comp'):
@@ -1138,8 +1164,6 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
                     # If no GRES info found but node is fully allocated,
                     # assume all GPUs are in use.
                     allocated_gpus = total_gpus
-            elif state == 'idle':
-                allocated_gpus = 0
 
         free_gpus = total_gpus - allocated_gpus if state not in ('down',
                                                                  'drain',

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -336,6 +336,28 @@ class TestGetGpuCountFromTres:
         assert utils.get_gpu_count_from_tres(tres_str) == expected
 
 
+class TestHasGpuGres:
+    """Test has_gpu_gres() presence detection."""
+
+    @pytest.mark.parametrize(
+        'gres_str,expected',
+        [
+            # A GPU entry is present, even when zero are allocated.
+            ('gpu:0', True),
+            ('gpu:h100:0', True),
+            ('gpu:h100:5(IDX:0-4)', True),
+            ('gpu:8', True),
+            ('gres/gpu=0', True),
+            # No GPU information at all.
+            ('(null)', False),
+            ('N/A', False),
+            ('', False),
+            ('shard:h100:64', False),
+        ])
+    def test_has_gpu_gres(self, gres_str, expected):
+        assert utils.has_gpu_gres(gres_str) is expected
+
+
 class _FakeSlurmClient:
     """Fake SlurmClient for _get_slurm_node_info_list tests."""
 
@@ -427,11 +449,11 @@ class TestGetSlurmNodeInfoList:
         assert result[0]['free_gpus'] == 8
 
     def test_fallback_when_tres_lacks_gpu(self, monkeypatch):
-        """Fall back to squeue if the cluster does not track gres/gpu in TRES.
+        """Fall back to squeue if neither TRES nor GresUsed reports GPUs.
 
         scontrol succeeds, but CfgTRES reports no GPUs while sinfo %G
-        reports 8: AllocTRES cannot be trusted for GPU accounting, so the
-        squeue-based path must be used.
+        reports 8, and GresUsed is absent: neither node-level source can
+        be trusted, so the squeue-based path must be used.
         """
         fake_client = _FakeSlurmClient(
             node_infos=[self._make_sinfo_node('alloc')],
@@ -448,6 +470,91 @@ class TestGetSlurmNodeInfoList:
 
         assert len(result) == 1
         assert result[0]['free_gpus'] == 0
+
+    def test_gres_used_when_tres_lacks_gpu(self, monkeypatch):
+        """GresUsed covers clusters that do not project GRES into TRES.
+
+        CfgTRES has no gres/gpu, so AllocTRES is untrustworthy, but
+        GresUsed is maintained by slurmctld regardless of
+        AccountingStorageTRES — no squeue round-trip needed.
+        """
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192',
+                    'AllocTRES': 'cpu=64,mem=400G,billing=64',
+                    'GresUsed': 'gpu:h100:5(IDX:0-4)',
+                },
+            },
+            jobs_gres={'node1': ['gpu:h100:8']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 3
+        assert fake_client.jobs_gres_calls == 0
+
+    def test_gres_used_zero_is_not_missing_info(self, monkeypatch):
+        """`GresUsed=gpu:h100:0` means 0 allocated, not 'no information'."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('idle')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192',
+                    'AllocTRES': '',
+                    'GresUsed': 'gpu:h100:0',
+                },
+            },
+            # Would report 8 allocated if the squeue path were taken.
+            jobs_gres={'node1': ['gpu:h100:8']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 8
+        assert fake_client.jobs_gres_calls == 0
+
+    def test_alloc_tres_preferred_over_gres_used(self, monkeypatch):
+        """AllocTRES wins when the cluster does track gres/gpu in TRES."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192,gres/gpu=8',
+                    'AllocTRES': 'cpu=64,mem=400G,gres/gpu=6',
+                    # Disagrees with AllocTRES; must not be consulted.
+                    'GresUsed': 'gpu:h100:2',
+                },
+            })
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 2
+
+    def test_squeue_when_gres_used_has_no_gpu_entry(self, monkeypatch):
+        """A GresUsed without any GPU entry still falls through to squeue."""
+        fake_client = _FakeSlurmClient(
+            node_infos=[self._make_sinfo_node('mix')],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=192,mem=800G,billing=192',
+                    'AllocTRES': 'cpu=64,mem=400G,billing=64',
+                    'GresUsed': '(null)',
+                },
+            },
+            jobs_gres={'node1': ['gres/gpu=1']})
+        self._patch(monkeypatch, fake_client)
+
+        result = utils._get_slurm_node_info_list('cluster-a')
+
+        assert len(result) == 1
+        assert result[0]['free_gpus'] == 7
+        assert fake_client.jobs_gres_calls == 1
 
     def test_fallback_when_node_missing_from_details(self, monkeypatch):
         """A sinfo node absent from scontrol output uses squeue accounting."""


### PR DESCRIPTION
Follow-up to #10285 (which fixed #10283).

## Summary

#10285 prefers node-level `AllocTRES` for allocated GPUs, but only trusts it when `CfgTRES` reports at least as many GPUs as `sinfo %G`. That guard is correct — GRES only appears in TRES when it is listed in `AccountingStorageTRES`, so on a cluster that does not track `gres/gpu`, `CfgTRES` shows no GPU entry and `AllocTRES` would silently under-report the allocation:

```
$ sinfo -N -o "%G"
gpu:h100:8                              # 8 GPUs, scheduling works fine

$ scontrol show node node01
CfgTRES=cpu=192,mem=800G,billing=192    # no GPU entry
AllocTRES=cpu=64,mem=400G,billing=64
GresUsed=gpu:h100:5(IDX:0-4)            # ...but this is populated
```

The consequence is that those clusters fall all the way back to job-level `squeue -o "%b"` — the unreliable source #10283 was about, where `%b` can be `N/A` for `--tres-per-task` jobs.

`GresUsed` closes that gap. It is the GRES-side equivalent of `AllocTRES`, maintained by slurmctld regardless of `AccountingStorageTRES`, so it is populated on exactly the clusters the `CfgTRES` check rejects. Like `AllocTRES` it is per-node and independent of how each job requested its GPUs. It comes from the same `scontrol show node -o` output already fetched by `get_all_node_details()`, so this adds **no SSH round-trips**, and it parses with the existing GRES parser.

## Changes

- Insert `GresUsed` between `AllocTRES` and `squeue`, making `squeue` a genuine last resort — reached only when `scontrol` is unavailable or reports neither `gres/gpu` in `CfgTRES` nor a GPU entry in `GresUsed`.
- Add `has_gpu_gres()` so `GresUsed=gpu:h100:0` (zero allocated) is distinguished from `(null)`/absent (no information). Both parse to a count of 0 today, so presence has to be checked separately rather than inferred from the count.
- Rename `use_tres` → `accounted`, now that two node-level sources feed it.
- Drop the dead `elif state == 'idle': allocated_gpus = 0` branch (`allocated_gpus` is already 0 there) and an unnecessary quoted type annotation on `_get_all_jobs_gres`.

Precedence is unchanged where TRES works: `AllocTRES` still wins whenever `CfgTRES` tracks `gres/gpu`, so this is a no-op for clusters already on the fast path.

### Known limitation (pre-existing)

On clusters using `gres/shard`, GPUs consumed via shards are reported under `gres/shard` rather than `gres/gpu`, so neither `AllocTRES` nor `GresUsed` attributes them to `gres/gpu`. That behavior is unchanged by this PR.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

### Test plan

`pytest tests/unit_tests/test_sky/provision/slurm/ tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py` — 208 passed.

New coverage in `tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py`:

| Test | Asserts |
|---|---|
| `TestHasGpuGres` | `gpu:0` / `gpu:h100:0` / `gres/gpu=0` → present; `(null)` / `N/A` / `''` / `shard:h100:64` → absent |
| `test_gres_used_when_tres_lacks_gpu` | `CfgTRES` without `gres/gpu` + `GresUsed=gpu:h100:5(IDX:0-4)` → 3 free, `squeue` not called |
| `test_gres_used_zero_is_not_missing_info` | `GresUsed=gpu:h100:0` → 8 free (not treated as "no info"), `squeue` not called |
| `test_alloc_tres_preferred_over_gres_used` | `AllocTRES` wins over a disagreeing `GresUsed` when `CfgTRES` tracks GPUs |
| `test_squeue_when_gres_used_has_no_gpu_entry` | `GresUsed=(null)` → falls through to `squeue`, called exactly once |

`test_fallback_when_tres_lacks_gpu` (added in #10285) is unchanged and still passes — it has no `GresUsed` key, so it continues to exercise the `squeue` path.

Manual verification against `scontrol show node -o` output, confirming `GresUsed` lands in the parsed details dict and needs no new parser:

```
GresUsed  = 'gpu:h100:5(IDX:0-4)'
get_gpu_type_and_count(GresUsed) -> ('h100', 5)
get_gpu_count_from_tres(CfgTRES) -> 0        # guard sends this node past AllocTRES
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQDqAXjcSsvnCznfuQvn2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQDqAXjcSsvnCznfuQvn2K)_