### PR TITLE
[Logs][Test] Bound apt stalls in the fluent-bit agent install, and raise log-store smoke-test timeouts

### DIFF
--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -31,12 +31,28 @@ class LoggingAgent(abc.ABC):
 class FluentbitAgent(LoggingAgent):
     """Base class for logging store that use fluentbit as the agent."""
 
+    # apt defaults to no retries and a 120s per-file inactivity timeout, so a
+    # single unresponsive package-mirror backend stalls the whole install --
+    # `apt-get update` alone fetches dozens of index files, and distro mirrors
+    # are commonly a DNS pool where only some backends are wedged. Since this
+    # install runs inline on every node of every cluster launch, that turns into
+    # minutes (or, with nothing bounding it, an apparently hung launch).
+    #
+    # Bound each stall and retry instead. Acquire::*::Timeout is an *inactivity*
+    # timeout rather than a total transfer deadline, so a slow-but-progressing
+    # download is not affected -- only one that has stopped sending data.
+    _APT_RETRY_OPTS = ('-o Acquire::Retries=3 '
+                       '-o Acquire::http::Timeout=15 '
+                       '-o Acquire::https::Timeout=15')
+
     def get_setup_command(self,
                           cluster_name: resources_utils.ClusterName) -> str:
+        apt_opts = self._APT_RETRY_OPTS
         install_cmd = (
             # pylint: disable=line-too-long
             'if ! command -v fluent-bit >/dev/null 2>&1 && [ ! -f /opt/fluent-bit/bin/fluent-bit ]; then '
-            'sudo apt-get update; sudo apt-get install -y gnupg; '
+            f'sudo apt-get update {apt_opts}; '
+            f'sudo apt-get install -y {apt_opts} gnupg; '
             # pylint: disable=line-too-long
             'sudo sh -c \'curl -L https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg\'; '
             # pylint: disable=line-too-long
@@ -45,11 +61,11 @@ class FluentbitAgent(LoggingAgent):
             'codename=$(grep -oP \'(?<=VERSION_CODENAME=).*\' /etc/os-release 2>/dev/null || lsb_release -cs 2>/dev/null); '
             # pylint: disable=line-too-long
             'echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/$os_id/$codename $codename main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list; '
-            'sudo apt-get update; '
+            f'sudo apt-get update {apt_opts}; '
             # Pin to <5.0 because fluent-bit 5.0.0 broke the stackdriver
             # output plugin's service account auth (google_service_credentials
             # and GOOGLE_APPLICATION_CREDENTIALS are both ignored).
-            'sudo apt-get install -y \"fluent-bit=4.*\"; '
+            f'sudo apt-get install -y {apt_opts} \"fluent-bit=4.*\"; '
             'fi')
         cfg = self.fluentbit_config(cluster_name)
         cfg_path = os.path.join(constants.LOGGING_CONFIG_DIR, 'fluentbit.yaml')

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -424,6 +424,26 @@ def get_cmd_wait_until_job_status_succeeded(cluster_name: str,
 
 DEFAULT_CMD_TIMEOUT = 15 * 60
 
+# Per-command timeout for tests that configure `logs.store`.
+#
+# Configuring a log store adds a "Setting up logging agent" step to every
+# cluster launch, which installs fluent-bit on each node. That install runs
+# `apt-get update` and `apt-get install` against the distro package mirrors
+# before fetching fluent-bit itself. On a freshly booted VM the package index
+# refresh is the dominant cost -- it has been observed taking anywhere from 4 to
+# 19 minutes when a mirror is serving at ~100 kB/s, while the (much larger)
+# fluent-bit package downloads from its own CDN in seconds. That pushes a single
+# `sky launch` past the default budget, so give these tests enough room to ride
+# out a slow mirror instead of relying on retries.
+LOG_STORE_CMD_TIMEOUT = 30 * 60
+
+# Time for a managed job to go from submitted to RUNNING when a log store is
+# configured: the job's cluster is provisioned from scratch and pays the
+# fluent-bit install described above before the job can start. Kept below
+# LOG_STORE_CMD_TIMEOUT so that this wait, rather than the enclosing per-command
+# timeout, is what reports the failure.
+LOG_STORE_JOB_START_TIMEOUT = 25 * 60
+
 
 class Test(NamedTuple):
     name: str

--- a/tests/smoke_tests/test_aws_logs.py
+++ b/tests/smoke_tests/test_aws_logs.py
@@ -89,6 +89,6 @@ def test_log_collection_to_aws_cloudwatch(generic_cloud: str):
                  f'{validate_logs_cmd}'),
             ],
             f'sky down -y {name}',
