### PR TITLE
[Client] Fix `sky api logs` traceback on 4xx from /api/stream

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2517,7 +2517,19 @@ def stream_and_get(
                  None),
         stream=True)
     if response.status_code in [404, 400]:
-        detail = response.json().get('detail')
+        # ``response`` is a streaming request; on some pooled connections the
+        # small error body cannot be read back and raises a
+        # ChunkedEncodingError. Read the detail defensively and fall back to a
+        # status-based message so the user gets a clean error, not a traceback.
+        detail = None
+        try:
+            detail = response.json().get('detail')
+        except Exception:  # pylint: disable=broad-except
+            pass
+        if not detail:
+            detail = ('the request or log path was not found or is not '
+                      'accessible' if response.status_code == 404 else
+                      'the request was invalid')
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClientError(f'Failed to stream logs: {detail}')
     stream_request_id: Optional[server_common.RequestId[


### PR DESCRIPTION
## Problem

When `/api/stream` returns `404` or `400`, `sky api logs` crashes with a raw traceback instead of a readable error:

```
urllib3.exceptions.IncompleteRead: IncompleteRead(0 bytes read, 41 more expected)
...
requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(0 bytes read, 41 more expected)', ...)
```

This happens on any 4xx from the stream endpoint, e.g. `sky api logs <request_id>` where the id does not exist or is not accessible to the caller.

## Root cause

`sdk.stream_and_get()` makes the `/api/stream` request with `stream=True` and, on a `404`/`400`, reads the error detail via `response.json()`. On some pooled connections that small error body cannot be read back and raises `ChunkedEncodingError`, so the CLI aborts with a traceback. The server response itself is well-formed (a plain `404` with `content-length` and a JSON `{"detail": ...}` body that e.g. `curl` reads fine) — only the streamed client read fails.

## Fix

Read the error detail defensively and fall back to a status-based message, so the user always gets a clean `Failed to stream logs: ...` `ClientError` instead of a traceback.

## Test

- `sky api logs <nonexistent-request-id>` → before: `ChunkedEncodingError` traceback; after: `ClientError: Failed to stream logs: the request or log path was not found or is not accessible`.
- Streaming a valid request's logs is unchanged (only the 404/400 branch is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)