### PR TITLE
[Jobs] Fix managed job crash on empty imagePullSecrets in task config

### DIFF
--- a/docs/source/reference/config-sources.rst
+++ b/docs/source/reference/config-sources.rst
@@ -169,7 +169,13 @@ Merging rules:
 
 * Lists are overridden by config sources with higher priority.
 
-  * Exception: lists in ``kubernetes.pod_config`` appended to the existing list.
+  * Exception: lists in ``kubernetes.pod_config`` that Kubernetes defines a patch
+    merge key for (e.g. ``containers`` and ``volumes`` by ``name``, ``volumeMounts``
+    by ``mountPath``) are merged item by item on that key: an item whose key
+    matches an existing one is merged into it, and other items are appended.
+    ``args``, ``command`` and ``imagePullSecrets`` are replaced as a whole, so an
+    empty ``imagePullSecrets`` list clears the secrets set by a lower-priority
+    source. Remaining lists are appended to the existing list.
 
 * Dictionaries are merged, with individual keys overridden by config sources with higher priority.
 

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -126,24 +126,27 @@ def _add_k8s_annotations(task: 'sky.Task', job_id: int) -> None:
     the kubernetes specific config is not used when launching
     a cluster on other clouds.
     """
-    original_resources = task.resources
-    new_resources_list: List['sky.Resources'] = []
-    for original_resource in original_resources:
-        # Get existing config overrides or create new dict
-        config_overrides = original_resource.cluster_config_overrides.copy()
-
-        # Initialize nested structure and add annotations
-        pod_annotations = config_overrides.setdefault(
-            'kubernetes',
-            {}).setdefault('pod_config',
-                           {}).setdefault('metadata',
-                                          {}).setdefault('annotations', {})
-        pod_annotations['skypilot-managed-job-id'] = str(job_id)
-        pod_annotations['skypilot-managed-job-name'] = str(task.name)
-        # Create new resource with updated config
-        new_resource = original_resource.copy(
-            _cluster_config_overrides=config_overrides)
-        new_resources_list.append(new_resource)
+    # Pass only the annotations we are adding: Resources.copy() overlays this
+    # on top of the resource's existing overrides, so passing the whole config
+    # would merge it with itself. That is not a no-op -- it duplicates every
+    # list without a patch merge key (e.g. tolerations) and trips the
+    # imagePullSecrets merge branch.
+    annotations_override = {
+        'kubernetes': {
+            'pod_config': {
+                'metadata': {
+                    'annotations': {
+                        'skypilot-managed-job-id': str(job_id),
+                        'skypilot-managed-job-name': str(task.name),
+                    }
+                }
+            }
+        }
+    }
+    new_resources_list: List['sky.Resources'] = [
+        original_resource.copy(_cluster_config_overrides=annotations_override)
+        for original_resource in task.resources
+    ]
 
     # Set the new resources back to the task
     task.set_resources(new_resources_list)

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -15,8 +15,6 @@ _REGION_CONFIG_CLOUDS = ['nebius', 'oci']
 # - If the value is None, the list is replaced atomically (e.g., args, command)
 # Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/
 #      #podspec-v1-core
-# NOTE: field imagePullSecrets are not included deliberately for backward
-# compatibility
 _PATCH_MERGE_KEYS = {
     'containers': 'name',
     'initContainers': 'name',
@@ -35,6 +33,11 @@ _PATCH_MERGE_KEYS = {
     # Atomic list fields - replaced entirely, not merged item-by-item
     'args': None,
     'command': None,
+    # Kubernetes patch-merges imagePullSecrets by 'name', but these items are
+    # credentials: unioning an admin-provided secret with a task's own would
+    # keep pulling with a credential the task meant to drop. Replace instead,
+    # which also lets an empty list clear inherited secrets.
+    'imagePullSecrets': None,
 }
 
 
@@ -237,17 +240,9 @@ def merge_k8s_configs(
         elif isinstance(value, list) and key in base_config:
             assert isinstance(base_config[key], list), \
                 f'Expected {key} to be a list, found {base_config[key]}'
-            if key == 'imagePullSecrets':
-                # For imagePullSecrets, merge the first item from override
-                # into the first item in base (legacy behavior).
-                assert len(value) == 1, \
-                    f'Expected only one imagePullSecret, found {value}'
-                merge_k8s_configs(base_config[key][0], value[0],
-                                  next_allowed_override_keys,
-                                  next_disallowed_override_keys)
             # For list fields with patch strategy "merge", we merge the list
             # by the patch merge key.
-            elif key in _PATCH_MERGE_KEYS:
+            if key in _PATCH_MERGE_KEYS:
                 patch_merge_key = _PATCH_MERGE_KEYS[key]
                 if patch_merge_key is None:
                     # Atomic list field (e.g., args, command) - replace entirely

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -227,7 +227,10 @@ def _validate_mergeable_types(key: Any, base_value: Any,
         # absent, so this is how a config clears an inherited subtree.
         return
     if isinstance(override_value, dict):
-        # Merged key by key, so the base has to be a dict to recurse into.
+        # Always merged key by key, so the base has to be a dict to recurse
+        # into. The atomic exemption below deliberately does not apply here:
+        # _PATCH_MERGE_KEYS is only consulted for list overrides, so a dict
+        # override recurses even for an atomic field.
         mergeable = isinstance(base_value, dict)
     elif isinstance(override_value, list):
         # Atomic list fields replace the base wholesale; the rest are merged by

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -216,12 +216,24 @@ def _validate_mergeable_types(key: Any, base_value: Any,
     Nested `pod_config` content is not type-checked by the config schema, so a
     dict/list/scalar mismatch is user input rather than a bug. Without this the
     merge below would raise a bare AssertionError or TypeError, or silently
-    replace a whole dict/list with a scalar.
+    replace a whole dict/list with a scalar (which the post-merge pod
+    validation does not reliably catch either).
+
+    Only checked where the merge actually reads the base value: an override
+    that replaces the base outright works whatever shape the base has.
     """