-            timeout=20 * 60,
+            timeout=smoke_tests_utils.LOG_STORE_CMD_TIMEOUT,
         )
         smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_logs.py
+++ b/tests/smoke_tests/test_logs.py
@@ -72,7 +72,7 @@ def test_log_collection_to_gcp(generic_cloud: str):
                  f'{validate_logs_cmd}'),
             ],
             f'sky down -y {name}',
-            timeout=20 * 60,
+            timeout=smoke_tests_utils.LOG_STORE_CMD_TIMEOUT,
         )
         smoke_tests_utils.run_one_test(test)
 
@@ -122,7 +122,7 @@ def test_managed_job_logs_with_log_store(generic_cloud: str):
                 get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                     job_name=job_name,
                     job_status=[sky.ManagedJobStatus.RUNNING],
-                    timeout=360),
+                    timeout=smoke_tests_utils.LOG_STORE_JOB_START_TIMEOUT),
                 'sleep 10',
                 f's=$(sky jobs logs -n {job_name} --no-follow); echo "$s"; '
                 f'echo "$s" | grep "{marker}_1"',
@@ -138,6 +138,6 @@ def test_managed_job_logs_with_log_store(generic_cloud: str):
             ],
             f'sky jobs cancel -y -n {job_name}',
             env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
-            timeout=20 * 60,
+            timeout=smoke_tests_utils.LOG_STORE_CMD_TIMEOUT,
         )
         smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
## Summary

Two layers of the same problem: cluster launches that configure `logs.store` spend minutes in `Setting up logging agent`, and the smoke tests covering that path had no headroom for it. Result: `test_log_collection_to_gcp`, `test_log_collection_to_aws_cloudwatch` and `test_managed_job_logs_with_log_store` were only going green after 3-5 retries.

**Layer 1 — `sky/logs/agent.py` (product fix).** Bound apt stalls so a wedged mirror backend can't block a launch.
**Layer 2 — smoke-test timeouts.** Give the log-store tests a budget that matches what the step actually costs even when the mirror is healthy.

## Why the install is slow

`FluentbitAgent.get_setup_command` runs, inline on **every node of every cluster launch**:

```
apt-get update                  # full package index refresh, ~27 MB
apt-get install -y gnupg        # ~2 MB, needed only for `gpg --dearmor`
apt-get update                  # again, for the newly added fluent-bit repo
apt-get install -y fluent-bit=4.*
```

The fluent-bit package is not the slow part — it comes from `packages.fluentbit.io` and lands in seconds. Measured on one affected run:

```
Fetched 26.8 MB in 5min 43s (78.1 kB/s)   <- apt-get update
Fetched 2248 kB in 2min 43s (13.8 kB/s)   <- apt-get install -y gnupg
Fetched 55.1 kB in 22s (2457 B/s)         <- 2nd apt-get update
Fetched 59.1 MB in 6s (9166 kB/s)         <- fluent-bit itself
```

The cause is not a uniformly slow mirror. `us-east-1.ec2.archive.ubuntu.com` is a DNS pool of 10+ backends, and only some are wedged. Three consecutive fetches of the same URL from the same VM:

```
try1: 1.0 MB/s   complete
try2: 3.6 MB/s   complete
try3: 110 kB/s   stalled at 2.77/4.49 MB, failed at 25s
```

A stalled apt process was observed blocked in `do_select` while holding the dpkg lock itself — i.e. waiting on the network, not on a lock. And apt is running with no protection:

```
$ apt-config dump | grep -iE "Acquire::Retries|Acquire::http::Timeout"
  (none set -> compiled-in defaults: 0 retries, 120s inactivity timeout)
```

So each wedged backend costs up to 120s, with no retry, across dozens of index files.

## Layer 1: `sky/logs/agent.py`

Pass `Acquire::Retries=3` and a 15s `Acquire::{http,https}::Timeout` to the four apt invocations. A stall is cut at 15s and retried instead of blocking the launch.

Verified on Ubuntu 22.04 / apt 2.4.13:

