### PR TITLE
[Core] Add plugin hook for task-overrideable config keys

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2688,10 +2688,16 @@ class Resources:
             # schema here: on the server (plugins loaded) this is the strict,
             # plugin-aware schema, so keys and value shapes a lenient client
             # passed through are enforced at deserialization.
+            # skip_none=False: the default strips top-level None-valued
+            # keys before validating, which would let an unknown section
+            # through as long as its value is null (it survives into the
+            # overrides regardless). Nested nulls are untouched either
+            # way, so `--config gcp.vpc_name=null` still validates.
             common_utils.validate_schema(
                 cluster_config_overrides,
                 schemas.get_task_schema()['properties']['config'],
-                'Invalid resources.config override: ')
+                'Invalid resources.config override: ',
+                skip_none=False)
         resources_fields['_cluster_config_overrides'] = (
             cluster_config_overrides)
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2268,14 +2268,23 @@ class Resources:
         # can act on them.
         filtered_new_configs = config_utils.Config()
         new_configs = config_utils.Config(new_override_configs or {})
+        missing = object()
         for key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
-            elem = new_configs.get_nested(key, None)
-            if elem is not None:
+            elem = new_configs.get_nested(key, missing)
+            if elem is not missing:
+                # Explicit null values are kept so they can clear an
+                # existing override below.
                 filtered_new_configs.set_nested(key, elem)
         override_configs = skypilot_config.overlay_skypilot_config(
             original_config=config_utils.Config(current_override_configs),
             override_configs=filtered_new_configs,
         )
+        # A null-valued overrideable key (e.g. `--config gcp.vpc_name=null`)
+        # clears the task-level override so the CLI/global config value takes
+        # effect, instead of the existing task value surviving the overlay.
+        for key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
+            if override_configs.get_nested(key, missing) is None:
+                override_configs.pop_nested(key, None)
 
         current_autostop_config = None
         if self.autostop_config is not None:
@@ -2669,8 +2678,22 @@ class Resources:
         resources_fields['_is_image_managed'] = config.pop(
             '_is_image_managed', None)
         resources_fields['_requires_fuse'] = config.pop('_requires_fuse', None)
-        resources_fields['_cluster_config_overrides'] = config.pop(
-            '_cluster_config_overrides', None)
+        cluster_config_overrides = config.pop('_cluster_config_overrides', None)
+        if cluster_config_overrides:
+            # A task's `config` field crosses the client/server boundary as
+            # `resources._cluster_config_overrides`, whose entry in the
+            # resources schema is just `{'type': 'object'}` — so unlike
+            # `job_recovery`, the resources-schema validation above does not
+            # cover its contents. Re-validate against the task-level config
+            # schema here: on the server (plugins loaded) this is the strict,
+            # plugin-aware schema, so keys and value shapes a lenient client
+            # passed through are enforced at deserialization.
+            common_utils.validate_schema(
+                cluster_config_overrides,
+                schemas.get_task_schema()['properties']['config'],
+                'Invalid resources.config override: ')
+        resources_fields['_cluster_config_overrides'] = (
+            cluster_config_overrides)
 
         if resources_fields['cpus'] is not None:
             resources_fields['cpus'] = str(resources_fields['cpus'])

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2258,15 +2258,24 @@ class Resources:
         if current_override_configs is None:
             current_override_configs = {}
         new_override_configs = override.pop('_cluster_config_overrides', {})
-        overlaid_configs = skypilot_config.overlay_skypilot_config(
-            original_config=config_utils.Config(current_override_configs),
-            override_configs=new_override_configs,
-        )
-        override_configs = config_utils.Config()
+        # Only the incoming overrides are filtered to the overrideable
+        # keys. The existing overrides are kept as-is: they were already
+        # accepted when this Resources was constructed, and on the client
+        # the full set of overrideable keys is not known (the server may
+        # register additional keys via
+        # skypilot_config.register_task_overrideable_config_key), so
+        # re-filtering here would silently drop them before the server
+        # can act on them.
+        filtered_new_configs = config_utils.Config()
+        new_configs = config_utils.Config(new_override_configs or {})
         for key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
-            elem = overlaid_configs.get_nested(key, None)
+            elem = new_configs.get_nested(key, None)
             if elem is not None:
