### PR TITLE
[Jobs] Don't re-create user buckets in post-job storage cleanup

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2783,9 +2783,16 @@ class ControllerManager:
             # because when SkyPilot API server machine sends the yaml config to
             # the controller machine, only storage metadata is sent, not the
             # storage object itself.
+            # Only construct the storages that teardown_ephemeral_storage()
+            # below will actually delete (persistent=False). Constructing a
+            # persistent storage here is not just unnecessary, it is harmful:
+            # construct() auto-creates missing buckets, so if the user deletes
+            # their bucket right after the job finishes (`sky storage delete`),
+            # this cleanup would silently re-create and leak it.
             try:
                 for storage in task.storage_mounts.values():
-                    storage.construct()
+                    if not storage.persistent:
+                        storage.construct()
             except (exceptions.StorageSpecError, exceptions.StorageError) as e:
                 logger.warning(
                     f'Failed to construct storage object for teardown: {e}\n'

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -97,8 +97,16 @@ def cleanup_storage(yaml_content: str) -> bool:
         # FAILED_CLEANUP, ha_recovery_for_consolidation_mode respawns the
         # controller, the controller re-reads the same yaml and crashes on
         # the same stale entry — forever.
+        # Only construct the storages that teardown_ephemeral_storage()
+        # below will actually delete (persistent=False). Constructing a
+        # persistent storage here is not just unnecessary, it is harmful:
+        # construct() auto-creates missing buckets, so if the user deletes
+        # their bucket after the service finishes, this cleanup would
+        # silently re-create and leak it.
         for storage_name in list(task.storage_mounts.keys()):
             storage = task.storage_mounts[storage_name]
+            if storage.persistent:
+                continue
             try:
                 storage.construct()
             except exceptions.StorageBucketGetError as e:

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -23,19 +23,26 @@ from sky.server import common as server_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
-# `sky storage delete` returns as soon as the DeleteBucket API call
-# succeeds, but S3 bucket deletion is eventually consistent: for a short
-# window afterwards head-bucket can still report the bucket as existing.
-# Poll (rather than assert once) so the check tolerates that propagation
-# delay instead of flaking. A non-zero head-bucket (bucket gone / 404)
-# means success; keep retrying only while the bucket still exists.
+# Check that `sky storage delete` actually removed the bucket. `head-bucket`
+# is NOT reliable here: this check runs on the cloud-cmd cluster, whose aws
+# CLI default region usually differs from the (us-east-1) bucket's region,
+# and a cross-region head-bucket keeps returning a redirect that the CLI
+# reports as success ("BucketRegion: ...") for a window after deletion (and
+# even flickers back to success afterwards). `get-bucket-location` instead
+# returns NoSuchBucket immediately and region-robustly, so use it as the
+# deletion signal: while it still resolves the bucket, keep waiting; once it
+# fails (NoSuchBucket / not accessible), the bucket is gone.
 _CHECK_AWS_BUCKET_DOESNT_EXIST = (
     'start=$SECONDS; '
-    'while aws s3api head-bucket --bucket {bucket_name} 2>/dev/null; do '
-    'if (( SECONDS - start > 90 )); then '
-    'echo "Bucket {bucket_name} still exists 90s after deletion"; exit 1; fi; '
-    'echo "Bucket {bucket_name} still exists, waiting for deletion to '
-    'propagate..."; sleep 5; '
+    'while aws s3api get-bucket-location --bucket {bucket_name} '
+    '> /dev/null 2>&1; do '
+    'if (( SECONDS - start > 60 )); then '
+    'echo "Bucket {bucket_name} still exists 60s after deletion"; '
+    'aws sts get-caller-identity || true; '
+    'aws s3api get-bucket-location --bucket {bucket_name} || true; '
+    'exit 1; fi; '
+    'echo "Bucket {bucket_name} still resolves, waiting for deletion..."; '
+    'sleep 5; '
     'done; '
     'echo "Bucket {bucket_name} no longer exists."; exit 0')
 

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -23,9 +23,21 @@ from sky.server import common as server_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
+# `sky storage delete` returns as soon as the DeleteBucket API call
+# succeeds, but S3 bucket deletion is eventually consistent: for a short
+# window afterwards head-bucket can still report the bucket as existing.
+# Poll (rather than assert once) so the check tolerates that propagation
+# delay instead of flaking. A non-zero head-bucket (bucket gone / 404)
+# means success; keep retrying only while the bucket still exists.
 _CHECK_AWS_BUCKET_DOESNT_EXIST = (
-    'aws s3api head-bucket --bucket {bucket_name} 2>/dev/null && exit 1 || exit 0'
-)
+    'start=$SECONDS; '
+    'while aws s3api head-bucket --bucket {bucket_name} 2>/dev/null; do '
+    'if (( SECONDS - start > 90 )); then '
+    'echo "Bucket {bucket_name} still exists 90s after deletion"; exit 1; fi; '
+    'echo "Bucket {bucket_name} still exists, waiting for deletion to '
+    'propagate..."; sleep 5; '
+    'done; '
+    'echo "Bucket {bucket_name} no longer exists."; exit 0')
 
 
 @pytest.mark.no_remote_server

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -23,34 +23,55 @@ from sky.server import common as server_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
-# Check that `sky storage delete` actually removed the bucket. Two subtleties
-# make this a polling check rather than a one-shot assertion:
-#   1. `head-bucket` is unreliable here: this check runs on the cloud-cmd
-#      cluster, whose aws CLI default region usually differs from the
-#      (us-east-1) bucket's region, and a cross-region head-bucket keeps
-#      returning a redirect the CLI reports as success ("BucketRegion: ...")
-#      for a window after deletion (and even flickers back). So use
-#      `get-bucket-location`, which is region-robust.
-#   2. Even with get-bucket-location, the deletion (done on the API server)
-#      is not immediately visible from the cloud-cmd cluster: observed to
-#      take >60s to become NoSuchBucket (systematic in CI, 3/3 runs; the
-#      bucket does get deleted -- it is gone minutes later). Poll up to 5min
-#      so the check tolerates that visibility lag instead of flaking.
-# While get-bucket-location still resolves the bucket, keep waiting; once it
-# fails (NoSuchBucket / not accessible), the bucket is gone.
+# [TEMP][DIAGNOSTIC] Root-causing the post-delete visibility lag seen on the
+# remote-server pipeline: after `sky storage delete` succeeds (bucket is
+# genuinely gone minutes later), the cloud-cmd cluster kept seeing the bucket
+# via get-bucket-location for >300s (same account), while the same probes
+# from a laptop converge instantly. This probe matrix samples six existence
+# probes every 10s with timestamps, from two vantage points (test client and
+# cloud-cmd cluster), to find which probe converges and how fast. Will be
+# replaced by the final check once the data is in.
+_BUCKET_GONE_PROBE = (
+    'echo "--- probe env ---"; '
+    'aws --version 2>&1 || true; '
+    'aws configure list 2>&1 || true; '
+    'TOK=$(curl -s -X PUT http://169.254.169.254/latest/api/token '
+    '-H "X-aws-ec2-metadata-token-ttl-seconds: 60" --max-time 2 '
+    '2>/dev/null || true); '
+    'echo "az: $(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: $TOK" '
+    'http://169.254.169.254/latest/meta-data/placement/availability-zone '
+    '2>/dev/null || true)"; '
+    'gone=0; probe_start=$SECONDS; '
+    'while (( SECONDS - probe_start < {limit} )); do '
+    't=$((SECONDS-probe_start)); '
+    'aws s3api head-bucket --bucket {bucket_name} >/dev/null 2>&1; hb=$?; '
+    'aws s3api head-bucket --bucket {bucket_name} --region us-east-1 '
+    '>/dev/null 2>&1; hbr=$?; '
+    'aws s3api get-bucket-location --bucket {bucket_name} '
+    '>/dev/null 2>&1; loc=$?; '
+    'aws s3api get-bucket-location --bucket {bucket_name} --region us-east-1 '
+    '>/dev/null 2>&1; locr=$?; '
+    'aws s3api list-objects-v2 --bucket {bucket_name} --max-keys 1 '
+    '>/dev/null 2>&1; lo=$?; '
+    'lb=$(aws s3api list-buckets '
+    '--query "Buckets[?Name==\'{bucket_name}\'].Name" --output text '
+    '2>/dev/null || true); '
+    'echo "$(date -u +%H:%M:%S) t+$t: head=$hb head_r=$hbr loc=$loc '
+    'loc_r=$locr listobj=$lo listbuckets=[$lb]"; '
+    'if [ "$hb" -ne 0 ] && [ "$hbr" -ne 0 ] && [ "$loc" -ne 0 ] && '
+    '[ "$locr" -ne 0 ] && [ "$lo" -ne 0 ] && [ -z "$lb" ]; then '
+    'gone=1; echo "all probes report bucket gone at t+$t"; break; fi; '
+    'sleep 10; '
+    'done')
+
 _CHECK_AWS_BUCKET_DOESNT_EXIST = (
-    'start=$SECONDS; '
-    'while aws s3api get-bucket-location --bucket {bucket_name} '
-    '> /dev/null 2>&1; do '
-    'if (( SECONDS - start > 300 )); then '
-    'echo "Bucket {bucket_name} still visible 300s after deletion"; '
+    _BUCKET_GONE_PROBE + '; '
+    'if [ "$gone" -eq 1 ]; then '
+    'echo "Bucket {bucket_name} confirmed gone."; exit 0; fi; '
+    'echo "Bucket {bucket_name} still visible after {limit}s"; '
     'aws sts get-caller-identity || true; '
     'aws s3api get-bucket-location --bucket {bucket_name} || true; '
-    'exit 1; fi; '
-    'echo "Bucket {bucket_name} still resolves, waiting for deletion..."; '
-    'sleep 5; '
-    'done; '
-    'echo "Bucket {bucket_name} no longer exists."; exit 0')
+    'exit 1')
 
 
 @pytest.mark.no_remote_server
