### PR TITLE
[Jobs] Reset each managed job at most once per HA recovery pass, via compare-and-swap

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3775,18 +3775,50 @@ def reset_jobs_for_recovery() -> None:
         session.commit()
 
 
-def reset_job_for_recovery(job_id: int) -> None:
-    """Set a job to WAITING and remove PID, allowing it to be recovered."""
+def reset_job_for_recovery(
+        job_id: int, *, expected_pid: Optional[int],
+        expected_pid_started_at: Optional[float],
+        expected_schedule_state: Optional[ManagedJobScheduleState]) -> bool:
+    """Set a job to WAITING and remove PID, allowing it to be recovered.
+
+    This is a compare-and-swap: the reset only takes effect if the job's
+    current controller_pid, controller_pid_started_at, and schedule_state
+    still match what the caller observed. All three are compared NULL-safely,
+    so an observed pid of None (the job was never claimed) only matches a
+    column that is still NULL - it is not an unconditional reset. This guards
+    against a race where a controller claimed (or re-claimed) the job between
+    the caller's observation and this write; without the CAS, the reset would
+    immediately orphan the job again, and the claiming controller would keep
+    running while another controller picks the job up.
+
+    schedule_state is part of the comparison too: a row whose schedule_state
+    moved on (e.g. to DONE) without any change to the pid columns must not be
+    re-armed to WAITING.
+
+    Returns whether the reset was applied.
+    """
+    expected_schedule_state_value = (None if expected_schedule_state is None
+                                     else expected_schedule_state.value)
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
-        session.query(job_info_table).filter(
-            job_info_table.c.spot_job_id == job_id).update({
-                job_info_table.c.controller_pid: None,
-                job_info_table.c.controller_pid_started_at: None,
-                job_info_table.c.schedule_state:
-                    ManagedJobScheduleState.WAITING.value,
-            })
+        result = session.execute(
+            sqlalchemy.update(job_info_table).where(
+                sqlalchemy.and_(
+                    job_info_table.c.spot_job_id == job_id,
+                    job_info_table.c.controller_pid.is_not_distinct_from(
+                        expected_pid),
+                    job_info_table.c.controller_pid_started_at.
+                    is_not_distinct_from(expected_pid_started_at),
+                    job_info_table.c.schedule_state.is_not_distinct_from(
+                        expected_schedule_state_value),
+                )).values({
+                    job_info_table.c.controller_pid: None,
+                    job_info_table.c.controller_pid_started_at: None,
+                    job_info_table.c.schedule_state:
+                        ManagedJobScheduleState.WAITING.value,
+                }))
         session.commit()
+        return result.rowcount == 1
 
 
 def get_all_job_ids_by_name(name: Optional[str]) -> List[int]:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -390,8 +390,19 @@ def ha_recovery_for_consolidation_mode() -> None:
             'job_id', 'controller_pid', 'controller_pid_started_at',
             'schedule_state', 'status'
         ])
+        # get_managed_jobs_with_filters returns one row per task, but
+        # multi-task jobs share the same job_id (and the same job_info
+        # columns we read here) -- process each job only once. Otherwise a
+        # multi-task job would be reset once per task, and each reset after
+        # the first can re-orphan the job right after a controller has
+        # claimed it, spawning duplicate controllers for the same job.
+        seen_job_ids: Set[int] = set()
         for job in jobs:
             job_id = job['job_id']
+            if job_id in seen_job_ids:
+                continue
+            seen_job_ids.add(job_id)
+
             controller_pid = job['controller_pid']
             controller_pid_started_at = job.get('controller_pid_started_at')
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -444,7 +444,24 @@ def ha_recovery_for_consolidation_mode() -> None:
                     # INACTIVE job may be mid-submission, don't set to WAITING.
                     managed_job_state.ManagedJobScheduleState.INACTIVE,
             ]:
