### PR TITLE
[Server] Export SQLite database on-disk size metrics

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -25,6 +25,8 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
+from sky.server import constants as server_constants
+from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common
 from sky.utils import common_utils
@@ -239,6 +241,92 @@ _BURN_RATE_COLLECTOR = BurnRateCollector()
 
 try:
     prom.REGISTRY.register(_BURN_RATE_COLLECTOR)  # for non-multiprocess
+except ValueError:
+    pass
+
+# SQLite sidecar files that count toward a database's disk footprint.
+# The -wal file can grow large on its own when checkpoints fall behind;
+# -shm is small but included for completeness.
+_SQLITE_SIDECAR_SUFFIXES = ('-wal', '-shm')
+
+_SQLITE_DB_SIZE_HELP = (
+    'Total on-disk size in bytes (main file plus -wal/-shm sidecars) of '
+    'each SkyPilot SQLite database, by database category. Emitted only '
+    'for databases whose file exists on this host; deployments backed '
+    'by Postgres emit nothing. SQLite files never shrink without a '
+    'VACUUM (row deletion only frees pages for reuse), so expect this '
+    'to be monotone within a process lifetime for append-heavy '
+    'databases.')
+
+
+def _sqlite_db_paths() -> Dict[str, str]:
+    """Returns {db category: absolute path} for SkyPilot SQLite databases.
+
+    Resolved at scrape time rather than import time so that
+    SKY_RUNTIME_DIR / HOME are honored the same way the owning modules
+    resolve their own DB paths (see db_utils.DatabaseManager and
+    server_constants.API_SERVER_REQUEST_DB_PATH).
+    """
+    return {
+        'state': runtime_utils.get_runtime_dir_path('.sky/state.db'),
+        'spot_jobs': runtime_utils.get_runtime_dir_path('.sky/spot_jobs.db'),
+        'serve': runtime_utils.get_runtime_dir_path('.sky/serve/services.db'),
+        'config': runtime_utils.get_runtime_dir_path('.sky/config.db'),
+        'requests': runtime_utils.expanduser(
+            server_constants.API_SERVER_REQUEST_DB_PATH),
+    }
+
+
+class SqliteDBSizeCollector:
+    """Collector for the on-disk size of SkyPilot's SQLite databases.
+
+    Emits ``sky_apiserver_sqlite_db_size_bytes{db}`` for each SkyPilot
+    SQLite database present on this host, where the value is the total
+    disk footprint: the main file plus its ``-wal`` / ``-shm`` sidecars.
+    A series is emitted only when the main database file exists, so
+    deployments backed by Postgres emit nothing.
+
+    Rationale: SQLite files never shrink without a VACUUM — row GC (e.g.
+    the requests retention cleanup) only frees pages for reuse — so on
+    long-lived deployments append-heavy databases like requests.db can
+    grow unbounded within the server's lifetime. This gauge gives
+    operators the visibility to alert on file growth before DB latency
+    degrades.
+
+    No caching: a scrape costs a handful of stat() calls.
+    """
+
+    def describe(self):
+        yield prom_core.GaugeMetricFamily('sky_apiserver_sqlite_db_size_bytes',
+                                          _SQLITE_DB_SIZE_HELP,
+                                          labels=['db'])
+
+    def collect(self):
+        metric = prom_core.GaugeMetricFamily(
+            'sky_apiserver_sqlite_db_size_bytes',
+            _SQLITE_DB_SIZE_HELP,
+            labels=['db'])
+        for db, path in _sqlite_db_paths().items():
+            try:
+                size = os.path.getsize(path)
+            except OSError:
+                # Main file missing: this DB is not in use on this host
+                # (e.g. Postgres backend) — skip rather than emit a
+                # misleading 0.
+                continue
+            for suffix in _SQLITE_SIDECAR_SUFFIXES:
+                try:
+                    size += os.path.getsize(path + suffix)
+                except OSError:
+                    pass
+            metric.add_metric([db], size)
+        yield metric
+
+
+_SQLITE_DB_SIZE_COLLECTOR = SqliteDBSizeCollector()
+
+try:
+    prom.REGISTRY.register(_SQLITE_DB_SIZE_COLLECTOR)  # for non-multiprocess
 except ValueError:
     pass
 
