### PR TITLE
[Jobs] Review fixes for inter_connection: networking hardening, terminal errors, admin-policy header preservation

### DIFF
--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -114,8 +114,11 @@ The header document supports the following fields:
        up hostname connectivity between them; hard-fail if either is not
        possible. ``false``: deliberately skip all networking setup; tasks
        still prefer co-location but may land on separate clusters.
-       Unset: behaves like ``true`` where supported,
-       like ``false`` (with a warning) where not.
+       Unset (default): assumes ``true`` — co-locate all tasks on a
+       single Kubernetes cluster and set up networking, unless the tasks
+       request non-Kubernetes infrastructure or pin infrastructures that
+       cannot be co-located, in which case it degrades to ``false`` with
+       a warning and skips networking setup.
        See :ref:`job-groups-inter-connection`.
 
 Each task document after the header follows the standard :ref:`SkyPilot task YAML format <yaml-spec>`.

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1029,14 +1029,14 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
 
         # Check if this is a JobGroup YAML
         if dag_utils.is_job_group_yaml(entrypoint):
-            click.secho('Detected JobGroup YAML', fg='cyan')
+            click.secho('Detected Job Group YAML', fg='cyan')
             dag = dag_utils.load_job_group_from_yaml(entrypoint,
                                                      env_overrides=env,
                                                      secrets_overrides=secret)
             if override_params:
                 click.secho(
                     f'WARNING: override params {override_params} are ignored '
-                    'for JobGroup YAML.',
+                    'for Job Group YAML.',
                     fg='yellow')
             for task in dag.tasks:
                 task.update_workdir(workdir, git_url, git_ref)

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1843,6 +1843,22 @@ class JobController:
             own_failures = [f for f in failed_nodes if f[0] == task.name]
             failed_desc = '; '.join(
                 f'{label}: {reason}' for _, label, reason in failed_nodes)
+            if own_failures and (job_group_networking.dns_addresses_for_task(
+                    task, self._job_id) is not None):
+                # The recovered task delivers its own networking: its
+                # relaunched task.run prelude starts the updater and its
+                # networking wait enforces the outcome. The controller
+                # push is a best-effort top-up for such tasks in every
+                # phase (Phase 3 skips them entirely), so its failure
+                # must not be fatal here either -- the prelude may well
+                # have succeeded.
+                logger.error(
+                    'Controller networking push after recovery of '
+                    f'self-delivering task {task.name!r} failed on node(s): '
+                    f'[{failed_desc}]. Not failing the task: its run '
+                    'prelude starts the updater and its networking wait '
+                    'enforces the outcome.')
+                return
             if not own_failures:
                 logger.error(
                     'Networking re-setup after recovery of task '

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1840,9 +1840,9 @@ class JobController:
             # failure means the peer is unreachable -- typically because
             # it was preempted at the same time and its own recovery,
             # which re-runs this setup, owns fixing it.
-            own_failures = [f for f in failed_nodes if f[0] == task.name]
+            own_failures = [f for f in failed_nodes if f.task_name == task.name]
             failed_desc = '; '.join(
-                f'{label}: {reason}' for _, label, reason in failed_nodes)
+                f'{f.node_label}: {f.reason}' for f in failed_nodes)
             if own_failures and (job_group_networking.dns_addresses_for_task(
                     task, self._job_id) is not None):
                 # The recovered task delivers its own networking: its
