### PR TITLE
[Core] Bound SSH ControlPath length for long user IDs

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -71,6 +71,26 @@ _DEFAULT_CONNECT_TIMEOUT = 30
 
 DEFAULT_SSH_CONTROL_NAME = '__default__'
 
+_SSH_CONTROL_PATH_PREFIX = '/tmp/skypilot_ssh_'
+# sockaddr_un.sun_path holds 104 bytes on macOS and 108 on Linux. Use the
+# smaller one, minus the NUL terminator, so ControlPaths fit on both.
+_UNIX_SOCKET_PATH_MAX_LENGTH = 103
+# ssh binds the ControlMaster listener at the ControlPath plus a '.' and 16
+# random characters, then links it into place, so that temporary name is what
+# has to fit. See muxserver_listen() in OpenSSH's mux.c.
+_SSH_CONTROL_PATH_TMP_SUFFIX_LENGTH = len('.') + 16
+# The ControlPath ends in '/%C', which ssh expands to a 40-character digest of
+# the connection parameters.
+_SSH_CONTROL_PATH_EXPANDED_C_LENGTH = 40
+# The user hash is the only variable-length component of
+# '<prefix><user hash>/<control name hash>/<%C>.<16 chars>', so cap it at the
+# space the fixed-length components leave over.
+_MAX_CONTROL_PATH_USER_HASH_LENGTH = (_UNIX_SOCKET_PATH_MAX_LENGTH -
+                                      len(_SSH_CONTROL_PATH_PREFIX) - len('/') -
+                                      _HASH_MAX_LENGTH - len('/') -
+                                      _SSH_CONTROL_PATH_EXPANDED_C_LENGTH -
+                                      _SSH_CONTROL_PATH_TMP_SUFFIX_LENGTH)
+
 # SSH authentication failure patterns to detect when interactive auth retry
 # is needed.
 _SSH_AUTH_FAILURE_PATTERNS = [
@@ -103,7 +123,15 @@ def _ssh_control_path(ssh_control_filename: Optional[str]) -> Optional[str]:
     if ssh_control_filename is None:
         return None
     user_hash = common_utils.get_user_hash()
-    path = f'/tmp/skypilot_ssh_{user_hash}/{ssh_control_filename}'
+    if len(user_hash) > _MAX_CONTROL_PATH_USER_HASH_LENGTH:
+        # User IDs are only validated for their characters, so externally
+        # assigned ones (UUIDs, service account ids) can be long enough to push
+        # the listener path past sun_path and fail every ssh that multiplexes.
+        # Digesting keeps the path bounded and each user on their own socket.
+        digest = hashlib.md5(user_hash.encode(),
+                             usedforsecurity=False).hexdigest()
+        user_hash = digest[:_MAX_CONTROL_PATH_USER_HASH_LENGTH]
+    path = f'{_SSH_CONTROL_PATH_PREFIX}{user_hash}/{ssh_control_filename}'
     os.makedirs(path, exist_ok=True)
     return path
 

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -15,6 +15,7 @@ import paramiko
 import pytest
 
 from sky import exceptions
+from sky.skylet import constants
 from sky.utils import auth_utils
 from sky.utils import command_runner
 from sky.utils import common_utils
@@ -1102,3 +1103,55 @@ class TestRsyncTimeout:
         assert 'timed out' in str(exc_info.value).lower()
         # Deadline tripped before max_retry was exhausted.
         assert len(calls) == 1
+
+
+class TestSSHControlPath:
+    """Test that the ssh ControlPath stays within sockaddr_un.sun_path."""
+
+    @staticmethod
+    def _listener_path(control_path: str) -> str:
+        """The path ssh actually binds, given a ControlPath of <dir>/%C."""
+        expanded_c = 'c' * command_runner._SSH_CONTROL_PATH_EXPANDED_C_LENGTH
+        tmp_suffix = 'x' * (command_runner._SSH_CONTROL_PATH_TMP_SUFFIX_LENGTH -
+                            len('.'))
+        return f'{control_path}/{expanded_c}.{tmp_suffix}'
+
+    @pytest.mark.parametrize('user_hash', [
+        'abcd1234',
+        'ci-container-current',
+        'ci-container-currentX',
+        '550e8400-e29b-41d4-a716-446655440000',
+        'sa-' + 'z' * 200,
+    ])
+    def test_listener_path_fits_unix_socket(self, monkeypatch, user_hash):
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, user_hash)
+        control_path = command_runner._ssh_control_path('0123456789')
+        assert control_path is not None
+
+        listener_path = self._listener_path(control_path)
+        assert len(listener_path) <= command_runner._UNIX_SOCKET_PATH_MAX_LENGTH
+
+        # The length bound is portable; binding proves it on this platform.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(listener_path)
+        finally:
+            sock.close()
+            with suppress(OSError):
+                os.unlink(listener_path)
+
+    def test_short_user_hash_is_used_verbatim(self, monkeypatch):
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, 'abcd1234')
+        assert command_runner._ssh_control_path('0123456789') == (
+            '/tmp/skypilot_ssh_abcd1234/0123456789')
+
+    def test_long_user_hashes_stay_isolated(self, monkeypatch):
+        paths = set()
+        for i in range(2):
+            monkeypatch.setenv(constants.USER_ID_ENV_VAR,
+                               f'sa-{i}-' + 'y' * 100)
+            paths.add(command_runner._ssh_control_path('0123456789'))
+        assert len(paths) == 2
+
+    def test_no_control_name_has_no_control_path(self):
+        assert command_runner._ssh_control_path(None) is None


