### PR TITLE
[Test] Pin only object stores whose cloud is enabled on the API server

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -1506,7 +1506,31 @@ def get_enabled_cloud_storages() -> List[clouds.Cloud]:
                 except ValueError:
                     pass
         return enabled_clouds
-    return [clouds.AWS()]
+    # Local API server: the client shares the server's state, so the cached
+    # enabled-storage-clouds list is authoritative and cheaper than shelling
+    # out to `sky check`.
+    #
+    # Do not hardcode a cloud here. Callers use this to decide which object
+    # stores are usable, so a wrong answer is wrong in both directions: too
+    # narrow silently drops real store coverage, too wide pins a store whose
+    # cloud is disabled and fails the job at FAILED_PRECHECKS.
+    #
+    # Imported lazily: smoke_tests_utils is imported by every test module,
+    # including the limited-dependency lane, and sky.data.storage pulls in the
+    # optional cloud storage SDKs.
+    from sky.data import storage as storage_lib
+    enabled_clouds = []
+    for cloud_name in (
+            storage_lib.get_cached_enabled_storage_cloud_names_or_refresh()):
+        try:
+            cloud_obj = registry.CLOUD_REGISTRY.from_str(cloud_name)
+        except ValueError:
+            # Non-cloud object stores (R2, CoreWeave, VAST, HuggingFace) are
+            # not in the cloud registry.
+            continue
+        if cloud_obj is not None:
+            enabled_clouds.append(cloud_obj)
+    return enabled_clouds
 
 
 def write_blob(file: BinaryIO, total_size: int):

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1538,23 +1538,25 @@ def test_managed_jobs_storage(generic_cloud: str):
             'azure': storage_lib.StoreType.AZURE,
             'nebius': storage_lib.StoreType.NEBIUS,
         }
-        # A remote API server may have only a subset of storage clouds
-        # enabled (e.g. the shared GKE API server only enables AWS), and
+        # An API server may have only a subset of storage clouds enabled, and
         # specifying a store whose cloud is disabled on the server fails the
-        # job at FAILED_PRECHECKS. Only pin stores whose cloud is enabled on
-        # the server.
-        if smoke_tests_utils.is_remote_server_test():
-            enabled_storage_cloud_names = {
-                str(cloud).lower()
-                for cloud in smoke_tests_utils.get_enabled_cloud_storages()
-            }
-            pinned_stores = {
-                store_str: store_type
-                for store_str, store_type in pinned_stores.items()
-                if store_type.to_cloud().lower() in enabled_storage_cloud_names
-            }
-            assert pinned_stores, ('No object store enabled on the API server: '
-                                   f'{enabled_storage_cloud_names}')
+        # job at FAILED_PRECHECKS. Only pin stores whose cloud is enabled.
+        #
+        # This applies to a local API server too, not just a remote one: the
+        # set of enabled storage clouds is a property of the server, not of how
+        # the test reaches it. Gating this filter on remote-server runs left
+        # local runs pinning stores that the server could not serve.
+        enabled_storage_cloud_names = {
+            str(cloud).lower()
+            for cloud in smoke_tests_utils.get_enabled_cloud_storages()
+        }
+        pinned_stores = {
+            store_str: store_type
+            for store_str, store_type in pinned_stores.items()
+            if store_type.to_cloud().lower() in enabled_storage_cloud_names
+        }
+        assert pinned_stores, ('No object store enabled on the API server: '
+                               f'{enabled_storage_cloud_names}')
         # For Azure, the bucket lands in the configured storage account when
         # the API server shares the client config, or in the default per-user
         # account (AzureBlobStore's default region) when a remote API server


### PR DESCRIPTION
## Problem

On the `kubernetes`/`slurm` lanes, `test_managed_jobs_storage` pins one output bucket per object store so every store is exercised deterministically rather than depending on which store the server happens to pick as the default.

Specifying a store whose cloud is **disabled** on the API server fails the job at `FAILED_PRECHECKS`, so the test already filters the pinned set down to the enabled clouds — but only `if smoke_tests_utils.is_remote_server_test()`.

The set of enabled storage clouds is a property of the **server**, not of how the test reaches it. A local API server can just as easily have a given storage cloud disabled, and in that case the test pins a store the server cannot serve and the job dies in precheck. The filter is missing exactly where nothing else compensates.

## Change

1. **Make the filter unconditional** (`tests/smoke_tests/test_managed_job.py`) — drop the `is_remote_server_test()` gate so local and remote runs pin the same way.

2. **Make `get_enabled_cloud_storages()` accurate for a local server** (`tests/smoke_tests/smoke_tests_utils.py`) — it previously returned a hardcoded `[AWS()]` on the non-remote path. That is wrong in both directions, and the naive version of change (1) would have inherited it: too narrow silently drops real store coverage (S3 only), too wide pins an unusable store. It now resolves from the cached enabled-storage-clouds list, which is authoritative for a local server (client and server share state) and cheaper than shelling out to `sky check`. Non-cloud object stores (R2, CoreWeave, VAST, HuggingFace) aren't in the cloud registry and are skipped, matching the existing remote-path behaviour.

`sky.data.storage` is imported lazily inside the helper: `smoke_tests_utils` is imported by every test module — including the limited-dependency lane — and that module pulls in the optional cloud storage SDKs.

## Tested

- `python -m py_compile` clean on both files; `isort` / `yapf` / `mypy` pre-commit hooks pass.
- Exercised the new local path directly against a real client state: it returned the actual enabled storage clouds (in my case `['Nebius', 'Azure']`) and resolved them to `['nebius', 'azure']`, correctly skipping registry misses — where the old code would have claimed `AWS`, which was not enabled for storage at all. Feeding that through the filter drops the stores the server cannot serve and keeps the rest.
- The `assert pinned_stores` guard still fires if a server has no object store enabled at all, so a misconfigured server is a loud failure rather than a silently empty pin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaW9tAQB171FDcmDhcLEo6