### PR TITLE
[Server] Keep /metrics responsive when a collector's data source hangs

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -175,6 +175,164 @@ async def multiproc_reaper_daemon(
         await asyncio.sleep(interval_seconds)
 
 
+# How long a ResilientCollector snapshot is considered fresh. A scrape
+# arriving after this triggers a background refresh (at most one in
+# flight per collector).
+_COLLECTOR_REFRESH_TTL_SECONDS = 30
+# How stale a snapshot may get before the collector is reported as
+# inactive via sky_apiserver_metrics_collector_active. Spans a couple of
+# refresh windows so a single slow-but-successful refresh does not flap
+# the gauge.
+_COLLECTOR_MAX_STALENESS_SECONDS = 3 * _COLLECTOR_REFRESH_TTL_SECONDS
+
+
+class ResilientCollector:
+    """Serves scrapes from a snapshot that is refreshed off the scrape path.
+
+    Wraps a Prometheus collector whose ``collect()`` may block on external
+    state (typically the state database). ``collect()`` here never blocks:
+    it returns the last snapshot immediately and, if the snapshot is older
+    than ``ttl_seconds``, kicks off a background refresh — at most one in
+    flight per collector, so a refresh hung on a saturated DB pool never
+    stacks additional threads or queries on top of an ongoing outage.
+
+    There is deliberately no cancellation or restart of a hung refresh: a
+    thread blocked inside a DB driver cannot be killed, and retrying
+    against an unhealthy database only adds load. Instead the collector
+    keeps serving its stale snapshot and ``CollectorHealthCollector``
+    flips ``sky_apiserver_metrics_collector_active`` to 0 once the last
+    successful refresh is older than ``max_staleness_seconds`` — that is
+    the signal operators alert on and intervene.
+    """
+
+    def __init__(
+        self,
+        wrapped,
+        ttl_seconds: float = _COLLECTOR_REFRESH_TTL_SECONDS,
+        max_staleness_seconds: float = (_COLLECTOR_MAX_STALENESS_SECONDS)):
+        self._wrapped = wrapped
+        # Label value for the health meta-metrics. May be suffixed by
+        # _wrap_collector() to stay unique across instances.
+        self.name = type(wrapped).__name__
+        self.max_staleness_seconds = max_staleness_seconds
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        self._snapshot: List[prom_core.Metric] = []
+        self._last_attempt_time = 0.0
+        self._last_success_time = 0.0
+        self._refresh_in_flight = False
+
+    def describe(self):
+        """Delegates to the wrapped ``describe()`` (never its ``collect()``).
+
+        Having a ``describe()`` — even one that yields nothing — matters:
+        ``prometheus_client`` falls back to calling ``collect()`` at
+        registration time for collectors without one, which would put a
+        potentially-blocking call back on the registration path.
+        """
+        describe = getattr(self._wrapped, 'describe', None)
+        if describe is not None:
+            yield from describe()
+
+    def collect(self):
+        now = time.time()
+        with self._lock:
+            snapshot = self._snapshot
+            refresh_due = (not self._refresh_in_flight and
+                           now - self._last_attempt_time >= self._ttl)
+            if refresh_due:
+                self._refresh_in_flight = True
+                self._last_attempt_time = now
+        if refresh_due:
+            threading.Thread(target=self._refresh,
+                             name=f'metrics-refresh-{self.name}',
+                             daemon=True).start()
+        yield from snapshot
+
+    def _refresh(self) -> None:
+        try:
+            # Materialize before swapping so a failure mid-iteration
+            # cannot leave a partial snapshot behind.
+            snapshot = list(self._wrapped.collect())
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                'Metrics collector %s failed to refresh; '
+                'serving stale snapshot.', self.name)
+            with self._lock:
+                self._refresh_in_flight = False
+            return
+        with self._lock:
+            self._snapshot = snapshot
+            self._last_success_time = time.time()
+            self._refresh_in_flight = False
+
+    def last_success_time(self) -> float:
+        with self._lock:
+            return self._last_success_time
+
+
+# All ResilientCollector instances, for CollectorHealthCollector. Also
+# gives the health meta-metrics a single emitter: were each wrapper to
+# yield its own copy of the family, the duplicate names would make the
+# exposition invalid (and fail registry duplicate-name checks).
+_resilient_collectors: List[ResilientCollector] = []
+
+_COLLECTOR_ACTIVE_HELP = (
+    '1 if the collector refreshed successfully within its staleness '
+    'bound; 0 means its metrics are being served from a stale snapshot '
+    '(e.g. the refresh is hung on a DB outage) and needs operator '
+    'attention. Also 0 between process start and the first successful '
+    'refresh.')
+_COLLECTOR_LAST_SUCCESS_HELP = (
+    'Unix timestamp of the collector\'s last successful refresh; 0 if it '
+    'has not succeeded since process start.')
+
+
+class CollectorHealthCollector:
+    """Health meta-metrics for every ResilientCollector in this process."""
+
+    def describe(self):
+        yield prom_core.GaugeMetricFamily(
+            'sky_apiserver_metrics_collector_active',
+            _COLLECTOR_ACTIVE_HELP,
+            labels=['collector'])
+        yield prom_core.GaugeMetricFamily(
+            'sky_apiserver_metrics_collector_last_success_timestamp_seconds',
+            _COLLECTOR_LAST_SUCCESS_HELP,
+            labels=['collector'])
+
+    def collect(self):
+        now = time.time()
+        active_family = prom_core.GaugeMetricFamily(
+            'sky_apiserver_metrics_collector_active',
+            _COLLECTOR_ACTIVE_HELP,
+            labels=['collector'])
+        last_success_family = prom_core.GaugeMetricFamily(
+            'sky_apiserver_metrics_collector_last_success_timestamp_seconds',
+            _COLLECTOR_LAST_SUCCESS_HELP,
+            labels=['collector'])
+        for collector in list(_resilient_collectors):
+            last_success = collector.last_success_time()
+            active = now - last_success <= collector.max_staleness_seconds
+            active_family.add_metric([collector.name], 1.0 if active else 0.0)
+            last_success_family.add_metric([collector.name], last_success)
+        yield active_family
+        yield last_success_family
+
+
+def _wrap_collector(collector) -> ResilientCollector:
+    """Wraps a collector in ResilientCollector with a unique health name."""
+    wrapped = ResilientCollector(collector)
+    existing = {c.name for c in _resilient_collectors}
+    if wrapped.name in existing:
+        suffix = 2
+        while f'{wrapped.name}-{suffix}' in existing:
+            suffix += 1
+        wrapped.name = f'{wrapped.name}-{suffix}'
+    _resilient_collectors.append(wrapped)
+    return wrapped
+
+
 class BurnRateCollector:
     """Collector for SkyPilot cluster burn rate metrics.
     This collector calculates the total hourly burn rate (in USD) of all
@@ -235,22 +393,36 @@ class BurnRateCollector:
         yield metric
 
 
-_BURN_RATE_COLLECTOR = BurnRateCollector()
+_BURN_RATE_COLLECTOR = _wrap_collector(BurnRateCollector())
 
 try:
     prom.REGISTRY.register(_BURN_RATE_COLLECTOR)  # for non-multiprocess
 except ValueError:
     pass
 
-# Collectors registered by plugins at runtime.
+_COLLECTOR_HEALTH_COLLECTOR = CollectorHealthCollector()
+
+try:
+    prom.REGISTRY.register(_COLLECTOR_HEALTH_COLLECTOR)
+except ValueError:
+    pass
+
+# Collectors registered by plugins at runtime (ResilientCollector-wrapped).
 _plugin_collectors: list = []
 
 
 def register_plugin_collector(collector):
-    """Register a custom Prometheus collector from a plugin."""
-    _plugin_collectors.append(collector)
+    """Register a custom Prometheus collector from a plugin.
+
+    The collector is wrapped in ResilientCollector, so a hung or failing
+    data source degrades its metrics to a stale snapshot (flagged by
+    sky_apiserver_metrics_collector_active) instead of hanging the whole
+    /metrics scrape.
+    """
+    wrapped = _wrap_collector(collector)
+    _plugin_collectors.append(wrapped)
     try:
-        prom.REGISTRY.register(collector)
+        prom.REGISTRY.register(wrapped)
     except ValueError:
         pass
 
@@ -674,14 +846,14 @@ class WorkspaceUsageCollector:
         yield m
 
 
-_WORKSPACE_USAGE_COLLECTOR = WorkspaceUsageCollector()
+_WORKSPACE_USAGE_COLLECTOR = _wrap_collector(WorkspaceUsageCollector())
 
 try:
     prom.REGISTRY.register(_WORKSPACE_USAGE_COLLECTOR)
 except ValueError:
     pass
 
-_MANAGED_JOBS_COLLECTOR: Optional[ManagedJobsCollector] = None
+_MANAGED_JOBS_COLLECTOR: Optional[ResilientCollector] = None
 
 
 def maybe_register_managed_jobs_collector():
@@ -692,11 +864,13 @@ def maybe_register_managed_jobs_collector():
     cluster and is not directly accessible.
     """
     global _MANAGED_JOBS_COLLECTOR
