### PR TITLE
[Slurm] Keep unreachable Slurm clusters listed on the Infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2480,6 +2480,9 @@ export function GPUs() {
   const [allSlurmGPUs, setAllSlurmGPUs] = useState([]);
   const [perClusterSlurmGPUs, setPerClusterSlurmGPUs] = useState([]);
   const [perNodeSlurmGPUs, setPerNodeSlurmGPUs] = useState([]);
+  // Slurm clusters from ~/.slurm/config, independent of whether they answer a
+  // query right now.
+  const [configuredSlurmClusters, setConfiguredSlurmClusters] = useState([]);
   const [cloudInfraData, setCloudInfraData] = useState([]);
   const [totalClouds, setTotalClouds] = useState(0);
   // Separate cluster/job counts for Cloud panel (for progressive loading)
@@ -2603,6 +2606,7 @@ export function GPUs() {
         setSshNodePools({});
         setSshLoading(false);
         setSlurmLoading(false);
+        setConfiguredSlurmClusters([]);
         setAllSlurmGPUs([]);
         setPerClusterSlurmGPUs([]);
         setPerNodeSlurmGPUs([]);
@@ -2839,6 +2843,7 @@ export function GPUs() {
     try {
       const slurmData = await dashboardCache.get(getSlurmInfrastructure);
       if (slurmData) {
+        setConfiguredSlurmClusters(slurmData.slurmClusterNames || []);
         setAllSlurmGPUs(slurmData.allSlurmGPUs || []);
         setPerClusterSlurmGPUs(slurmData.perClusterSlurmGPUs || []);
         setPerNodeSlurmGPUs(slurmData.perNodeSlurmGPUs || []);
@@ -2847,6 +2852,7 @@ export function GPUs() {
       setSlurmLoading(false);
     } catch (error) {
       console.error('Error in fetchSlurmData:', error);
+      setConfiguredSlurmClusters([]);
       setAllSlurmGPUs([]);
       setPerClusterSlurmGPUs([]);
       setPerNodeSlurmGPUs([]);
@@ -3263,16 +3269,23 @@ export function GPUs() {
     return allGPUs.filter((gpu) => kubeGpuNames.has(gpu.gpu_name));
   }, [allGPUs, perContextGPUs]);
 
-  // Extract Slurm cluster names. Union the cluster names from both the
-  // GPU-availability data (perClusterSlurmGPUs) and the per-node data
-  // (perNodeSlurmGPUs). GPU availability only reports clusters that have
-  // GPUs, so a CPU-only cluster would otherwise never appear here and the
-  // Slurm section would render "not configured" even though the cluster is
-  // reachable. Node info lists every node regardless of GPUs, so unioning
-  // it in keeps parity with the Kubernetes section, which always lists a
+  // Extract Slurm cluster names. Union three sources, because each on its own
+  // omits clusters the section should still list:
+  // - configuredSlurmClusters is answered from ~/.slurm/config without
+  //   contacting a login node, so a cluster that is unreachable still gets a
+  //   row (with empty node/GPU cells) instead of vanishing from the page.
+  // - GPU availability (perClusterSlurmGPUs) only reports clusters that have
+  //   GPUs, so a CPU-only cluster would never appear from it alone.
+  // - Node info (perNodeSlurmGPUs) lists every node regardless of GPUs.
+  // Together they keep parity with the Kubernetes section, which always lists a
   // context whether or not it has GPUs (GPU counts are just extra columns).
   const slurmClusters = React.useMemo(() => {
     const clusterSet = new Set();
+    if (Array.isArray(configuredSlurmClusters)) {
+      configuredSlurmClusters.forEach((cluster) => {
+        if (cluster) clusterSet.add(cluster);
+      });
+    }
     if (Array.isArray(perClusterSlurmGPUs)) {
       perClusterSlurmGPUs.forEach((gpu) => {
         if (gpu.cluster) clusterSet.add(gpu.cluster);
@@ -3284,7 +3297,7 @@ export function GPUs() {
       });
     }
     return [...clusterSet].sort();
-  }, [perClusterSlurmGPUs, perNodeSlurmGPUs]);
+  }, [configuredSlurmClusters, perClusterSlurmGPUs, perNodeSlurmGPUs]);
 
   // Group perClusterSlurmGPUs by cluster
   const groupedPerClusterSlurmGPUs = React.useMemo(() => {

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -1,3 +1,17 @@
+// Expose each plugin slot's name and row context as data attributes so the
+// row-identity contract can be asserted. Renders no text, so the cell-content
+// assertions below are unaffected.
+jest.mock('@/plugins/PluginSlot', () => ({
+  __esModule: true,
+  PluginSlot: ({ name, context }) => (
+    <span
+      data-slot={name}
+      data-row-id={context?.id}
+      data-row-kind={context?.kind}
+    />
+  ),
+}));
+
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
   InfrastructureSection,
@@ -177,6 +191,46 @@ describe('InfrastructureSection Slurm partition rows', () => {
       container.querySelectorAll('table tbody td')
     ).find((td) => td.textContent.includes('3 partitions'));
     expect(summaryCell.getAttribute('rowspan')).toBe('1');
+  });
+});
+
+// A cluster configured in ~/.slurm/config is listed whether or not it answers
+// a query, so an unreachable login node leaves the section with a cluster name
+// and nothing else to show for it.
+describe('InfrastructureSection unreachable Slurm cluster', () => {
+  it('renders one row with empty node, partition and GPU cells', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['offline-cluster'],
+      gpus: [],
+      groupedPerContextGPUs: {},
+      groupedPerNodeGPUs: {},
+    });
+    const rows = tableRows(container);
+    expect(rows).toHaveLength(1);
+    expect(normalize(rows[0])).toMatch(/offline-cluster\s*0/);
+    // Partition cell plus the three GPU cells, all with nothing to report.
+    expect(cellTexts(rows[0]).filter((text) => text === '-')).toHaveLength(4);
+    expect(container.textContent).toContain('1 cluster');
+    expect(container.textContent).not.toContain('not configured');
+  });
+
+  // The row's identity is what a plugin keys its status off, so it has to be
+  // the same for an unreachable cluster as for a healthy one.
+  it('keeps the namePrefix slot on the row, keyed slurm/<cluster name>', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['offline-cluster'],
+      gpus: [],
+      groupedPerContextGPUs: {},
+      groupedPerNodeGPUs: {},
+    });
+    const slot = container.querySelector(
+      'table tbody [data-slot="infra.row.namePrefix"]'
+    );
+    expect(slot).not.toBeNull();
+    expect(slot.getAttribute('data-row-kind')).toBe('slurm');
+    expect(slot.getAttribute('data-row-id')).toBe('offline-cluster');
   });
 });
 

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -1170,6 +1170,35 @@ async function getSlurmPerNodeGPUs() {
   }
 }
 