+    if override_value is None:
+        # An explicit null replaces the value; Kubernetes reads a null field as
+        # absent, so this is how a config clears an inherited subtree.
+        return
     if isinstance(override_value, dict):
+        # Merged key by key, so the base has to be a dict to recurse into.
         mergeable = isinstance(base_value, dict)
     elif isinstance(override_value, list):
-        mergeable = isinstance(base_value, list)
+        # Atomic list fields replace the base wholesale; the rest are merged by
+        # patch merge key or appended, both of which read the base list.
+        atomic = key in _PATCH_MERGE_KEYS and _PATCH_MERGE_KEYS[key] is None
+        mergeable = atomic or isinstance(base_value, list)
     else:
         mergeable = not isinstance(base_value, (dict, list))
     if not mergeable:

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -2,6 +2,7 @@
 import copy
 from typing import Any, Dict, List, Optional, Tuple
 
+from sky import exceptions
 from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
@@ -208,6 +209,28 @@ def _get_nested(configs: Optional[Dict[str, Any]],
     return curr
 
 
+def _validate_mergeable_types(key: Any, base_value: Any,
+                              override_value: Any) -> None:
+    """Rejects an override whose shape cannot be merged into the base value.
+
+    Nested `pod_config` content is not type-checked by the config schema, so a
+    dict/list/scalar mismatch is user input rather than a bug. Without this the
+    merge below would raise a bare AssertionError or TypeError, or silently
+    replace a whole dict/list with a scalar.
+    """
+    if isinstance(override_value, dict):
+        mergeable = isinstance(base_value, dict)
+    elif isinstance(override_value, list):
+        mergeable = isinstance(base_value, list)
+    else:
+        mergeable = not isinstance(base_value, (dict, list))
+    if not mergeable:
+        raise exceptions.InvalidSkyPilotConfigError(
+            f'Cannot override config field {key!r} of type '
+            f'{type(base_value).__name__} with a value of type '
+            f'{type(override_value).__name__}: {override_value!r}.')
+
+
 def merge_k8s_configs(
         base_config: Dict[Any, Any],
         override_config: Dict[Any, Any],
@@ -233,13 +256,13 @@ def merge_k8s_configs(
         (next_allowed_override_keys, next_disallowed_override_keys
         ) = _check_allowed_and_disallowed_override_keys(
             key, allowed_override_keys, disallowed_override_keys)
+        if key in base_config:
+            _validate_mergeable_types(key, base_config[key], value)
         if isinstance(value, dict) and key in base_config:
             merge_k8s_configs(base_config[key], value,
                               next_allowed_override_keys,
                               next_disallowed_override_keys)
         elif isinstance(value, list) and key in base_config:
-            assert isinstance(base_config[key], list), \
-                f'Expected {key} to be a list, found {base_config[key]}'
             # For list fields with patch strategy "merge", we merge the list
             # by the patch merge key.
             if key in _PATCH_MERGE_KEYS:

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2606,7 +2606,7 @@ def test_kubernetes_task_clears_image_pull_secrets():
                 'echo "imagePullSecrets=$secrets" && '
                 '! echo "$secrets" | grep -q absent-regcred'),
         ],
-        f'sky down -y {name} && '
+        f'sky down -y {name}; '
         f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
         timeout=25 * 60,
         config_dict={

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2572,6 +2572,57 @@ def test_kubernetes_pod_long_image_pull():
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.kubernetes
+def test_kubernetes_task_clears_image_pull_secrets():
+    """A task-level empty imagePullSecrets clears the server-side one.
+
+    The server config sets an imagePullSecrets entry and the task config
+    (tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml) sets an
+    empty list, so both sides of the pod_config merge carry the field. The
+    launch used to fail outright in that case.
+
+    The referenced secret does not exist: kubelet warns and falls back to an
+    anonymous pull, which is enough for the public test image. If that ever
+    turns flaky, create a dummy docker-registry secret instead.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    task_yaml = 'tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml'
+    test = smoke_tests_utils.Test(
+        'kubernetes_task_clears_image_pull_secrets',
+        [
+            f'sky launch -y -c {name} --infra kubernetes '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_yaml}',
+            f'sky logs {name} 1 --status',
+            f'sky logs {name} 1 --no-follow | grep "image_pull_secrets_check: ok"',
+            smoke_tests_utils.resolve_k8s_context_cmd(name),
+            smoke_tests_utils.launch_cloud_cmd_on_landed_context(name),
+            # The task's empty list must win over the server config, so the
+            # pod carries no imagePullSecrets at all.
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name,
+                f"pod=$(kubectl get pods -o custom-columns=NAME:.metadata.name,ANN:.metadata.annotations.skypilot-cluster-name --no-headers | awk -v n=\"{name}\" '$NF==n{{print $1}}' | sed -n 1p) && "
+                'echo "pod=$pod" && test -n "$pod" && '
+                'secrets=$(kubectl get pod $pod -o jsonpath="{.spec.imagePullSecrets}") && '
+                'echo "imagePullSecrets=$secrets" && '
+                '! echo "$secrets" | grep -q absent-regcred'),
+        ],
+        f'sky down -y {name} && '
+        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
+        timeout=25 * 60,
+        config_dict={
+            'kubernetes': {
+                'pod_config': {
+                    'spec': {
+                        'imagePullSecrets': [{
+                            'name': f'{name}-absent-regcred'
+                        }]
+                    }
+                }
+            }
+        })
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.azure
 def test_azure_start_stop_two_nodes():
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2001,6 +2001,82 @@ def test_managed_jobs_pod_config_ray_node_container(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+# Only run this test on Kubernetes since this test relies on
+# kubernetes.pod_config
+@pytest.mark.kubernetes
+@pytest.mark.managed_jobs
+def test_managed_jobs_task_pod_config_not_self_merged(generic_cloud: str):
+    """The controller must not overlay the task's pod_config onto itself.
+
+    Before launching, the controller adds two pod annotations to the task's
+    resources. It used to do so by passing the task's whole config as the
+    override, merging the config with itself: that duplicated every list
+    without a patch merge key and failed outright on an empty
+    imagePullSecrets. The task config
+    (tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml) carries
+    both, and the server config sets an imagePullSecrets entry so the
+    task-level empty list has something to clear.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    task_yaml = 'tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml'
+    # Look the pod up by the annotation the controller stamps, so a lost
+    # annotation fails this step too. The cloud-cmd helper pod carries no such
+    # annotation, so it can never match.
+    check_pod_spec_cmd = (
+        f"pod=$(kubectl get pods -o custom-columns=NAME:.metadata.name,ANN:.metadata.annotations.skypilot-managed-job-name --no-headers | awk -v n=\"{name}\" '$NF==n{{print $1}}' | sed -n 1p) && "
+        'echo "pod=$pod" && test -n "$pod" && '
+        # Appended by the merge, so a self-merge would list it twice.
+        'tolerations=$(kubectl get pod $pod -o jsonpath="{.spec.tolerations[*].key}") && '
+        'echo "tolerations=$tolerations" && '
+        'test "$(echo "$tolerations" | tr " " "\\n" | '
+        'grep -c skypilot-smoke-image-pull-secrets)" = "1" && '
+        # The task's empty list must win over the server config.
+        'secrets=$(kubectl get pod $pod -o jsonpath="{.spec.imagePullSecrets}") && '
+        'echo "imagePullSecrets=$secrets" && '
+        '! echo "$secrets" | grep -q absent-regcred')
+    test = smoke_tests_utils.Test(
+        'managed_jobs_task_pod_config_not_self_merged',
+        [
+            smoke_tests_utils.launch_cluster_for_cloud_cmd(generic_cloud, name),
+            # The task sleeps 60 so the job is still RUNNING when we look at
+            # its pod (same workaround as test_managed_jobs_env_isolation).
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} -y -d {task_yaml}',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}',
+                job_status=[sky.ManagedJobStatus.RUNNING],
+                timeout=600
+                if smoke_tests_utils.is_remote_server_test() else 120),
+            f'sky jobs logs -n {name} --no-follow | '
+            'grep "image_pull_secrets_check: ok"',
+            smoke_tests_utils.run_cloud_cmd_on_cluster(name,
+                                                       cmd=check_pod_spec_cmd),
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=f'{name}',
+                job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                timeout=600
+                if smoke_tests_utils.is_remote_server_test() else 120),
+        ],
+        f'sky jobs cancel -y -n {name}; '
+        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=25 * 60,
+        config_dict={
+            'kubernetes': {
+                'pod_config': {
+                    'spec': {
+                        'imagePullSecrets': [{
+                            'name': f'{name}-absent-regcred'
+                        }]
+                    }
+                }
+            }
+        })
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.no_remote_server
 @pytest.mark.managed_jobs
 def test_managed_jobs_config_labels_isolation(generic_cloud: str, request):