-                managed_job_state.reset_job_for_recovery(job_id)
+                # Compare-and-swap against the values we observed above: if a
+                # controller claimed the job since then, the reset must not
+                # apply, or we would orphan the job again immediately after
+                # the claim and end up with a duplicate controller for it.
+                if not managed_job_state.reset_job_for_recovery(
+                        job_id,
+                        expected_pid=controller_pid,
+                        expected_pid_started_at=controller_pid_started_at,
+                        expected_schedule_state=job['schedule_state']):
+                    # Lost the race to a concurrent claim (or to some other
+                    # actor that changed the job's state). Whoever won owns
+                    # the job now, so don't retry - just move on.
+                    message = (f'Skipping recovery of job {job_id}: its '
+                               'controller ownership or schedule state '
+                               'changed since it was observed.\n')
+                    logger.info(message)
+                    f.write(message)
+                    continue
                 message = (f'Job {job_id} completed recovery at '
                            f'{datetime.now()}\n')
                 logger.info(message)

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import datetime
 import time
+from typing import Optional
 from unittest import mock
 
 import filelock
@@ -1487,3 +1488,201 @@ class TestGetLatestRecoveryAndPendingReasons:
                                                                           [1])
         assert recovery == {}
         assert pending == {1: 'Job is in backoff'}
