### PR TITLE
[Core] Lease leader election: heartbeat on a dedicated unpooled connection

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -592,21 +592,31 @@ def _pooler_configured() -> bool:
 @typing.overload
 def get_engine(db_name: Optional[str],
                async_engine: Literal[False] = False,
-               direct: bool = False) -> sqlalchemy.engine.Engine:
+               direct: bool = False,
+               no_pool: bool = False) -> sqlalchemy.engine.Engine:
     ...
 
 
 @typing.overload
 def get_engine(db_name: Optional[str],
                async_engine: Literal[True],
-               direct: bool = False) -> sqlalchemy_async.AsyncEngine:
+               direct: bool = False,
+               no_pool: bool = False) -> sqlalchemy_async.AsyncEngine:
     ...
+
+
+# Bound on the connect phase of a no_pool engine. Unlike a pooled checkout,
+# connection establishment is part of every operation on a NullPool engine,
+# and a server-side statement_timeout cannot bound it — an unresponsive
+# database would otherwise hang the caller for the OS default.
+_NO_POOL_CONNECT_TIMEOUT_SECONDS = 10
 
 
 def get_engine(
     db_name: Optional[str],
     async_engine: bool = False,
     direct: bool = False,
+    no_pool: bool = False,
 ) -> Union[sqlalchemy.engine.Engine, sqlalchemy_async.AsyncEngine]:
     """Get the engine for the given database name.
 
@@ -620,6 +630,17 @@ def get_engine(
         transaction-mode pooler. When no pooler is configured (the default),
         direct and non-direct resolve to the same connection string and thus
         the same cached engine.
+        no_pool: When True (Postgres, sync only), return a dedicated
+        ``NullPool`` engine: every operation opens a fresh connection and
+        closes it afterwards, and the engine shares no pool state with the
+        default engine for the same connection string. For low-frequency
+        control-plane calls (e.g. the leader-election heartbeat) that must
+        not queue behind application traffic on a shared pool — a pool
+        exhausted by slow application queries would otherwise starve exactly
+        the calls that need to stay reliable under DB pressure. The connect
+        phase is bounded by ``connect_timeout``, since unlike a pooled
+        checkout it is part of every call. No effect on SQLite (a file open
+        is effectively unpooled already).
     """
     conn_string = _resolve_conn_string(direct)
     if conn_string:
