### PR TITLE
[Nebius] Unpin nebius SDK now that 0.4.3 is loop-aware

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -269,8 +269,10 @@ cloud_dependencies: Dict[str, List[str]] = {
     'nebius': [
         # Nebius requires grpcio and protobuf, so we need to include
         # our constraints here.
-        # 0.4.1 fails with "attached to a different loop".
-        'nebius>=0.3.59,<0.4',
+        # 0.4.1 and 0.4.2 pool grpc.aio channels without event loop affinity
+        # and fail with "attached to a different loop"; fixed in 0.4.3.
+        # https://github.com/nebius/pysdk/issues/178
+        'nebius>=0.3.59,!=0.4.1,!=0.4.2',
         GRPC,
         PROTOBUF,
     ] + aws_dependencies,


### PR DESCRIPTION
Reverts the cap added in #10280.

#10280 pinned `nebius<0.4` because 0.4.1 returned finished `grpc.aio` channels to a per-address free pool (`Channel._free_channels`) with no event loop affinity. A channel created under one loop could be handed to a caller running on another, and the request aborted with:

```
RuntimeError: Task <... Request._request_with_authorization_loop ...> got Future
<... InterceptedUnaryUnaryCall._invoke ...> attached to a different loop
```

SkyPilot hits this because it drives the SDK from more than one loop by design: the dedicated background loop in `sky/adaptors/nebius.py::sync_call`, the SDK's own loop behind `Request.wait()` (`sky/clouds/nebius.py`, `sky/catalog/data_fetchers/fetch_nebius.py`), and `asyncio.run()` in the Nebius catalog fetcher.

Upstream fixed it in **0.4.3** ([nebius/pysdk#178](https://github.com/nebius/pysdk/issues/178#issuecomment-5129647275)). Diffing 0.4.2 → 0.4.3 in `nebius/aio/channel.py`:

- a new `_get_working_loop()` returns the loop a newly created gRPC channel will bind to;
- `_free_channels` is now `dict[str, list[AddressChannel]]` and `get_channel_by_addr` only pops an entry whose `event_loop` **is** the running loop, otherwise it creates a fresh channel;
- checkout/return/close are serialised under a new `_channel_pool_lock`, with leased channels tracked in `_leased_channels` so shutdown cannot race a checkout.

That is option 1/2 from the issue, so the cap is no longer needed.

Dropping `<0.4` and keeping only the two known-broken releases excluded — 0.4.1 and 0.4.2 are the affected versions, and there is no 0.4.0 on PyPI:

```
'nebius>=0.3.59,!=0.4.1,!=0.4.2'
```

Excluding them rather than a bare `>=0.3.59` means a resolver that is held back from 0.4.3 for some other reason lands on 0.3.101, not on a version that is known to break `sky launch`.

## Tested (run the relevant ones):

- [x] Code formatting: `pre-commit` (all hooks pass)
- [x] Any manual or new tests for this PR (please specify below)
  - Constraint resolution: `pip install --dry-run 'nebius>=0.3.59,!=0.4.1,!=0.4.2'` → **nebius 0.4.3**.
  - Ran the upstream reproducer from the issue (one `SDK`, two long-lived background loops, same unary `GetProfile` RPC) against both releases in clean venvs, service-account credentials, `grpcio==1.83.0`:
    - `nebius==0.4.2` → `loop A: OK`, then `loop B` raises the `attached to a different loop` `RuntimeError` above (control — the bug is still there).
    - `nebius==0.4.3` → `loop A: OK`, `loop B: OK`.
- [x] Relevant individual tests: `/smoke-test -k test_api_server_start_stop` (same test used to validate #10280)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
