### PR TITLE
[Jobs] Add a managed-job addressed external log read-back hook

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2003,6 +2003,19 @@ def stream_logs_by_id(
                             None,
                             follow=False,
                             tail=tail if tail is not None else 0)
+                        if returncode is None:
+                            # Not cluster-addressed: runtimes whose forwarded
+                            # records carry the managed-job identity instead of
+                            # an on-cluster job id (e.g. bare-pod runtimes with
+                            # no per-job log files) are read back directly by
+                            # (job_id, task_id). Readers without managed-job
+                            # addressing return None again and we fall through
+                            # to the terminal-state message.
+                            returncode = log_reader.read_managed_job_logs(
+                                job_id,
+                                task_id,
+                                follow=False,
+                                tail=tail if tail is not None else 0)
                     except Exception as e:  # pylint: disable=broad-except
                         # Surface the failure (streamed to the user via the
                         # request's stdout redirection) and fall through to the

--- a/sky/logs/reader.py
+++ b/sky/logs/reader.py
@@ -31,6 +31,33 @@ class LogReader(abc.ABC):
         """
         raise NotImplementedError
 
+    def read_managed_job_logs(self, job_id: int, task_id: Optional[int], *,
+                              follow: bool, tail: int) -> Optional[int]:
+        """Streams a managed job task's logs from the external store to stdout.
+
+        Addresses logs by the managed job's identity instead of the cluster the
+        job ran on, for runtimes whose forwarded log records carry the managed
+        job id rather than an on-cluster job id (so ``read_cluster_job_logs``
+        cannot locate them). Non-abstract: readers without managed-job
+        addressing inherit the default and return None; callers then rely on
+        ``read_cluster_job_logs`` alone.
+
+        Args:
+            job_id: The managed job id.
+            task_id: The task id within the job, or None for all tasks.
+            follow: Whether to follow the log. An external store is historical,
+                so this may be treated as a no-op.
+            tail: Number of lines from the end to stream; 0 means all.
+
+        Returns:
+            The exit code to report if logs were streamed, or None if this
+            reader does not support managed-job addressing or found no records
+            for the job. A reader that cannot determine the job's status from
+            the store should return 0.
+        """
+        del job_id, task_id, follow, tail  # Unsupported by default.
+        return None
+
 
 _log_reader: Optional[LogReader] = None
 

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1452,6 +1452,7 @@ class TestStreamLogsByIdExternalStoreFallback:
 
         fake_reader = MagicMock()
         fake_reader.read_cluster_job_logs.return_value = None
+        fake_reader.read_managed_job_logs.return_value = None
         self._patch_logs(monkeypatch, fake_reader)
         monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
                             lambda name, jid: f'sky-managed-{jid}-{name}')
@@ -1460,6 +1461,49 @@ class TestStreamLogsByIdExternalStoreFallback:
 
         fake_reader.read_cluster_job_logs.assert_called_once()
         assert 'external log store' in msg
+
+    def test_managed_job_addressing_fallback(self, monkeypatch):
+        # The cluster-addressed read finds nothing (e.g. a runtime whose
+        # forwarded records carry the managed-job identity instead of an
+        # on-cluster job id); the reader is then consulted by (job_id,
+        # task_id) and its success is reported like a streamed log.
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        fake_reader.read_cluster_job_logs.return_value = None
+        fake_reader.read_managed_job_logs.return_value = 0
+        self._patch_logs(monkeypatch, fake_reader)
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            lambda name, jid: f'sky-managed-{jid}-{name}')
+
+        _, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        fake_reader.read_managed_job_logs.assert_called_once_with(5,
+                                                                  0,
+                                                                  follow=False,
+                                                                  tail=0)
+        assert code == exceptions.JobExitCode.from_managed_job_status(
+            managed_job_state.ManagedJobStatus.SUCCEEDED)
+
+    def test_managed_job_addressing_not_consulted_on_cluster_hit(
+            self, monkeypatch):
+        # A successful cluster-addressed read must not trigger a second,
+        # managed-job-addressed store query.
+        task_info = [(0, 'mytask', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                      None, None)]
+        self._patch_terminal_job(monkeypatch, task_info)
+
+        fake_reader = MagicMock()
+        fake_reader.read_cluster_job_logs.return_value = 0
+        self._patch_logs(monkeypatch, fake_reader)
+        monkeypatch.setattr(jobs_utils, 'generate_managed_job_cluster_name',
+                            lambda name, jid: f'sky-managed-{jid}-{name}')
+
+        jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
+
+        fake_reader.read_managed_job_logs.assert_not_called()
 
     def test_reader_exception_is_logged_and_falls_through(self, monkeypatch):
         # A reader error must not crash sky jobs logs; it falls through to the


### PR DESCRIPTION
Some runtimes forward job logs to the external store with records that carry the managed job's identity rather than an on-cluster job id (e.g. bare-pod runtimes with no per-job log files), so `read_cluster_job_logs` cannot locate them. This adds `LogReader.read_managed_job_logs(job_id, task_id)` (non-abstract, default returns None = unsupported) and consults it in the managed-job terminal log path when the cluster-addressed read finds nothing. Readers without managed-job addressing are unaffected.

Tested (see the buildkite CI):

- Unit tests: `pytest tests/unit_tests/test_sky/jobs/test_utils.py::TestStreamLogsByIdExternalStoreFallback` (2 new cases: fallback consulted on cluster-read miss with the right identity; not consulted on cluster-read hit) and `pytest tests/unit_tests/test_sky/logs/`.
- Verified an external `LogReader` implementing the new hook streams a finished managed job's logs via `sky jobs logs` after the job's cluster is gone.