--- a/tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml
+++ b/tests/test_yamls/test_k8s_pod_config_image_pull_secrets.yaml
@@ -1,0 +1,21 @@
+resources:
+  cloud: kubernetes
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+          - imagePullPolicy: IfNotPresent
+        # Clears the imagePullSecrets the server-side config sets.
+        imagePullSecrets: []
+        # Appended by the merge, so a config overlaid on itself would list
+        # this toleration twice. The key matches no taint, so it is inert.
+        tolerations:
+          - key: skypilot-smoke-image-pull-secrets
+            operator: Exists
+            effect: NoSchedule
+
+run: |
+  echo "image_pull_secrets_check: ok"
+  sleep 60

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -9,6 +9,7 @@ Also tests the cancelled job log download feature in ControllerManager
 and file mount cleanup in task_cleanup().
 """
 import asyncio
+import copy
 import runpy
 import sys
 from typing import Dict, List, Optional, Tuple
@@ -19,6 +20,8 @@ import warnings
 
 import pytest
 
+import sky
+from sky import task as task_lib
 from sky.jobs import controller as controller_module
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
@@ -1665,3 +1668,114 @@ class TestTransientJobStatusRecoveryWindow:
                 executor=MagicMock())
 
         status_logger.flush.assert_called_once()
+
+
+class TestAddK8sAnnotations:
+    """Tests for _add_k8s_annotations.
+
+    The function stamps two pod annotations onto every resource. It must add
+    only those annotations: it used to pass the resource's whole config as the
+    override to Resources.copy(), which overlays the config on top of itself.
+    """
+
+    def _make_task(self, pod_config):
+        task = task_lib.Task(name='test-task', run='echo hi')
+        task.set_resources(
+            sky.Resources(cpus=2,
+                          _cluster_config_overrides={
+                              'kubernetes': {
+                                  'pod_config': pod_config
+                              }
+                          }))
+        return task
+
+    @staticmethod
+    def _pod_config(resource_or_task):
+        # Task.resources is a set before _add_k8s_annotations and a list
+        # after it, so index through a list either way.
+        resource = resource_or_task
+        if isinstance(resource_or_task, task_lib.Task):
+            resource = list(resource_or_task.resources)[0]
+        return resource.cluster_config_overrides['kubernetes']['pod_config']
+
+    def test_lists_without_patch_merge_key_not_duplicated(self):
+        """Lists appended by the merge must not be doubled."""
+        task = self._make_task({
+            'spec': {
+                'tolerations': [{
+                    'key': 'nvidia.com/gpu',
+                    'operator': 'Exists'
+                }],
+                'dnsConfig': {
+                    'nameservers': ['1.1.1.1']
+                },
+            }
+        })
+
+        controller_module._add_k8s_annotations(task, job_id=1)
+
+        spec = self._pod_config(task)['spec']
+        assert spec['tolerations'] == [{
+            'key': 'nvidia.com/gpu',
+            'operator': 'Exists'
+        }]
+        assert spec['dnsConfig']['nameservers'] == ['1.1.1.1']
+
+    def test_original_resource_config_not_mutated(self):
+        """The annotations must not leak into the resource we copied from."""
+        task = self._make_task({'spec': {'runtimeClassName': 'nvidia'}})
+        original_resource = list(task.resources)[0]
+
+        controller_module._add_k8s_annotations(task, job_id=1)
+
+        assert 'metadata' not in self._pod_config(original_resource)
+
+    def test_empty_image_pull_secrets_preserved(self):
+        """A task clearing imagePullSecrets must not break the job loop."""
+        task = self._make_task({
+            'spec': {
+                'containers': [{
+                    'imagePullPolicy': 'IfNotPresent'
+                }],
+                'imagePullSecrets': [],
+            }
+        })
+
+        controller_module._add_k8s_annotations(task, job_id=1)
+
+        spec = self._pod_config(task)['spec']
+        assert spec['imagePullSecrets'] == []
+        assert spec['containers'] == [{'imagePullPolicy': 'IfNotPresent'}]
+
+    def test_annotations_added_without_dropping_existing_ones(self):
+        task = self._make_task(
+            {'metadata': {
+                'annotations': {
+                    'user': 'annotation'
+                }
+            }})
+
+        controller_module._add_k8s_annotations(task, job_id=384)
+
+        assert self._pod_config(task)['metadata']['annotations'] == {
+            'user': 'annotation',
+            'skypilot-managed-job-id': '384',
+            'skypilot-managed-job-name': 'test-task',
+        }
+
+    def test_repeated_calls_are_idempotent(self):
+        """Every emergency-recovery retry re-runs this on the same task."""
+        task = self._make_task({
+            'spec': {
+                'tolerations': [{
+                    'key': 'nvidia.com/gpu',
+                    'operator': 'Exists'
+                }]
+            }
+        })
+
+        controller_module._add_k8s_annotations(task, job_id=1)
+        after_first = copy.deepcopy(self._pod_config(task))
+        controller_module._add_k8s_annotations(task, job_id=1)
+
+        assert self._pod_config(task) == after_first

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -258,34 +258,60 @@ def test_merge_k8s_configs_image_pull_secrets_empty_base():
     assert base_config['imagePullSecrets'] == [{'name': 'regcred'}]
 
 
-@pytest.mark.parametrize('base_value,override_value', [
-    ({
-        'name': 'regcred'
+@pytest.mark.parametrize('key,base_value,override_value', [
+    ('containers', {
+        'name': 'ray-node'
     }, [{
         'name': 'other'
     }]),
-    ([{
+    ('tolerations', 'oops', [{
+        'key': 'a'
+    }]),
+    ('imagePullSecrets', [{
         'name': 'regcred'
     }], {
         'name': 'other'
     }),
-    ([{
+    ('imagePullSecrets', [{
         'name': 'regcred'
-    }], 'other'),
+    }], 'oops'),
 ])
-def test_merge_k8s_configs_rejects_shape_mismatch(base_value, override_value):
+def test_merge_k8s_configs_rejects_shape_mismatch(key, base_value,
+                                                  override_value):
     """A dict/list/scalar mismatch is user input, not an internal error.
 
     Nested pod_config content is not type-checked by the schema, so these
     shapes reach the merge and used to raise a bare AssertionError/TypeError
     or silently replace the whole field.
     """
-    base_config = {'imagePullSecrets': base_value}
+    base_config = {key: base_value}
 
-    with pytest.raises(exceptions.InvalidSkyPilotConfigError,
-                       match='imagePullSecrets'):
-        config_utils.merge_k8s_configs(base_config,
-                                       {'imagePullSecrets': override_value})
+    with pytest.raises(exceptions.InvalidSkyPilotConfigError, match=key):
+        config_utils.merge_k8s_configs(base_config, {key: override_value})
+
+
+def test_merge_k8s_configs_atomic_list_ignores_base_shape():
+    """An atomic list replaces the base, so its shape is irrelevant."""
+    base_config = {'imagePullSecrets': {'name': 'regcred'}}
+
+    config_utils.merge_k8s_configs(base_config,
+                                   {'imagePullSecrets': [{
+                                       'name': 'other'
+                                   }]})
+    assert base_config['imagePullSecrets'] == [{'name': 'other'}]
+
+
+@pytest.mark.parametrize('base_value', [{'runAsUser': 0}, [{'key': 'a'}], 'x'])
+def test_merge_k8s_configs_null_override_clears(base_value):
+    """An explicit null replaces the value, whatever shape the base has.
+
+    Kubernetes reads a null field as absent, so this is how a config clears a
+    subtree inherited from a lower-priority source.
+    """
+    base_config = {'securityContext': base_value}
+
+    config_utils.merge_k8s_configs(base_config, {'securityContext': None})
+    assert base_config == {'securityContext': None}
 
 
 def test_merge_k8s_configs_allows_scalar_override():

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 from sky.utils import config_utils
@@ -215,6 +217,95 @@ def test_merge_k8s_configs_with_image_pull_secrets():
     assert len(base_config['imagePullSecrets']) == 1
     assert base_config['imagePullSecrets'][0]['name'] == 'secret2'
     assert base_config['imagePullSecrets'][0]['namespace'] == 'test'
+
+
+def test_merge_k8s_configs_image_pull_secrets_empty_override_clears():
+    """An empty override list clears the inherited secrets."""
+    base_config = {'imagePullSecrets': [{'name': 'regcred'}]}
+
+    config_utils.merge_k8s_configs(base_config, {'imagePullSecrets': []})
+    assert base_config['imagePullSecrets'] == []
+
+
+def test_merge_k8s_configs_image_pull_secrets_multiple():
+    """More than one secret in the override replaces the base list."""
+    base_config = {'imagePullSecrets': [{'name': 'regcred'}]}
+    override_config = {
+        'imagePullSecrets': [{
+            'name': 'secret1'
+        }, {
+            'name': 'secret2'
+        }]
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+    assert base_config['imagePullSecrets'] == [{
+        'name': 'secret1'
+    }, {
+        'name': 'secret2'
+    }]
+
+
+def test_merge_k8s_configs_image_pull_secrets_empty_base():
+    """An empty base list must not be indexed into."""
+    base_config = {'imagePullSecrets': []}
+
+    config_utils.merge_k8s_configs(base_config,
+                                   {'imagePullSecrets': [{
+                                       'name': 'regcred'
+                                   }]})
+    assert base_config['imagePullSecrets'] == [{'name': 'regcred'}]
+
+
+def test_merge_k8s_configs_self_merge_keyed_lists_are_idempotent():
+    """Self-merging must not duplicate items in lists with a patch merge key.
+
+    Lists without a patch merge key are appended by design, so they are
+    excluded here; callers that may self-merge must avoid it themselves.
+    """
+    pod_config = {
+        'metadata': {
+            'annotations': {
+                'existing': 'annotation'
+            }
+        },
+        'spec': {
+            'containers': [{
+                'name': 'ray-node',
+                'env': [{
+                    'name': 'FOO',
+                    'value': 'bar'
+                }],
+                'args': ['--flag'],
+            }],
+            'volumes': [{
+                'name': 'vol',
+                'emptyDir': {}
+            }],
+            'imagePullSecrets': [{
+                'name': 'regcred'
+            }],
+        },
+    }
+    expected = copy.deepcopy(pod_config)
+
+    config_utils.merge_k8s_configs(pod_config, copy.deepcopy(pod_config))
+    assert pod_config == expected
+
+
+def test_merge_k8s_configs_self_merge_with_empty_image_pull_secrets():
+    """Self-merge of a config that clears imagePullSecrets must not raise."""
+    pod_config = {
+        'spec': {
+            'containers': [{
+                'imagePullPolicy': 'IfNotPresent'
+            }],
+            'imagePullSecrets': [],
+        }
+    }
+
+    config_utils.merge_k8s_configs(pod_config, copy.deepcopy(pod_config))
+    assert pod_config['spec']['imagePullSecrets'] == []
 
 
 def test_config_override_with_allowed_keys():

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -2,6 +2,7 @@ import copy
 
 import pytest
 
+from sky import exceptions
 from sky.utils import config_utils
 
 
@@ -255,6 +256,47 @@ def test_merge_k8s_configs_image_pull_secrets_empty_base():
                                        'name': 'regcred'
                                    }]})
     assert base_config['imagePullSecrets'] == [{'name': 'regcred'}]
+
+
+@pytest.mark.parametrize('base_value,override_value', [
+    ({
+        'name': 'regcred'
+    }, [{
+        'name': 'other'
+    }]),
+    ([{
+        'name': 'regcred'
+    }], {
+        'name': 'other'
+    }),
+    ([{
+        'name': 'regcred'
+    }], 'other'),
+])
+def test_merge_k8s_configs_rejects_shape_mismatch(base_value, override_value):
+    """A dict/list/scalar mismatch is user input, not an internal error.
+
+    Nested pod_config content is not type-checked by the schema, so these
+    shapes reach the merge and used to raise a bare AssertionError/TypeError
+    or silently replace the whole field.
+    """
+    base_config = {'imagePullSecrets': base_value}
+
+    with pytest.raises(exceptions.InvalidSkyPilotConfigError,
+                       match='imagePullSecrets'):
+        config_utils.merge_k8s_configs(base_config,
+                                       {'imagePullSecrets': override_value})
+
+
+def test_merge_k8s_configs_allows_scalar_override():
+    """Only container/scalar mismatches are rejected, not scalar retyping."""
+    base_config = {'runtimeClassName': 'nvidia', 'replicas': 1}
+
+    config_utils.merge_k8s_configs(base_config, {
+        'runtimeClassName': 'gvisor',
+        'replicas': '2'
+    })
+    assert base_config == {'runtimeClassName': 'gvisor', 'replicas': '2'}
 
 
 def test_merge_k8s_configs_self_merge_keyed_lists_are_idempotent():

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -314,6 +314,34 @@ def test_merge_k8s_configs_null_override_clears(base_value):
     assert base_config == {'securityContext': None}
 
 
+@pytest.mark.parametrize('key,override_value', [
+    ('securityContext', {
+        'runAsUser': 0
+    }),
+    ('containers', [{
+        'name': 'x'
+    }]),
+    ('tolerations', [{
+        'key': 'a'
+    }]),
+    ('imagePullSecrets', [{
+        'name': 'regcred'
+    }]),
+    ('runtimeClassName', 'nvidia'),
+    ('securityContext', None),
+])
+def test_merge_k8s_configs_adds_key_missing_from_base(key, override_value):
+    """A key the base does not have is added as-is, whatever its shape.
+
+    The shape check only applies to keys present on both sides, so it must not
+    reject a field that only the higher-priority config sets.
+    """
+    base_config = {'unrelated': 1}
+
+    config_utils.merge_k8s_configs(base_config, {key: override_value})
+    assert base_config == {'unrelated': 1, key: override_value}
+
+
 def test_merge_k8s_configs_allows_scalar_override():
     """Only container/scalar mismatches are rejected, not scalar retyping."""
     base_config = {'runtimeClassName': 'nvidia', 'replicas': 1}

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -258,24 +258,34 @@ def test_merge_k8s_configs_image_pull_secrets_empty_base():
     assert base_config['imagePullSecrets'] == [{'name': 'regcred'}]
 
 
-@pytest.mark.parametrize('key,base_value,override_value', [
-    ('containers', {
-        'name': 'ray-node'
-    }, [{
-        'name': 'other'
-    }]),
-    ('tolerations', 'oops', [{
-        'key': 'a'
-    }]),
-    ('imagePullSecrets', [{
-        'name': 'regcred'
-    }], {
-        'name': 'other'
-    }),
-    ('imagePullSecrets', [{
-        'name': 'regcred'
-    }], 'oops'),
-])
+@pytest.mark.parametrize(
+    'key,base_value,override_value',
+    [
+        ('containers', {
+            'name': 'ray-node'
+        }, [{
+            'name': 'other'
+        }]),
+        ('tolerations', 'oops', [{
+            'key': 'a'
+        }]),
+        # An atomic field is exempt only for a list override: a dict override
+        # recurses into the base, so it still needs a dict there.
+        ('imagePullSecrets', [{
+            'name': 'regcred'
+        }], {
+            'name': 'other'
+        }),
+        ('imagePullSecrets', [{
+            'name': 'regcred'
+        }], 'oops'),
+    ],
+    ids=[
+        'keyed-list-over-dict-base',
+        'appended-list-over-scalar-base',
+        'dict-over-atomic-list-base',
+        'scalar-over-list-base',
+    ])
 def test_merge_k8s_configs_rejects_shape_mismatch(key, base_value,
                                                   override_value):
     """A dict/list/scalar mismatch is user input, not an internal error.


