### PR TITLE
[Server] Batch supervision status polls of in-flight requests

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -997,7 +997,12 @@ async def _execute_request_coroutine(request: api_requests.Request):
         return
 
     async def poll_task(request_id: str) -> bool:
-        req_status = await api_requests.get_request_status_async(request_id)
+        # Batched: all in-flight coroutine requests on this loop share one
+        # snapshot query per tick instead of a point lookup each. A
+        # CANCELLED transition is detected via the point-lookup fallback
+        # (the request drops out of the active snapshot), adding at most
+        # the snapshot staleness (0.5s) to cancellation latency.
+        req_status = await api_requests.get_request_status_batched(request_id)
         if req_status is None:
             raise RuntimeError('Request not found')
 

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -16,6 +16,7 @@ import traceback
 from typing import (Any, Callable, Dict, Generator, List, NamedTuple, NoReturn,
                     Optional, Set, Tuple)
 import uuid
+import weakref
 
 import anyio
 import colorama
@@ -1077,9 +1078,22 @@ class RequestTaskFilter:
         filters = []
         filter_params: List[Any] = []
         if self.status is not None:
-            status_placeholders = ','.join(['?'] * len(self.status))
-            filters.append(f'status IN ({status_placeholders})')
-            filter_params.extend(status.value for status in self.status)
+            # Inline the status values as literals instead of binding them.
+            # The partial indexes on this table (e.g. ``status_name_idx``,
+            # predicated on the active statuses) can only be used when the
+            # planner can prove the query's status predicate implies the
+            # index predicate, which SQLite does at prepare time and thus
+            # never for bound parameters: with placeholders this query is a
+            # full table scan. The values are members of the RequestStatus
+            # enum (enforced here), not caller input, so interpolating them
+            # is safe.
+            assert all(
+                isinstance(status, RequestStatus) for status in self.status), (
+                    f'status filter must be RequestStatus members, got '
+                    f'{self.status}')
+            status_literals = ','.join(
+                f'\'{status.value}\'' for status in self.status)
+            filters.append(f'status IN ({status_literals})')
         if self.include_request_names is not None:
             name_placeholders = ','.join(['?'] *
                                          len(self.include_request_names))
@@ -1149,6 +1163,99 @@ async def get_api_request_ids_start_with(incomplete: str) -> List[str]:
     """Get a list of API request ids for shell completion."""
     return await request_storage.get_request_backend(
     ).get_api_request_ids_start_with(incomplete)
