### PR TITLE
[Core] Add equality for the Cloud class; fix JobGroup common-infra selection

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -320,6 +320,18 @@ class Cloud:
     def is_same_cloud(self, other: 'Cloud') -> bool:
         return isinstance(other, self.__class__)
 
+    def __eq__(self, other: object) -> bool:
+        # Exact-type equality, deliberately stricter than is_same_cloud():
+        # is_same_cloud() is isinstance-based and asymmetric under
+        # inheritance (Kubernetes().is_same_cloud(SSH()) is True, the
+        # reverse is False), which would violate the __eq__ contract and
+        # make dict/set behavior order-dependent. Cloud objects carry no
+        # instance state, so the type is the whole identity.
+        return type(self) is type(other)
+
+    def __hash__(self) -> int:
+        return hash(type(self))
+
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1395,6 +1395,10 @@ class Optimizer:
             if cloud_obj:
                 result.append((cloud_obj, region))
 
+        # Deterministic order: the intersection above is a set, so without
+        # sorting the caller's tie-breaks (and any [0] fallback) would vary
+        # run to run.
+        result.sort(key=lambda infra: (str(infra[0]).lower(), infra[1] or ''))
         return result
 
     @staticmethod

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1395,10 +1395,6 @@ class Optimizer:
             if cloud_obj:
                 result.append((cloud_obj, region))
 
-        # Deterministic order: the intersection above is a set, so without
-        # sorting the caller's tie-breaks (and any [0] fallback) would vary
-        # run to run.
-        result.sort(key=lambda infra: (str(infra[0]).lower(), infra[1] or ''))
         return result
 
     @staticmethod
@@ -1420,6 +1416,15 @@ class Optimizer:
         """
         if len(common_infras) == 1:
             return common_infras[0]
+
+        # The scoring loop below keeps the FIRST of equal-score options
+        # (strict '<'), and equal scores are the norm on Kubernetes where
+        # every context costs 0.0 - so the input order is a tie-breaker.
+        # common_infras comes from a set intersection; sort so ties (and
+        # the last-resort [0] fallback) don't ride set iteration order.
+        common_infras = sorted(common_infras,
+                               key=lambda infra:
+                               (str(infra[0]).lower(), infra[1] or ''))
 
         # Estimate total cost/time for each infra
         best_infra: Optional[Tuple[clouds.Cloud, Optional[str]]] = None

--- a/tests/unit_tests/test_cloud.py
+++ b/tests/unit_tests/test_cloud.py
@@ -12,3 +12,59 @@ def test_cloud_get_reservations_available_resources(specific_reservations,
     available_resources = Cloud().get_reservations_available_resources(
         "instance_type", "region", "zone", specific_reservations)
     assert available_resources == expected
+
+
+class TestCloudEquality:
+    """Cloud.__eq__/__hash__: value semantics over identity.
+
+    Cloud objects are stateless, so two instances of the same class are
+    the same cloud. Before __eq__/__hash__ existed, cloud-keyed dicts
+    and `in` checks silently used identity, which broke any lookup where
+    the probe instance differed from the key instance (see
+    Optimizer._select_best_infra).
+    """
+
+    def test_same_class_instances_are_equal(self):
+        from sky import clouds
+        for cloud_cls in (clouds.AWS, clouds.GCP, clouds.Azure,
+                          clouds.Kubernetes, clouds.Lambda):
+            assert cloud_cls() == cloud_cls()
+            assert hash(cloud_cls()) == hash(cloud_cls())
+
+    def test_different_clouds_are_not_equal(self):
+        from sky import clouds
+        assert clouds.AWS() != clouds.GCP()
+        assert clouds.Kubernetes() != clouds.AWS()
+
+    def test_not_equal_to_non_cloud(self):
+        from sky import clouds
+        assert clouds.AWS() != 'AWS'
+        assert clouds.AWS() != None  # pylint: disable=singleton-comparison
+
+    def test_ssh_and_kubernetes_are_not_equal_either_direction(self):
+        """SSH subclasses Kubernetes; equality must stay symmetric.
+
+        is_same_cloud() keeps its historical isinstance semantics
+        (asymmetric: k8s considers SSH the same *family*), which is why
+        __eq__ is exact-type instead of delegating to it.
+        """
+        from sky import clouds
+        ssh, k8s = clouds.SSH(), clouds.Kubernetes()
+        assert ssh != k8s
+        assert k8s != ssh
+        # Family semantics preserved, unchanged by __eq__:
+        assert k8s.is_same_cloud(ssh)
+        assert not ssh.is_same_cloud(k8s)
+
+    def test_dict_membership_across_instances(self):
+        """The exact lookup shape that failed in _select_best_infra."""
+        from sky import clouds
+        candidates = {clouds.AWS(): ['res-a'], clouds.Kubernetes(): ['res-k']}
+        assert clouds.AWS() in candidates
+        assert clouds.Kubernetes() in candidates
+        assert clouds.GCP() not in candidates
+        assert candidates[clouds.AWS()] == ['res-a']
+
+    def test_set_deduplicates_instances(self):
+        from sky import clouds
+        assert len({clouds.AWS(), clouds.AWS(), clouds.Kubernetes()}) == 2

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -1223,3 +1223,127 @@ class TestPrintJobGroupPlan:
             # (no "Best plan:" message)
             for call in mock_logger.info.call_args_list:
                 assert 'Best plan' not in str(call)
+
+
+class TestSelectBestInfraDistinctCloudInstances:
+    """Regression tests for cloud-keyed candidate lookups with real clouds.
+
+    Production builds each task's candidate dict with its own Cloud
+    instances. Before Cloud.__eq__/__hash__ existed, the value lookup
+    `cloud in candidates` in _select_best_infra failed for every task
+    except the one whose instance _find_common_infras happened to reuse,
+    so every common infra was skipped as invalid and the fallback
+    returned an arbitrary member of an unordered set. Observed in the
+    wild: a 2-task group placed on paid AWS while free Kubernetes
+    capacity was listed under "Other available common infras".
+
+    The mock-cloud fixtures elsewhere in this file wire up __eq__ on the
+    mocks and share one instance across tasks, which is exactly why they
+    could not catch this; these tests use real cloud objects and fresh
+    instances per task on purpose.
+    """
+
+    def _res(self, cloud, region, cost):
+        res = MagicMock(spec=resources_lib.Resources)
+        res.cloud = cloud
+        res.region = region
+        res.get_cost = MagicMock(return_value=cost)
+        return res
+
+    def _task(self, name):
+        task = MagicMock(spec=task_lib.Task)
+        task.name = name
+        task.time_estimator_func = None
+        task.num_nodes = 1
+        return task
+
+    def _candidates_for_task(self):
+        """Fresh cloud instances every call, as in production."""
+        return {
+            clouds.Kubernetes(): [
+                self._res(clouds.Kubernetes(), 'ctx-dev', cost=0.0)
+            ],
+            clouds.AWS(): [self._res(clouds.AWS(), 'ap-northeast-1', cost=8.6)],
+        }
+
+    def test_free_kubernetes_beats_paid_aws_across_instances(self):
+        task1, task2 = self._task('a'), self._task('b')
+        task_candidates = {
+            task1: self._candidates_for_task(),
+            task2: self._candidates_for_task(),
+        }
+
+        common_infras = optimizer.Optimizer._find_common_infras(task_candidates)
+        as_names = {(str(c), r) for c, r in common_infras}
+        assert as_names == {('Kubernetes', 'ctx-dev'),
+                            ('AWS', 'ap-northeast-1')}
+
+        cloud, region = optimizer.Optimizer._select_best_infra(
+            common_infras, task_candidates, [task1, task2], minimize_cost=True)
+        assert str(cloud) == 'Kubernetes'
+        assert region == 'ctx-dev'
+
+    def test_find_common_infras_order_is_deterministic(self):
+        """The intersection is computed over a set; the returned list
+        must not leak set iteration order into placement decisions."""
+        task1, task2 = self._task('a'), self._task('b')
+
+        def candidates():
+            return {
+                clouds.AWS(): [
+                    self._res(clouds.AWS(), 'us-east-1', cost=1.0),
+                    self._res(clouds.AWS(), 'ap-northeast-1', cost=1.0),
+                ],
+                clouds.Kubernetes(): [
+                    self._res(clouds.Kubernetes(), 'ctx-dev', cost=0.0)
+                ],
+            }
+
+        task_candidates = {task1: candidates(), task2: candidates()}
+        result = optimizer.Optimizer._find_common_infras(task_candidates)
+        assert [(str(c), r) for c, r in result] == [
+            ('AWS', 'ap-northeast-1'),
+            ('AWS', 'us-east-1'),
+            ('Kubernetes', 'ctx-dev'),
+        ]
+
+    def test_optimize_same_infra_end_to_end_distinct_instances(self):
+        """Full _optimize_same_infra pass with per-task cloud instances:
+        the group must land on the free Kubernetes context, not AWS, and
+        the unset inter_connection must NOT degrade (placement is k8s)."""
+        dag = MagicMock(spec=dag_lib.Dag)
+        dag.name = 'g'
+        dag.inter_connection = None
+        dag.inter_connection_enabled = MagicMock(return_value=True)
+
+        task1, task2 = self._task('a'), self._task('b')
+        task1.estimate_runtime = MagicMock(return_value=3600)
+        task2.estimate_runtime = MagicMock(return_value=3600)
+        dag.tasks = [task1, task2]
+
+        per_task_resources = {}
+
+        def mock_fill(task, blocked_resources, quiet):
+            k8s_res = self._res(clouds.Kubernetes(), 'ctx-dev', cost=0.0)
+            k8s_res.cloud.get_vcpus_mem_from_instance_type = MagicMock(
+                return_value=(2.0, 4.0))
+            k8s_res.instance_type = '2CPU--4GB'
+            k8s_res.get_accelerators_str = MagicMock(return_value='-')
+            k8s_res.get_spot_str = MagicMock(return_value='')
+            k8s_res.infra = MagicMock()
+            aws_res = self._res(clouds.AWS(), 'ap-northeast-1', cost=8.6)
+            per_task_resources[task.name] = k8s_res
+            return ({'any': [k8s_res, aws_res]}, None, None, None)
+
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=mock_fill):
+            optimizer.Optimizer._optimize_same_infra(
+                dag,
+                minimize=common.OptimizeTarget.COST,
+                blocked_resources=None,
+                quiet=True)
+
+        assert task1.best_resources is per_task_resources['a']
+        assert task2.best_resources is per_task_resources['b']
+        # k8s placement: the unset default must survive undegraded.
+        assert dag.inter_connection is None

--- a/tests/unit_tests/test_optimizer_job_group.py
+++ b/tests/unit_tests/test_optimizer_job_group.py
@@ -1283,29 +1283,33 @@ class TestSelectBestInfraDistinctCloudInstances:
         assert str(cloud) == 'Kubernetes'
         assert region == 'ctx-dev'
 
-    def test_find_common_infras_order_is_deterministic(self):
-        """The intersection is computed over a set; the returned list
-        must not leak set iteration order into placement decisions."""
+    def test_select_best_infra_tie_break_ignores_input_order(self):
+        """Equal-score options (the norm on k8s: every context costs 0.0)
+        must tie-break deterministically, not by whatever order the
+        common-infra set intersection happened to iterate in."""
         task1, task2 = self._task('a'), self._task('b')
 
         def candidates():
             return {
-                clouds.AWS(): [
-                    self._res(clouds.AWS(), 'us-east-1', cost=1.0),
-                    self._res(clouds.AWS(), 'ap-northeast-1', cost=1.0),
-                ],
                 clouds.Kubernetes(): [
-                    self._res(clouds.Kubernetes(), 'ctx-dev', cost=0.0)
+                    self._res(clouds.Kubernetes(), 'ctx-a', cost=0.0),
+                    self._res(clouds.Kubernetes(), 'ctx-b', cost=0.0),
                 ],
             }
 
         task_candidates = {task1: candidates(), task2: candidates()}
-        result = optimizer.Optimizer._find_common_infras(task_candidates)
-        assert [(str(c), r) for c, r in result] == [
-            ('AWS', 'ap-northeast-1'),
-            ('AWS', 'us-east-1'),
-            ('Kubernetes', 'ctx-dev'),
-        ]
+        k8s = clouds.Kubernetes()
+        forward = [(k8s, 'ctx-a'), (k8s, 'ctx-b')]
+        reverse = [(k8s, 'ctx-b'), (k8s, 'ctx-a')]
+
+        picks = {
+            optimizer.Optimizer._select_best_infra(order,
+                                                   task_candidates,
+                                                   [task1, task2],
+                                                   minimize_cost=True)[1]
+            for order in (forward, reverse)
+        }
+        assert picks == {'ctx-a'}
 
     def test_optimize_same_infra_end_to_end_distinct_instances(self):
         """Full _optimize_same_infra pass with per-task cloud instances:
@@ -1321,19 +1325,23 @@ class TestSelectBestInfraDistinctCloudInstances:
         task2.estimate_runtime = MagicMock(return_value=3600)
         dag.tasks = [task1, task2]
 
-        per_task_resources = {}
+        per_task_k8s_res = {}
 
         def mock_fill(task, blocked_resources, quiet):
+            # _fill_in_launchable_resources is called once PER TASK and
+            # returns that task's launchable candidates across ALL clouds
+            # (a Dict[Resources, List[Resources]]; the code under test only
+            # reads the value lists). Each task gets BOTH a free k8s option
+            # and a paid AWS option - AWS is a viable common infra that
+            # must lose - with fresh Cloud instances per call, as in
+            # production.
             k8s_res = self._res(clouds.Kubernetes(), 'ctx-dev', cost=0.0)
-            k8s_res.cloud.get_vcpus_mem_from_instance_type = MagicMock(
-                return_value=(2.0, 4.0))
-            k8s_res.instance_type = '2CPU--4GB'
-            k8s_res.get_accelerators_str = MagicMock(return_value='-')
-            k8s_res.get_spot_str = MagicMock(return_value='')
-            k8s_res.infra = MagicMock()
             aws_res = self._res(clouds.AWS(), 'ap-northeast-1', cost=8.6)
-            per_task_resources[task.name] = k8s_res
-            return ({'any': [k8s_res, aws_res]}, None, None, None)
+            # Remember each task's own k8s candidate: Step 4 must assign
+            # THIS task's instance back to it, not another task's.
+            per_task_k8s_res[task.name] = k8s_res
+            requested = MagicMock(spec=resources_lib.Resources)
+            return ({requested: [k8s_res, aws_res]}, None, None, None)
 
         with patch('sky.optimizer._fill_in_launchable_resources',
                    side_effect=mock_fill):
@@ -1343,7 +1351,7 @@ class TestSelectBestInfraDistinctCloudInstances:
                 blocked_resources=None,
                 quiet=True)
 
-        assert task1.best_resources is per_task_resources['a']
-        assert task2.best_resources is per_task_resources['b']
+        assert task1.best_resources is per_task_k8s_res['a']
+        assert task2.best_resources is per_task_k8s_res['b']
         # k8s placement: the unset default must survive undegraded.
         assert dag.inter_connection is None


### PR DESCRIPTION
Add equality/identity evaluator for the `Cloud` python class.

Fixes a bug where Job Groups fail to colocate in any scenario where >1 common infra is possible, and prevents a whole class of similar errors.

(see `if cloud not in candidates` in `Optimizer._select_best_infra`)

Tested: new unit tests (`TestCloudEquality`, `TestSelectBestInfraDistinctCloudInstances`) fail on master, pass with the fix; full `tests/unit_tests/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)