### PR DESCRIPTION
## Summary

A managed job whose task config set `kubernetes.pod_config.spec.imagePullSecrets: []` never started. The controller raised `AssertionError: Expected only one imagePullSecret, found []` before provisioning, then spun through all 10 emergency-recovery attempts (~3h of backoff) stuck in PENDING.

Two independent defects, both fixed here:

- **`_add_k8s_annotations` merged the task config with itself.** It only wants to stamp two pod annotations, but it passed the resource's *whole* config as the override to `Resources.copy()`, which overlays that on top of the same config. It now passes just the annotations. Self-merging was never a no-op — it also duplicated every list without a patch merge key, so a task setting `spec.tolerations` silently got each toleration twice. The config is no longer shallow-copied and mutated in place either, so the original resource's overrides are left alone.

- **The `imagePullSecrets` merge branch asserted exactly one entry.** This one is reachable on its own, on *every* launch (`sky launch` included), whenever the server config sets the field for the target context and the task overrides it: an empty list raised, more than one raised, and an empty base list would have raised `IndexError`. It now uses the existing atomic-list handling — the override replaces the base, which is exactly what the single-entry case already did, and an empty list clears inherited secrets.

On that last point: Kubernetes patch-merges `imagePullSecrets` by `name`, so replacing rather than merging is a deliberate divergence. These entries are credentials — unioning an admin-provided secret with a task's own would keep pulling with a credential the task meant to drop, and a task has no way to opt out. The bespoke branch was originally copied from the `containers` one (which has since moved to proper patch-merge-by-name), carrying over a "we only support one container per pod" comment that never applied to secrets.

