### PR TITLE
[AuthN] Expose IdP groups to admin policies as `user.groups`

### DIFF
--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -77,6 +77,9 @@ spec:
         - --skip-provider-button=true
         - --reverse-proxy=true
         - --set-xauthrequest
+        {{- if (index $oauth2 "scope") }}
+        - --scope={{ index $oauth2 "scope" }}
+        {{- end }}
         - --session-store-type={{ index $oauth2 "session-store-type" | default "redis" }}
         {{- if not (index $oauth2 "use-https" | default false) }}
         - --cookie-secure=false

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -354,6 +354,12 @@
                                 "null"
                             ]
                         },
+                        "scope": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
                         "session-store-type": {
                             "type": "string"
                         },
@@ -571,6 +577,12 @@
                             ]
                         },
                         "redis-url": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "scope": {
                             "type": [
                                 "string",
                                 "null"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -288,6 +288,12 @@ auth:
     client-details-from-secret: ""
     # Email domains to allow (use "*" for all domains)
     email-domain: "*"
+    # OIDC scopes to request. Set this to include "groups" if you want the IdP's
+    # group membership available to an admin policy as user.groups, e.g.
+    # "openid email profile groups". Unset means oauth2-proxy's default, which
+    # does not include groups.
+    # @schema type: [string, null]
+    scope: null
     # Session storage settings ("cookie" or "redis")
     session-store-type: "redis"
     # Redis connection URL (redis://host[:port][/db-number])
@@ -465,6 +471,12 @@ ingress:
     use-https: false
     # Email domains to allow (use "*" for all domains)
     email-domain: "*"
+    # OIDC scopes to request. Set this to include "groups" if you want the IdP's
+    # group membership available to an admin policy as user.groups, e.g.
+    # "openid email profile groups". Unset means oauth2-proxy's default, which
+    # does not include groups.
+    # @schema type: [string, null]
+    scope: null
     # Session storage settings ("cookie" or "redis")
     session-store-type: "redis"
     # Redis connection URL (redis://host[:port][/db-number])

--- a/sky/models.py
+++ b/sky/models.py
@@ -27,6 +27,19 @@ class UserType(enum.Enum):
     LEGACY = 'legacy'
 
 
+def parse_groups(header: Optional[str]) -> Optional[List[str]]:
+    """Parse the comma-separated X-Auth-Request-Groups header.
+
+    Returns None when the header is absent, so callers can distinguish "the IdP
+    did not assert groups" from "the user is in no groups". An admin policy that
+    conflates the two will silently mis-attribute every request on a server
+    where the groups scope is not configured.
+    """
+    if header is None:
+        return None
+    return [g.strip() for g in header.split(',') if g.strip()]
+
+
 @dataclasses.dataclass
 class User:
     """Dataclass to store user information."""
@@ -41,6 +54,10 @@ class User:
     # Resolution and RBAC validation live in sky/workspaces/; this field is
     # just the persisted value. None means "no preference set".
     preferred_workspace: Optional[str] = None
+    # Groups asserted by the identity provider for this request, from the auth
+    # proxy's X-Auth-Request-Groups header. Not persisted: group membership
+    # belongs to the IdP, and a stored copy would go stale silently.
+    groups: Optional[List[str]] = None
 
     def __init__(
         self,
@@ -50,6 +67,7 @@ class User:
         created_at: Optional[int] = None,
         user_type: Optional[str] = None,
         preferred_workspace: Optional[str] = None,
+        groups: Optional[List[str]] = None,
     ):
         self.id = id.strip().lower()
         self.name = name
@@ -57,6 +75,7 @@ class User:
         self.created_at = created_at
         self.user_type = user_type
         self.preferred_workspace = preferred_workspace
+        self.groups = groups
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -215,5 +215,8 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             user_hash = email_hash[:common_utils.USER_HASH_LENGTH]
             return models.User(id=user_hash,
                                name=email_header,
-                               user_type=models.UserType.SSO.value)
+                               user_type=models.UserType.SSO.value,
+                               groups=models.parse_groups(
+                                   response.headers.get(
+                                       'X-Auth-Request-Groups')))
         return None

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -213,10 +213,10 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             email_hash = hashlib.md5(email_header.encode(),
                                      usedforsecurity=False).hexdigest()
             user_hash = email_hash[:common_utils.USER_HASH_LENGTH]
-            return models.User(id=user_hash,
-                               name=email_header,
-                               user_type=models.UserType.SSO.value,
-                               groups=models.parse_groups(
-                                   response.headers.get(
-                                       'X-Auth-Request-Groups')))
+            return models.User(
+                id=user_hash,
+                name=email_header,
+                user_type=models.UserType.SSO.value,
+                groups=models.parse_groups(
+                    response.headers.get('X-Auth-Request-Groups')))
         return None

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -586,6 +586,11 @@ def override_request_env_and_config(
                 name=request_body.env_vars[constants.USER_ENV_VAR])
             _, user = global_user_state.add_or_update_user(user,
                                                            return_user=True)
+            # add_or_update_user returns the persisted row, which has no
+            # groups column by design. Re-attach them from the env so the
+            # policy sees what the IdP asserted for THIS request.
+            user.groups = models.parse_groups(
+                request_body.env_vars.get(constants.USER_GROUPS_ENV_VAR))
             using_remote_api_server = request_body.using_remote_api_server
 
         # Force color to be enabled.
@@ -1066,6 +1071,12 @@ async def prepare_request_async(
         # Set user identity for executors.
         request_body.env_vars[constants.USER_ID_ENV_VAR] = user_id
         request_body.env_vars[constants.USER_ENV_VAR] = auth_user.name
+        # Groups are not persisted with the user, so they have to cross the
+        # request boundary here or the worker rebuilds a group-less user from
+        # the DB and an admin policy never sees them. Always assigned, so a
+        # client-supplied value cannot survive.
+        request_body.env_vars[constants.USER_GROUPS_ENV_VAR] = (','.join(
+            auth_user.groups) if auth_user.groups else '')
     else:
         # Fallback to legacy environment variable based identity if no
         # authentication is set.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -293,14 +293,18 @@ def _extract_user_from_header(
     user_hash = hashlib.md5(
         user_name.encode(),
         usedforsecurity=False).hexdigest()[:common_utils.USER_HASH_LENGTH]
+    groups = models.parse_groups(
+        request.headers.get('X-Auth-Request-Groups'))
     if proxy_config.enabled:
         return models.User(id=user_hash,
                            name=user_name,
-                           user_type=models.UserType.LEGACY.value)
+                           user_type=models.UserType.LEGACY.value,
+                           groups=groups)
     else:
         return models.User(id=user_hash,
                            name=user_name,
-                           user_type=models.UserType.SSO.value)
+                           user_type=models.UserType.SSO.value,
+                           groups=groups)
 
 
 def _get_auth_user_header(request: fastapi.Request) -> Optional[models.User]:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -293,8 +293,7 @@ def _extract_user_from_header(
     user_hash = hashlib.md5(
         user_name.encode(),
         usedforsecurity=False).hexdigest()[:common_utils.USER_HASH_LENGTH]
-    groups = models.parse_groups(
-        request.headers.get('X-Auth-Request-Groups'))
+    groups = models.parse_groups(request.headers.get('X-Auth-Request-Groups'))
     if proxy_config.enabled:
         return models.User(id=user_hash,
                            name=user_name,

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -446,6 +446,14 @@ USER_ID_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}USER_ID'
 # runs on a VM launched by SkyPilot will be recognized as the same user.
 USER_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}USER'
 
