### PR TITLE
[Jobs] Start status retry budget after healthy-cluster refresh

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1066,10 +1066,6 @@ class JobController:
                     f'status. Reason: {transient_job_check_error_reason}.\n'
                     'Check cluster status to determine if the job is '
                     'preempted or failed.')
-                if transient_job_check_error_start_time is None:
-                    transient_job_check_error_start_time = time.time()
-                    job_check_backoff = common_utils.Backoff(
-                        initial_backoff=1, max_backoff_factor=5)
             else:
                 transient_job_check_error_start_time = None
                 job_check_backoff = None
@@ -1426,6 +1422,12 @@ class JobController:
                     # job status. Try to recover the job (will not restart the
                     # cluster, if the cluster is healthy).
                     if transient_job_check_error_reason is not None:
+                        # Do not let the first forced refresh exhaust the retry
+                        # budget before a retry.
+                        if transient_job_check_error_start_time is None:
+                            transient_job_check_error_start_time = time.time()
+                            job_check_backoff = common_utils.Backoff(
+                                initial_backoff=1, max_backoff_factor=5)
                         assert (transient_job_check_error_start_time
                                 is not None), (
                                     transient_job_check_error_start_time,

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1531,30 +1531,27 @@ class TestDunderMainDispatchesToImportedModule:
 
 
 class TestTransientJobStatusRecoveryWindow:
-    """Tests for the transient job-status-check retry window across recovery.
+    """Tests the transient job-status-check retry window lifecycle.
 
     When the controller cannot fetch a task's job status but the cluster is
     healthy, it retries for up to JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS before
-    recovering, to avoid a false alarm from a transient control-plane error.
-    That window (`transient_job_check_error_start_time`) must be reset after a
-    recovery; otherwise the first status-fetch failure after a recovery is
-    measured from before the recovery, exceeds the timeout immediately, and
-    triggers another recovery with no retries -- turning one transient error
-    into an unbounded recovery loop.
+    recovering, to avoid a false alarm from a transient control-plane error. The
+    initial forced cluster-status refresh must not consume that window, and the
+    window must be reset after recovery.
     """
 
     class _StopLoop(Exception):
         """Sentinel to break the otherwise-infinite monitoring loop."""
 
     @pytest.mark.asyncio
-    async def test_window_reset_after_recovery(self, monkeypatch):
-        """A transient failure after a recovery starts a fresh retry window.
+    async def test_first_refresh_is_excluded_and_window_resets_after_recovery(
+            self, monkeypatch):
+        """The first refresh is excluded and recovery starts a fresh window.
 
         Drives ``_monitor_one_task_impl`` through: transient failure (retry) ->
         transient failure past the timeout (recover) -> transient failure
-        again. With the window reset, the third failure retries instead of
-        recovering, so ``recover`` is called exactly once. Without the reset it
-        would recover a second time immediately.
+        again. The first refresh exceeds the timeout but must not recover. With
+        the window reset, the third failure retries instead of recovering.
 
         Calls the ``_impl`` body rather than ``_monitor_one_task``: the retry
         window lives entirely in the body, and the wrapper only owns the status
@@ -1566,26 +1563,29 @@ class TestTransientJobStatusRecoveryWindow:
         monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_CHECK_GAP_SECONDS',
                             0)
 
-        # A logical clock advanced at the top of each loop iteration (inside
-        # the get_job_status stub) so `elapsed` is fully deterministic:
-        #   iter 1: +0   -> elapsed 0   < 60 -> retry
-        #   iter 2: +100 -> elapsed 100 >= 60 -> recover (#1); window reset
-        #   iter 3: +50  -> fresh window, elapsed 0 < 60 -> retry
+        # A logical clock keeps the retry windows deterministic. The first
+        # forced refresh takes 61 seconds but is excluded from the budget:
+        #   iter 1: status +0, refresh +61 -> elapsed 0   < 60 -> retry
+        #   iter 2: status +100            -> elapsed 100 >= 60 -> recover
+        #   iter 3: status +50             -> elapsed 0   < 60 -> retry
         #   iter 4: stub raises _StopLoop to end the loop
         clock = {'t': 1000.0}
-        deltas = iter([0.0, 100.0, 50.0])
-        recover_calls = 0
+        status_deltas = iter([0.0, 100.0, 50.0])
+        refresh_deltas = iter([61.0, 0.0, 0.0])
+        status_fetches = 0
+        recovery_fetch_counts: List[int] = []
 
         async def fake_get_job_status(*args, **kwargs):
+            nonlocal status_fetches
             try:
-                clock['t'] += next(deltas)
+                clock['t'] += next(status_deltas)
             except StopIteration:
                 raise TestTransientJobStatusRecoveryWindow._StopLoop()
+            status_fetches += 1
             return None, 'Job status check timed out after 30s.'
 
         async def fake_recover(*args, **kwargs):
-            nonlocal recover_calls
-            recover_calls += 1
+            recovery_fetch_counts.append(status_fetches)
             return clock['t']
 
         handle = MagicMock()
@@ -1593,6 +1593,7 @@ class TestTransientJobStatusRecoveryWindow:
             return_value = False
 
         def fake_refresh(*args, **kwargs):
+            clock['t'] += next(refresh_deltas)
             return status_lib.ClusterStatus.UP, handle
 
         mock_self = MagicMock()
@@ -1634,9 +1635,7 @@ class TestTransientJobStatusRecoveryWindow:
                     callback_func=MagicMock(),
                     force_transit_to_recovering=False)
 
-        assert recover_calls == 1, (
-            'expected exactly one recovery; a second recovery means the '
-            'transient retry window was not reset after the first recovery')
+        assert recovery_fetch_counts == [2]
 
     @pytest.mark.asyncio
     async def test_status_logger_flushed_when_body_raises(self, monkeypatch):


### PR DESCRIPTION
## Summary

Addresses #10123.

**TL;DR:** Start the managed-job status-fetch retry clock after the first forced cluster-status refresh confirms the cluster is `UP`. This guarantees at least one retry when that refresh alone exceeds the 60-second budget, instead of immediately recovering and relaunching a potentially live job.

## Root cause

The controller currently starts the retry clock before a mandatory provider/Ray refresh:

1. A job-status fetch times out.
2. The controller starts the 60-second retry clock.
3. The forced cluster refresh takes 60+ seconds and reports `UP`.
4. The first elapsed-time check sees an expired budget and recovers with zero retries.

The change moves the existing clock/backoff initialization into the healthy-cluster branch, after the first refresh. Subsequent retry, backoff, timeout, reset, and recovery behavior is unchanged.

## Suggested review order

1. `sky/jobs/controller.py`: the behavioral change is only the placement of the existing clock/backoff initialization.
2. `tests/unit_tests/test_sky/jobs/test_controller.py`: one deterministic lifecycle test now covers both invariants—first-refresh time is excluded, and recovery resets the window.

## Risk

Low and localized to the `job_status is None`, transient-error, cluster-`UP` path. The timeout value, backoff policy, provider refresh, and destructive recovery path are unchanged. Clusters reported non-`UP` do not enter this retry branch.

## Test plan

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` (YAPF, mypy on 587 files, Pylint 10.00/10)
- [x] Any manual or new tests for this PR:
  - `pytest -n 8 tests/unit_tests/test_sky/jobs/` (455 passed)
  - Regression proof: restoring the old clock placement makes `test_first_refresh_is_excluded_and_window_resets_after_recovery` fail with recovery after fetch 1 instead of fetch 2; the PR passes.
- [x] Upstream automatic CI (21/21 checks passed)
- [ ] All smoke tests: `/smoke-test`
- [ ] Relevant individual tests: `/smoke-test -k test_managed_jobs_recovery_gcp --gcp --managed-jobs`
- [ ] Backward compatibility: `/quicktest-core`

The cloud smoke commands require a repository member; the trigger request is posted below. All resources from local cloud-smoke attempts were terminated.