@@ -258,22 +279,29 @@ def test_storage_delete(generic_cloud: str):
         job_yaml.write(bucket_job_yaml.encode('utf-8'))
         job_yaml.flush()
 
-        test = smoke_tests_utils.Test('storage_delete', [
-            f'echo "bucket name: {bucket_name}"',
-            smoke_tests_utils.launch_cluster_for_cloud_cmd(
-                'aws', name, skip_remote_server_check=True),
-            f's=$(SKYPILOT_DEBUG=0 sky jobs launch -y {job_yaml.name}) && echo "$s" | grep "Job finished (status: SUCCEEDED)."',
-            f's=$(SKYPILOT_DEBUG=0 sky storage delete -y {bucket_name}) && echo "$s" && echo "$s" | grep "Deleted S3 bucket {bucket_name}"',
-            smoke_tests_utils.run_cloud_cmd_on_cluster(
-                name,
-                cmd=_CHECK_AWS_BUCKET_DOESNT_EXIST.format(
-                    bucket_name=bucket_name)),
-        ],
-                                      teardown=smoke_tests_utils.
-                                      down_cluster_for_cloud_cmd(
-                                          name, skip_remote_server_check=True),
-                                      timeout=smoke_tests_utils.get_timeout(
-                                          generic_cloud))
+        test = smoke_tests_utils.Test(
+            'storage_delete',
+            [
+                f'echo "bucket name: {bucket_name}"',
+                smoke_tests_utils.launch_cluster_for_cloud_cmd(
+                    'aws', name, skip_remote_server_check=True),
+                f's=$(SKYPILOT_DEBUG=0 sky jobs launch -y {job_yaml.name}) && echo "$s" | grep "Job finished (status: SUCCEEDED)."',
+                f's=$(SKYPILOT_DEBUG=0 sky storage delete -y {bucket_name}) && echo "$s" && echo "$s" | grep "Deleted S3 bucket {bucket_name}"',
+                # [TEMP][DIAGNOSTIC] Same probe matrix from the test client
+                # (data-gathering only, never fails the test) for contrast with
+                # the cloud-cmd cluster's vantage point below.
+                ('echo "=== [diagnostic] bucket visibility from test client ==="; '
+                 +
+                 _BUCKET_GONE_PROBE.format(bucket_name=bucket_name, limit=120) +
+                 '; echo "client probe done (gone=$gone)"; true'),
+                smoke_tests_utils.run_cloud_cmd_on_cluster(
+                    name,
+                    cmd=_CHECK_AWS_BUCKET_DOESNT_EXIST.format(
+                        bucket_name=bucket_name, limit=480)),
+            ],
+            teardown=smoke_tests_utils.down_cluster_for_cloud_cmd(
+                name, skip_remote_server_check=True),
+            timeout=smoke_tests_utils.get_timeout(generic_cloud, 25 * 60))
         smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
 

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -23,21 +23,27 @@ from sky.server import common as server_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
-# Check that `sky storage delete` actually removed the bucket. `head-bucket`
-# is NOT reliable here: this check runs on the cloud-cmd cluster, whose aws
-# CLI default region usually differs from the (us-east-1) bucket's region,
-# and a cross-region head-bucket keeps returning a redirect that the CLI
-# reports as success ("BucketRegion: ...") for a window after deletion (and
-# even flickers back to success afterwards). `get-bucket-location` instead
-# returns NoSuchBucket immediately and region-robustly, so use it as the
-# deletion signal: while it still resolves the bucket, keep waiting; once it
+# Check that `sky storage delete` actually removed the bucket. Two subtleties
+# make this a polling check rather than a one-shot assertion:
+#   1. `head-bucket` is unreliable here: this check runs on the cloud-cmd
+#      cluster, whose aws CLI default region usually differs from the
+#      (us-east-1) bucket's region, and a cross-region head-bucket keeps
+#      returning a redirect the CLI reports as success ("BucketRegion: ...")
+#      for a window after deletion (and even flickers back). So use
+#      `get-bucket-location`, which is region-robust.
+#   2. Even with get-bucket-location, the deletion (done on the API server)
+#      is not immediately visible from the cloud-cmd cluster: observed to
+#      take >60s to become NoSuchBucket (systematic in CI, 3/3 runs; the
+#      bucket does get deleted -- it is gone minutes later). Poll up to 5min
+#      so the check tolerates that visibility lag instead of flaking.
+# While get-bucket-location still resolves the bucket, keep waiting; once it
 # fails (NoSuchBucket / not accessible), the bucket is gone.
 _CHECK_AWS_BUCKET_DOESNT_EXIST = (
     'start=$SECONDS; '
     'while aws s3api get-bucket-location --bucket {bucket_name} '
     '> /dev/null 2>&1; do '
-    'if (( SECONDS - start > 60 )); then '
-    'echo "Bucket {bucket_name} still exists 60s after deletion"; '
+    'if (( SECONDS - start > 300 )); then '
+    'echo "Bucket {bucket_name} still visible 300s after deletion"; '
     'aws sts get-caller-identity || true; '
     'aws s3api get-bucket-location --bucket {bucket_name} || true; '
     'exit 1; fi; '

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -23,55 +23,41 @@ from sky.server import common as server_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
-# [TEMP][DIAGNOSTIC] Root-causing the post-delete visibility lag seen on the
-# remote-server pipeline: after `sky storage delete` succeeds (bucket is
-# genuinely gone minutes later), the cloud-cmd cluster kept seeing the bucket
-# via get-bucket-location for >300s (same account), while the same probes
-# from a laptop converge instantly. This probe matrix samples six existence
-# probes every 10s with timestamps, from two vantage points (test client and
-# cloud-cmd cluster), to find which probe converges and how fast. Will be
-# replaced by the final check once the data is in.
-_BUCKET_GONE_PROBE = (
-    'echo "--- probe env ---"; '
-    'aws --version 2>&1 || true; '
-    'aws configure list 2>&1 || true; '
-    'TOK=$(curl -s -X PUT http://169.254.169.254/latest/api/token '
-    '-H "X-aws-ec2-metadata-token-ttl-seconds: 60" --max-time 2 '
-    '2>/dev/null || true); '
-    'echo "az: $(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: $TOK" '
-    'http://169.254.169.254/latest/meta-data/placement/availability-zone '
-    '2>/dev/null || true)"; '
-    'gone=0; probe_start=$SECONDS; '
-    'while (( SECONDS - probe_start < {limit} )); do '
-    't=$((SECONDS-probe_start)); '
-    'aws s3api head-bucket --bucket {bucket_name} >/dev/null 2>&1; hb=$?; '
-    'aws s3api head-bucket --bucket {bucket_name} --region us-east-1 '
-    '>/dev/null 2>&1; hbr=$?; '
-    'aws s3api get-bucket-location --bucket {bucket_name} '
-    '>/dev/null 2>&1; loc=$?; '
-    'aws s3api get-bucket-location --bucket {bucket_name} --region us-east-1 '
-    '>/dev/null 2>&1; locr=$?; '
-    'aws s3api list-objects-v2 --bucket {bucket_name} --max-keys 1 '
-    '>/dev/null 2>&1; lo=$?; '
-    'lb=$(aws s3api list-buckets '
-    '--query "Buckets[?Name==\'{bucket_name}\'].Name" --output text '
-    '2>/dev/null || true); '
-    'echo "$(date -u +%H:%M:%S) t+$t: head=$hb head_r=$hbr loc=$loc '
-    'loc_r=$locr listobj=$lo listbuckets=[$lb]"; '
-    'if [ "$hb" -ne 0 ] && [ "$hbr" -ne 0 ] && [ "$loc" -ne 0 ] && '
-    '[ "$locr" -ne 0 ] && [ "$lo" -ne 0 ] && [ -z "$lb" ]; then '
-    'gone=1; echo "all probes report bucket gone at t+$t"; break; fi; '
-    'sleep 10; '
-    'done')
-
+# Check that `sky storage delete` removed the bucket AND that it stays
+# removed. Two lessons baked in (root-caused via CloudTrail, see #10353):
+#   1. The managed-job controller's post-job cleanup used to re-create the
+#      just-deleted bucket a few seconds after deletion (construct() on the
+#      task's storage mounts auto-creates missing buckets). A one-shot
+#      existence check right after delete races ahead of the recreation and
+#      false-passes, silently leaking the bucket. So after the bucket is
+#      first observed gone, hold the assertion open for another 60s and fail
+#      if it reappears.
+#   2. Use `get-bucket-location` rather than `head-bucket`: cross-region
+#      head-bucket keeps returning a redirect the CLI reports as success for
+#      a window after deletion, and this check may run on a cloud-cmd
+#      cluster whose default region differs from the bucket's.
 _CHECK_AWS_BUCKET_DOESNT_EXIST = (
-    _BUCKET_GONE_PROBE + '; '
-    'if [ "$gone" -eq 1 ]; then '
-    'echo "Bucket {bucket_name} confirmed gone."; exit 0; fi; '
-    'echo "Bucket {bucket_name} still visible after {limit}s"; '
+    'start=$SECONDS; '
+    'while aws s3api get-bucket-location --bucket {bucket_name} '
+    '>/dev/null 2>&1; do '
+    'if (( SECONDS - start > 120 )); then '
+    'echo "Bucket {bucket_name} still exists 120s after deletion"; '
     'aws sts get-caller-identity || true; '
     'aws s3api get-bucket-location --bucket {bucket_name} || true; '
-    'exit 1')
+    'exit 1; fi; '
+    'echo "Bucket {bucket_name} still resolves, waiting..."; sleep 5; '
+    'done; '
+    'echo "Bucket {bucket_name} gone; verifying it stays gone '
+    '(no recreation)..."; '
+    'for i in 1 2 3 4 5 6; do '
+    'sleep 10; '
+    'if aws s3api get-bucket-location --bucket {bucket_name} '
+    '>/dev/null 2>&1; then '
+    'echo "Bucket {bucket_name} REAPPEARED after deletion (recreated at '
+    '+$((SECONDS-start))s)"; exit 1; fi; '
+    'done; '
+    'echo "Bucket {bucket_name} confirmed deleted and not recreated."; '
+    'exit 0')
 
 
 @pytest.mark.no_remote_server