@@ -2156,8 +2156,7 @@ class JobController:
                                  'job group.')
                     await self._cleanup_job_group_clusters(cluster_names)
                     failed_desc = '; '.join(
-                        f'{label}: {reason}'
-                        for _, label, reason in failed_nodes)
+                        f'{f.node_label}: {f.reason}' for f in failed_nodes)
                     raise exceptions.ClusterSetUpError(
                         f'Failed to set up in-group networking for Job Group '
                         f'{job_group_name!r} on node(s): [{failed_desc}]. '

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1809,16 +1809,22 @@ class JobController:
             """
             if not self._dag.inter_connection_enabled():
                 return
-            updated_handles = []
-            for t, _ in all_tasks_handles:
+
+            async def _fetch_handle(t: 'sky.Task') -> typing.Any:
                 t_name = t.name
                 assert t_name is not None
                 # JobGroups don't support pools, cluster name is deterministic
                 t_cluster = managed_job_utils.generate_managed_job_cluster_name(
                     t_name, self._job_id)
-                t_handle = await asyncio.to_thread(
+                return await asyncio.to_thread(
                     global_user_state.get_handle_from_cluster_name, t_cluster)
-                updated_handles.append((t, t_handle))
+
+            # Independent DB reads; fetched in parallel, mirroring the
+            # Phase 2 handle sync.
+            group_tasks = [t for t, _ in all_tasks_handles]
+            handles = await asyncio.gather(
+                *(_fetch_handle(t) for t in group_tasks))
+            updated_handles = list(zip(group_tasks, handles))
 
             failed_nodes = await (
                 job_group_networking.setup_job_group_networking(

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1629,7 +1629,28 @@ class JobController:
 
             # Call recovery callback if provided
             if on_recovery is not None:
-                await on_recovery()
+                try:
+                    await on_recovery()
+                except exceptions.ClusterSetUpError as e:
+                    # Job Groups: in-group networking could not be
+                    # re-established on this task's own nodes after its
+                    # recovery. Without it the relaunched task would only
+                    # stall at its networking wait and fail minutes later
+                    # with a generic message; fail the task now with the
+                    # actual reason instead. Raising here would instead be
+                    # swallowed into the Phase 4 monitor results with no
+                    # terminal state set for this task, which run()'s
+                    # finally would then mislabel as CANCELLED.
+                    failure_reason = common_utils.format_exception(e)
+                    logger.error(failure_reason)
+                    await managed_job_state.set_failed_async(
+                        self._job_id,
+                        task_id,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_SETUP,
+                        failure_reason=failure_reason,
+                        callback_func=callback_func)
+                    return False
 
             logger.info(f'Task {task.name} recovered, continuing monitoring')
 
@@ -1799,8 +1820,34 @@ class JobController:
                     global_user_state.get_handle_from_cluster_name, t_cluster)
                 updated_handles.append((t, t_handle))
 
-            await job_group_networking.setup_job_group_networking(
-                job_group_name, updated_handles)
+            failed_nodes = await (
+                job_group_networking.setup_job_group_networking(
+                    job_group_name, updated_handles))
+            if not failed_nodes:
+                return
+            # Only failures on the recovered task's own nodes are fatal:
+            # its fresh pod has no DNS updater or readiness marker, so
+            # without this setup its networking wait would stall and fail
+            # the task minutes later with a generic message. Failures on
+            # peer nodes are not: a healthy peer's running updater
+            # short-circuits the re-push (it never fails), so a peer
+            # failure means the peer is unreachable -- typically because
+            # it was preempted at the same time and its own recovery,
+            # which re-runs this setup, owns fixing it.
+            own_failures = [f for f in failed_nodes if f[0] == task.name]
+            failed_desc = '; '.join(
+                f'{label}: {reason}' for _, label, reason in failed_nodes)
+            if not own_failures:
+                logger.error(
+                    'Networking re-setup after recovery of task '
+                    f'{task.name!r} failed on peer node(s): [{failed_desc}]. '
+                    'Not failing the task: unreachable peers are usually '
+                    'themselves mid-recovery, which re-runs this setup.')
+                return
+            raise exceptions.ClusterSetUpError(
+                'Failed to re-establish in-group networking for Job Group '
+                f'{job_group_name!r} after recovery of task {task.name!r}; '
+                f'failed node(s): [{failed_desc}]')
 
         # Mirror the dispatch in `_run_one_task`: give the recovery
         # strategy first refusal at owning the per-task monitor loop so
@@ -1844,7 +1891,7 @@ class JobController:
         assert job_group_name is not None, 'JobGroup name must be set'
         assert self._pool is None, 'JobGroups do not support pools'
         tasks = self._dag.tasks
-        logger.info(f'Starting JobGroup "{job_group_name}" with '
+        logger.info(f'Starting Job Group "{job_group_name}" with '
                     f'{len(tasks)} jobs: {[t.name for t in tasks]}')
 
         # Inject JobGroup environment variables into all tasks
@@ -1888,7 +1935,7 @@ class JobController:
                             f'terminal state: {task_status}')
             elif task_status == managed_job_state.ManagedJobStatus.CANCELLING:
                 # Job was being cancelled when controller went down
-                logger.info('JobGroup was being cancelled, '
+                logger.info('Job Group was being cancelled, '
                             're-raising cancellation')
                 raise asyncio.CancelledError()
             elif task_status == managed_job_state.ManagedJobStatus.RUNNING:
@@ -2061,34 +2108,44 @@ class JobController:
             tasks_handles.append((task, task_handle))
 
         if not self._dag.inter_connection_enabled():
-            logger.info('Phase 3: Skipping JobGroup networking setup '
+            logger.info('Phase 3: Skipping Job Group networking setup '
                         '(inter_connection disabled).')
         else:
-            logger.info('Phase 3: Setting up JobGroup networking...')
+            logger.info('Phase 3: Setting up Job Group networking...')
             if tasks_handles:
-                networking_success = await (
+                failed_nodes = await (
                     job_group_networking.setup_job_group_networking(
                         job_group_name, tasks_handles))
-                if not networking_success:
+                if failed_nodes:
                     # This group requires in-group networking
                     # (inter_connection enabled): without it, every task
                     # would stall at its networking wait and fail anyway.
                     # Fail fast and clean up instead. Phase 2/3 run outside
                     # the Phase 1 and Phase 4 try blocks, so clean up here
                     # before raising to avoid leaking clusters.
-                    logger.error('JobGroup networking setup failed and '
+                    # ClusterSetUpError (not a generic error) so run()
+                    # marks the job terminal (FAILED_SETUP): a generic
+                    # error would trigger emergency recovery, which
+                    # resumes in place against the clusters just cleaned
+                    # up here (Phase 2 already marked tasks RUNNING, so
+                    # the resume would skip Phase 1 relaunch).
+                    logger.error('Job Group networking setup failed and '
                                  'inter_connection is enabled; failing the '
                                  'job group.')
                     await self._cleanup_job_group_clusters(cluster_names)
-                    raise RuntimeError(
-                        f'Failed to set up in-group networking for JobGroup '
-                        f'{job_group_name!r}, which requires inter-task '
-                        'connectivity (inter_connection is enabled). If '
-                        'tasks in this job group do not need to reach each '
-                        'other by hostname, set \'inter_connection: false\' '
-                        'in the job group header.')
+                    failed_desc = '; '.join(
+                        f'{label}: {reason}'
+                        for _, label, reason in failed_nodes)
+                    raise exceptions.ClusterSetUpError(
+                        f'Failed to set up in-group networking for Job Group '
+                        f'{job_group_name!r} on node(s): [{failed_desc}]. '
+                        'This job group requires inter-task connectivity '
+                        '(inter_connection is enabled). If tasks in this job '
+                        'group do not need to reach each other by hostname, '
+                        'set \'inter_connection: false\' in the job group '
+                        'header.')
 
-        logger.info('JobGroup setup complete, all jobs are running')
+        logger.info('Job Group setup complete, all jobs are running')
 
         # Phase 4: Monitor all jobs in parallel with primary/auxiliary support
         logger.info('Phase 4: Monitoring all jobs...')
@@ -2354,7 +2411,7 @@ class JobController:
                     # Check if this is a JobGroup (parallel execution)
                     if self._dag.is_job_group():
                         logger.info(
-                            f'Running as JobGroup with {len(self._dag.tasks)} '
+                            f'Running as Job Group with {len(self._dag.tasks)} '
                             f'parallel jobs')
                         succeeded = await self._run_job_group()
                     else:

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -20,22 +20,37 @@ Design Goals:
 """
 import asyncio
 import base64
+import functools
 import os
 import tempfile
 import textwrap
 import traceback
 import typing
-from typing import List, Optional, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple
 
 from sky import clouds as sky_clouds
 from sky import sky_logging
 from sky.utils import command_runner
+from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:
     from sky import task as task_lib
     from sky.backends import cloud_vm_ray_backend
 
 logger = sky_logging.init_logger(__name__)
+
+# Per-node networking setup runs with its own retry budget: each node
+# retries independently (no barrier between nodes), so one flaky SSH
+# connection or slow node never blocks -- or fails -- the whole group.
+_SETUP_MAX_ATTEMPTS = 3
+_SETUP_ATTEMPT_TIMEOUT_SECONDS = 60.0
+_SETUP_RETRY_INITIAL_BACKOFF_SECONDS = 5.0
+
+# One entry per node whose networking setup failed after its retry
+# budget: (task_name, node_label, reason). task_name is carried
+# separately so callers can tell failures on a specific task's own nodes
+# from failures on its peers.
+SetupFailure = Tuple[str, str, str]
 
 # ============================================================================
 # Layer 2: JobAddressResolver - Address resolution abstraction
@@ -229,15 +244,25 @@ def generate_inline_networking_setup_script(
     updater_script = generate_k8s_dns_updater_script(dns_mappings,
                                                      job_group_name)
     encoded_script = base64.b64encode(updater_script.encode()).decode()
-    process_id = f'skypilot-jobgroup-dns-updater-{job_group_name}'
-    script_path = f'/tmp/{process_id}.sh'
-    log_path = f'/tmp/{process_id}.log'
+    updater_process_name = f'skypilot-jobgroup-dns-updater-{job_group_name}'
+    script_path = f'/tmp/{updater_process_name}.sh'
+    log_path = f'/tmp/{updater_process_name}.log'
+    # Must match the PID file path written by the updater script in
+    # generate_k8s_dns_updater_script.
+    pid_file = f'/tmp/{updater_process_name}.pid'
     marker_file = get_network_ready_marker_path(job_group_name)
+    # The start is guarded by the updater's PID file: task restarts
+    # (max_restarts_on_errors) re-run task.run on the same cluster, and an
+    # unconditional start would stack a duplicate updater per restart.
     return textwrap.dedent(f"""\
-        # Start JobGroup DNS updater inside the task runtime.
-        echo '{encoded_script}' | base64 -d > {script_path}
-        chmod +x {script_path}
-        (nohup {script_path} < /dev/null > {log_path} 2>&1 &) || true
+        # Start JobGroup DNS updater inside the task runtime (skipped if
+        # one is already running).
+        if ! ([ -f {pid_file} ] &&
+              kill -0 "$(cat {pid_file})" 2> /dev/null); then
+          echo '{encoded_script}' | base64 -d > {script_path}
+          chmod +x {script_path}
+          (nohup {script_path} < /dev/null > {log_path} 2>&1 &) || true
+        fi
         touch {marker_file}
         """).strip()
 
@@ -355,6 +380,11 @@ def generate_k8s_dns_updater_script(dns_mappings: List[Tuple[str, str]],
         MAPPINGS="{mapping_pairs}"
         MARKER="# SkyPilot JobGroup K8s entries"
 
+        # Record our PID so the controller can check liveness (and skip
+        # starting a duplicate updater) without pgrep, whose -f pattern
+        # would match the checking shell's own command line.
+        echo $$ > "/tmp/skypilot-jobgroup-dns-updater-{job_group_name}.pid"
+
         echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Starting DNS updater for {job_group_name}"
         echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Monitoring mappings: $MAPPINGS"
 
@@ -427,11 +457,11 @@ async def _start_k8s_dns_updater_on_node(
                                                      job_group_name)
 
     # Note: job_group_name is validated at YAML load time to be shell-safe
-    # (alphanumeric, hyphens, underscores only - see dag_utils.py:477-485)
-    # This ensures the process_id is safe for use in pgrep patterns and paths
-    process_id = f'skypilot-jobgroup-dns-updater-{job_group_name}'
-    script_path = f'/tmp/{process_id}.sh'
-    log_path = f'/tmp/{process_id}.log'
+    # (alphanumeric, hyphens, underscores only - see dag_utils.py:477-485),
+    # so updater_process_name is safe to embed in shell commands and paths.
+    updater_process_name = f'skypilot-jobgroup-dns-updater-{job_group_name}'
+    script_path = f'/tmp/{updater_process_name}.sh'
+    log_path = f'/tmp/{updater_process_name}.log'
 
     loop = asyncio.get_running_loop()
 
@@ -455,17 +485,34 @@ async def _start_k8s_dns_updater_on_node(
         finally:
             os.remove(local_script_path)
 
-        # Make executable and run in background, then verify it started.
+        # Start the updater only if one is not already alive. This makes
+        # re-pushes (post-recovery refreshes) safe on healthy surviving
+        # nodes: their running updater is left untouched (restarting it
+        # would open a window with no updater at all if the restart
+        # failed), and repeated pushes never accumulate duplicate updater
+        # processes. Liveness is checked via the PID file the updater
+        # writes on startup -- NOT pgrep -f, whose pattern would match
+        # this very command line (it contains the script path) and always
+        # report "running".
         # Uses nohup with a subshell to fully detach from kubectl exec.
-        # After a brief sleep, pgrep confirms the process is running.
-        # Use 0.5s sleep to ensure process is visible on loaded systems.
-        # Also create the marker file to signal networking setup is initiated.
+        # The 0.5s sleep gives a newly started updater time to write its
+        # PID file on loaded systems.
+        # Also create the marker file to signal networking setup is
+        # initiated.
         marker_file = get_network_ready_marker_path(job_group_name)
-        run_cmd = (f'chmod +x {script_path} && '
+        # Must match the PID file path written by the updater script in
+        # generate_k8s_dns_updater_script.
+        pid_file = f'/tmp/{updater_process_name}.pid'
+        # Edge case: if the updater died and the OS recycled its PID for an
+        # unrelated process, this reports alive and we skip a needed restart.
+        alive_check = (f'[ -f {pid_file} ] && '
+                       f'kill -0 "$(cat {pid_file})" 2> /dev/null')
+        run_cmd = (f'if {alive_check}; then touch {marker_file}; else '
+                   f'chmod +x {script_path} && '
                    f'(nohup {script_path} < /dev/null > {log_path} 2>&1 &) && '
                    f'sleep 0.5 && '
-                   f'pgrep -f "{process_id}" > /dev/null && '
-                   f'touch {marker_file}')
+                   f'{alive_check} && '
+                   f'touch {marker_file}; fi')
         logger.info(f'Starting DNS updater in background (log: {log_path})...')
         returncode, _, stderr = await loop.run_in_executor(
             None,
@@ -487,6 +534,62 @@ async def _start_k8s_dns_updater_on_node(
         return False
 
 
+async def _setup_node_with_retries(
+    make_attempt: Callable[[], Awaitable[bool]],
+    node_label: str,
+    setup_type: str,
+) -> Optional[str]:
+    """Run one node's networking setup with its own retry budget.
+
+    Each node retries independently -- there is no barrier between nodes,
+    so a slow or flaky node never delays the others' retries. A fresh
+    attempt coroutine is built per try (a coroutine cannot be awaited
+    twice), with a per-attempt timeout and jittered exponential backoff
+    between tries.
+
+    Args:
+        make_attempt: Zero-arg factory building one attempt coroutine
+            that resolves to True on success.
+        node_label: '{task_name}-{node_idx}', for logs and failure
+            reporting.
+        setup_type: Human-readable setup kind ('K8s DNS updater' or
+            '/etc/hosts').
+
+    Returns:
+        None on success; a short failure reason after the retry budget
+        is exhausted. Never raises.
+    """
+    backoff = common_utils.Backoff(
+        initial_backoff=_SETUP_RETRY_INITIAL_BACKOFF_SECONDS)
+    reason = f'{setup_type} failed'
+    for attempt in range(1, _SETUP_MAX_ATTEMPTS + 1):
+        try:
+            ok = await asyncio.wait_for(make_attempt(),
+                                        timeout=_SETUP_ATTEMPT_TIMEOUT_SECONDS)
+            if ok:
+                if attempt > 1:
+                    logger.info(f'{setup_type} succeeded on {node_label} '
+                                f'(attempt {attempt}/{_SETUP_MAX_ATTEMPTS})')
+                return None
+            # The attempt logged its own error details.
+            reason = f'{setup_type} failed'
+        except asyncio.TimeoutError:
+            reason = (f'{setup_type} timed out after '
+                      f'{_SETUP_ATTEMPT_TIMEOUT_SECONDS:.0f}s')
+        except Exception as e:  # pylint: disable=broad-except
+            reason = (f'{setup_type} raised: '
+                      f'{common_utils.format_exception(e)}')
+        if attempt < _SETUP_MAX_ATTEMPTS:
+            delay = backoff.current_backoff()
+            logger.warning(f'{reason} on {node_label} (attempt '
+                           f'{attempt}/{_SETUP_MAX_ATTEMPTS}); retrying in '
+                           f'{delay:.1f}s')
+            await asyncio.sleep(delay)
+    logger.error(f'{reason} on {node_label}; giving up after '
+                 f'{_SETUP_MAX_ATTEMPTS} attempts')
+    return reason
+
+
 class NetworkConfigurator:
     """Configures network infrastructure for JobGroups.
 
@@ -500,7 +603,7 @@ class NetworkConfigurator:
         job_group_name: str,
         tasks_handles: List[Tuple[
             'task_lib.Task', 'cloud_vm_ray_backend.CloudVmRayResourceHandle']],
-    ) -> bool:
+    ) -> List[SetupFailure]:
         """Set up network configuration for JobGroup.
 
         Args:
@@ -508,7 +611,8 @@ class NetworkConfigurator:
             tasks_handles: List of (Task, ResourceHandle) tuples.
 
         Returns:
-            True if all configuration succeeded, False otherwise.
+            Empty list when every node succeeded; otherwise one
+            SetupFailure per node that failed after its retry budget.
         """
         return await NetworkConfigurator._inject_etc_hosts(
             job_group_name, tasks_handles)
@@ -518,19 +622,24 @@ class NetworkConfigurator:
         job_group_name: str,
         tasks_handles: List[Tuple[
             'task_lib.Task', 'cloud_vm_ray_backend.CloudVmRayResourceHandle']],
-    ) -> bool:
+    ) -> List[SetupFailure]:
         """Inject /etc/hosts entries for all clusters in the JobGroup.
 
         This maps the unified hostname format to actual addresses:
         - K8s: Write DNS mappings file for skylet's HostUpdater
         - SSH: Inject static internal IPs
 
+        Every node runs with its own retry budget (see
+        _setup_node_with_retries); a node that still fails is reported
+        in the result rather than aborting the other nodes.
+
         Args:
             job_group_name: Name of the JobGroup.
             tasks_handles: List of (Task, ResourceHandle) tuples for all jobs.
 
         Returns:
-            True if all injections succeeded, False otherwise.
+            Empty list when every node succeeded; otherwise one
+            SetupFailure per node that failed after its retry budget.
         """
         logger.info(f'Setting up networking on all {len(tasks_handles)} jobs')
 
@@ -539,71 +648,69 @@ class NetworkConfigurator:
         k8s_dns_mappings = _generate_k8s_dns_mappings(job_group_name,
                                                       tasks_handles)
 
-        # Each entry: (coroutine, task_name, node_idx, is_k8s)
-        setup_tasks: List[Tuple] = []
+        # Each entry: (make_attempt, task_name, node_label, setup_type).
+        # A factory rather than a coroutine, so each retry can build a
+        # fresh attempt.
+        setup_specs: List[Tuple[Callable[[], Awaitable[bool]], str, str,
+                                str]] = []
+        failures: List[SetupFailure] = []
         for task, handle in tasks_handles:
             if handle is None:
+                # The cluster is in transition (e.g., a peer that is
+                # itself mid-recovery). Not a failure: its own recovery
+                # re-runs networking setup once it is back up.
+                logger.warning(f'No handle for {task.name}; skipping its '
+                               'networking setup')
                 continue
 
+            task_name = str(task.name)
             is_k8s = _is_kubernetes(handle)
             try:
                 runners = handle.get_command_runners()
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(
-                    f'Failed to get command runners for {task.name}: {e}')
+                    f'Failed to get command runners for {task_name}: {e}')
+                failures.append((task_name, task_name,
+                                 f'failed to get command runners: {e}'))
                 continue
 
             for node_idx, runner in enumerate(runners):
+                node_label = f'{task_name}-{node_idx}'
                 if is_k8s:
-                    coro = _start_k8s_dns_updater_on_node(
-                        runner, k8s_dns_mappings, job_group_name)
-                    setup_tasks.append((coro, task.name, node_idx, True))
+                    setup_specs.append(
+                        (functools.partial(_start_k8s_dns_updater_on_node,
+                                           runner, k8s_dns_mappings,
+                                           job_group_name), task_name,
+                         node_label, 'K8s DNS updater'))
                 else:
                     # ssh_hosts_content is always truthy (has header comment)
                     assert ssh_hosts_content, 'unreachable'
-                    coro = _inject_hosts_on_node(runner, ssh_hosts_content,
-                                                 job_group_name)
-                    setup_tasks.append((coro, task.name, node_idx, False))
-                logger.debug(
-                    f'Queued networking setup for {task.name}-{node_idx}')
+                    setup_specs.append(
+                        (functools.partial(_inject_hosts_on_node, runner,
+                                           ssh_hosts_content, job_group_name),
+                         task_name, node_label, '/etc/hosts'))
+                logger.debug(f'Queued networking setup for {node_label}')
 
-        if not setup_tasks:
+        if not setup_specs and not failures:
             logger.warning('No nodes to set up networking')
-            return True
+            return []
 
-        coroutines = [entry[0] for entry in setup_tasks]
-        logger.info(f'Setting up networking on {len(coroutines)} nodes...')
-        try:
-            results = await asyncio.wait_for(asyncio.gather(
-                *coroutines, return_exceptions=True),
-                                             timeout=60.0)
-        except asyncio.TimeoutError:
-            logger.error('Networking setup timed out after 60 seconds')
-            return False
+        logger.info(f'Setting up networking on {len(setup_specs)} nodes...')
+        # _setup_node_with_retries never raises, so a plain gather is safe.
+        results = await asyncio.gather(*[
+            _setup_node_with_retries(make_attempt, node_label, setup_type)
+            for make_attempt, _, node_label, setup_type in setup_specs
+        ])
+        node_failures: List[SetupFailure] = [
+            (spec[1], spec[2], reason)
+            for spec, reason in zip(setup_specs, results)
+            if reason is not None
+        ]
+        failures.extend(node_failures)
 
-        success_count = 0
-        for i, result in enumerate(results):
-            if result is True:
-                success_count += 1
-                continue
-
-            # Log error details for failed tasks
-            _, task_name, node_idx, is_k8s = setup_tasks[i]
-            setup_type = 'K8s DNS updater' if is_k8s else '/etc/hosts'
-            node_label = f'{task_name}-{node_idx}'
-
-            if isinstance(result, Exception):
-                tb_str = ''.join(
-                    traceback.format_exception(type(result), result,
-                                               result.__traceback__))
-                logger.error(
-                    f'{setup_type} failed on {node_label}: {result}\n{tb_str}')
-            else:
-                logger.error(f'{setup_type} failed on {node_label}')
-
-        logger.info(
-            f'Hosts injection: {success_count}/{len(results)} succeeded')
-        return success_count == len(results)
+        logger.info(f'Networking setup: {len(results) - len(node_failures)}/'
+                    f'{len(results)} nodes succeeded')
+        return failures
 
 
 # ============================================================================
@@ -615,19 +722,22 @@ async def setup_job_group_networking(
     job_group_name: str,
     tasks_handles: List[Tuple['task_lib.Task',
                               'cloud_vm_ray_backend.CloudVmRayResourceHandle']],
-) -> bool:
+) -> List[SetupFailure]:
     """Set up networking for all tasks in a JobGroup.
 
-    This is the main entry point for JobGroup networking setup.
+    This is the main entry point for JobGroup networking setup. Each
+    node is set up with its own retry budget; nodes that still fail are
+    reported in the result so callers can decide how to surface them.
 
     Args:
         job_group_name: Name of the JobGroup.
         tasks_handles: List of (Task, ResourceHandle) tuples for each task.
 
     Returns:
-        True if setup succeeded, False otherwise.
+        Empty list when every node succeeded; otherwise one SetupFailure
+        per node that failed after its retry budget.
     """
-    logger.info(f'Setting up networking for JobGroup: {job_group_name}')
+    logger.info(f'Setting up networking for Job Group: {job_group_name}')
     return await NetworkConfigurator.setup(job_group_name, tasks_handles)
 
 
@@ -683,7 +793,10 @@ def generate_wait_for_networking_script(job_group_name: str,
     marker_file = get_network_ready_marker_path(job_group_name)
     updater_log = (f'/tmp/skypilot-jobgroup-dns-updater-'
                    f'{job_group_name}.log')
-    updater_process = f'skypilot-jobgroup-dns-updater-{job_group_name}'
+    # Must match the PID file path written by the updater script in
+    # generate_k8s_dns_updater_script.
+    updater_pid_file = (f'/tmp/skypilot-jobgroup-dns-updater-'
+                        f'{job_group_name}.pid')
 
     wait_script = textwrap.dedent(f"""
         # Wait for JobGroup networking to be ready. This job group requires
@@ -720,12 +833,12 @@ def generate_wait_for_networking_script(job_group_name: str,
           MAX_WAIT=300  # 5 minutes
           ELAPSED=0
           UPDATER_LOG="{updater_log}"
-          UPDATER_PROCESS="{updater_process}"
+          UPDATER_PID_FILE="{updater_pid_file}"
           for hostname in $HOSTNAMES; do
             while ! getent hosts "$hostname" >/dev/null 2>&1; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "[SkyPilot] Error: Network setup timed out for \\"$hostname\\" after ${{ELAPSED}}s"
-                echo "[SkyPilot] DNS updater running: $(pgrep -f "$UPDATER_PROCESS" > /dev/null && echo 'yes' || echo 'no')"
+                echo "[SkyPilot] DNS updater running: $([ -f "$UPDATER_PID_FILE" ] && kill -0 "$(cat "$UPDATER_PID_FILE")" 2>/dev/null && echo 'yes' || echo 'no')"
                 NETWORK_READY=false
                 break 2  # Break out of both loops
               fi

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -20,6 +20,7 @@ Design Goals:
 """
 import asyncio
 import base64
+import dataclasses
 import functools
 import os
 import tempfile
@@ -46,11 +47,31 @@ _SETUP_MAX_ATTEMPTS = 3
 _SETUP_ATTEMPT_TIMEOUT_SECONDS = 60.0
 _SETUP_RETRY_INITIAL_BACKOFF_SECONDS = 5.0
 
-# One entry per node whose networking setup failed after its retry
-# budget: (task_name, node_label, reason). task_name is carried
-# separately so callers can tell failures on a specific task's own nodes
-# from failures on its peers.
-SetupFailure = Tuple[str, str, str]
+
+@dataclasses.dataclass(frozen=True)
+class SetupFailure:
+    """A node whose networking setup failed after its retry budget.
+
+    task_name is carried separately from node_label so callers can tell
+    failures on a specific task's own nodes from failures on its peers.
+    """
+    task_name: str
+    node_label: str
+    reason: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _NodeSetupSpec:
+    """One node's networking setup work.
+
+    make_attempt is a factory rather than a coroutine, so each retry can
+    build a fresh attempt (a coroutine cannot be awaited twice).
+    """
+    make_attempt: Callable[[], Awaitable[bool]]
+    task_name: str
+    node_label: str
+    setup_type: str
+
 
 # ============================================================================
 # Layer 2: JobAddressResolver - Address resolution abstraction
@@ -648,11 +669,7 @@ class NetworkConfigurator:
         k8s_dns_mappings = _generate_k8s_dns_mappings(job_group_name,
                                                       tasks_handles)
 
-        # Each entry: (make_attempt, task_name, node_label, setup_type).
-        # A factory rather than a coroutine, so each retry can build a
-        # fresh attempt.
-        setup_specs: List[Tuple[Callable[[], Awaitable[bool]], str, str,
-                                str]] = []
+        setup_specs: List[_NodeSetupSpec] = []
         failures: List[SetupFailure] = []
         for task, handle in tasks_handles:
             if handle is None:
@@ -670,25 +687,32 @@ class NetworkConfigurator:
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(
                     f'Failed to get command runners for {task_name}: {e}')
-                failures.append((task_name, task_name,
-                                 f'failed to get command runners: {e}'))
+                failures.append(
+                    SetupFailure(task_name=task_name,
+                                 node_label=task_name,
+                                 reason=f'failed to get command runners: {e}'))
                 continue
 
             for node_idx, runner in enumerate(runners):
                 node_label = f'{task_name}-{node_idx}'
                 if is_k8s:
                     setup_specs.append(
-                        (functools.partial(_start_k8s_dns_updater_on_node,
-                                           runner, k8s_dns_mappings,
-                                           job_group_name), task_name,
-                         node_label, 'K8s DNS updater'))
+                        _NodeSetupSpec(make_attempt=functools.partial(
+                            _start_k8s_dns_updater_on_node, runner,
+                            k8s_dns_mappings, job_group_name),
+                                       task_name=task_name,
+                                       node_label=node_label,
+                                       setup_type='K8s DNS updater'))
                 else:
                     # ssh_hosts_content is always truthy (has header comment)
                     assert ssh_hosts_content, 'unreachable'
                     setup_specs.append(
-                        (functools.partial(_inject_hosts_on_node, runner,
-                                           ssh_hosts_content, job_group_name),
-                         task_name, node_label, '/etc/hosts'))
+                        _NodeSetupSpec(make_attempt=functools.partial(
+                            _inject_hosts_on_node, runner, ssh_hosts_content,
+                            job_group_name),
+                                       task_name=task_name,
+                                       node_label=node_label,
+                                       setup_type='/etc/hosts'))
                 logger.debug(f'Queued networking setup for {node_label}')
 
         if not setup_specs and not failures:
@@ -698,11 +722,13 @@ class NetworkConfigurator:
         logger.info(f'Setting up networking on {len(setup_specs)} nodes...')
         # _setup_node_with_retries never raises, so a plain gather is safe.
         results = await asyncio.gather(*[
-            _setup_node_with_retries(make_attempt, node_label, setup_type)
-            for make_attempt, _, node_label, setup_type in setup_specs
+            _setup_node_with_retries(spec.make_attempt, spec.node_label,
+                                     spec.setup_type) for spec in setup_specs
         ])
         node_failures: List[SetupFailure] = [
-            (spec[1], spec[2], reason)
+            SetupFailure(task_name=spec.task_name,
+                         node_label=spec.node_label,
+                         reason=reason)
             for spec, reason in zip(setup_specs, results)
             if reason is not None
         ]

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -281,6 +281,14 @@ class StrategyExecutor:
         # uniform result), the controller could own a single generic loop
         # and this override would be unnecessary.
 
+        Contract for implementations: if the strategy owns the loop and
+        invokes ``on_recovery`` (JobGroups pass their networking refresh
+        here), it must handle ``exceptions.ClusterSetUpError`` from it the
+        way ``JobController._monitor_one_task`` does: mark the task
+        FAILED_SETUP with the exception message and return False. Letting
+        it escape gets swallowed into the group's monitor results with no
+        terminal state set for the task.
+
         Returns:
             None: fall back to OSS default monitor.
             True: task succeeded (strategy handled monitoring).

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -698,11 +698,11 @@ def launch(
     dag.resolve_and_validate_volumes()
     if not dag.is_chain() and not dag.is_job_group():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('Only single-task, chain DAG, or JobGroup is '
+            raise ValueError('Only single-task, chain DAG, or Job Group is '
                              f'allowed for job_launch. Dag: {dag}')
     if dag.is_job_group() and pool is not None:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('JobGroups do not support pools. Please remove '
+            raise ValueError('Job Groups do not support pools. Please remove '
                              'the --pool argument when launching a job group.')
     dag.validate()
     # TODO(aylei): use consolidated job controller instead of performing
@@ -746,13 +746,20 @@ def launch(
                 if task_.best_resources is not None and
                 task_.best_resources.cloud is not None
             }
-            assert len(best_clouds) <= 1, (
-                f'JobGroup {dag.name!r} has in-group networking enabled '
-                f'but was placed on multiple clouds: {sorted(best_clouds)}')
-            assert all(
-                cloud.lower() == 'kubernetes' for cloud in best_clouds), (
-                    f'JobGroup {dag.name!r} has in-group networking '
-                    f'enabled but was placed on {sorted(best_clouds)}')
+            if (len(best_clouds) > 1 or not all(cloud.lower() == 'kubernetes'
+                                                for cloud in best_clouds)):
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        f'Internal error: Job Group {dag.name!r} requires '
+                        'in-group networking (inter_connection is enabled), '
+                        'which is only supported on a single Kubernetes '
+                        'cluster, but the optimizer placed it on '
+                        f'{sorted(best_clouds)}. This is likely a SkyPilot '
+                        'bug; please report it at '
+                        'https://github.com/skypilot-org/skypilot/issues. '
+                        'Set \'inter_connection: false\' '
+                        'in the job group header if the jobs do not need '
+                        'to reach each other by hostname.')
 
     # If there is a local postgres db, when the api server tries launching on
     # the remote jobs controller it will fail. therefore, we should remove this

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1259,12 +1259,14 @@ class Optimizer:
                     matched_resources = resources
                     break
             # Same invariant as above, at region granularity.
+            candidate_regions = sorted(
+                {str(r.region) for r in candidates[matching_cloud]})
             assert matched_resources is not None, (
                 f'Job {task.name!r} has no candidate in the selected region '
                 f'{cloud_name}/{region}; its candidate regions in that cloud '
-                f'are {sorted({str(r.region) for r in candidates[matching_cloud]})}. '
-                'Likely a bug in _find_common_infras or in how candidate '
-                'regions are matched.')
+                f'are {candidate_regions}. Likely a bug in '
+                '_find_common_infras or in how candidate regions are '
+                'matched.')
 
             # Set best_resources on the task
             task.best_resources = matched_resources

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1066,7 +1066,7 @@ class Optimizer:
 
         if not quiet:
             logger.info(
-                f'Optimizing JobGroup "{dag.name}" with {len(tasks)} jobs')
+                f'Optimizing Job Group "{dag.name}" with {len(tasks)} jobs')
 
         # Spec-level validation of the user's infra pins against
         # inter_connection (no catalog lookups). May persist an
@@ -1123,7 +1123,7 @@ class Optimizer:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.ResourcesUnavailableError(
                         f'No resources available for job "{task.name}" '
-                        f'in JobGroup "{dag.name}"')
+                        f'in Job Group "{dag.name}"')
 
             # Build cloud -> launchable resources mapping (with regions)
             cloud_launchables: _PerCloudCandidates = collections.defaultdict(
@@ -1151,7 +1151,7 @@ class Optimizer:
                     # _validate_inter_connection_pins before placement.
                     with ux_utils.print_exception_no_traceback():
                         raise exceptions.ResourcesUnavailableError(
-                            f'JobGroup "{dag.name}" sets '
+                            f'Job Group "{dag.name}" sets '
                             '`inter_connection: true`, which requires '
                             'in-group networking, only supported on '
                             f'Kubernetes, but job "{task.name}" has no '
@@ -1172,7 +1172,7 @@ class Optimizer:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.ResourcesUnavailableError(
                         f'No single infrastructure can host all jobs in '
-                        f'JobGroup "{dag.name}", and in-group networking '
+                        f'Job Group "{dag.name}", and in-group networking '
                         '(inter_connection, enabled by default) requires '
                         'all jobs to be co-located. Set '
                         '`inter_connection: false` to allow jobs to be '
@@ -1183,7 +1183,7 @@ class Optimizer:
             # place each job independently.
             if not quiet:
                 logger.info(f'No common infrastructure for all jobs in '
-                            f'JobGroup "{dag.name}"; placing jobs '
+                            f'Job Group "{dag.name}"; placing jobs '
                             'independently (inter_connection: false).')
             return Optimizer._optimize_independent(dag, minimize,
                                                    blocked_resources, quiet)
@@ -1238,13 +1238,19 @@ class Optimizer:
                 if str(cand_cloud) == cloud_name:
                     matching_cloud = cand_cloud
                     break
-            # best_infra came from the intersection of every task's
-            # candidates, so every task must have a matching candidate. A
-            # silently unpinned task would be re-optimized independently
-            # on the controller and could land on a different infra.
+            # Unreachable by construction: best_infra came from the
+            # intersection _find_common_infras computed over these same
+            # candidates (both sides match clouds by str()); user
+            # infeasibility exits in Step 2. If this fires, the
+            # intersection logic and this lookup have drifted apart.
+            # Restructuring _find_common_infras to return the per-task
+            # matches would make this assert unnecessary.
             assert matching_cloud is not None, (
-                f'Job {task.name!r} has no candidates in the selected '
-                f'cloud {cloud_name!r}')
+                f'Job {task.name!r} has no candidate matching the selected '
+                f'cloud {cloud_name!r}; its candidate clouds are '
+                f'{sorted(str(c) for c in candidates.keys())}. Likely a bug '
+                'in _find_common_infras or in how candidate clouds are '
+                'matched by name.')
 
             # Find resources in this cloud+region
             matched_resources = None
@@ -1252,9 +1258,13 @@ class Optimizer:
                 if resources.region == region:
                     matched_resources = resources
                     break
+            # Same invariant as above, at region granularity.
             assert matched_resources is not None, (
-                f'Job {task.name!r} has no candidates in the selected '
-                f'infra {cloud_name}/{region}')
+                f'Job {task.name!r} has no candidate in the selected region '
+                f'{cloud_name}/{region}; its candidate regions in that cloud '
+                f'are {sorted({str(r.region) for r in candidates[matching_cloud]})}. '
+                'Likely a bug in _find_common_infras or in how candidate '
+                'regions are matched.')
 
             # Set best_resources on the task
             task.best_resources = matched_resources
@@ -1805,6 +1815,9 @@ def _validate_inter_connection_pins(dag: 'dag_lib.Dag', quiet: bool) -> bool:
         job must be placed independently; False when the common-infra
         search should run.
     """
+    # Gather everything first -- each job's pins, any job pinned off
+    # Kubernetes, and whether the pins conflict -- then branch on the
+    # inter_connection value exactly once per case below.
     pinned_task_clouds: Dict[str, Set[str]] = {}
     pinned_task_infras: Dict[str, Set[str]] = {}
     for task in dag.tasks:
@@ -1814,45 +1827,61 @@ def _validate_inter_connection_pins(dag: 'dag_lib.Dag', quiet: bool) -> bool:
         if infra_pins is not None:
             pinned_task_infras[str(task.name)] = infra_pins
 
-    if dag.inter_connection is True:
-        for task_name, cloud_pins in pinned_task_clouds.items():
-            if not any(cloud.lower() == 'kubernetes' for cloud in cloud_pins):
-                with ux_utils.print_exception_no_traceback():
-                    raise exceptions.ResourcesUnavailableError(
-                        f'JobGroup "{dag.name}" sets '
-                        '`inter_connection: true`, which requires '
-                        'in-group networking, only supported on '
-                        f'Kubernetes, but job "{task_name}" pins '
-                        f'non-Kubernetes infra ({sorted(cloud_pins)}). '
-                        'Remove the non-Kubernetes infra pins, or set '
-                        '`inter_connection: false` if the jobs do not '
-                        'need to reach each other by hostname.')
+    # First job whose options pin only non-Kubernetes clouds, if any
+    # (in-group networking is Kubernetes-only).
+    non_k8s_pin: Optional[Tuple[str, Set[str]]] = next(
+        ((task_name, cloud_pins)
+         for task_name, cloud_pins in pinned_task_clouds.items()
+         if not any(cloud.lower() == 'kubernetes' for cloud in cloud_pins)),
+        None)
 
     clouds_conflict = (len(pinned_task_clouds) > 1 and
                        not set.intersection(*pinned_task_clouds.values()))
     infras_conflict = (len(pinned_task_infras) > 1 and
                        not set.intersection(*pinned_task_infras.values()))
-    if not (clouds_conflict or infras_conflict):
+    pins_conflict = clouds_conflict or infras_conflict
+    pins_desc = ''
+    if pins_conflict:
+        # Show each job's own pins so the user can see exactly which jobs
+        # disagree, at the granularity that conflicted.
+        conflicting_pins = (pinned_task_infras
+                            if infras_conflict else pinned_task_clouds)
+        pins_desc = '; '.join(f'{name}: {sorted(pins)}'
+                              for name, pins in conflicting_pins.items())
+
+    if dag.inter_connection is True:
+        # Explicitly required networking: both a non-Kubernetes pin and
+        # conflicting pins are user-ask contradictions -> error.
+        if non_k8s_pin is not None:
+            task_name, cloud_pins = non_k8s_pin
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ResourcesUnavailableError(
+                    f'Job Group "{dag.name}" sets '
+                    '`inter_connection: true`, which requires '
+                    'in-group networking, only supported on '
+                    f'Kubernetes, but job "{task_name}" pins '
+                    f'non-Kubernetes infra ({sorted(cloud_pins)}). '
+                    'Remove the non-Kubernetes infra pins, or set '
+                    '`inter_connection: false` if the jobs do not '
+                    'need to reach each other by hostname.')
+        if pins_conflict:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ResourcesUnavailableError(
+                    f'Jobs in Job Group "{dag.name}" pin infrastructures '
+                    f'with no common option ({pins_desc}), but '
+                    '`inter_connection: true` requires in-group networking, '
+                    'which does not work across infrastructures. Unify the '
+                    'infra pins, or set `inter_connection: false` if the '
+                    'jobs do not need to reach each other by hostname.')
         return False
 
-    # Show each job's own pins so the user can see exactly which jobs
-    # disagree, at the granularity that conflicted.
-    conflicting_pins = (pinned_task_infras
-                        if infras_conflict else pinned_task_clouds)
-    pins_desc = '; '.join(
-        f'{name}: {sorted(pins)}' for name, pins in conflicting_pins.items())
-    if dag.inter_connection is True:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.ResourcesUnavailableError(
-                f'Jobs in JobGroup "{dag.name}" pin infrastructures with '
-                f'no common option ({pins_desc}), but '
-                '`inter_connection: true` requires in-group networking, '
-                'which does not work across infrastructures. Unify the '
-                'infra pins, or set `inter_connection: false` if the jobs '
-                'do not need to reach each other by hostname.')
+    if not pins_conflict:
+        return False
+
+    # Deliberately cross-infra pins: place each job independently.
     if dag.inter_connection is None:
         logger.warning(
-            f'Jobs in JobGroup "{dag.name}" pin infrastructures with no '
+            f'Jobs in Job Group "{dag.name}" pin infrastructures with no '
             f'common option ({pins_desc}); in-group networking will not '
             'be set up and jobs cannot reach each other by hostname. Set '
             '`inter_connection: false` to silence this warning.')
@@ -1862,7 +1891,7 @@ def _validate_inter_connection_pins(dag: 'dag_lib.Dag', quiet: bool) -> bool:
         # placement where hostnames can never resolve.
         dag.inter_connection = False
     elif not quiet:
-        logger.info(f'Jobs in JobGroup "{dag.name}" pin different '
+        logger.info(f'Jobs in Job Group "{dag.name}" pin different '
                     'infrastructures; optimizing each job independently.')
     return True
 

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -159,6 +159,13 @@ def apply(
     if dag.is_job_group():
         assert dag.execution is not None
         mutated_dag.set_execution(dag.execution)
+        # Preserve the rest of the JobGroup header: these live on the Dag,
+        # not on the tasks the policy mutates, so a fresh Dag would
+        # silently drop them (e.g., an explicit `inter_connection: false`
+        # would revert to unset, which behaves as enabled).
+        mutated_dag.inter_connection = dag.inter_connection
+        mutated_dag.primary_tasks = dag.primary_tasks
+        mutated_dag.termination_delay = dag.termination_delay
 
     mutated_config = None
     for task in dag.tasks:

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -499,26 +499,26 @@ def _load_job_group(
     """
     if not configs or len(configs) < 2:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('JobGroup YAML must have at least 2 documents: '
+            raise ValueError('Job Group YAML must have at least 2 documents: '
                              'header and at least one job definition.')
 
     # Parse header
     header = configs[0]
     if header is None:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('JobGroup header cannot be empty.')
+            raise ValueError('Job Group header cannot be empty.')
 
     # Validate header has required fields
     missing_fields = _JOB_GROUP_REQUIRED_HEADER_FIELDS - set(header.keys())
     if missing_fields:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(
-                f'JobGroup header missing required fields: {missing_fields}')
+                f'Job Group header missing required fields: {missing_fields}')
 
     # Warn about unknown fields in header
     unknown_fields = set(header.keys()) - _JOB_GROUP_HEADER_FIELDS
     if unknown_fields:
-        logger.warning(f'Unknown fields in JobGroup header: {unknown_fields}. '
+        logger.warning(f'Unknown fields in Job Group header: {unknown_fields}. '
                        'These will be ignored.')
 
     group_name = header['name']
@@ -548,7 +548,7 @@ def _load_job_group(
     job_configs = configs[1:]
     if not job_configs:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('JobGroup must have at least one job definition.')
+            raise ValueError('Job Group must have at least one job definition.')
 
     # Create DAG using context manager pattern (consistent with _load_chain_dag)
     job_names = set()
@@ -562,7 +562,7 @@ def _load_job_group(
             if job_name is None:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        f'Job {i + 1} in JobGroup must have a "name" field.')
+                        f'Job {i + 1} in Job Group must have a "name" field.')
 
             # Validate job name is safe for shell/filesystem use
             if not all(c.isalnum() or c in '-_' for c in job_name):
@@ -576,7 +576,7 @@ def _load_job_group(
             if job_name in job_names:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        f'Duplicate job name in JobGroup: {job_name}')
+                        f'Duplicate job name in Job Group: {job_name}')
             job_names.add(job_name)
 
             # Create task from job config (auto-added to current dag context)
@@ -657,7 +657,7 @@ def _load_job_group(
                                  f'{inter_connection!r}')
         dag.inter_connection = inter_connection
 
-    logger.info(f'Loaded JobGroup "{group_name}" with {len(dag.tasks)} jobs: '
+    logger.info(f'Loaded Job Group "{group_name}" with {len(dag.tasks)} jobs: '
                 f'{[t.name for t in dag.tasks]}')
 
     return dag

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -3132,6 +3132,99 @@ def test_job_group_networking_custom_image(generic_cloud: str, image_id: str):
 
 @pytest.mark.managed_jobs
 @pytest.mark.kubernetes
+def test_job_group_networking_recovery():
+    """In-group networking re-establishes after a task is preempted.
+
+    Deletes one task's pod mid-run and asserts, via epoch-tagged connect
+    logs from both tasks, that after recovery (a) the surviving peer
+    reaches the recovered task's new pod, and (b) the recovered task's
+    fresh pod gets networking set up again and reaches its peer.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    # Task names become the managed cluster names (and the
+    # `skypilot-cluster-name` pod annotation the deletion command greps),
+    # so they must be unique per test run in a shared namespace.
+    suffix = name.replace('-', '')[-8:]
+    srv_task = f'srv{suffix}'
+    png_task = f'png{suffix}'
+    yaml_path = _render_job_group_yaml(
+        'tests/test_job_groups/smoke_networking_recovery.yaml',
+        name,
+        'kubernetes',
+        suffix=suffix)
+
+    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
+                      f'awk \'{{print $1}}\'')
+    delete_server_pod_cmd = (
+        'kubectl get pods -l skypilot-cluster-name --no-headers '
+        '-o custom-columns="NAME:.metadata.name,'
+        'CLUSTER:.metadata.annotations.skypilot-cluster-name" | '
+        f'grep -- "{srv_task}-" | grep -v -- "-cloud-cmd" | '
+        'awk \'{print $1}\' | head -1 | xargs kubectl delete pod')
+
+    def wait_connect_after(task: str, epoch_file: str, timeout: int) -> str:
+        """Poll a task's logs for a CONNECT_OK whose epoch is newer than
+        the recorded pod-deletion epoch (pre-deletion lines don't count)."""
+        return (
+            f'DEL=$(cat {epoch_file}); END=$(($(date +%s) + {timeout})); '
+            f'until sky jobs logs $({get_job_id_cmd}) {task} --no-follow | '
+            'grep -o "epoch=[0-9]*" | cut -d= -f2 | '
+            'awk -v t="$DEL" \'$1 > t\' | grep -q .; do '
+            'if [ $(date +%s) -gt $END ]; then '
+            f'echo "Timed out waiting for post-recovery connect from {task}"; '
+            'exit 1; fi; sleep 15; done; '
+            f'echo "{task} reconnected post-recovery"')
+
+    epoch_file = f'/tmp/{name}-del-epoch'
+    test = smoke_tests_utils.Test(
+        'job_group_networking_recovery',
+        [
+            smoke_tests_utils.launch_cluster_for_cloud_cmd('kubernetes', name),
+            f'sky jobs launch {yaml_path} -y -d',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.RUNNING],
+                timeout=300),
+            # Initial connectivity before the preemption, so the recovery
+            # assertions below measure re-establishment, not first setup.
+            (f'END=$(($(date +%s) + 240)); '
+             f'until sky jobs logs $({get_job_id_cmd}) {png_task} '
+             '--no-follow | grep -q CONNECT_OK; do '
+             'if [ $(date +%s) -gt $END ]; then '
+             'echo "Timed out waiting for initial connectivity"; exit 1; fi; '
+             'sleep 10; done'),
+            # Record the deletion epoch, then preempt the server task's pod.
+            f'date +%s | tee {epoch_file}',
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name, cmd=delete_server_pod_cmd),
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.RECOVERING],
+                timeout=managed_jobs_utils.JOB_STATUS_CHECK_GAP_SECONDS * 3,
+                gap_seconds=2),
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.RUNNING],
+                timeout=300),
+            # Surviving peer reaches the recovered task's NEW pod.
+            wait_connect_after(png_task, epoch_file, timeout=300),
+            # Recovered task's fresh pod got networking set up again
+            # (its wait script passed and it resolves its peer).
+            wait_connect_after(srv_task, epoch_file, timeout=300),
+        ],
+        (f'sky jobs cancel -y -n {name}; '
+         f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}'),
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.kubernetes
 def test_job_group_rl_architecture(generic_cloud: str):
     """Test JobGroup with RL-style heterogeneous architecture (4 components)."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/test_job_groups/smoke_networking_recovery.yaml
+++ b/tests/test_job_groups/smoke_networking_recovery.yaml
@@ -1,0 +1,42 @@
+# JobGroup networking recovery smoke test.
+# Two long-running tasks curl each other's hostname in a loop, logging
+# epoch-tagged CONNECT_OK lines. The test deletes one task's pod and
+# asserts both directions reconnect after recovery. Task names are
+# uniquified via {{suffix}} because they become the managed cluster names
+# (the `skypilot-cluster-name` pod annotation), which the test greps to
+# pick its deletion target in a shared namespace.
+---
+name: {{name}}
+execution: parallel
+---
+name: srv{{suffix}}
+resources:
+  cpus: 2
+  infra: {{cloud}}
+run: |
+  python3 -m http.server 8080 &
+  PEER="png{{suffix}}-0.${SKYPILOT_JOBGROUP_NAME}"
+  for i in $(seq 1 600); do
+    if curl -s --connect-timeout 5 http://$PEER:8080/ > /dev/null 2>&1; then
+      echo "CONNECT_OK peer=$PEER attempt=$i epoch=$(date +%s)"
+    else
+      echo "CONNECT_FAIL peer=$PEER attempt=$i"
+    fi
+    sleep 3
+  done
+---
+name: png{{suffix}}
+resources:
+  cpus: 2
+  infra: {{cloud}}
+run: |
+  python3 -m http.server 8080 &
+  PEER="srv{{suffix}}-0.${SKYPILOT_JOBGROUP_NAME}"
+  for i in $(seq 1 600); do
+    if curl -s --connect-timeout 5 http://$PEER:8080/ > /dev/null 2>&1; then
+      echo "CONNECT_OK peer=$PEER attempt=$i epoch=$(date +%s)"
+    else
+      echo "CONNECT_FAIL peer=$PEER attempt=$i"
+    fi
+    sleep 3
+  done

--- a/tests/test_job_groups/test_job_group.py
+++ b/tests/test_job_groups/test_job_group.py
@@ -953,7 +953,7 @@ class TestControllerAsyncPatterns:
     """
 
     def test_download_log_uses_to_thread_in_monitor_job_group_task(self):
-        """Verify _download_log_and_stream is called via to_thread.
+        """Verify download_log_and_stream is called via to_thread.
 
         This test ensures the async blocking bug fix is in place by
         checking that the code structure properly awaits to_thread.
@@ -968,26 +968,26 @@ class TestControllerAsyncPatterns:
 
         # Parse the source to check for the pattern
         # We're looking for:
-        #   await context_utils.to_thread(..._download_log_and_stream...)
+        #   await context_utils.to_thread(...download_log_and_stream...)
         tree = ast.parse(source)
 
         # Find all function definitions
         async_methods_with_download = []
         for node in ast.walk(tree):
             if isinstance(node, ast.AsyncFunctionDef):
-                # Check if this async method contains _download_log_and_stream
+                # Check if this async method contains download_log_and_stream
                 method_source = ast.unparse(node)
-                if '_download_log_and_stream' in method_source:
+                if 'download_log_and_stream' in method_source:
                     async_methods_with_download.append(node.name)
                     # Verify it's called via to_thread
                     assert 'to_thread' in method_source, (
                         f'Async method {node.name} calls '
-                        f'_download_log_and_stream but does not use '
+                        f'download_log_and_stream but does not use '
                         f'to_thread - this will block the event loop!')
 
         # Ensure we found the relevant methods
         assert len(async_methods_with_download) > 0, (
-            'No async methods found that call _download_log_and_stream')
+            'No async methods found that call download_log_and_stream')
 
 
 class TestDocstringQuality:

--- a/tests/test_job_groups/test_job_group.py
+++ b/tests/test_job_groups/test_job_group.py
@@ -1351,3 +1351,47 @@ class TestPrimaryAuxiliaryDagMethods:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
+
+
+class TestAdminPolicyPreservesJobGroupHeader:
+    """admin_policy_utils.apply builds a fresh Dag for the mutated
+    request; JobGroup header fields live on the Dag (not the tasks the
+    policy mutates), so they must be copied over explicitly. Without
+    this, an explicit `inter_connection: false` silently reverts to
+    unset -- which behaves as enabled -- once any admin policy is
+    registered (and primary_tasks/termination_delay are dropped too).
+    """
+
+    def test_apply_preserves_job_group_header_fields(self, monkeypatch):
+        from sky import admin_policy
+        from sky import dag as dag_lib
+        from sky import task as task_lib
+        from sky.server.requests import request_names
+        from sky.utils import admin_policy_utils
+
+        dag = dag_lib.Dag()
+        dag.name = 'group'
+        dag.add(task_lib.Task(name='job-a', run='echo hi'))
+        dag.set_execution(dag_lib.DagExecution.PARALLEL)
+        dag.inter_connection = False
+        dag.primary_tasks = ['job-a']
+        dag.termination_delay = '30s'
+
+        class _IdentityPolicy:
+
+            def apply(self, user_request):
+                return admin_policy.MutatedUserRequest(
+                    task=user_request.task,
+                    skypilot_config=user_request.skypilot_config)
+
+        monkeypatch.setattr(admin_policy_utils, '_get_policy_impl',
+                            lambda location: _IdentityPolicy())
+
+        mutated_dag, _ = admin_policy_utils.apply(
+            dag, request_name=request_names.AdminPolicyRequestName.JOBS_LAUNCH)
+
+        assert mutated_dag is not dag
+        assert mutated_dag.is_job_group()
+        assert mutated_dag.inter_connection is False
+        assert mutated_dag.primary_tasks == ['job-a']
+        assert mutated_dag.termination_delay == '30s'

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1957,3 +1957,60 @@ class TestJobGroupOnRecoveryNetworking:
             setup_failures=[], inter_connection_enabled=False)
         assert error is None
         net.setup_job_group_networking.assert_not_awaited()
+
+
+class TestOnRecoveryIncludesInlineTasks:
+    """on_recovery must refresh ALL group tasks, including tasks that
+    inline their DNS delivery in task.run.
+
+    The inline/push split exists only in Phase 3 (initial delivery,
+    where the inline prelude will do the job itself). Post-recovery,
+    inline tasks go through the same push path as everyone else -- same
+    retries, same own-vs-peer classification -- and the PID-file-guarded
+    start makes the controller push race-safe against the recovered
+    task's own prelude. Guard against anyone 'harmonizing' on_recovery
+    with Phase 3's inline skip.
+    """
+
+    @pytest.mark.asyncio
+    async def test_setup_receives_every_group_task(self):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._dag = MagicMock()
+        controller._dag.inter_connection_enabled = MagicMock(return_value=True)
+        task = MagicMock()
+        task.name = 'job-a'
+        inline_peer = MagicMock()
+        inline_peer.name = 'job-inline'
+
+        captured = {}
+
+        async def fake_monitor_task(**kwargs):
+            captured['on_recovery'] = kwargs['on_recovery']
+            return True
+
+        executor = MagicMock()
+        executor.monitor_task = fake_monitor_task
+
+        with patch('sky.jobs.controller.job_group_networking') as net, \
+             patch('sky.jobs.controller.managed_job_utils') as utils, \
+             patch('sky.jobs.controller.global_user_state') as gus:
+            net.setup_job_group_networking = AsyncMock(return_value=[])
+            # Even if the peer inlines its DNS delivery, on_recovery must
+            # not consult dns_addresses_for_task -- assert it is never
+            # used as a filter.
+            net.dns_addresses_for_task.return_value = ['inline-addr']
+            utils.generate_managed_job_cluster_name.side_effect = (
+                lambda name, job_id: f'{name}-{job_id}')
+            gus.get_handle_from_cluster_name.return_value = MagicMock()
+
+            await JobController._monitor_job_group_task(
+                controller, 0, task, 'cluster-a', executor, 'group',
+                [(task, MagicMock()), (inline_peer, MagicMock())])
+            await captured['on_recovery']()
+
+            net.setup_job_group_networking.assert_awaited_once()
+            _, passed_handles = (net.setup_job_group_networking.await_args.args)
+            passed_tasks = [t for t, _ in passed_handles]
+            assert passed_tasks == [task, inline_peer]
+            net.dns_addresses_for_task.assert_not_called()

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -744,6 +744,11 @@ class TestTaskCleanup:
                 'sky.jobs.utils.generate_managed_job_cluster_name',
                 return_value='test-cluster'),
             'status': patch('sky.core.status', return_value=[]),
