### PR TITLE
[Core] Resolve Slurm node index by node name instead of relying on IP matching

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6922,6 +6922,35 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             return task.envs[constants.USER_ID_ENV_VAR]
         return None
 
+    @staticmethod
+    def _get_slurm_node_names(handle: CloudVmRayResourceHandle,
+                              internal_ips: List[str]) -> Optional[List[str]]:
+        """Returns Slurm node names aligned with the given internal IPs.
+
+        The executor prefers node names over IP matching to determine the
+        node index, since the IP resolved inside a Slurm job can differ
+        from the NodeAddr recorded at provisioning time (#10333).
+
+        Returns None if the cached cluster info does not cover every IP,
+        e.g. for clusters whose cached info predates node name recording.
+        """
+        cluster_info = handle.cached_cluster_info
+        if cluster_info is None:
+            return None
+        ip_to_node = {}
+        for instances in cluster_info.instances.values():
+            for instance in instances:
+                node = instance.tags.get('node')
+                if node is not None and instance.internal_ip is not None:
+                    ip_to_node[instance.internal_ip] = node
+        node_names = []
+        for ip in internal_ips:
+            node = ip_to_node.get(ip)
+            if node is None:
+                return None
+            node_names.append(node)
+        return node_names
+
     def _get_task_codegen_class(
             self, handle: CloudVmRayResourceHandle) -> task_codegen.TaskCodeGen:
         """Returns the appropriate TaskCodeGen for the given handle."""
@@ -6940,9 +6969,19 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 container_name = slurm_utils.pyxis_container_name(
                     handle.cluster_name_on_cloud)
 
+            # Map through the internal IPs rather than re-deriving the node
+            # order: internal_ips() applies its own head-first ordering, and
+            # the node names must stay aligned with --cluster-ips.
+            internal_ips = handle.internal_ips()
+            cluster_node_names = None
+            if internal_ips is not None:
+                cluster_node_names = self._get_slurm_node_names(
+                    handle, internal_ips)
+
             return task_codegen.SlurmCodeGen(
                 slurm_job_id,
                 container_name,
+                cluster_node_names=cluster_node_names,
             )
         else:
             return task_codegen.RayCodeGen()

--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -695,16 +695,23 @@ class SlurmCodeGen(TaskCodeGen):
         self,
         slurm_job_id: str,
         container_name: Optional[str],
+        cluster_node_names: Optional[List[str]] = None,
     ):
         """Initialize SlurmCodeGen.
 
         Args:
             slurm_job_id: The Slurm job ID, i.e. SLURM_JOB_ID
             container_name: pyxis container name, or None
+            cluster_node_names: Slurm node names aligned with the stable
+                cluster internal IPs, or None if unavailable. The executor
+                prefers these over IP matching to determine the node index,
+                since the IP resolved inside a Slurm job can differ from the
+                one recorded at provisioning time (#10333).
         """
         super().__init__()
         self._slurm_job_id = slurm_job_id
         self._container_name = container_name
+        self._cluster_node_names = cluster_node_names
 
     def add_prologue(self, job_id: int) -> None:
         assert not self._has_prologue, 'add_prologue() called twice?'
@@ -887,6 +894,15 @@ class SlurmCodeGen(TaskCodeGen):
 
                     cluster_home = shlex.quote(os.path.expanduser('~'))
                     runner_args = f'--log-dir={{log_dir}} --env-vars={{env_vars}} --cluster-num-nodes={self._cluster_num_nodes} --cluster-ips={{cluster_ips}} --cluster-home-dir={{cluster_home}}'
+
+                    # The executor prefers Slurm node names over IP matching
+                    # to determine the node index, since the IP resolved
+                    # inside a Slurm job can differ from the one recorded at
+                    # provisioning time (#10333). Executors below skylet
+                    # version 40 do not accept --cluster-nodes.
+                    cluster_nodes = {self._cluster_node_names!r}
+                    if cluster_nodes is not None and int(constants.SKYLET_VERSION) >= 40:
+                        runner_args += ' --cluster-nodes=' + shlex.quote(','.join(cluster_nodes))
 
                     if task_name is not None:
                         runner_args += f' --task-name={{shlex.quote(task_name)}}'

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -172,7 +172,7 @@ MANAGED_JOB_ID_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}MANAGED_JOB_ID'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '39'  # add external-link log-scan skylet event.
+SKYLET_VERSION = '40'  # add --cluster-nodes to the Slurm executor.
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.

--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import sys
 import time
+from typing import List
 
 import colorama
 import hostlist