- **`Acquire::*::Timeout` is an inactivity timeout, not a total deadline.** A transfer trickled at 40 B/s for 60s (never idle >1s) *completed* under `Timeout=15`. Slow-but-progressing downloads are therefore unaffected — only ones that have stopped sending data.
- **It does bound a dead backend.** Against a blackholed backend (SYN dropped), `apt-get update` took 38s with defaults vs 22s with these options.
- **The flags take effect.** `apt-get update <opts>` and `apt-get install -y <opts> <pkg>` both return 0, and `apt-config dump <opts>` shows `Retries=3` plus both 15s timeouts rather than silently ignoring them.

Not claimed: whether a retry re-resolves DNS onto a different backend IP. Every fetch in that experiment succeeded first try, so no retry was observed. The fix does not depend on it — the load-bearing part is cutting the stall at 15s instead of 120s.

## Layer 2: smoke-test timeouts

Layer 1 shortens the tail, but it cannot make the step cheap: ~29 MB of package indices plus gnupg on every fresh VM is irreducible. A run observed end-to-end with a **healthy** mirror (945 kB/s, no stalls) still took 3m45s for the install, and the managed job reached `RUNNING` only 51 seconds inside its 360s budget. Four earlier attempts, with the same code, missed it.

Near-zero margin on the best case is the actual test defect, so:

- `LOG_STORE_CMD_TIMEOUT = 30 * 60` — per-command budget for the three log-store tests (was `20 * 60` each). `Test.timeout` is enforced *per command*, and a single `sky launch` was seen spending 1130s in the logging-agent step alone, blowing the old cap mid-launch.
- `LOG_STORE_JOB_START_TIMEOUT = 25 * 60` — submitted -> `RUNNING` for a managed job with a log store (was `360`). Deliberately below `LOG_STORE_CMD_TIMEOUT` so this wait, not the enclosing per-command timeout, reports the failure.

Both are named constants in `smoke_tests_utils` so the reason the budget exceeds `DEFAULT_CMD_TIMEOUT` sits next to the number.

The `RUNNING` -> `SUCCEEDED` wait is left at 360s: nothing on that path touches apt, and it was never the failing step.

## Test plan

- `yapf` and `isort` clean on all four touched files (pinned versions from `requirements-dev.txt`); no added line exceeds 80 chars.
- apt behaviour verified live on Ubuntu 22.04 / apt 2.4.13 as described above (inactivity-vs-deadline, blackhole bounding, flag placement and effect).
- Smoke, all three log-store tests on AWS: **all pass**.
  - `test_log_collection_to_gcp` — passed on the first attempt.
  - `test_log_collection_to_aws_cloudwatch` — passed on the first attempt.
  - `test_managed_job_logs_with_log_store` — passed. Its first attempt failed at a
    later step for a reason unrelated to this change: the controller had two managed
    jobs sharing the generated name, so `sky jobs logs -n <name>` raised
    `ValueError: Multiple running jobs found with name ...`. Notably that attempt
    reached `RUNNING` after **494s** — i.e. it got past the wait only because of the
    new budget; the old 360s cap would have failed it outright. A re-run without the
    duplicate-name collision passes first attempt.

Verified live on the provisioned VM that Layer 1 is actually in effect — apt's own
`history.log` records the flags, and both installs complete in seconds:

```
Commandline: apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 gnupg
  Start 09:06:53 -> End 09:06:55
Commandline: apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 fluent-bit=4.*
  Start 09:07:15 -> End 09:07:16
```

fluent-bit then starts and tails real job logs (`output:stackdriver worker #0 started`,
`input:tail inotify_fs_add() ... sky_logs/<job>/run.log`), so log shipping is unaffected.

### Unrelated issue noticed while verifying

`smoke_tests_utils.get_cluster_name()` derives its suffix from `str(uuid.uuid4())[-2:]`
— 2 hex chars, 256 values — and `test_managed_job_logs_with_log_store` looks its job up
by name (`sky jobs logs -n <name>`), which hard-fails when a name is ambiguous. The
fallback `get_job_id_cmd` picks `sort -un | head -1`, i.e. the *lowest* id, which under
duplication is the wrong job. Not addressed here; noting it since it is what made the
first attempt flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BktRddCTqWoPbmmvppZJfw