### PR DESCRIPTION
## Summary

`_ssh_control_path()` embeds the raw `SKYPILOT_USER_ID` in the ControlMaster
socket directory:

```
/tmp/skypilot_ssh_<user-id>/<control-name-hash>/%C
```

`common_utils.is_valid_user_hash()` constrains the *characters* of a user ID
but not its *length*, so externally assigned IDs (UUIDs, service account IDs)
push the socket path past `sockaddr_un.sun_path` and ssh fails before it ever
runs the remote command:

```
unix_listener: path "..." too long for Unix domain socket
```

ssh exits 255, so every operation that multiplexes fails. Working through the
fixed-length parts of the path:

| component | bytes |
|---|---|
| `/tmp/skypilot_ssh_` | 18 |
| `/` + control name hash (`_HASH_MAX_LENGTH`) | 11 |
| `/` + `%C` expansion | 41 |
| `.` + 16 random chars — see `muxserver_listen()` in OpenSSH's `mux.c`, which binds the listener at a temporary name before linking it into place | 17 |
| **fixed total** | **87** |

`sun_path` is 108 bytes on Linux and 104 on macOS, so the usable pathname is
107 and 103 bytes respectively. That leaves **20** characters for the user ID
on Linux and **16** on macOS — a 36-character UUID overshoots by 16 bytes.

This replaces any user hash longer than the budget with a fixed-length digest,
so the path is bounded on both platforms regardless of ID length while each
user keeps its own socket directory. IDs that already fit are used verbatim, so
short hashes see no change in ssh behavior. The affected code is shared by
`SSHCommandRunner`, so this is not specific to any one cloud.

## Tested

Reproduced and verified end to end against a real Slurm cluster (SSH to the
login node, `sky check`, and a full `sky launch`), driving the API server with
`SKYPILOT_USER_ID` set to each ID under test.

**Before** — a 21-character ID and a 36-character UUID both fail:

```
SKYPILOT_USER_ID = 'ci-container-currentX' (len=21)
temp listener    = /tmp/skypilot_ssh_ci-container-currentX/3b650b2020/<40 chars>.<16 chars> (len=108)
--- returncode: 255
--- stderr: 'unix_listener: path ".../3b650b2020/7f013a640b0988d96f0381d77d1480143207d42e.63ZrQSbVgIHSP2CT" too long for Unix domain socket'
```

```
$ sky check slurm --verbose
  Slurm: disabled
    Reason [compute]:
        Allowed clusters:
        └── <cluster>: disabled. Credential check failed: sky.exceptions.CommandError: Command sinfo failed with return code 255.
    Failed to get Slurm cluster information.
    unix_listener: path "/tmp/skypilot_ssh_550e8400-e29b-41d4-a716-446655440000/3651d5b8ee/....Sop0952efAhNhc5q" too long for Unix domain socket

$ sky launch -c test --infra slurm/<cluster> -y -- 'echo hi'
sky.exceptions.ResourcesUnavailableError: Task 'sky-cmd' requires slurm which is not enabled.
```

**After** — the same IDs land at 103 bytes and connect, each on its own socket
directory; the 8-character default hash is untouched:

| `SKYPILOT_USER_ID` | len | ControlPath dir | listener len | rc |
|---|---|---|---|---|
| `d19d734e` | 8 | `/tmp/skypilot_ssh_d19d734e` | 95 | 0 |
| `ci-container-current` | 20 | `/tmp/skypilot_ssh_5995fba751c4d09a` | 103 | 0 |
| `ci-container-currentX` | 21 | `/tmp/skypilot_ssh_42c10bc8d5aa1752` | 103 | 0 |
| `550e8400-e29b-41d4-a716-446655440000` | 36 | `/tmp/skypilot_ssh_e8456cee7fd2348c` | 103 | 0 |
| `sa-…` service-account style | 63 | `/tmp/skypilot_ssh_7a4dca373e258b0f` | 103 | 0 |

```
$ sky check slurm
  Slurm: enabled [compute]

$ sky launch -c test --infra slurm/<cluster> -y -- 'echo SKY_E2E_OK; hostname'
(sky-cmd, pid=2027849) SKY_E2E_OK
(sky-cmd, pid=2027849) slurm-gh200-...
✓ Job finished (status: SUCCEEDED).
```

The exact `sky launch` that failed with this patch reverted succeeds with it
applied.

**Unit tests** — `tests/unit_tests/test_sky/utils/test_command_runner.py` gains
`TestSSHControlPath`, which builds the temporary listener name ssh actually
binds (`<ControlPath>/<40-char %C>.<16 chars>`), asserts it fits the portable
limit, and then `bind()`s a real `AF_UNIX` socket at it to prove the limit on
the running platform. It also covers socket isolation between distinct long IDs
and verbatim handling of short ones. Removing the length cap while keeping the
constants fails 4 of the 5 parametrized cases.

```
$ pytest tests/unit_tests/test_sky/utils/test_command_runner.py -n0
59 passed
```

`format.sh` (yapf, isort, pylint 10.00/10) is clean on both changed files.