Since `kubernetes.pod_config` is not in `SKIPPED_CLIENT_OVERRIDE_KEYS`, a *client* config can also override it per request, so `[]`-clears means a client can drop admin-set pull secrets for its own requests. That is intentional and follows the same reasoning: a pull secret grants access to a registry, so dropping it can only break your own image pull, never grant access to anything. Master already let a client's `{name: ...}` overwrite the first admin secret's name, i.e. effectively replace it — this widens "can replace" to "can also clear", not "can now reach something new".

Following review, one more thing in the same branch: the remaining `assert isinstance(base_config[key], list)` was also user-trippable, because nested `pod_config` content is not type-checked by the schema. Three shapes reached it and none produced a usable error — a base dict/scalar with a list override hit the bare `AssertionError`, a base list with a dict override hit `TypeError: list indices must be integers`, and a base list with a scalar override silently replaced the whole field, handing an invalid pod spec to Kubernetes. Those now raise `InvalidSkyPilotConfigError` naming the field and both types.

The check is deliberately scoped to the cases where the merge *reads* the base value, so it cannot reject an override that would have worked:

- a dict override needs a dict to recurse into, and a non-atomic list override needs a list to merge or append into — those are checked;
- atomic list fields (`args`, `command`, `imagePullSecrets`) replace the base wholesale, so their base shape is irrelevant and is not checked;
- an explicit `null` replaces the value whatever the base is. Kubernetes reads a null field as absent, so writing a bare `securityContext:` in a higher-priority config is how you clear an inherited subtree. That already worked and still does — it would have been gratuitous to break it in a change whose point is that clearing an inherited value should be expressible.
- scalar-to-scalar overrides, including YAML retyping like `1` → `'2'`, are untouched.

