### PR TITLE
[Kubernetes] Don't match a GPU variant request to a bare-name node

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -863,12 +863,18 @@ def _accelerator_name_matches(requested_acc: str,
 
     For backward compatibility with GPU name changes (e.g., when canonical names
     like 'H200' are added to replace fallback names like 'H200-SXM-80GB'), this
-    function also matches if one name is a prefix of the other separated by '-'.
+    function also matches if one name is a prefix of the other separated by '-'
+    and the extra suffix only describes packaging (a form factor such as 'SXM'
+    or a device memory size such as '80GB').
 
     This handles cases where:
     - Clusters were launched with fallback names (e.g., 'H200-SXM-80GB') but
       after upgrading, the same label now maps to canonical name (e.g., 'H200').
     - Users specify canonical names but the cluster uses fallback names.
+
+    A suffix that names a different model does not match, so a request for a
+    variant the cluster does not have (e.g. 'H100-MEGA' or 'RTX3090-TI') is not
+    satisfied by its bare-name sibling ('H100', 'RTX3090').
 
     Args:
         requested_acc: The accelerator type requested (e.g., from launched_resources).
@@ -883,28 +889,40 @@ def _accelerator_name_matches(requested_acc: str,
         if requested_lower == viable_lower:
             return True
         # Check prefix match with '-' separator for backward compatibility.
-        # E.g., 'H200' matches 'H200-SXM-80GB' and vice versa.
-        shorter, longer = ((requested_lower, viable_lower)
-                           if len(requested_lower) <= len(viable_lower) else
-                           (viable_lower, requested_lower))
-        if longer.startswith(shorter):
-            # Ensure it's a proper prefix (followed by '-' or end of string)
-            if len(longer) == len(shorter) or longer[len(shorter)] == '-':
-                # Guard against the OOM direction: a request must not be
-                # satisfied by a node with strictly LESS device memory (e.g.
-                # an 'A100-80GB' (or typo'd 'A100-80G') request on a 40GB
-                # 'A100' node). Only applies when both names imply a known
-                # memory size; same-or-larger node memory still matches, which
-                # preserves backward compatibility (an 'A100' request may still
-                # land on an 'A100-80GB' node) and same-hardware renames (e.g.
-                # 'H100' == 'H100-80GB', both 80GB).
-                requested_mem = gpu_names.get_gpu_device_memory_gib(
-                    requested_lower)
-                viable_mem = gpu_names.get_gpu_device_memory_gib(viable_lower)
-                if (requested_mem is not None and viable_mem is not None and
-                        requested_mem > viable_mem):
-                    continue
-                return True
+        # E.g., 'H200' matches 'H200-SXM-80GB' and vice versa. Which name is
+        # the more specific one decides how much leeway the match gets.
+        if viable_lower.startswith(f'{requested_lower}-'):
+            # The node label is the more specific name, so the node is an
+            # instance of what was asked for (e.g. an 'H100' request on an
+            # 'H100-MEGA' node) and satisfies the request.
+            matched = True
+        elif requested_lower.startswith(f'{viable_lower}-'):
+            # The request is the more specific name. Accept it only when the
+            # extra suffix describes packaging, which is the pre-
+            # canonicalization spelling of the same GPU (e.g. an
+            # 'H200-SXM-80GB' request on an 'H200' node). A suffix naming a
+            # distinct model must not be satisfied by the bare-name node: a
+            # request for 'H100-MEGA' or 'RTX3090-TI' is not met by a plain
+            # 'H100' or 'RTX3090' node.
+            matched = gpu_names.is_packaging_variant(viable_lower,
+                                                     requested_lower)
+        else:
+            matched = False
+        if matched:
+            # Guard against the OOM direction: a request must not be
+            # satisfied by a node with strictly LESS device memory (e.g.
+            # an 'A100-80GB' (or typo'd 'A100-80G') request on a 40GB
+            # 'A100' node). Only applies when both names imply a known
+            # memory size; same-or-larger node memory still matches, which
+            # preserves backward compatibility (an 'A100' request may still
+            # land on an 'A100-80GB' node) and same-hardware renames (e.g.
+            # 'H100' == 'H100-80GB', both 80GB).
+            requested_mem = gpu_names.get_gpu_device_memory_gib(requested_lower)
+            viable_mem = gpu_names.get_gpu_device_memory_gib(viable_lower)
+            if (requested_mem is not None and viable_mem is not None and
+                    requested_mem > viable_mem):
+                continue
+            return True
     return False
 
 

--- a/sky/utils/gpu_names.py
+++ b/sky/utils/gpu_names.py
@@ -76,6 +76,52 @@ _CANONICAL_GPU_MEMORY_GIB_LOWER = {
 # (e.g. 'A100-80G') since user-typed names are not always canonicalized.
 _MEMORY_SUFFIX_RE = re.compile(r'-(\d+)\s*gb?(?:-|$)', re.IGNORECASE)
 
+# Suffix tokens that describe how a GPU is packaged rather than which GPU it
+# is: a bus/form factor or an on-device memory size. Two names differing only
+# by these tokens denote the same physical GPU (e.g. 'H200-SXM-80GB' is an
+# H200). Any other token marks a distinct model -- 'H100-MEGA', 'H100-NVL' and
+# 'RTX3090-TI' are all different GPUs from their bare-name prefix, and several
+# appear in CANONICAL_GPU_NAMES in their own right.
+_FORM_FACTOR_TOKENS = frozenset({
+    'sxm',
+    'sxm2',
+    'sxm3',
+    'sxm4',
+    'sxm5',
+    'pci',
+    'pcie',
+    'hbm',
+    'hbm2',
+    'hbm2e',
+    'hbm3',
+    'hbm3e',
+})
+
+# Matches a standalone memory token like '80GB', '80G' or '32gb'.
+_MEMORY_TOKEN_RE = re.compile(r'^\d+\s*gb?$', re.IGNORECASE)
+
+
+def is_packaging_variant(shorter: str, longer: str) -> bool:
+    """Returns whether `longer` names the same physical GPU as `shorter`.
+
+    `longer` qualifies only when it is `shorter` followed by '-' and suffix
+    tokens that all describe packaging -- a form factor ('SXM', 'PCIE') or a
+    device memory size ('80GB'). This distinguishes a fallback name for the
+    same hardware, e.g. 'H200-SXM-80GB' for 'H200', from a genuinely different
+    model that happens to share a prefix, e.g. 'H100-MEGA' for 'H100'.
+
+    Comparison is case-insensitive. Callers still need to compare device memory
+    (see get_gpu_device_memory_gib) to reject a smaller-memory node.
+    """
+    shorter_lower = shorter.lower()
+    longer_lower = longer.lower()
+    if not longer_lower.startswith(f'{shorter_lower}-'):
+        return False
+    suffix_tokens = longer_lower[len(shorter_lower) + 1:].split('-')
+    return all(token in _FORM_FACTOR_TOKENS or
+               _MEMORY_TOKEN_RE.match(token) is not None
+               for token in suffix_tokens)
+
 
 def get_gpu_device_memory_gib(name: str) -> Optional[int]:
     """Returns the single-device memory (GiB) implied by a GPU name.

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -349,6 +349,37 @@ class TestAcceleratorNameMatches:
         # A10 should not match A100
         assert not _accelerator_name_matches('A10', ['a100'])
 
+    def test_no_match_for_distinct_model_variant(self):
+        """Test that a model-differentiating suffix is not a prefix match.
+
+        Regression test for #9035: on a cluster whose only GPU is H100,
+        requesting a variant that does not exist there (e.g. H100-MEGA) used to
+        succeed because the bare name is a '-'-separated prefix of it.
+
+        The match is directional. A request naming a specific variant is not
+        satisfied by a node that is only known to be the bare model, but the
+        converse still holds: a bare 'H100' request may land on an 'H100-MEGA'
+        node, since that node is an H100.
+        """
+        for variant in ['H100-MEGA', 'H100-NVL', 'H100-NVLINK']:
+            assert not _accelerator_name_matches(variant, ['h100'])
+            assert _accelerator_name_matches('H100', [variant.lower()])
+        # The variant must still match itself.
+        assert _accelerator_name_matches('H100-MEGA', ['h100-mega'])
+
+    def test_no_match_across_ti_variant(self):
+        """Test that a '-Ti' GPU is distinct from its non-Ti sibling.
+
+        Regression test for the report in #9035 of a cluster holding both
+        RTX3090 and RTX3090-Ti nodes: a job explicitly requesting RTX3090-TI
+        was scheduled onto plain RTX3090 nodes, leaving the Ti nodes idle.
+        """
+        assert not _accelerator_name_matches('RTX3090-TI', ['rtx3090'])
+        assert _accelerator_name_matches('RTX3090-TI', ['rtx3090-ti'])
+        # A Ti node is an acceptable home for a plain RTX3090 request, the
+        # same direction that lets an H100 request use an H100-MEGA node.
+        assert _accelerator_name_matches('RTX3090', ['rtx3090-ti'])
+
     def test_case_insensitive(self):
         """Test case-insensitive matching."""
         assert _accelerator_name_matches('H200', ['H200'])
@@ -423,21 +454,18 @@ class TestAcceleratorNameMatches:
         assert _accelerator_name_matches('H100', ['h100-80gb'])
         assert _accelerator_name_matches('H100-80GB', ['h100'])
 
-        # H100-MEGA is the same H100 80GB silicon (A3 Mega instance), so
-        # cross-matching with H100 is harmless and preserved.
+        # H100-MEGA is the same H100 80GB silicon (A3 Mega instance), so a
+        # bare H100 request may still land on an H100-MEGA node. The converse
+        # is rejected: see test_no_match_for_distinct_model_variant.
         assert _accelerator_name_matches('H100', ['h100-mega'])
-        assert _accelerator_name_matches('H100-MEGA', ['h100'])
 
     def test_no_cross_variant_matching(self):
         """Test that different GPU variants don't incorrectly match.
 
-        H100 and H100-MEGA are different GPUs and should not match each
-        other. However, due to prefix matching, H100 will match H100-MEGA.
-        This is a known limitation that's acceptable because:
-        1. It's unlikely a user launches with H100-MEGA and expects H100
-        2. Not matching would break backward compat for valid cases
+        A bare H100 request still matches an H100-MEGA node, which is an H100.
+        The reverse no longer matches; see
+        test_no_match_for_distinct_model_variant.
         """
-        # These will match due to prefix logic - this is expected behavior
         assert _accelerator_name_matches('H100', ['h100-mega'])
         # But ensure unrelated GPUs don't match
         assert not _accelerator_name_matches('H200', ['h100-mega'])


### PR DESCRIPTION
Fixes #9035.

On a cluster whose only GPU is H100, `sky launch --gpus H100-MEGA` succeeded, and `sky launch --gpus 'NVIDIA:40GB+'` offered H100-NVLINK / H100-SXM / H100-MEGA / H100-NVL as separate options that all resolved to the same physical H100.

`_accelerator_name_matches()` accepted a match whenever either name was a `-`-separated prefix of the other, in both directions. So a request naming a variant the cluster does not have was satisfied by its bare-name sibling. The same matching is behind the report in the issue thread of a cluster holding both RTX3090 and RTX3090-Ti nodes, where jobs that explicitly requested `RTX3090-TI` were given node affinity for plain `RTX3090`, leaving the Ti nodes permanently idle.

### Fix

Make the match directional:

- **Node label more specific than the request** — still matches. Such a node is an instance of what was asked for, so a bare `H100` request may land on an `H100-MEGA` node.
- **Request more specific than the node label** — matches only when the extra suffix describes *packaging*: a form factor (`SXM`, `PCIe`, `HBM3`) or a device memory size (`80GB`). That is the pre-canonicalization spelling of the same GPU (`H200-SXM-80GB` for an `H200` node), which is the case the prefix match existed to support.

A suffix naming a distinct model no longer matches. This is consistent with the rest of the codebase: several such names (`H100-MEGA`, `H100-80GB`, `A100-80GB`) are already listed in `CANONICAL_GPU_NAMES` as GPUs in their own right.

The existing device-memory guard is unchanged, so an `A100-80GB` request still cannot land on a 40GB `A100` node.

### Note for reviewers — intentional behavior change

`test_no_cross_variant_matching` previously documented this as a known limitation and asserted `_accelerator_name_matches('H100-MEGA', ['h100']) is True`. That assertion is exactly the behavior this issue asks to change, so it is removed; the surrounding tests that keep the reverse direction working are retained and now point at the new test. No other assertion in the suite was relaxed.

`sky/provision/slurm/utils.py` has a separate matcher that uses ordered segment-subsequence matching and already rejects these cases, so it needs no change.

### Tested

- [x] Code formatting: `bash format.sh` — pylint 10.00/10, mypy and dashboard lint clean
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New regression tests in `tests/unit_tests/kubernetes/test_gpu_label_formatters.py`:

- `test_no_match_for_distinct_model_variant` — `H100-MEGA`, `H100-NVL` and `H100-NVLINK` requests are not satisfied by an `h100` node, while a bare `H100` request still matches those nodes.
- `test_no_match_across_ti_variant` — an `RTX3090-TI` request is not satisfied by an `rtx3090` node.

```console
$ pytest tests/unit_tests/kubernetes/ tests/unit_tests/slurm/
542 passed
```

Those two directories hold every test in the repo that references the changed functions. The rest of `tests/unit_tests/` was also run: the only failures are pre-existing on the base commit in my environment (Azure tests needing the Azure SDK, `test_admin_policy` needing port 8080, and the `test_adaptor` memory-threshold test), all verified by re-running them on an unmodified checkout of master.

This is a Kubernetes scheduling-path change with no cloud dependency, so it is covered by unit tests. Happy to run any smoke tests you would like — I do not have permission to trigger the CI commands.