### PR TITLE
[API] Bound auth middleware DB lookups with a deadline

### DIFF
--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -1,0 +1,86 @@
+"""Bounded DB lookups for the authentication middlewares.
+
+Authentication middlewares perform DB lookups on the request path (user
+rows, service-account tokens, RBAC policies). Without a deadline, a
+degraded database — slow queries, a starved connection pool, or time
+queued inside a transaction pooler — holds each lookup, and the executor
+thread running it, for as long as the DB layer allows. At a hold time of
+minutes the bounded auth executor saturates within seconds and every
+authenticated endpoint fails for the duration of the DB incident.
+
+``call_with_deadline`` puts a client-side total deadline on each lookup.
+``asyncio.wait_for`` is deliberately the bounding layer: a server-side
+``statement_timeout`` cannot cover time spent queued inside a transaction
+pooler (no server connection is assigned yet) or waiting for a pool
+checkout. On timeout the request fails fast with a 503 the client retries
+with backoff; note the executor thread itself keeps running until the DB
+layer releases it, so the auth executor still acts as a saturation
+buffer — requests beyond it fail fast with the worker-exhausted 503.
+
+Both timeout and executor exhaustion must be converted to responses
+*inside* the middleware: app-level exception handlers wrap the router
+only, so an exception raised in a middleware surfaces as a bare 500,
+which clients do not retry.
+"""
+import asyncio
+import os
+from typing import Any, Callable
+
+import fastapi
+
+from sky.server.requests import executor
+from sky.utils import context_utils
+
+# Total client-side deadline on each auth DB lookup. Healthy lookups are
+# small indexed queries; this only trips when the DB layer is in real
+# trouble, while staying well below the SQLAlchemy pool checkout timeout
+# (30s) and typical pooler queue-wait timeouts so requests fail fast
+# before executor threads pile up.
+AUTH_DB_TIMEOUT_SECONDS = float(
+    os.environ.get('SKYPILOT_AUTH_DB_TIMEOUT_SECONDS', '5'))
+
+
+async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
+    """Run a sync auth DB lookup on the auth executor with a total deadline.
+
+    Raises ``asyncio.TimeoutError`` when the deadline elapses and
+    ``ConcurrentWorkerExhaustedError`` when the executor is saturated.
+    """
+    return await asyncio.wait_for(context_utils.to_thread_with_executor(
+        executor.get_auth_thread_executor(), func, *args),
+                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+
+
+def db_timeout_response() -> fastapi.responses.JSONResponse:
+    """503 for an auth lookup that timed out on a degraded database.
+
+    503 (not 504/429) because the client maps exactly 503 to
+    ``ServerTemporarilyUnavailableError`` and retries with backoff (see
+    ``sky/server/rest.py``); any other status surfaces as a hard error.
+    The detail message is distinct from the worker-exhausted 503 so
+    operators can tell the two apart in logs.
+    """
+    return fastapi.responses.JSONResponse(
+        status_code=503,
+        headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
+        content={
+            'detail': ('Authentication lookup timed out because the server '
+                       'database is slow or unavailable. Please try again.')
+        })
+
+
+def worker_exhausted_response() -> fastapi.responses.JSONResponse:
+    """503 for an auth lookup rejected by a saturated auth executor.
+
+    Mirrors ``handle_concurrent_worker_exhausted_error`` in
+    ``sky/server/server.py`` — that app-level handler cannot see
+    exceptions raised in middlewares, so middlewares must convert the
+    error themselves or it surfaces as a bare 500.
+    """
+    return fastapi.responses.JSONResponse(
+        status_code=503,
+        content={
+            'detail':
+                ('The server has exhausted its concurrent worker limit. '
+                 'Please try again or scale the server if the load persists.')
+        })

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -75,6 +75,7 @@ from sky.server import stream_utils
 from sky.server import version_check
 from sky.server import versions
 from sky.server import websocket_utils
+from sky.server.auth import db_lookup
 from sky.server.auth import loopback
 from sky.server.auth import oauth2_proxy
 from sky.server.auth import sessions as auth_sessions
@@ -169,7 +170,27 @@ def _bearer_auth_401_response(content):
         content=content)
 
 
