### PR TITLE
[API] Throttle per-request service-account last_used_at writes

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3277,15 +3277,37 @@ def get_user_service_account_tokens(user_hash: str) -> List[Dict[str, Any]]:
 
 
 @metrics_lib.time_me
-def update_service_account_token_last_used(token_id: str) -> None:
-    """Update the last_used_at timestamp for a service account token."""
+def update_service_account_token_last_used(token_id: str,
+                                           min_interval_seconds: int = 0
+                                          ) -> None:
+    """Update the last_used_at timestamp for a service account token.
+
+    With ``min_interval_seconds > 0`` the UPDATE is conditional: it only
+    lands when the stored ``last_used_at`` is NULL or older than the
+    interval. The staleness check lives in the WHERE clause (not in the
+    caller) so concurrent callers that all read a stale timestamp cannot
+    herd on the row at an interval boundary: the first transaction to
+    commit refreshes the row, and every other caller's UPDATE re-evaluates
+    against the committed row, matches zero rows, and writes nothing (no
+    redundant WAL/dead-tuple churn).
+    """
     engine = _db_manager.get_engine()
     last_used_at = int(time.time())
 
     with orm.Session(engine) as session:
-        session.query(service_account_token_table).filter_by(
-            token_id=token_id).update(
-                {service_account_token_table.c.last_used_at: last_used_at})
+        query = session.query(service_account_token_table).filter_by(
+            token_id=token_id)
+        if min_interval_seconds > 0:
+            query = query.filter(
+                sqlalchemy.or_(
+                    service_account_token_table.c.last_used_at.is_(None),
+                    service_account_token_table.c.last_used_at <
+                    last_used_at - min_interval_seconds))
+        # synchronize_session=False: the session is scoped to this single
+        # statement, and the conditional criteria above are not evaluatable
+        # in-memory by the default strategy.
+        query.update({service_account_token_table.c.last_used_at: last_used_at},
+                     synchronize_session=False)
         session.commit()
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -576,9 +576,15 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # Update last used timestamp for token tracking, skipped while
             # the row's last_used_at is fresher than
             # _SA_LAST_USED_UPDATE_INTERVAL_SECONDS (see the constant for
-            # why an unthrottled per-request write is dangerous). Use the
-            # DB row's token_id (not the JWT's): after rotation the JWT
-            # carries a different token_id than the DB row.
+            # why an unthrottled per-request write is dangerous). This
+            # pre-check filters the steady state for free (the row is
+            # already in hand); the interval is ALSO passed to the update,
+            # whose WHERE clause re-checks staleness atomically, so the
+            # in-flight requests that all read a stale timestamp at an
+            # interval boundary collapse to one real write instead of
+            # herding on the row lock. Use the DB row's token_id (not the
+            # JWT's): after rotation the JWT carries a different token_id
+            # than the DB row.
             last_used_at = token_row.get('last_used_at')
             if (last_used_at is None or time.time() - last_used_at >=
                     _SA_LAST_USED_UPDATE_INTERVAL_SECONDS):
@@ -586,7 +592,8 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     await db_lookup.call_with_deadline(
                         global_user_state.
                         update_service_account_token_last_used,
-                        token_row['token_id'])
+                        token_row['token_id'],
+                        _SA_LAST_USED_UPDATE_INTERVAL_SECONDS)
                 except Exception as e:  # pylint: disable=broad-except
                     logger.debug(f'Failed to update token last used time: {e}')
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -432,6 +432,18 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         return await call_next(request)
 
 
+# Minimum seconds between persisted last_used_at updates per service-account
+# token. The update is an UPDATE on the token's single DB row, so Postgres
+# row-level locking serializes it across the whole deployment; with an
+# unthrottled per-request write, a high-concurrency SDK fleet sharing one
+# token queues on that row lock, each waiter pinning an auth-executor thread
+# and a sync DB connection, until the auth executor exhausts and unrelated
+# requests fail with retryable 503s. last_used_at is an audit/freshness
+# field, so interval granularity is sufficient; each server process writes at
+# most once per interval per token.
+_SA_LAST_USED_UPDATE_INTERVAL_SECONDS = 60
+
+
 @middleware_utils.websocket_aware
 class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     """Middleware to handle Bearer Token Auth (Service Accounts)."""
