### PR TITLE
fix(helm): keep /root/.ssh/config writable when sshKeySecret ships a config (#10332)

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -269,7 +269,16 @@ spec:
           for file in /var/skypilot/ssh_keys/*; do
             if [ -f "$file" ]; then
               filename=$(basename "$file")
-              ln -sf "$file" "/root/.ssh/$filename"
+              if [ "$filename" = "config" ]; then
+                # /root/.ssh/config must stay writable: SkyPilot appends
+                # generated cluster entries to it during launches. Secret
+                # volumes are mounted read-only, so copy the user-provided
+                # config instead of symlinking it into the read-only mount.
+                cp "$file" /root/.ssh/config
+                chmod 600 /root/.ssh/config
+              else
+                ln -sf "$file" "/root/.ssh/$filename"
+              fi
             fi
           done
           {{- end }}


### PR DESCRIPTION
## Problem

When the API server is deployed with the Helm chart and `apiService.sshKeySecret` references a Secret that contains a key named `config`, the startup script symlinks it into `/root/.ssh/config`:

```sh
for file in /var/skypilot/ssh_keys/*; do
  if [ -f "$file" ]; then
    filename=$(basename "$file")
    ln -sf "$file" "/root/.ssh/$filename"
  fi
done
```

Kubernetes Secret volumes are mounted **read-only**, so `/root/.ssh/config` becomes a symlink into a read-only tmpfs. SkyPilot later appends generated cluster SSH entries to `/root/.ssh/config` during launches, which then fails:

```text
OSError: [Errno 30] Read-only file system: '/root/.ssh/config'
```

Fixes #10332.

## Fix

Treat `config` specially: **copy** it into a writable `/root/.ssh/config` (mode `600`) instead of symlinking it into the read-only mount. All other key/cert files keep the existing symlink behavior, so nothing else changes. This preserves a user-provided SSH config while keeping the path mutable for SkyPilot's generated entries.

Of the options suggested in the issue, copying was chosen over skipping so a user-supplied config is still honored rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