-def _try_set_basic_auth_user(request: fastapi.Request):
+def _find_basic_auth_user(username: str,
+                          password: str) -> Optional[models.User]:
+    """Look up and verify a basic-auth user. Sync: DB query + bcrypt verify.
+
+    Runs on the auth thread executor — both the DB lookup and the
+    (CPU-heavy) password hash verification would otherwise block the
+    request event loop.
+    """
+    users = global_user_state.get_user_by_name(username)
+    for user in users:
+        if not user.name or not user.password:
+            continue
+        username_encoded = username.encode('utf8')
+        db_username_encoded = user.name.encode('utf8')
+        if (username_encoded == db_username_encoded and
+                common.crypt_ctx.verify(password, user.password)):
+            return user
+    return None
+
+
+async def _try_set_basic_auth_user(request: fastapi.Request):
     auth_header = request.headers.get('authorization')
     if not auth_header or not auth_header.lower().startswith('basic '):
         return
@@ -182,19 +203,18 @@ def _try_set_basic_auth_user(request: fastapi.Request):
     except Exception:  # pylint: disable=broad-except
         return
 
-    users = global_user_state.get_user_by_name(username)
-    if not users:
+    try:
+        user = await db_lookup.call_with_deadline(_find_basic_auth_user,
+                                                  username, password)
+    except (asyncio.TimeoutError, exceptions.ConcurrentWorkerExhaustedError):
+        # Best-effort only: this path serves /api/health, which must stay
+        # available during a DB incident. Proceed unauthenticated instead
+        # of failing the probe.
+        logger.warning('Basic auth lookup unavailable on health path; '
+                       'proceeding unauthenticated')
         return
-
-    for user in users:
-        if not user.name or not user.password:
-            continue
-        username_encoded = username.encode('utf8')
-        db_username_encoded = user.name.encode('utf8')
-        if (username_encoded == db_username_encoded and
-                common.crypt_ctx.verify(password, user.password)):
-            request.state.auth_user = user
-            break
+    if user is not None:
+        request.state.auth_user = user
 
 
 @middleware_utils.websocket_aware
@@ -213,10 +233,23 @@ class RBACMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             return await call_next(request)
 
         permission_service = permission.permission_service
-        # Check the role permission
-        if permission_service.check_endpoint_permission(auth_user.id,
-                                                        request.url.path,
-                                                        request.method):
+        # Check the role permission. Offload to the bounded auth thread
+        # executor under a deadline: the check acquires the casbin enforcer
+        # read lock (and reads the DB on a cache miss), so running it on
+        # the loop lets a slow DB or a concurrent policy reload stall every
+        # request on this worker. Fails closed: a timeout is a retryable
+        # 503, never an allow.
+        try:
+            blocked = await db_lookup.call_with_deadline(
+                permission_service.check_endpoint_permission, auth_user.id,
+                request.url.path, request.method)
+        except asyncio.TimeoutError:
+            logger.error('RBAC check timed out, path: %s', request.url.path)
+            return db_lookup.db_timeout_response()
+        except exceptions.ConcurrentWorkerExhaustedError as e:
+            logger.error(f'Concurrent worker exhausted during RBAC check: {e}')
+            return db_lookup.worker_exhausted_response()
+        if blocked:
             return fastapi.responses.JSONResponse(
                 status_code=403, content={'detail': 'Forbidden'})
 
@@ -356,7 +389,7 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         if request.url.path.startswith('/api/health'):
             # Try to set the auth user from basic auth
-            _try_set_basic_auth_user(request)
+            await _try_set_basic_auth_user(request)
             return await call_next(request)
 
         auth_header = request.headers.get('authorization')
@@ -375,23 +408,26 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         except Exception:  # pylint: disable=broad-except
             return _basic_auth_401_response('Invalid basic auth')
 
