### PR TITLE
[Jobs] Pass task_name to read_managed_job_logs and document id scope

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2014,6 +2014,7 @@ def stream_logs_by_id(
                             returncode = log_reader.read_managed_job_logs(
                                 job_id,
                                 task_id,
+                                task_name=task_name,
                                 follow=False,
                                 tail=tail if tail is not None else 0)
                     except Exception as e:  # pylint: disable=broad-except

--- a/sky/logs/reader.py
+++ b/sky/logs/reader.py
@@ -31,8 +31,13 @@ class LogReader(abc.ABC):
         """
         raise NotImplementedError
 
-    def read_managed_job_logs(self, job_id: int, task_id: Optional[int], *,
-                              follow: bool, tail: int) -> Optional[int]:
+    def read_managed_job_logs(self,
+                              job_id: int,
+                              task_id: Optional[int],
+                              *,
+                              task_name: Optional[str] = None,
+                              follow: bool,
+                              tail: int) -> Optional[int]:
         """Streams a managed job task's logs from the external store to stdout.
 
         Addresses logs by the managed job's identity instead of the cluster the
@@ -42,9 +47,20 @@ class LogReader(abc.ABC):
         addressing inherit the default and return None; callers then rely on
         ``read_cluster_job_logs`` alone.
 
+        Note on identity: a managed job id is only unique within one API
+        server -- every server mints ids from 1, and a rebuilt jobs database
+        restarts the sequence. A store shared by more than one deployment (or
+        reused across a database rebuild, within its retention window) can
+        therefore hold several jobs under the same id. Implementations should
+        narrow the query with whatever additional identity their records carry
+        (``task_name``, an owner hash, a deployment label) rather than trusting
+        the id alone.
+
         Args:
             job_id: The managed job id.
             task_id: The task id within the job, or None for all tasks.
+            task_name: The task's name, when the caller knows it. Part of the
+                job's identity in some record layouts; see the note above.
             follow: Whether to follow the log. An external store is historical,
                 so this may be treated as a no-op.
             tail: Number of lines from the end to stream; 0 means all.
@@ -55,7 +71,7 @@ class LogReader(abc.ABC):
             for the job. A reader that cannot determine the job's status from
             the store should return 0.
         """
-        del job_id, task_id, follow, tail  # Unsupported by default.
+        del job_id, task_id, task_name, follow, tail  # Unsupported by default.
         return None
 
 

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1480,10 +1480,11 @@ class TestStreamLogsByIdExternalStoreFallback:
 
         _, code = jobs_utils.stream_logs_by_id(5, follow=False, tail=None)
 
-        fake_reader.read_managed_job_logs.assert_called_once_with(5,
-                                                                  0,
-                                                                  follow=False,
-                                                                  tail=0)
+        # task_name rides along: a managed job id is unique only within one API
+        # server, so a reader needs it to narrow a store shared by several
+        # deployments.
+        fake_reader.read_managed_job_logs.assert_called_once_with(
+            5, 0, task_name='mytask', follow=False, tail=0)
         assert code == exceptions.JobExitCode.from_managed_job_status(
             managed_job_state.ManagedJobStatus.SUCCEEDED)
 


### PR DESCRIPTION
Follow-up to #10376.

A managed job id is unique only within one API server — every server mints ids from 1, and a rebuilt jobs database restarts the sequence — so a log store shared by more than one deployment (or reused across a DB rebuild, within its retention window) can hold several jobs under the same id. A reader that trusts the id alone silently interleaves foreign records.

- Pass `task_name` (which the caller already has in hand) to `read_managed_job_logs` so readers can narrow the query.
- Document the constraint on the `LogReader` base method, so implementations know the id is not a sufficient key on its own.

Both are additive: `task_name` is keyword-only with a default, and the base implementation still returns None.

Tested:

- `pytest tests/unit_tests/test_sky/jobs/test_utils.py tests/unit_tests/test_sky/logs/` — 117 pass, including the updated assertion that the caller forwards the task name.
- Verified against an external reader that uses the task name to scope read-back: a record set containing two different jobs under the same id returns only the requesting deployment's lines.