### PR TITLE
[Core] Advisory try_acquire confirms a held role instead of contending with it

### DIFF
--- a/sky/utils/leader_election.py
+++ b/sky/utils/leader_election.py
@@ -141,11 +141,12 @@ class LeaderElector(abc.ABC):
 class AdvisoryLockElector(LeaderElector):
     """Leader election backed by a Postgres session-scoped advisory lock.
 
-    Wraps ``sky.utils.locks`` with no behavior change from the historical path:
-    ``try_acquire`` is a non-blocking advisory-lock acquire, ``renew`` is the
-    session-liveness probe, and ``release`` drops the lock. Provides no fencing
-    token. On non-Postgres backends the underlying ``FileLock`` makes this a
-    process-local lock, which is exactly right for single-node deployments.
+    Wraps ``sky.utils.locks``: ``try_acquire`` confirms a session this
+    candidate already holds and otherwise bids for the lock without blocking,
+    ``renew`` is the session-liveness probe, and ``release`` drops the lock.
+    Provides no fencing token. On non-Postgres backends the underlying
+    ``FileLock`` makes this a process-local lock, which is exactly right for
+    single-node deployments.
     """
 
     def __init__(self, lock_id: str):
@@ -153,8 +154,18 @@ class AdvisoryLockElector(LeaderElector):
         self._lock: Optional[locks.DistributedLock] = None
 
     def try_acquire(self) -> bool:
-        # Build a fresh lock object each bid so a prior term's closed connection
-        # is never reused (mirrors the historical per-cycle ``get_lock`` call).
+        if self._lock is not None:
+            # A previous bid won, and that session may well still hold the
+            # lock. A fresh bid would open a new session and be refused by our
+            # own exclusive lock -- answering False, to the leader, with the
+            # role unmoved and nothing left that would ever release it.
+            # Confirm the held session instead, and bid anew only after a dead
+            # one has been dropped.
+            if self.renew():
+                return True
+            self.release()
+        # A contending bid builds a fresh lock object, so a prior term's
+        # closed connection is never reused.
         lock = locks.get_lock(self._lock_id)
         try:
             lock.acquire(blocking=False)

--- a/tests/unit_tests/test_leader_election.py
+++ b/tests/unit_tests/test_leader_election.py
@@ -264,7 +264,7 @@ def test_pg_release_hands_over_immediately(lease_db):
 # synchronisation point, so the machine is still one call at a time.
 #
 # Both backends implement the same ``LeaderElector`` contract, so one machine
-# drives both. They differ in four places, and only those live in the adapters
+# drives both. They differ in three places, and only those live in the adapters
 # below; every invariant is shared.
 
 # A lease TTL far longer than a run, so a lease only ever ends because the
@@ -491,9 +491,6 @@ class _LeaseBackend:
     pre-commit park seam.
     """
 
-    # The upsert matches on ``holder``, so the current holder re-bidding for
-    # its own still-valid lease is served the same row back.
-    holder_can_reacquire = True
     has_fencing_token = True
     # Losing the role leaves the row in place, named but expired. That is what
     # lets a same-holder re-acquire be told apart from a first acquire.
@@ -570,11 +567,6 @@ class _AdvisoryBackend:
     reset.
     """
 
-    # Each bid opens its own session and an exclusive advisory lock admits one
-    # session, so the holder re-bidding is refused by the lock it is already
-    # holding -- and keeps holding it. See
-    # ``test_advisory_reacquire_while_leading_is_refused``.
-    holder_can_reacquire = False
     has_fencing_token = False
     # A reaped or released session frees the lock outright; the server keeps
     # no record of who held it.
@@ -782,14 +774,6 @@ class LeaderElectionMachine(stateful.RuleBasedStateMachine):
         self._server_state = _UNREAD
         elector = self._electors[actor]
         leader = self._leader()
-        if leader == actor and not self._backend.holder_can_reacquire:
-            # Left out of the machine on this backend: the bid answers False
-            # while the role stays put, so the actor's belief and the server's
-            # state come apart and no interleaving can put them back together.
-            # Pinned on its own by
-            # ``test_advisory_reacquire_while_leading_is_refused``.
-            hypothesis.event('acquire: self-bid, not modelled')
-            return
         if self._blocks_acquire():
             # The upsert waits on the parked transaction's row and dies at the
             # statement timeout. A lost role is the safe reading of a bid that
