### PR TITLE
[Helm] History dashboard: bound GPU utilization to 0-100 (fix >100%)

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -85,7 +85,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
+          "expr": "avg(avg by (cluster, Hostname, gpu) (DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"} >= 0 <= 100))",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -375,7 +375,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
+          "expr": "avg(avg by (cluster, Hostname, gpu) (DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"} >= 0 <= 100))",
           "instant": false,
           "legendFormat": "GPU Utilization",
           "range": true,
@@ -399,7 +399,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg_over_time((avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"}))[$__range:$__interval] @ end())",
+          "expr": "avg_over_time((avg(avg by (cluster, Hostname, gpu) (DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"} >= 0 <= 100)))[$__range:$__interval] @ end())",
           "instant": false,
           "legendFormat": "Avg GPU Utilization",
           "range": true,
@@ -602,5 +602,5 @@
   "timezone": "",
   "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
## Problem

The GPU Utilization gauge and the utilization series on "Allocation & Utilization Over Time" computed `avg(DCGM_FI_DEV_GPU_UTIL)`, which is unbounded. `avg()` can never exceed its largest sample, so one bad sample takes the whole fleet number with it.

`DCGM_FI_DEV_GPU_UTIL` is documented as a 0-100 percentage, but the exporter can emit a garbage value for a single GPU. On a customer deployment, GPU 0 of one H200 node reported **218322032** across five consecutive scrapes while that same card reported `FB_USED=0`, `GPU_TEMP=28C`, `POWER_USAGE=76.4W` — the GPU was idle and the true value was 0.

Replayed against that Prometheus at the reported timestamp:

| Query | Result |
|---|---|
| `avg(DCGM_FI_DEV_GPU_UTIL)` | **1240483.8** (176 series) |
| `avg(DCGM_FI_DEV_GPU_UTIL >= 0 <= 100)` | 17.8 (175 series) |

`1240483.8` is exactly `218322032/176` plus the 175 real GPUs averaging 17.8% — the reported number is fully accounted for by that one series. The "Avg GPU Utilization" reference line then smeared the spike across the whole range, reading 4955.1% where the true average was single digits. Exactly one series exceeded 100 in the entire 7-day retention window.

## Fix

Two changes to all three utilization expressions:

1. **Filter to the documented range** with `>= 0 <= 100`. Filtering rather than clamping is deliberate — a GPU whose reading is nonsense should drop out of the average entirely, not masquerade as 100% busy. An idle GPU reporting 0 is unaffected.

2. **Collapse per-GPU series** with `avg by (cluster, Hostname, gpu)` before averaging. DCGM emits several label-series per GPU (one per pod holding it, plus an unattributed one), so the raw average weights a GPU by how many pods reference it — 176 raw series for 128 distinct GPUs on the deployment above. This is the same GPU-weighting the GPU Manager tile already applies server-side, so the panel and the tile now agree.

> [!NOTE]
> Change (2) shifts the displayed number even on healthy data (17.8% raw vs 24.4% GPU-weighted at the timestamp above). The GPU-weighted value is the correct fleet utilization. Happy to split it out if you would rather ship only the >100% bound.

## Verification

Validated against live data over a 2-day range at 1-minute resolution:

- **new expression**: min `0.00%`, max `80.41%` — zero points outside [0, 100]
- **previous expression**: peaked at `1505691%` over the same window

All three rewritten expressions were executed against a real Prometheus before committing. Dashboard `version` bumped 5 -> 6.

## Scope

GPU Allocation expressions are unchanged — already bounded by the per-node capping in #9877. This is the utilization counterpart to #9855 (exclude unscheduled pods) and #9877 (cap allocation at per-node capacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
