### PR TITLE
[Test] Stop the auth-pool test from spawning 128 threads

### DIFF
--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -1418,12 +1418,19 @@ def test_saturating_request_executor_does_not_block_auth():
     answered 503 to traffic that had nothing to do with streaming.
     """
     _reset_thread_executors()
+    release = threading.Event()
+    futures = []
     try:
-        request_executor = executor.get_request_thread_executor()
+        # Shrink the request pool for the duration: what matters is that it
+        # reaches *its* limit, not how big that limit is. Filling the real 128
+        # would spawn 128 threads inside a test worker, which under `pytest
+        # -n` starves the whole run -- enough to push neighbouring tests past
+        # their own timeouts.
+        with mock.patch.object(executor, '_REQUEST_THREADS_LIMIT', 4):
+            request_executor = executor.get_request_thread_executor()
         auth_executor = executor.get_auth_thread_executor()
+        assert request_executor.max_workers == 4
 
-        release = threading.Event()
-        futures = []
         # Fill the request executor to its limit with tasks that do not finish,
         # standing in for in-flight log streams.
         for _ in range(request_executor.max_workers):


### PR DESCRIPTION
Follow-up to #10313 — my test in that PR regressed CI, both in time and in reliability.

## What happened

`test_saturating_request_executor_does_not_block_auth` filled the request executor to its **real** limit, so it spawned 128 threads inside a pytest worker process. Under `pytest -n` that starves the whole run.

Measured on the same downstream repo, same job, consecutive runs:

| Submodule pin | Result | Unit-test duration |
|---|---|---|
| before #10313 | 5772 passed | **339s** |
| with #10313 | 5773 passed, **1 failed** | **614s** |

So two added tests cost **+274s (+81%)**, and pushed a neighbour over its own timeout: `test_idle_worker_survives_sigterm_with_gated_handler` allows a `ProcessPoolExecutor` 10s to start a worker, and began failing consistently (twice in a row, not intermittently). The two tests are in the same file, so `-n`'s scheduler can run them in parallel on a loaded runner.

## Fix

The test needs the pool to reach *its* limit — the size of that limit is irrelevant to what it asserts. Patch `_REQUEST_THREADS_LIMIT` to 4 for the duration, so it fills 4 threads instead of 128.

Also hoisted `release` and `futures` above the `try`, so the `finally` cleanup cannot raise `NameError` if the body fails before they are bound.

## Tested

- The three tests together now run in **~1s**.
- Reverting the split (making the auth getter return the request executor) still fails both auth-pool tests, so the cheaper version still pins the behaviour it was written to pin.

Apologies for the noise — the cost only showed up under `-n` on a loaded runner, not when running the tests on their own.