### PR TITLE
[Slurm] Stop the multi-node run-done barrier from failing completed jobs

### DIFF
--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -4,6 +4,7 @@ This module is invoked on each Slurm compute node via:
     srun python -m sky.skylet.executor.slurm --script=... --log-dir=...
 """
 import argparse
+import errno
 import json
 import os
 import pathlib
@@ -35,6 +36,13 @@ UNSET_STEP_SCOPED_SLURM_ENV = (
     'SLURM_DISTRIBUTION SLURM_SRUN_COMM_HOST SLURM_SRUN_COMM_PORT '
     'SLURM_LAUNCH_NODE_IPADDR SLURM_TASK_PID '
     'SLURM_PROCID SLURM_LOCALID SLURM_NODEID SLURM_GTIDS SLURM_STEPID')
+
+# How long the run-done barrier keeps retrying while the shared filesystem
+# returns hard errors before giving up. The shared home is typically an NFS
+# export, where a client can keep serving a stale view of a directory for its
+# attribute cache timeout (acdirmax, 60s by default), so this needs enough
+# headroom to outlast that window.
+BARRIER_ERROR_TIMEOUT_SECONDS = 300
 
 
 def _is_proctrack_cgroup_enabled(shared_home_dir: str) -> bool:
@@ -84,6 +92,60 @@ def _get_job_node_ips() -> str:
                                f'{hostname}') from e
 
     return '\n'.join(ips)
+
+
+def _wait_for_all_ranks(run_done_dir: str, rank: int, num_nodes: int) -> None:
+    """Waits until every rank has written its done file under run_done_dir.
+
+    Never raises. The barrier only exists to hold this task's cgroup open
+    until its peers finish, so failing to coordinate must not change the exit
+    status of the user's script.
+    """
+    pending = set(range(num_nodes)) - {rank}
+    # When the filesystem first started erroring, or None if the last sweep
+    # was clean.
+    erroring_since = None
+    while pending:
+        last_error = None
+        for peer in sorted(pending):
+            done_file = os.path.join(run_done_dir, str(peer))
+            try:
+                # Poll each rank's file by name instead of listing the
+                # directory, so that a rank that has not finished yet is an
+                # ordinary ENOENT rather than something the caller has to tell
+                # apart from a filesystem error.
+                os.close(os.open(done_file, os.O_RDONLY))
+                pending.discard(peer)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                last_error = e
+        if not pending:
+            return
+        if last_error is None and not os.path.isdir(run_done_dir):
+            # Nothing in this barrier removes the directory, so its absence
+            # means something outside removed it and no rank will ever be
+            # able to report in. Count it as an error rather than as "not
+            # ready yet" so that the wait ends instead of running forever.
+            last_error = FileNotFoundError(errno.ENOENT,
+                                           'Barrier directory is gone',
+                                           run_done_dir)
+        if last_error is None:
+            # Ranks legitimately finish minutes or hours apart, so a clean but
+            # incomplete sweep is not a reason to stop waiting. Only a
+            # filesystem that keeps erroring is bounded by a deadline.
+            erroring_since = None
+        elif erroring_since is None:
+            erroring_since = time.monotonic()
+        elif time.monotonic() - erroring_since > BARRIER_ERROR_TIMEOUT_SECONDS:
+            print(
+                f'Gave up waiting for rank(s) {sorted(pending)} after '
+                f'{BARRIER_ERROR_TIMEOUT_SECONDS}s of errors reading '
+                f'{run_done_dir}: {last_error!r}. Ranks that are still '
+                'running may be killed by Slurm when this task exits.',
+                file=sys.stderr)
+            return
+        time.sleep(0.5)
 
 
 def main():
@@ -243,6 +305,8 @@ def main():
         done_file = f'{run_done_dir}/{rank}'
 
         if rank == 0:
+            # Clear the path first so that leftover done files can never
+            # satisfy the barrier early.
             shutil.rmtree(run_done_dir, ignore_errors=True)
             os.makedirs(run_done_dir, exist_ok=True)
         else:
@@ -252,25 +316,13 @@ def main():
 
         pathlib.Path(done_file).touch()
 
-        # All ranks wait for all done files to exist.
-        max_errs = 10
-        errs = 0
-        while True:
-            try:
-                num_ready = len(os.listdir(run_done_dir))
-                errs = 0
-            except OSError as e:
-                errs += 1
-                if errs >= max_errs:
-                    raise OSError(f'Failed to read {run_done_dir} after '
-                                  f'{max_errs} attempts') from e
-                num_ready = 0
-            if num_ready >= num_nodes:
-                break
-            time.sleep(0.5)
-
-        if rank == 0:
-            shutil.rmtree(run_done_dir, ignore_errors=True)
+        # All ranks wait for all done files to exist. The directory stays in
+        # place until the provision script's cleanup trap removes the cluster
+        # home directory at the end of the Slurm job: removing it as ranks
+        # leave the barrier takes it away from the ranks still reading it,
+        # which on a shared filesystem is long enough for them to never
+        # observe the full set.
+        _wait_for_all_ranks(run_done_dir, rank, num_nodes)
 
     sys.exit(returncode)
 

--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -105,6 +105,13 @@ def _wait_for_all_ranks(run_done_dir: str, rank: int, num_nodes: int) -> None:
     # When the filesystem first started erroring, or None if the last sweep
     # was clean.
     erroring_since = None
+    # TODO(kevin): A peer that never writes its done file leaves every other
+    # rank waiting here indefinitely. srun's --kill-on-bad-exit covers the
+    # common case, where the peer's task dies and Slurm tears the whole step
+    # down, but a peer that stays alive without ever reporting does not reach
+    # it. Bounding this by wall clock would be wrong, since ranks can
+    # legitimately finish hours apart; it needs a liveness signal such as the
+    # peer's Slurm task state.
     while pending:
         last_error = None
         for peer in sorted(pending):

--- a/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
+++ b/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
@@ -1,5 +1,9 @@
 """Tests for the Slurm task executor."""
+# pylint: disable=protected-access
+import errno
+import os
 import subprocess
+import threading
 
 from sky.skylet.executor import slurm
 
@@ -68,3 +72,104 @@ def test_unset_step_scoped_slurm_env():
         assert result[name] == 'UNSET', f'{name} leaked into user script env'
     for name, value in _JOB_SCOPED_VARS.items():
         assert result[name] == value, f'{name} was wrongly unset'
+
+
+def _fail_reads_under(monkeypatch, run_done_dir, exc_factory, num_failures):
+    """Makes the first num_failures reads under run_done_dir raise.
+
+    Returns a one-element list holding how many injected failures are left, so
+    callers can assert the injection actually fired.
+    """
+    real_open = os.open
+    remaining = [num_failures]
+
+    def fake_open(path, *args, **kwargs):
+        if str(path).startswith(str(run_done_dir)) and remaining[0] > 0:
+            remaining[0] -= 1
+            raise exc_factory()
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, 'open', fake_open)
+    return remaining
+
+
+def test_wait_for_all_ranks_returns_once_every_rank_is_done(tmp_path):
+    run_done_dir = tmp_path / 'run_done'
+    run_done_dir.mkdir()
+    for peer in range(4):
+        (run_done_dir / str(peer)).touch()
+
+    slurm._wait_for_all_ranks(str(run_done_dir), rank=0, num_nodes=4)
+
+
+def test_wait_for_all_ranks_waits_for_a_late_rank(tmp_path):
+    run_done_dir = tmp_path / 'run_done'
+    run_done_dir.mkdir()
+    (run_done_dir / '0').touch()
+    (run_done_dir / '1').touch()
+
+    # Rank 2 finishes well after the others, which is normal: the barrier has
+    # no business bounding how long a peer's workload takes.
+    late = threading.Timer(1.0, (run_done_dir / '2').touch)
+    late.start()
+    try:
+        slurm._wait_for_all_ranks(str(run_done_dir), rank=1, num_nodes=3)
+    finally:
+        late.cancel()
+
+    assert (run_done_dir / '2').exists()
+
+
+def test_wait_for_all_ranks_survives_a_transient_error(tmp_path, monkeypatch,
+                                                       capsys):
+    run_done_dir = tmp_path / 'run_done'
+    run_done_dir.mkdir()
+    for peer in range(2):
+        (run_done_dir / str(peer)).touch()
+    remaining = _fail_reads_under(
+        monkeypatch,
+        run_done_dir,
+        lambda: OSError(errno.ESTALE, 'Stale file handle'),
+        num_failures=1)
+    # Even with no error budget at all, one bad read followed by a good one
+    # must not end the wait: the error clock only runs while reads keep
+    # failing.
+    monkeypatch.setattr(slurm, 'BARRIER_ERROR_TIMEOUT_SECONDS', 0)
+
+    slurm._wait_for_all_ranks(str(run_done_dir), rank=0, num_nodes=2)
+
+    assert remaining == [0], 'the injected error never fired'
+    assert 'Gave up waiting' not in capsys.readouterr().err
+
+
+def test_wait_for_all_ranks_gives_up_if_the_directory_is_removed(
+        tmp_path, monkeypatch, capsys):
+    # A rank that removed the directory on its way out is exactly the race
+    # this barrier must not have, so nothing here removes it. If something
+    # else does, the wait has to end rather than hang forever.
+    run_done_dir = tmp_path / 'run_done'
+    monkeypatch.setattr(slurm, 'BARRIER_ERROR_TIMEOUT_SECONDS', 0)
+
+    slurm._wait_for_all_ranks(str(run_done_dir), rank=0, num_nodes=2)
+
+    assert 'Gave up waiting for rank(s) [1]' in capsys.readouterr().err
+
+
+def test_wait_for_all_ranks_gives_up_without_raising(tmp_path, monkeypatch,
+                                                     capsys):
+    run_done_dir = tmp_path / 'run_done'
+    run_done_dir.mkdir()
+    (run_done_dir / '1').touch()
+    remaining = _fail_reads_under(
+        monkeypatch,
+        run_done_dir,
+        lambda: OSError(errno.ESTALE, 'Stale file handle'),
+        num_failures=1000)
+    monkeypatch.setattr(slurm, 'BARRIER_ERROR_TIMEOUT_SECONDS', 0)
+
+    # A barrier that cannot read the shared filesystem must not turn a
+    # successful user script into a failed job.
+    slurm._wait_for_all_ranks(str(run_done_dir), rank=0, num_nodes=2)
+
+    assert remaining[0] < 1000, 'the injected error never fired'
+    assert 'Gave up waiting for rank(s) [1]' in capsys.readouterr().err

--- a/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
+++ b/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
@@ -3,8 +3,13 @@
 import errno
 import os
 import subprocess
+import sys
 import threading
+import time
 
+import pytest
+
+from sky.skylet import constants
 from sky.skylet.executor import slurm
 
 # Step/task-scoped variables Slurm sets for the executor's own job step. A
@@ -173,3 +178,54 @@ def test_wait_for_all_ranks_gives_up_without_raising(tmp_path, monkeypatch,
 
     assert remaining[0] < 1000, 'the injected error never fired'
     assert 'Gave up waiting for rank(s) [1]' in capsys.readouterr().err
+
+
+def test_barrier_leaves_the_done_directory_in_place(tmp_path, monkeypatch):
+    """Rank 0 must not remove the barrier directory as it leaves.
+
+    Removing it there is the write side of the race this barrier is built to
+    avoid: the ranks still polling lose the directory before they have seen
+    everyone report in. Drive main() so that a cleanup call reintroduced next
+    to the barrier is caught here.
+    """
+    cluster_home = tmp_path / 'cluster_home'
+    cluster_home.mkdir()
+    (cluster_home / constants.SLURM_PROCTRACK_TYPE_FILE).write_text('cgroup')
+    log_dir = tmp_path / 'logs'
+    log_dir.mkdir()
+    run_done_dir = cluster_home / '.sky_run_done_42_7'
+
+    monkeypatch.setenv('SLURM_PROCID', '0')
+    monkeypatch.setenv('SLURM_NNODES', '2')
+    monkeypatch.setenv('SLURM_JOB_ID', '42')
+    monkeypatch.setenv('SLURM_STEP_ID', '7')
+    monkeypatch.setattr(slurm, '_get_ip_address', lambda: '10.0.0.1')
+    monkeypatch.setattr(slurm, '_get_job_node_ips',
+                        lambda: '10.0.0.1\n10.0.0.2')
+    monkeypatch.setattr(slurm, 'run_bash_command_with_log', lambda *a, **kw: 0)
+    monkeypatch.setattr(sys, 'argv', [
+        'slurm.py', '--script', 'true', '--log-dir',
+        str(log_dir), '--cluster-num-nodes', '2', '--cluster-ips',
+        '10.0.0.1,10.0.0.2', '--cluster-home-dir',
+        str(cluster_home)
+    ])
+
+    # Stand in for rank 1, which reports in once rank 0 has created the
+    # directory.
+    def peer_reports_in():
+        deadline = time.monotonic() + 30
+        while not run_done_dir.is_dir() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        (run_done_dir / '1').touch()
+
+    peer = threading.Thread(target=peer_reports_in, daemon=True)
+    peer.start()
+    try:
+        with pytest.raises(SystemExit) as exit_info:
+            slurm.main()
+    finally:
+        peer.join(timeout=30)
+
+    assert exit_info.value.code == 0
+    assert run_done_dir.is_dir(), 'the barrier directory was removed'
+    assert sorted(p.name for p in run_done_dir.iterdir()) == ['0', '1']


### PR DESCRIPTION
The multi-node completion barrier in `sky/skylet/executor/slurm.py` could turn a job whose ranks had all succeeded into a failed one.

Rank 0 removed the barrier directory as soon as it observed every rank's done file, while the other ranks were still polling that directory. Those ranks then got `ENOENT` from `os.listdir()` and, after 10 consecutive failures (5s), raised:

```
OSError: Failed to read ~/.sky_run_done_<job>_<step> after 10 attempts
srun: error: node-0: task 7: Exited with exit code 1
srun: error: node-11: task 5: Terminated
```

srun killed the remaining tasks and the job was reported as failed even though every rank's workload had finished.

The race exists on any filesystem — nothing orders rank 0's removal against the other ranks' reads. On a shared filesystem with cached directory attributes, the window between rank 0 observing completion and another rank observing it is easily wider than the 5s budget, and it widens with node count.

## Changes

1. **Nothing removes the barrier directory on the way out.** It is left in the cluster home directory, which the provision script's cleanup trap removes when the Slurm job ends.
2. **The barrier never raises.** It exists only to hold a task's cgroup open until its peers finish, so failing to coordinate must not change the exit status of the user's script. On giving up it logs a warning and returns.
3. **Poll each rank's done file by name** instead of listing the directory, and bound the wait with a deadline that runs only while the filesystem is returning errors. Ranks legitimately finish minutes or hours apart, so a clean but incomplete read is not a reason to stop waiting. A barrier directory removed by something outside the barrier counts as an error rather than "not ready yet", so the wait ends instead of running forever.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

### Unit tests

Five new tests in `tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py` covering: completion once every rank reports in, waiting indefinitely for a late rank, surviving a transient `ESTALE` even with no error budget, giving up when the directory is removed, and giving up without raising. `pytest tests/unit_tests/test_sky/skylet/executor/ -n0` — 6 passed.

### Manual tests

On a 2-node Slurm cluster with `ProctrackType=proctrack/cgroup` and an NFSv3 shared home.

**1. End-to-end, with ranks finishing at different times.** `sky launch --num-nodes 2` running `sleep $((SKYPILOT_NODE_RANK * 45))`, so rank 0 enters the barrier and waits while rank 1 is still working:

- Job `SUCCEEDED` (49s), `sky launch` exited 0, both ranks' output streamed.
- Confirmed the executor installed on the compute node was the patched one (`_wait_for_all_ranks` present, `max_errs` absent) rather than only the client being patched.
- The barrier directory still held both ranks' done files after the job finished — before this change rank 0 would have removed it — and `sky down` removed it along with the cluster home.

**2. The race itself, across both nodes over the same NFS mount.** Two srun tasks where rank 0 removes the barrier directory as soon as it sees both done files, and rank 1's poll loop starts 2s later:

| barrier | result |
| --- | --- |
| previous loop (restored for the test) | rank 1 **raised** after 4.5s: `OSError: Failed to read … after 10 attempts` |
| this PR | rank 1 **returned** after 4.0s, logged a warning, no exception (error deadline lowered to 3s for the test) |

**3. Directory listing vs. per-file visibility on that mount.** After rank 0 created a file, rank 1 first observed it at 22ms via `os.listdir()` and 23ms via `os.open()` — no measurable difference on this mount (`lookupcache=pos,forcerdirplus`). Change 3 above is motivated by close-to-open semantics, not by a measured improvement here.

**Not covered:** the failure was originally seen on a 16-node job. The cluster available for this test has 2 nodes, which is a size that passed before this change as well, so the original 16-node failure is not reproduced here. Changes 1 and 2 are what make the reported failure impossible; change 3 is a robustness improvement whose benefit is mount-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