@@ -561,15 +573,22 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 return _bearer_auth_401_response(
                     {'detail': 'Service account user no longer exists'})
 
-            # Update last used timestamp for token tracking. Use the
+            # Update last used timestamp for token tracking, skipped while
+            # the row's last_used_at is fresher than
+            # _SA_LAST_USED_UPDATE_INTERVAL_SECONDS (see the constant for
+            # why an unthrottled per-request write is dangerous). Use the
             # DB row's token_id (not the JWT's): after rotation the JWT
             # carries a different token_id than the DB row.
-            try:
-                await db_lookup.call_with_deadline(
-                    global_user_state.update_service_account_token_last_used,
-                    token_row['token_id'])
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to update token last used time: {e}')
+            last_used_at = token_row.get('last_used_at')
+            if (last_used_at is None or time.time() - last_used_at >=
+                    _SA_LAST_USED_UPDATE_INTERVAL_SECONDS):
+                try:
+                    await db_lookup.call_with_deadline(
+                        global_user_state.
+                        update_service_account_token_last_used,
+                        token_row['token_id'])
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug(f'Failed to update token last used time: {e}')
 
             # Set the authenticated user
             auth_user = models.User(id=user_id,

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -337,8 +337,8 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_stale_last_used_is_updated(self, middleware,
-                                              base_mock_request,
-                                              mock_call_next, mock_token_row):
+                                              base_mock_request, mock_call_next,
+                                              mock_token_row):
         """A row whose last_used_at is older than the interval IS re-written."""
         base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
         mock_token_row['last_used_at'] = int(time.time()) - 3600

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 import fastapi
 import pytest
 
+from sky.server.server import _SA_LAST_USED_UPDATE_INTERVAL_SECONDS
 from sky.server.server import BearerTokenMiddleware
 from sky.skylet import constants
 
@@ -291,7 +292,8 @@ class TestBearerTokenMiddleware:
             assert base_mock_request.state.auth_user.name == 'test-service-account'
             # last_used must be updated with the DB row's token_id, not
             # the JWT's.
-            mock_update_last_used.assert_called_once_with('token_db_id_456')
+            mock_update_last_used.assert_called_once_with(
+                'token_db_id_456', _SA_LAST_USED_UPDATE_INTERVAL_SECONDS)
 
     @pytest.mark.asyncio
     async def test_fresh_last_used_skips_update(self, middleware,
@@ -367,7 +369,8 @@ class TestBearerTokenMiddleware:
                                                  mock_call_next)
 
             assert response.status_code == 200
