### PR TITLE
[Jobs] Fail deterministic task-prep errors fast instead of retrying them

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -544,6 +544,8 @@ class JobController:
                 1. The optimizer cannot find a feasible solution.
                 2. Precheck errors: invalid cluster name, failure in getting
                 cloud user identity, or unsupported feature.
+                It is also raised when preparing the task spec fails, which is
+                deterministic and so must not be retried.
             exceptions.ManagedJobReachedMaxRetriesError: This will be raised
                 when all prechecks passed but the maximum number of retries is
                 reached for `sky.launch`. The failure of `sky.launch` can be
@@ -559,7 +561,16 @@ class JobController:
                 unrecoverable for the job.
         Other exceptions may be raised depending on the backend.
         """
-        _add_k8s_annotations(task, self._job_id)
+        try:
+            _add_k8s_annotations(task, self._job_id)
+        except Exception as e:
+            # Preparing the task spec reads only the task and the job id, so a
+            # failure here is deterministic and retrying cannot fix it. Report
+            # it as a precheck failure instead of letting the job loop's
+            # catch-all spend the emergency-recovery budget on it. This runs
+            # before the resume classification below, so a resumed task lands
+            # here too; its cluster is still torn down by the caller.
+            raise exceptions.ProvisionPrechecksError(reasons=[e]) from e
         logger.info(
             f'Starting task {task_id} ({task.name}) for job {self._job_id}')
 

--- a/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
+++ b/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
@@ -982,3 +982,46 @@ class TestPoolEmergencyDuplicateGuard:
         # relaunch — so the two copies never overlap.
         assert order == [('cancel', [777]), ('recover', None)]
         cancel_spy.assert_called_once()
+
+
+class TestTaskPrepFailureIsTerminal:
+    """Preparing the task spec is deterministic, so it must not be retried.
+
+    _add_k8s_annotations runs before anything touches a cluster and reads only
+    the task and the job id. Letting its failures reach the job loop's
+    catch-all would spend the whole emergency-recovery budget (10 attempts,
+    ~3h of backoff) on an error that cannot change.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prep_failure_becomes_precheck_error(self, monkeypatch):
+        jc = controller.JobController.__new__(controller.JobController)
+        jc._job_id = 1
+        boom = AssertionError('Expected only one imagePullSecret, found []')
+        monkeypatch.setattr('sky.jobs.controller._add_k8s_annotations',
+                            MagicMock(side_effect=boom))
+
+        with pytest.raises(exceptions.ProvisionPrechecksError) as exc_info:
+            await jc._run_one_task(0, MagicMock())
+
+        assert list(exc_info.value.reasons) == [boom]
+
+    @pytest.mark.asyncio
+    async def test_prep_failure_fails_job_without_spending_budget(
+            self, monkeypatch):
+        """End to end through run(): terminal, and no emergency attempt."""
+        boom = AssertionError('Expected only one imagePullSecret, found []')
+        h = _RetryLoopHarness(
+            monkeypatch, [exceptions.ProvisionPrechecksError(reasons=[boom])])
+
+        await h.jc.run()
+
+        assert h.jc._run_one_task.call_count == 1
+        h.jc._update_failed_task_state.assert_awaited_once()
+        assert h.jc._update_failed_task_state.await_args.args[1] == (
+            state.ManagedJobStatus.FAILED_PRECHECKS)
+        assert 'imagePullSecret' in (
+            h.jc._update_failed_task_state.await_args.args[2])
+        h.get_budget.assert_not_awaited()
+        h.record_attempt.assert_not_awaited()
+        assert not h.sleeps


### PR DESCRIPTION
## Summary

`_run_one_task` starts by building the task spec (`_add_k8s_annotations`), which reads only the task object and the job id — no I/O, no cluster, no DB. A failure there is deterministic, but it escaped to the job loop's catch-all and was therefore treated as an unknown controller error: the job spent all 10 emergency-recovery attempts on it — ~3h of exponential backoff sitting in PENDING, with the recovery bookkeeping re-run on every attempt — before finally reporting `FAILED_CONTROLLER` with a traceback.

It now raises `ProvisionPrechecksError`, which the loop already routes to `FAILED_PRECHECKS` with the reasons surfaced in `sky jobs queue` and the dashboard. Emergency recovery is untouched for everything that can actually benefit from a retry.

This was found while fixing #10325, which is one concrete way to trip it: a task config carrying `imagePullSecrets: []` made the spec build raise, and the job then sat in PENDING for hours instead of reporting the config error. That crash is fixed there; this makes the *class* of failure report promptly.

One wrinkle worth knowing about: prep runs before the resume classification a few lines down, so a controller restart that fails here reports `FAILED_PRECHECKS` even though the task may already have provisioned. The cluster is still torn down by the caller, so this is a status-accuracy nit rather than a leak — and preferable to burning the retry budget. Called out in a comment at the raise site.

Deliberately **not** included:

- Classifying `AssertionError` globally as terminal — an assert can fire from genuinely retryable state, and the narrow prep wrapper already covers the deterministic case.
- Routing `InvalidSkyPilotConfigError` to a terminal state. I wrote that handler first and then removed it as dead code: every site that raises it either runs outside the retry loop (task-YAML parsing via `Task.from_yaml_config`, the `reload_config()` in `run_job_loop`) or sits under `recovery_strategy._launch`'s broad `except Exception`, which swallows it into the launch-retry path and surfaces it as `ManagedJobReachedMaxRetriesError`. If we ever want config errors terminal, the reachable seam is the "failure happened before provisioning" allowlist in `recovery_strategy._launch`, not `run()`.

## Test plan

```bash
pytest tests/unit_tests/test_sky/jobs/
```

444 passed. The one failure (`TestTaskCleanup::test_local_dir_mounts_cleaned_up`) reproduces on master with this change stashed.

New `TestTaskPrepFailureIsTerminal` covers both layers:

- a prep failure becomes `ProvisionPrechecksError` carrying the original exception;
- driven through the real `run()`, the job ends `FAILED_PRECHECKS` with the original message in the failure reason, having spent **no** emergency-recovery budget (no budget read, no attempt recorded) and slept for no backoff.

Reverting the change fails `test_prep_failure_becomes_precheck_error`.

Manual verification: submit a managed job whose task config makes the spec build fail (e.g. the `imagePullSecrets: []` case from #10325, against a server config that also sets the field). Before, `sky jobs queue` shows PENDING and the controller log repeats `Emergency recovery attempt k/10`; after, the job goes to FAILED_PRECHECKS immediately with the underlying error as its failure reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)