### PR TITLE
[Nebius] Add SkyPilot user-agent prefix

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -282,16 +282,26 @@ def sdk():
     return _sdk(None, default_cred_path)
 
 
+def _user_agent_prefix() -> str:
+    # Import locally to avoid a circular import while sky is initialized.
+    # pylint: disable=import-outside-toplevel
+    from sky import __version__
+    return f'skypilot/{__version__}'
+
+
 @annotations.lru_cache(scope='request')
 def _sdk(token: Optional[str], cred_path: Optional[str]):
     # Exactly one of token or cred_path must be provided
     assert (token is None) != (cred_path is None), (token, cred_path)
     if token is not None:
-        return nebius.sdk.SDK(credentials=token, domain=api_domain())
+        return nebius.sdk.SDK(credentials=token,
+                              domain=api_domain(),
+                              user_agent_prefix=_user_agent_prefix())
     if cred_path is not None:
         return nebius.sdk.SDK(
             credentials_file_name=os.path.expanduser(cred_path),
             domain=api_domain(),
+            user_agent_prefix=_user_agent_prefix(),
         )
     raise ValueError('Either token or credentials file path must be provided')
 

--- a/tests/unit_tests/test_nebius.py
+++ b/tests/unit_tests/test_nebius.py
@@ -11,6 +11,36 @@ from sky.clouds import nebius
 from sky.utils import resources_utils
 
 
+class TestNebiusAdaptorSDK:
+    """Tests for SkyPilot's Nebius SDK configuration."""
+
+    def test_user_agent_prefix_is_passed_for_all_credentials(self):
+        mock_nebius = MagicMock()
+        with patch.object(nebius_adaptor, 'nebius', mock_nebius), \
+             patch.object(nebius_adaptor,
+                          'api_domain',
+                          return_value='api.nebius.test'), \
+             patch('sky.__version__', '1.2.3'):
+            nebius_adaptor._sdk.cache_clear()
+            try:
+                nebius_adaptor._sdk('iam-token', None)
+                nebius_adaptor._sdk(None, '~/credentials.json')
+            finally:
+                nebius_adaptor._sdk.cache_clear()
+
+        calls = mock_nebius.sdk.SDK.call_args_list
+        assert calls[0].kwargs == {
+            'credentials': 'iam-token',
+            'domain': 'api.nebius.test',
+            'user_agent_prefix': 'skypilot/1.2.3',
+        }
+        assert calls[1].kwargs == {
+            'credentials_file_name': os.path.expanduser('~/credentials.json'),
+            'domain': 'api.nebius.test',
+            'user_agent_prefix': 'skypilot/1.2.3',
+        }
+
+
 class TestNebiusNetworkTier:
     """Test cases for Nebius network_tier functionality."""
 


### PR DESCRIPTION
## Summary

- Prefix Nebius SDK requests with `skypilot/<version>` so Nebius can identify SkyPilot requests and calculate the share.
- Apply the prefix for both IAM-token and credentials-file authentication paths.
- Add unit coverage for both SDK construction paths.

The Nebius SDK keeps its own user-agent after this prefix, so the resulting value includes both SkyPilot and Nebius SDK version information.

## Test plan

- [x] `pytest tests/unit_tests/test_nebius.py -q`
- [x] `bash format.sh --files sky/adaptors/nebius.py` (YAPF, isort, mypy, pylint, and dashboard checks pass; the script's final status reports the expected uncommitted Python changes.)
- [x] `yapf --diff tests/unit_tests/test_nebius.py`

Manual verification: the new unit test constructs the SDK through both supported credential paths with a mocked SkyPilot version and confirms each receives `user_agent_prefix='skypilot/1.2.3'`.