+            # File-mount cleanup is gated on NOT consolidation mode; pin
+            # it so the test does not depend on the local ~/.sky config
+            # (a configured API server endpoint flips it to True).
+            'consolidation': patch('sky.jobs.utils.is_consolidation_mode',
+                                   return_value=False),
             'backend': patch('sky.backends.cloud_vm_ray_backend.'
                              'CloudVmRayBackend'),
         }

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1877,7 +1877,8 @@ class TestJobGroupOnRecoveryNetworking:
 
     async def _captured_on_recovery(self,
                                     setup_failures,
-                                    inter_connection_enabled=True):
+                                    inter_connection_enabled=True,
+                                    self_delivering=False):
         """Run _monitor_job_group_task with a fake executor, return the
         captured on_recovery callback invoked under patches."""
         controller = MagicMock(spec=JobController)
@@ -1904,6 +1905,10 @@ class TestJobGroupOnRecoveryNetworking:
              patch('sky.jobs.controller.global_user_state') as gus:
             net.setup_job_group_networking = AsyncMock(
                 return_value=setup_failures)
+            # Non-None marks the recovered task as self-delivering
+            # (inline task.run prelude owns its updater delivery).
+            net.dns_addresses_for_task.return_value = (
+                ['inline-addr'] if self_delivering else None)
             utils.generate_managed_job_cluster_name.side_effect = (
                 lambda name, job_id: f'{name}-{job_id}')
             gus.get_handle_from_cluster_name.return_value = MagicMock()
