### PR TITLE
[Test] Fix cloud-cmd exclusion in test_services_on_kubernetes

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1348,9 +1348,32 @@ def test_task_labels_kubernetes():
 @pytest.mark.kubernetes
 def test_services_on_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
+    # The check runs from inside the cloud-cmd helper pod, which shares the
+    # namespace with the cluster under test, so the helper's own Services must
+    # be excluded. Resolve the helper by its *on-cloud* name instead of
+    # matching a literal '-cloud-cmd' in the Service name: the helper's display
+    # name '<name>-cloud-cmd' is longer than the budget left by Kubernetes'
+    # 42-char cluster-name limit minus the user hash, so
+    # make_cluster_name_on_cloud() truncates it to '<name>-clou-<hash>' and the
+    # suffix never reaches the Service name. Only the pod *annotation* keeps
+    # the full cluster name (labels have a length limit); Service labels carry
+    # the truncated on-cloud name, which is what the exclusion must match.
+    # With no helper (local API server) the command runs on the test driver and
+    # there is nothing to exclude.
+    resolve_helper = (
+        'helper=$(kubectl get pods -o custom-columns='
+        "':metadata.labels.skypilot-cluster-name"
+        ",:metadata.annotations.skypilot-cluster-name' --no-headers | "
+        'awk -v n=' + shlex.quote(f'{name}-cloud-cmd') +
+        " '$2==n {print $1; exit}')")
     service_check = smoke_tests_utils.run_cloud_cmd_on_cluster(
-        name,
-        f'services=$(kubectl get svc -o name | grep -F {name} | grep -v -- "-cloud-cmd" || true); '
+        name, f'{resolve_helper}; '
+        'if [ -n "$helper" ]; then '
+        'services=$(kubectl get svc -l "skypilot-cluster-name!=$helper" '
+        f'-o name | grep -F {name} || true); '
+        'else '
+        f'services=$(kubectl get svc -o name | grep -F {name} || true); '
+        'fi; '
         'echo "[$services]"; '
         'if [ -n "$services" ]; then echo "services found"; exit 1; else echo "services not found"; fi'
     )


### PR DESCRIPTION
## Problem

`test_services_on_kubernetes` asserts that `sky down` leaves no Kubernetes
Services behind. It lists Services by name and excludes the cloud-cmd helper's
own with a literal `grep -v -- "-cloud-cmd"`:

```python
f'services=$(kubectl get svc -o name | grep -F {name} | grep -v -- "-cloud-cmd" || true); '
```

Service names carry the **on-cloud** cluster name. The helper's display name
`<name>-cloud-cmd` no longer fits the budget left by Kubernetes' 42-char
cluster-name limit minus the user hash (33 chars), so
`make_cluster_name_on_cloud()` truncates it and the `-cloud-cmd` marker
disappears:

| display name | len | on-cloud name | `-cloud-cmd` survives? |
|---|---|---|---|
| `t-services-on-kub-7r-79-cloud-cmd` | 33 | `…-79-cloud-cmd-<user hash>` | yes |
| `t-services-on-kub-7r-112c-cloud-cmd` | **35** | `…-112c-clou-55-<user hash>` | **no** |

The exclusion never fires, so the helper's own Services are reported as
leftovers and teardown fails with a `CalledProcessError`:

```
[service/t-services-on-kub-7r-112c-clou-55-<hash>-head
 service/t-services-on-kub-7r-112c-clou-55-<hash>-head-ssh]
services found
```

`sky down` itself is fine — the cluster under test is fully cleaned up; only the
helper's Services remain, and they are the ones being misattributed.

Only runs that use a cloud-cmd helper are affected (a remote API server); with a
local API server the check runs on the test driver and there is no helper. Note
the two spellings above differ only by the length of the per-run test id, so
cluster names sit right on the truncation boundary — the exclusion cannot depend
on the display suffix surviving into the Service name.

## Fix

Resolve the helper by its on-cloud name instead of by the display suffix.

Pods carry the full cluster name in the `skypilot-cluster-name` **annotation** —
that annotation exists precisely because labels have a length limit
(`sky/provision/kubernetes/instance.py`) — while Services are labelled with the
truncated on-cloud name. So: find the pod whose annotation is
`<name>-cloud-cmd`, read its `skypilot-cluster-name` label, and exclude Services
carrying that label. When no helper pod is found there is nothing to exclude and
the listing is unfiltered, preserving the local-API-server path.

`test_managed_jobs_recovery_kubernetes_multinode` already matches on the
annotation for this exact reason; this brings the Services check in line with it.

## Testing

Run against a Kubernetes cluster holding the exact objects the failure produces
(helper pod with label = on-cloud name and annotation = full name, plus its two
Services):

- **Post-`sky down` state, only the helper's Services present** — old check
  reports both and exits 1; new check reports `[]` and passes.
- **A genuine leftover Service for the cluster under test** — new check still
  reports it and exits 1, so the assertion keeps its value.
- **No helper (local-API-server path)** — unfiltered listing, unchanged
  behaviour.

`pytest tests/smoke_tests/test_cluster_job.py::test_services_on_kubernetes --kubernetes --remote-server`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->