### PR TITLE
[Core] Scope the sky log level to the current context

### DIFF
--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -1,6 +1,7 @@
 """Logging utilities."""
 import builtins
 import contextlib
+import contextvars
 from datetime import datetime
 import logging
 import os
@@ -52,6 +53,15 @@ class NewLineFormatter(logging.Formatter):
         return msg
 
 
+# Log level requested by the currently running request / background daemon, or
+# None to fall back to the handler's own level. Scoped to the contextvars
+# Context rather than applied to the shared `sky.*` Logger objects: the API
+# server runs many requests and daemons in one process, so mutating logger
+# levels there lets one component's verbosity silence another's logs.
+_level_override: contextvars.ContextVar = contextvars.ContextVar(
+    'sky_logging_level_override', default=None)
+
+
 class EnvAwareHandler(rich_utils.RichSafeStreamHandler):
     """A handler that awares environment variables.
 
@@ -76,11 +86,21 @@ class EnvAwareHandler(rich_utils.RichSafeStreamHandler):
                 # SKYPILOT_DEBUG env var if SUPPRESS_SENSITIVE_LOG is set
                 if env_options.Options.SUPPRESS_SENSITIVE_LOG.get():
                     return logging.INFO
+            # An explicit per-context level (set by set_sky_logging_levels)
+            # wins over SKYPILOT_DEBUG: it is how a background daemon asks for
+            # its own verbosity, and the daemon shares this process - and this
+            # handler object - with everything else running here.
+            override = _level_override.get()
+            if override is not None:
+                return override
             if env_options.Options.SHOW_DEBUG_INFO.get():
                 return logging.DEBUG
             else:
                 return self._level
         else:
+            override = _level_override.get()
+            if override is not None:
+                return override
             return self._level
 
     @level.setter
@@ -165,32 +185,31 @@ def init_logger(name: str) -> logging.Logger:
 
 @contextlib.contextmanager
 def set_sky_logging_levels(level: int):
-    """Set the logging level for all loggers."""
-    # Turn off logger
-    previous_levels = {}
-    for logger_name in logging.Logger.manager.loggerDict:
-        if logger_name.startswith('sky'):
-            logger = logging.getLogger(logger_name)
-            previous_levels[logger_name] = logger.level
-            logger.setLevel(level)
+    """Sets the sky logging level for the current context.
+
+    The level applies to whatever runs inside this context manager - a request,
+    or one background daemon's tick - and to nothing else. It is deliberately
+    not applied to the `sky.*` Logger objects: those are process-global, and
+    the API server runs requests and daemons concurrently in one process, so
+    setting levels there made one component's verbosity suppress another's log
+    records (the `sky` root logger is intentionally left at DEBUG so that the
+    context-aware handler decides, see `_setup_logger` and `logging_enabled`).
+
+    Filtering happens in EnvAwareHandler.level, which reads the override below.
+    """
+    token = _level_override.set(level)
+    previous_show_debug_info = None
     if level == logging.DEBUG:
         previous_show_debug_info = env_options.Options.SHOW_DEBUG_INFO.get()
+        # Context-aware: writes land in this context's env overrides when a
+        # SkyPilotContext is active, so subprocesses spawned here inherit it.
         os.environ[env_options.Options.SHOW_DEBUG_INFO.env_key] = '1'
     try:
         yield
     finally:
-        # Restore logger
-        for logger_name in logging.Logger.manager.loggerDict:
-            if logger_name.startswith('sky'):
-                logger = logging.getLogger(logger_name)
-                try:
-                    logger.setLevel(previous_levels[logger_name])
-                except KeyError:
-                    # New loggers maybe initialized after the context manager,
-                    # no need to restore the level.
-                    pass
+        _level_override.reset(token)
         if level == logging.DEBUG and not previous_show_debug_info:
-            os.environ.pop(env_options.Options.SHOW_DEBUG_INFO.env_key)
+            os.environ.pop(env_options.Options.SHOW_DEBUG_INFO.env_key, None)
 
 
 def logging_enabled(logger: logging.Logger, level: int) -> bool:

--- a/tests/unit_tests/test_sky/test_sky_logging.py
+++ b/tests/unit_tests/test_sky/test_sky_logging.py
@@ -122,3 +122,62 @@ def test_handler_output(mock_get, handler, stream, monkeypatch):
     handler.level = logging.DEBUG
     logger.debug('Debug message 2')
     assert 'Debug message 2' in stream.getvalue()
+
+
+def test_set_sky_logging_levels_does_not_mutate_shared_loggers():
+    """The level must be scoped to the caller, not written to shared state.
+
+    `logging.Logger` objects are process-global, and the API server runs
+    requests and background daemons concurrently in one process. Setting levels
+    on those objects let one component's verbosity change what another wrote,
+    and left a logger at the wrong level for good when two callers interleaved
+    their save/restore.
+    """
+    probe = logging.getLogger('sky.test_no_shared_mutation')
+    original = probe.level
+
+    with sky_logging.set_sky_logging_levels(logging.WARNING):
+        assert probe.level == original, (
+            'set_sky_logging_levels mutated a shared Logger object; the level '
+            'must live in the context instead')
+
+    assert probe.level == original
+
+
+def test_set_sky_logging_levels_applies_to_the_handler(monkeypatch):
+    """The requested level must still take effect, via the handler."""
+    monkeypatch.setattr(context, 'get', lambda: None)
+    handler = sky_logging.EnvAwareHandler(io.StringIO(), level=logging.INFO)
+    assert handler.level == logging.INFO
+
+    with sky_logging.set_sky_logging_levels(logging.WARNING):
+        assert handler.level == logging.WARNING
+
+    assert handler.level == logging.INFO
+
+
+def test_set_sky_logging_levels_is_isolated_per_context():
+    """Two contexts must not see each other's level."""
+    import contextvars
+
+    handler = sky_logging.EnvAwareHandler(io.StringIO(), level=logging.INFO)
+    seen = {}
+
+    def quiet():
+        with sky_logging.set_sky_logging_levels(logging.WARNING):
+            seen['inside'] = handler.level
+            # A sibling context running concurrently must be unaffected.
+            contextvars.copy_context().run(other)
+            seen['after_sibling'] = handler.level
+
+    def other():
+        seen['sibling'] = handler.level
+
+    contextvars.copy_context().run(quiet)
+
+    assert seen['inside'] == logging.WARNING
+    assert seen['after_sibling'] == logging.WARNING
+    # The sibling context inherits a copy, so it sees the same level; what must
+    # hold is that it cannot leak a change back out.
+    assert handler.level == logging.INFO, (
+        'the level escaped the context that set it')

