### PR TITLE
[Kubernetes] Add opt-in authoritative Helm config mode

### DIFF
--- a/charts/skypilot/developer.md
+++ b/charts/skypilot/developer.md
@@ -8,6 +8,11 @@
 the API server. Instead, we provide instructions for updating config 
 (see: https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#setting-the-skypilot-config).
 
+For GitOps deployments, `apiService.configAuthoritative: true` opts into
+using the ConfigMap as the source of truth. It requires a non-empty
+`apiService.config` and overwrites the PVC copy whenever the API server
+starts. Keep it disabled when configuration is managed through the dashboard.
+
 ### Why PVC?
 - **Fast:** Immediate reflection of config changes
 - **Unified:** Consistent with non-Kubernetes deployments  

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -80,7 +80,7 @@ when umbrella charts set apiService.nodeSelector / tolerations / affinity.
 Check for apiService.config during upgrade and display warning
 */}}
 {{- define "skypilot.checkUpgradeConfig" -}}
-{{- if and .Release.IsUpgrade .Values.apiService.config -}}
+{{- if and .Release.IsUpgrade .Values.apiService.config (not .Values.apiService.configAuthoritative) -}}
 WARNING: apiService.config is set during an upgrade operation, which will be IGNORED.
 
 To update your SkyPilot config, follow the instructions in the upgrade guide:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -5,6 +5,9 @@
        storage mounts / ephemeral ~/.sky / env below key off this rather than
        storage.enabled alone. */ -}}
 {{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
+{{- if and .Values.apiService.configAuthoritative (not .Values.apiService.config) }}
+{{- fail "apiService.config must be set when apiService.configAuthoritative is true" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,6 +41,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.apiService.configAuthoritative }}
+        checksum/config: {{ .Values.apiService.config | sha256sum }}
+        {{- end }}
         {{- if .Values.apiService.metrics.enabled }}
         {{- if .Values.prometheus.useDedicatedScrapeConfig }}
         skypilot.co/scrape: "true"
@@ -227,6 +233,11 @@ spec:
             rm /root/.sky/config.yaml
           fi
           # Initialize the SkyPilot config.
+          {{- if .Values.apiService.configAuthoritative }}
+          # The ConfigMap is the source of truth for deployments that manage
+          # apiService.config through Helm or GitOps.
+          cp /var/skypilot/config/config.yaml /root/.sky/config.yaml
+          {{- else }}
           if [ -s /root/.sky/config.yaml ]; then
             # If the config.yaml is not empty, sync the PVC config to ConfigMap
             python3 -c "from sky.utils.kubernetes import config_map_utils; config_map_utils.initialize_configmap_sync_on_startup('~/.sky/config.yaml')"
@@ -235,6 +246,7 @@ spec:
             # user specified config.
             cp /var/skypilot/config/config.yaml /root/.sky/config.yaml
           fi
+          {{- end }}
           {{- if .Values.apiService.sshNodePools }}
           mkdir -p /root/.sky
           echo "Linking ssh_node_pools.yaml from secret to /root/.sky/ssh_node_pools.yaml"

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1357,3 +1357,39 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "initialize_configmap_sync_on_startup"
+
+  - it: should use authoritative config with ephemeral state when storage is disabled
+    set:
+      storage.enabled: false
+      apiService.configAuthoritative: true
+      apiService.config: |
+        kubernetes:
+          provision_timeout: 901
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: state-volume
+            emptyDir: {}
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "cp /var/skypilot/config/config.yaml /root/.sky/config.yaml"
+
+  - it: should attach an existing claim in authoritative mode
+    set:
+      storage.enabled: false
+      storage.existingClaim: existing-state
+      apiService.configAuthoritative: true
+      apiService.config: |
+        kubernetes:
+          provision_timeout: 901
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: state-volume
+            persistentVolumeClaim:
+              claimName: existing-state
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "cp /var/skypilot/config/config.yaml /root/.sky/config.yaml"

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1318,3 +1318,42 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "exec sky api start .*--host=::"
+
+  # Test cases for apiService.configAuthoritative configuration
+  - it: should keep the PVC-to-ConfigMap sync by default
+    set:
+      apiService.config: |
+        kubernetes:
+          provision_timeout: 901
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "if \\[ -s /root/\\.sky/config\\.yaml \\]; then"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "initialize_configmap_sync_on_startup"
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: should require config when authoritative mode is enabled
+    set:
+      apiService.configAuthoritative: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "apiService.config must be set when apiService.configAuthoritative is true"
+
+  - it: should make the ConfigMap authoritative when configured
+    set:
+      apiService.configAuthoritative: true
+      apiService.config: |
+        kubernetes:
+          provision_timeout: 901
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "cp /var/skypilot/config/config.yaml /root/.sky/config.yaml"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "initialize_configmap_sync_on_startup"

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -26,6 +26,9 @@
                         "null"
                     ]
                 },