+    if _MANAGED_JOBS_COLLECTOR is not None:
+        return
     # pylint: disable=import-outside-toplevel
     from sky.jobs import utils as managed_job_utils
     if not managed_job_utils.is_consolidation_mode():
         return
-    _MANAGED_JOBS_COLLECTOR = ManagedJobsCollector()
+    _MANAGED_JOBS_COLLECTOR = _wrap_collector(ManagedJobsCollector())
     try:
         prom.REGISTRY.register(_MANAGED_JOBS_COLLECTOR)
     except ValueError:
@@ -717,6 +891,7 @@ def metrics() -> fastapi.Response:
         multiprocess.MultiProcessCollector(registry)
         registry.register(_BURN_RATE_COLLECTOR)
         registry.register(_WORKSPACE_USAGE_COLLECTOR)
+        registry.register(_COLLECTOR_HEALTH_COLLECTOR)
         if _MANAGED_JOBS_COLLECTOR is not None:
             registry.register(_MANAGED_JOBS_COLLECTOR)
         for c in _plugin_collectors:

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -2,6 +2,7 @@
 
 import base64
 import os
+import threading
 import time
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -10,7 +11,9 @@ from unittest.mock import patch
 import fastapi
 from prometheus_client import CollectorRegistry
 from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client import core as prom_core
 from prometheus_client import generate_latest