+
+
+class _BatchedStatusPoller:
+    """Serves point status polls of active requests from one shared snapshot.
+
+    Every loop that supervises an in-flight request — a log stream waiting
+    for its request to be scheduled, a tail checking for cancellation, the
+    coroutine executor's poll task — issues the same point lookup once per
+    tick. The lookups are identical in shape and dominated by connection
+    acquisition rather than execution, so N concurrent supervisors cost N
+    queries per tick even though one query answers all of them. With
+    hundreds of launches parked WAITING (e.g. for Kueue admission), the
+    supervision polls alone can saturate the request DB's connection layer
+    and drag P95 of every request-DB function above 1s.
+
+    Instead, keep a snapshot of (status, status_msg) for every active
+    (PENDING / WAITING / RUNNING) request, refreshed at most every
+    ``_MAX_STALENESS`` seconds by whichever poller asks first; concurrent
+    pollers await the same refresh (single-flight) and read from it. The
+    snapshot query is served by the ``status_name_idx`` partial index, so
+    it only ever touches active rows. A request absent from the snapshot
+    has finished, vanished, or was created after the snapshot was taken —
+    cases the caller must act on precisely — so it falls back to an
+    authoritative point lookup: at most one point lookup per supervisor
+    transition instead of one per supervisor per tick.
+    """
+
+    # Upper bound on how stale a served status may be. All current callers
+    # poll on a 0.5-1s cadence, so this halves at most one tick's freshness
+    # while collapsing N queries/tick into <= 1/_MAX_STALENESS queries/s.
+    _MAX_STALENESS = 0.5
+
+    def __init__(self) -> None:
+        self._snapshot: Dict[str, StatusWithMsg] = {}
+        self._snapshot_time: float = float('-inf')
+        self._refresh_lock = asyncio.Lock()
+
+    async def get(self, request_id: str) -> Optional[StatusWithMsg]:
+        snapshot = await self._fresh_snapshot()
+        status = snapshot.get(request_id)
+        if status is not None:
+            return status
+        return await get_request_status_async(request_id, include_msg=True)
+
+    async def _fresh_snapshot(self) -> Dict[str, StatusWithMsg]:
+        loop_time = asyncio.get_running_loop().time
+        if loop_time() - self._snapshot_time < self._MAX_STALENESS:
+            return self._snapshot
+        async with self._refresh_lock:
+            # The refresh may have run while this poller waited for the
+            # lock; reuse it instead of refreshing again.
+            if loop_time() - self._snapshot_time < self._MAX_STALENESS:
+                return self._snapshot
+            active = await get_request_tasks_async(
+                RequestTaskFilter(
+                    status=RequestStatus.active_statuses(),
+                    fields=['request_id', 'status', COL_STATUS_MSG]))
+            snapshot = {
+                request.request_id: StatusWithMsg(request.status,
+                                                  request.status_msg)
+                for request in active
+            }
+            # Assign both only after the query succeeded, so a failed
+            # refresh neither poisons the snapshot nor marks it fresh.
+            self._snapshot = snapshot
+            self._snapshot_time = loop_time()
+            return self._snapshot
+
+
+# One poller per event loop: uvicorn workers and the executor each run
+# their own loop (today in separate processes, where this is simply the
+# per-process singleton). Weak keys let short-lived loops (e.g. in tests)
+# drop their poller when they are garbage collected.
+_status_pollers: 'weakref.WeakKeyDictionary[Any, _BatchedStatusPoller]' = (
+    weakref.WeakKeyDictionary())
+
+
+async def get_request_status_batched(
+        request_id: str) -> Optional[StatusWithMsg]:
+    """Batched equivalent of ``get_request_status_async(include_msg=True)``.
+
+    For supervision poll loops: amortizes all concurrent pollers on this
+    event loop into one shared active-requests snapshot query per
+    ``_MAX_STALENESS`` interval. The result may be up to ``_MAX_STALENESS``
+    seconds stale for an active request; finished or missing requests are
+    always answered by an authoritative point lookup.
+    """
+    loop = asyncio.get_running_loop()
+    poller = _status_pollers.get(loop)
+    if poller is None:
+        poller = _BatchedStatusPoller()
+        _status_pollers[loop] = poller
+    return await poller.get(request_id)
 
 
 def get_active_file_mounts_blob_ids() -> set:

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -126,14 +126,14 @@ async def wait_for_request_to_start(
             last_waiting_msg = waiting_msg
             # Padding forces browser rendering of the streamed chunk.
             yield waiting_msg + ' ' * 4096 + '\n'
-        # Sleep shortly to avoid storming the DB and CPU and allow other
-        # coroutines to run.
-        # TODO(aylei): we should use a better mechanism to avoid busy
-        # polling the DB, which can be a bottleneck for high-concurrency
-        # requests.
+        # Sleep shortly to avoid storming the CPU and allow other
+        # coroutines to run. The status poll itself is batched: all
+        # concurrent waiters share one active-requests snapshot query per
+        # tick, so many parked requests (e.g. launches queued for quota)
+        # no longer translate into that many DB polls per second.
         await asyncio.sleep(backoff.current_backoff())
-        status_with_msg = await requests_lib.get_request_status_async(
-            request_id, include_msg=True)
+        status_with_msg = await requests_lib.get_request_status_batched(
+            request_id)
         if status_with_msg is None:
             # Request record vanished (e.g. deleted while polling).
             break
@@ -287,8 +287,14 @@ async def _tail_log_file(
                 should_check_status = True
             if request_id is not None and should_check_status:
                 last_status_check_time = current_time
-                req_status = await requests_lib.get_request_status_async(
+                # Batched: concurrent tails share one snapshot query per
+                # tick instead of one point lookup per tail. Terminal
+                # statuses still come from an authoritative point lookup.
+                req_status = await requests_lib.get_request_status_batched(
                     request_id)
+                if req_status is None:
+                    # Request record vanished (e.g. deleted while tailing).
+                    break
                 if req_status.status > requests_lib.RequestStatus.RUNNING:
                     if (req_status.status ==
                             requests_lib.RequestStatus.CANCELLED):

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1275,11 +1275,13 @@ def test_requests_filter():
     filter_status = requests.RequestTaskFilter(
         status=[RequestStatus.PENDING, RequestStatus.RUNNING], sort=True)
     sql, params = filter_status.build_query()
+    # Status values are inlined as literals (not bound) so the planner can
+    # match the partial indexes predicated on status; see build_query.
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE status IN (?,?) '
+                    'WHERE status IN (\'PENDING\',\'RUNNING\') '
                     'ORDER BY created_at DESC')
     assert sql == expected_sql
-    assert params == ['PENDING', 'RUNNING']
+    assert params == []
 
     # Test cluster_names filter
     filter_clusters = requests.RequestTaskFilter(
@@ -1339,7 +1341,7 @@ def test_requests_filter():
         sort=True)
     sql, params = filter_combined.build_query()
     expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
-                    'WHERE status IN (?,?) AND '
+                    'WHERE status IN (\'SUCCEEDED\',\'FAILED\') AND '
                     'name NOT IN (?) AND '
                     'cluster_name IN (?) AND '
                     'user_id = ? AND finished_at < ? '
@@ -1347,8 +1349,7 @@ def test_requests_filter():
     assert sql == expected_sql
     # Parameter order must match placeholder order in the SQL above.
     assert params == [
-        'SUCCEEDED', 'FAILED', 'internal-task', 'prod-cluster', 'admin-user',
-        9876543210.0
+        'internal-task', 'prod-cluster', 'admin-user', 9876543210.0
     ]
 
     # Test mutually exclusive filters raise ValueError
@@ -2357,3 +2358,182 @@ async def test_kill_requests_unscoped_cancels_all(isolated_database):
     cancelled = requests.kill_requests(request_ids=['shutdown-a', 'shutdown-b'],
                                        user_id=None)
     assert set(cancelled) == {'shutdown-a', 'shutdown-b'}
+
+
+# ---------------------------------------------------------------------------
+# get_request_status_batched
+# ---------------------------------------------------------------------------
+
+
+def _make_status_request(request_id: str,
+                         status: RequestStatus,
+                         status_msg: Optional[str] = None) -> requests.Request:
+    return requests.Request(request_id=request_id,
+                            name='test-request',
+                            entrypoint=dummy,
+                            request_body=payloads.RequestBody(),
+                            status=status,
+                            status_msg=status_msg,
+                            created_at=0.0,
+                            user_id='test-user')
+
+
+@pytest.mark.asyncio
+async def test_get_request_status_batched_basic(isolated_database):
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-pending', RequestStatus.PENDING))
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-waiting',
+                             RequestStatus.WAITING,
+                             status_msg='Workload is pending on queue q.'))
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-running', RequestStatus.RUNNING))
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-cancelled', RequestStatus.CANCELLED))
+
+    # Active requests are served from the snapshot, including status_msg.
+    result = await requests.get_request_status_batched('batched-pending')
+    assert result.status == RequestStatus.PENDING
+    result = await requests.get_request_status_batched('batched-waiting')
+    assert result.status == RequestStatus.WAITING
+    assert result.status_msg == 'Workload is pending on queue q.'
+    result = await requests.get_request_status_batched('batched-running')
+    assert result.status == RequestStatus.RUNNING
+
+    # Finished requests are not in the snapshot: point-lookup fallback.
+    result = await requests.get_request_status_batched('batched-cancelled')
+    assert result.status == RequestStatus.CANCELLED
+
+    # Missing requests resolve to None, like get_request_status_async.
+    assert await requests.get_request_status_batched('batched-missing') is None
+
+
+@pytest.mark.asyncio
+async def test_get_request_status_batched_single_flight(isolated_database):
+    num_requests = 25
+    for i in range(num_requests):
+        await requests.create_if_not_exists_async(
+            _make_status_request(f'batched-sf-{i}', RequestStatus.WAITING))
+
+    real_get_request_tasks_async = requests.get_request_tasks_async
+    snapshot_queries = 0
+
+    async def counting_get_request_tasks_async(req_filter):
+        nonlocal snapshot_queries
+        snapshot_queries += 1
+        # Force all concurrent pollers to overlap with the refresh, so a
+        # non-single-flight implementation would issue one query each.
+        await asyncio.sleep(0.05)
+        return await real_get_request_tasks_async(req_filter)
+
+    point_lookups = 0
+    real_get_request_status_async = requests.get_request_status_async
+
+    async def counting_get_request_status_async(*args, **kwargs):
+        nonlocal point_lookups
+        point_lookups += 1
+        return await real_get_request_status_async(*args, **kwargs)
+
+    with mock.patch.object(requests, 'get_request_tasks_async',
+                           counting_get_request_tasks_async):
+        with mock.patch.object(requests, 'get_request_status_async',
+                               counting_get_request_status_async):
+            results = await asyncio.gather(*[
+                requests.get_request_status_batched(f'batched-sf-{i}')
+                for i in range(num_requests)
+            ])
+
+    assert snapshot_queries == 1
+    # Every poller was answered from the shared snapshot.
+    assert point_lookups == 0
+    assert all(r.status == RequestStatus.WAITING for r in results)
+
+
+@pytest.mark.asyncio
+async def test_get_request_status_batched_staleness_bound(isolated_database):
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-stale', RequestStatus.RUNNING))
+
+    # Populate the snapshot.
+    result = await requests.get_request_status_batched('batched-stale')
+    assert result.status == RequestStatus.RUNNING
+
+    await requests.set_request_cancelled_async('batched-stale')
+
+    # Within the staleness window the snapshot still answers RUNNING: the
+    # documented (bounded) lag of the batched path.
+    result = await requests.get_request_status_batched('batched-stale')
+    assert result.status == RequestStatus.RUNNING
+
+    # Once the snapshot expires, the request is no longer active, so the
+    # authoritative point lookup reports the terminal status.
+    with mock.patch.object(requests._BatchedStatusPoller, '_MAX_STALENESS', 0):
+        result = await requests.get_request_status_batched('batched-stale')
+    assert result.status == RequestStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_get_request_status_batched_refresh_failure_not_cached(
+        isolated_database):
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-fail', RequestStatus.PENDING))
+
+    async def failing_get_request_tasks_async(req_filter):
+        raise RuntimeError('db down')
+
+    with mock.patch.object(requests._BatchedStatusPoller, '_MAX_STALENESS', 0):
+        with mock.patch.object(requests, 'get_request_tasks_async',
+                               failing_get_request_tasks_async):
+            with pytest.raises(RuntimeError, match='db down'):
+                await requests.get_request_status_batched('batched-fail')
+
+        # The failed refresh is not cached as a fresh (empty) snapshot: the
+        # next call refreshes again and succeeds.
+        result = await requests.get_request_status_batched('batched-fail')
+    assert result.status == RequestStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_batched_snapshot_query_uses_partial_index(isolated_database):
+    # The snapshot query must be served by the partial index over active
+    # requests (status_name_idx); a full scan of the requests table is what
+    # made per-poller point lookups melt large deployments in the first
+    # place.
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-plan', RequestStatus.PENDING))
+    sql, params = requests.RequestTaskFilter(
+        status=RequestStatus.active_statuses(),
+        fields=['request_id', 'status', 'status_msg']).build_query()
+    cursor = requests._DB.conn.cursor()
+    plan_rows = cursor.execute('EXPLAIN QUERY PLAN ' + sql, params).fetchall()
+    plan = ' '.join(str(row) for row in plan_rows)
+    assert 'status_name_idx' in plan, plan
+
+
+@pytest.mark.asyncio
+async def test_wait_for_request_to_start_with_batched_polls(isolated_database):
+    from sky.server import stream_utils
+
+    await requests.create_if_not_exists_async(
+        _make_status_request('batched-wait-loop', RequestStatus.PENDING))
+
+    async def flip_to_running():
+        await asyncio.sleep(0.3)
+        with requests.update_request('batched-wait-loop') as request_task:
+            request_task.status = RequestStatus.RUNNING
+
+    flip_task = asyncio.create_task(flip_to_running())
+    with mock.patch.object(requests._BatchedStatusPoller, '_MAX_STALENESS',
+                           0.05):
+        chunks = []
+
+        async def consume():
+            async for chunk in stream_utils.wait_for_request_to_start(
+                    'batched-wait-loop', plain_logs=True):
+                chunks.append(chunk)
+
+        # The generator exits once the (batched) poll observes RUNNING; a
+        # hang here means the batched path failed to surface the flip.
+        await asyncio.wait_for(consume(), timeout=10)
+    await flip_task
+    assert any('Waiting for' in chunk for chunk in chunks)