+// The clusters in ~/.slurm/config, which the server answers without
+// contacting any login node. Independent of the GPU and node queries, so it is
+// fetched alongside them rather than before them: a cluster that is
+// unreachable still comes back here after those two report nothing for it.
+async function getSlurmClusterNames() {
+  try {
+    const response = await apiClient.post(`/slurm_cluster_names`, {});
+    if (!response.ok) {
+      const msg = `Failed to get slurm cluster names with status ${response.status}`;
+      throw new Error(msg);
+    }
+    const id = response.headers.get('X-Skypilot-Request-ID');
+    if (!id) {
+      const msg = 'No request ID received from server for slurm cluster names';
+      throw new Error(msg);
+    }
+    const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
+    if (!fetchedData.ok) {
+      const msg = `Failed to get slurm cluster names result with status ${fetchedData.status}`;
+      throw new Error(msg);
+    }
+    const data = await fetchedData.json();
+    return data.return_value ? JSON.parse(data.return_value) : [];
+  } catch (error) {
+    console.error('Error fetching Slurm cluster names:', error);
+    return [];
+  }
+}
+
 // Export Slurm infrastructure fetching for parallel loading
 export async function getSlurmInfrastructure() {
   return await getSlurmServiceGPUs();
@@ -1177,8 +1206,10 @@ export async function getSlurmInfrastructure() {
 
 async function getSlurmServiceGPUs() {
   try {
-    // Fetch cluster GPUs and node GPUs in parallel for better performance
-    const [clusterGPUsRaw, nodeGPUsRaw] = await Promise.all([
+    // Fetch the configured cluster names, cluster GPUs and node GPUs in
+    // parallel — none of the three depends on another.
+    const [clusterNames, clusterGPUsRaw, nodeGPUsRaw] = await Promise.all([
+      getSlurmClusterNames(),
       getSlurmClusterGPUs(),
       getSlurmPerNodeGPUs(),
     ]);
@@ -1240,6 +1271,7 @@ async function getSlurmServiceGPUs() {
     }
 
     return {
+      slurmClusterNames: clusterNames,
       allSlurmGPUs: Object.values(allSlurmGPUs).sort((a, b) =>
         a.gpu_name.localeCompare(b.gpu_name)
       ),
@@ -1258,6 +1290,7 @@ async function getSlurmServiceGPUs() {
   } catch (error) {
     console.error('Error fetching Slurm GPUs:', error);
     return {
+      slurmClusterNames: [],
       allSlurmGPUs: [],
       perClusterSlurmGPUs: [],
       perNodeSlurmGPUs: [],

--- a/sky/dashboard/src/data/connectors/infra.test.jsx
+++ b/sky/dashboard/src/data/connectors/infra.test.jsx
@@ -1,0 +1,101 @@
+// The dashboard cache is a pass-through here so the connector's own logic is
+// what's under test, not the caching layer.
+jest.mock('@/lib/cache', () => ({
+  __esModule: true,
+  default: { get: jest.fn((fn, args = []) => fn(...args)) },
+}));
+
+jest.mock('@/data/connectors/client', () => ({
+  __esModule: true,
+  apiClient: { post: jest.fn(), get: jest.fn() },
+}));
+
+import { apiClient } from '@/data/connectors/client';
+import { getSlurmInfrastructure } from '@/data/connectors/infra';
+
+// Every Slurm endpoint answers the same way: POST returns a request id in a
+// header, then /api/get returns the result under a JSON-encoded return_value.
+const scheduled = (requestId) => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => requestId },
+});
+
+const result = (returnValue) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ return_value: JSON.stringify(returnValue) }),
+});
+
+// The Infra page must list a cluster that is configured but currently
+// unreachable, so the configured-cluster query has to be independent of the
+// node and GPU queries rather than derived from them.
+describe('getSlurmInfrastructure configured clusters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiClient.post.mockImplementation(async (path) => {
+      if (path === '/slurm_cluster_names') return scheduled('req-clusters');
+      if (path === '/slurm_gpu_availability') return scheduled('req-gpus');
+      if (path === '/slurm_node_info') return scheduled('req-nodes');
+      throw new Error(`unexpected POST to ${path}`);
+    });
+  });
+
+  it('reports a configured cluster whose node and GPU queries are empty', async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return result(['offline-cluster']);
+      return result([]);
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    expect(data.slurmClusterNames).toEqual(['offline-cluster']);
+    expect(data.perNodeSlurmGPUs).toEqual([]);
+    expect(data.perClusterSlurmGPUs).toEqual([]);
+  });
+
+  it('does not hold the node and GPU queries behind the cluster list', async () => {
+    // Assertions stay in the test body: the connector catches everything a
+    // mock throws, so an assertion made inside one would be swallowed and the
+    // test would pass regardless.
+    let releaseClusters;
+    const clusterListPending = new Promise((resolve) => {
+      releaseClusters = resolve;
+    });
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) {
+        await clusterListPending;
+        return result(['cluster-a']);
+      }
+      return result([]);
+    });
+
+    const pending = getSlurmInfrastructure();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The cluster list is still in flight, yet the other two have already got
+    // past their own POST to fetching a result. Serializing them behind it
+    // would leave these uncalled.
+    const fetched = apiClient.get.mock.calls.map(([path]) => path);
+    expect(fetched).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('req-nodes'),
+        expect.stringContaining('req-gpus'),
+      ])
+    );
+
+    releaseClusters();
+    expect((await pending).slurmClusterNames).toEqual(['cluster-a']);
+  });
+
+  it('falls back to an empty list when the cluster query fails', async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return { ok: false, status: 500 };
+      return result([]);
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    expect(data.slurmClusterNames).toEqual([]);
+  });
+});

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1194,6 +1194,20 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     return list(slurm_nodes_info.values())
 
 
+def slurm_cluster_names() -> List[str]:
+    """Gets the names of the Slurm clusters this server is configured with.
+
+    Derived from ~/.slurm/config and the ``allowed_clusters`` config alone —
+    nothing here contacts a login node, so a cluster that is currently
+    unreachable is still reported. Callers that need node or GPU data still
+    have to query the cluster itself.
+
+    Returns:
+        List[str]: The configured and allowed Slurm cluster names.
+    """
+    return clouds.Slurm.existing_allowed_clusters()
+
+
 def slurm_node_info(
         slurm_cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
     """Gets detailed information for each node in the Slurm cluster(s).

--- a/sky/server/requests/request_names.py
+++ b/sky/server/requests/request_names.py
@@ -13,6 +13,7 @@ class RequestName(str, enum.Enum):
     KUBERNETES_NODE_INFO = 'kubernetes_node_info'
     REALTIME_SLURM_GPU_AVAILABILITY = 'realtime_slurm_gpu_availability'
     SLURM_NODE_INFO = 'slurm_node_info'
+    SLURM_CLUSTER_NAMES = 'slurm_cluster_names'
     STATUS_KUBERNETES = 'status_kubernetes'
     KUBERNETES_LABEL_GPUS = 'kubernetes_label_gpus'
     LIST_ACCELERATORS = 'list_accelerators'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1385,6 +1385,25 @@ async def slurm_node_info(
     )
 
 
+@app.post('/slurm_cluster_names')
+async def slurm_cluster_names(request: fastapi.Request) -> None:
+    """Lists the names of the Slurm clusters this server is configured with.
+
+    Answers from ~/.slurm/config without contacting any login node, so it
+    returns promptly and covers clusters that are currently unreachable —
+    unlike /slurm_node_info and /slurm_gpu_availability, which can only
+    report a cluster that answers them.
+    """
+    await executor.schedule_request_async(
+        request_id=request.state.request_id,
+        request_name=request_names.RequestName.SLURM_CLUSTER_NAMES,
+        request_body=payloads.RequestBody(),
+        func=slurm_utils.slurm_cluster_names,
+        schedule_type=requests_lib.ScheduleType.SHORT,
+        auth_user=request.state.auth_user,
+    )
+
+
 @app.get('/status_kubernetes')
 async def status_kubernetes(request: fastapi.Request) -> None:
     """[Experimental] Get all SkyPilot resources (including from other '

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -239,6 +239,10 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'method': 'POST'
     },
     {
+        'path': '/slurm_cluster_names',
+        'method': 'POST'
+    },
+    {
         'path': '/status_kubernetes',
         'method': 'GET'
     },

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -254,6 +254,7 @@ _REQUEST_BODY_ALLOWLIST: Dict[str, Tuple[str, ...]] = {
     'sky.status_kubernetes': (),
     'sky.realtime_slurm_gpu_availability': (),
     'sky.slurm_node_info': (),
+    'sky.slurm_cluster_names': (),
     'sky.list_accelerators': (),
     'sky.list_accelerator_counts': (),
     'sky.workspaces.delete': (),

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -287,6 +287,32 @@ class TestSlurmNodeInfo:
         assert not utils.slurm_node_info(slurm_cluster_name='cluster-a')
 
 
+class TestSlurmClusterNames:
+    """Test slurm_cluster_names()."""
+
+    def test_returns_configured_clusters(self, monkeypatch):
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=['cluster-a', 'cluster-b']))
+        assert utils.slurm_cluster_names() == ['cluster-a', 'cluster-b']
+
+    def test_returns_empty_list_when_none_configured(self, monkeypatch):
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=[]))
+        assert utils.slurm_cluster_names() == []
+
+    def test_does_not_query_the_clusters(self, monkeypatch):
+        """The point of the call: names without contacting a login node."""
+        monkeypatch.setattr('sky.clouds.Slurm.existing_allowed_clusters',
+                            mock.Mock(return_value=['cluster-a']))
+        get_node_info_list = mock.Mock(
+            side_effect=AssertionError('must not query the cluster'))
+        monkeypatch.setattr(utils, '_get_slurm_node_info_list',
+                            get_node_info_list)
+
+        assert utils.slurm_cluster_names() == ['cluster-a']
+        get_node_info_list.assert_not_called()
+
+
 class TestGetGpuTypeAndCount:
     """Test get_gpu_type_and_count() GRES parsing."""
 