+                "configAuthoritative": {
+                    "type": "boolean"
+                },
                 "dbConnectionSecretName": {
                     "type": [
                         "string",

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -109,8 +109,10 @@ apiService:
     timeoutSeconds: 1
 
   # Set ~/.sky/config.yaml content on the API server
-  # This value is IGNORED during an helm upgrade if there is an existing config
-  # due to the potential accidental loss of existing config. Use the SkyPilot dashboard to update the config.
+  # By default, this value is ignored during a helm upgrade if there is an
+  # existing config due to the potential accidental loss of existing config.
+  # Set configAuthoritative to true for GitOps-managed configuration.
+  # Otherwise, use the SkyPilot dashboard to update the config.
   # If remote database is configured (either via dbConnectionSecretName or dbConnectionString), config must be null.
   # In such case, you can add the config via the dashboard once the API server is deployed.
   # Refer to https://docs.skypilot.co/en/latest/reference/config.html for more details.

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -116,6 +116,11 @@ apiService:
   # Refer to https://docs.skypilot.co/en/latest/reference/config.html for more details.
   # @schema type: [string, null]
   config: null
+  # When true, copy apiService.config to ~/.sky/config.yaml on every API server start.
+  # This makes the ConfigMap authoritative and is useful when Helm values are managed by GitOps.
+  # When false, an existing config on the persistent volume remains authoritative.
+  # @schema type: [boolean]
+  configAuthoritative: false
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy
   #

--- a/docs/source/admin/workspaces.rst
+++ b/docs/source/admin/workspaces.rst
@@ -140,9 +140,10 @@ To apply the configuration, follow the following steps:
          helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
             --namespace $NAMESPACE \
             --reuse-values \
+            --set apiService.configAuthoritative=true \
             --set-file apiService.config=/your/path/to/config.yaml
 
-      To change workspace configuration, update the config file and run the same command again. The API server will reload the new configuration automatically with no downtime. For more details, refer to :ref:`Setting the SkyPilot config in Helm Deployment <sky-api-server-config>`.
+      To change workspace configuration, update the config file and run the same command again. The ``configAuthoritative`` setting is required for Helm to replace an existing config on the persistent volume. The API server will reload the new configuration automatically with no downtime. For more details, refer to :ref:`Setting the SkyPilot config in Helm Deployment <sky-api-server-config>`.
 
    .. tab-item:: VM Deployment or Local API Server
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -1341,7 +1341,7 @@ To modify your SkyPilot config, use the SkyPilot dashboard: ``http://<api-server
 
     .. note::
 
-        ``apiService.config`` will be IGNORED during an ``helm upgrade`` if there is an existing config, due to the potential accidental loss of existing config. Use the SkyPilot dashboard instead.
+        By default, ``apiService.config`` is ignored during a ``helm upgrade`` if there is an existing config, due to the potential accidental loss of existing config. Use the SkyPilot dashboard instead. For GitOps deployments where the Helm values are the source of truth, set :ref:`apiService.configAuthoritative <helm-values-apiService-configAuthoritative>` to ``true`` together with a non-empty ``apiService.config``. This overwrites the persistent-volume config every time the API server starts, so do not enable it for configurations managed through the dashboard.
 
     .. note::
 

--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -144,7 +144,7 @@ The upgraded API server is ready to serve requests after the pod becomes running
 
 .. note::
 
-    ``apiService.config`` will be IGNORED during an upgrade. To update your SkyPilot config, see :ref:`here <sky-api-server-config>`.
+    By default, ``apiService.config`` is ignored during an upgrade when a config already exists on the persistent volume. To make Helm values authoritative for a GitOps deployment, set :ref:`apiService.configAuthoritative <helm-values-apiService-configAuthoritative>` to ``true``. Otherwise, update your SkyPilot config through the dashboard as described :ref:`here <sky-api-server-config>`.
 
 
 Step 3: Verify the upgrade

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -54,6 +54,7 @@ Below is the available helm value keys and the default value of each key:
       # echo "Installing admin policy"
       # pip install git+https://github.com/michaelvll/admin-policy-examples
     :ref:`config <helm-values-apiService-config>`: null
+    :ref:`configAuthoritative <helm-values-apiService-configAuthoritative>`: false
     :ref:`dbConnectionSecretName <helm-values-apiService-dbConnectionSecretName>`: null
     :ref:`dbConnectionString <helm-values-apiService-dbConnectionString>`: null
     :ref:`sshNodePools <helm-values-apiService-sshNodePools>`: null
@@ -586,6 +587,22 @@ Default: ``null``
       allowed_clouds:
         - aws
         - gcp
+
+.. _helm-values-apiService-configAuthoritative:
+
+``apiService.configAuthoritative``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When enabled, the API server copies ``apiService.config`` to ``~/.sky/config.yaml`` every time the API server starts. This makes the ConfigMap the source of truth and is useful when Helm values are managed by GitOps. Any existing configuration on the persistent volume is overwritten. ``apiService.config`` must be set to a non-empty value when this option is enabled.
+
+When disabled, an existing configuration on the persistent volume remains the source of truth. ``apiService.config`` is used only to initialize an empty persistent volume, preserving the default behavior for configurations managed through the SkyPilot dashboard.
+
+Default: ``false``
+
+.. code-block:: yaml
+
+  apiService:
+    configAuthoritative: true
 
 .. _helm-values-apiService-dbConnectionSecretName:
 


### PR DESCRIPTION
## Summary

- Add an opt-in `apiService.configAuthoritative` mode for GitOps-managed Helm deployments.
- Keep the existing PVC-first behavior by default, while allowing the ConfigMap to overwrite the PVC config on API server startup when explicitly enabled.
- Document the ownership trade-off and cover persistent, ephemeral, checksum, and invalid empty-config cases in the chart tests.

Fixes #10397

## Behavior

With the default `configAuthoritative: false`, an existing `~/.sky/config.yaml` on the persistent volume remains authoritative and the chart preserves the current PVC-to-ConfigMap sync behavior.

With `configAuthoritative: true`, a non-empty `apiService.config` is required. The chart copies the ConfigMap value to the persistent volume on every API server start and adds a config checksum so Helm changes roll the Deployment. The upgrade warning is suppressed for this explicit mode.

## Validation

- `helm unittest charts/skypilot --failfast` — 157 passed
- `helm lint charts/skypilot` — passed
- `helm schema -o ...` followed by a schema comparison — exact match
- `helm template` verified both default and authoritative startup branches
- `git diff --check` — passed

I did not run a live Kubernetes deployment; the change is limited to Helm
templates, values/schema, documentation, and chart tests.

AI assistance was used for research, implementation, and test drafting. I reviewed the resulting diff and verified the behavior locally.
