### PR TITLE
fix(slurm): use SLURM_NODEID to determine the node index (#10333)

### DIFF
--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import sys
 import time
+from typing import List
 
 import colorama
 import hostlist
@@ -71,6 +72,33 @@ def _get_ip_address() -> str:
     # which resolves hostnames the same way. Using `hostname -I` can return
     # Docker bridge IPs (172.17.x.x) first, causing IP mismatch errors.
     return socket.gethostbyname(socket.gethostname())
+
+
+def _get_node_idx(cluster_ips: List[str], ip_addr: str) -> int:
+    """Get the index of the current node within the cluster.
+
+    Slurm's own node index is preferred over IP matching: the IP resolved
+    inside the task can differ from the IP recorded at provisioning time,
+    e.g. for containerized jobs, nodes with several network interfaces, or
+    clusters where NodeAddr/DNS resolves differently on the login node and
+    inside the compute node runtime.
+    """
+    slurm_node_id = os.environ.get('SLURM_NODEID')
+    if slurm_node_id is not None:
+        try:
+            node_idx = int(slurm_node_id)
+        except ValueError:
+            node_idx = -1
+        if 0 <= node_idx < len(cluster_ips):
+            return node_idx
+    if len(cluster_ips) == 1:
+        # Single-node cluster: 0 is the only possible index.
+        return 0
+    try:
+        return cluster_ips.index(ip_addr)
+    except ValueError as e:
+        raise RuntimeError(f'IP address {ip_addr} not found in '
+                           f'cluster IPs: {cluster_ips}') from e
 
 
 def _get_job_node_ips() -> str:
@@ -202,14 +230,11 @@ def main():
     num_nodes = int(os.environ.get('SLURM_NNODES', 1))
     is_single_node_cluster = (args.cluster_num_nodes == 1)
 
-    # Determine node index from IP (like Ray's cluster_ips_to_node_id)
+    # Determine node index, falling back to matching the node IP (like Ray's
+    # cluster_ips_to_node_id).
     cluster_ips = args.cluster_ips.split(',')
     ip_addr = _get_ip_address()
-    try:
-        node_idx = cluster_ips.index(ip_addr)
-    except ValueError as e:
-        raise RuntimeError(f'IP address {ip_addr} not found in '
-                           f'cluster IPs: {cluster_ips}') from e
+    node_idx = _get_node_idx(cluster_ips, ip_addr)
     node_name = 'head' if node_idx == 0 else f'worker{node_idx}'
 
     # Log files are written to a shared filesystem, so each node must use a

--- a/tests/unit_tests/slurm/test_node_idx.py
+++ b/tests/unit_tests/slurm/test_node_idx.py
@@ -1,0 +1,41 @@
+"""Tests for Slurm node index resolution."""
+
+import pytest
+
+from sky.skylet.executor import slurm
+
+
+class TestGetNodeIdx:
+    """Tests for _get_node_idx."""
+
+    @pytest.mark.parametrize('slurm_node_id,expected', [('0', 0), ('1', 1),
+                                                        ('2', 2)])
+    def test_prefers_slurm_node_id(self, monkeypatch, slurm_node_id, expected):
+        """SLURM_NODEID wins even when the runtime IP is not in cluster_ips."""
+        monkeypatch.setenv('SLURM_NODEID', slurm_node_id)
+        cluster_ips = ['10.244.10.126', '10.244.10.127', '10.244.10.128']
+        assert slurm._get_node_idx(cluster_ips, '10.102.3.53') == expected
+
+    def test_falls_back_to_ip_when_node_id_unset(self, monkeypatch):
+        monkeypatch.delenv('SLURM_NODEID', raising=False)
+        cluster_ips = ['10.0.0.1', '10.0.0.2']
+        assert slurm._get_node_idx(cluster_ips, '10.0.0.2') == 1
+
+    @pytest.mark.parametrize('slurm_node_id', ['2', '-1', 'not-an-int'])
+    def test_falls_back_to_ip_when_node_id_unusable(self, monkeypatch,
+                                                    slurm_node_id):
+        """Out-of-range or non-integer SLURM_NODEID must not be trusted."""
+        monkeypatch.setenv('SLURM_NODEID', slurm_node_id)
+        cluster_ips = ['10.0.0.1', '10.0.0.2']
+        assert slurm._get_node_idx(cluster_ips, '10.0.0.2') == 1
+
+    def test_single_node_cluster_skips_ip_matching(self, monkeypatch):
+        """A one-node cluster has only one possible index."""
+        monkeypatch.delenv('SLURM_NODEID', raising=False)
+        assert slurm._get_node_idx(['10.244.10.126'], '10.102.3.53') == 0
+
+    def test_raises_when_ip_not_in_cluster_ips(self, monkeypatch):
+        monkeypatch.delenv('SLURM_NODEID', raising=False)
+        cluster_ips = ['10.244.10.126', '10.244.10.127']
+        with pytest.raises(RuntimeError, match='not found in cluster IPs'):
+            slurm._get_node_idx(cluster_ips, '10.102.3.53')


### PR DESCRIPTION
Fixes #10333.

## Problem

`sky/skylet/executor/slurm.py` derives the node index by looking up the IP resolved *inside* the task in the cluster IP list recorded *at provisioning time*:

```python
cluster_ips = args.cluster_ips.split(',')
ip_addr = _get_ip_address()
node_idx = cluster_ips.index(ip_addr)
```

Those two views do not always agree — containerized Slurm jobs, nodes with several network interfaces, or clusters where `NodeAddr`/DNS resolves differently on the login node and inside the compute node runtime. When they disagree the task dies during setup:

```
ValueError: '10.102.3.53' is not in list
RuntimeError: IP address 10.102.3.53 not found in cluster IPs: ['10.244.10.126']
```

even though the executor is running on exactly the node Slurm scheduled it on.

## Fix

Prefer Slurm's own `SLURM_NODEID`, which is authoritative for the node's position in the allocation, and keep IP matching as the fallback:

- `SLURM_NODEID` is used when it is present and in range for `cluster_ips`.
- Out-of-range or non-integer values are not trusted and fall through to IP matching.
- A single-node cluster short-circuits to index `0`, since that is the only possible index.
- Otherwise the previous IP lookup runs unchanged, including the same `RuntimeError`.

`SLURM_NODEID` is available here: the executor already reads `SLURM_PROCID` from its own environment a few lines above. `UNSET_STEP_SCOPED_SLURM_ENV` strips those variables from the *user script*, not from the executor process.

## Verification

The executor module cannot be exercised on a real Slurm allocation here, so I ran it against a stub package tree with the real source file, comparing master's logic to the patched one:

| Scenario | master | this PR |
|---|---|---|
| Reporter's case: `SLURM_NODEID=0`, runtime IP `10.102.3.53`, `cluster_ips=['10.244.10.126']` | `RuntimeError: IP address 10.102.3.53 not found in cluster IPs` | `node_idx = 0` |
| Multi-node, `SLURM_NODEID=1`, IP not in list | `RuntimeError: ... not found in cluster IPs` | `node_idx = 1` |
| No `SLURM_NODEID`, IP matches `cluster_ips[1]` | `1` | `1` (unchanged) |

`tests/unit_tests/slurm/test_node_idx.py` adds 9 cases covering all of the above plus the out-of-range / non-integer / raise paths; all pass.

`ip_addr` stays bound in `main()` — it is still used for the worker log prefixes — and is passed into the helper.

`yapf==0.32.0`, `isort==5.12.0` and `mypy==1.19.1` (repo config) are clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