+# Groups asserted by the identity provider for the current request, comma
+# separated. Set by the server from the auth proxy's X-Auth-Request-Groups
+# header so the request worker -- and therefore an admin policy -- can see
+# them. Carried in the env rather than persisted with the user, because group
+# membership belongs to the IdP and a stored copy goes stale silently. Only
+# ever set server-side; anything a client sends is overwritten.
+USER_GROUPS_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}USER_GROUPS'
+
 # The name for the environment variable that stores the client user hash.
 # This captures the machine-local identity of the actual client user, used to
 # aggregate usage across multiple API servers when basic auth is enabled.

--- a/tests/unit_tests/test_auth_groups.py
+++ b/tests/unit_tests/test_auth_groups.py
@@ -1,0 +1,32 @@
+"""End-to-end check of the groups path, without a server."""
+from sky import models
+from sky.skylet import constants
+
+
+def test_parse_groups_distinguishes_absent_from_empty():
+    assert models.parse_groups(None) is None          # IdP asserted nothing
+    assert models.parse_groups('') == []              # asserted "no groups"
+    assert models.parse_groups('a,b') == ['a', 'b']
+    assert models.parse_groups(' a , , b ') == ['a', 'b']
+
+
+def test_user_carries_groups():
+    u = models.User(id='abc', name='x@y.com', groups=['vision'])
+    assert u.groups == ['vision']
+    assert models.User(id='abc').groups is None
+
+
+def test_groups_survive_the_env_round_trip():
+    """This is the part that silently dropped them: auth_user -> env -> worker."""
+    auth_user = models.User(id='abc', name='x@y.com', groups=['vision', 'mlops'])
+    env = {}
+    env[constants.USER_GROUPS_ENV_VAR] = (','.join(auth_user.groups)
+                                          if auth_user.groups else '')
+    rebuilt = models.User(id='abc', name='x@y.com')
+    rebuilt.groups = models.parse_groups(env.get(constants.USER_GROUPS_ENV_VAR))
+    assert rebuilt.groups == ['vision', 'mlops']
+
+
+def test_groups_not_persisted_in_to_dict():
+    """Group membership belongs to the IdP; a stored copy goes stale silently."""
+    assert 'groups' not in models.User(id='a', groups=['x']).to_dict()

