### PR TITLE
fix(jobs): request worker autodown only where the cloud supports it (#10390)

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -15,6 +15,7 @@ import typing
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Set
 
 from sky import backends
+from sky import clouds
 from sky import dag as dag_lib
 from sky import exceptions
 from sky import global_user_state
@@ -70,6 +71,43 @@ def _is_oom_failure(exception: Exception) -> bool:
     """Whether `exception` indicates an out-of-memory pod termination."""
     message = common_utils.format_exception(exception).lower()
     return any(sig in message for sig in _OOM_FAILURE_SIGNATURES)
+
+
+def _autodown_is_supported(dag: 'dag_lib.Dag') -> bool:
+    """Whether the worker cluster's autodown failsafe can be requested.
+
+    Autodown on the ephemeral worker cluster is only a failsafe against a
+    resource leak if the controller dies; the normal path tears the cluster
+    down explicitly. Requesting it adds ``CloudImplementationFeatures.AUTODOWN``
+    to the launch's required features, which normally just narrows the
+    candidates to the clouds that implement autodown. When *every* candidate
+    is on a cloud that does not, that leaves nothing to fail over to and the
+    failsafe turns a launchable job into a provisioning precheck failure --
+    drop the failsafe rather than the job.
+
+    A resources candidate that leaves the cloud open counts as supporting
+    autodown, since the feature check can still resolve it to a cloud that
+    does.
+    """
+    for task in dag.tasks:
+        if not any(
+                _resources_support_autodown(candidate)
+                for candidate in task.resources):
+            return False
+    return True
+
+
+def _resources_support_autodown(candidate: 'resources.Resources') -> bool:
+    """Whether autodown can be requested for a single resources candidate."""
+    cloud = candidate.cloud
+    if cloud is None:
+        return True
+    try:
+        cloud.check_features_are_supported(
+            candidate, {clouds.CloudImplementationFeatures.AUTODOWN})
+    except exceptions.NotSupportedError:
+        return False
+    return True
 
 
 ENV_VARS_TO_CLEAR = [
@@ -944,18 +982,21 @@ class StrategyExecutor:
                             try:
                                 if reattach_request_id is None:
                                     extra_ctx = self.extra_launch_context()
+                                    # We expect to tear down the cluster as
+                                    # soon as the job is finished. However, in
+                                    # case the controller dies, set autodown to
+                                    # try and avoid a resource leak. Clouds
+                                    # without autodown support get no failsafe
+                                    # rather than a failed precheck.
+                                    autodown = _autodown_is_supported(self.dag)
                                     request_id = await asyncio.to_thread(
                                         sdk.launch,
                                         self.dag,
                                         cluster_name=self.cluster_name,
-                                        # We expect to tear down the cluster as
-                                        # soon as the job is finished. However,
-                                        # in case the controller dies, set
-                                        # autodown to try and avoid a resource
-                                        # leak.
                                         idle_minutes_to_autostop=(
-                                            _AUTODOWN_MINUTES),
-                                        down=True,
+                                            _AUTODOWN_MINUTES
+                                            if autodown else None),
+                                        down=autodown,
                                         _is_launched_by_jobs_controller=True,
                                         _file_mounts_blob_id=(
                                             self.file_mounts_blob_id),

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -988,7 +988,8 @@ class StrategyExecutor:
                                     # try and avoid a resource leak. Clouds
                                     # without autodown support get no failsafe
                                     # rather than a failed precheck.
-                                    autodown = _autodown_is_supported(self.dag)
+                                    autodown = await asyncio.to_thread(
+                                        _autodown_is_supported, self.dag)
                                     request_id = await asyncio.to_thread(
                                         sdk.launch,
                                         self.dag,

--- a/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
@@ -5,6 +5,9 @@ from unittest import mock
 
 import pytest
 
+import sky
+from sky import clouds
+from sky import dag as dag_lib
 from sky import exceptions
 from sky.jobs import recovery_strategy
 from sky.jobs import scheduler as scheduler_module
@@ -30,6 +33,53 @@ def test_is_oom_failure_is_case_insensitive():
 def test_is_oom_failure_false_for_unrelated():
     assert recovery_strategy._is_oom_failure(
         RuntimeError('/bin/bash: line 1: conda: command not found')) is False
+
+
+# ---------------------------------------------------------------------------
+# Worker-cluster autodown failsafe (skipped on clouds without autodown, so the
+# failsafe cannot turn a launchable job into a failed precheck).
+# ---------------------------------------------------------------------------
+
+
+def _dag_with(*infras):
+    dag = dag_lib.Dag()
+    dag.add(sky.Task().set_resources(
+        {sky.Resources(infra=infra) for infra in infras}))
+    return dag
+
+
+def test_autodown_is_supported_for_cloud_that_implements_it():
+    assert recovery_strategy._autodown_is_supported(_dag_with('aws')) is True
+
+
+def test_autodown_is_not_supported_when_the_pinned_cloud_rejects_it():
+    # Verda lists AUTODOWN in _CLOUD_UNSUPPORTED_FEATURES.
+    with pytest.raises(exceptions.NotSupportedError):
+        clouds.Verda.check_features_are_supported(
+            sky.Resources(infra='verda'),
+            {clouds.CloudImplementationFeatures.AUTODOWN})
+    assert recovery_strategy._autodown_is_supported(_dag_with('verda')) is False
+
+
+def test_autodown_is_kept_when_one_candidate_cloud_supports_it():
+    # With a supporting candidate left to fail over to, requesting autodown
+    # only narrows the candidates -- it does not fail the launch -- so the
+    # failsafe is worth keeping.
+    assert recovery_strategy._autodown_is_supported(_dag_with('aws',
+                                                              'verda')) is True
+
+
+def test_autodown_is_dropped_when_no_candidate_cloud_supports_it():
+    assert recovery_strategy._autodown_is_supported(
+        _dag_with('verda', 'verda/FIN-01')) is False
+
+
+def test_autodown_is_supported_when_no_cloud_is_pinned():
+    # An open cloud choice keeps the current behaviour: the requested feature
+    # narrows the candidates rather than failing the launch outright.
+    dag = dag_lib.Dag()
+    dag.add(sky.Task())
+    assert recovery_strategy._autodown_is_supported(dag) is True
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +321,42 @@ def _patch_launch_environment(monkeypatch):
     return types.SimpleNamespace(sdk_launch=sdk_launch,
                                  set_restarting=set_restarting,
                                  set_backoff_pending=set_backoff_pending)
+
+
+@pytest.mark.asyncio
+async def test_launch_requests_autodown_on_a_supporting_cloud(monkeypatch):
+    """The leak failsafe stays on where the cloud implements autodown."""
+    executor = _make_launch_executor()
+    executor.dag = _dag_with('aws')
+    patches = _patch_launch_environment(monkeypatch)
+    executor._await_launch_request = mock.AsyncMock(return_value=None)
+
+    assert await executor._launch(max_retry=1, raise_on_failure=True) == 123.45
+
+    kwargs = patches.sdk_launch.call_args.kwargs
+    assert kwargs['down'] is True
+    assert kwargs['idle_minutes_to_autostop'] == (
+        recovery_strategy._AUTODOWN_MINUTES)
+
+
+@pytest.mark.asyncio
+async def test_launch_skips_autodown_on_a_cloud_without_it(monkeypatch):
+    """Autodown must not be requested on a cloud that cannot do it.
+
+    Otherwise the failsafe adds AUTODOWN to the launch's required features and
+    the job fails prechecks on that cloud instead of running.
+    """
+    executor = _make_launch_executor()
+    executor.dag = _dag_with('verda')
+    patches = _patch_launch_environment(monkeypatch)
+    executor._await_launch_request = mock.AsyncMock(return_value=None)
+
+    assert await executor._launch(max_retry=1, raise_on_failure=True) == 123.45
+
+    kwargs = patches.sdk_launch.call_args.kwargs
+    assert kwargs['down'] is False
+    # Left unset rather than flipped to autostop, which Verda also rejects.
+    assert kwargs['idle_minutes_to_autostop'] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Fixes #10390.

`StrategyExecutor._launch` starts the ephemeral managed-job worker cluster with `down=True` (`sky/jobs/recovery_strategy.py`) as a leak failsafe in case the controller dies — normal completion tears the cluster down explicitly. `down=True` makes `sky/execution.py` add `CloudImplementationFeatures.AUTODOWN` to the launch's `requested_features`.

Usually that only *narrows* the candidates: clouds without autodown get filtered out during failover. But when every candidate sits on such a cloud there is nothing left to fail over to, and the failsafe fails the whole job before provisioning:

```
sky.exceptions.NotSupportedError: The following features are not supported by Verda:
        Feature   Reason
        autodown  Auto-down is not supported on Verda.
⨯ Failed to provision resources. ... Provision prechecks failed for task 0
```

Worker autodown was originally disabled in #6873 for exactly this reason and restored unconditionally in #9573 while fixing Nebius autodown; Verda (#8160) landed in between.

## Fix

Ask the cloud before requesting the failsafe, using the same `check_features_are_supported` pattern already used in `sky/core.py`'s autostop path:

* a resources candidate whose cloud is unset counts as supporting autodown (the feature check can still resolve it to a cloud that does);
* the failsafe is requested unless **every** candidate of a task rejects `AUTODOWN`.

So the leak protection is unchanged wherever it can apply — including a mixed `aws` + `verda` request, where AWS is still a valid fallback — and is dropped only in the case that would otherwise fail the launch. When it is dropped, `idle_minutes_to_autostop` is left `None` rather than flipped to autostop, since a cloud without `AUTODOWN` typically rejects `AUTOSTOP` too.

## Tests

Added to `tests/unit_tests/test_sky/jobs/test_recovery_strategy.py`, using the real `Verda`/`AWS` cloud classes rather than stubs:

* `_autodown_is_supported` for a supporting cloud, a rejecting cloud, a mixed candidate set, and an unpinned cloud;
* two end-to-end assertions on the `sdk.launch` call from `_launch`: `down=True` / `idle_minutes_to_autostop=10` on AWS (guards the existing behaviour) and `down=False` / `idle_minutes_to_autostop=None` on Verda.

6 of the 7 autodown tests fail on `master` and all pass with the change; the full `test_recovery_strategy.py` + `test_controller.py` suites are green (30 and 92 tests respectively). `yapf==0.32.0` and `isort==5.12.0` are clean on both changed files.

Note on scope: the same unconditional `down=True` is not present on the serve replica path, so this touches the jobs controller only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->