@@ -71,6 +72,48 @@ def _get_ip_address() -> str:
     # which resolves hostnames the same way. Using `hostname -I` can return
     # Docker bridge IPs (172.17.x.x) first, causing IP mismatch errors.
     return socket.gethostbyname(socket.gethostname())
+
+
+def _get_node_idx(cluster_nodes: List[str], cluster_ips: List[str],
+                  ip_addr: str) -> int:
+    """Determines this node's index in the cluster.
+
+    Never raises: the node index only feeds log filenames and streaming
+    log prefixes, so failing to resolve it must not fail the task.
+    """
+    # 1. Match by Slurm node name. slurmstepd sets SLURMD_NODENAME per task,
+    # and it is stable across containers, network interfaces and job steps,
+    # unlike the IP resolved inside the job. With containerized slurmd or
+    # multiple network views, the runtime IP may not match the NodeAddr
+    # recorded at provisioning time. See #10333.
+    node_name = os.environ.get('SLURMD_NODENAME')
+    if node_name is not None and node_name in cluster_nodes:
+        return cluster_nodes.index(node_name)
+
+    # 2. Match by IP, for clusters where the provisioning-time and runtime
+    # network views agree (and for executors launched without
+    # --cluster-nodes).
+    if ip_addr in cluster_ips:
+        return cluster_ips.index(ip_addr)
+
+    # 3. Single-node cluster: only one possible index.
+    if len(cluster_ips) == 1:
+        return 0
+
+    # 4. Last resort: SLURM_NODEID is this node's index within the job
+    # *step*, which may differ from its index in the cluster (e.g. a 1-node
+    # task on a multi-node cluster always sees SLURM_NODEID=0). It is still
+    # unique per node within the step, which keeps per-node log filenames on
+    # the shared filesystem from colliding.
+    print(
+        f'Could not locate node {node_name!r} (IP {ip_addr}) in cluster '
+        f'nodes {cluster_nodes} / IPs {cluster_ips}; falling back to '
+        'SLURM_NODEID. Node labels in logs may be inaccurate.',
+        file=sys.stderr)
+    try:
+        return int(os.environ.get('SLURM_NODEID', 0))
+    except ValueError:
+        return 0
 
 
 def _get_job_node_ips() -> str:
@@ -174,6 +217,10 @@ def main():
     parser.add_argument('--cluster-ips',
                         required=True,
                         help='Comma-separated list of cluster node IPs')
+    parser.add_argument('--cluster-nodes',
+                        default=None,
+                        help='Comma-separated list of Slurm node names, '
+                        'aligned with --cluster-ips')
     parser.add_argument('--task-name',
                         default=None,
                         help='Task name for single-node log prefix')
@@ -202,14 +249,13 @@ def main():
     num_nodes = int(os.environ.get('SLURM_NNODES', 1))
     is_single_node_cluster = (args.cluster_num_nodes == 1)
 
-    # Determine node index from IP (like Ray's cluster_ips_to_node_id)
+    # Determine this node's index in the cluster, preferring the Slurm node
+    # name over the runtime IP (like Ray's cluster_ips_to_node_id).
     cluster_ips = args.cluster_ips.split(',')
+    cluster_nodes = (args.cluster_nodes.split(',')
+                     if args.cluster_nodes else [])
     ip_addr = _get_ip_address()