-        users = global_user_state.get_user_by_name(username)
-        if not users:
+        # Offload the DB lookup + bcrypt verification to the bounded auth
+        # thread executor under a deadline, so a slow DB (or the CPU-heavy
+        # hash verification) cannot stall the request event loop or hold
+        # executor threads indefinitely. Both failure modes convert to a
+        # 503 here: app-level exception handlers wrap the router only, so
+        # an exception raised in a middleware surfaces as a bare 500,
+        # which clients do not retry.
+        try:
+            user = await db_lookup.call_with_deadline(_find_basic_auth_user,
+                                                      username, password)
+        except asyncio.TimeoutError:
+            logger.error('Basic auth DB lookup timed out, path: %s',
+                         request.url.path)
+            return db_lookup.db_timeout_response()
+        except exceptions.ConcurrentWorkerExhaustedError as e:
+            logger.error(f'Concurrent worker exhausted during basic auth: {e}')
+            return db_lookup.worker_exhausted_response()
+        if user is None:
             return _basic_auth_401_response('Invalid credentials')
-
-        valid_user = False
-        for user in users:
-            if not user.name or not user.password:
-                continue
-            username_encoded = username.encode('utf8')
-            db_username_encoded = user.name.encode('utf8')
-            if (username_encoded == db_username_encoded and
-                    common.crypt_ctx.verify(password, user.password)):
-                valid_user = True
-                request.state.auth_user = user
-                break
-        if not valid_user:
-            return _basic_auth_401_response('Invalid credentials')
+        request.state.auth_user = user
 
         return await call_next(request)
 
@@ -492,19 +528,15 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # JWT carries a freshly-generated token_id; only the hash is
             # consistent between the live JWT and the live DB row.
             incoming_hash = hashlib.sha256(sa_token.encode()).hexdigest()
-            # Offload the sync DB lookups to the bounded auth thread executor so
-            # a slow/locked DB cannot stall the request event loop (this runs on
-            # the loop for every service-account-authenticated request).
-            # Using a dedicated executor (not asyncio's shared default thread
-            # pool) avoids saturating that pool under DB slowness; when it is
-            # exhausted it raises ConcurrentWorkerExhaustedError, which the
-            # app-level handler turns into a 503 so the client retries. The auth
-            # executor is kept separate from the request executor so long-lived
-            # streaming requests cannot starve authentication.
-            loop = asyncio.get_running_loop()
-            auth_executor = executor.get_auth_thread_executor()
-            token_row = await loop.run_in_executor(
-                auth_executor,
+            # Offload the sync DB lookups to the bounded auth thread executor
+            # under a deadline, so a slow/locked DB cannot stall the request
+            # event loop (this runs on the loop for every
+            # service-account-authenticated request) nor hold executor
+            # threads for as long as the DB layer allows. The auth executor
+            # is kept separate from the request executor so long-lived
+            # streaming requests cannot starve authentication; timeouts and
+            # executor exhaustion are converted to retryable 503s below.
+            token_row = await db_lookup.call_with_deadline(
                 global_user_state.get_service_account_token_by_hash,
                 incoming_hash)
             if token_row is None:
@@ -521,9 +553,8 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     {'detail': 'Service account token has expired'})
 
             # Verify user still exists in database
-            user_info = await loop.run_in_executor(auth_executor,
-                                                   global_user_state.get_user,
-                                                   user_id)
+            user_info = await db_lookup.call_with_deadline(
+                global_user_state.get_user, user_id)
             if user_info is None:
                 logger.warning(
                     f'Service account user {user_id} no longer exists')
@@ -534,8 +565,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # DB row's token_id (not the JWT's): after rotation the JWT
             # carries a different token_id than the DB row.
             try:
-                await loop.run_in_executor(
-                    auth_executor,
+                await db_lookup.call_with_deadline(
                     global_user_state.update_service_account_token_last_used,
                     token_row['token_id'])
             except Exception as e:  # pylint: disable=broad-except
@@ -548,10 +578,19 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
             logger.debug(f'Authenticated service account: {user_id}')
 
-        except exceptions.ConcurrentWorkerExhaustedError:
-            # Request thread executor is full: let the app-level handler return
-            # 503 so the client retries, instead of masking it as a 401 below.
-            raise
+        except asyncio.TimeoutError:
+            # Convert to a retryable 503 here (not a 401 below, and not a
+            # raise): app-level exception handlers wrap the router only, so
+            # an exception raised in a middleware surfaces as a bare 500,
+            # which clients do not retry.
+            logger.error('Service account auth DB lookup timed out')
+            return db_lookup.db_timeout_response()
+        except exceptions.ConcurrentWorkerExhaustedError as e:
+            # Same reasoning as the timeout above: convert in-middleware so
+            # the client sees a retryable 503 instead of a bare 500.
+            logger.error(f'Concurrent worker exhausted during service account '
+                         f'auth: {e}')
+            return db_lookup.worker_exhausted_response()
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'Service account authentication failed: {e}',
                          exc_info=True)
