### PR TITLE
[Test] Capture cluster-job setup logs when wait-for-job-status times out

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -254,7 +254,22 @@ _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID = (
     'start_time=$SECONDS; '
     'while true; do '
     'if (( $SECONDS - $start_time > {timeout} )); then '
-    '  echo "Timeout after {timeout} seconds waiting for job status \'{job_status}\'"; exit 1; '
+    '  echo "Timeout after {timeout} seconds waiting for job status \'{job_status}\'"; '
+    # A cluster job whose (detached) setup fails ends up in FAILED_SETUP and
+    # never reaches the target status, so we only find out via this timeout.
+    # `sky logs <cluster> <job>` tails run.log, which is empty on setup
+    # failure, and the cluster is torn down afterwards -- so the actual setup
+    # error is otherwise lost. Sync the log dir down (works against a remote
+    # API server) and dump setup-*.log / run.log so CI captures the reason.
+    '  echo "=== Diagnostics: sky queue {cluster_name} ==="; '
+    '  sky queue {cluster_name} 2>&1 || true; '
+    '  echo "=== Diagnostics: syncing down logs for {cluster_name} ==="; '
+    '  timeout 120 sky logs {cluster_name} \'*\' --sync-down > /dev/null 2>&1 || true; '
+    '  for f in $(find ~/sky_logs/{cluster_name} -type f -name "setup-*.log" 2>/dev/null) '
+    '$(find ~/sky_logs/{cluster_name} -type f -name "run.log" 2>/dev/null); do '
+    '    echo "----- $f -----"; tail -n 200 "$f"; '
+    '  done; '
+    '  exit 1; '
     'fi; '
     'current_queue=$(sky queue {cluster_name}); '
     'current_status=$(echo "$current_queue" | '


### PR DESCRIPTION
## Summary

Diagnostics-first fix for `test_cancel_pytorch` failing on the remote server. The job's (detached) setup fails → the job lands in `FAILED_SETUP` → it never reaches the target `RUNNING/SUCCEEDED`, so the smoke-test wait helper only surfaces a bare `Timeout after 360 seconds`. The actual setup error was **unrecoverable in CI**:

- `sky logs <cluster> <job>` only tails `run.log`, which is empty when setup fails (`log_lib.tail_logs`);
- `scripts/fetch_failed_job_logs.sh` only covers **managed** jobs, not cluster jobs;
- the cluster is torn down after the test, so `~/sky_logs/<run>/setup-*.log` is gone.

So `FAILED_SETUP` had no diagnosable root cause.

This adds diagnostics at the exact failure point (the wait-for-job-status timeout): dump `sky queue`, `sky logs <cluster> '*' --sync-down` (rsyncs the whole job log dir, including `setup-*.log`, and works against a remote API server), then print `setup-*.log` / `run.log`. Uses only `{cluster_name}`, so it applies uniformly to all three `get_cmd_wait_until_job_status_contains_*` variants. **Diagnostics only — no behavior change on success.**

Follow-up (not in this PR): the helper still waits the full timeout on a terminal `FAILED_*` status; a fail-fast could save ~6 min, but that touches shared multi-job wait semantics and is left out to keep this change safe.

## Test

- [x] Code formatting: pre-commit (yapf/isort/mypy) passed
- [x] All three helper variants render valid bash (`bash -n`)
- [x] Dump snippet locally prints a stubbed `setup-*.log` (find + tail)
- [ ] `/smoke-test --aws --remote-server -k test_cancel_pytorch` (to confirm the setup error now appears in the log)