@@ -1952,6 +1957,19 @@ class TestJobGroupOnRecoveryNetworking:
         assert isinstance(error, exceptions.ClusterSetUpError)
 
     @pytest.mark.asyncio
+    async def test_self_delivering_own_failure_does_not_raise(self):
+        # An inline (self-delivering) task's relaunched run prelude
+        # starts its own updater; the controller push is a best-effort
+        # top-up in every phase (Phase 3 skips such tasks entirely), so
+        # a push failure on its own nodes must not be fatal either --
+        # the prelude may well have succeeded.
+        _, error = await self._captured_on_recovery(setup_failures=[
+            ('job-a', 'job-a-0', 'exec transport broken')
+        ],
+                                                    self_delivering=True)
+        assert error is None
+
+    @pytest.mark.asyncio
     async def test_disabled_inter_connection_skips_setup(self):
         net, error = await self._captured_on_recovery(
             setup_failures=[], inter_connection_enabled=False)
@@ -1997,8 +2015,9 @@ class TestOnRecoveryIncludesInlineTasks:
              patch('sky.jobs.controller.global_user_state') as gus:
             net.setup_job_group_networking = AsyncMock(return_value=[])
             # Even if the peer inlines its DNS delivery, on_recovery must
-            # not consult dns_addresses_for_task -- assert it is never
-            # used as a filter.
+            # not use dns_addresses_for_task to filter the push list (it
+            # is only consulted for fatality classification, and only
+            # when the recovered task's own nodes failed).
             net.dns_addresses_for_task.return_value = ['inline-addr']
             utils.generate_managed_job_cluster_name.side_effect = (
                 lambda name, job_id: f'{name}-{job_id}')

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1860,3 +1860,100 @@ class TestAddK8sAnnotations:
         controller_module._add_k8s_annotations(task, job_id=1)
 
         assert self._pod_config(task) == after_first