### PR DESCRIPTION
## Problem

The Infra page derives its Slurm cluster list purely from query results: `slurmClusters` is the union of the cluster names appearing in `POST /slurm_gpu_availability` and `POST /slurm_node_info`. A cluster that is configured in `~/.slurm/config` but currently unreachable — login node down, network partition, cluster still being set up — contributes zero rows to either query, so it disappears from the page entirely.

Two visible symptoms:

- The Slurm section stops listing the cluster, so a temporarily-down cluster looks unconfigured rather than down.
- Its detail page at `/infra/<name>` is misclassified as a Kubernetes context, because that classification is `slurmClusters.includes(selectedContext)`. The `<h1>` picks up the `font-mono` Kubernetes styling and `renderContextDetails` passes `isSlurm={false}`, which swaps the Partitions column for the Kubernetes IP/vCPU/Memory columns and turns the Grafana GPU-metrics section back on.

## Design

Add `POST /slurm_cluster_names`, which lists the configured clusters via `Slurm.existing_allowed_clusters()`. That reads `~/.slurm/config` and applies `allowed_clusters` filtering, but contacts no login node, so it answers promptly whether or not any cluster is up. It is scheduled through the executor exactly like its two neighbours, returns a plain `List[str]` (so the default encoder covers it, as with `slurm_node_info`), is registered in the debug-dump body allowlist alongside them, and is added to the viewer allowlist next to `/slurm_node_info` and `/slurm_gpu_availability` — it backs the same read-only page, so a viewer that can see the Slurm section's nodes should also see which clusters exist.

