### PR TITLE
fix(dashboard): derive the download-logs user id from getCurrentUserInfo (#9976)

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.downloadLogs.test.js
+++ b/sky/dashboard/src/data/connectors/jobs.downloadLogs.test.js
@@ -1,0 +1,90 @@
+/**
+ * Regression test for the managed-job log download identity.
+ *
+ * `downloadManagedJobLogs` dispatches two requests that the API server
+ * validates against each other: `/jobs/download_logs` decides where the logs
+ * are written (from the `SKYPILOT_USER_ID` it is given), and `/download` then
+ * refuses any folder outside that same user's log directory. The two must
+ * therefore derive the user identity the same way — see
+ * https://github.com/skypilot-org/skypilot/issues/9976, where a blank id made
+ * the first write to `clients//sky_logs` while the second validated against
+ * `clients/local/sky_logs` and returned a 400.
+ */
+
+import { getCurrentUserInfo, apiClient } from './client';
+
+jest.mock('./client', () => ({
+  getCurrentUserInfo: jest.fn(),
+  apiClient: { fetchImmediate: jest.fn() },
+}));
+jest.mock('./toast', () => ({ showToast: jest.fn() }));
+jest.mock('@/lib/analytics', () => ({ trackJobAction: jest.fn() }));
+// Breaks the jobs.jsx -> dataEnhancement -> cache-preloader -> jobs.jsx cycle.
+jest.mock('@/plugins/dataEnhancement', () => ({
+  applyEnhancements: (_name, data) => data,
+}));
+
+const { downloadManagedJobLogs } = require('./jobs');
+
+// The identity endpoint answers with blank fields when auth is disabled;
+// `getCurrentUserInfo` is what normalizes that to 'local'.
+const BLANK_ROLE_RESPONSE = { id: '', name: '' };
+const LOG_DIR = '~/.sky/api_server/clients/local/sky_logs/managed_jobs/job-1';
+
+describe('downloadManagedJobLogs user identity', () => {
+  let dispatchBody;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dispatchBody = null;
+
+    getCurrentUserInfo.mockResolvedValue({ id: 'local', name: 'local' });
+
+    global.fetch.mockImplementation(async (url, options) => {
+      if (String(url).includes('/internal/dashboard/users/role')) {
+        return { ok: true, json: async () => BLANK_ROLE_RESPONSE };
+      }
+      if (String(url).includes('/jobs/download_logs')) {
+        dispatchBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          headers: { get: () => 'request-id-1' },
+        };
+      }
+      if (String(url).includes('/api/get')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ return_value: JSON.stringify({ 1: LOG_DIR }) }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    apiClient.fetchImmediate.mockResolvedValue({
+      ok: true,
+      blob: async () => ({}),
+    });
+
+    window.URL.createObjectURL = jest.fn(() => 'blob:zip');
+    window.URL.revokeObjectURL = jest.fn();
+  });
+
+  it('sends the same user id that apiClient sends on /download', async () => {
+    await downloadManagedJobLogs({ jobId: 1 });
+
+    const expected = (await getCurrentUserInfo()).id;
+    expect(dispatchBody).not.toBeNull();
+    expect(dispatchBody.env_vars.SKYPILOT_USER_ID).toBe(expected);
+    expect(dispatchBody.env_vars.SKYPILOT_USER).toBe('local');
+  });
+
+  it('still reaches /download with the folders returned by the dispatch', async () => {
+    await downloadManagedJobLogs({ jobId: 1 });
+
+    expect(apiClient.fetchImmediate).toHaveBeenCalledWith(
+      '/download?relative=items',
+      { folder_paths: [LOG_DIR] }
+    );
+  });
+});

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -12,7 +12,7 @@ import {
 } from '@/data/connectors/constants';
 import dashboardCache from '@/lib/cache';
 import jobsCacheManager from '@/lib/jobs-cache-manager';
-import { apiClient } from './client';
+import { apiClient, getCurrentUserInfo } from './client';
 import { trackJobAction } from '@/lib/analytics';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
 