-                override_configs.set_nested(key, elem)
+                filtered_new_configs.set_nested(key, elem)
+        override_configs = skypilot_config.overlay_skypilot_config(
+            original_config=config_utils.Config(current_override_configs),
+            override_configs=filtered_new_configs,
+        )
 
         current_autostop_config = None
         if self.autostop_config is not None:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1069,6 +1069,39 @@ def register_config_update_hook(fn: Callable[[], None]) -> None:
         _CONFIG_UPDATE_HOOKS.append(fn)
 
 
+def register_task_overrideable_config_key(key: Tuple[str, ...]) -> None:
+    """Register a config key that may be overridden via a task YAML.
+
+    Extends ``constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK`` so the key is
+    accepted in a task's ``config`` field, survives ``Resources.copy()``,
+    and may be passed to ``get_nested`` via ``override_configs``. This
+    lets plugins make their config keys tunable per task instead of only
+    server-wide.
+
+    The key must already exist in the global config schema (e.g. added
+    via ``schemas.register_jobs_property``) before this is called, since
+    the task-level config schema is derived from the global one.
+
+    Called at server startup during plugin loading (single-threaded), so
+    no lock is needed.
+    """
+    # Fail fast at registration time if the key is not part of the
+    # config schema — otherwise the first task-schema build would fail
+    # with an opaque assertion inside schema filtering.
+    node: Dict[str, Any] = schemas.get_config_schema()
+    for part in key:
+        properties = node.get('properties', {})
+        if part not in properties:
+            raise ValueError(
+                f'Cannot register task-overrideable config key {key!r}: '
+                f'{".".join(key)} is not present in the config schema. '
+                'Register the schema property first (e.g. via '
+                'schemas.register_jobs_property).')
+        node = properties[part]
+    if key not in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
+        constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK.append(key)
+
+
 # Validators invoked at the start of `update_api_server_config_no_lock`,
 # before the new config is persisted. Each validator receives the currently
 # persisted config and the incoming config, and may reject the save by

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1144,7 +1144,13 @@ def _task_config_schema():
         constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK)['properties']
     return {
         'type': 'object',
-        'additionalProperties': False,
+        # On the client, let unknown keys pass through so config keys
+        # registered as task-overrideable on the server (via
+        # skypilot_config.register_task_overrideable_config_key) are not
+        # rejected by a client that does not know about them — mirroring
+        # how the global config schema handles plugin-registered
+        # properties. The server enforces the full set.
+        'additionalProperties': _allow_additional_properties(),
         'properties': {
             **overrideable,
             'hooks': _HOOKS_SCHEMA,

--- a/tests/unit_tests/test_task_overrideable_config_keys.py
+++ b/tests/unit_tests/test_task_overrideable_config_keys.py
@@ -166,6 +166,33 @@ def test_from_yaml_config_revalidates_overrides_when_strict(
                 }
             }
         })
+    # ... including when the value is null. validate_schema's default
+    # strips top-level None-valued keys before validating, which would
+    # wave an unknown section through while it still survives into the
+    # overrides.
+    with pytest.raises(ValueError, match='Invalid resources.config override'):
+        Resources.from_yaml_config(
+            {'_cluster_config_overrides': {
+                'unknown_section': None
+            }})
+
+
+def test_from_yaml_config_keeps_nested_null_overrides(monkeypatch):
+    """Strict validation must not break `--config <key>=null`.
+
+    Only top-level nulls are the smuggling vector; a null *leaf* under a
+    known section is how an override is cleared, and has to keep passing.
+    """
+    monkeypatch.setattr(schemas, '_allow_additional_properties', lambda: False)
+    resources = next(
+        iter(
+            Resources.from_yaml_config(
+                {'_cluster_config_overrides': {
+                    'gcp': {
+                        'vpc_name': None
+                    }
+                }})))
+    assert resources.cluster_config_overrides['gcp']['vpc_name'] is None
 
 
 def test_from_yaml_config_passes_unknown_overrides_on_client():

--- a/tests/unit_tests/test_task_overrideable_config_keys.py
+++ b/tests/unit_tests/test_task_overrideable_config_keys.py
@@ -14,6 +14,7 @@ from sky import clouds
 from sky import skypilot_config
 from sky.resources import Resources
 from sky.skylet import constants
+from sky.utils import config_utils
 from sky.utils import schemas
 
 _TEST_PROP = 'test_task_overrideable_prop'
@@ -103,6 +104,84 @@ def test_copy_filters_unknown_incoming_overrides():
     overrides = copied.cluster_config_overrides
     assert 'jobs' not in overrides
     assert overrides['docker']['run_options'] == ['-v /tmp:/tmp']