@@ -598,9 +637,23 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                              'auth user was already set.')
             return await call_next(request)
 
-        # Add user to database if auth_user is present
+        # Add user to database if auth_user is present. Offload the sync DB
+        # upsert to the bounded auth thread executor under a deadline (it
+        # would otherwise run on the event loop for every
+        # auth-proxy-authenticated request); failures convert to retryable
+        # 503s here because app-level exception handlers cannot see
+        # exceptions raised in middlewares.
         if auth_user is not None:
-            newly_added = global_user_state.add_or_update_user(auth_user)
+            try:
+                newly_added = await db_lookup.call_with_deadline(
+                    global_user_state.add_or_update_user, auth_user)
+            except asyncio.TimeoutError:
+                logger.error('Auth proxy user upsert timed out')
+                return db_lookup.db_timeout_response()
+            except exceptions.ConcurrentWorkerExhaustedError as e:
+                logger.error(f'Concurrent worker exhausted during auth proxy '
+                             f'user upsert: {e}')
+                return db_lookup.worker_exhausted_response()
             if newly_added:
                 # Offload the blocking config reload + role seed to a worker
                 # thread so this async middleware doesn't block the event loop.

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -1,0 +1,252 @@
+"""Auth middleware DB lookups must be bounded by a deadline.
+
+Every authenticated request runs DB lookups in the auth middlewares
+(bearer token rows, basic-auth user rows, RBAC policies, auth-proxy user
+upserts) on the bounded auth thread executor. Without a deadline, a
+degraded database holds each lookup — and its executor thread — for as
+long as the DB layer allows; at a hold time of minutes the executor
+saturates within seconds and every authenticated endpoint fails for the
+duration of the DB incident.
+
+These tests pin the containment behavior:
+
+* a lookup that outlives ``AUTH_DB_TIMEOUT_SECONDS`` fails that single
+  request fast with a retryable 503 (and ``Retry-After``) instead of
+  queueing threads;
+* executor exhaustion also surfaces as a 503 from *inside* the
+  middleware — app-level exception handlers wrap the router only, so a
+  raise from a middleware would surface as a bare 500, which clients do
+  not retry;
+* the basic-auth path on ``/api/health`` stays best-effort: probes must
+  survive a DB incident, so it proceeds unauthenticated instead of
+  failing.
+"""
+
+import asyncio
+import os
+import time
+import unittest.mock as mock
+
+import fastapi
+import pytest
+
+from sky import models
+from sky.server import server
+from sky.server.auth import db_lookup
+from sky.server.requests import threads
+from sky.skylet import constants
+
+# Lookups sleep _SLOW_DB_SECONDS while the deadline is patched to
+# _DEADLINE_SECONDS, so every "slow DB" test trips the deadline quickly and
+# the leaked executor thread exits shortly after the test.
+_SLOW_DB_SECONDS = 0.3
+_DEADLINE_SECONDS = 0.05
+
+
+def _slow(return_value):
+    """A synchronous stand-in for a DB call stuck on a degraded database."""
+
+    def _call(*args, **kwargs):
+        del args, kwargs
+        time.sleep(_SLOW_DB_SECONDS)
+        return return_value
+
+    return _call
+
+
+@pytest.fixture(autouse=True)
+def short_deadline(monkeypatch):
+    monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', _DEADLINE_SECONDS)
+
+
+@pytest.fixture
+def mock_request():
+    request = mock.Mock(spec=fastapi.Request)
+    request.headers = {}
+    request.state = mock.Mock()
+    request.state.auth_user = None
+    request.url = mock.Mock()
+    request.url.path = '/users'
+    request.method = 'GET'
+    request.cookies = {}
+    return request
+
+
+@pytest.fixture
+def call_next_sentinel():
+    """call_next that records whether the request reached the router."""
+
+    async def call_next(_request):
+        call_next.reached = True
+        return fastapi.responses.JSONResponse({'message': 'success'})
+
+    call_next.reached = False
+    return call_next
+
+
+def _assert_retryable_timeout_503(response):
+    assert response.status_code == 503, getattr(response, 'body', response)
+    assert 'Retry-After' in response.headers
+    # The detail is distinct from the worker-exhausted 503 so operators can
+    # tell a DB timeout from executor saturation.
+    assert b'timed out' in response.body
+
+
+class TestBearerTokenDeadline:
+
+    @pytest.mark.asyncio
+    async def test_slow_token_lookup_times_out_to_503(self, mock_request,
+                                                      call_next_sentinel):
+        mock_request.headers = {'authorization': 'Bearer sky_token'}
+        middleware = server.BearerTokenMiddleware(app=mock.Mock())
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as tks, \
+                mock.patch(
+                    'sky.global_user_state.get_service_account_token_by_hash',
+                    _slow(None)):
+            tks.verify_token.return_value = {
+                'sub': 'sa-1',
+                'name': 'sa',
+                'token_id': 'tok-1'
+            }
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+    @pytest.mark.asyncio
+    async def test_exhausted_executor_is_503_not_500(self, mock_request,
+                                                     call_next_sentinel):
+        """A saturated auth executor must surface as a 503 from inside the
+        middleware. Raising (the previous behavior) surfaces as a bare 500:
+        app-level exception handlers wrap the router only and cannot see
+        exceptions raised in middlewares."""
+        mock_request.headers = {'authorization': 'Bearer sky_token'}
+        middleware = server.BearerTokenMiddleware(app=mock.Mock())
+        exhausted = threads.OnDemandThreadExecutor(name='test-exhausted',
+                                                   max_workers=0)
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as tks, \
+                mock.patch.object(db_lookup.executor,
+                                  'get_auth_thread_executor',
+                                  return_value=exhausted):
+            tks.verify_token.return_value = {
+                'sub': 'sa-1',
+                'name': 'sa',
+                'token_id': 'tok-1'
+            }
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        assert response.status_code == 503
+        assert b'concurrent worker limit' in response.body
+        assert not call_next_sentinel.reached
+
+
+class TestBasicAuthDeadline:
+
+    @pytest.mark.asyncio
+    async def test_slow_user_lookup_times_out_to_503(self, mock_request,
+                                                     call_next_sentinel):
+        # 'user:pass' base64-encoded.
+        mock_request.headers = {'authorization': 'Basic dXNlcjpwYXNz'}
+        middleware = server.BasicAuthMiddleware(app=mock.Mock())
+
+        with mock.patch.object(server.loopback,
+                               'is_loopback_request',
+                               return_value=False), \
+                mock.patch('sky.global_user_state.get_user_by_name',
+                           _slow([])):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+    @pytest.mark.asyncio
+    async def test_health_path_survives_db_timeout(self, mock_request,
+                                                   call_next_sentinel):
+        """/api/health must stay available during a DB incident: the
+        best-effort basic-auth lookup proceeds unauthenticated on timeout
+        instead of failing the probe."""
+        mock_request.url.path = '/api/health'
+        mock_request.headers = {'authorization': 'Basic dXNlcjpwYXNz'}
+        middleware = server.BasicAuthMiddleware(app=mock.Mock())
+
+        with mock.patch.object(server.loopback,
+                               'is_loopback_request',
+                               return_value=False), \
+                mock.patch('sky.global_user_state.get_user_by_name',
+                           _slow([])):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        assert response.status_code == 200
+        assert call_next_sentinel.reached
+        assert mock_request.state.auth_user is None
+
+
+class TestRBACDeadline:
+
+    @pytest.mark.asyncio
+    async def test_slow_permission_check_times_out_to_503(
+            self, mock_request, call_next_sentinel):
+        """A timed-out RBAC check fails closed with a retryable 503 — never
+        an allow."""
+        mock_request.state.auth_user = models.User(id='u-1', name='tester')
+        middleware = server.RBACMiddleware(app=mock.Mock())
+
+        with mock.patch(
+                'sky.users.permission.permission_service') as perm_service:
+            perm_service.check_endpoint_permission = _slow(False)
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+
+class TestAuthProxyDeadline:
+
+    @pytest.mark.asyncio
+    async def test_slow_user_upsert_times_out_to_503(self, mock_request,
+                                                     call_next_sentinel):
+        proxy_config = mock.Mock()
+        proxy_config.enabled = True
+        with mock.patch.object(server.server_config,
+                               'load_external_proxy_config',
+                               return_value=proxy_config):
+            middleware = server.AuthProxyMiddleware(app=mock.Mock())
+
+        with mock.patch.object(
+                server,
+                '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           _slow(False)):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+
+@pytest.mark.asyncio
+async def test_call_with_deadline_returns_fast_results(monkeypatch):
+    """The healthy path is unperturbed: fast lookups return their value."""
+    monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+    result = await db_lookup.call_with_deadline(lambda: 'ok')
+    assert result == 'ok'
+
+
+@pytest.mark.asyncio
+async def test_call_with_deadline_raises_timeout():
+    with pytest.raises(asyncio.TimeoutError):
+        await db_lookup.call_with_deadline(_slow(None))


### PR DESCRIPTION
Every authenticated request runs DB lookups in the auth middlewares (bearer token rows, basic-auth user rows, RBAC policies, auth-proxy user upserts). Without a deadline, a degraded database — slow queries, a starved connection pool, or time queued inside a transaction pooler — holds each lookup, and the executor thread or event loop running it, for as long as the DB layer allows (a pgbouncer `query_wait_timeout` alone is 120s by default). At that hold time the 32-thread auth executor saturates within seconds, so a DB slowdown escalates into full API unavailability.

Changes:

- New `sky/server/auth/db_lookup.py`: `call_with_deadline` runs a sync lookup on the bounded auth thread executor under a 5s `asyncio.wait_for` deadline. The deadline is deliberately client-side: a server-side `statement_timeout` cannot cover time queued inside a transaction pooler (no server connection assigned yet) or waiting for a pool checkout. On timeout the request fails fast with a 503 + `Retry-After` — 503 because the client maps exactly that status to `ServerTemporarilyUnavailableError` and retries with backoff (`sky/server/rest.py`); the detail message is distinct from the worker-exhausted 503 so operators can tell the two apart.
- **BearerTokenMiddleware**: the three service-account lookups now run under the deadline. Also fixes a latent bug: executor exhaustion was re-raised expecting the app-level `ConcurrentWorkerExhaustedError` handler to convert it to a 503, but app-level exception handlers wrap the router only — an exception raised in a middleware surfaces as a bare 500, which clients do not retry. Both timeout and exhaustion now convert to 503 responses inside the middleware.
- **BasicAuthMiddleware** / **RBACMiddleware**: the DB lookup + bcrypt verification and the casbin permission check previously ran synchronously **on the event loop** (blocking every in-flight request on this worker when the DB is slow); both are now offloaded to the auth executor under the deadline. RBAC fails closed — a timeout is a retryable 503, never an allow.
- **AuthProxyMiddleware**: the per-request user upsert (`add_or_update_user`) also ran on the loop; offloaded and bounded the same way.
- The best-effort basic-auth lookup on `/api/health` proceeds unauthenticated on timeout/exhaustion so health probes survive a DB incident instead of failing.

Knob: `SKYPILOT_AUTH_DB_TIMEOUT_SECONDS` (default 5). Healthy lookups are single-digit-ms indexed queries; the deadline only trips when the DB layer is in real trouble, and it stays well below the SQLAlchemy pool checkout timeout (30s).

Tested:

- New `tests/unit_tests/test_sky/server/test_auth_db_deadline.py` (8 tests): slow lookups in each of the four middlewares → 503 + `Retry-After` with the timeout detail, request never reaches the router; exhausted executor in the bearer path → 503 (not 500); `/api/health` with a hanging basic-auth lookup → 200, unauthenticated; `call_with_deadline` healthy path returns values, deadline path raises `asyncio.TimeoutError`.
- Existing `tests/unit_tests/test_sky/server/test_bearer_token_middleware.py` (17 tests, including the event-loop-lag test) passes unchanged.
- `format.sh` (yapf/isort clean), `mypy sky/server/server.py sky/server/auth/db_lookup.py` clean, pylint 10.00/10 on changed files.