### PR DESCRIPTION
## Problem

Every loop that supervises an in-flight request issues the same point status lookup once per tick:

- `stream_utils.wait_for_request_to_start` — a log stream attached to a not-yet-RUNNING request polls `get_request_status_async` on a backoff that converges to ~1/s, for as long as the request stays PENDING/WAITING;
- `stream_utils.log_streamer` — each active tail checks the request status every `polling_interval`;
- `executor._execute_request_coroutine.poll_task` — each in-flight coroutine request polls every 0.5s for cancellation.

The lookups are identical in shape and dominated by connection acquisition rather than execution, so N concurrent supervisors cost N queries per tick even though one query answers all of them.

In a production incident (2026-08-07), a customer launch burst parked **576 launches WAITING** for Kueue quota admission. Each parked launch was supervised by its log stream's ~1/s status poll, so `get_request_status_async` went from ~30/s to **562/s in lockstep with the parked count**, saturated the request DB's connection layer, and dragged the P95 of *every* async request-DB function to 2.3–3.6s (pool wait, not execution — the sync twins stayed at milliseconds, and the DB executed the polls in µs). The `TODO(aylei)` in `wait_for_request_to_start` calls out exactly this.

## Change

**`get_request_status_batched`** (`requests.py`): all supervisors on an event loop share one snapshot of active (PENDING/WAITING/RUNNING) requests' `(status, status_msg)`, refreshed at most every 0.5s by whichever poller asks first (single-flight; concurrent pollers await the same refresh). A request absent from the snapshot has finished, vanished, or was just created — cases the caller must act on precisely — so it falls back to an authoritative point lookup. Net: at most one point lookup per supervisor *transition* instead of one per supervisor per *tick*. The three loops above now call it; no other behavior changes.

