### PR TITLE
[Storage] Fix AWS CLI bootstrap for R2/OCI-S3/Nebius/CoreWeave/VastData stores

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -388,8 +388,9 @@ class R2CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -424,7 +425,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               '$awscli_path s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--endpoint {endpoint_url} '
@@ -441,7 +442,7 @@ class R2CloudStorage(CloudStorage):
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               '$awscli_path s3 '
                                f'cp {source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -585,8 +586,9 @@ class OciS3CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -627,7 +629,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
@@ -649,7 +651,7 @@ class OciS3CloudStorage(CloudStorage):
             # upload path and OCI's S3 SDK guidance.
             'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
             'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
 
@@ -663,8 +665,9 @@ class NebiusCloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -696,7 +699,7 @@ class NebiusCloudStorage(CloudStorage):
         # aws config file (Default path: ~/.aws/config).
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+        download_via_awscli = ('$awscli_path s3 '
                                'sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
@@ -709,7 +712,7 @@ class NebiusCloudStorage(CloudStorage):
         """Downloads a file using AWS CLI."""
         assert 'nebius://' in source, 'nebius:// is not in source'
         source = source.replace('nebius://', 's3://')
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+        download_via_awscli = ('$awscli_path s3 '
                                f'cp {source} {destination} '
                                f'--profile={nebius.NEBIUS_PROFILE_NAME}')
 
@@ -723,8 +726,9 @@ class CoreWeaveCloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -763,7 +767,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
@@ -780,7 +784,7 @@ class CoreWeaveCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{coreweave.COREWEAVE_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={coreweave.COREWEAVE_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--profile={coreweave.COREWEAVE_PROFILE_NAME}')
 
@@ -797,8 +801,9 @@ class VastDataCloudStorage(CloudStorage):
     """
 
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -826,7 +831,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             'sync --no-follow-symlinks '
             f'{source} {destination} '
             f'--endpoint {endpoint_url} '
@@ -845,7 +850,7 @@ class VastDataCloudStorage(CloudStorage):
             'AWS_SHARED_CREDENTIALS_FILE='
             f'{vastdata.VASTDATA_CREDENTIALS_PATH} '
             f'AWS_CONFIG_FILE={vastdata.VASTDATA_CONFIG_PATH} '
-            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            '$awscli_path s3 '
             f'cp {source} {destination} '
             f'--endpoint {endpoint_url} '
             f'--profile={vastdata.VASTDATA_PROFILE_NAME}')

--- a/tests/unit_tests/test_sky/storage/test_cloud_stores.py
+++ b/tests/unit_tests/test_sky/storage/test_cloud_stores.py
@@ -190,3 +190,47 @@ def test_gcs_directory_copy_keeps_rsync_arguments(monkeypatch):
         'gs://private-bucket/prefix', '/tmp/prefix')
 
     assert 'rsync -e -r gs://private-bucket/prefix /tmp/prefix' in command
+
+
+# Stores that install the AWS CLI and drive it for their sync/copy commands.
+_AWSCLI_STORES = [
+    cloud_stores.R2CloudStorage,
+    cloud_stores.OciS3CloudStorage,
+    cloud_stores.NebiusCloudStorage,
+    cloud_stores.CoreWeaveCloudStorage,
+    cloud_stores.VastDataCloudStorage,
+]
+
+
+@pytest.mark.parametrize('store_cls', _AWSCLI_STORES)
+def test_awscli_stores_share_s3_bootstrap(store_cls):
+    """Every awscli-based store bootstraps the CLI the same way S3 does.
+
+    Regression test for #10125. These stores used to check `aws --version` on
+    PATH but then execute the venv's aws binary. On an image that already ships
+    `aws`, the install was skipped and the sync died with
+    `.../bin/aws: No such file or directory`. The check and the exec target
+    have to agree, so they should reuse S3's `awscli_path` bootstrap.
+    """
+    assert store_cls._GET_AWSCLI == cloud_stores.S3CloudStorage._GET_AWSCLI
+    bootstrap = '\n'.join(store_cls._GET_AWSCLI)
+    assert 'awscli_path=$(which aws)' in bootstrap
+    assert 'aws --version' not in bootstrap
+
+
+def test_r2_sync_commands_execute_resolved_awscli(monkeypatch):
+    """R2 sync/copy must run `$awscli_path`, not a hardcoded venv binary."""
+    monkeypatch.setattr(cloud_stores.cloudflare, 'create_endpoint',
+                        lambda: 'https://fake.r2.endpoint')
+    store = cloud_stores.R2CloudStorage()
+    commands = [
+        store.make_sync_dir_command('r2://bucket/src', '/dst'),
+        store.make_sync_file_command('r2://bucket/obj', '/dst/obj'),
+    ]
+    for command in commands:
+        # Bootstrap resolves the binary into $awscli_path...
+        assert 'awscli_path=$(which aws)' in command
+        # ...and the sync/copy actually executes it.
+        assert '$awscli_path s3 ' in command
+        # The old hardcoded exec target must be gone.
+        assert '/bin/aws s3 ' not in command

--- a/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
@@ -149,7 +149,8 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
             'oci://bucket/path', '/dest')
         self.assertIn('s3://bucket/path', cmd)
         self.assertNotIn('oci://', cmd)
-        self.assertIn('aws s3 sync', cmd)
+        # Runs the resolved AWS CLI (see #10125), not a hardcoded venv binary.
+        self.assertIn('$awscli_path s3 sync', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('AWS_CONFIG_FILE=~/.oci/s3.config', cmd)
         self.assertIn('--profile=oci', cmd)
@@ -159,7 +160,8 @@ class TestOciS3CloudStorageCommands(unittest.TestCase):
             'oci://bucket/path/file', '/dest')
         self.assertIn('s3://bucket/path/file', cmd)
         self.assertNotIn('oci://', cmd)
-        self.assertIn('aws s3 cp', cmd)
+        # Runs the resolved AWS CLI (see #10125), not a hardcoded venv binary.
+        self.assertIn('$awscli_path s3 cp', cmd)
         self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
         self.assertIn('--profile=oci', cmd)
 


### PR DESCRIPTION
Five storage backends install and run the AWS CLI, but they check for it one way and then run it another way.

`S3CloudStorage` does it right: it resolves the binary with `awscli_path=$(which aws)`, falls back to installing it into the SkyPilot venv, and then runs `$awscli_path`. But `R2CloudStorage`, `OciS3CloudStorage`, `NebiusCloudStorage`, `CoreWeaveCloudStorage`, and `VastDataCloudStorage` still check `aws --version` on PATH and then hardcode `{SKY_REMOTE_PYTHON_ENV}/bin/aws` in their sync/copy commands.

So if the machine or docker image already ships `aws` on PATH, the `aws --version` check passes, the venv install is skipped, and the sync then tries to run a venv binary that was never installed:

```
bash: /root/skypilot-runtime/bin/aws: No such file or directory
... failed with return code 127.
```

That breaks any `r2://` (and the other four) file mount. It is easy to hit, since a docker image can pull awscli in transitively (ours gets it from `skypilot[cloudflare]`'s own extras), and the launch then retries forever on the failed pre-rsync step. Closes #10125.

Fix: give the five stores the same `awscli_path` bootstrap S3 already uses, and have their sync/copy commands run `$awscli_path`, so the check and the exec target always point at the same binary.

Testing:

- [x] Code formatting: yapf, isort, mypy, and pylint all pass (pylint 10.00/10).
- [x] Unit tests: `pytest tests/unit_tests/test_sky/storage/test_cloud_stores.py -k awscli`. The new tests assert all five stores share S3's bootstrap, and that R2's sync/copy commands actually run `$awscli_path` instead of the hardcoded venv path.
- [ ] Smoke tests: not run (would need a real `r2://` bucket plus a docker-mode cluster), but the bug lives entirely in the generated shell-command string, which the unit tests cover.