A scalar over a dict/list is still rejected: it drops the structure, and the post-merge pod validation does not reliably catch it (it flags `containers: 'oops'` but passes `imagePullSecrets: 'oops'`). One pre-existing gap is left alone — a list of non-dicts for a field with a patch merge key (`containers: ['foo']`) still raises `AttributeError` from the merge loop before pod validation can report it.

`docs/source/reference/config-sources.rst` claimed lists in `kubernetes.pod_config` are appended to the existing list. That was already inaccurate for the patch-merge-keyed fields and for `args`/`command`; updated to describe all three behaviours.

## Test plan

Unit tests, on a Kubernetes context:

```bash
pytest tests/test_config.py tests/unit_tests/test_sky/utils/test_config_utils.py \
       tests/unit_tests/test_sky/jobs/ tests/unit_tests/kubernetes/
```

972 passed, 1 failed. The failure (`TestTaskCleanup::test_local_dir_mounts_cleaned_up`) reproduces on master with this change stashed — it appears to be machine-specific, as it passes in @cg505's environment.

I also ran the full `pytest tests/unit_tests/` both ways, since the new type guard sits in a shared merge path: 25 failures on this branch and 33 on master with the change stashed, with differences in *both* directions — this environment is flaky under `-n 8`. Every test that failed only on the branch side passes when run on its own with the change applied, except `test_sky/clouds/test_kubernetes.py::test_remote_identity_with_cluster_overrides`, which fails identically with the change stashed and for an unrelated reason (`AssertionError: False is not true : remote_identity config should be fetched`, a mock assertion that never reaches the merge). So: no regressions attributable to this change, but the local full-suite numbers are not a clean signal either way — CI is the better check.

