### PR TITLE
[CI] Don't auto-retry exclusive smoke steps

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -464,8 +464,12 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
             elif concurrency_limit is not None:
                 step['concurrency'] = concurrency_limit
                 step['concurrency_group'] = concurrency_group
-            if no_auto_retry:
+            if no_auto_retry or exclusive:
                 # Disable automatic retries but allow manual retries.
+                # Exclusive runs are serialized (concurrency 1), so an
+                # auto-retried failure re-runs the whole (often long) step and
+                # blocks every other exclusive step queued behind it. Fail fast
+                # and leave retrying to a human.
                 step['retry'] = {
                     'automatic': False,
                     'manual': {


### PR DESCRIPTION
## Summary

Exclusive smoke steps (`generate_pipeline.py --exclusive`) run **serialized** — the whole exclusive run shares one concurrency group with limit 1, so steps execute strictly one at a time. Today each step still gets `retry: {automatic: True}`, so a failing step auto-retries (Buildkite default), and because the run is serialized, every retry re-runs the (often long) step and **blocks every exclusive step queued behind it** — one flaky/failing case can stall the entire serialized queue for a long time.

This disables automatic retry for exclusive runs (manual retry stays allowed, same as the existing `no_auto_retry` marker path). A failure now fails fast and lets the queue drain to the remaining steps; a human can manually retry the one step if needed.

Non-exclusive runs are unaffected — they still auto-retry as before.

## Tested

- `python -m py_compile .buildkite/generate_pipeline.py`.
- `exclusive` is already unpacked from `_parse_args` in the same function, so it is in scope where the retry block is built; the change reuses the existing `automatic: False` + `manual.allowed: True` branch.