The name deliberately stays out of the `/slurm_clusters` namespace that #10135 introduces for the Slurm cluster registration CRUD API; that PR mounts GET/POST/DELETE there and blocks the whole prefix for the `user` role, neither of which should apply to this read.

The dashboard fires it from the same `Promise.all` as the two data queries in `getSlurmServiceGPUs`. The three are independent, and holding the GPU/node queries behind the cluster list would slow down the common case where every cluster is reachable. The frontend then reconciles: `slurmClusters` unions the configured names with the clusters seen in the query results. Everything downstream — the section's row list, the cluster-count badge, `allInfrastructureDisabled`, the detail-page `isSlurm` classification and heading style — reads that memo and is fixed by the union.

An unreachable cluster renders the row shape that already exists for a context with no GPU data: 0 nodes, `-` in the partition and GPU cells. `ContextDetails` already has a "No nodes found" empty state, so its detail page needed no change.

The row's identity is unchanged and now pinned by a test: `kind` `'slurm'`, `id` the cluster name, with the `infra.row.namePrefix` slot rendered as on every other row, so anything keying status off `slurm:<name>` still attaches to a cluster that is down.

### Why not derive this from `/enabled_clouds?expand=true`

Worth recording, since it looks like it would avoid a new endpoint: that response already carries `slurm/<cluster>` entries via `Slurm.expand_infras()`, and the dashboard already fetches it. But `expand_infras()` only runs for clouds in the *cached enabled-clouds verdict*. If every configured cluster is unreachable when `sky check` next runs, `Slurm.check_credentials()` fails, Slurm drops out of that cache, and the entries vanish — exactly the case this PR is about. The dedicated query has no such dependency.

