### PR TITLE
[Test] Classify /slurm_cluster_names as read in workspace-access guard

### DIFF
--- a/tests/unit_tests/test_sky/server/requests/test_workspace_access.py
+++ b/tests/unit_tests/test_sky/server/requests/test_workspace_access.py
@@ -147,6 +147,7 @@ _EXPECTED: Dict[Tuple[str, str], str] = {
     ('POST', '/serve/logs'): READ,
     ('POST', '/serve/status'): READ,
     ('POST', '/serve/sync-down-logs'): READ,
+    ('POST', '/slurm_cluster_names'): READ,
     ('POST', '/slurm_gpu_availability'): READ,
     ('GET', '/slurm_node_info'): READ,
     ('POST', '/slurm_node_info'): READ,


### PR DESCRIPTION
## Summary

`POST /slurm_cluster_names` (added in #10329) is already declared read-only in the viewer allowlist (`rbac`), but was not added to the `_EXPECTED` classification map in `test_workspace_access.py`. The completeness drift-guard `TestEveryExecutorEndpointIsClassified::test_no_endpoint_is_unclassified` (added in #10228) therefore fails now that both are in the same tree — it flags the endpoint as unclassified.

The endpoint is a pure read (it only lists cluster names from the local `~/.slurm/config`, without contacting any node), so it is classified `READ` — matching the existing viewer-allowlist entry. Runtime behavior is unchanged; this only syncs the test's intent map.

## Test plan

```
pytest tests/unit_tests/test_sky/server/requests/test_workspace_access.py::TestEveryExecutorEndpointIsClassified
```

- Passes with the added `_EXPECTED` entry.
- Revert-checked: removing the line makes `test_no_endpoint_is_unclassified` fail (the guard genuinely catches the drift).