+
+
+def _make_waiting_job(name: str = 'job') -> int:
+    """Create a job in WAITING schedule state, ready to be claimed."""
+    job_id = state.set_job_info_without_job_id(name=name,
+                                               workspace='ws1',
+                                               entrypoint='ep',
+                                               pool=None,
+                                               pool_hash=None,
+                                               user_hash='user1')
+    state.set_pending(job_id,
+                      task_id=0,
+                      task_name='task0',
+                      resources_str='{}',
+                      metadata='{}')
+    state.scheduler_set_waiting([job_id], '/tmp/dag.yaml', '/tmp/user.yaml',
+                                '/tmp/env', None, 100)
+    return job_id
+
+
+def _get_job_info_row(engine, job_id: int):
+    """Read the raw job_info row for job_id (controller_* columns et al)."""
+    with state.orm.Session(engine) as session:
+        return session.execute(
+            state.sqlalchemy.select(
+                state.job_info_table.c.controller_pid,
+                state.job_info_table.c.controller_pid_started_at,
+                state.job_info_table.c.schedule_state,
+            ).where(state.job_info_table.c.spot_job_id == job_id)).fetchone()
+
+
+def _set_controller_ownership(
+        engine,
+        job_id: int,
+        *,
+        pid: Optional[int],
+        pid_started_at: Optional[float],
+        schedule_state: Optional[state.ManagedJobScheduleState] = None):
+    """Directly write controller ownership columns, bypassing the claim path.
+
+    Used to set up CAS test scenarios that aren't reachable through
+    get_waiting_job_async (e.g. a job already ALIVE with an arbitrary
+    recorded pid/started_at).
+    """
+    updates = {
+        state.job_info_table.c.controller_pid: pid,
+        state.job_info_table.c.controller_pid_started_at: pid_started_at,
+    }
+    if schedule_state is not None:
+        updates[state.job_info_table.c.schedule_state] = schedule_state.value
+    with state.orm.Session(engine) as session:
+        session.query(state.job_info_table).filter(
+            state.job_info_table.c.spot_job_id == job_id).update(updates)
+        session.commit()
+
+
+class TestResetJobForRecoveryCAS:
+    """Compare-and-swap semantics of reset_job_for_recovery."""
+
+    def _seed(self, engine, *, pid, pid_started_at, schedule_state=None):
+        if schedule_state is None:
+            schedule_state = state.ManagedJobScheduleState.ALIVE
+        job_id = _make_waiting_job()
+        _set_controller_ownership(engine,
+                                  job_id,
+                                  pid=pid,
+                                  pid_started_at=pid_started_at,
+                                  schedule_state=schedule_state)
+        return job_id
+
+    def test_matching_expected_succeeds(self, _mock_managed_jobs_db_conn):
+        job_id = self._seed(_mock_managed_jobs_db_conn,
+                            pid=100,
+                            pid_started_at=1.0)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=100,
+            expected_pid_started_at=1.0,
+            expected_schedule_state=state.ManagedJobScheduleState.ALIVE) is True
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid is None
+        assert row.controller_pid_started_at is None
+        assert row.schedule_state == state.ManagedJobScheduleState.WAITING.value
+
+    def test_concurrent_claim_loses_race_and_row_unchanged(
+            self, _mock_managed_jobs_db_conn):
+        """The scenario the CAS exists for: a controller claimed the job
+        (stamping its own pid and moving to LAUNCHING) after the caller
+        observed the old ownership. The reset must not apply, or the fresh
+        claim would be orphaned immediately."""
+        job_id = self._seed(_mock_managed_jobs_db_conn,
+                            pid=100,
+                            pid_started_at=1.0)
+        # Concurrent claim, after the caller's observation.
+        _set_controller_ownership(
+            _mock_managed_jobs_db_conn,
+            job_id,
+            pid=200,
+            pid_started_at=2.0,
+            schedule_state=state.ManagedJobScheduleState.LAUNCHING)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=100,
+            expected_pid_started_at=1.0,
+            expected_schedule_state=state.ManagedJobScheduleState.ALIVE
+        ) is False
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid == 200
+        assert row.controller_pid_started_at == 2.0
+        assert (
+            row.schedule_state == state.ManagedJobScheduleState.LAUNCHING.value)
+
+    def test_stale_expected_started_at_fails(self, _mock_managed_jobs_db_conn):
+        job_id = self._seed(_mock_managed_jobs_db_conn,
+                            pid=100,
+                            pid_started_at=1.0)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=100,
+            expected_pid_started_at=0.5,
+            expected_schedule_state=state.ManagedJobScheduleState.ALIVE
+        ) is False
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid == 100
+        assert row.controller_pid_started_at == 1.0
+        assert row.schedule_state == state.ManagedJobScheduleState.ALIVE.value
+
+    def test_expected_none_pid_matches_null_columns(self,
+                                                    _mock_managed_jobs_db_conn):
+        """NULL-safe comparison: an observed pid of None (the job was never
+        claimed) matches a still-NULL column, so the reset applies."""
+        job_id = self._seed(
+            _mock_managed_jobs_db_conn,
+            pid=None,
+            pid_started_at=None,
+            schedule_state=state.ManagedJobScheduleState.LAUNCHING)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=None,
+            expected_pid_started_at=None,
+            expected_schedule_state=state.ManagedJobScheduleState.LAUNCHING
+        ) is True
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid is None
+        assert row.schedule_state == state.ManagedJobScheduleState.WAITING.value
+
+    def test_expected_none_pid_does_not_match_claimed_column(
+            self, _mock_managed_jobs_db_conn):
+        """The reverse NULL-safe mismatch: an observed pid of None must not
+        match a row that has since been claimed. An unconditional reset here
+        would clobber the concurrent claim."""
+        job_id = self._seed(
+            _mock_managed_jobs_db_conn,
+            pid=100,
+            pid_started_at=1.0,
+            schedule_state=state.ManagedJobScheduleState.LAUNCHING)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=None,
+            expected_pid_started_at=None,
+            expected_schedule_state=state.ManagedJobScheduleState.LAUNCHING
+        ) is False
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid == 100
+        assert row.controller_pid_started_at == 1.0
+        assert (
+            row.schedule_state == state.ManagedJobScheduleState.LAUNCHING.value)
+
+    def test_changed_schedule_state_fails_even_if_pid_matches(
+            self, _mock_managed_jobs_db_conn):
+        """The pid columns can be unchanged while the schedule state moved on
+        (e.g. the controller finished the job and set DONE without ever
+        clearing its pid). Such a row must not be re-armed to WAITING."""
+        job_id = self._seed(_mock_managed_jobs_db_conn,
+                            pid=100,
+                            pid_started_at=1.0,
+                            schedule_state=state.ManagedJobScheduleState.DONE)
+
+        assert state.reset_job_for_recovery(
+            job_id,
+            expected_pid=100,
+            expected_pid_started_at=1.0,
+            expected_schedule_state=state.ManagedJobScheduleState.ALIVE
+        ) is False
+
+        row = _get_job_info_row(_mock_managed_jobs_db_conn, job_id)
+        assert row.controller_pid == 100
+        assert row.schedule_state == state.ManagedJobScheduleState.DONE.value

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1,9 +1,13 @@
 """Unit tests for sky.jobs.utils functions."""
+import contextlib
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 from unittest.mock import MagicMock
 
+import filelock
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from sky import exceptions
 from sky.jobs import state as managed_job_state
@@ -1557,3 +1561,276 @@ class TestTryToGetJobEndTime:
         monkeypatch.setattr(jobs_utils, 'get_job_timestamp', _raise)
         with pytest.raises(ValueError):
             jobs_utils.try_to_get_job_end_time(MagicMock(), 'cluster', 1)
