### PR TITLE
[Test] Pin enable_docker off in the non-Debian image smoke test

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -543,7 +543,14 @@ def test_kubernetes_non_debian_image(image, pkg_mgr, num_nodes):
         [
             # `sky launch` returns 0 only if the non-apt bootstrap installed the
             # prereqs and ray came up on the non-Debian image.
+            # kubernetes.enable_docker is Debian-only by design (its bootstrap
+            # installs the Docker CLI via apt and exits 1 otherwise), so a
+            # server whose config enables it globally would fail these images
+            # during bootstrap before reaching the code under test. This test
+            # exercises the non-Debian runtime bootstrap, not Docker -- pin it
+            # off for this launch.
             f'sky launch -y -c {name} --infra kubernetes '
+            f'--config kubernetes.enable_docker=false '
             f'--num-nodes {num_nodes} {smoke_tests_utils.LOW_RESOURCE_ARG} '
             f'--image-id docker:{image}',
             # Confirm it really ran on the non-Debian image (not a fallback):


### PR DESCRIPTION
## Summary
- **Test:** `test_kubernetes_non_debian_image` (rockylinux:9, redhat/ubi9) on `kubernetes`
- **Classification:** TEST_ENV_CONFLICT
- **Confidence:** HIGH

## Root Cause
`kubernetes.enable_docker` is Debian-only by design: its bootstrap block installs the Docker CLI via apt and deliberately exits 1 on any non-apt image (guard added in #10077). When the smoke test runs against an API server whose config sets `kubernetes.enable_docker` globally, the rockylinux:9 / redhat/ubi9 pods terminate ~20s into bootstrap, before reaching the pkg-manager-agnostic runtime path this test actually covers. The provisioner surfaces this as the misleading `container not found ("ray-node")`; the real error only lands in `/tmp/apt-update.log` inside the dead container.

## Fix
Add `--config kubernetes.enable_docker=false` to the test's `sky launch`, pinning Docker injection off for these launches regardless of server-side config. This test exercises the non-Debian runtime bootstrap, not Docker, so overriding (rather than skipping on such servers) keeps full coverage everywhere. Same pattern as the existing `--config kubernetes.set_pod_resource_limits=true` usage in this file; `kubernetes.enable_docker` is not in `SKIPPED_CLIENT_OVERRIDE_KEYS`, so the client override is honored.

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)