**Inline status literals in `RequestTaskFilter.build_query`**: SQLite decides partial-index usability at prepare time, so with bound parameters a status-filtered query can never use the `status_name_idx` partial index (predicated on the active statuses) and always full-scans the requests table — this was true for the existing `/api/status` listing queries too, and would have made the new snapshot query a per-tick full scan (the new `test_batched_snapshot_query_uses_partial_index` caught it: `SCAN requests` before, index search after). The interpolated values are `RequestStatus` enum members (asserted), never caller input.

## Correctness

- **Staleness is bounded and one-sided.** An *active* request's status may be served up to 0.5s stale — at the callers' 0.5–1s cadence this delays observing PENDING→RUNNING or a cancellation by at most one extra tick. Terminal/missing answers are never stale (always a point lookup). Cancellation latency for coroutine requests grows from ≤0.5s to ≤1s worst case.
- **`None` semantics preserved** (request vanished → `None`, same as `get_request_status_async`). Wiring this into `log_streamer` also fixes a latent `None`-deref there (mypy caught it once the call was annotated; the tail now stops cleanly if the request row is deleted mid-tail).
- **Failed refreshes are not cached** — the exception propagates to the caller (as a failed point lookup would have) and the next poller retries.
- **Per event loop, no cross-loop state**; uvicorn workers and the executor each get their own instance, so this also holds pre-fork/multi-process.
- **Backend-portable**: uses only the existing `get_request_tasks_async(RequestTaskFilter(...))` backend API — no request-backend interface change, so alternative request backends keep working unmodified (they consume the filter's fields, not `build_query`, which only the SQLite backend uses).

Tests (all in `test_requests.py`): snapshot correctness incl. `status_msg`, single-flight coalescing (25 concurrent pollers → exactly 1 query, 0 point lookups), staleness bound + authoritative terminal answer, refresh-failure non-caching, `EXPLAIN QUERY PLAN` guard for the partial index, and an end-to-end `wait_for_request_to_start` test (PENDING→RUNNING flip observed through the batched path).

`tests/unit_tests/test_sky/server/requests/` (110) and `tests/unit_tests/test_sky/server/test_server.py` (45) pass; pre-commit (mypy/pylint/yapf/isort) clean.

## Performance

Benchmark reproducing the incident shape — 600 parked supervisors polling at 1s over a 5,600-row requests table for 10s, SQLite backend:

| | supervision ticks | point lookups | snapshot queries | request-DB queries | process CPU |
|---|---|---|---|---|---|
| before | 6,000 | 6,000 | — | 6,000 (**600.0/s**) | 0.65s |
| after | 6,000 | **0** | 10 | 10 (**1.0/s**) | 0.20s |

**600× fewer request-DB queries** at identical supervision behavior. Query pressure is now O(1) in the number of parked/tailed requests instead of O(N): the incident's 562 polls/s (which alone saturated a pgbouncer pool and pushed every request-DB function's P95 over the 1s alert threshold) becomes ~2/s per process. On the SQLite backend, `/api/status`-style listings additionally switch from full table scans to the partial index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
