### PR TITLE
[Test] Pin provision_timeout in test_launching_with_pending_pods

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3579,7 +3579,19 @@ def test_launching_with_pending_pods():
             # helper's context so the two are co-located; on a local
             # single-context server this is a no-op (`--infra kubernetes`).
             smoke_tests_utils.resolve_cloud_cmd_k8s_context_cmd(name),
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra {smoke_tests_utils.cloud_cmd_landed_k8s_infra(name)} --cpus 0.1+ \'echo hi\'); echo "$s"; echo; echo; echo "$s" | grep "Timed out while waiting for nodes to start"',
+            # Pin provision_timeout: this test asserts on the *provisioning*
+            # timeout path, but the effective default depends on the target
+            # context's config. If a Kueue local queue is configured for that
+            # context (`kueue.local_queue_name` / `quota.queue`),
+            # Kubernetes._calculate_provision_timeout() returns 24 hours, and
+            # the launch would wait on the pending pod far past this test's
+            # per-command timeout instead of emitting the expected message.
+            # 10s is what that same helper computes for a single node when no
+            # queue is configured, i.e. this restores the timeout the test was
+            # written against. The override lands at the cloud level, which
+            # applies as long as the context does not set provision_timeout of
+            # its own.
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra {smoke_tests_utils.cloud_cmd_landed_k8s_infra(name)} --config kubernetes.provision_timeout=10 --cpus 0.1+ \'echo hi\'); echo "$s"; echo; echo; echo "$s" | grep "Timed out while waiting for nodes to start"',
             # Check Pods have been deleted
             smoke_tests_utils.run_cloud_cmd_on_cluster(
                 name,


### PR DESCRIPTION
## Summary

`test_launching_with_pending_pods` parks an unschedulable head pod (via a `nodeSelector` that matches nothing) and asserts that a subsequent `sky launch` reports `Timed out while waiting for nodes to start`.

The timeout it depends on is the one `Kubernetes._calculate_provision_timeout()` computes — 10s for a single node. But that helper returns **24 hours** when a Kueue local queue is configured for the target context:

```python
if is_using_queueing:
    # Queued (e.g. Kueue) workloads wait for quota admission before
    # they can schedule. ...
    return 24 * 60 * 60  # 24 hours
```

`is_using_queueing` is set from `get_effective_queue_name()`, which reads `kubernetes.context_configs.<ctx>.quota.queue` (or `.kueue.local_queue_name`). So on a multi-context API server where the context the test lands on has a queue configured, the launch waits on the parked pod essentially forever, never prints the expected message, and the step is killed by the smoke runner's per-command timeout.

Note the parked pod is created with plain `kubectl` and carries no queue labels, so it is never gated — the scheduling-gate pause in `_wait_for_pods_to_schedule` does not apply here. It is the plain provisioning wait that gets stretched to 24h.

This is orthogonal to what the test is checking, so pin it:

```
--config kubernetes.provision_timeout=10
```

10s is exactly what `_calculate_provision_timeout()` yields for a single node with no queue configured, i.e. this restores the timeout the test was written against rather than inventing a new one. The override merges at the cloud level and leaves `context_configs` untouched, so nothing else about the launch changes.

## Test plan

- `pytest tests/smoke_tests/test_cluster_job.py::test_launching_with_pending_pods --kubernetes` against an API server whose target context has `quota.queue` configured. Before this change the launch step hangs until the per-command timeout; after it, the launch fails fast with `Timed out while waiting for nodes to start` and the test passes.
- Verified the resulting timeout matches the no-queue default:
  ```
  >>> Kubernetes._calculate_provision_timeout(1, None, False, False)
  10
  >>> Kubernetes._calculate_provision_timeout(1, None, False, True)
  86400
  ```
- Verified the CLI override parses, passes config-schema validation, and merges without clobbering sibling keys:
  ```
  >>> _compose_cli_config(['kubernetes.provision_timeout=10'])
  {'kubernetes': {'provision_timeout': 10}}
  # overlaid on a config with kubernetes.context_configs.<ctx>.quota.queue:
  #   context_configs preserved, get_effective_queue_name() still resolves
  #   the queue, get_effective_region_config(provision_timeout) -> 10
  ```
- `format.sh --files tests/smoke_tests/test_cluster_job.py` adds no new findings (pylint `C0301` count unchanged at 387 before and after).

One caveat that applies at any sub-60s value: `_wait_for_pods_to_schedule` raises timeouts below `_AUTOSCALE_INITIAL_MIN_TIMEOUT_SECONDS` (60s) to 60s when the context has an `autoscaler` configured, so on such a context the effective wait is 60s. That is still well inside the test's budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)