@@ -1483,25 +1467,43 @@ def test_advisory_election_invariants_hold_under_contention(advisory_db):
 
 @pg_only
 @pytest.mark.xdist_group('leader_election_lease')
-def test_advisory_reacquire_while_leading_is_refused(advisory_db):
-    """The holder's own bid loses to its own lock, and it keeps the lock.
+def test_advisory_reacquire_while_leading_confirms_leadership(advisory_db):
+    """The holder's own bid confirms the role instead of contending with it.
 
-    Each ``try_acquire`` opens a fresh session (a prior term's connection is
-    never reused), and an exclusive advisory lock admits one session, so the
-    holder's second bid is refused by the lock it is already holding. The role
-    does not move: ``renew`` still reports leadership, the lock stays held, and
-    no other candidate can take it. So the ``False`` here does not mean what it
-    means everywhere else -- the lease backend answers True in this position --
-    which is why the state machine leaves this transition to this test.
+    A fresh bid opens its own session, and an exclusive advisory lock admits
+    one, so an unconditional re-bid would be refused by the very lock the
+    caller is holding -- ``False``, to the leader, with the role unmoved and
+    nothing left that would ever release it. ``try_acquire`` therefore
+    confirms a held session first ("True iff this candidate leads", matching
+    the lease backend's answer in this position), and opens a fresh bid only
+    once a dead session has been dropped.
     """
     a = leader_election.AdvisoryLockElector('reacquire-lock')
     assert a.try_acquire() is True
-    assert a.try_acquire() is False
+    assert a.try_acquire() is True
     assert a.renew() is True
     assert a._lock.is_locked() is True
 
     b = leader_election.AdvisoryLockElector('reacquire-lock')
     assert b.try_acquire() is False
+
+    # A dead session is not blindly confirmed: reap it, and the holder's next
+    # bid drops the dead lock and contends fresh for the freed role.
+    key = locks.PostgresLock('reacquire-lock')._lock_key
+    with advisory_db.connect() as connection:
+        pid = connection.execute(
+            sqlalchemy.text(
+                'SELECT l.pid FROM pg_locks l WHERE l.locktype = '
+                "'advisory' "
+                'AND l.granted '
+                'AND ((l.classid::bigint << 32) | l.objid::bigint) = :key'), {
+                    'key': key
+                }).scalar()
+        connection.execute(sqlalchemy.text('SELECT pg_terminate_backend(:p)'),
+                           {'p': pid})
+        connection.commit()
+    assert a.renew() is False
+    assert a.try_acquire() is True
     a.release()
     assert b.try_acquire() is True
     b.release()


### PR DESCRIPTION
Stacked on #10359, which found and pinned this. Fixes finding 1 there and flips the pinning test.

## The bug

`AdvisoryLockElector.try_acquire` opens a fresh Postgres session per bid, so the holder's own re-bid is refused **by the lock it is already holding** and returns `False` — to the leader, with the role unmoved. The ABC says "True iff this candidate leads", and `PgLeaseElector` answers `True` in the same position, so the two backends disagreed on the contract. The sharp edge: a caller that reads `False` as "not the leader" has no reason to `release()`, so its own live session holds the lock indefinitely and no candidate can ever win it. `get_elector` has no callers in-tree yet; this lands the contract before the first consumer pattern ossifies.

## The fix

Confirm a held session first (`renew()`, the existing liveness probe), and open a fresh bid only after a dead lock has been dropped. A blind `return True` would be wrong after the session was reaped — the flipped test grows a leg for exactly that: reap the holder's backend, assert `renew()` goes `False`, and assert the next bid drops the dead lock and contends fresh.

## Test changes

- `test_advisory_reacquire_while_leading_is_refused` → `test_advisory_reacquire_while_leading_confirms_leadership`, assertions flipped, dead-session leg added.
- The state machine's `holder_can_reacquire` per-backend split is deleted: with both backends agreeing, the advisory machine now drives the held-by-self transition itself (role confirmed, fencing token unchanged) instead of excluding it.

`28 passed` with `SKYPILOT_TEST_PG_URL` set — both property machines and every hand-written transition, on the fixed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