@@ -279,29 +265,22 @@ def test_storage_delete(generic_cloud: str):
         job_yaml.write(bucket_job_yaml.encode('utf-8'))
         job_yaml.flush()
 
-        test = smoke_tests_utils.Test(
-            'storage_delete',
-            [
-                f'echo "bucket name: {bucket_name}"',
-                smoke_tests_utils.launch_cluster_for_cloud_cmd(
-                    'aws', name, skip_remote_server_check=True),
-                f's=$(SKYPILOT_DEBUG=0 sky jobs launch -y {job_yaml.name}) && echo "$s" | grep "Job finished (status: SUCCEEDED)."',
-                f's=$(SKYPILOT_DEBUG=0 sky storage delete -y {bucket_name}) && echo "$s" && echo "$s" | grep "Deleted S3 bucket {bucket_name}"',
-                # [TEMP][DIAGNOSTIC] Same probe matrix from the test client
-                # (data-gathering only, never fails the test) for contrast with
-                # the cloud-cmd cluster's vantage point below.
-                ('echo "=== [diagnostic] bucket visibility from test client ==="; '
-                 +
-                 _BUCKET_GONE_PROBE.format(bucket_name=bucket_name, limit=120) +
-                 '; echo "client probe done (gone=$gone)"; true'),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    cmd=_CHECK_AWS_BUCKET_DOESNT_EXIST.format(
-                        bucket_name=bucket_name, limit=480)),
-            ],
-            teardown=smoke_tests_utils.down_cluster_for_cloud_cmd(
-                name, skip_remote_server_check=True),
-            timeout=smoke_tests_utils.get_timeout(generic_cloud, 25 * 60))
+        test = smoke_tests_utils.Test('storage_delete', [
+            f'echo "bucket name: {bucket_name}"',
+            smoke_tests_utils.launch_cluster_for_cloud_cmd(
+                'aws', name, skip_remote_server_check=True),
+            f's=$(SKYPILOT_DEBUG=0 sky jobs launch -y {job_yaml.name}) && echo "$s" | grep "Job finished (status: SUCCEEDED)."',
+            f's=$(SKYPILOT_DEBUG=0 sky storage delete -y {bucket_name}) && echo "$s" && echo "$s" | grep "Deleted S3 bucket {bucket_name}"',
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name,
+                cmd=_CHECK_AWS_BUCKET_DOESNT_EXIST.format(
+                    bucket_name=bucket_name)),
+        ],
+                                      teardown=smoke_tests_utils.
+                                      down_cluster_for_cloud_cmd(
+                                          name, skip_remote_server_check=True),
+                                      timeout=smoke_tests_utils.get_timeout(
+                                          generic_cloud))
         smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
 

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -472,10 +472,13 @@ class TestCleanupStorageStaleBucket:
         from sky import exceptions as sky_exc
 
         stale_storage = mock.MagicMock()