+
+
+def test_copy_null_incoming_override_clears_existing():
+    """`--config <key>=null` clears an existing task-level override.
+
+    The override must not survive the overlay — otherwise the task value
+    would keep masking the CLI/global config null.
+    """
+    resources = Resources(
+        cloud=clouds.Kubernetes(),
+        _cluster_config_overrides={'gcp': {
+            'vpc_name': 'task-vpc'
+        }})
+    copied = resources.copy(
+        _cluster_config_overrides={'gcp': {
+            'vpc_name': None
+        }})
+    missing = object()
+    overrides = config_utils.Config(copied.cluster_config_overrides)
+    assert overrides.get_nested(('gcp', 'vpc_name'), missing) is missing
+
+
+def test_from_yaml_config_revalidates_overrides_when_strict(
+        registered_test_key, monkeypatch):
+    """Server-side, deserialized overrides are re-validated.
+
+    A task's `config` field crosses the client/server boundary as
+    `resources._cluster_config_overrides` (schema: bare object), so
+    `Resources.from_yaml_config` must re-validate the contents against
+    the task config schema — which is strict on the server.
+    """
+    monkeypatch.setattr(schemas, '_allow_additional_properties', lambda: False)
+    # Well-formed value passes.
+    resources = next(
+        iter(
+            Resources.from_yaml_config(
+                {'_cluster_config_overrides': {
+                    'jobs': {
+                        _TEST_PROP: True
+                    }
+                }})))
+    assert resources.cluster_config_overrides['jobs'][_TEST_PROP] is True
+    # Malformed value for a registered boolean is rejected.
+    with pytest.raises(ValueError, match='Invalid resources.config override'):
+        Resources.from_yaml_config({
+            '_cluster_config_overrides': {
+                'jobs': {
+                    _TEST_PROP: {
+                        'wrong': 'shape'
+                    }
+                }
+            }
+        })
+    # Unregistered keys are rejected under strict validation.
+    with pytest.raises(ValueError, match='Invalid resources.config override'):
+        Resources.from_yaml_config({
+            '_cluster_config_overrides': {
+                'jobs': {
+                    'unregistered_prop': True
+                }
+            }
+        })
+
+
+def test_from_yaml_config_passes_unknown_overrides_on_client():
+    """Client-side (lenient), unknown override keys still pass through so
+    the server can validate them."""
+    resources = next(
+        iter(
+            Resources.from_yaml_config({
+                '_cluster_config_overrides': {
+                    'jobs': {
+                        'some_server_side_prop': True
+                    }
+                }
+            })))
+    assert resources.cluster_config_overrides['jobs'][
+        'some_server_side_prop'] is True
 
 
 def test_task_config_schema_lenient_on_client(monkeypatch):

