### PR TITLE
Do not let clients override admin_policy

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -643,6 +643,11 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     ('serve', 'controller', 'consolidation_mode'),
     ('jobs', 'controller', 'controller_logs_gc_retention_hours'),
     ('jobs', 'controller', 'task_logs_gc_retention_hours'),
+    # An admin policy the client can replace is not an admin policy: a client that sets its own
+    # `admin_policy` (a module path, or a URL to a server it controls) has the API server apply
+    # that instead. Nothing rejects it, so the request still succeeds and the resulting cluster
+    # looks normal.
+    ('admin_policy',),
     # Slurm submit identity and cluster settings are managed server-side.
     ('slurm', 'cluster_configs'),
     ('slurm', 'submit_as_user'),

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -628,6 +628,7 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     ('api_server',),
     ('allowed_clouds',),
     ('workspaces',),
+    ('admin_policy',),
     ('db',),
     ('daemons',),
     ('metrics',),
@@ -643,11 +644,6 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     ('serve', 'controller', 'consolidation_mode'),
     ('jobs', 'controller', 'controller_logs_gc_retention_hours'),
     ('jobs', 'controller', 'task_logs_gc_retention_hours'),
-    # An admin policy the client can replace is not an admin policy: a client that sets its own
-    # `admin_policy` (a module path, or a URL to a server it controls) has the API server apply
-    # that instead. Nothing rejects it, so the request still succeeds and the resulting cluster
-    # looks normal.
-    ('admin_policy',),
     # Slurm submit identity and cluster settings are managed server-side.
     ('slurm', 'cluster_configs'),
     ('slurm', 'submit_as_user'),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2193,10 +2193,11 @@ def test_admin_policy_is_not_client_overridable(monkeypatch, tmp_path):
     """
     server_config = tmp_path / 'server.yaml'
     server_config.write_text('admin_policy: server_pkg.ServerPolicy\n')
-    monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, str(server_config))
+    monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG,
+                       str(server_config))
     skypilot_config.reload_config()
 
     with skypilot_config.override_skypilot_config(
         {'admin_policy': 'attacker_pkg.NoOpPolicy'}):
-        assert skypilot_config.get_nested(
-            ('admin_policy',), None) == 'server_pkg.ServerPolicy'
+        assert skypilot_config.get_nested(('admin_policy',),
+                                          None) == 'server_pkg.ServerPolicy'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2182,3 +2182,21 @@ def test_replace_skypilot_config_restores_env_var_on_exception(
 
     skypilot_config.reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+
+
+def test_admin_policy_is_not_client_overridable(monkeypatch, tmp_path):
+    """A client-supplied admin_policy must never reach the server config.
+
+    Without this the client can point admin_policy at its own module or URL and the server
+    applies that instead — the request succeeds and the resulting cluster looks normal, so an
+    operator has no signal that the policy did not run.
+    """
+    server_config = tmp_path / 'server.yaml'
+    server_config.write_text('admin_policy: server_pkg.ServerPolicy\n')
+    monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, str(server_config))
+    skypilot_config.reload_config()
+
+    with skypilot_config.override_skypilot_config(
+        {'admin_policy': 'attacker_pkg.NoOpPolicy'}):
+        assert skypilot_config.get_nested(
+            ('admin_policy',), None) == 'server_pkg.ServerPolicy'


### PR DESCRIPTION
`admin_policy` is missing from `SKIPPED_CLIENT_OVERRIDE_KEYS`, so a client can replace the operator's policy with its own.

Setting `admin_policy` in the client's `~/.sky/config.yaml` (or via `override_skypilot_config` on the REST API) makes the server apply that value instead. The field accepts a module path **or a URL**, so a client can point it at a no-op policy or at a server it controls.

Nothing rejects the request. The launch succeeds and the resulting cluster looks entirely normal, so an operator has no signal that their policy never ran — which is worse than a failure for anyone relying on `AdminPolicy` for attribution, quotas or backend routing.

The fix matches how `api_server`, `allowed_clouds`, `workspaces` and `rbac` are already handled: the server's value wins.

```python
SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
    ...
    ('admin_policy',),
]
```

Reproduced against a deployed `0.13.1rc1` server before reporting. The added test fails without the constant change and passes with it.

Happy to adjust if there is an intended use for a client-supplied policy that I have missed — I could not find one, and the surrounding keys suggest the omission is accidental.