+        # Ephemeral storage: it is a teardown target, so cleanup constructs it.
+        stale_storage.persistent = False
         stale_storage.construct.side_effect = sky_exc.StorageBucketGetError(
             'Attempted to use a non-existent bucket as a source: s3://gone')
 
         live_storage = mock.MagicMock()
+        live_storage.persistent = False
         # construct() returns normally → storage stays in storage_mounts.
 
         mock_task = mock.MagicMock()
@@ -508,6 +511,7 @@ class TestCleanupStorageStaleBucket:
         """Non-bucket-missing construct errors still fail cleanup — we
         don't want to silently swallow real bugs like expired creds."""
         broken_storage = mock.MagicMock()
+        broken_storage.persistent = False
         broken_storage.construct.side_effect = RuntimeError(
             'credential expired')
 
@@ -528,3 +532,35 @@ class TestCleanupStorageStaleBucket:
             'unexpected construct errors must propagate as cleanup failure')
         # The broader except block aborted before reaching teardown.
         mock_backend.teardown_ephemeral_storage.assert_not_called()
+
+    def test_persistent_storage_not_constructed(self):
+        """A persistent storage must NOT be constructed during cleanup.
+
+        construct() auto-creates a missing bucket, so constructing a
+        persistent storage whose bucket the user just deleted would silently
+        re-create and leak it. teardown_ephemeral_storage() only deletes
+        persistent=False storages, so persistent ones need no construction.
+        """
+        persistent_storage = mock.MagicMock()
+        persistent_storage.persistent = True
+
+        mock_task = mock.MagicMock()
+        mock_task.storage_mounts = {'/persist': persistent_storage}
+        mock_task.file_mounts = None
+
+        mock_backend = mock.MagicMock()
+
+        with mock.patch('sky.serve.service.task_lib.Task.from_yaml_str',
+                        return_value=mock_task), \
+             mock.patch(
+                 'sky.serve.service.cloud_vm_ray_backend.CloudVmRayBackend',
+                 return_value=mock_backend):
+            result = service.cleanup_storage('dummy: yaml')
+
+        assert result is True
+        persistent_storage.construct.assert_not_called()
+        # It stays in storage_mounts and teardown (which skips persistent
+        # storages) is still invoked for the ephemeral ones.
+        assert '/persist' in mock_task.storage_mounts
+        mock_backend.teardown_ephemeral_storage.assert_called_once_with(
+            mock_task)


