### PR TITLE
[Slurm] Do not fail node info aggregation on an unreachable cluster

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1200,7 +1200,14 @@ def slurm_node_info(
 
     Args:
         slurm_cluster_name: The Slurm cluster to query. If None, node info
-            is aggregated across all existing allowed Slurm clusters.
+            is aggregated across all existing allowed Slurm clusters and a
+            cluster that cannot be queried contributes no nodes instead of
+            failing the whole aggregation.
+
+    Raises:
+        Any error from querying the cluster, when slurm_cluster_name is
+        given. Callers that name a cluster get the failure reported rather
+        than an empty node list.
 
     Returns:
         List[Dict[str, Any]]: One dictionary per node with keys:
@@ -1213,16 +1220,16 @@ def slurm_node_info(
             reports N/A.
     """
     if slurm_cluster_name is not None:
-        clusters_to_query = [slurm_cluster_name]
-    else:
-        clusters_to_query = clouds.Slurm.existing_allowed_clusters()
-        if not clusters_to_query:
-            return []
+        return _get_slurm_node_info_list(slurm_cluster_name=slurm_cluster_name)
+
+    clusters_to_query = clouds.Slurm.existing_allowed_clusters()
+    if not clusters_to_query:
+        return []
 
     def _query_cluster(cluster_name: str) -> List[Dict[str, Any]]:
         try:
             return _get_slurm_node_info_list(slurm_cluster_name=cluster_name)
-        except (FileNotFoundError, RuntimeError,
+        except (FileNotFoundError, RuntimeError, exceptions.CommandError,
                 exceptions.NotSupportedError) as e:
             logger.debug('Could not retrieve Slurm node info for cluster '
                          f'{cluster_name!r}: {e}')

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -280,11 +280,55 @@ class TestSlurmNodeInfo:
         assert len(result) == 1
         assert result[0]['slurm_cluster_name'] == 'cluster-b'
 
-    def test_single_cluster_error_returns_empty_list(self, monkeypatch):
-        monkeypatch.setattr(
-            utils, '_get_slurm_node_info_list',
-            mock.Mock(side_effect=exceptions.NotSupportedError('nope')))
-        assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')
+    def test_unreachable_login_node_does_not_break_others(self, monkeypatch):
+        """An `sinfo` that fails over SSH degrades to no nodes."""
+        clusters = ['cluster-a', 'cluster-b']
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=clusters))
+
+        def _fake_get_node_info_list(slurm_cluster_name):
+            if slurm_cluster_name == 'cluster-a':
+                raise exceptions.CommandError(
+                    255, 'sinfo -h --Node', 'Failed to get Slurm node '
+                    'information.', None)
+            return [_make_node_info('node-0', slurm_cluster_name)]
+
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            _fake_get_node_info_list)
+
+        result = utils.slurm_node_info()
+
+        assert len(result) == 1
+        assert result[0]['slurm_cluster_name'] == 'cluster-b'
+
+    @pytest.mark.parametrize('error', [
+        FileNotFoundError('no ssh config'),
+        RuntimeError('SSH connection failed'),
+        exceptions.CommandError(255, 'sinfo -h --Node', 'Failed to get Slurm '
+                                'node information.', None),
+        exceptions.NotSupportedError('nope'),
+    ])
+    def test_sole_cluster_error_returns_empty_list(self, monkeypatch, error):
+        """The one-cluster fast path degrades like the parallel path."""
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=['cluster-a']))
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            mock.Mock(side_effect=error))
+        assert not utils.slurm_node_info()
+
+    @pytest.mark.parametrize('error_type,error', [
+        (exceptions.CommandError,
+         exceptions.CommandError(255, 'sinfo -h --Node', 'Failed to get Slurm '
+                                 'node information.', None)),
+        (exceptions.NotSupportedError, exceptions.NotSupportedError('nope')),
+    ])
+    def test_named_cluster_error_propagates(self, monkeypatch, error_type,
+                                            error):
+        """A caller that names a cluster is told the query failed."""
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            mock.Mock(side_effect=error))
+        with pytest.raises(error_type):
+            utils.slurm_node_info(slurm_cluster_name='cluster-a')
 
 
 class TestGetGpuTypeAndCount:


### PR DESCRIPTION
## Problem

`slurm_node_info()` called with no cluster name aggregates node info across every
allowed Slurm cluster, and deliberately degrades a cluster it cannot query to "no
nodes" so that one bad cluster does not take down the whole request. The catch list
missed `exceptions.CommandError`, which is exactly what a temporarily unreachable
login node produces: `sinfo` fails over SSH with return code 255, and
`SlurmClient.info_nodes()` → `subprocess_utils.handle_returncode` raises
`CommandError`, which fell straight through the aggregation.

The user-visible effect is that the dashboard's Infra page — which posts to
`/slurm_node_info` with no cluster name — gets a FAILED request and renders an empty
infrastructure list, even when every other Slurm cluster is healthy.

```
File "sky/provision/slurm/utils.py", line 1232, in slurm_node_info
    return _query_cluster(clusters_to_query[0])
File "sky/provision/slurm/utils.py", line 1224, in _query_cluster
    return _get_slurm_node_info_list(slurm_cluster_name=cluster_name)
File "sky/provision/slurm/utils.py", line 1062, in _get_slurm_node_info_list
    node_infos = slurm_client.info_nodes()
File "sky/adaptors/slurm.py", line 285, in info_nodes
    subprocess_utils.handle_returncode(...)
sky.exceptions.CommandError: Command sinfo -h --Node -o "..." failed with return code 255.
```

## Fix

Add `exceptions.CommandError` to the per-cluster catch list, and scope that
degradation to the aggregating path only.

**Why not swallow it for a named cluster too.** Today the `len(clusters_to_query) == 1`
fast path is shared between "the caller named one cluster" and "we found exactly one
cluster to aggregate", so a named-cluster query silently inherited the degradation.
Those two cases want opposite things, and every caller that names a cluster already
handles the exception and reports it:

- `sky show-gpus` (`_format_slurm_partition_info`) wraps each per-cluster
  `slurm_node_info(slurm_cluster_name=...)` in its own `try/except` to build
  `failed_clusters`, and prints `(skipped unreachable clusters: ...)`. Adding
  `CommandError` to a shared catch list would have silently deleted that message —
  an unreachable cluster would just vanish from the table with no explanation.
- `slurm_catalog.list_accelerators_realtime` queries per cluster and lets the error
  propagate to `core.realtime_slurm_gpu_availability`, whose broad `except` turns it
  into a per-cluster error string shown to the user.

So the rule is: degrade per-cluster when we picked the cluster list ourselves;
propagate when the caller named the cluster. The aggregating path keeps the same
behavior whether it queries one cluster (fast path) or many (`run_in_parallel`).

I also audited the rest of `sky/provision/slurm/utils.py` for sibling aggregation
functions with the same catch-list shape — this is the only one. The
`/slurm_gpu_availability` path already degrades per cluster via the broad `except` in
`core.realtime_slurm_gpu_availability` and needs no change.

## Tested

Ran `pytest tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py::TestSlurmNodeInfo`
— 11 passed, including the three new/rewritten cases:

- `test_unreachable_login_node_does_not_break_others` — one cluster raises
  `CommandError(255, 'sinfo ...')`, another returns nodes; the aggregation returns
  only the healthy cluster's nodes.
- `test_sole_cluster_error_returns_empty_list` — parametrized over `FileNotFoundError`,
  `RuntimeError`, `CommandError`, `NotSupportedError`; the one-cluster fast path
  degrades to `[]` exactly like the parallel path.
- `test_named_cluster_error_propagates` — a query that names a cluster raises instead
  of reporting an empty node list.

Negative control: with `exceptions.CommandError` removed from the catch list, exactly
the two `CommandError` cases fail with
`sky.exceptions.CommandError: Command sinfo -h --Node failed with return code 255.`,
confirming the tests pin the fix rather than passing vacuously.

Also ran the wider Slurm-adjacent unit tests — `tests/unit_tests/test_sky/provision/slurm/`,
`tests/unit_tests/slurm/`, `tests/unit_tests/test_sky/test_cli_gpus_list.py`,
`tests/unit_tests/test_catalog.py`, `tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py`
— 393 passed.

`bash format.sh` passes clean (yapf, isort, mypy, pylint 10.00/10).

Not verified: I did not reproduce this against a live Slurm cluster with an
unreachable login node; the coverage above is unit-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
