### PR TITLE
[Nebius] Support InfiniBand on Blackwell (B200/B300) platforms

### DIFF
--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -96,7 +96,7 @@ class Nebius(clouds.Cloud):
             (f'Migrating disk is currently not supported on {_REPR}.'),
         clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER:
             ('Custom network tier is currently only supported for '
-             'H100:8 and H200:8 on Nebius.'),
+             'H100:8, H200:8, B200:8 and B300:8 on Nebius.'),
         clouds.CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS:
             ('High availability controllers are not supported on Nebius.'),
         clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK:
@@ -133,10 +133,11 @@ class Nebius(clouds.Cloud):
     ) -> Dict[clouds.CloudImplementationFeatures, str]:
         unsupported = cls._CLOUD_UNSUPPORTED_FEATURES.copy()
 
-        # Check if the accelerators support InfiniBand (H100 or H200) and 8 GPUs
+        # Check if the accelerators support InfiniBand and come as 8 GPUs
         if resources.accelerators is not None:
             for acc_name, acc_count in resources.accelerators.items():
-                if acc_name.lower() in ('h100', 'h200') and acc_count == 8:
+                if (acc_name.lower() in nebius_constants.INFINIBAND_ACCELERATORS
+                        and acc_count == nebius_constants.INFINIBAND_GPU_COUNT):
                     # Remove CUSTOM_NETWORK_TIER from unsupported features for
                     # InfiniBand-capable accelerators. Refer to:
                     # https://docs.nebius.com/compute/clusters/gpu#fabrics

--- a/sky/provision/nebius/constants.py
+++ b/sky/provision/nebius/constants.py
@@ -24,7 +24,22 @@ def round_up_disk_size(disk_size_gib: int) -> int:
 INFINIBAND_INSTANCE_PLATFORMS = [
     'gpu-h100-sxm',
     'gpu-h200-sxm',
+    'gpu-b200-sxm',
+    # me-west1 exposes the B200 platform under a distinct name.
+    'gpu-b200-sxm-a',
+    'gpu-b300-sxm',
 ]