+
+
+@pytest.fixture
+def _mock_managed_jobs_db_conn(tmp_path, monkeypatch):
+    """Create a temporary SQLite DB for managed jobs state.
+
+    Same pattern as tests/unit_tests/test_sky/jobs/test_jobs_state.py.
+    """
+    db_path = tmp_path / 'managed_jobs_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(_section: str):
+        lock_path = tmp_path / f'.{_section}.lock'
+        with filelock.FileLock(str(lock_path), timeout=10):
+            yield
+
+    monkeypatch.setattr(managed_job_state.migration_utils, 'db_lock',
+                        _tmp_db_lock)
+    monkeypatch.setattr(managed_job_state._db_manager, '_engine', engine)
+    monkeypatch.setattr(managed_job_state._db_manager, '_engine_async',
+                        async_engine)
+    managed_job_state.create_table(engine)
+    yield engine
+
+
+class TestHaRecoveryForConsolidationMode:
+    """ha_recovery_for_consolidation_mode: one CAS-guarded reset per job."""
+
+    def _patch_common(self, monkeypatch, tmp_path, jobs=None):
+        """Stub the pieces of the recovery pass we're not exercising.
+
+        jobs, if given, replaces the state query with canned rows (following
+        TestGetManagedJobQueue's convention) instead of reading a real DB.
+        """
+        monkeypatch.setattr(jobs_utils.scheduler, 'maybe_start_controllers',
+                            lambda: None)
+        # Redirect the recovery log off of the real, possibly shared
+        # /tmp/jobs_ha_recovery.log path.
+        monkeypatch.setattr(jobs_utils.constants,
+                            'HA_PERSISTENT_RECOVERY_LOG_PATH',
+                            str(tmp_path / '{}ha_recovery.log'))
+        if jobs is not None:
+            monkeypatch.setattr(jobs_utils.managed_job_state,
+                                'get_managed_jobs_with_filters',
+                                lambda fields=None: (jobs, len(jobs)))
+
+    def _job_row(self, **overrides):
+        job = {
+            'job_id': 1,
+            'controller_pid': 100,
+            'controller_pid_started_at': 1.0,
+            'schedule_state': managed_job_state.ManagedJobScheduleState.ALIVE,
+            'status': managed_job_state.ManagedJobStatus.RUNNING,
+        }
+        job.update(overrides)
+        return job
+
+    def _patch_liveness(self, monkeypatch, alive):
+        """Make controller_process_alive return `alive`, or raise if it is an
+        exception instance."""
+
+        def _check(record, legacy_job_id):
+            del record, legacy_job_id  # Unused.
+            if isinstance(alive, BaseException):
+                raise alive
+            return alive
+
+        monkeypatch.setattr(jobs_utils, 'controller_process_alive', _check)
+
+    def _spy_reset(self, monkeypatch, return_value=None):
+        """Count reset_job_for_recovery calls, delegating to the real one
+        unless return_value is given."""
+        calls = []
+        real = managed_job_state.reset_job_for_recovery
+
+        def _reset(job_id, **kwargs):
+            calls.append((job_id, kwargs))
+            if return_value is not None:
+                return return_value
+            return real(job_id, **kwargs)
+
+        monkeypatch.setattr(jobs_utils.managed_job_state,
+                            'reset_job_for_recovery', _reset)
+        return calls
+
+    def _seed_multi_task_alive_job(self, engine, num_tasks: int, *, pid,
+                                   pid_started_at):
+        """Seed one job with num_tasks tasks, owned by (pid, pid_started_at)
+        and in the ALIVE schedule state."""
+        job_id = managed_job_state.set_job_info_without_job_id(
+            name='multi-task-job',
+            workspace='ws1',
+            entrypoint='ep',
+            pool=None,
+            pool_hash=None,
+            user_hash='user1')
+        for task_id in range(num_tasks):
+            managed_job_state.set_pending(job_id,
+                                          task_id=task_id,
+                                          task_name=f'task{task_id}',
+                                          resources_str='{}',
+                                          metadata='{}')
+        managed_job_state.scheduler_set_waiting([job_id], '/tmp/dag.yaml',
+                                                '/tmp/user.yaml', '/tmp/env',
+                                                None, 100)
+        with managed_job_state.orm.Session(engine) as session:
+            session.query(managed_job_state.job_info_table).filter(
+                managed_job_state.job_info_table.c.spot_job_id == job_id
+            ).update({
+                managed_job_state.job_info_table.c.controller_pid: pid,
+                managed_job_state.job_info_table.c.controller_pid_started_at: pid_started_at,
+                managed_job_state.job_info_table.c.schedule_state:
+                    managed_job_state.ManagedJobScheduleState.ALIVE.value,
+            })
+            session.commit()
+        return job_id
+
+    def _read_job_info(self, engine, job_id):
+        with managed_job_state.orm.Session(engine) as session:
+            return session.execute(
+                managed_job_state.sqlalchemy.select(
+                    managed_job_state.job_info_table.c.controller_pid,
+                    managed_job_state.job_info_table.c.schedule_state,
+                ).where(managed_job_state.job_info_table.c.spot_job_id ==
+                        job_id)).fetchone()
+
+    def test_multi_task_job_is_reset_exactly_once(self, monkeypatch, tmp_path,
+                                                  _mock_managed_jobs_db_conn):
+        """The state query returns one row per task. A multi-task job whose
+        controller is dead must still be reset exactly once: each extra reset
+        can re-orphan the job right after a controller claims it, which is how
+        one recovery pass ends up with several controllers for one job."""
+        engine = _mock_managed_jobs_db_conn
+        job_id = self._seed_multi_task_alive_job(engine,
+                                                 4,
+                                                 pid=100,
+                                                 pid_started_at=1.0)
+        self._patch_common(monkeypatch, tmp_path)
+        self._patch_liveness(monkeypatch, alive=False)
+        calls = self._spy_reset(monkeypatch)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert calls == [(job_id, {
+            'expected_pid': 100,
+            'expected_pid_started_at': 1.0,
+            'expected_schedule_state':
+                managed_job_state.ManagedJobScheduleState.ALIVE,
+        })]
+        row = self._read_job_info(engine, job_id)
+        assert row.controller_pid is None
+        assert (row.schedule_state ==
+                managed_job_state.ManagedJobScheduleState.WAITING.value)
+
+    def test_dead_controller_reset_passes_observed_values(
+            self, monkeypatch, tmp_path):
+        self._patch_common(monkeypatch, tmp_path, [self._job_row()])
+        self._patch_liveness(monkeypatch, alive=False)
+        calls = self._spy_reset(monkeypatch, return_value=True)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert calls == [(1, {
+            'expected_pid': 100,
+            'expected_pid_started_at': 1.0,
+            'expected_schedule_state':
+                managed_job_state.ManagedJobScheduleState.ALIVE,
+        })]
+
+    def test_live_controller_is_not_reset(self, monkeypatch, tmp_path):
+        self._patch_common(monkeypatch, tmp_path, [self._job_row()])
+        self._patch_liveness(monkeypatch, alive=True)
+        calls = self._spy_reset(monkeypatch, return_value=True)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert not calls
+
+    def test_lost_cas_race_does_not_retry_and_continues(self, monkeypatch,
+                                                        tmp_path):
+        """A lost CAS is not retried, and does not stop the pass."""
+        self._patch_common(monkeypatch, tmp_path,
+                           [self._job_row(job_id=1),
+                            self._job_row(job_id=2)])
+        self._patch_liveness(monkeypatch, alive=False)
+        calls = self._spy_reset(monkeypatch, return_value=False)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert [job_id for job_id, _ in calls] == [1, 2]
+
+    def test_liveness_check_exception_falls_through_to_reset(
+            self, monkeypatch, tmp_path):
+        """A liveness check that raises is logged and then falls through to
+        the reset, and the pass continues to the next job.
+
+        Falling through is deliberate: the check can raise deterministically
+        for a pid that really is gone (e.g. the pid was recycled by another
+        user's process, so reading its cmdline raises every time), and this
+        pass only runs once per leadership acquisition -- skipping such a job
+        would leave it unrecovered until the next one. Distinguishing
+        indeterminate liveness from confirmed death needs a real verdict from
+        the liveness check, which is future work; until then the
+        compare-and-swap is what keeps a wrongly-reset live job from being
+        stolen, since a controller that is actually alive still owns the row.
+        """
+        raising_row = self._job_row(job_id=1)
+        ok_row = self._job_row(job_id=2)
+        self._patch_common(monkeypatch, tmp_path, [raising_row, ok_row])
+        calls = self._spy_reset(monkeypatch, return_value=True)
+
+        def _check(record, legacy_job_id):
+            del record  # Unused.
+            if legacy_job_id == 1:
+                raise RuntimeError('psutil blew up')
+            return False
+
+        monkeypatch.setattr(jobs_utils, 'controller_process_alive', _check)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        # Both jobs are reset, with the ownership values observed for each.
+        expected_kwargs = {
+            'expected_pid': 100,
+            'expected_pid_started_at': 1.0,
+            'expected_schedule_state':
+                managed_job_state.ManagedJobScheduleState.ALIVE,
+        }
+        assert calls == [(1, expected_kwargs), (2, expected_kwargs)]
+
+    def test_dedupe_checks_liveness_once_per_job(self, monkeypatch, tmp_path):
+        """The dedupe happens before the liveness check, so a multi-task job
+        costs one process check, not one per task."""
+        self._patch_common(
+            monkeypatch, tmp_path,
+            [self._job_row(), self._job_row(),
+             self._job_row()])
+        checked = []
+
+        def _check(record, legacy_job_id):
+            del record  # Unused.
+            checked.append(legacy_job_id)
+            return False
+
+        monkeypatch.setattr(jobs_utils, 'controller_process_alive', _check)
+        calls = self._spy_reset(monkeypatch, return_value=True)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert checked == [1]
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize('schedule_state', [
+        managed_job_state.ManagedJobScheduleState.DONE,
+        managed_job_state.ManagedJobScheduleState.WAITING,
+        managed_job_state.ManagedJobScheduleState.INACTIVE,
+    ])
+    def test_not_eligible_schedule_states_are_not_reset(self, monkeypatch,
+                                                        tmp_path,
+                                                        schedule_state):
+        self._patch_common(monkeypatch, tmp_path, [
+            self._job_row(controller_pid=None,
+                          controller_pid_started_at=None,
+                          schedule_state=schedule_state)
+        ])
+        calls = self._spy_reset(monkeypatch, return_value=True)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        assert not calls

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1,4 +1,5 @@
 """Unit tests for sky.jobs.utils functions."""