+
+
+class TestJobGroupOnRecoveryNetworking:
+    """on_recovery re-runs networking setup after a task recovers.
+
+    Failures on the recovered task's OWN nodes are fatal
+    (ClusterSetUpError -> FAILED_SETUP): its fresh pod has no DNS
+    updater or readiness marker, so without setup its networking wait
+    would stall and fail minutes later with a generic message.
+    Peer-only failures must NOT fail the task: a healthy peer's running
+    updater short-circuits the re-push, so a failing peer is usually
+    itself mid-recovery (simultaneous preemption) and its own recovery
+    re-runs this setup.
+    """
+
+    async def _captured_on_recovery(self,
+                                    setup_failures,
+                                    inter_connection_enabled=True):
+        """Run _monitor_job_group_task with a fake executor, return the
+        captured on_recovery callback invoked under patches."""
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._dag = MagicMock()
+        controller._dag.inter_connection_enabled = MagicMock(
+            return_value=inter_connection_enabled)
+        task = MagicMock()
+        task.name = 'job-a'
+        peer = MagicMock()
+        peer.name = 'job-b'
+
+        captured = {}
+
+        async def fake_monitor_task(**kwargs):
+            captured['on_recovery'] = kwargs['on_recovery']
+            return True
+
+        executor = MagicMock()
+        executor.monitor_task = fake_monitor_task
+
+        with patch('sky.jobs.controller.job_group_networking') as net, \
+             patch('sky.jobs.controller.managed_job_utils') as utils, \
+             patch('sky.jobs.controller.global_user_state') as gus:
+            net.setup_job_group_networking = AsyncMock(
+                return_value=setup_failures)
+            utils.generate_managed_job_cluster_name.side_effect = (
+                lambda name, job_id: f'{name}-{job_id}')
+            gus.get_handle_from_cluster_name.return_value = MagicMock()
+
+            result = await JobController._monitor_job_group_task(
+                controller, 0, task, 'cluster-a', executor, 'group',
+                [(task, MagicMock()), (peer, MagicMock())])
+            assert result is True
+            error = None
+            try:
+                await captured['on_recovery']()
+            except Exception as e:  # pylint: disable=broad-except
+                error = e
+            return net, error
+
+    @pytest.mark.asyncio
+    async def test_no_failures_no_error(self):
+        net, error = await self._captured_on_recovery(setup_failures=[])
+        assert error is None
+        net.setup_job_group_networking.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_own_node_failure_raises_cluster_setup_error(self):
+        from sky import exceptions
+        _, error = await self._captured_on_recovery(
+            setup_failures=[('job-a', 'job-a-0', 'K8s DNS updater failed')])
+        assert isinstance(error, exceptions.ClusterSetUpError)
+        assert 'job-a' in str(error)
+        assert 'K8s DNS updater failed' in str(error)
+
+    @pytest.mark.asyncio
+    async def test_peer_only_failure_does_not_raise(self):
+        # Simultaneous preemption: the peer is down awaiting its own
+        # recovery; failing this task for it would turn every
+        # multi-task preemption into a group failure.
+        _, error = await self._captured_on_recovery(
+            setup_failures=[('job-b', 'job-b-0', 'K8s DNS updater failed')])
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_mixed_failures_raise(self):
+        from sky import exceptions
+        _, error = await self._captured_on_recovery(
+            setup_failures=[('job-b', 'job-b-0',
+                             'peer down'), ('job-a', 'job-a-1', 'timeout')])
+        assert isinstance(error, exceptions.ClusterSetUpError)
+
+    @pytest.mark.asyncio
+    async def test_disabled_inter_connection_skips_setup(self):
+        net, error = await self._captured_on_recovery(
+            setup_failures=[], inter_connection_enabled=False)
+        assert error is None
+        net.setup_job_group_networking.assert_not_awaited()

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2038,3 +2038,62 @@ class TestOnRecoveryIncludesInlineTasks:
             passed_tasks = [t for t, _ in passed_handles]
             assert passed_tasks == [task, inline_peer]
             net.dns_addresses_for_task.assert_not_called()
