### PR TITLE
[Test] Resolve managed jobs by job id in smoke tests, not by reused names

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -48,7 +48,10 @@ from sky.utils import yaml_utils
 # manual termination with aws ec2 does not accidentally terminate other clusters
 # for the different managed jobs launch with the same job name but a
 # different job id.
-test_id = str(uuid.uuid4())[-2:]
+# 4 chars: on a long-lived API server the jobs table accumulates every past
+# run of a test, so 2 chars (256 possible names per test) collides with an
+# older same-named job roughly N_history/256 of the time.
+test_id = str(uuid.uuid4())[-4:]
 
 LAMBDA_GPU_TYPE = 'A100'
 LAMBDA_TYPE = f'--infra lambda --gpus {LAMBDA_GPU_TYPE}'
@@ -1544,22 +1547,38 @@ def write_blob(file: BinaryIO, total_size: int):
     file.flush()
 
 
-def wait_for_managed_job_status_sdk(job_name: str,
-                                    target_statuses: list,
-                                    timeout: int = 360) -> dict:
+def wait_for_managed_job_status_sdk(job_name: Optional[str] = None,
+                                    target_statuses: Optional[list] = None,
+                                    timeout: int = 360,
+                                    job_id: Optional[int] = None) -> dict:
     """Wait for a managed job to reach one of the target statuses.
+
+    Identify the job by ``job_id`` where possible: job names are not unique,
+    so on a long-lived API server a name-based wait can match a terminal
+    job left over from an earlier run of the same test and return before
+    the current job has even started. When only ``job_name`` is given, the
+    newest exactly-matching job is tracked for the same reason.
 
     Returns the job record when the status is reached.
     """
+    assert target_statuses, 'target_statuses must be non-empty'
+    assert (job_id is None) != (job_name is None), (
+        'Exactly one of job_id or job_name must be provided.')
     start_time = time.time()
     while time.time() - start_time < timeout:
         jobs_list = sky.get(
-            sky.jobs.queue_v2(refresh=False, fields=['job_name', 'status']))[0]
-        for job in jobs_list:
-            if job['job_name'] == job_name:
-                if job['status'] in target_statuses:
-                    return job
-            print(f'Job {job_name} status: {job["status"]}')
+            sky.jobs.queue_v2(refresh=False,
+                              job_ids=None if job_id is None else [job_id],
+                              fields=['job_id', 'job_name', 'status']))[0]
+        if job_id is None:
+            matches = [j for j in jobs_list if j['job_name'] == job_name]
+        else:
+            matches = jobs_list
+        if matches:
+            job = max(matches, key=lambda j: j['job_id'])
+            if job['status'] in target_statuses:
+                return job
+            print(f'Job {job_name or job_id} status: {job["status"]}')
         time.sleep(5)
-    raise TimeoutError(
-        f'Timeout waiting for job {job_name} to reach {target_statuses}')
+    raise TimeoutError(f'Timeout waiting for job {job_name or job_id} to reach '
+                       f'{target_statuses}')

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -3429,8 +3429,12 @@ def test_job_group_primary_auxiliary(generic_cloud: str):
                 # transitioning when we check
                 f's=$({smoke_tests_utils.GET_JOB_QUEUE} | grep -A 2 {name}); '
                 f'echo "$s"; echo "$s" | grep replay-buffer | grep -E "CANCELLING|CANCELLED"',
-                # Verify logs show the termination delay message
-                f'sky jobs logs --controller -n {name} --no-follow | '
+                # Verify logs show the termination delay message. Resolve the
+                # job id first: `-n` errors out on an API server that retains
+                # an older same-named job from a previous run of this test.
+                f'JOB_ID=$(sky jobs queue | grep {name} | head -1 | '
+                f'awk \'{{print $1}}\'); '
+                f'sky jobs logs --controller "$JOB_ID" --no-follow | '
                 f'grep -E "Waiting.*before terminating|Terminating auxiliary"',
             ],
             f'sky jobs cancel -y -n {name}',
@@ -3551,25 +3555,36 @@ def test_managed_job_node_names_single_node(generic_cloud: str):
             task.set_resources(
                 sky.Resources(infra=generic_cloud,
                               **smoke_tests_utils.LOW_RESOURCE_PARAM))
+            job_id = None
             try:
-                sky.stream_and_get(sky.jobs.launch(task, name=name))
+                # Track the job by id, not name: an API server shared across
+                # runs may retain an older SUCCEEDED job with the same name.
+                job_ids, _ = sky.stream_and_get(sky.jobs.launch(task,
+                                                                name=name))
+                assert job_ids, 'jobs.launch returned no job ids'
+                job_id = job_ids[0]
                 # Wait for job to be running and node_names to be populated
                 # Use longer timeout to account for controller startup
-                job = smoke_tests_utils.wait_for_managed_job_status_sdk(
-                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=400)
+                smoke_tests_utils.wait_for_managed_job_status_sdk(
+                    job_id=job_id,
+                    target_statuses=[sky.ManagedJobStatus.SUCCEEDED],
+                    timeout=400)
                 # Give time for node_names to be populated after launch
                 time.sleep(10)
                 # Re-fetch to get updated node_names
                 jobs_list = sky.get(
                     sky.jobs.queue_v2(refresh=False,
-                                      fields=['job_name', 'node_names']))[0]
-                job = [j for j in jobs_list if j['job_name'] == name][0]
-                node_names = job['node_names']
+                                      job_ids=[job_id],
+                                      fields=['job_id', 'node_names']))[0]
+                node_names = jobs_list[0]['node_names']
                 assert node_names, (f'node_names should not be empty, '
                                     f'got: {node_names}')
                 print(f'node_names: {node_names}')
             finally:
-                sky.jobs.cancel(name=name)
+                if job_id is not None:
+                    sky.jobs.cancel(job_ids=[job_id])
+                else:
+                    sky.jobs.cancel(name=name)
 
 
 @pytest.mark.managed_jobs
@@ -3585,20 +3600,28 @@ def test_managed_job_node_names_multi_node(generic_cloud: str):
             task.set_resources(
                 sky.Resources(infra=generic_cloud,
                               **smoke_tests_utils.LOW_RESOURCE_PARAM))
+            job_id = None
             try:
-                sky.stream_and_get(sky.jobs.launch(task, name=name))
+                # Track the job by id, not name: an API server shared across
+                # runs may retain an older SUCCEEDED job with the same name.
+                job_ids, _ = sky.stream_and_get(sky.jobs.launch(task,
+                                                                name=name))
+                assert job_ids, 'jobs.launch returned no job ids'
+                job_id = job_ids[0]
                 # Wait for job to be running
                 # Use longer timeout to account for controller startup
-                job = smoke_tests_utils.wait_for_managed_job_status_sdk(
-                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=400)
+                smoke_tests_utils.wait_for_managed_job_status_sdk(
+                    job_id=job_id,
+                    target_statuses=[sky.ManagedJobStatus.SUCCEEDED],
+                    timeout=400)
                 # Give time for node_names to be populated after launch
                 time.sleep(10)
                 # Re-fetch to get updated node_names
                 jobs_list = sky.get(
                     sky.jobs.queue_v2(refresh=False,
-                                      fields=['job_name', 'node_names']))[0]
-                job = [j for j in jobs_list if j['job_name'] == name][0]
-                node_names = job['node_names']
+                                      job_ids=[job_id],
+                                      fields=['job_id', 'node_names']))[0]
+                node_names = jobs_list[0]['node_names']
                 assert node_names, (f'node_names should not be empty, '
                                     f'got: {node_names}')
                 nodes = node_names.split(',')
@@ -3606,7 +3629,10 @@ def test_managed_job_node_names_multi_node(generic_cloud: str):
                                          f'got {len(nodes)}: {nodes}')
                 print(f'node_names: {node_names} ({len(nodes)} nodes)')
             finally:
-                sky.jobs.cancel(name=name)
+                if job_id is not None:
+                    sky.jobs.cancel(job_ids=[job_id])
+                else:
+                    sky.jobs.cancel(name=name)
 
 
 @pytest.mark.managed_jobs


### PR DESCRIPTION
## Problem

Two smoke tests fail deterministically-looking on shared/staging API servers (e.g. `smoke-tests-private-repo-feature-plugin` build 2183, 3/3 attempts each), but the product behavior is correct. The real cause is **job-name collisions with historical CI jobs**:

`get_cluster_name()` truncates the test name deterministically (e.g. always `t-managed-job-nod-lg` for `test_managed_job_node_names_single_node`) and appends `test_id = str(uuid.uuid4())[-2:]` — only 256 possible names per test. A long-lived API server retains every past run's jobs (the staging CI tenant currently holds 117 jobs for that one prefix), so each attempt collides with an older *exactly-identical* name ~46% of the time, and worse every day.

Two distinct failure modes observed:

- **`test_managed_job_node_names_single_node`**: `wait_for_managed_job_status_sdk` matches by name only, so it returned instantly on a *historical* SUCCEEDED job while the current job was still provisioning; the `node_names` re-fetch then read the current (still-STARTING) job → `AssertionError: node_names should not be empty, got: None`. All three Buildkite attempts collided (verified against the staging jobs DB: `-lg-0b`↔job 6784, `-lg-7d`↔12128, `-lg-23`↔415).
- **`test_job_group_primary_auxiliary`**: the last step runs `sky jobs logs --controller -n <name>`, which raises `Multiple managed jobs found with name ... Please specify the job_id instead.` on any duplicate → empty grep → step fails. The current job's controller log does contain the expected "Waiting 5s before terminating auxiliary job" / "Terminating auxiliary job" lines.

## Fix

- Capture the job id `jobs.launch` already returns and use it end-to-end in both node_names tests (wait, `queue_v2(job_ids=[...])` re-fetch, cancel) — collision-proof regardless of history.
- `wait_for_managed_job_status_sdk`: add a `job_id` parameter; the remaining name-based path now tracks the **newest** exact match instead of returning on the first one (which can be a historical job). Also fixes the misleading per-poll print that logged every job's status under the target's name.
- `test_job_group_primary_auxiliary`: resolve the job id from `sky jobs queue` (same pattern as `test_job_group_git_workdir`) before `sky jobs logs --controller`.
- Widen `test_id` to 4 hex chars (65,536 names per test) as insurance for the remaining name-based shell checks. The on-cloud name grows by 2 chars, staying within the managed-jobs budget.

## Tests

- `pre-commit run --files tests/smoke_tests/smoke_tests_utils.py tests/smoke_tests/test_managed_job.py` — all hooks pass (isort, mypy, yapf).
- Helper logic exercised against the recorded collision data: id path returns only the target job; name path no longer returns prematurely on a historical SUCCEEDED job.
- The third `wait_for_managed_job_status_sdk` caller (emergency-recovery test) passes positionally and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->