New unit coverage: empty / multi-entry / empty-base `imagePullSecrets`; the three shape mismatches above plus a scalar-override case that must still be allowed; self-merge idempotency for patch-merge-keyed lists; and `_add_k8s_annotations` (tolerations not duplicated, original config not mutated, empty `imagePullSecrets` preserved, annotations added without dropping existing ones, repeated calls idempotent — the last mirrors the emergency-retry path, which re-runs it).

Each fix was checked in isolation:

- Reverting only the controller fix fails 3 of the 5 `_add_k8s_annotations` tests. Note the empty-`imagePullSecrets` assertion still passes there, since the merge fix alone makes `[]` legal — the tolerations and non-mutation assertions are what actually pin this half down.
- Reverting only the merge fix fails the 4 new `imagePullSecrets` tests, while the pre-existing `test_merge_k8s_configs_with_image_pull_secrets` passes both ways.

On that last point: the single-entry case is unchanged for schema-valid single named secrets, which is what that test and `tests/test_config.py` cover, but it is not a general invariant. Two shapes do differ from master: a base entry carrying an extra non-schema key loses that key (master kept it, and the post-merge pod validation then rejected the launch anyway), and an override of `[{}]` now replaces instead of being a no-op.

Smoke tests (`/smoke-test --kubernetes`), both with `imagePullSecrets` in the server config *and* an empty list in the task, so both sides of the merge carry the field:

- `test_kubernetes_task_clears_image_pull_secrets` — `sky launch`; asserts the pod carries no pull secret. Covers the merge fix on the ordinary provisioning path.
- `test_managed_jobs_task_pod_config_not_self_merged` — managed job; additionally asserts the task's toleration appears **exactly once**, and looks the pod up by the annotation the controller stamps, so a lost annotation fails the step too.

Manual verification: launch a managed job with the task YAML added here against a server whose config sets `kubernetes.pod_config.spec.imagePullSecrets`. Before, the job sits in PENDING and `sky jobs logs --controller` shows the assertion plus `Emergency recovery attempt 1/10`; after, it reaches RUNNING and the pod has no pull secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