-    try:
-        node_idx = cluster_ips.index(ip_addr)
-    except ValueError as e:
-        raise RuntimeError(f'IP address {ip_addr} not found in '
-                           f'cluster IPs: {cluster_ips}') from e
+    node_idx = _get_node_idx(cluster_nodes, cluster_ips, ip_addr)
     node_name = 'head' if node_idx == 0 else f'worker{node_idx}'
 
     # Log files are written to a shared filesystem, so each node must use a

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend_slurm.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend_slurm.py
@@ -1,0 +1,88 @@
+"""Unit tests for CloudVmRayBackend Slurm helpers."""
+
+# pylint: disable=protected-access
+
+from unittest import mock
+
+from sky.backends import cloud_vm_ray_backend
+from sky.provision import common as provision_common
+
+
+def _make_handle(cluster_info):
+    handle = mock.MagicMock()
+    handle.cached_cluster_info = cluster_info
+    return handle
+
+
+class TestCloudVmRayBackendSlurmNodeNames:
+    """Tests for Slurm node name extraction from cluster metadata."""
+
+    def test_returns_names_aligned_with_internal_ips(self):
+        cluster_info = provision_common.ClusterInfo(
+            instances={
+                'job-node-a': [
+                    provision_common.InstanceInfo(instance_id='job-node-a',
+                                                  internal_ip='10.0.0.1',
+                                                  external_ip=None,
+                                                  tags={'node': 'node-a'})
+                ],
+                'job-node-b': [
+                    provision_common.InstanceInfo(instance_id='job-node-b',
+                                                  internal_ip='10.0.0.2',
+                                                  external_ip=None,
+                                                  tags={'node': 'node-b'})
+                ],
+            },
+            head_instance_id='job-node-a',
+            provider_name='slurm')
+
+        node_names = (
+            cloud_vm_ray_backend.CloudVmRayBackend._get_slurm_node_names(
+                _make_handle(cluster_info), ['10.0.0.2', '10.0.0.1']))
+
+        assert node_names == ['node-b', 'node-a']
+
+    def test_returns_none_when_metadata_is_incomplete(self):
+        cluster_info = provision_common.ClusterInfo(
+            instances={
+                'job-node-a': [
+                    provision_common.InstanceInfo(instance_id='job-node-a',
+                                                  internal_ip='10.0.0.1',
+                                                  external_ip=None,
+                                                  tags={})
+                ],
+            },
+            head_instance_id='job-node-a',
+            provider_name='slurm')
+
+        node_names = (
+            cloud_vm_ray_backend.CloudVmRayBackend._get_slurm_node_names(
+                _make_handle(cluster_info), ['10.0.0.1']))
+
+        assert node_names is None
+
+    def test_returns_none_when_an_ip_is_not_covered(self):
+        cluster_info = provision_common.ClusterInfo(
+            instances={
+                'job-node-a': [
+                    provision_common.InstanceInfo(instance_id='job-node-a',
+                                                  internal_ip='10.0.0.1',
+                                                  external_ip=None,
+                                                  tags={'node': 'node-a'})
+                ],
+            },
+            head_instance_id='job-node-a',
+            provider_name='slurm')
+
+        node_names = (
+            cloud_vm_ray_backend.CloudVmRayBackend._get_slurm_node_names(
+                _make_handle(cluster_info), ['10.0.0.1', '10.0.0.2']))
+
+        assert node_names is None
+
+    def test_returns_none_without_cached_cluster_info(self):
+        node_names = (
+            cloud_vm_ray_backend.CloudVmRayBackend._get_slurm_node_names(
+                _make_handle(None), ['10.0.0.1']))
+
+        assert node_names is None

--- a/tests/unit_tests/test_sky/backends/test_task_codegen.py
+++ b/tests/unit_tests/test_sky/backends/test_task_codegen.py
@@ -193,6 +193,51 @@ def test_slurm_single_node_with_gpu():
                                     testdata_dir=SLURM_TESTDATA_DIR)
 
 