--- a/tests/unit_tests/test_sky/test_sky_logging.py
+++ b/tests/unit_tests/test_sky/test_sky_logging.py
@@ -156,10 +156,14 @@ def test_set_sky_logging_levels_applies_to_the_handler(monkeypatch):
     assert handler.level == logging.INFO
 
 
-def test_set_sky_logging_levels_is_isolated_per_context():
+def test_set_sky_logging_levels_is_isolated_per_context(monkeypatch):
     """Two contexts must not see each other's level."""
     import contextvars
 
+    # Pin out the SKYPILOT_DEBUG branch of EnvAwareHandler.level so this test
+    # is about the override alone: the suite runs with SKYPILOT_DEBUG=1, and a
+    # SkyPilotContext initialized by an earlier test can still be active here.
+    monkeypatch.setattr(context, 'get', lambda: None)
     handler = sky_logging.EnvAwareHandler(io.StringIO(), level=logging.INFO)
     seen = {}
 


### PR DESCRIPTION
## Summary

`set_sky_logging_levels` applied the requested level by calling `setLevel()` on every `sky.*` `Logger` object. Those objects are process-global, while the API server runs requests and background daemons concurrently in one process — so the log level was shared mutable state. Three consequences:

1. **One component's verbosity changed what another wrote.** A daemon configured with `daemons.<id>.log_level: WARNING` clamped every `sky.*` logger for the duration of its tick, so anything else running in that process lost its DEBUG/INFO records — the record is gated on the *logger* before it ever reaches the context-aware handler.

2. **Interleaved callers could leave a logger permanently at the wrong level.** Each caller captures `previous_levels` on entry; if B snapshots a level A had already changed, B's restore writes A's temporary value back as though it were the original, and nothing puts it right again.

3. **The walk used to find those loggers was itself unsafe.** `logging.Logger.manager.loggerDict` is process-global, and `getLogger()` inserts into it (under the logging lock) for every name it has not seen — which every first-time module import does, including the lazily imported cloud SDKs. An unlocked reader racing those locked writers raises `RuntimeError: dictionary changed size during iteration`.

The fix carries the level in a `contextvars.ContextVar` and has `EnvAwareHandler.level` honor it. The level then applies to exactly what runs inside the context manager, no shared object is mutated, and the `loggerDict` walk disappears rather than being worked around.

This is the direction the module already points: `_setup_logger` deliberately leaves the `sky` root logger at `DEBUG` so that the context-aware handler decides, as `logging_enabled`'s own comment notes. `set_sky_logging_levels` was the one place still mutating global logger state.

### Behavior note for reviewers

A contextvar propagates into `asyncio.to_thread` / `copy_context` workers but not into plain `threading.Thread` or `multiprocessing.pool.ThreadPool` workers. Work a daemon farms out through `subprocess_utils.run_in_parallel` therefore logs at the handler's own level instead of inheriting the daemon's. That inheritance only existed because the level was global — it is the same leak seen from the other side — but it is a visible change in daemon log output, so calling it out explicitly.

## Tested

```
pytest tests/unit_tests/test_sky/test_sky_logging.py      # 10 passed
```

Three new tests, each confirmed to **fail before this change** and pass after:

| test | failure on `master` |
|---|---|
| `test_set_sky_logging_levels_does_not_mutate_shared_loggers` | `AssertionError: assert 30 == 0` — the shared `Logger` was set to `WARNING` |
| `test_set_sky_logging_levels_applies_to_the_handler` | `assert 20 == 30` — the level never reached the handler |
| `test_set_sky_logging_levels_is_isolated_per_context` | `assert 20 == 30` |

The `RuntimeError` above also reproduces directly on `master` with a harness whose only mutation is `logging.getLogger(<new name>)` — i.e. exactly what a module import does:

```
File "sky/sky_logging.py", line 171, in set_sky_logging_levels
    for logger_name in logging.Logger.manager.loggerDict:
RuntimeError: dictionary changed size during iteration
```

Manual end-to-end check on a local API server: with `daemons.skypilot-status-refresh-daemon.log_level: WARNING` and a second daemon left at `DEBUG`, the first daemon's log stays empty while the second logs 40 `DEBUG` records, and concurrent requests keep the verbosity they asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPereKStKsRuQCzYeSuZjn
