### PR TITLE
[k8s] Gracefully skip Docker CLI install on non-Debian images when enable_docker: ALL

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1300,13 +1300,22 @@ available_node_types:
                 # sources.list.d, calls dpkg, and installs via apt. Rather than
                 # letting a non-Debian image fail obscurely partway through
                 # (`dpkg: command not found`, or a 404 on a Docker repo that has
-                # no build for this $ID), say so plainly. Making it portable is
-                # out of scope for this change.
+                # no build for this $ID), handle it explicitly. In BUILD mode
+                # the task asked for Docker, so fail plainly. In ALL mode the
+                # config is a cluster-wide default that must not brick every
+                # non-Debian image on the cluster: warn and skip the CLI
+                # install (the dind sidecar still runs; only the `docker` CLI
+                # in this container is unavailable). Making the install
+                # portable is out of scope for this change.
                 if [ "$PKG_MGR" != "apt" ]; then
+                {% if k8s_enable_docker_build %}
                   echo "Error: kubernetes.enable_docker requires a Debian-family image (apt); detected PKG_MGR='${PKG_MGR:-none}'." >> /tmp/apt-update.log
                   dump_apt_log
                   exit 1
-                fi
+                {% else %}
+                  echo "Warning: kubernetes.enable_docker: skipping Docker CLI install; requires a Debian-family image (apt), detected PKG_MGR='${PKG_MGR:-none}'. The docker CLI will not be available in the task container." >> /tmp/apt-update.log
+                {% endif %}
+                else
                 set -e
                 $(prefix_cmd) install -m 0755 -d /etc/apt/keyrings
                 curl -fsSL "https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg" \
@@ -1322,6 +1331,7 @@ available_node_types:
                   dump_apt_log
                   exit 1
                 }
+                fi
                 {% endif %}
 
                 {% if k8s_fuse_device_required %}


### PR DESCRIPTION
## Summary
- **Test:** `test_kubernetes_non_debian_image` (params `rockylinux:9` and `redhat/ubi9`) on `kubernetes`
- **Classification:** deterministic bootstrap failure
- **Confidence:** MEDIUM

## Root Cause
When `kubernetes.enable_docker: ALL` is set in the server config, the pod bootstrap script includes the apt-only Docker CLI / buildx install block for every pod on the cluster. #10077 added an explicit fail-fast for non-apt images, so any launch with a dnf/yum/apk/zypper image (for example `rockylinux:9`, `redhat/ubi9`) now exits 1 during setup and the pod terminates, failing the launch with `unable to upgrade connection: container not found ("ray-node")`.

`ALL` is a cluster-wide default set by the cluster admin, not something the task asked for, so it should not make every non-Debian image on the cluster unlaunchable.

## Fix
In the bootstrap template, when `PKG_MGR != apt`:
- **ALL mode:** log a warning and skip the Docker CLI install instead of exiting. The dind sidecar still runs; only the `docker` CLI inside the task container is unavailable.
- **BUILD mode:** keep the existing hard failure, since the task explicitly requested Docker.

Verified by rendering the template block for ALL / BUILD / disabled modes and executing it with a simulated dnf image: ALL warns and continues, BUILD exits 1, disabled is unchanged.

## CI Failure
Found via internal CI running smoke tests against a server configured with `enable_docker: ALL`. The failure started with the first nightly containing #10077.

---
> **Note:** This fix was auto-generated. Confidence level: MEDIUM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)