### PR TITLE
fix(schemas): accept every StoreType prefix in jobs/serve bucket (#10387)

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1788,7 +1788,12 @@ def get_config_schema():
             },
             'bucket': {
                 'type': 'string',
-                'pattern': '^(https|s3|gs|r2|cos)://.+',
+                # Keep in sync with the URL prefixes `StoreType` understands
+                # (`StoreType.store_prefix()`). `controller_utils` resolves
+                # this value with `StoreType.get_fields_from_store_url()`, so
+                # every prefix that resolver accepts has to validate here.
+                'pattern': ('^(https|s3|gs|r2|cos|oci|nebius|cw|vastdata|hf)'
+                            '://.+'),
                 'required': [],
             },
             'force_disable_cloud_bucket': {

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -1596,5 +1596,47 @@ class TestDashboardConfigUrlTemplateValidation(unittest.TestCase):
             config, 'test_config')
 
 
+class TestControllerBucketSchema(unittest.TestCase):
+    """Tests for the `bucket` field of the jobs/serve controller schema."""
+
+    def _validate(self, section, url):
+        jsonschema.validate({section: {
+            'bucket': url
+        }}, schemas.get_config_schema())
+
+    def test_every_store_prefix_is_accepted(self):
+        """Every URL prefix `StoreType` understands must validate.
+
+        `controller_utils.maybe_translate_local_file_mounts_and_sync_up`
+        resolves `jobs.bucket`/`serve.bucket` with
+        `StoreType.get_fields_from_store_url`, so a prefix that resolver
+        accepts must not be rejected by config validation first. Derive the
+        expectation from `StoreType` rather than restating the list, so a
+        newly added store fails here instead of at config-load time.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from sky.data import storage as storage_lib
+        for store_type in storage_lib.StoreType:
+            if store_type == storage_lib.StoreType.VOLUME:
+                # Not an object store; never a valid controller bucket.
+                continue
+            url = f'{store_type.store_prefix()}my-bucket/sub-path'
+            for section in ('jobs', 'serve'):
+                with self.subTest(store=store_type.value, section=section):
+                    self._validate(section, url)
+
+    def test_non_store_urls_are_rejected(self):
+        invalid_urls = [
+            'ftp://my-bucket/sub-path',
+            'my-bucket/sub-path',
+            's3://',
+        ]
+        for url in invalid_urls:
+            for section in ('jobs', 'serve'):
+                with self.subTest(url=url, section=section):
+                    with self.assertRaises(jsonschema.ValidationError):
+                        self._validate(section, url)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #10387.

## Problem

`jobs.bucket` / `serve.bucket` are resolved at runtime by `StoreType.get_fields_from_store_url()` (`sky/utils/controller_utils.py:1085-1086`), which understands every store registered through `_S3_COMPATIBLE_STORES` plus GCS/Azure/IBM/HF. The JSON schema guarding those fields still carries the pattern from before the S3-compatible-store abstraction existed:

```python
'pattern': '^(https|s3|gs|r2|cos)://.+',
```

so a URL the resolver handles perfectly well never reaches it. `_validate_config` runs on **every** config load, not just on save (`sky/skypilot_config.py:707`), so the jobs controller re-rejects the config file the API server hands it — there is no way to work around this from the client side.

Measured on `skypilot-nightly==1.0.0.dev20260807` (the three relevant files are byte-identical to `master`), for `<prefix>my-bucket/sub-path`:

| store | URL | accepted by schema (before) |
|---|---|---|
| S3 | `s3://…` | ✅ |
| GCS | `gs://…` | ✅ |
| Azure | `https://…` | ✅ |
| R2 | `r2://…` | ✅ |
| IBM | `cos://…` | ✅ |
| **OCI** | `oci://…` | ❌ |
| **Nebius** | `nebius://…` | ❌ |
| **CoreWeave** | `cw://…` | ❌ |
| **VAST Data** | `vastdata://…` | ❌ |
| **Hugging Face** | `hf://buckets/…` | ❌ |

## Fix

Widen the pattern to the URL prefixes `StoreType.store_prefix()` actually exposes:

```python
'pattern': ('^(https|s3|gs|r2|cos|oci|nebius|cw|vastdata|hf)'
            '://.+'),
```

`VOLUME` is deliberately excluded — it is not an object store and has no URL prefix. Non-store URLs (`ftp://…`, a bare path, a scheme with an empty body) are still rejected exactly as before.

Because `_S3_COMPATIBLE_STORES` is a registry that stores join at import time, a hand-maintained alternation will drift again. So the test derives its expectation from `StoreType` rather than restating the list — a newly registered store fails in CI instead of at a user's config load:

```python
for store_type in storage_lib.StoreType:
    if store_type == storage_lib.StoreType.VOLUME:
        continue
    url = f'{store_type.store_prefix()}my-bucket/sub-path'
    for section in ('jobs', 'serve'):
        self._validate(section, url)
```

This is schema-only; no runtime path changes. Both `jobs` and `serve` are covered because they share `_get_controller_schema()`.

## Tested

Against `skypilot-nightly==1.0.0.dev20260807`, whose `sky/utils/schemas.py`, `sky/data/storage.py` and `sky/utils/controller_utils.py` are byte-identical to `master` (verified with `diff`):

- **Before** (upstream `schemas.py`): the new test fails on 10 subtests — `oci://`, `nebius://`, `cw://`, `vastdata://`, `hf://buckets/`, each under both `jobs` and `serve`:
  ```
  jsonschema.exceptions.ValidationError: 'nebius://my-bucket/sub-path'
      does not match '^(https|s3|gs|r2|cos)://.+'
  ```
- **After**: the whole file passes — `103 passed, 26 subtests passed`.
- `yapf==0.32.0` reports no changes for either modified file. (`isort==5.12.0` flags `tests/unit_tests/test_sky/utils/test_schemas.py` identically before and after this change — pre-existing, left alone.)

One note for reviewers: `oci://` resolves only when the OCI extra is installed, since `OCIStore` registers itself into `_S3_COMPATIBLE_STORES` at import time. That does not affect the test above, which reads `store_prefix()` — it does not depend on the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->