### PR TITLE
fix(ssh_node_pools): run the TCP-forwarding sudo calls under askpass (#10303)

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy.py
+++ b/sky/ssh_node_pools/deploy/deploy.py
@@ -447,14 +447,7 @@ def deploy_single_cluster(cluster_name,
         return []
 
     logger.debug('Checking TCP Forwarding Options...')
-    cmd = (
-        'if [ "$(sudo sshd -T | grep allowtcpforwarding)" = "allowtcpforwarding yes" ]; then '
-        f'echo "TCP Forwarding already enabled on head node ({head_node})."; '
-        'else '
-        'sudo sed -i \'s/^#\\?\\s*AllowTcpForwarding.*/AllowTcpForwarding yes/\' '
-        '/etc/ssh/sshd_config && sudo systemctl restart sshd && '
-        f'echo "Successfully enabled TCP Forwarding on head node ({head_node})."; '
-        'fi')
+    cmd = _tcp_forwarding_cmd(askpass_block, head_node)
     result = deploy_utils.run_remote(head_node,
                                      shlex.quote(cmd),
                                      ssh_user,
@@ -1086,6 +1079,26 @@ cat <<'DCGM_SVC' | kubectl --kubeconfig ~/.kube/config apply -f -
 {svc_yaml}
 DCGM_SVC
 """
+
+
+def _tcp_forwarding_cmd(askpass_block: str, head_node: str) -> str:
+    """Build the shell command that ensures sshd allows TCP forwarding.
+
+    Reading `sshd -T` and rewriting `/etc/ssh/sshd_config` both need root,
+    so the sudo calls run under `-A` with the askpass block prepended --
+    the same contract every other privileged block here uses. Without it a
+    host that was not set up for passwordless sudo fails with `sudo: a
+    terminal is required to read the password`.
+    """
+    return (
+        f'{askpass_block}\n'
+        'if [ "$(sudo -A sshd -T | grep allowtcpforwarding)" = "allowtcpforwarding yes" ]; then '
+        f'echo "TCP Forwarding already enabled on head node ({head_node})."; '
+        'else '
+        'sudo -A sed -i \'s/^#\\?\\s*AllowTcpForwarding.*/AllowTcpForwarding yes/\' '
+        '/etc/ssh/sshd_config && sudo -A systemctl restart sshd && '
+        f'echo "Successfully enabled TCP Forwarding on head node ({head_node})."; '
+        'fi')
 
 
 def _prometheus_install_cmd(askpass_block: str) -> str:

--- a/tests/unit_tests/test_ssh_node_pools_deploy.py
+++ b/tests/unit_tests/test_ssh_node_pools_deploy.py
@@ -1,5 +1,7 @@
 """Unit tests for sky/ssh_node_pools/deploy/deploy.py helpers."""
 
+import re
+
 from sky.ssh_node_pools.deploy import deploy
 
 
@@ -67,3 +69,44 @@ def test_prometheus_install_cmd_node_exporter_enabled_not_disabled():
     # The first 'enabled:' after the node-exporter key must be 'true'.
     enabled_line = ne_section[ne_section.index('enabled:'):].splitlines()[0]
     assert enabled_line.strip() == 'enabled: true'
+
+
+def test_tcp_forwarding_cmd_runs_sudo_under_askpass():
+    """Regression for #10303: every sudo here must be reachable without a tty.
+
+    Reading `sshd -T` and rewriting sshd_config need root. When the node has
+    no passwordless sudo, a bare `sudo` aborts with "a terminal is required to
+    read the password" and the deploy fails before k3s is ever installed.
+    """
+    askpass_block = 'echo "askpass"'
+    cmd = deploy._tcp_forwarding_cmd(askpass_block, 'head.example.com')
+
+    # The askpass block must be present verbatim, as in every sibling helper.
+    assert askpass_block in cmd
+
+    # It must come first: SUDO_ASKPASS has to be exported before any sudo runs.
+    assert cmd.index(askpass_block) < cmd.index('sudo')
+
+    # Every sudo invocation must pass -A so it consults SUDO_ASKPASS instead
+    # of trying to prompt on a tty that ssh did not allocate.
+    sudos = re.findall(r'sudo(?: -\S+)*', cmd)
+    assert sudos, cmd
+    assert all(s.startswith('sudo -A') for s in sudos), sudos
+
+    # The behaviour itself is unchanged.
+    assert 'allowtcpforwarding' in cmd
+    assert '/etc/ssh/sshd_config' in cmd
+    assert 'systemctl restart sshd' in cmd
+    assert 'head.example.com' in cmd
+
+
+def test_tcp_forwarding_cmd_without_password_has_no_askpass_block():
+    """Guard against over-fixing: passwordless hosts must be unaffected.
+
+    With no password there is no askpass block to prepend, and `sudo -A` is a
+    no-op because sudo never needs to prompt -- the same reason every other
+    privileged block here passes -A unconditionally.
+    """
+    cmd = deploy._tcp_forwarding_cmd('', 'head.example.com')
+    assert 'SUDO_ASKPASS' not in cmd
+    assert cmd.lstrip().startswith('if [')


### PR DESCRIPTION
Fixes #10303.

## Problem

`sky/ssh_node_pools/deploy/deploy.py` prepends the askpass block and calls `sudo -A` in every privileged remote block — `cleanup_node`, the k3s head/server/agent installs, `_dcgm_exporter_service_cmd`, `_prometheus_install_cmd`. The TCP-forwarding pre-flight was the one exception: it used a bare `sudo` three times and never got the block.

`run_remote` invokes `ssh` without a tty, so on a node that is not configured for passwordless sudo the deploy aborts with exactly what the issue reports:

```
sudo: a terminal is required to read the password; either use the -S option
to read from standard input or configure an askpass helper
```

This happens *before* k3s is installed, so the pool never comes up — even though the user supplied `password:` in the node-pool config. Thanks to @MitchellWeg for pinpointing the line.

## Fix

Extract the command into `_tcp_forwarding_cmd(askpass_block, head_node)`, mirroring the existing `_prometheus_install_cmd(askpass_block)` / `_dcgm_exporter_service_cmd(askpass_block, selector)` helpers, prepend the askpass block, and switch its three `sudo` calls to `sudo -A`.

The command text is otherwise byte-for-byte unchanged.

**Hosts with passwordless sudo are unaffected.** With no password, `create_askpass_script` returns `''` and sudo never needs to prompt, so `-A` is a no-op — which is precisely why every other block in this file already passes `-A` unconditionally.

## Verification

No cloud or cluster needed — this is a string-building helper.

`sudo`/`systemctl` were stubbed to model the two host types, and the command was run through a real shell before and after the change:

| host | before | after |
|---|---|---|
| password required, no tty | ❌ exit 1, `sudo: a terminal is required to read the password` (×2) | ✅ exit 0, `Successfully enabled TCP Forwarding on head node (...)` |
| passwordless sudo (NOPASSWD) | ✅ exit 0 | ✅ exit 0 — unchanged |

Two unit tests added to `tests/unit_tests/test_ssh_node_pools_deploy.py`, following the existing `test_prometheus_install_cmd_*` style:

- `test_tcp_forwarding_cmd_runs_sudo_under_askpass` — the block is present, comes before the first `sudo`, and *every* `sudo` occurrence carries `-A`. Confirmed to fail against the pre-fix command shape.
- `test_tcp_forwarding_cmd_without_password_has_no_askpass_block` — a no-regression guard for the passwordless path.

```
$ pytest tests/unit_tests/test_ssh_node_pools_deploy.py
4 passed
```

`yapf` (0.32.0, `based_on_style = google` from `pyproject.toml`) reports no changes for either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
