### PR TITLE
fix(k8s): ignore stale Kueue ErrWorkloadCompose in the pending-reason scan (#10379)

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -99,6 +99,21 @@ _PENDING_REASON_NORMAL_EVENT_ALLOWLIST = {
     'WaitForFirstConsumer',  # late-binding storage class
 }
 
+# Warning-type pod events that are emitted once during normal startup and
+# then left on the pod after the condition they describe has resolved. The
+# Warning pass skips them, so the scan falls through to a later Warning or to
+# an allow-listed Normal instead of pinning a healthy launch to a stale
+# complaint.
+_PENDING_REASON_WARNING_EVENT_IGNORELIST = {
+    # Kueue's pod reconciler races the creation of a pod group: it fires on
+    # the first pod it observes, sees fewer live pods than
+    # pod-group-total-count, and emits this Warning. It self-resolves within
+    # seconds once the remaining pods exist, but the event object survives
+    # for its full TTL -- see
+    # https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_pods/
+    'ErrWorkloadCompose',
+}
+
 # Warning-type pod events (emitted by the kubelet, after scheduling) that
 # indicate a volume attach/mount failure. A pod hit by one of these stays in
 # the uninformative 'ContainerCreating' waiting state, so the failure is only
@@ -3089,7 +3104,8 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
     """Get the reason why a pod is pending from its events.
 
     Two-pass scan over the event list (sorted newest-first by _get_pod_events):
-      1. Tier 2 -- return the newest event with event.type == 'Warning'.
+      1. Tier 2 -- return the newest event with event.type == 'Warning' whose
+         reason is not in _PENDING_REASON_WARNING_EVENT_IGNORELIST.
       2. Tier 3 -- return the newest event whose reason is in
          _PENDING_REASON_NORMAL_EVENT_ALLOWLIST.
     Warnings always beat allow-listed Normals, regardless of timestamp ordering
@@ -3107,9 +3123,10 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
     if not pod_events:
         return None
 
-    # Tier 2: Warning events.
+    # Tier 2: Warning events, minus the ones known to go stale in place.
     for event in pod_events:
-        if event.type == 'Warning':
+        if (event.type == 'Warning' and
+                event.reason not in _PENDING_REASON_WARNING_EVENT_IGNORELIST):
             return event.reason or 'Unknown', event.message or ''
 
     # Tier 3: allow-listed Normal events.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -99,6 +99,21 @@ _PENDING_REASON_NORMAL_EVENT_ALLOWLIST = {
     'WaitForFirstConsumer',  # late-binding storage class
 }
 
+# Warning-type pod events that are emitted once during normal startup and
+# then left on the pod after the condition they describe has resolved. The
+# Warning pass skips them, so the scan falls through to a later Warning or to
+# an allow-listed Normal instead of pinning a healthy launch to a stale
+# complaint.
+_PENDING_REASON_WARNING_EVENT_IGNORELIST = {
+    # Kueue's pod reconciler races the creation of a pod group: it fires on
+    # the first pod it observes, sees fewer live pods than
+    # pod-group-total-count, and emits this Warning. It self-resolves within
+    # seconds once the remaining pods exist, but the event object survives
+    # for its full TTL -- see
+    # https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_pods/
+    'ErrWorkloadCompose',
+}
+
 # Warning-type pod events (emitted by the kubelet, after scheduling) that
 # indicate a volume attach/mount failure. A pod hit by one of these stays in
 # the uninformative 'ContainerCreating' waiting state, so the failure is only
@@ -3278,7 +3293,8 @@ def _get_pod_pending_reason(
     """Get the reason why a pod is pending from its events.
 
     Two-pass scan over the event list (sorted newest-first by _get_pod_events):
-      1. Tier 2 -- the newest event with event.type == 'Warning'.
+      1. Tier 2 -- the newest event with event.type == 'Warning' whose reason
+         is not in _PENDING_REASON_WARNING_EVENT_IGNORELIST.
       2. Tier 3 -- the newest event whose reason is in
          _PENDING_REASON_NORMAL_EVENT_ALLOWLIST.
     A Warning beats an allow-listed Normal -- a FailedScheduling Warning is a
@@ -3288,7 +3304,7 @@ def _get_pod_pending_reason(
     condition that produced it by a long way, and reporting a stale one is not
     just a mislabeled spinner: the reason then never changes while the pod
     makes progress, which is exactly what the no-progress deadline in
-    _wait_for_pods_to_run reads as a stall. Two independent checks demote one:
+    _wait_for_pods_to_run reads as a stall. Three independent checks demote one:
 
       a. A Warning last observed before the pod was bound cannot describe what
          the kubelet is doing, because every caller of this function observes
@@ -3298,13 +3314,17 @@ def _get_pod_pending_reason(
       b. A Warning observed less recently than the allow-listed Normal has
          been overtaken by it -- e.g. a mount the kubelet retried successfully,
          whose FailedMount predates the image pull now under way.
+      c. A Warning whose reason is in _PENDING_REASON_WARNING_EVENT_IGNORELIST
+         is never reported, whatever its timestamps: it is emitted once during
+         normal startup and re-emitted while the condition it names resolves
+         itself, so neither (a) nor (b) can catch it.
 
-    Both compare last-observed times, not creation times: kubernetes folds a
-    repeated event back into the original object, bumping count/last_timestamp
-    while creation_timestamp stays pinned to the first occurrence. So a live
-    Warning being re-emitted survives both checks, and an event that cannot be
-    dated is never treated as stale. Ordering *within* a tier is left to
-    _get_pod_events' newest-first creation order.
+    (a) and (b) compare last-observed times, not creation times: kubernetes
+    folds a repeated event back into the original object, bumping
+    count/last_timestamp while creation_timestamp stays pinned to the first
+    occurrence. So a live Warning being re-emitted survives both checks, and an
+    event that cannot be dated is never treated as stale. Ordering *within* a
+    tier is left to _get_pod_events' newest-first creation order.
 
     With warnings_only, tier 3 is answered with None rather than the Normal
     event: the caller has a reason already and is asking the narrower question
@@ -3331,15 +3351,18 @@ def _get_pod_pending_reason(
                      if e.reason == _POD_BOUND_EVENT_REASON), None)
 
     def _describes_pod_now(event: Any) -> bool:
+        if event.reason in _PENDING_REASON_WARNING_EVENT_IGNORELIST:
+            return False
         if bound_at is None:
             return True
         observed_at = _event_last_observed(event)
         return observed_at is None or observed_at >= bound_at
 
-    # Tier 2: Warning events.
+    # Tier 2: Warning events, minus the ones known to go stale in place.
     warning = next((
         e for e in pod_events if e.type == 'Warning' and _describes_pod_now(e)),
                    None)
+
     # Tier 3: allow-listed Normal events.
     normal = next((e for e in pod_events
                    if e.reason in _PENDING_REASON_NORMAL_EVENT_ALLOWLIST), None)

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2996,6 +2996,43 @@ class TestGetPodPendingReasonTieredEventFilter:
         monkeypatch.setattr(instance, '_get_pod_events', raise_for_events)
         assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
 
+    def test_stale_kueue_warning_does_not_mask_pulling(self, monkeypatch):
+        # Kueue's pod reconciler emits ErrWorkloadCompose while the pod group
+        # is still being created, and leaves the event on the pod after the
+        # group is composed. Without the ignore-list it outranks Pulling for
+        # the event's whole TTL, so every multi-node Kueue launch reports
+        # "pending due to ErrWorkloadCompose" while it is merely pulling.
+        events = [
+            self._event('Pulling', 'Normal', 'Pulling image "foo:bar"'),
+            self._event(
+                'ErrWorkloadCompose', 'Warning',
+                "'sky-abc' group has fewer runnable pods than "
+                'expected'),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
+
+    def test_stale_kueue_warning_yields_to_a_real_warning(self, monkeypatch):
+        # Ignoring ErrWorkloadCompose must not swallow a genuine Warning that
+        # is older than it.
+        events = [
+            self._event('ErrWorkloadCompose', 'Warning', 'newer but stale'),
+            self._event('FailedScheduling', 'Warning',
+                        '0/3 nodes are available: insufficient cpu.'),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') == (
+            'FailedScheduling',
+            '0/3 nodes are available: insufficient cpu.',
+        )
+
+    def test_only_ignored_warning_returns_none(self, monkeypatch):
+        # Nothing truthful left to report -- better no reason than a stale one.
+        events = [self._event('ErrWorkloadCompose', 'Warning', 'stale')]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
+
 
 class TestInspectPodStatusTierIntegration:
     """End-to-end behavior of _inspect_pod_status with the new tier-1 helper.

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3165,6 +3165,43 @@ class TestGetPodPendingReasonTieredEventFilter:
         monkeypatch.setattr(instance, '_get_pod_events', raise_for_events)
         assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
 
+    def test_stale_kueue_warning_does_not_mask_pulling(self, monkeypatch):
+        # Kueue's pod reconciler emits ErrWorkloadCompose while the pod group
+        # is still being created, and leaves the event on the pod after the
+        # group is composed. Without the ignore-list it outranks Pulling for
+        # the event's whole TTL, so every multi-node Kueue launch reports
+        # "pending due to ErrWorkloadCompose" while it is merely pulling.
+        events = [
+            self._event('Pulling', 'Normal', 'Pulling image "foo:bar"'),
+            self._event(
+                'ErrWorkloadCompose', 'Warning',
+                "'sky-abc' group has fewer runnable pods than "
+                'expected'),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
+
+    def test_stale_kueue_warning_yields_to_a_real_warning(self, monkeypatch):
+        # Ignoring ErrWorkloadCompose must not swallow a genuine Warning that
+        # is older than it.
+        events = [
+            self._event('ErrWorkloadCompose', 'Warning', 'newer but stale'),
+            self._event('FailedScheduling', 'Warning',
+                        '0/3 nodes are available: insufficient cpu.'),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') == (
+            'FailedScheduling',
+            '0/3 nodes are available: insufficient cpu.',
+        )
+
+    def test_only_ignored_warning_returns_none(self, monkeypatch):
+        # Nothing truthful left to report -- better no reason than a stale one.
+        events = [self._event('ErrWorkloadCompose', 'Warning', 'stale')]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
+
 
 class TestInspectPodStatusTierIntegration:
     """End-to-end behavior of _inspect_pod_status with the new tier-1 helper.


### PR DESCRIPTION
Fixes #10379.

## The bug

`_get_pod_pending_reason` (`sky/provision/kubernetes/instance.py`) is a two-pass scan: the newest **Warning** event wins outright, and only if there is none does it fall back to the allow-listed Normals (`Pulling` / `Provisioning` / `WaitForFirstConsumer`).

Kueue's pod reconciler races the creation of a pod group. It fires on the first pod it observes, sees fewer live pods than `pod-group-total-count`, and emits

```
Warning  ErrWorkloadCompose  'sky-...' group has fewer runnable pods than expected
```

The race is unavoidable — `sky/templates/kubernetes-ray.yml.j2` stamps `kueue.x-k8s.io/pod-group-name` + `pod-group-total-count` on pods that are created by sequential API calls — and Kueue [documents](https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_pods/) that the event stays on the pod after the Workload is composed successfully.

So this benign, already-resolved Warning outranks `Pulling` for the event's whole TTL (~1h), and a perfectly healthy multi-node Kueue launch reports

```
Launching (N pod(s) pending due to ErrWorkloadCompose)
```

in the status line and in `LAUNCH_PROGRESS` cluster events, instead of `pending due to Pulling`.

## The fix

Add `_PENDING_REASON_WARNING_EVENT_IGNORELIST` next to the existing Normal allow-list, seeded with `ErrWorkloadCompose`, and skip those reasons in the tier-2 Warning pass. The scan then falls through to the next Warning, or to the allow-listed Normals.

Deliberately an ignore-list rather than a timestamp heuristic: the event is not *old*, it is *stale in place* — Kueue never updates or deletes it, so no ordering rule can distinguish it from a live complaint.

## Tests

Three cases added to `TestGetPodPendingReasonTieredEventFilter` in `tests/unit_tests/kubernetes/test_provision.py`:

| test | asserts |
|---|---|
| `test_stale_kueue_warning_does_not_mask_pulling` | `ErrWorkloadCompose` + `Pulling` → `Pulling` (the reported bug) |
| `test_stale_kueue_warning_yields_to_a_real_warning` | a newer `ErrWorkloadCompose` does not swallow an older `FailedScheduling` |
| `test_only_ignored_warning_returns_none` | `ErrWorkloadCompose` alone → `None`, rather than a stale reason |

All three fail on `master` and pass with this change; the six existing cases in that class (Warning-beats-Normal, newest-Warning-first, non-allow-listed Normal, empty message, fetch failure, no events) are unaffected in both directions.

Formatting checked with the repo's pins — `yapf==0.32.0` (`--diff` clean on both files) and `isort==5.12.0`; note `tests/unit_tests/kubernetes/test_provision.py` already fails `isort --check-only` on unmodified `master`, so I left its import block alone rather than adding unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