## Tested

Python, run from the repo root:

- `pytest tests/unit_tests/test_sky/users/test_viewer_route_coverage.py tests/unit_tests/test_sky/users/test_rbac.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py` — 96 tests, 0 failures, 0 errors (read from `--junit-xml`, since the debug logging buries the terminal summary). `test_every_route_has_a_viewer_decision` is the one that forces a deliberate viewer decision on the new route; it failed with "POST /slurm_cluster_names has no viewer decision" until the allowlist entry was added, which is how that entry got there. The three new `TestSlurmClusterNames` cases cover names passed through, empty when nothing is configured, and an assertion that no node query is issued.
- `bash format.sh` — yapf, isort, mypy (`no issues found in 586 source files`), pylint `10.00/10`, plus the dashboard eslint/prettier pass. Clean.

Dashboard, from `sky/dashboard/`:

- `npx jest src/data/connectors/infra.test.jsx` — 3 passed. New file: a configured cluster survives empty node/GPU results, the three queries are not serialized, and a failing cluster query degrades to an empty list. I verified the non-serialization test actually bites by temporarily `await`ing the cluster list before the other two — that test fails, the other two still pass.
- `npx jest src/components/infra.test.jsx` — 12 passed (10 pre-existing + 2 new): the unreachable-cluster row renders with 0 nodes and four `-` cells, and it still carries the `infra.row.namePrefix` slot keyed `slurm` / `<cluster name>`.
- `npx jest` (full suite) — 73 passed, 6 failed across `src/components/elements/version-display.test.jsx` and `src/data/connectors/jobs.test.jsx`. Both suites fail identically on unmodified `master` (verified by stashing this change and re-running); they are pre-existing and unrelated to this PR.
- `npm ci && npm run build` — build succeeded, 24 static pages generated.

Not verified: no manual browser run against a live server with an actually-unreachable Slurm cluster. The behaviour above rests on the unit tests and on reading the render path, not on a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