@@ -917,14 +917,13 @@ export async function handleJobAction(action, jobId, cluster) {
 async function downloadLogsWithRetry(body, maxAttempts = 30) {
   // Step 1: dispatch the request and grab its server-side ID.
   const baseUrl = window.location.origin;
-  const userInfo = await (async () => {
-    // Mirror what apiClient.fetch does — the env_vars path matters.
-    const r = await fetch(`${baseUrl}/internal/dashboard/users/role`).catch(
-      () => null
-    );
-    if (r && r.ok) return r.json();
-    return { id: 'local', name: 'local' };
-  })();
+  // Reuse the shared helper instead of re-deriving the identity here. It
+  // normalizes a blank `id`/`name` to 'local', which is what the
+  // apiClient-driven /download call below sends. Deriving it separately let
+  // the two disagree: /jobs/download_logs wrote the logs under
+  // `clients//sky_logs` while /download validated against
+  // `clients/local/sky_logs` and rejected them with a 400.
+  const userInfo = await getCurrentUserInfo();
   const dispatch = await fetch(`${baseUrl}${ENDPOINT}/jobs/download_logs`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Fixes #9976.

## The report

Downloading **Job logs** or **Controller logs** from the dashboard fails with:

```
Error downloading managed job logs: Download failed: 400 {"detail":"Invalid folder path: ~/.sky/api_server/clients/sky_logs/managed_jobs/managed-jobs-consolidation-mode-55; ~/.sky/api_server/clients/local/sky_logs"}
```

The `;` in that message is just the separator in the server's `detail` string — it is not a semicolon-joined path. The two halves are the folder the client asked for and the prefix the server allows, and they differ by one path component: `clients/**sky_logs**` vs `clients/**local**/sky_logs`.

## Root cause

The download is two requests, and they derive the user identity by different routes:

| request | identity source |
| --- | --- |
| `/download` | `apiClient.fetchImmediate` → `getCurrentUserInfo()` (`client.js`) |
| `/jobs/download_logs` | re-derived inline in `downloadLogsWithRetry` (`jobs.jsx`) |

`downloadLogsWithRetry` deliberately hand-rolls its polling to survive edge timeouts, and while doing so it also re-implemented the identity lookup:

```js
const r = await fetch(`${baseUrl}/internal/dashboard/users/role`).catch(() => null);
if (r && r.ok) return r.json();      // <- raw response, no normalization
return { id: 'local', name: 'local' };
```

`getCurrentUserInfo()` does not return the raw body — it normalizes it:

```js
cachedUserInfo = {
  id: data.id || 'local',
  name: data.name || data.id || 'local',
};
```

So when `/internal/dashboard/users/role` answers with a blank `id`, the two disagree: the inline copy sends `SKYPILOT_USER_ID: ''` while `apiClient` sends `'local'`. On the server side:

* `sky/jobs/server/server.py` writes the logs under `bs.get_blob_storage().download_tmp_dir('')` → `API_SERVER_CLIENT_DIR / '' / 'sky_logs'` → `clients/sky_logs` (`pathlib` drops the empty component),
* `sky/server/server.py` `/download` then validates that folder against `api_server_user_logs_dir_prefix('local')` → `clients/local/sky_logs`, does not match, and raises the 400.

That is exactly the path pair in the report. The inline copy also skipped the `withVersionHeader({})` headers the helper sends.

## The fix

Call the shared helper instead of re-deriving the identity, so both requests agree by construction — and get the existing cache for free. The hand-rolled long-polling of `/jobs/download_logs`, which is what the comment above the function is actually about, is untouched.

## Verification

Added `sky/dashboard/src/data/connectors/jobs.downloadLogs.test.js`, which drives `downloadManagedJobLogs` with the role endpoint returning a blank id and asserts that the `SKYPILOT_USER_ID` sent to `/jobs/download_logs` matches what `apiClient` sends on `/download`.

Before the change (`sky/dashboard`, `npx jest src/data/connectors/jobs.downloadLogs.test.js`):

```
× sends the same user id that apiClient sends on /download
    expect(received).toBe(expected)
    Expected: "local"
    Received: ""
√ still reaches /download with the folders returned by the dispatch
```

After:

```
√ sends the same user id that apiClient sends on /download
√ still reaches /download with the folders returned by the dispatch
Tests: 2 passed, 2 total
```

Full dashboard suite is unchanged by this PR — `2 failed, 6 failing tests` both before and after (pre-existing drift on `master` @ `605e982`, in suites this PR does not touch); the counts only move by the 2 tests added here. `npx prettier --check` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
