### PR TITLE
[CI Fix] Pin infra and add autodown in test_multiple_accelerators_ordered

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1639,12 +1639,22 @@ class TestYamlSpecs:
 @pytest.mark.no_nebius  # Nebius does not support K80s
 @pytest.mark.no_hyperbolic  # Hyperbolic only supports one GPU type per instance
 @pytest.mark.no_seeweb  # Seeweb does not support K80s
-def test_multiple_accelerators_ordered():
+def test_multiple_accelerators_ordered(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(
         'multiple-accelerators-ordered',
         [
-            f'sky launch -y -c {name} tests/test_yamls/test_multiple_accelerators_ordered.yaml | grep "Using user-specified accelerators list"',
+            # Pin the lane's cloud: the task YAML has no infra, so an
+            # unpinned launch is optimized across every enabled cloud and
+            # can land on one whose provisioning queues instead of failing
+            # over (e.g. a busy Slurm partition), hanging the test until
+            # timeout. Autodown (-i 10 --down) backstops cluster cleanup:
+            # teardown is skipped when the CI job is killed mid-launch, and
+            # the abandoned cluster otherwise provisions later and sits UP
+            # holding a GPU indefinitely.
+            f'sky launch -y -c {name} --infra {generic_cloud} -i 10 --down '
+            f'tests/test_yamls/test_multiple_accelerators_ordered.yaml | '
+            f'grep "Using user-specified accelerators list"',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
         ],
         f'sky down -y {name}',


### PR DESCRIPTION
## Summary
- **Test:** `test_multiple_accelerators_ordered`
- **Classification:** TEST_ASSERTION (test escapes its lane) + resource leak
- **Confidence:** HIGH

## Root Cause
The task YAML pins no infra, so `sky launch` is optimized across every cloud enabled on the API server, not the lane's cloud. On a server with a Slurm cluster enabled, the ordered list put A100-40GB first, the optimizer selected the Slurm cluster, and the launch sat in the Slurm queue (which waits rather than failing over) until the 1200s test timeout.

The queue was occupied by this same test's cluster leaked from a previous run: teardown never runs when the CI job is killed mid-launch, and the abandoned in-flight cluster later finished provisioning and sat UP holding the only free A100 indefinitely, starving every subsequent run.

## Fix
1. `--infra {generic_cloud}`: pin the launch to the lane's cloud (this is what the job name, e.g. "on kubernetes", already claims it tests). Kubernetes fails fast on infeasible/unavailable resources instead of queueing.
2. `-i 10 --down`: autodown as a server-side backstop so a cluster abandoned by a killed CI job cleans itself up 10 minutes after it stops being used, instead of leaking a GPU forever. Teardown (`sky down`) still handles the normal path; same pattern as the existing `-i 10 --down` launch in `test_cluster_job.py`.

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)