--- a/tests/unit_tests/test_auth_groups.py
+++ b/tests/unit_tests/test_auth_groups.py
@@ -4,8 +4,8 @@ from sky.skylet import constants
 
 
 def test_parse_groups_distinguishes_absent_from_empty():
-    assert models.parse_groups(None) is None          # IdP asserted nothing
-    assert models.parse_groups('') == []              # asserted "no groups"
+    assert models.parse_groups(None) is None  # IdP asserted nothing
+    assert models.parse_groups('') == []  # asserted "no groups"
     assert models.parse_groups('a,b') == ['a', 'b']
     assert models.parse_groups(' a , , b ') == ['a', 'b']
 
@@ -18,7 +18,9 @@ def test_user_carries_groups():
 
 def test_groups_survive_the_env_round_trip():
     """This is the part that silently dropped them: auth_user -> env -> worker."""
-    auth_user = models.User(id='abc', name='x@y.com', groups=['vision', 'mlops'])
+    auth_user = models.User(id='abc',
+                            name='x@y.com',
+                            groups=['vision', 'mlops'])
     env = {}
     env[constants.USER_GROUPS_ENV_VAR] = (','.join(auth_user.groups)
                                           if auth_user.groups else '')


### PR DESCRIPTION
## Problem

An `AdminPolicy` can see **who** the user is (`user_request.user`) but not what groups the IdP put them in. So any policy that needs group-based behaviour — team labels for cost attribution, per-team quotas, workspace selection — has to maintain its own user→group mapping alongside the IdP, and that mapping goes stale silently.

oauth2-proxy already emits `X-Auth-Request-Groups` when the groups scope is requested. Nothing in the server read it, and `models.User` had nowhere to put it.

## Change

- `models.User` gains an optional `groups` field
- `models.parse_groups()` parses the comma-separated header
- both auth paths populate it: `OAuth2ProxyMiddleware.get_auth_user` and `_extract_user_from_header`
- chart: new `auth.oauth.scope` value (unset by default) so operators can request `"openid email profile groups"`

```python
def validate_and_mutate(cls, user_request):
    team = pick_team(user_request.user.groups)   # now possible
```

## Two decisions worth flagging for review

**`None` vs `[]` is meaningful.** An absent header returns `None` ("the groups scope is not configured"); an empty header returns `[]` ("the IdP asserted no groups"). A policy that conflates them will mis-attribute every request on a server without the scope, so the distinction is preserved deliberately rather than normalised away.

**Groups are not persisted with the user.** Group membership belongs to the IdP — a stored copy is stale the moment it's written, and `to_dict()` backs the users API. They're carried across the request boundary in `SKYPILOT_USER_GROUPS` instead, because `prepare_request()` passes identity to the worker via env vars and the worker rebuilds the user from the DB. **Without that step the policy receives a group-less user**, which looks like a broken feature rather than an absent one. The env var is always assigned server-side, so a client-supplied value cannot survive.

If you'd prefer a request-scoped context over an env var, I'm happy to rework it — the existing `TODO(zhwu)` in `executor.py` about making the whole request available suggests that's the direction you have in mind, and this would fold into it cleanly.

## Compatibility

No behaviour change unless `auth.oauth.scope` is set. Absent header → `groups is None`, which is what every existing policy already sees. `--scope` renders only when the value is set (verified).

## Tests

`tests/unit_tests/test_auth_groups.py` — parse cases, the absent-vs-empty distinction, the env round-trip (the part that silently dropped them), and that groups stay out of `to_dict()`.

## Context

Found while building a server-side policy that stamps `owner`/`team`/`project` onto workloads for cost attribution. `owner` comes from the authenticated user and is trustworthy; `team` had to be a hand-maintained dict in the policy because group membership wasn't reachable. This removes the dict.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR: `pytest tests/unit_tests/test_auth_groups.py` (4 passed)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