+import asyncio
 import contextlib
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -1563,6 +1564,27 @@ class TestTryToGetJobEndTime:
             jobs_utils.try_to_get_job_end_time(MagicMock(), 'cluster', 1)
 
 
+def _claim_waiting_job(pid: int, pid_started_at: float) -> Optional[int]:
+    """Claim a job the way a controller does, via the production claim path.
+
+    get_waiting_job_async is the real WAITING -> LAUNCHING compare-and-swap
+    that stamps the claiming controller's pid; it is async, so run it to
+    completion on a throwaway event loop. Returns the claimed job id, or None
+    if nothing was claimable.
+    """
+
+    async def _claim():
+        return await managed_job_state.get_waiting_job_async(
+            pid=pid, pid_started_at=pid_started_at)
+
+    loop = asyncio.new_event_loop()
+    try:
+        claimed = loop.run_until_complete(_claim())
+    finally:
+        loop.close()
+    return None if claimed is None else claimed['job_id']
+
+
 @pytest.fixture
 def _mock_managed_jobs_db_conn(tmp_path, monkeypatch):
     """Create a temporary SQLite DB for managed jobs state.
@@ -1649,12 +1671,17 @@ class TestHaRecoveryForConsolidationMode:
                             'reset_job_for_recovery', _reset)
         return calls
 
-    def _seed_multi_task_alive_job(self, engine, num_tasks: int, *, pid,
-                                   pid_started_at):
+    def _seed_multi_task_alive_job(self,
+                                   engine,
+                                   num_tasks: int,
+                                   *,
+                                   pid,
+                                   pid_started_at,
+                                   name: str = 'multi-task-job'):
         """Seed one job with num_tasks tasks, owned by (pid, pid_started_at)
         and in the ALIVE schedule state."""
         job_id = managed_job_state.set_job_info_without_job_id(
-            name='multi-task-job',
+            name=name,
             workspace='ws1',
             entrypoint='ep',
             pool=None,
@@ -1686,6 +1713,8 @@ class TestHaRecoveryForConsolidationMode:
             return session.execute(
                 managed_job_state.sqlalchemy.select(
                     managed_job_state.job_info_table.c.controller_pid,
+                    managed_job_state.job_info_table.c.
+                    controller_pid_started_at,
                     managed_job_state.job_info_table.c.schedule_state,
                 ).where(managed_job_state.job_info_table.c.spot_job_id ==
                         job_id)).fetchone()
@@ -1717,6 +1746,101 @@ class TestHaRecoveryForConsolidationMode:
         assert row.controller_pid is None
         assert (row.schedule_state ==
                 managed_job_state.ManagedJobScheduleState.WAITING.value)
+
+    def test_concurrent_real_claim_survives_the_rest_of_the_pass(
+            self, monkeypatch, tmp_path, _mock_managed_jobs_db_conn):
+        """End-to-end interleaving of a recovery pass and real controller
+        claims, using the production claim path (get_waiting_job_async) rather
+        than hand-written row updates.
+
+        Three jobs are eligible for recovery, and a controller claims two of
+        them in the middle of the pass:
+
+        - job_a (4 tasks) is claimed right after the pass resets it. The
+          remaining 3 task rows must not reset it again (dedupe), so the fresh
+          claim keeps the job.
+        - job_b is recovered by someone else and then claimed before the pass
+          reaches its row, so the pass's own reset must lose the
+          compare-and-swap and leave the claim alone.
+        - job_c is untouched by the claims and must still be recovered, i.e.
+          neither of the above stops the pass.
+        """
+        engine = _mock_managed_jobs_db_conn
+        alive = managed_job_state.ManagedJobScheduleState.ALIVE
+        # get_managed_jobs_with_filters orders by spot_job_id descending, so
+        # seed in reverse: the last job seeded is the first one processed.
+        job_c = self._seed_multi_task_alive_job(engine,
+                                                1,
+                                                name='job-c',
+                                                pid=300,
+                                                pid_started_at=3.0)
+        job_b = self._seed_multi_task_alive_job(engine,
+                                                1,
+                                                name='job-b',
+                                                pid=200,
+                                                pid_started_at=2.0)
+        job_a = self._seed_multi_task_alive_job(engine,
+                                                4,
+                                                name='job-a',
+                                                pid=100,
+                                                pid_started_at=1.0)
+        self._patch_common(monkeypatch, tmp_path)
+        self._patch_liveness(monkeypatch, alive=False)
+
+        real_reset = managed_job_state.reset_job_for_recovery
+        calls = []
+        claimed = []
+
+        def _reset_and_let_controllers_claim(job_id, **kwargs):
+            calls.append(job_id)
+            applied = real_reset(job_id, **kwargs)
+            if job_id != job_a or not applied or claimed:
+                return applied
+            claimed.append(job_id)
+            # A controller polls for work and claims the job the pass just
+            # released -- the interleaving that used to be undone by the
+            # job's remaining task rows.
+            assert _claim_waiting_job(pid=999, pid_started_at=9.0) == job_a
+            # Meanwhile job_b is recovered by another actor and claimed too,
+            # before this pass reaches job_b's row.
+            assert real_reset(job_b,
+                              expected_pid=200,
+                              expected_pid_started_at=2.0,
+                              expected_schedule_state=alive) is True
+            assert _claim_waiting_job(pid=888, pid_started_at=8.0) == job_b
+            return applied
+
+        monkeypatch.setattr(jobs_utils.managed_job_state,
+                            'reset_job_for_recovery',
+                            _reset_and_let_controllers_claim)
+
+        jobs_utils.ha_recovery_for_consolidation_mode()
+
+        # Each job is visited once, in row order, despite job_a's 4 task rows.
+        assert calls == [job_a, job_b, job_c]
+
+        launching = managed_job_state.ManagedJobScheduleState.LAUNCHING.value
+        # job_a: the claim that landed mid-pass still owns the job.
+        row_a = self._read_job_info(engine, job_a)
+        assert row_a.controller_pid == 999
+        assert row_a.controller_pid_started_at == 9.0
+        assert row_a.schedule_state == launching
+        # job_b: the pass's reset lost the compare-and-swap to the claim.
+        row_b = self._read_job_info(engine, job_b)
+        assert row_b.controller_pid == 888
+        assert row_b.controller_pid_started_at == 8.0
+        assert row_b.schedule_state == launching
+        # job_c: recovered as usual.
+        row_c = self._read_job_info(engine, job_c)
+        assert row_c.controller_pid is None
+        assert (row_c.schedule_state ==
+                managed_job_state.ManagedJobScheduleState.WAITING.value)
+
+        log = (tmp_path / 'jobs_ha_recovery.log').read_text(encoding='utf-8')
+        assert log.count(f'Job {job_a} completed recovery') == 1
+        assert log.count(f'Job {job_c} completed recovery') == 1
+        assert f'Job {job_b} completed recovery' not in log
+        assert f'Skipping recovery of job {job_b}' in log
 
     def test_dead_controller_reset_passes_observed_values(
             self, monkeypatch, tmp_path):


### PR DESCRIPTION
The consolidation-mode HA recovery pass (`ha_recovery_for_consolidation_mode`)
iterates over the rows returned by `get_managed_jobs_with_filters`, which
returns **one row per task**, not one row per job. For a multi-task managed
job, that means the job is checked -- and reset -- once per task.

That is worse than redundant work, because the reset
(`reset_job_for_recovery`) was a blind `UPDATE ... WHERE spot_job_id = :job_id`
that cleared `controller_pid` / `controller_pid_started_at` and set
`schedule_state = WAITING`, regardless of what the row looked like at write
time. Claiming a job, by contrast, is a proper compare-and-swap (WAITING ->
LAUNCHING, stamping the claiming controller's pid). So each reset after the
first can land right after a controller has claimed the job, orphaning that
claim: the pid is cleared and the job goes back to WAITING while the claiming
controller keeps running. A single recovery pass over a job with N tasks can
therefore hand the same job to a series of controllers. Those duplicate
controllers then race each other's guarded status transitions, which can fail
the job (and tear down its clusters).

Two fixes, one per commit:

1. **Dedupe by job id.** The recovery loop keeps a `seen_job_ids` set and
   processes each job once. The job-level columns it reads are identical
   across a job's task rows, so nothing is lost.
2. **Make the reset a compare-and-swap.** `reset_job_for_recovery` now takes
   the `controller_pid`, `controller_pid_started_at`, and `schedule_state`
   the caller observed, compares all three NULL-safely
   (`IS NOT DISTINCT FROM`), and returns whether the reset applied. An
   observed pid of `None` is therefore not an unconditional reset -- it only
   matches a row that is still unclaimed. Including `schedule_state` in the
   comparison also means a row that moved on (e.g. to `DONE`) without a pid
   change is not re-armed to `WAITING`. The recovery loop passes what it
   observed and, on a lost race, logs and moves on to the next job rather
   than retrying: whoever won owns the job now.
No schema change and no new config.

This overlaps with in-flight work in #10114 / #9869; those branches can rebase
on this.

## Tested

- New unit tests (there was no coverage of this loop or of
  `reset_job_for_recovery` before):
  - `tests/unit_tests/test_sky/jobs/test_utils.py`:
    `TestHaRecoveryForConsolidationMode` -- a 4-task job with a dead
    controller is reset exactly once against a real (temp sqlite) jobs DB and
    ends up `WAITING` with a NULL pid; the observed values are passed to the
    CAS; a lost CAS is not retried and does not stop the pass; the dedupe
    happens before the liveness check; a liveness check that raises still
    falls through to the reset (the existing behavior, now pinned by a test);
    non-eligible schedule states are never reset. One
    end-to-end test drives the production claim path
    (`get_waiting_job_async`) in the middle of a real recovery pass: a job
    claimed right after its reset keeps the claim (the remaining task rows
    don't reset it again), a job claimed before the pass reaches its row
    survives because the pass's reset loses the compare-and-swap, and a third
    job is still recovered normally.
  - `tests/unit_tests/test_sky/jobs/test_jobs_state.py`:
    `TestResetJobForRecoveryCAS` -- matching snapshot wins; a concurrent
    claim (different pid + `LAUNCHING`) loses and leaves the row untouched; a
    stale `started_at` loses; NULL-safety in both directions for the pid
    columns; a `schedule_state` that moved to `DONE` loses even though the pid
    columns still match.
- `pytest tests/unit_tests/test_sky/jobs/ -n 4`
- `./format.sh`

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