+import prometheus_client as prom
 import pytest
 
 from sky.metrics import utils as metrics_utils
@@ -1010,3 +1013,196 @@ def test_managed_jobs_collector_handles_empty_db():
         samples = _collect_to_dict(collector)
     # Metric family exists, just with no rows.
     assert samples.get('sky_managed_jobs_count', {}) == {}
+
+
+# ── ResilientCollector ──────────────────────────────────────────────
+
+
+class _ControlledCollector:
+    """Collector whose behavior on each collect() call is scripted.
+
+    Script entries: ``'ok:<value>'`` yields a gauge with that value,
+    ``'hang'`` blocks until ``release`` is set (then yields 0.0),
+    ``'raise'`` raises. The last entry repeats for further calls.
+    """
+
+    def __init__(self, script):
+        self._script = script
+        self.calls = 0
+        self.hang_started = threading.Event()
+        self.release = threading.Event()
+
+    def collect(self):
+        action = self._script[min(self.calls, len(self._script) - 1)]
+        self.calls += 1
+        value = 0.0
+        if action == 'hang':
+            self.hang_started.set()
+            self.release.wait(timeout=30)
+        elif action == 'raise':
+            raise RuntimeError('scripted failure')
+        else:
+            value = float(action.split(':', 1)[1])
+        family = prom_core.GaugeMetricFamily('test_resilient_gauge', 'test')
+        family.add_metric([], value)
+        yield family
+
+
+def _wait_until(predicate, timeout=10.0, interval=0.01):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def _gauge_value(families):
+    for family in families:
+        for sample in family.samples:
+            if sample.name == 'test_resilient_gauge':
+                return sample.value
+    return None
+
+
+def test_resilient_collector_scrape_not_blocked_by_hung_refresh():
+    wrapped = _ControlledCollector(['hang'])
+    collector = metrics.ResilientCollector(wrapped, ttl_seconds=0)
+    try:
+        start = time.time()
+        assert not list(collector.collect())
+        assert time.time() - start < 5.0
+        assert _wait_until(wrapped.hang_started.is_set)
+        # Repeated scrapes while the refresh is hung neither block nor
+        # stack additional refreshes (single in-flight).
+        for _ in range(5):
+            assert not list(collector.collect())
+        assert wrapped.calls == 1
+    finally:
+        wrapped.release.set()
+    # Once the hung refresh finally returns, its data is served.
+    assert _wait_until(lambda: _gauge_value(collector.collect()) is not None)
+
+
+def test_resilient_collector_serves_stale_snapshot_while_hung():
+    wrapped = _ControlledCollector(['ok:1', 'hang'])
+    collector = metrics.ResilientCollector(wrapped, ttl_seconds=0)
+    try:
+        list(collector.collect())  # Triggers the first (successful) refresh.
+        assert _wait_until(lambda: collector.last_success_time() > 0)
+        # This scrape serves the snapshot and triggers the hanging refresh.
+        assert _gauge_value(collector.collect()) == 1.0
+        assert _wait_until(wrapped.hang_started.is_set)
+        # Stale-but-served while hung; last success does not advance.
+        assert _gauge_value(collector.collect()) == 1.0
+        assert wrapped.calls == 2
+    finally:
+        wrapped.release.set()
+
+
+def test_resilient_collector_refresh_error_keeps_snapshot_and_retries():
+    wrapped = _ControlledCollector(['ok:1', 'raise', 'ok:2'])
+    collector = metrics.ResilientCollector(wrapped, ttl_seconds=0)
+    list(collector.collect())
+    assert _wait_until(lambda: collector.last_success_time() > 0)
+    first_success = collector.last_success_time()
+    list(collector.collect())  # Triggers the failing refresh.
+    assert _wait_until(lambda: wrapped.calls == 2)
+    # The failure left the old snapshot in place and did not advance
+    # the success time.
+    assert _gauge_value(collector.collect()) == 1.0
+    assert collector.last_success_time() == first_success
+    # The previous collect() already triggered the third (recovering)
+    # refresh; the in-flight flag was not left stuck by the failure.
+    assert _wait_until(lambda: _gauge_value(collector.collect()) == 2.0)
+
+
+def test_resilient_collector_describe_never_calls_collect():
+
+    class _NoDescribe:
+
+        def __init__(self):
+            self.collected = False
+
+        def collect(self):
+            self.collected = True
+            yield prom_core.GaugeMetricFamily('x', 'x')
+
+    wrapped = _NoDescribe()
+    collector = metrics.ResilientCollector(wrapped)
+    assert not list(collector.describe())
+    assert not wrapped.collected
+    # With a wrapped describe(), it is delegated.
+    described = metrics.ResilientCollector(_ControlledCollector(['ok:1']))
+    described._wrapped.describe = lambda: iter(
+        [prom_core.GaugeMetricFamily('described', 'd')])
+    assert [f.name for f in described.describe()] == ['described']
+
+
+def test_collector_health_active_flips_on_staleness():
+    wrapped = _ControlledCollector(['ok:1', 'hang'])
+    collector = metrics.ResilientCollector(wrapped,
+                                           ttl_seconds=0,
+                                           max_staleness_seconds=0.2)
+    health = metrics.CollectorHealthCollector()
+
+    def health_samples():
+        samples = {}
+        for family in health.collect():
+            for sample in family.samples:
+                samples[sample.name] = sample.value
+        return samples
+
+    with patch.object(metrics, '_resilient_collectors', [collector]):
+        try:
+            # Never refreshed yet: inactive, zero timestamp.
+            samples = health_samples()
+            assert samples['sky_apiserver_metrics_collector_active'] == 0.0
+            assert samples[
+                'sky_apiserver_metrics_collector_last_success_timestamp_'
+                'seconds'] == 0.0
+            list(collector.collect())
+            assert _wait_until(lambda: collector.last_success_time() > 0)
+            samples = health_samples()
+            assert samples['sky_apiserver_metrics_collector_active'] == 1.0
+            # Trigger the hanging refresh and outwait max_staleness.
+            list(collector.collect())
+            assert _wait_until(wrapped.hang_started.is_set)
+            assert _wait_until(lambda: health_samples()[
+                'sky_apiserver_metrics_collector_active'] == 0.0)
+        finally:
+            wrapped.release.set()
+
+
+def test_wrap_collector_dedupes_health_names():
+    with patch.object(metrics, '_resilient_collectors', []):
+        first = metrics._wrap_collector(_ControlledCollector(['ok:1']))
+        second = metrics._wrap_collector(_ControlledCollector(['ok:1']))
+        assert first.name == '_ControlledCollector'
+        assert second.name == '_ControlledCollector-2'
+
+
+def test_metrics_endpoint_responsive_with_hung_plugin_collector():
+    """A plugin collector hung on its data source (e.g. DB outage) must
+    not hang the /metrics scrape: the endpoint responds promptly and the
+    health gauge reports the collector as inactive."""
+    if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+        del os.environ['PROMETHEUS_MULTIPROC_DIR']
+    hung = _ControlledCollector(['hang'])
+    metrics.register_plugin_collector(hung)
+    wrapper = metrics._plugin_collectors[-1]
+    try:
+        start = time.time()
+        response = metrics.metrics()
+        elapsed = time.time() - start
+        assert response.status_code == 200
+        assert elapsed < 10.0
+        assert _wait_until(hung.hang_started.is_set)
+        body = metrics.metrics().body.decode()
+        assert ('sky_apiserver_metrics_collector_active'
+                '{collector="_ControlledCollector"} 0.0') in body
+    finally:
+        hung.release.set()
+        prom.REGISTRY.unregister(wrapper)
+        metrics._plugin_collectors.remove(wrapper)
+        metrics._resilient_collectors.remove(wrapper)

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -1108,10 +1108,12 @@ def test_resilient_collector_refresh_error_keeps_snapshot_and_retries():
     first_success = collector.last_success_time()
     list(collector.collect())  # Triggers the failing refresh.
     assert _wait_until(lambda: wrapped.calls == 2)
