### PR TITLE
[API] Measure /api/get latency broken out by request name

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -188,6 +188,19 @@ SKY_APISERVER_REQUEST_DURATION_SECONDS = prom.Histogram(
     buckets=_LATENCY_BUCKETS,
 )
 
+# Time clients spend fetching an async request result via /api/get, broken out
+# by request name. /api/get long-polls until the request reaches a terminal
+# state, so this is the client-observed end-to-end latency of that request type.
+# The name label lets bounded request types (status/queue/...) be monitored
+# separately from inherently unbounded ones (launch/exec/...), which the single
+# path-labeled SKY_APISERVER_REQUEST_DURATION_SECONDS series conflates.
+SKY_APISERVER_REQUEST_GET_DURATION_SECONDS = prom.Histogram(
+    'sky_apiserver_request_get_duration_seconds',
+    'Time spent in /api/get fetching a request result, by request name',
+    ['name', 'status'],
+    buckets=_LATENCY_BUCKETS,
+)
+
 # Aggregated across all worker processes — the prometheus_client multiprocess
 # collector sums per-process histograms automatically. For per-process
 # visibility, see SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS below.

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1006,9 +1006,9 @@ class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 # /api/get long-polls until the underlying request is terminal,
                 # so its duration is the client-observed latency of that request
                 # type. The handler stamps request.state.request_name once it
-                # knows which request is being fetched; record it broken out by
-                # name so bounded request types can be alerted on separately from
-                # unbounded ones (launch/exec/...).
+                # knows which request is being fetched; record it by name so
+                # bounded types can be alerted on separately from unbounded ones
+                # (launch/exec/...).
                 request_name = getattr(request.state, 'request_name', None)
                 if request_name is not None:
                     metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS \

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1003,6 +1003,17 @@ class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.labels(
                     path=path, method=method,
                     status=status_code_group).observe(duration)
+                # /api/get long-polls until the underlying request is terminal,
+                # so its duration is the client-observed latency of that request
+                # type. The handler stamps request.state.request_name once it
+                # knows which request is being fetched; record it broken out by
+                # name so bounded request types can be alerted on separately from
+                # unbounded ones (launch/exec/...).
+                request_name = getattr(request.state, 'request_name', None)
+                if request_name is not None:
+                    metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS \
+                        .labels(name=request_name,
+                                status=status_code_group).observe(duration)
 
         return response
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2461,7 +2461,8 @@ async def get_expanded_request_id(request_id: str) -> str:
 
 # === API server related APIs ===
 @app.get('/api/get')
-async def api_get(request_id: str) -> payloads.RequestPayload:
+async def api_get(request: fastapi.Request,
+                  request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
     # Validate request_id prefix matches a single request.
     request_id = await get_expanded_request_id(request_id)
@@ -2486,6 +2487,11 @@ async def api_get(request_id: str) -> payloads.RequestPayload:
         # Back off: 10ms -> 20ms -> 40ms -> 80ms -> 100ms (cap)
         poll_interval = min(poll_interval * 2, 0.1)
     request_task = await requests_lib.get_request_async(request_id)
+    # Stamp the request name so PrometheusMiddleware can record this /api/get
+    # call's latency broken out by request type (see
+    # SKY_APISERVER_REQUEST_GET_DURATION_SECONDS). Set on every non-404 outcome
+    # (success, error, should_retry) since request_task is available here.
+    request.state.request_name = request_task.name
     # Check the error before should_retry: an interrupted request is in a
     # terminal state (the server does not re-execute it after a restart),
     # so clients polling /api/get must get a definitive error telling them

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -341,6 +341,7 @@ def prometheus_middleware():
     # Clear metric values before each test
     metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.clear()
     metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.clear()
+    metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS.clear()
 
     return middleware
 
@@ -675,6 +676,61 @@ async def test_middleware_user_metrics_with_basic_auth(
     assert user_requests == 1.0
 
 
+@pytest.mark.asyncio
+async def test_middleware_records_api_get_duration_by_name(
+        prometheus_middleware):
+    """/api/get latency is recorded under the request name the handler stamps."""
+    request = MagicMock()
+    request.url.path = '/api/v1/api/get'
+    request.method = 'GET'
+    request.state.auth_user = None
+    # The api_get handler stamps request.state.request_name once it knows which
+    # request is being fetched.
+    request.state.request_name = 'status'
+
+    response = MagicMock()
+    response.status_code = 200
+
+    call_next = AsyncMock(return_value=response)
+
+    await prometheus_middleware.dispatch(request, call_next)
+
+    get_collectors = [metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS]
+    duration_count = _get_metric_value(
+        'sky_apiserver_request_get_duration_seconds_count', {
+            'name': 'status',
+            'status': '2xx'
+        },
+        collectors=get_collectors)
+    assert duration_count == 1.0
+
+
+@pytest.mark.asyncio
+async def test_middleware_no_api_get_duration_without_name(
+        prometheus_middleware):
+    """No per-name /api/get series is recorded when the name is not stamped."""
+    request = MagicMock(spec=['url', 'method', 'state'])
+    request.url.path = '/api/v1/status'
+    request.method = 'GET'
+    request.state = MagicMock(
+        spec=[])  # No request_name / auth_user attributes.
+
+    response = MagicMock()
+    response.status_code = 200
+
+    call_next = AsyncMock(return_value=response)
+
+    await prometheus_middleware.dispatch(request, call_next)
+
+    # No per-name series recorded: every _count sample stays at 0.
+    registry = CollectorRegistry()
+    registry.register(metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS)
+    output = generate_latest(registry).decode('utf-8')
+    for line in output.split('\n'):
+        if line.startswith('sky_apiserver_request_get_duration_seconds_count'):
+            assert float(line.split()[-1]) == 0.0
+
+
 @pytest.fixture(autouse=True)
 def cleanup_metrics():
     """Clean up metrics after each test to avoid interference."""
@@ -682,6 +738,7 @@ def cleanup_metrics():
     # Clear all metrics after each test
     metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.clear()
     metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.clear()
+    metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS.clear()
     metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL.clear()
 
 


### PR DESCRIPTION
## Summary

The only request-latency signal, `sky_apiserver_request_duration_seconds`, is labeled by `path` only. Clients fetch every async result through the single `/api/get` endpoint, which long-polls until the underlying request reaches a terminal state — so its handler latency is the client-observed time-to-completion of that request. All request types therefore collapse into one `path="/api/get"` histogram series, dominated by inherently unbounded requests (`launch`/`exec`/`serve.up`/…), which makes a latency regression in the bounded ones (`status`/`queue`/`jobs.queue`/…) invisible.

This adds `sky_apiserver_request_get_duration_seconds{name, status}`: the `/api/get` handler stamps `request.state.request_name` once it knows which request is being fetched, and `PrometheusMiddleware` records the already-computed duration under that name. The generic path-labeled histogram is unchanged; the extra name-cardinality is paid only for `/api/get`. This also resolves the standing `# TODO(aylei): measure the duration of async execution instead` in the middleware for these long-polled requests.

## Test

- Unit (`tests/unit_tests/test_sky/server/test_metrics.py`): the new series is recorded under the stamped request name, and no per-name series is recorded when the name is not stamped.
- Verified via a Starlette `TestClient` repro that a `request.state` value set inside the route handler propagates to the `BaseHTTPMiddleware` after `call_next`.
- `bash format.sh` clean on the changed files.