@@ -716,6 +804,7 @@ def metrics() -> fastapi.Response:
         registry = prom.CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
         registry.register(_BURN_RATE_COLLECTOR)
+        registry.register(_SQLITE_DB_SIZE_COLLECTOR)
         registry.register(_WORKSPACE_USAGE_COLLECTOR)
         if _MANAGED_JOBS_COLLECTOR is not None:
             registry.register(_MANAGED_JOBS_COLLECTOR)

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -1010,3 +1010,35 @@ def test_managed_jobs_collector_handles_empty_db():
         samples = _collect_to_dict(collector)
     # Metric family exists, just with no rows.
     assert samples.get('sky_managed_jobs_count', {}) == {}
+
+
+def test_sqlite_db_size_collector_no_files(tmp_path, monkeypatch):
+    """No SQLite files on disk (e.g. Postgres backend) -> no series."""
+    monkeypatch.setenv('SKY_RUNTIME_DIR', str(tmp_path))
+    collector = metrics.SqliteDBSizeCollector()
+    samples = _collect_to_dict(collector)
+    assert samples.get('sky_apiserver_sqlite_db_size_bytes', {}) == {}
+
+
+def test_sqlite_db_size_collector_reports_existing_dbs(tmp_path, monkeypatch):
+    """Existing DB files are reported with WAL/SHM sidecars included."""
+    monkeypatch.setenv('SKY_RUNTIME_DIR', str(tmp_path))
+    sky_dir = tmp_path / '.sky'
+    (sky_dir / 'api_server').mkdir(parents=True)
+    (sky_dir / 'state.db').write_bytes(b'x' * 100)
+    # WAL/SHM sidecars count toward the db's footprint.
+    (sky_dir / 'state.db-wal').write_bytes(b'x' * 40)
+    (sky_dir / 'state.db-shm').write_bytes(b'x' * 10)
+    (sky_dir / 'spot_jobs.db').write_bytes(b'x' * 7)
+    (sky_dir / 'api_server' / 'requests.db').write_bytes(b'x' * 55)
+    # A sidecar without its main file must not create a series.
+    (sky_dir / 'config.db-wal').write_bytes(b'x' * 5)
+
+    collector = metrics.SqliteDBSizeCollector()
+    sizes = _collect_to_dict(collector)['sky_apiserver_sqlite_db_size_bytes']
+
+    assert sizes == {
+        (('db', 'state'),): 150.0,
+        (('db', 'spot_jobs'),): 7.0,
+        (('db', 'requests'),): 55.0,
+    }


### PR DESCRIPTION
## Summary

Adds a `sky_apiserver_sqlite_db_size_bytes{db=...}` gauge to the API server `/metrics` endpoint, exporting the on-disk size of each SkyPilot SQLite database — main file plus `-wal`/`-shm` sidecars — labeled by database category: `state`, `spot_jobs`, `serve`, `config`, `requests`. A series is emitted only when the database file exists, so Postgres-backed deployments emit nothing.

Motivation: SQLite files never shrink without a `VACUUM` (row GC only frees pages for internal reuse), so on long-lived deployments append-heavy databases like `requests.db` grow unbounded within the server's lifetime and can degrade DB latency. This gauge gives operators a signal to alert on before that happens.

## Test

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - New unit tests for the collector (existing DBs with WAL/SHM sidecars, missing files, sidecar-without-main): `pytest tests/unit_tests/test_sky/server/test_metrics.py` — 40 passed.
  - Manual: rendered the metric through `prometheus_client.generate_latest()` with a populated runtime dir and verified the exposition output:
    ```
    # TYPE sky_apiserver_sqlite_db_size_bytes gauge
    sky_apiserver_sqlite_db_size_bytes{db="state"} 2048.0
    ```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