### PR DESCRIPTION
## Summary

`test_storage_delete` failing consistently on the remote server turned out to be a **real product bug caught by the test**, not a test flake: **the managed-job controller's post-job cleanup re-creates the bucket the user just deleted, and leaks it.**

### Root cause (CloudTrail-verified)

After a managed job finishes, the controller's `_cleanup` constructs **all** of the task's storage mounts before calling `teardown_ephemeral_storage()` (`sky/jobs/controller.py`), and `Storage.construct()` **auto-creates missing buckets** (`S3Store._get_bucket`: *"If bucket cannot be found, create it if needed"*). `teardown_ephemeral_storage()` then only deletes `persistent=False` storages — so a persistent user bucket deleted between job completion and cleanup gets silently **re-created and leaked**.

CloudTrail sequence, reproduced on every run (local and remote pipelines):

```
CreateBucket  (Boto3,  jobs launch)
DeleteBucket  (aws-cli, sky storage delete)     ← delete succeeds
CreateBucket  (Boto3,  +4–7s, controller cleanup)  ← THE BUG
```

Why the pipelines disagreed:
- **remote-server**: the check reaches the bucket via the cloud-cmd cluster ~15–40s after delete → after the recreation → correctly fails, consistently.
- **local**: the one-shot check runs ~1s after delete → **races ahead of the +4–7s recreation → false-passes** and the bucket leaks. (19 leaked `t-storage-delete-*` buckets were found in the CI account and cleaned up.)

The same construct-all-then-teardown pattern exists in the serve controller cleanup (`sky/serve/service.py`) and is fixed the same way.

### Fix

- `sky/jobs/controller.py`, `sky/serve/service.py`: only construct storages that `teardown_ephemeral_storage()` will actually delete (`persistent=False`). Persistent storages need no construction there.
- `tests/smoke_tests/test_cli.py`: the bucket-gone check now (a) polls `get-bucket-location` (region-robust, unlike cross-region `head-bucket`) until the bucket is gone, then (b) **asserts it stays gone for 60s** — so recreation-class regressions fail on both pipelines instead of racing past the check.

## Test

- [x] CloudTrail event-history repro of the recreation on 3 separate CI runs + the passing local run (false pass)
- [x] Check logic validated locally (`bash -n`; gone→0, reappear→1, never-deleted→1)
- [x] pre-commit (yapf/isort/mypy/pylint) passed
- [ ] `/smoke-test --aws --remote-server -k test_storage_delete`