+
+# Accelerators whose 8-GPU instances can be grouped into an InfiniBand GPU
+# cluster. Kept in sync with INFINIBAND_INSTANCE_PLATFORMS, which names the
+# same hardware as Nebius platform strings.
+INFINIBAND_ACCELERATORS = frozenset({'h100', 'h200', 'b200', 'b300'})
+
+# Only 8-GPU VMs can be grouped into a GPU cluster. The vCPU/memory part of the
+# preset differs per platform (e.g. '8gpu-128vcpu-1600gb' for H100/H200,
+# '8gpu-192vcpu-2768gb' for B300), so match on the GPU count alone.
+INFINIBAND_PRESET_PREFIX = '8gpu-'
+INFINIBAND_GPU_COUNT = 8
 
 # InfiniBand environment variables for NCCL and UCX
 INFINIBAND_ENV_VARS = {
@@ -41,6 +56,7 @@ INFINIBAND_DOCKER_OPTIONS = ['--device=/dev/infiniband', '--cap-add=IPC_LOCK']
 
 # InfiniBand fabric mapping by platform and region
 # Based on Nebius documentation
+# https://docs.nebius.com/compute/clusters/gpu#fabrics
 INFINIBAND_FABRIC_MAPPING = {
     # H100 platforms
     ('gpu-h100-sxm', 'eu-north1'): [
@@ -51,18 +67,27 @@ INFINIBAND_FABRIC_MAPPING = {
     ('gpu-h200-sxm', 'eu-north1'): ['fabric-7'],
     ('gpu-h200-sxm', 'eu-west1'): ['fabric-5'],
     ('gpu-h200-sxm', 'us-central1'): ['us-central1-a'],
+
+    # B200 platforms
+    ('gpu-b200-sxm', 'us-central1'): ['us-central1-b'],
+    ('gpu-b200-sxm-a', 'me-west1'): ['me-west1-a'],
+
+    # B300 platforms
+    ('gpu-b300-sxm', 'uk-south1'): ['uk-south1-a'],
 }
 
 
 def get_default_fabric(platform: str, region: str) -> str:
-    """Get the default (first) fabric for a given platform and region."""
+    """Get the default (first) fabric for a given platform and region.
+
+    Raises:
+        ValueError: if the platform is not offered in the region. A fabric is
+            tied to a specific platform in a specific region, so there is no
+            usable default to fall back on; the caller is expected to report
+            this and let the user set one explicitly.
+    """
     fabrics = INFINIBAND_FABRIC_MAPPING.get((platform, region), [])
     if not fabrics:
-        # Select north europe region as default
-        fabrics = INFINIBAND_FABRIC_MAPPING.get(('gpu-h100-sxm', 'eu-north1'),
-                                                [])
-        if not fabrics:
-            raise ValueError(
-                f'No InfiniBand fabric available for platform {platform} '
-                f'in region {region}')
+        raise ValueError(f'No InfiniBand fabric available for platform '
+                         f'{platform} in region {region}')
     return fabrics[0]

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -564,7 +564,7 @@ def launch(cluster_name_on_cloud: str,
     # The GPU clusters are built with InfiniBand secure high-speed networking.
     # https://docs.nebius.com/compute/clusters/gpu
     if platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS:
-        if preset == '8gpu-128vcpu-1600gb':
+        if preset.startswith(nebius_constants.INFINIBAND_PRESET_PREFIX):
             fabric = skypilot_config.get_effective_region_config(
                 cloud='nebius',
                 region=region,

--- a/tests/unit_tests/test_nebius.py
+++ b/tests/unit_tests/test_nebius.py
@@ -4,10 +4,13 @@ import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
+
 from sky import clouds
 from sky import resources as resources_lib
 from sky.adaptors import nebius as nebius_adaptor
 from sky.clouds import nebius
+from sky.provision.nebius import constants as nebius_constants
 from sky.utils import resources_utils
 
 
@@ -80,6 +83,35 @@ class TestNebiusNetworkTier:
 
         # Should NOT have CUSTOM_NETWORK_TIER as unsupported
         assert clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER not in unsupported_features
+
+    def test_network_tier_supported_for_blackwell_8gpu(self):
+        """Test that network_tier=best is supported for B200:8 and B300:8.
+
+        The Blackwell platforms are InfiniBand-capable but were rejected
+        because the accelerator check only listed H100/H200.
+        """
+        for acc in ['B200', 'B300']:
+            resources = resources_lib.Resources(cloud=nebius.Nebius(),
+                                                accelerators={acc: 8},
+                                                network_tier='best')
+
+            unsupported_features = (
+                nebius.Nebius._unsupported_features_for_resources(resources))
+
+            assert (clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER
+                    not in unsupported_features), acc
+
+    def test_network_tier_unsupported_for_blackwell_partial_node(self):
+        """Only 8-GPU instances can join an InfiniBand GPU cluster."""
+        resources = resources_lib.Resources(cloud=nebius.Nebius(),
+                                            accelerators={'B300': 1},
+                                            network_tier='best')
+
+        unsupported_features = nebius.Nebius._unsupported_features_for_resources(
+            resources)
+
+        assert (clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER
+                in unsupported_features)
 
     @patch('sky.provision.nebius.utils.get_project_by_region',
            return_value='test-project-id')
@@ -218,3 +250,53 @@ class TestNebiusAdaptorLogging:
         other_path = os.path.join('site-packages', 'otherlib', 'client.py')
         assert not log_filter.filter(_record(nebius_path))
         assert log_filter.filter(_record(other_path))
+
+
+class TestNebiusInfinibandFabrics:
+    """Tests for InfiniBand fabric selection per platform and region."""
+
+    def test_default_fabric_for_known_platforms(self):
+        """Every fabric is looked up by both platform and region."""
+        expected = {
+            ('gpu-h100-sxm', 'eu-north1'): 'fabric-2',
+            ('gpu-h200-sxm', 'eu-west1'): 'fabric-5',
+            ('gpu-h200-sxm', 'us-central1'): 'us-central1-a',
+            ('gpu-b200-sxm', 'us-central1'): 'us-central1-b',
+            ('gpu-b200-sxm-a', 'me-west1'): 'me-west1-a',
+            ('gpu-b300-sxm', 'uk-south1'): 'uk-south1-a',
+        }
+        for (platform, region), fabric in expected.items():
+            assert nebius_constants.get_default_fabric(platform,
+                                                       region) == fabric
+
+    def test_default_fabric_rejects_unavailable_combination(self):
+        """An unknown platform/region must not fall back to another region.
+
+        A fabric belongs to one platform in one region, so returning a default
+        from elsewhere (previously eu-north1's H100 fabric) would attach the
+        GPU cluster to a fabric that does not exist for the request.
+        """
+        with pytest.raises(ValueError, match='No InfiniBand fabric'):
+            nebius_constants.get_default_fabric('gpu-b300-sxm', 'eu-north1')
+        with pytest.raises(ValueError, match='No InfiniBand fabric'):
+            nebius_constants.get_default_fabric('gpu-l40s', 'uk-south1')
+
+    def test_infiniband_platforms_cover_mapped_fabrics(self):
+        """Every platform with a fabric must be treated as InfiniBand-capable."""
+        for platform, _ in nebius_constants.INFINIBAND_FABRIC_MAPPING:
+            assert platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS
+
+    def test_preset_prefix_matches_8gpu_presets(self):
+        """The GPU-cluster preset check must cover every 8-GPU shape.
+
+        The vCPU/memory portion differs per platform, so an exact-match check
+        silently skipped GPU cluster creation on B200 and B300.
+        """
+        prefix = nebius_constants.INFINIBAND_PRESET_PREFIX
+        for preset in [
+                '8gpu-128vcpu-1600gb',  # H100, H200
+                '8gpu-160vcpu-1792gb',  # B200
+                '8gpu-192vcpu-2768gb',  # B300
+        ]:
+            assert preset.startswith(prefix)
+        assert not '1gpu-16vcpu-200gb'.startswith(prefix)


### PR DESCRIPTION
Refs #10264.

The reporter's `nebius/uk-south1` + `B300:1` YAML failed with `Invalid region 'uk-south1'`. That specific error is a stale local catalog — the hosted v8 catalog already lists uk-south1 with B300, and `rm ~/.sky/catalogs/v8/nebius/vms.csv` fixes it. But looking into it surfaced a real gap underneath, which is what this PR fixes.

B300 is the **only** GPU platform Nebius offers in uk-south1, and SkyPilot never recognized the Blackwell platforms as InfiniBand-capable. So even once the region resolves, `network_tier: best` on a B300 (or B200) instance is rejected outright and no GPU cluster is created.

Four places hardcoded the Hopper-only assumption:

| Location | Problem |
|---|---|
| `Nebius._unsupported_features_for_resources` | Accelerator check listed `('h100', 'h200')`, so `CUSTOM_NETWORK_TIER` stayed unsupported for `B200:8` / `B300:8` |
| `INFINIBAND_INSTANCE_PLATFORMS` | Omitted the Blackwell platforms, so InfiniBand env vars and Docker device options were never applied |
| GPU cluster preset check | Compared against the literal `'8gpu-128vcpu-1600gb'` (the H100/H200 shape). B300 is `'8gpu-192vcpu-2768gb'` and B200 is `'8gpu-160vcpu-1792gb'`, so cluster creation was silently skipped |
| `INFINIBAND_FABRIC_MAPPING` | No Blackwell entries at all |

Fabric values come from the [Nebius GPU cluster docs](https://docs.nebius.com/compute/clusters/gpu#fabrics): `uk-south1-a` for `gpu-b300-sxm` in uk-south1, `me-west1-a` for `gpu-b200-sxm-a` in me-west1, and `us-central1-b` for `gpu-b200-sxm` in us-central1. Note me-west1 exposes the B200 platform under the distinct name `gpu-b200-sxm-a`, so both spellings are listed.

The accelerator names and the 8-GPU preset rule now live in `sky/provision/nebius/constants.py` next to the platform list, so the cloud class and the provisioner read the same source of truth instead of repeating literals.

### Also: a wrong-region fabric fallback

`get_default_fabric()` fell back to eu-north1's H100 fabric whenever the platform/region pair was unknown. A fabric is tied to one platform in one region, so that default returned a fabric that does not exist for the request — for a B300 in uk-south1 it would have returned `fabric-2`. It now raises `ValueError`, which the caller already handles by warning and asking the user to set a fabric explicitly:

```python
except ValueError as e:
    logger.warning(f'InfiniBand fabric auto-selection failed: {e}')
```

### Not addressed here

Region availability itself needs no code change — `sky/catalog/data_fetchers/fetch_nebius.py` enumerates regions from the tenant's own projects, so uk-south1 appears once the hosted catalog is regenerated, which has already happened. If you would like the stale-catalog behavior improved separately (`is_catalog_modified()` treats a missing `.md5` as a manual edit and then never refreshes), I am happy to open a second PR.

### Tested

- [x] Code formatting: `bash format.sh` — pylint 10.00/10, mypy clean across 589 source files
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New tests in `tests/unit_tests/test_nebius.py`:

- `test_network_tier_supported_for_blackwell_8gpu` — `B200:8` and `B300:8` accept `network_tier: best`
- `test_network_tier_unsupported_for_blackwell_partial_node` — `B300:1` still does not
- `test_default_fabric_for_known_platforms` — every mapped platform/region resolves to its documented fabric
- `test_default_fabric_rejects_unavailable_combination` — an unavailable pair raises instead of returning another region's fabric
- `test_infiniband_platforms_cover_mapped_fabrics` — guards the two constants against drifting apart
- `test_preset_prefix_matches_8gpu_presets` — covers all three 8-GPU preset shapes

```console
$ pytest tests/unit_tests/test_nebius.py tests/unit_tests/test_nebius_catalog.py \
         tests/unit_tests/test_nebius_security_groups.py tests/unit_tests/test_sky/clouds/
440 passed, 11 skipped
```

I do not have a Nebius account, so the provisioning path is covered by unit tests rather than a live launch — happy to have smoke tests run against it.