-            mock_update_last_used.assert_called_once_with('token_db_id_456')
+            mock_update_last_used.assert_called_once_with(
+                'token_db_id_456', _SA_LAST_USED_UPDATE_INTERVAL_SECONDS)
 
     @pytest.mark.asyncio
     async def test_missing_user_id_in_token(self, middleware, base_mock_request,

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -294,6 +294,82 @@ class TestBearerTokenMiddleware:
             mock_update_last_used.assert_called_once_with('token_db_id_456')
 
     @pytest.mark.asyncio
+    async def test_fresh_last_used_skips_update(self, middleware,
+                                                base_mock_request,
+                                                mock_call_next, mock_token_row):
+        """A row whose last_used_at is fresh must NOT be re-written.
+
+        The write UPDATEs the token's single row, so per-request writes from
+        a concurrent fleet sharing one token serialize on the row lock and
+        can exhaust the auth executor; the middleware throttles the write to
+        once per _SA_LAST_USED_UPDATE_INTERVAL_SECONDS per token.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+        mock_token_row['last_used_at'] = int(time.time()) - 1
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+        mock_user_info = mock.Mock()
+        mock_user_info.name = 'test-service-account'
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
+                mock.patch('sky.global_user_state.get_user') as mock_get_user, \
+                mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used:
+
+            mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
+            mock_get_user.return_value = mock_user_info
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            # Authentication still succeeds; only the write is skipped.
+            assert response.status_code == 200
+            assert base_mock_request.state.auth_user.id == 'sa-123456'
+            mock_update_last_used.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_last_used_is_updated(self, middleware,
+                                              base_mock_request,
+                                              mock_call_next, mock_token_row):
+        """A row whose last_used_at is older than the interval IS re-written."""
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+        mock_token_row['last_used_at'] = int(time.time()) - 3600
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+        mock_user_info = mock.Mock()
+        mock_user_info.name = 'test-service-account'
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
+                mock.patch('sky.global_user_state.get_user') as mock_get_user, \
+                mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used:
+
+            mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
+            mock_get_user.return_value = mock_user_info
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 200
+            mock_update_last_used.assert_called_once_with('token_db_id_456')
+
+    @pytest.mark.asyncio
     async def test_missing_user_id_in_token(self, middleware, base_mock_request,
                                             mock_call_next):
         """Test middleware when token payload is missing user_id."""

--- a/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
@@ -218,6 +218,28 @@ class TestServiceAccountDatabaseOperations:
             )
             mock_session.commit.assert_called_once()
 
+    def test_update_service_account_token_last_used_conditional(
+            self, mock_engine, mock_session):
+        """With min_interval_seconds set, staleness rides the WHERE clause.
+
+        The conditional filter (last_used_at IS NULL OR older than the
+        interval) must be part of the UPDATE itself so concurrent callers
+        that all read a stale timestamp cannot herd on the row: only the
+        first commit writes, the rest match zero rows.
+        """
+        with mock.patch('time.time', return_value=1234567999):
+            global_user_state.update_service_account_token_last_used(
+                'token123', min_interval_seconds=60)
+
+            filter_by = mock_session.query.return_value.filter_by
+            filter_by.assert_called_once_with(token_id='token123')
+            # The staleness condition is applied as an additional filter...
+            filter_by.return_value.filter.assert_called_once()
+            # ...and the update runs on the filtered query.
+            filter_by.return_value.filter.return_value.update.assert_called_once(
+            )
+            mock_session.commit.assert_called_once()
+
     def test_delete_service_account_token_success(self, mock_engine,
                                                   mock_session):
         """Test successfully deleting a service account token."""


### PR DESCRIPTION
## Summary

- The bearer-token middleware persists `last_used_at` on every service-account-authenticated request. Each write is an `UPDATE` on the token's single DB row, so Postgres row-level locking serializes the writes deployment-wide. Under a high-concurrency SDK fleet authenticating with one shared token, writers queue on the row lock while each holds an auth-executor thread **and** a sync DB connection; the token/user lookups queue behind them, the 32-thread auth executor exhausts (`ConcurrentWorkerExhaustedError`), and unrelated requests start failing with retryable 503s.
- Fix: skip the write while the row's `last_used_at` is fresher than `_SA_LAST_USED_UPDATE_INTERVAL_SECONDS` (60s). The middleware already has the token row in hand, so the guard is free; `last_used_at` is an audit/freshness field where minute granularity is sufficient. Each server process now writes at most once per interval per token instead of once per request.

## Tested

- Unit tests: two new cases in `test_bearer_token_middleware.py` (fresh `last_used_at` → write skipped, auth still succeeds; stale → write issued with the DB row's `token_id`, preserving the rotation semantics covered by the existing test). Full file: 19 passed.
- Load test: 256 concurrent SDK workers sharing one service-account token against a single-replica API server (6 CPU, Postgres-backed). Before: recurring `Maximum concurrent workers 32 of threads executor [auth_thread_executor] reached`, client-visible 503s after retry exhaustion. After: zero auth-executor exhaustion across the full run; storm-time p50 request latency improved ~20% on an otherwise healthy deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->