+def test_slurm_multi_node_with_node_names():
+    """Multi-node Slurm job with node names passed to the executor.
+
+    The executor prefers node names over IP matching to determine the node
+    index (#10333), so the generated driver must forward them via
+    --cluster-nodes on new enough skylets.
+    """
+    codegen = task_codegen.SlurmCodeGen(
+        slurm_job_id='12345',
+        container_name=None,
+        cluster_node_names=['node-1', 'node-2'],
+    )
+    codegen.add_prologue(job_id=3)
+
+    resources_dict = {'CPU': 2.0}
+    task_env_vars = {
+        'SKYPILOT_TASK_ID': 'sky-2024-11-17-00-00-00-000002-cluster-3',
+    }
+
+    codegen.add_setup(
+        2,
+        resources_dict=resources_dict,
+        stable_cluster_internal_ips=['10.0.0.1', '10.0.0.2'],
+        env_vars=task_env_vars,
+        log_dir='/sky/logs',
+        setup_cmd=None,
+    )
+
+    codegen.add_task(
+        2,
+        bash_script='echo "Running on node $SKYPILOT_NODE_RANK"',
+        task_name='distributed_task',
+        resources_dict={'CPU': 2.0},
+        log_dir='/sky/logs/tasks',
+        env_vars=task_env_vars,
+    )
+
+    codegen.add_epilogue()
+
+    result = codegen.build()
+    assert_codegen_matches_snapshot('slurm_multi_node_with_node_names',
+                                    result,
+                                    testdata_dir=SLURM_TESTDATA_DIR)
+
+
 def test_slurm_codegen_with_container():
     codegen = task_codegen.SlurmCodeGen(
         slurm_job_id='12345',

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_multi_node_with_node_names.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_multi_node_with_node_names.py
@@ -447,7 +447,7 @@ def _cancel_slurm_job_steps():
             parts = line.split()
             assert len(parts) >= 2, 'Expected at least 2 parts'
             step_id, step_name = parts[0], parts[1]
-            if step_name == f'sky-2':
+            if step_name == f'sky-3':
                 subprocess.run(['scancel', step_id],
                                 check=False, capture_output=True)
     except Exception as e:
@@ -463,17 +463,18 @@ def _slurm_cleanup_handler(signum, _frame):
 signal.signal(signal.SIGTERM, _slurm_cleanup_handler)
 
 autostop_lib.set_last_active_time_to_now()
-job_lib.set_status(2, job_lib.JobStatus.PENDING)
-plural = 's' if 1 > 1 else ''
-node_str = f'1 node{plural}'
+job_lib.set_status(3, job_lib.JobStatus.PENDING)
+plural = 's' if 2 > 1 else ''
+node_str = f'2 node{plural}'
 message = ('[2m├── [0m[2m'
            'Waiting for task resources on '
            f'{node_str}.[0m')
 print(message, flush=True)
 sky_env_vars_dict = {}
-sky_env_vars_dict['SKYPILOT_INTERNAL_JOB_ID'] = 2
+sky_env_vars_dict['SKYPILOT_INTERNAL_JOB_ID'] = 3
 
-script = 'echo hello\n__skypilot_user_exit_code=$?\n# Only waits if cached mount is enabled (RCLONE_MOUNT_CACHED_LOG_DIR is not empty)\n# findmnt alone is not enough, as some clouds (e.g. AWS on ARM64) uses\n# rclone for normal mounts as well.\nif [ $(findmnt -t fuse.rclone --noheading | wc -l) -gt 0 ] &&            [ -d ~/.sky/rclone_log ] &&            [ "$(ls -A ~/.sky/rclone_log)" ]; then\n    FLUSH_START_TIME=$(date +%s)\n    flushed=0\n    # extra second on top of --vfs-cache-poll-interval to\n    # avoid race condition between rclone log line creation and this check.\n    sleep 1\n    while [ $flushed -eq 0 ]; do\n        # sleep for the same interval as --vfs-cache-poll-interval\n        sleep 10\n        flushed=1\n        for file in ~/.sky/rclone_log/*; do\n            exitcode=0\n            tac $file | grep "vfs cache: cleaned:" -m 1 | grep "in use 0, to upload 0, uploading 0" -q || exitcode=$?\n            if [ $exitcode -ne 0 ]; then\n                ELAPSED=$(($(date +%s) - FLUSH_START_TIME))\n                # Extract the last vfs cache status line to show what we\'re waiting for\n                CACHE_STATUS=$(tac $file | grep "vfs cache: cleaned:" -m 1 | sed \'s/.*vfs cache: cleaned: //\' 2>/dev/null)\n                # Extract currently uploading files from recent log lines (show up to 2 files)\n                UPLOADING_FILES=$(tac $file | head -30 | grep -E "queuing for upload" | head -2 | sed \'s/.*INFO  : //\' | sed \'s/: vfs cache:.*//\' | tr \'\\n\' \',\' | sed \'s/,$//\' | sed \'s/,/, /g\' 2>/dev/null)\n                # Build status message with available info\n                if [ -n "$CACHE_STATUS" ] && [ -n "$UPLOADING_FILES" ]; then\n                    echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) [${CACHE_STATUS}] uploading: ${UPLOADING_FILES}"\n                elif [ -n "$CACHE_STATUS" ]; then\n                    echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) [${CACHE_STATUS}]"\n                else\n                    # Fallback: show last non-empty line from log\n                    LAST_LINE=$(tac $file | grep -v "^$" | head -1 | sed \'s/.*INFO  : //\' | sed \'s/.*ERROR : //\' | sed \'s/.*NOTICE: //\' 2>/dev/null)\n                    if [ -n "$LAST_LINE" ]; then\n                        echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) ${LAST_LINE}"\n                    else\n                        echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s)"\n                    fi\n                fi\n                flushed=0\n                break\n            fi\n        done\n    done\n    TOTAL_FLUSH_TIME=$(($(date +%s) - FLUSH_START_TIME))\n    echo "skypilot: cached mount upload complete (took ${TOTAL_FLUSH_TIME}s)"\nfi\nexit $__skypilot_user_exit_code'
+sky_env_vars_dict['SKYPILOT_TASK_ID'] = 'sky-2024-11-17-00-00-00-000002-cluster-3'
+script = 'echo "Running on node $SKYPILOT_NODE_RANK"\n__skypilot_user_exit_code=$?\n# Only waits if cached mount is enabled (RCLONE_MOUNT_CACHED_LOG_DIR is not empty)\n# findmnt alone is not enough, as some clouds (e.g. AWS on ARM64) uses\n# rclone for normal mounts as well.\nif [ $(findmnt -t fuse.rclone --noheading | wc -l) -gt 0 ] &&            [ -d ~/.sky/rclone_log ] &&            [ "$(ls -A ~/.sky/rclone_log)" ]; then\n    FLUSH_START_TIME=$(date +%s)\n    flushed=0\n    # extra second on top of --vfs-cache-poll-interval to\n    # avoid race condition between rclone log line creation and this check.\n    sleep 1\n    while [ $flushed -eq 0 ]; do\n        # sleep for the same interval as --vfs-cache-poll-interval\n        sleep 10\n        flushed=1\n        for file in ~/.sky/rclone_log/*; do\n            exitcode=0\n            tac $file | grep "vfs cache: cleaned:" -m 1 | grep "in use 0, to upload 0, uploading 0" -q || exitcode=$?\n            if [ $exitcode -ne 0 ]; then\n                ELAPSED=$(($(date +%s) - FLUSH_START_TIME))\n                # Extract the last vfs cache status line to show what we\'re waiting for\n                CACHE_STATUS=$(tac $file | grep "vfs cache: cleaned:" -m 1 | sed \'s/.*vfs cache: cleaned: //\' 2>/dev/null)\n                # Extract currently uploading files from recent log lines (show up to 2 files)\n                UPLOADING_FILES=$(tac $file | head -30 | grep -E "queuing for upload" | head -2 | sed \'s/.*INFO  : //\' | sed \'s/: vfs cache:.*//\' | tr \'\\n\' \',\' | sed \'s/,$//\' | sed \'s/,/, /g\' 2>/dev/null)\n                # Build status message with available info\n                if [ -n "$CACHE_STATUS" ] && [ -n "$UPLOADING_FILES" ]; then\n                    echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) [${CACHE_STATUS}] uploading: ${UPLOADING_FILES}"\n                elif [ -n "$CACHE_STATUS" ]; then\n                    echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) [${CACHE_STATUS}]"\n                else\n                    # Fallback: show last non-empty line from log\n                    LAST_LINE=$(tac $file | grep -v "^$" | head -1 | sed \'s/.*INFO  : //\' | sed \'s/.*ERROR : //\' | sed \'s/.*NOTICE: //\' 2>/dev/null)\n                    if [ -n "$LAST_LINE" ]; then\n                        echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s) ${LAST_LINE}"\n                    else\n                        echo "skypilot: cached mount is still uploading (elapsed: ${ELAPSED}s)"\n                    fi\n                fi\n                flushed=0\n                break\n            fi\n        done\n    done\n    TOTAL_FLUSH_TIME=$(($(date +%s) - FLUSH_START_TIME))\n    echo "skypilot: cached mount upload complete (took ${TOTAL_FLUSH_TIME}s)"\nfi\nexit $__skypilot_user_exit_code'
 
 if script or False:
     sky_env_vars_dict['SKYPILOT_NUM_GPUS_PER_NODE'] = 0
@@ -487,9 +488,9 @@ if script or False:
     # To support clusters with non-NFS home directories, we would
     # need to let users specify an NFS-backed "working directory"
     # or use a different coordination mechanism.
-    alloc_signal_file = f'~/.sky_alloc_12345_2'
+    alloc_signal_file = f'~/.sky_alloc_12345_3'
     alloc_signal_file = os.path.expanduser(alloc_signal_file)
-    setup_done_signal_file = f'~/.sky_setup_done_12345_2'
+    setup_done_signal_file = f'~/.sky_setup_done_12345_3'
     setup_done_signal_file = os.path.expanduser(setup_done_signal_file)
 
     # Start exclusive srun in a thread to reserve allocation (similar to ray.get(pg.ready()))
@@ -502,17 +503,17 @@ if script or False:
 
         log_dir = shlex.quote(log_dir)
         env_vars = shlex.quote(env_vars_json)
-        cluster_ips = shlex.quote(",".join(['10.0.0.1']))
+        cluster_ips = shlex.quote(",".join(['10.0.0.1', '10.0.0.2']))
 
         cluster_home = shlex.quote(os.path.expanduser('~'))
-        runner_args = f'--log-dir={log_dir} --env-vars={env_vars} --cluster-num-nodes=1 --cluster-ips={cluster_ips} --cluster-home-dir={cluster_home}'
+        runner_args = f'--log-dir={log_dir} --env-vars={env_vars} --cluster-num-nodes=2 --cluster-ips={cluster_ips} --cluster-home-dir={cluster_home}'
 
         # The executor prefers Slurm node names over IP matching
         # to determine the node index, since the IP resolved
         # inside a Slurm job can differ from the one recorded at
         # provisioning time (#10333). Executors below skylet
         # version 40 do not accept --cluster-nodes.
-        cluster_nodes = None
+        cluster_nodes = ['node-1', 'node-2']
         if cluster_nodes is not None and int(constants.SKYLET_VERSION) >= 40:
             runner_args += ' --cluster-nodes=' + shlex.quote(','.join(cluster_nodes))
 
@@ -566,7 +567,7 @@ if script or False:
         # Only unset SKY_RUNTIME_DIR for container runs. For non-container
         # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
         # SlurmCommandRunner to avoid SQLite WAL issues on shared filesystems.
-        if True:
+        if False:
             cmd_parts.append('unset SKY_RUNTIME_DIR;')
         cmd_parts.extend([
             constants.SKY_SLURM_PYTHON_CMD,
@@ -577,7 +578,7 @@ if script or False:
         srun_cmd = (
             "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '
-            f'--job-name=sky-2{job_suffix} --ntasks-per-node=1 --container-remap-root --container-name=test-cluster:exec {extra_flags} '
+            f'--job-name=sky-3{job_suffix} --ntasks-per-node=1 {extra_flags} '
             f'/bin/bash -c {bash_cmd}'
         )
 
@@ -590,10 +591,10 @@ if script or False:
     def run_thread_func():
         # This blocks until Slurm allocates resources (--exclusive)
         # --mem=0 to match RayCodeGen's behavior where we don't explicitly request memory.
-        run_flags = f'--nodes=1 --cpus-per-task=1 --mem=0 {gpu_arg} --exclusive'
+        run_flags = f'--nodes=2 --cpus-per-task=2 --mem=0 {gpu_arg} --exclusive'
         srun_cmd, cleanup = build_task_runner_cmd(
             script, run_flags, '/sky/logs/tasks', sky_env_vars_dict,
-            task_name='hello',
+            task_name='distributed_task',
             alloc_signal=alloc_signal_file,
             setup_done_signal=setup_done_signal_file
         )
@@ -624,20 +625,20 @@ if script or False:
             result = run_thread_result['result']
             returncode = int(result.get('return_code', 1))
             pid = result.get('pid', os.getpid())
-            msg = f'ERROR: [31mJob 2\'s setup failed with return code {returncode} (pid={pid}).'
+            msg = f'ERROR: [31mJob 3\'s setup failed with return code {returncode} (pid={pid}).'
             msg += f' See error logs above for more details.[0m'
             print(msg, flush=True)
             returncodes = [returncode]
             if int(constants.SKYLET_VERSION) >= 28:
-                job_lib.set_exit_codes(2, returncodes)
-            job_lib.set_status(2, job_lib.JobStatus.FAILED_SETUP)
+                job_lib.set_exit_codes(3, returncodes)
+            job_lib.set_status(3, job_lib.JobStatus.FAILED_SETUP)
             sys.exit(1)
         time.sleep(0.1)
 
     print('\x1b[2m└── \x1b[0mJob started. Streaming logs... \x1b[2m(Ctrl-C to exit log streaming; job will not be killed)\x1b[0m', flush=True)
 
     if False:
-        job_lib.set_status(2, job_lib.JobStatus.SETTING_UP)
+        job_lib.set_status(3, job_lib.JobStatus.SETTING_UP)
 
         # The schedule_step should be called after the job status is set to
         # non-PENDING, otherwise, the scheduler will think the current job
@@ -666,15 +667,15 @@ if script or False:
         setup_returncode = setup_proc.returncode
         if setup_returncode != 0:
             setup_pid = setup_proc.pid
-            msg = f'ERROR: [31mJob 2\'s setup failed with return code {setup_returncode} (pid={setup_pid}).'
+            msg = f'ERROR: [31mJob 3\'s setup failed with return code {setup_returncode} (pid={setup_pid}).'
             msg += f' See error logs above for more details.[0m'
             print(msg, flush=True)
-            job_lib.set_status(2, job_lib.JobStatus.FAILED_SETUP)
+            job_lib.set_status(3, job_lib.JobStatus.FAILED_SETUP)
             # Cancel the srun spawned by run_thread_func.
             _cancel_slurm_job_steps()
             sys.exit(1)
 
-    job_lib.set_job_started(2)
+    job_lib.set_job_started(3)
     if not False:
         # Need to call schedule_step() to make sure the scheduler
         # schedule the next pending job.
@@ -700,8 +701,8 @@ else:
 if sum(returncodes) != 0:
     # Save exit codes to job metadata for potential recovery logic
     if int(constants.SKYLET_VERSION) >= 28:
-        job_lib.set_exit_codes(2, returncodes)
-    job_lib.set_status(2, job_lib.JobStatus.FAILED)
+        job_lib.set_exit_codes(3, returncodes)
+    job_lib.set_status(3, job_lib.JobStatus.FAILED)
     # Schedule the next pending job immediately to make the job
     # scheduling more efficient.
     job_lib.scheduler.schedule_step()
@@ -715,7 +716,7 @@ if sum(returncodes) != 0:
         # Find the first non-137 return code
         non_137 = next(r for r in returncodes if r != 137)
         reason = f'(A Worker failed with return code {non_137}, SkyPilot cleaned up the processes on other nodes with return code 137)'
-    print('ERROR: [31mJob 2 failed with '
+    print('ERROR: [31mJob 3 failed with '
           'return code list:[0m',
           returncodes,
           reason,
@@ -723,7 +724,7 @@ if sum(returncodes) != 0:
     # Need this to set the job status in ray job to be FAILED.
     sys.exit(1)
 else:
-    job_lib.set_status(2, job_lib.JobStatus.SUCCEEDED)
+    job_lib.set_status(3, job_lib.JobStatus.SUCCEEDED)
     # Schedule the next pending job immediately to make the job
     # scheduling more efficient.
     job_lib.scheduler.schedule_step()

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -509,6 +509,15 @@ if script or True:
         cluster_home = shlex.quote(os.path.expanduser('~'))
         runner_args = f'--log-dir={log_dir} --env-vars={env_vars} --cluster-num-nodes=1 --cluster-ips={cluster_ips} --cluster-home-dir={cluster_home}'
 
+        # The executor prefers Slurm node names over IP matching
+        # to determine the node index, since the IP resolved
+        # inside a Slurm job can differ from the one recorded at
+        # provisioning time (#10333). Executors below skylet
+        # version 40 do not accept --cluster-nodes.
+        cluster_nodes = None
+        if cluster_nodes is not None and int(constants.SKYLET_VERSION) >= 40:
+            runner_args += ' --cluster-nodes=' + shlex.quote(','.join(cluster_nodes))
+
         if task_name is not None:
             runner_args += f' --task-name={shlex.quote(task_name)}'
 

--- a/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
+++ b/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
@@ -79,6 +79,64 @@ def test_unset_step_scoped_slurm_env():
         assert result[name] == value, f'{name} was wrongly unset'
 
 
+class TestGetNodeIdx:
+    """Tests for node index resolution (#10333).
+
+    The index only feeds log filenames and streaming prefixes, so
+    resolution must never raise, and must not depend on the runtime IP
+    matching the provisioning-time IP.
+    """
+
+    def test_node_name_match_wins_over_ip(self, monkeypatch):
+        # Even when the IP would resolve to a different (wrong) index, the
+        # Slurm node name is authoritative.
+        monkeypatch.setenv('SLURMD_NODENAME', 'node-2')
+        idx = slurm._get_node_idx(['node-1', 'node-2'],
+                                  ['10.0.0.1', '10.0.0.2'], '10.0.0.1')
+        assert idx == 1
+
+    def test_ip_match_when_node_name_unavailable(self, monkeypatch):
+        monkeypatch.delenv('SLURMD_NODENAME', raising=False)
+        idx = slurm._get_node_idx(['node-1', 'node-2'],
+                                  ['10.0.0.1', '10.0.0.2'], '10.0.0.2')
+        assert idx == 1
+
+    def test_ip_match_when_no_cluster_nodes_passed(self, monkeypatch):
+        # Old codegen does not pass --cluster-nodes; behavior matches the
+        # original IP lookup.
+        monkeypatch.setenv('SLURMD_NODENAME', 'node-2')
+        idx = slurm._get_node_idx([], ['10.0.0.1', '10.0.0.2'], '10.0.0.2')
+        assert idx == 1
+
+    def test_single_node_mismatched_ip_returns_zero(self, monkeypatch):
+        # The reporter's case: containerized slurmd resolves a different IP
+        # than the NodeAddr recorded at provisioning time. A single-node
+        # cluster has only one possible index.
+        monkeypatch.delenv('SLURMD_NODENAME', raising=False)
+        idx = slurm._get_node_idx([], ['10.244.10.126'], '10.102.3.53')
+        assert idx == 0
+
+    def test_falls_back_to_slurm_nodeid_and_warns(self, monkeypatch, capsys):
+        monkeypatch.setenv('SLURMD_NODENAME', 'unknown-node')
+        monkeypatch.setenv('SLURM_NODEID', '1')
+        idx = slurm._get_node_idx(['node-1', 'node-2'],
+                                  ['10.0.0.1', '10.0.0.2'], '10.0.0.9')
+        assert idx == 1
+        assert 'falling back to SLURM_NODEID' in capsys.readouterr().err
+
+    def test_never_raises_without_any_signal(self, monkeypatch):
+        monkeypatch.delenv('SLURMD_NODENAME', raising=False)
+        monkeypatch.delenv('SLURM_NODEID', raising=False)
+        idx = slurm._get_node_idx([], ['10.0.0.1', '10.0.0.2'], '10.0.0.9')
+        assert idx == 0
+
+    def test_never_raises_on_bad_slurm_nodeid(self, monkeypatch):
+        monkeypatch.delenv('SLURMD_NODENAME', raising=False)
+        monkeypatch.setenv('SLURM_NODEID', 'not-a-number')
+        idx = slurm._get_node_idx([], ['10.0.0.1', '10.0.0.2'], '10.0.0.9')
+        assert idx == 0
+
+
 def _fail_reads_under(monkeypatch, run_done_dir, exc_factory, num_failures):
     """Makes the first num_failures reads under run_done_dir raise.
 


### PR DESCRIPTION
Fixes #10333. Implements the direction discussed in https://github.com/skypilot-org/skypilot/issues/10333#issuecomment-5162437467 (node-name based indexing, never fatal), rather than the `SLURM_NODEID`-as-primary approach of #10334, since `SLURM_NODEID` is step-relative and mislabels nodes for subset steps and reordered allocations.

## Summary

- `sky/skylet/executor/slurm.py`: the executor no longer raises `RuntimeError` when the runtime IP is not in the provisioning-time cluster IP list. `_get_node_idx()` resolves the index as:
  1. `SLURMD_NODENAME` matched against the new `--cluster-nodes` list — set per task by slurmstepd, stable across containers, NICs, and job steps;
  2. the existing IP match, for clusters where both network views agree (and for drivers that don't pass `--cluster-nodes`);
  3. index `0` for single-node clusters;
  4. `SLURM_NODEID` as a warned last resort — it may not be the cluster index, but it is unique per node within the step, which keeps per-node log files (`setup-*.log` etc.) on the shared filesystem from clobbering each other.
- `sky/backends/cloud_vm_ray_backend.py`: new `_get_slurm_node_names()` builds the node-name list from the provisioner's `InstanceInfo.tags['node']`, mapped through `handle.internal_ips()` so it stays aligned with `--cluster-ips` (rather than re-deriving the head-first order). Returns `None` (degrading gracefully to IP matching) if any IP is not covered.
- `sky/backends/task_codegen.py`: `SlurmCodeGen` forwards the names via `--cluster-nodes`, gated on `int(constants.SKYLET_VERSION) >= 40` evaluated on the cluster, so drivers targeting older executors (which reject unknown flags) keep the old invocation. `SKYLET_VERSION` bumped to 40. New executors accept old drivers since `--cluster-nodes` is optional.

## Why not IP matching

`cluster_ips` is built on the login node from `scontrol show node ... NodeAddr`, while the executor resolves `socket.gethostbyname(socket.gethostname())` inside the job. With containerized `slurmd` or multiple network views these disagree even though the task is on exactly the node Slurm scheduled. Since the node index only feeds log filenames and streamed log prefixes, failing the task over it is never the right response.

## Tested

- Added unit tests:
  - `tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py`: 7 cases for `_get_node_idx` — name match wins over IP, IP fallback (with and without `--cluster-nodes`), the reporter's single-node mismatched-IP case, `SLURM_NODEID` fallback with warning, and never-raises on missing/garbage `SLURM_NODEID`.
  - `tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend_slurm.py`: `_get_slurm_node_names` alignment with reordered IPs, and `None` on missing tags / uncovered IPs / missing cached cluster info.
  - `tests/unit_tests/test_sky/backends/test_task_codegen.py`: new multi-node snapshot with node names; existing Slurm snapshots regenerated (they emit `cluster_nodes = None`, preserving the old executor invocation).
- End-to-end simulation of the executor `main()`:
  - Issue repro (single-node, `cluster_ips=['10.244.10.126']`, runtime IP `10.102.3.53`, no `--cluster-nodes`): exits 0 with `run.log` (previously `RuntimeError`).
  - Multi-node with mismatched IP and `--cluster-nodes=nodeA,nodeB`, `SLURMD_NODENAME=nodeB`: resolves index 1, logs to `1-worker1.log`.
- `pytest tests/unit_tests/test_sky/backends/test_task_codegen.py tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend_slurm.py tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py` — 37 passed.
- `bash format.sh` (yapf/isort/mypy/pylint) clean on the changed source files.
- Manual verification on our containerized-slurmd cluster: `SLURMD_NODENAME` is set inside both setup and run steps and matches `scontrol show hostnames $SLURM_JOB_NODELIST` (see issue thread); will re-validate a managed job against this branch.