-    # The failure left the old snapshot in place and did not advance
-    # the success time.
-    assert _gauge_value(collector.collect()) == 1.0
+    # The failure left the old snapshot in place and did not advance the
+    # success time. Checked before the next collect(): that one triggers
+    # the recovering refresh, which may advance the success time at any
+    # point after it.
     assert collector.last_success_time() == first_success
+    assert _gauge_value(collector.collect()) == 1.0
     # The previous collect() already triggered the third (recovering)
     # refresh; the in-flight flag was not left stuck by the failure.
     assert _wait_until(lambda: _gauge_value(collector.collect()) == 2.0)


### PR DESCRIPTION
## Summary

The custom collectors behind `/metrics` (burn rate, workspace usage, managed jobs, plugin-registered) run their DB queries on the scrape path. When the database hangs (saturated pool, network black hole), the scrape blocks until Prometheus' `scrape_timeout` marks the target down — hiding exactly the incident the metrics are needed for — and each subsequent scrape stacks another hung handler thread holding a DB connection.

This PR wraps every custom collector in a `ResilientCollector`:

- `collect()` never blocks: it serves the last snapshot and, when the snapshot is older than 30s, triggers a background refresh — at most one in flight per collector, so an outage cannot stack threads or queries.
- A hung refresh is deliberately not cancelled or restarted: a thread blocked in a DB driver cannot be killed, and retrying only adds load to an unhealthy database.
- Degradation is observable instead of silent: `sky_apiserver_metrics_collector_active{collector}` flips to 0 once the last successful refresh exceeds the staleness bound (90s), and `sky_apiserver_metrics_collector_last_success_timestamp_seconds{collector}` exposes the raw timestamp for alerting.

Collectors registered via `register_plugin_collector()` are wrapped automatically, so out-of-tree collectors get the same protection without changes.

## Tested

- Unit tests: 7 new tests in `tests/unit_tests/test_sky/server/test_metrics.py` covering non-blocking scrape under a hung refresh, single in-flight refresh, stale snapshot serving, error recovery, active-gauge transitions, describe() never invoking collect(), and endpoint responsiveness with a hung plugin collector. Full file (existing + new) passes.
- E2E: ran the production `metrics_app` under uvicorn with a collector whose `collect()` sleeps 300s. Pre-change code path (raw collector in the registry): `curl --max-time 10` times out (exit 28). With this change: 200 in ~15ms, hung collector reported `active 0`, healthy built-ins `active 1`.
- Full API server boot smoke with `SKY_API_SERVER_METRICS_ENABLED=true` (multiprocess mode): `/metrics` responds in milliseconds and health series carry real timestamps.