+
+
+class TestOnRecoveryClusterSetUpErrorHandling:
+    """ClusterSetUpError from a Job Group's on_recovery callback must be
+    converted at the _monitor_one_task call site into a terminal
+    FAILED_SETUP (with the real reason) + return False.
+
+    Letting it propagate instead would terminate the Phase 4 monitor
+    asyncio.Task with an exception, which the Phase 4 collection loop
+    swallows into task_results with no terminal state ever set for the
+    task -- run()'s finally would then mislabel the still-RUNNING task
+    as CANCELLED, with the failure reason existing only in controller
+    logs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sets_failed_setup_and_returns_false(self):
+        from sky import exceptions
+
+        controller = JobController.__new__(JobController)
+        controller._job_id = 1
+        controller._pool = None
+        controller._backend = MagicMock()
+        controller._cleanup_cluster = AsyncMock()
+
+        mock_task = MagicMock()
+        mock_task.name = 'test-task'
+        mock_task.num_nodes = 1
+
+        executor = MagicMock()
+        executor.recover = AsyncMock(return_value=12345.0)
+
+        on_recovery = AsyncMock(
+            side_effect=exceptions.ClusterSetUpError('networking gone'))
+
+        with patch('asyncio.sleep', new=AsyncMock()), \
+             patch('sky.jobs.state.get_job_status_with_task_id_async',
+                   new=AsyncMock(return_value=managed_job_state.
+                                 ManagedJobStatus.RECOVERING)), \
+             patch('sky.jobs.state.set_recovered_async', new=AsyncMock()), \
+             patch('sky.jobs.state.set_failed_async',
+                   new=AsyncMock()) as mock_set_failed:
+            succeeded = await controller._monitor_one_task(
+                task_id=0,
+                task=mock_task,
+                cluster_name='test-cluster',
+                executor=executor,
+                callback_func=MagicMock(),
+                force_transit_to_recovering=True,
+                on_recovery=on_recovery,
+            )
+
+        assert succeeded is False
+        on_recovery.assert_awaited_once()
+        mock_set_failed.assert_awaited_once()
+        kwargs = mock_set_failed.call_args.kwargs
+        assert (kwargs['failure_type'] ==
+                managed_job_state.ManagedJobStatus.FAILED_SETUP)
+        assert 'networking gone' in kwargs['failure_reason']

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -23,6 +23,7 @@ import pytest
 import sky
 from sky import task as task_lib
 from sky.jobs import controller as controller_module
+from sky.jobs import job_group_networking
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.controller import ControllerManager
@@ -1938,8 +1939,10 @@ class TestJobGroupOnRecoveryNetworking:
     @pytest.mark.asyncio
     async def test_own_node_failure_raises_cluster_setup_error(self):
         from sky import exceptions
-        _, error = await self._captured_on_recovery(
-            setup_failures=[('job-a', 'job-a-0', 'K8s DNS updater failed')])
+        _, error = await self._captured_on_recovery(setup_failures=[
+            job_group_networking.SetupFailure('job-a', 'job-a-0',
+                                              'K8s DNS updater failed')
+        ])
         assert isinstance(error, exceptions.ClusterSetUpError)
         assert 'job-a' in str(error)
         assert 'K8s DNS updater failed' in str(error)
@@ -1949,16 +1952,19 @@ class TestJobGroupOnRecoveryNetworking:
         # Simultaneous preemption: the peer is down awaiting its own
         # recovery; failing this task for it would turn every
         # multi-task preemption into a group failure.
-        _, error = await self._captured_on_recovery(
-            setup_failures=[('job-b', 'job-b-0', 'K8s DNS updater failed')])
+        _, error = await self._captured_on_recovery(setup_failures=[
+            job_group_networking.SetupFailure('job-b', 'job-b-0',
+                                              'K8s DNS updater failed')
+        ])
         assert error is None
 
     @pytest.mark.asyncio
     async def test_mixed_failures_raise(self):
         from sky import exceptions
-        _, error = await self._captured_on_recovery(
-            setup_failures=[('job-b', 'job-b-0',
-                             'peer down'), ('job-a', 'job-a-1', 'timeout')])
+        _, error = await self._captured_on_recovery(setup_failures=[
+            job_group_networking.SetupFailure('job-b', 'job-b-0', 'peer down'),
+            job_group_networking.SetupFailure('job-a', 'job-a-1', 'timeout')
+        ])
         assert isinstance(error, exceptions.ClusterSetUpError)
 
     @pytest.mark.asyncio
@@ -1969,7 +1975,8 @@ class TestJobGroupOnRecoveryNetworking:
         # a push failure on its own nodes must not be fatal either --
         # the prelude may well have succeeded.
         _, error = await self._captured_on_recovery(setup_failures=[
-            ('job-a', 'job-a-0', 'exec transport broken')
+            job_group_networking.SetupFailure('job-a', 'job-a-0',
+                                              'exec transport broken')
         ],
                                                     self_delivering=True)
         assert error is None

--- a/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
+++ b/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
@@ -290,7 +290,10 @@ class TestInjectEtcHosts:
                 'group',
                 [(self._mk_task('job-a'), self._mk_handle([ok_runner])),
                  (self._mk_task('job-b'), self._mk_handle([bad_runner]))]))
-        assert failures == [('job-b', 'job-b-0', 'K8s DNS updater failed')]
+        assert failures == [
+            job_group_networking.SetupFailure('job-b', 'job-b-0',
+                                              'K8s DNS updater failed')
+        ]
 
     @pytest.mark.asyncio
     async def test_all_success_returns_empty(self, monkeypatch):
@@ -321,5 +324,5 @@ class TestInjectEtcHosts:
             job_group_networking.NetworkConfigurator._inject_etc_hosts(
                 'group', [(self._mk_task('job-a'), handle)]))
         assert len(failures) == 1
-        assert failures[0][0] == 'job-a'
-        assert 'command runners' in failures[0][2]
+        assert failures[0].task_name == 'job-a'
+        assert 'command runners' in failures[0].reason

--- a/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
+++ b/tests/unit_tests/test_sky/jobs/test_job_group_networking.py
@@ -1,4 +1,11 @@
-"""Unit tests for JobGroup networking script generation."""
+"""Unit tests for JobGroup networking script generation and setup."""
+import asyncio
+from unittest import mock
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
 from sky.jobs import job_group_networking
 
 
@@ -81,3 +88,238 @@ class TestPhase3VariableScoping:
             f'Names bound only inside the Phase 3 inter_connection gate but '
             f'read afterwards: {sorted(leaked)}. Bind them before the gate '
             'so both branches reach Phase 4.')
+
+
+class TestWaitScriptDiagnostic:
+    """The timeout diagnostic must report updater liveness truthfully."""
+
+    def test_diagnostic_uses_pid_file_not_pgrep(self):
+        # pgrep -f can match the probing shell's own command line (it
+        # contains the pattern), reporting 'yes' for a dead updater --
+        # exactly when someone is reading this output to debug.
+        script = job_group_networking.generate_wait_for_networking_script(
+            'group', ['peer1'])
+        assert 'UPDATER_PID_FILE' in script
+        assert 'kill -0' in script
+        assert 'pgrep' not in script
+
+
+class TestUpdaterScriptPidFile:
+    """The updater records its PID so liveness checks (idempotent start,
+    wait-script diagnostic) never rely on self-matching pgrep."""
+
+    def test_updater_script_writes_pid_file(self):
+        script = job_group_networking.generate_k8s_dns_updater_script(
+            [('svc.cluster.local', 'peer-0.group')], 'group')
+        assert ('echo $$ > "/tmp/skypilot-jobgroup-dns-updater-group.pid"'
+                in script)
+
+
+class TestUpdaterStartCommand:
+    """The updater start command is idempotent via the PID file: healthy
+    survivors keep their running updater on re-pushes, and repeated
+    pushes never stack duplicate updater processes."""
+
+    def _make_runner(self, returncode=0):
+        runner = MagicMock()
+        runner.rsync = MagicMock()
+        runner.run = MagicMock(return_value=(returncode, '', ''))
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_start_is_pid_file_guarded(self):
+        runner = self._make_runner()
+        ok = await job_group_networking._start_k8s_dns_updater_on_node(
+            runner, [('svc.cluster.local', 'peer-0.group')], 'group')
+        assert ok is True
+        run_cmd = runner.run.call_args[0][0]
+        pid_file = '/tmp/skypilot-jobgroup-dns-updater-group.pid'
+        marker = '/tmp/skypilot-jobgroup-network-ready-group'
+        assert run_cmd.startswith(f'if [ -f {pid_file} ]')
+        assert 'kill -0' in run_cmd
+        # pgrep -f would match this very command line and always report
+        # 'running' (the old start verification was vacuous because of
+        # this).
+        assert 'pgrep' not in run_cmd
+        assert 'nohup' in run_cmd
+        # The readiness marker is created on both branches: already-alive
+        # and started-and-verified.
+        assert run_cmd.count(f'touch {marker}') == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_start_fails(self):
+        runner = self._make_runner(returncode=1)
+        ok = await job_group_networking._start_k8s_dns_updater_on_node(
+            runner, [('svc.cluster.local', 'peer-0.group')], 'group')
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_returncode_143_treated_as_success(self):
+        # kubectl exec closing the connection SIGTERMs the shell; the
+        # detached updater keeps running.
+        runner = self._make_runner(returncode=143)
+        ok = await job_group_networking._start_k8s_dns_updater_on_node(
+            runner, [('svc.cluster.local', 'peer-0.group')], 'group')
+        assert ok is True
+
+
+class TestInlinePreludeGuard:
+    """The inline task.run prelude must not stack a duplicate updater
+    when the task is restarted on the same cluster
+    (max_restarts_on_errors re-runs task.run on the same pod)."""
+
+    def test_inline_start_is_pid_file_guarded(self):
+        with mock.patch.object(job_group_networking,
+                               '_generate_k8s_dns_mappings_from_runtime',
+                               return_value=[('svc.cluster.local',
+                                              'peer-0.group')]):
+            script = (
+                job_group_networking.generate_inline_networking_setup_script(
+                    'group', [MagicMock()], 1))
+        pid_file = '/tmp/skypilot-jobgroup-dns-updater-group.pid'
+        assert f'if ! ([ -f {pid_file} ]' in script
+        assert 'kill -0' in script
+        # The marker is created whether or not a new updater started.
+        assert script.strip().endswith(
+            'touch /tmp/skypilot-jobgroup-network-ready-group')
+
+
+class TestSetupNodeWithRetries:
+    """Each node retries independently with its own budget; the final
+    reason string is what surfaces in the ClusterSetUpError."""
+
+    @pytest.mark.asyncio
+    async def test_success_first_attempt(self):
+        attempt = AsyncMock(return_value=True)
+        reason = await job_group_networking._setup_node_with_retries(
+            attempt, 'a-0', 'K8s DNS updater')
+        assert reason is None
+        assert attempt.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_RETRY_INITIAL_BACKOFF_SECONDS', 0.001)
+        attempt = AsyncMock(side_effect=[False, True])
+        reason = await job_group_networking._setup_node_with_retries(
+            attempt, 'a-0', 'K8s DNS updater')
+        assert reason is None
+        assert attempt.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausted_budget_reports_reason(self, monkeypatch):
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_RETRY_INITIAL_BACKOFF_SECONDS', 0.001)
+        attempt = AsyncMock(return_value=False)
+        reason = await job_group_networking._setup_node_with_retries(
+            attempt, 'a-0', 'K8s DNS updater')
+        assert reason == 'K8s DNS updater failed'
+        assert (attempt.await_count == job_group_networking._SETUP_MAX_ATTEMPTS)
+
+    @pytest.mark.asyncio
+    async def test_timeout_reports_reason(self, monkeypatch):
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_ATTEMPT_TIMEOUT_SECONDS', 0.01)
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_RETRY_INITIAL_BACKOFF_SECONDS', 0.001)
+
+        async def hang():
+            await asyncio.sleep(10)
+            return True
+
+        reason = await job_group_networking._setup_node_with_retries(
+            hang, 'a-0', '/etc/hosts')
+        assert reason is not None
+        assert 'timed out' in reason
+
+    @pytest.mark.asyncio
+    async def test_exception_reports_reason(self, monkeypatch):
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_RETRY_INITIAL_BACKOFF_SECONDS', 0.001)
+
+        async def boom():
+            raise RuntimeError('ssh broke')
+
+        reason = await job_group_networking._setup_node_with_retries(
+            boom, 'a-0', '/etc/hosts')
+        assert reason is not None
+        assert 'raised' in reason
+        assert 'ssh broke' in reason
+
+
+class TestInjectEtcHosts:
+    """Failure aggregation: per-node failures are reported with their
+    task name (so on_recovery can tell own-node from peer failures);
+    handles in transition are skipped, broken handles are reported."""
+
+    def _mk_task(self, name):
+        task = MagicMock()
+        task.name = name
+        return task
+
+    def _mk_handle(self, runners):
+        handle = MagicMock()
+        handle.get_command_runners.return_value = runners
+        return handle
+
+    def _patch_common(self, monkeypatch):
+        monkeypatch.setattr(job_group_networking, '_is_kubernetes',
+                            lambda h: True)
+        monkeypatch.setattr(job_group_networking, '_generate_k8s_dns_mappings',
+                            lambda *a: [('svc', 'host')])
+        monkeypatch.setattr(job_group_networking, '_generate_hosts_entries',
+                            lambda *a: '# header')
+        monkeypatch.setattr(job_group_networking,
+                            '_SETUP_RETRY_INITIAL_BACKOFF_SECONDS', 0.001)
+
+        async def fake_start(runner, mappings, group):
+            return runner.setup_ok
+
+        monkeypatch.setattr(job_group_networking,
+                            '_start_k8s_dns_updater_on_node', fake_start)
+
+    @pytest.mark.asyncio
+    async def test_reports_only_failed_nodes_with_task_name(self, monkeypatch):
+        self._patch_common(monkeypatch)
+        ok_runner = MagicMock()
+        ok_runner.setup_ok = True
+        bad_runner = MagicMock()
+        bad_runner.setup_ok = False
+        failures = await (
+            job_group_networking.NetworkConfigurator._inject_etc_hosts(
+                'group',
+                [(self._mk_task('job-a'), self._mk_handle([ok_runner])),
+                 (self._mk_task('job-b'), self._mk_handle([bad_runner]))]))
+        assert failures == [('job-b', 'job-b-0', 'K8s DNS updater failed')]
+
+    @pytest.mark.asyncio
+    async def test_all_success_returns_empty(self, monkeypatch):
+        self._patch_common(monkeypatch)
+        runner = MagicMock()
+        runner.setup_ok = True
+        failures = await (
+            job_group_networking.NetworkConfigurator._inject_etc_hosts(
+                'group', [(self._mk_task('job-a'), self._mk_handle([runner]))]))
+        assert failures == []
+
+    @pytest.mark.asyncio
+    async def test_none_handle_skipped_not_failed(self, monkeypatch):
+        # A peer mid-recovery has no handle; its own recovery re-runs
+        # setup, so this must not count as a failure.
+        self._patch_common(monkeypatch)
+        failures = await (
+            job_group_networking.NetworkConfigurator._inject_etc_hosts(
+                'group', [(self._mk_task('job-a'), None)]))
+        assert failures == []
+
+    @pytest.mark.asyncio
+    async def test_runner_build_error_is_reported(self, monkeypatch):
+        self._patch_common(monkeypatch)
+        handle = MagicMock()
+        handle.get_command_runners.side_effect = RuntimeError('bad handle')
+        failures = await (
+            job_group_networking.NetworkConfigurator._inject_etc_hosts(
+                'group', [(self._mk_task('job-a'), handle)]))
+        assert len(failures) == 1
+        assert failures[0][0] == 'job-a'
+        assert 'command runners' in failures[0][2]


### PR DESCRIPTION
Stacked on #10297 — everything since Lloyd's review, for self-review before merging into the PR branch.

## Map of Lloyd's review comments → changes

| Lloyd's comment | Resolution | Where |
|---|---|---|
| Docs: unset description implies degrade on placement failure | Rewrote table cell: unset assumes `true` (co-locate + network, capacity failures still hard-fail) and only degrades to `false` when the spec rules networking out (non-k8s request / un-co-locatable pins). Degrade kept deliberately for backward compat with pre-existing non-k8s job groups. | `docs/examples/job-groups.rst` |
| `best_clouds` assert: "make clear k8s-only" | Unreachable via user input (optimizer degrades/raises first), but now a defensive `RuntimeError` with "internal error, please report" + `inter_connection: false` workaround instead of a bare assert. | `jobs/server/core.py` |
| "Is inter_connection + non-k8s even possible at that point?" | No — replied on PR; kept as cheap defense, no code change. | — |
| "Handle the return value of `setup_job_group_networking` in on_recovery?" | Yes. Setup now returns per-node `(task_name, node_label, reason)` failures. **Own-node** failures after recovery → `ClusterSetUpError` → caught at monitor call site → task `FAILED_SETUP` with the real reason (previously: silent, task stalls ~15 min at its networking wait, dies with generic message). **Peer-only** failures → loud log, don't fail the task (see deviation note below). | `jobs/controller.py` |
| "Emergency recovery will catch the RuntimeError and 'fix' nuked clusters — raise ClusterSetUpError?" | Confirmed + fixed exactly as suggested. Mechanism verified: Phase 2 marks tasks RUNNING before Phase 3, so an emergency retry resumes in place and skips relaunch against deleted clusters. `ClusterSetUpError` → `FAILED_SETUP`, terminal. | `jobs/controller.py` Phase 3 |
| "Retry so one flaky SSH doesn't kill a big group?" | Per-node independent retries (3 attempts, 60s per-attempt timeout, jittered backoff), no barrier between nodes. Replaces the global 60s gather timeout, which also destroyed per-node results on timeout. | `job_group_networking.py` |
| "assert matching_cloud → ResourcesUnavailableError?" | Pushed back (replied on PR): unreachable by construction (`best_infra` ∈ intersection of these same candidates); `ResourcesUnavailableError` would mislabel a deterministic bug as retryable capacity. Comment rewritten to state the invariant; assert messages now dump the task's actual candidate clouds/regions so drift is directly visible. | `optimizer.py` |
| Readability nit: gather-then-branch in `_validate_inter_connection_pins` | Done — pins/conflicts gathered up front, one branch per `inter_connection` value. Behavior unchanged (existing direct tests pass). | `optimizer.py` |
| Top-level: "admin_policy_utils — mutated dag should keep inter_connection, False could become True" | Confirmed and fixed. `apply()` builds a **fresh Dag** and only copied `name`/`execution`; with any admin policy registered, `inter_connection` (and also `primary_tasks` + `termination_delay` — same pre-existing hole) were dropped, so explicit `false` reverted to unset ≙ enabled. Full header now copied + regression test. | `utils/admin_policy_utils.py` |

## Extras found while implementing (not in Lloyd's review)

- **pgrep self-match**: the updater start verification used `pgrep -f <name>` whose pattern appears in the probing command line itself → always "running" → verification was vacuous. Updater now writes a PID file (`$$`) on startup; all liveness checks (start guard, verification, wait-script timeout diagnostic) use `[ -f pidfile ] && kill -0`.
- **Duplicate updater accumulation**: every recovery re-push (and every same-pod task restart via the inline `task.run` prelude) `nohup`-ed another updater. Start is now idempotent (skip if alive) in both delivery paths. Deliberately *not* evict-and-restart: a failed restart would leave a healthy survivor with no updater mid-recovery.
- **"Job Group" naming** in all user-facing strings (zhanghao's docs nit, applied to messages).

## ⚠️ One deviation from what we'd discussed (please sanity-check)

We'd converged on "blanket-raise after retries" in `on_recovery`. Implementation surfaced a case that breaks: **simultaneous multi-task preemption** (the normal k8s co-located case). While task A runs `on_recovery`, peer B is down awaiting its own recovery; the push to B exhausts retries every time, and blanket-raise turns every multi-task preemption into a group failure. So: own-node failures raise, peer failures log-and-continue (B's own recovery re-runs the full setup; if B is truly dead its own monitor fails it with correct attribution). Residual accepted gap: a peer that's alive but updater-dead *and* unreachable for the re-push runs on frozen `/etc/hosts` until the next recovery event retries it — logged loudly, surfaces at app level if hit.

## Test plan

`pytest tests/unit_tests/test_optimizer_job_group.py tests/unit_tests/test_sky/jobs/test_job_group_networking.py tests/unit_tests/test_sky/jobs/test_controller.py tests/test_job_groups/test_job_group.py tests/unit_tests/test_admin_policy.py` → **195 passed**; `format.sh` clean.

New coverage: retry wrapper (first-try success / retry-then-success / exhaustion / timeout / exception reasons); PID-file-guarded start command (shape, no pgrep, marker on both branches, rc 143, failure rc); inline prelude guard; wait-script diagnostic; `_inject_etc_hosts` aggregation (own-vs-peer task names, None-handle skip, runner-build error); `on_recovery` fatality split (5 cases); admin-policy header preservation.

**Deliberately not unit-tested** (disclosed, not forgotten): the Phase 3 raise path end-to-end — requires a full `_run_job_group` harness (launch/sync/monitor mocks); the raise site is 6 lines gated on the setup result, and `run()`'s `ClusterSetUpError`→`FAILED_SETUP` dispatch is pre-existing tested behavior. Exercised by the existing inter_connection smoke tests at the integration level. (The `_monitor_one_task` catch — originally on this list — is now unit-tested via the forced-recovery path: FAILED_SETUP + reason + return False.) **Pre-existing base-branch test failures — now fixed in this PR**: `test_download_log_uses_to_thread_in_monitor_job_group_task` (stale on master too: greps for a method renamed upstream; the tests/test_job_groups path isn't in CI selection) and `test_local_dir_mounts_cleaned_up` (under-mocked: outcome depended on the local ~/.sky config flipping `is_consolidation_mode()`). Neither would have been fixed by merging master — test and code were identical to master in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