@@ -627,13 +648,24 @@ def get_engine(
         # because we prefix the cache key in the async case,
         # so they would not overlap.
         cache_key = f'async:{conn_string}' if async_engine else conn_string
+        if no_pool and not async_engine:
+            cache_key = f'nopool:{conn_string}'
         with _db_creation_lock:
             if cache_key not in _postgres_engine_cache:
                 engine_type = 'sync' if not async_engine else 'async'
                 logger.debug(
                     f'Creating a new postgres {engine_type} engine with '
                     f'maximum {_max_connections} connections')
-                if async_engine:
+                if no_pool and not async_engine:
+                    # Isolated per-operation engine: never shares (or starves
+                    # on) the default engine's pool. See the docstring.
+                    _postgres_engine_cache[cache_key] = (sqlalchemy.create_engine(
+                        conn_string,
+                        poolclass=sqlalchemy.NullPool,
+                        connect_args={
+                            'connect_timeout': _NO_POOL_CONNECT_TIMEOUT_SECONDS
+                        }))
+                elif async_engine:
                     # Use NullPool for async engines to avoid event loop binding
                     # issues. asyncpg connection pools bind to the event loop on
                     # first use, which causes "Future attached to a different

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -589,6 +589,13 @@ def _pooler_configured() -> bool:
         os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
 
 
+# Bound on the connect phase of a no_pool engine. Unlike a pooled checkout,
+# connection establishment is part of every operation on a NullPool engine,
+# and a server-side statement_timeout cannot bound it — an unresponsive
+# database would otherwise hang the caller for the OS default.
+_NO_POOL_CONNECT_TIMEOUT_SECONDS = 10
+
+
 @typing.overload
 def get_engine(db_name: Optional[str],
                async_engine: Literal[False] = False,
@@ -603,13 +610,6 @@ def get_engine(db_name: Optional[str],
                direct: bool = False,
                no_pool: bool = False) -> sqlalchemy_async.AsyncEngine:
     ...
-
-
-# Bound on the connect phase of a no_pool engine. Unlike a pooled checkout,
-# connection establishment is part of every operation on a NullPool engine,
-# and a server-side statement_timeout cannot bound it — an unresponsive
-# database would otherwise hang the caller for the OS default.
-_NO_POOL_CONNECT_TIMEOUT_SECONDS = 10
 
 
 def get_engine(
@@ -659,12 +659,13 @@ def get_engine(
                 if no_pool and not async_engine:
                     # Isolated per-operation engine: never shares (or starves
                     # on) the default engine's pool. See the docstring.
-                    _postgres_engine_cache[cache_key] = (sqlalchemy.create_engine(
+                    engine_no_pool = sqlalchemy.create_engine(
                         conn_string,
                         poolclass=sqlalchemy.NullPool,
                         connect_args={
                             'connect_timeout': _NO_POOL_CONNECT_TIMEOUT_SECONDS
-                        }))
+                        })
+                    _postgres_engine_cache[cache_key] = engine_no_pool
                 elif async_engine:
                     # Use NullPool for async engines to avoid event loop binding
                     # issues. asyncpg connection pools bind to the event loop on

--- a/sky/utils/leader_election.py
+++ b/sky/utils/leader_election.py
@@ -4,8 +4,9 @@ This module abstracts leader election behind :class:`LeaderElector` and offers
 a second, lease-based backend. A *lease* is a single row
 (``leader_leases(lock_id, holder, epoch, expires_at)``) refreshed by a short
 ``UPDATE`` in its own bounded transaction. Each renewal is a self-contained
-transaction, so it can ride a pooled/pgBouncer connection and holds no
-persistent connection between renewals; the row
+transaction on a dedicated direct, unpooled engine — no persistent connection
+is held between renewals, and the heartbeat never contends with application
+traffic for a shared pool (see ``PgLeaseElector._execute_bounded``); the row
 also carries a monotonic ``epoch`` that acts as a fencing token, letting a
 caller verify leadership atomically inside its own write transaction.
 
@@ -194,9 +195,10 @@ class PgLeaseElector(LeaderElector):
     ``try_acquire`` is an insert-or-take-over upsert that bumps ``epoch`` on
     every fresh acquisition; ``renew`` is a separate statement that only extends
     a lease we still validly hold, keeping ``epoch`` fixed for the term. Every
-    call is one short bounded transaction (see :meth:`_execute_bounded`) on the
-    pooled engine, so it rides a transaction-mode pooler and holds no persistent
-    connection between renewals.
+    call is one short bounded transaction on a dedicated direct, unpooled
+    engine (see :meth:`_execute_bounded`): no persistent connection is held
+    between renewals, and the heartbeat never shares — so can never be starved
+    by — the application engine's pool or a transaction pooler's server pool.
     """
 
     # Insert-or-take-over in one statement, used only by ``try_acquire``. All
@@ -288,8 +290,21 @@ class PgLeaseElector(LeaderElector):
         only takes effect inside a transaction block, so do NOT "simplify" this
         to ``isolation_level='AUTOCOMMIT'`` -- under autocommit ``SET LOCAL``
         degrades to a WARNING no-op and the statement timeout silently
-        disappears."""
-        engine = db_utils.get_engine(None)
+        disappears.
+
+        Runs on a dedicated direct + unpooled engine, never the shared
+        application engine. These calls are the leader-election heartbeat: if
+        they queue behind application traffic on a shared pool (or behind a
+        transaction pooler's starved server pool), DB pressure fails renewals
+        and churns the leader at exactly the moment stability matters most --
+        and each new leader's catch-up work adds more pressure, a feedback
+        loop. A fresh direct connection per call cannot be starved by any
+        shared pool state; at the renew cadence (one short statement every
+        ``renew_interval_seconds`` per held lease) the per-connection setup
+        cost is negligible, and holding a persistent connection instead would
+        reintroduce the standing per-process backend this backend exists to
+        avoid."""
+        engine = db_utils.get_engine(None, direct=True, no_pool=True)
         with engine.connect() as conn:
             conn.execute(
                 sqlalchemy.text(f'SET LOCAL statement_timeout = '

--- a/tests/unit_tests/test_leader_election.py
+++ b/tests/unit_tests/test_leader_election.py
@@ -90,6 +90,30 @@ def test_lease_timing_is_independently_tunable():
         is None
 
 
+def test_lease_statements_use_the_dedicated_unpooled_engine(monkeypatch):
+    """Every lease statement must ask for the direct, no_pool engine — the
+    heartbeat may never ride the shared application engine or a transaction
+    pooler, where a pool starved by slow application queries would fail
+    renewals (and churn the leader) exactly when the DB is under pressure."""
+    calls = []
+
+    def record_get_engine(*args, **kwargs):
+        calls.append(kwargs)
+        raise RuntimeError('no db in this test')
+
+    monkeypatch.setattr(leader_election.db_utils, 'get_engine',
+                        record_get_engine)
+    e = leader_election.PgLeaseElector('lock', holder='a')
+    # Errors are swallowed into "not leading"; the engine request is the point.
+    assert e.try_acquire() is False
+    assert e.renew() is False
+    e.release()
+    assert len(calls) == 3
+    for kwargs in calls:
+        assert kwargs.get('direct') is True
+        assert kwargs.get('no_pool') is True
+
+
 def test_advisory_elector_filelock_lifecycle(monkeypatch):
     """On the (non-Postgres) file-lock path, renew is always true while held."""
     monkeypatch.delenv(leader_election.ENV_VAR_BACKEND, raising=False)

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -228,6 +228,51 @@ class TestGetEngine:
             assert call_args[1]['pool_recycle'] == 1800
             assert engine == mock_engine
 
+    def test_postgres_no_pool_engine_is_nullpool_with_bounded_connect(
+            self, monkeypatch):
+        """no_pool returns a NullPool engine with a bounded connect phase,
+        even when a pool size is configured (which would otherwise pick
+        QueuePool)."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@localhost/db')
+        db_utils.set_max_connections(10)
+
+        with mock.patch('sqlalchemy.create_engine') as mock_create:
+            mock_create.return_value = mock.MagicMock()
+
+            db_utils.get_engine(None, direct=True, no_pool=True)
+
+            mock_create.assert_called_once()
+            call_args = mock_create.call_args
+            assert call_args[1]['poolclass'] == sqlalchemy.NullPool
+            assert call_args[1]['connect_args'] == {
+                'connect_timeout': db_utils._NO_POOL_CONNECT_TIMEOUT_SECONDS
+            }
+
+    def test_postgres_no_pool_direct_bypasses_pooler_and_default_engine(
+            self, monkeypatch):
+        """no_pool+direct connects to the direct URI (not the pooler rewrite)
+        and is cached separately from the default engine, so the two never
+        share pool state."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@h:5432/db')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(10)
+
+        default = db_utils.get_engine(None)
+        nopool = db_utils.get_engine(None, direct=True, no_pool=True)
+
+        assert nopool is not default
+        # The default engine routes through the pooler; no_pool goes direct.
+        assert '127.0.0.1:6432' in str(default.url)
+        assert 'h:5432' in str(nopool.url)
+        assert isinstance(nopool.pool, sqlalchemy.NullPool)
+        # Both are cached: repeat calls return the same objects.
+        assert db_utils.get_engine(None) is default
+        assert db_utils.get_engine(None, direct=True, no_pool=True) is nopool
+
     def test_postgres_sync_engine_queuepool_max_overflow_calculation(
             self, monkeypatch):
         """Test max_overflow calculation with different pool sizes."""


### PR DESCRIPTION
## Summary

Move the lease leader-election heartbeat (acquire / renew / release) off the shared application engine onto a dedicated **direct, unpooled** connection path.

Previously these statements ran on `db_utils.get_engine(None)` — the same engine (and, when configured, the same transaction pooler) as application traffic. That couples the heartbeat to application load: a pool exhausted by slow application queries starves renewals, the leader steps down and re-elects at exactly the moment the DB is under pressure, and each new leader's catch-up work adds more load — a feedback loop that amplifies pressure instead of riding it out.

- **`db_utils.get_engine(no_pool=True)`** (new): a dedicated `NullPool` engine, cached separately from the default engine. Every operation opens a fresh connection and closes it; the connect phase is bounded by `connect_timeout` (unlike a pooled checkout, it is part of every call). No effect on any existing caller.
- **`PgLeaseElector`** now uses `get_engine(None, direct=True, no_pool=True)`: the heartbeat bypasses both the shared pool and any transaction pooler in every configuration, and cannot be starved by shared pool state.

## Why per-operation connections rather than a dedicated persistent connection

Renewals are one short statement per `renew_interval` (10s) per held lease — a few fresh connections per second fleet-wide, each alive for tens of milliseconds. A persistent connection would amortize the handshake only if many renewals shared it; in practice daemons are spread across processes and replicas, so it would pin one mostly-idle direct backend per process — reintroducing the standing per-process connection the lease backend exists to avoid. Per-operation connections also leave no shared state to poison: nothing to starve, no stale connections after a pooler restart.

## Test

- New `test_leader_election.py` seam test: every lease statement requests `direct=True, no_pool=True` (the heartbeat can never silently ride the shared engine again).
- New `test_db_utils.py` cases: `no_pool` yields `NullPool` + bounded `connect_timeout` even when a pool size is configured; `no_pool+direct` resolves the direct URI (not the pooler rewrite) and is cached separately from the default engine.
- Full affected set green locally: `test_leader_election.py` (19, incl. the Postgres-backed lease SQL tests against a real server) + `test_db_utils.py` (36).
- `format.sh --files` clean on the four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