--- a/tests/unit_tests/test_task_overrideable_config_keys.py
+++ b/tests/unit_tests/test_task_overrideable_config_keys.py
@@ -1,0 +1,113 @@
+"""Tests for plugin-registered task-overrideable config keys.
+
+Plugins can extend the set of config keys that may be overridden via a
+task YAML's ``config`` field with
+``skypilot_config.register_task_overrideable_config_key``. These tests
+cover the registration hook and the properties the extension relies on:
+the key survives ``Resources.copy()``, is honored by
+``skypilot_config.get_nested(override_configs=...)``, and unknown keys
+pass through on the client for server-side validation.
+"""
+import pytest
+
+from sky import clouds
+from sky import skypilot_config
+from sky.resources import Resources
+from sky.skylet import constants
+from sky.utils import schemas
+
+_TEST_PROP = 'test_task_overrideable_prop'
+_TEST_KEY = ('jobs', _TEST_PROP)
+
+
+@pytest.fixture
+def registered_test_key():
+    """Register a throwaway jobs property as task-overrideable."""
+    schemas.register_jobs_property(_TEST_PROP, {'type': 'boolean'})
+    skypilot_config.register_task_overrideable_config_key(_TEST_KEY)
+    yield _TEST_KEY
+    constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK.remove(_TEST_KEY)
+    schemas._extra_jobs_properties.pop(_TEST_PROP)  # pylint: disable=protected-access
+
+
+def test_register_appends_to_overrideable_keys(registered_test_key):
+    assert registered_test_key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK
+    # Idempotent.
+    skypilot_config.register_task_overrideable_config_key(registered_test_key)
+    assert constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK.count(
+        registered_test_key) == 1
+
+
+def test_register_rejects_key_missing_from_config_schema():
+    with pytest.raises(ValueError, match='not present in the config schema'):
+        skypilot_config.register_task_overrideable_config_key(
+            ('jobs', 'nonexistent_prop'))
+    assert (('jobs', 'nonexistent_prop')
+            not in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK)
+
+
+def test_registered_key_in_task_config_schema(registered_test_key):
+    task_config_schema = schemas.get_task_schema()['properties']['config']
+    assert _TEST_PROP in task_config_schema['properties']['jobs']['properties']
+
+
+def test_registered_key_survives_resources_copy(registered_test_key):
+    resources = Resources(
+        cloud=clouds.Kubernetes(),
+        _cluster_config_overrides={'jobs': {
+            _TEST_PROP: True
+        }})
+    copied = resources.copy()
+    assert copied.cluster_config_overrides['jobs'][_TEST_PROP] is True
+
+
+def test_registered_key_honored_by_get_nested(registered_test_key):
+    assert skypilot_config.get_nested(
+        _TEST_KEY, False, override_configs={'jobs': {
+            _TEST_PROP: True
+        }}) is True
+    assert skypilot_config.get_nested(_TEST_KEY, False,
+                                      override_configs={}) is False
+
+
+def test_copy_preserves_existing_unknown_overrides():
+    """Existing overrides pass through copy() unfiltered.
+
+    On the client the full set of overrideable keys is not known (the
+    server may register more via plugins), so copy() must not silently
+    drop keys that were accepted at construction time — the server is
+    responsible for validating them.
+    """
+    resources = Resources(
+        cloud=clouds.Kubernetes(),
+        _cluster_config_overrides={'jobs': {
+            'some_server_side_prop': True
+        }})
+    copied = resources.copy()
+    assert copied.cluster_config_overrides['jobs']['some_server_side_prop'] is (
+        True)
+
+
+def test_copy_filters_unknown_incoming_overrides():
+    """Incoming overrides (e.g. from --config) are still filtered."""
+    resources = Resources(cloud=clouds.Kubernetes())
+    copied = resources.copy(
+        _cluster_config_overrides={
+            'jobs': {
+                'some_server_side_prop': True
+            },
+            'docker': {
+                'run_options': ['-v /tmp:/tmp']
+            },
+        })
+    overrides = copied.cluster_config_overrides
+    assert 'jobs' not in overrides
+    assert overrides['docker']['run_options'] == ['-v /tmp:/tmp']
+
+
+def test_task_config_schema_lenient_on_client(monkeypatch):
+    """Off-server, unknown task config keys pass schema validation so a
+    stock client can submit them for server-side validation."""
+    monkeypatch.delenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, raising=False)
+    task_config_schema = schemas.get_task_schema()['properties']['config']
+    assert task_config_schema['additionalProperties'] is True


### PR DESCRIPTION
Allow plugins to extend the set of config keys that may be overridden via a task YAML's `config` field:

- `skypilot_config.register_task_overrideable_config_key(key)` extends `constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK` at plugin load time, validating that the key exists in the global config schema (fail-fast at registration instead of an opaque assertion at the first task-schema build).
- The task-level `config` schema now allows additional properties on the client (mirroring how the global config schema already handles plugin-registered properties), so a client can submit keys that only the server knows about; the server enforces the full set.
- `Resources.copy()` keeps existing cluster config overrides as-is and only filters the *incoming* overrides. Previously the client-side copy silently re-filtered everything against the client's static allowlist, dropping any plugin-registered key before the server could act on it. Filtering of incoming overrides (e.g. from `--config`) is unchanged.

This follows the same pattern as the existing plugin registration hooks (`schemas.register_jobs_property`, `skypilot_config.register_config_save_validator`, ...): the OSS side exposes a plain registration point, plugins opt their keys in at load time.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - New `tests/unit_tests/test_task_overrideable_config_keys.py` (8 tests): registration + schema validation + idempotency, key survives `Resources.copy()`, honored by `get_nested(override_configs=...)`, existing-unknown-overrides pass-through vs incoming-overrides filtering, client-lenient task config schema.
  - Existing suites pass: `tests/unit_tests/test_resources.py`, `tests/unit_tests/test_sky/test_task.py`, `tests/unit_tests/test_sky/utils/test_config_utils.py`, `tests/test_config.py`.
  - Manually verified end-to-end with a plugin registering a `jobs`-section key: the key passes task-YAML validation from the CLI, survives the resource copies on the launch path, and is readable via `get_nested` with the task's overrides at provisioning time; a task without the key is unaffected.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)