### PR TITLE
[Slurm] Preserve accelerator env in SSH sessions

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1440,6 +1440,8 @@ def srun_sshd_command(
         'GPU_DEVICE_ORDINAL',
     )
     accelerator_env_var_names = ' '.join(accelerator_env_vars)
+    dropbear_env_var_names = ' '.join(
+        (*accelerator_env_vars, 'LD_LIBRARY_PATH'))
 
     if is_container_image:
         # Dropbear + socat bridge for container mode.
@@ -1453,16 +1455,24 @@ def srun_sshd_command(
             'echo "dropbear not found" >&2; exit 1; fi; '
             # -e was added in Dropbear 2022.83. Existing images can provide an
             # older binary in PATH, so preserve the old SSH behavior when the
-            # installed server does not advertise environment forwarding.
+            # installed server does not support environment forwarding.
             'DROPBEAR_ENV_FLAG=(); '
-            'if "$DROPBEAR" -h 2>&1 | '
-            'grep -Eq -- \'(^|[[:space:]])-e([[:space:]]|$)\'; then '
+            'DROPBEAR_VERSION=$("$DROPBEAR" -V 2>&1 || true); '
+            'if [[ $DROPBEAR_VERSION =~ '
+            '([0-9][0-9][0-9][0-9])\\.([0-9]+) ]]; then '
+            'DROPBEAR_VERSION_YEAR=${BASH_REMATCH[1]}; '
+            'DROPBEAR_VERSION_RELEASE=${BASH_REMATCH[2]}; '
+            'if (( DROPBEAR_VERSION_YEAR > 2022 || '
+            '(DROPBEAR_VERSION_YEAR == 2022 && '
+            'DROPBEAR_VERSION_RELEASE >= 83) )); then '
             'DROPBEAR_ENV_FLAG=(-e); fi; '
+            'fi; '
             # Dropbear -e forwards its entire environment. Start it with only
             # the accelerator variables so proxy-step SLURM_* variables and
-            # unrelated submit-side values do not leak into SSH sessions.
+            # unrelated submit-side values do not leak into SSH sessions. Keep
+            # LD_LIBRARY_PATH so dynamically linked custom binaries still load.
             'DROPBEAR_ENV=(); '
-            f'for NAME in {accelerator_env_var_names}; do '
+            f'for NAME in {dropbear_env_var_names}; do '
             'if declare -p "$NAME" &>/dev/null; then '
             'DROPBEAR_ENV+=("$NAME=${!NAME}"); fi; done; '
             # Find a free port in the ephemeral range
@@ -1509,8 +1519,7 @@ def srun_sshd_command(
     # covers NVIDIA, AMD, and Intel accelerator visibility variables emitted
     # by Slurm's GRES plugins. Skip unexpected values instead of allowing them
     # to alter sshd's configuration parser input.
-    sshd_command = shlex.join([
-        '/usr/sbin/sshd',
+    sshd_command = '"$SSHD" ' + shlex.join([
         '-i',  # Uses stdin/stdout
         '-e',  # Writes errors to stderr
         '-f',  # Use /dev/null to avoid reading system sshd_config
@@ -1532,13 +1541,20 @@ def srun_sshd_command(
         f'AcceptEnv={constants.SKY_CLUSTER_NAME_ENV_VAR_KEY}',
     ])
     ssh_bootstrap_cmd = (
-        'SSHD_SET_ENV=; '
+        'SSHD=/usr/sbin/sshd; SSHD_SET_ENV_SUPPORTED=0; '
+        'SSHD_VERSION=$("$SSHD" -V 2>&1 || true); '
+        'if [[ $SSHD_VERSION =~ OpenSSH_([0-9]+)\\.([0-9]+) ]]; then '
+        'SSHD_VERSION_MAJOR=${BASH_REMATCH[1]}; '
+        'SSHD_VERSION_MINOR=${BASH_REMATCH[2]}; '
+        'if (( SSHD_VERSION_MAJOR > 7 || '
+        '(SSHD_VERSION_MAJOR == 7 && SSHD_VERSION_MINOR >= 8) )); then '
+        'SSHD_SET_ENV_SUPPORTED=1; fi; fi; SSHD_SET_ENV=; '
         f'for NAME in {accelerator_env_var_names}; do '
         'if declare -p "$NAME" &>/dev/null; then VALUE=${!NAME}; '
         'case "$VALUE" in *[!a-zA-Z0-9_.,:/@%+=-]*) continue;; esac; '
         'SSHD_SET_ENV+="${SSHD_SET_ENV:+ }$NAME=$VALUE"; fi; done; '
         f'set -- {sshd_command}; '
-        '[[ -z $SSHD_SET_ENV ]] || '
+        '[[ -z $SSHD_SET_ENV || $SSHD_SET_ENV_SUPPORTED != 1 ]] || '
         'set -- "$@" -o "SetEnv=$SSHD_SET_ENV"; exec "$@"')
 
     return shlex.join([

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1429,9 +1429,17 @@ def srun_sshd_command(
     # because we override the home directory in SlurmCommandRunner.run.
     user_home_ssh_dir = f'~{unix_user}/.ssh'
 
-    # TODO(kevin): SSH sessions don't inherit Slurm env vars (SLURM_*, CUDA_*,
-    # etc.) because sshd/dropbear spawns a fresh shell. Fix by capturing env
-    # to a file and sourcing it.
+    # Slurm sets accelerator visibility variables on the process launched by
+    # srun. SSH servers build a fresh environment for child sessions, so these
+    # variables need to be forwarded explicitly. Keep this list limited to
+    # values whose syntax is safe in an sshd SetEnv directive.
+    accelerator_env_vars = (
+        'CUDA_VISIBLE_DEVICES',
+        'ROCR_VISIBLE_DEVICES',
+        'ZE_AFFINITY_MASK',
+        'GPU_DEVICE_ORDINAL',
+    )
+    accelerator_env_var_names = ' '.join(accelerator_env_vars)
 
     if is_container_image:
         # Dropbear + socat bridge for container mode.
@@ -1449,7 +1457,9 @@ def srun_sshd_command(
             'ss -tln | awk \'{print $4}\' | grep -q ":$PORT$" || break; '
             'done; '
             # Start dropbear and wait for it to bind
-            '"$DROPBEAR" -F -s -R -p "127.0.0.1:$PORT" & '
+            # Dropbear normally rebuilds the child environment too. -e passes
+            # the environment injected by Slurm into the SSH session.
+            '"$DROPBEAR" -e -F -s -R -p "127.0.0.1:$PORT" & '
             'DROPBEAR_PID=$!; '
             'trap "kill $DROPBEAR_PID 2>/dev/null" EXIT; '
             'for i in $(seq 1 50); do '
@@ -1480,16 +1490,12 @@ def srun_sshd_command(
             ssh_bootstrap_cmd,
         ])
 
-    # Non-container: OpenSSH sshd
-    return shlex.join([
-        'srun',
-        '--quiet',
-        '--unbuffered',
-        '--overlap',
-        '--jobid',
-        job_id,
-        '-w',
-        target_node,
+    # Non-container: OpenSSH sshd. Build one SetEnv directive because sshd uses
+    # only the first value of a keyword supplied multiple times. The allowlist
+    # covers NVIDIA, AMD, and Intel accelerator visibility variables emitted
+    # by Slurm's GRES plugins. Skip unexpected values instead of allowing them
+    # to alter sshd's configuration parser input.
+    sshd_command = shlex.join([
         '/usr/sbin/sshd',
         '-i',  # Uses stdin/stdout
         '-e',  # Writes errors to stderr
@@ -1510,4 +1516,27 @@ def srun_sshd_command(
         'UsePAM=no',
         '-o',
         f'AcceptEnv={constants.SKY_CLUSTER_NAME_ENV_VAR_KEY}',
+    ])
+    ssh_bootstrap_cmd = (
+        'SSHD_SET_ENV=; '
+        f'for NAME in {accelerator_env_var_names}; do '
+        'if declare -p "$NAME" &>/dev/null; then VALUE=${!NAME}; '
+        'case "$VALUE" in *[!a-zA-Z0-9_.,:/@%+=-]*) continue;; esac; '
+        'SSHD_SET_ENV+="${SSHD_SET_ENV:+ }$NAME=$VALUE"; fi; done; '
+        f'set -- {sshd_command}; '
+        '[[ -z $SSHD_SET_ENV ]] || '
+        'set -- "$@" -o "SetEnv=$SSHD_SET_ENV"; exec "$@"')
+
+    return shlex.join([
+        'srun',
+        '--quiet',
+        '--unbuffered',
+        '--overlap',
+        '--jobid',
+        job_id,
+        '-w',
+        target_node,
+        '/bin/bash',
+        '-c',
+        ssh_bootstrap_cmd,
     ])

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1451,15 +1451,29 @@ def srun_sshd_command(
             'DROPBEAR=$(command -v dropbear); '
             'if [ -z "$DROPBEAR" ]; then '
             'echo "dropbear not found" >&2; exit 1; fi; '
+            # -e was added in Dropbear 2022.83. Existing images can provide an
+            # older binary in PATH, so preserve the old SSH behavior when the
+            # installed server does not advertise environment forwarding.
+            'DROPBEAR_ENV_FLAG=(); '
+            'if "$DROPBEAR" -h 2>&1 | '
+            'grep -Eq -- \'(^|[[:space:]])-e([[:space:]]|$)\'; then '
+            'DROPBEAR_ENV_FLAG=(-e); fi; '
+            # Dropbear -e forwards its entire environment. Start it with only
+            # the accelerator variables so proxy-step SLURM_* variables and
+            # unrelated submit-side values do not leak into SSH sessions.
+            'DROPBEAR_ENV=(); '
+            f'for NAME in {accelerator_env_var_names}; do '
+            'if declare -p "$NAME" &>/dev/null; then '
+            'DROPBEAR_ENV+=("$NAME=${!NAME}"); fi; done; '
             # Find a free port in the ephemeral range
             'while :; do '
             'PORT=$((30000 + RANDOM % 30000)); '
             'ss -tln | awk \'{print $4}\' | grep -q ":$PORT$" || break; '
             'done; '
             # Start dropbear and wait for it to bind
-            # Dropbear normally rebuilds the child environment too. -e passes
-            # the environment injected by Slurm into the SSH session.
-            '"$DROPBEAR" -e -F -s -R -p "127.0.0.1:$PORT" & '
+            'env -i "${DROPBEAR_ENV[@]}" "$DROPBEAR" '
+            '"${DROPBEAR_ENV_FLAG[@]}" -F -s -R '
+            '-p "127.0.0.1:$PORT" & '
             'DROPBEAR_PID=$!; '
             'trap "kill $DROPBEAR_PID 2>/dev/null" EXIT; '
             'for i in $(seq 1 50); do '

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -1,4 +1,9 @@
 """Unit tests for sky.provision.slurm.utils."""
+import json
+import os
+import shlex
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -6,6 +11,66 @@ import pytest
 from sky import exceptions
 from sky.adaptors import slurm as slurm_adaptor
 from sky.provision.slurm import utils
+
+
+class TestSrunSshdCommand:
+    """Tests for accelerator environment forwarding through SSH."""
+
+    def test_openssh_forwards_accelerator_environment(self):
+        command = utils.srun_sshd_command(
+            job_id='123',
+            target_node='node-1',
+            unix_user='alice',
+            cluster_name_on_cloud='cluster',
+            is_container_image=False,
+        )
+
+        args = shlex.split(command)
+        assert args[:8] == [
+            'srun', '--quiet', '--unbuffered', '--overlap', '--jobid', '123',
+            '-w', 'node-1'
+        ]
+        assert args[8:10] == ['/bin/bash', '-c']
+        bootstrap = args[10]
+        assert 'CUDA_VISIBLE_DEVICES' in bootstrap
+        assert 'ROCR_VISIBLE_DEVICES' in bootstrap
+        assert 'ZE_AFFINITY_MASK' in bootstrap
+        assert 'GPU_DEVICE_ORDINAL' in bootstrap
+        assert 'SetEnv=$SSHD_SET_ENV' in bootstrap
+        assert 'exec "$@"' in bootstrap
+
+        # Execute the bootstrap with sshd replaced by an argv probe. This
+        # verifies that values injected by srun become one SetEnv directive
+        # and that unsafe values cannot alter sshd configuration arguments.
+        probe = shlex.join([
+            sys.executable, '-c',
+            'import json,sys; print(json.dumps(sys.argv[1:]))'
+        ])
+        bootstrap = bootstrap.replace('/usr/sbin/sshd', probe, 1)
+        env = {
+            **os.environ,
+            'CUDA_VISIBLE_DEVICES': '4,5',
+            'ROCR_VISIBLE_DEVICES': 'unsafe value',
+        }
+        result = subprocess.run(['/bin/bash', '-c', bootstrap],
+                                env=env,
+                                check=True,
+                                capture_output=True,
+                                text=True)
+        sshd_args = json.loads(result.stdout)
+        assert sshd_args[-2:] == ['-o', 'SetEnv=CUDA_VISIBLE_DEVICES=4,5']
+
+    def test_dropbear_forwards_srun_environment(self):
+        command = utils.srun_sshd_command(
+            job_id='123',
+            target_node='node-1',
+            unix_user='alice',
+            cluster_name_on_cloud='cluster',
+            is_container_image=True,
+        )
+
+        bootstrap = shlex.split(command)[-1]
+        assert '"$DROPBEAR" -e -F -s -R' in bootstrap
 
 
 class TestFormatSlurmDuration:

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -16,7 +16,13 @@ from sky.provision.slurm import utils
 class TestSrunSshdCommand:
     """Tests for accelerator environment forwarding through SSH."""
 
-    def test_openssh_forwards_accelerator_environment(self):
+    @pytest.mark.parametrize('openssh_version,expected_setenv', [
+        ('9.0', 'SetEnv=CUDA_VISIBLE_DEVICES=4,5'),
+        ('7.4', None),
+    ])
+    def test_openssh_forwards_accelerator_environment(self, tmp_path,
+                                                      openssh_version,
+                                                      expected_setenv):
         command = utils.srun_sshd_command(
             job_id='123',
             target_node='node-1',
@@ -39,14 +45,21 @@ class TestSrunSshdCommand:
         assert 'SetEnv=$SSHD_SET_ENV' in bootstrap
         assert 'exec "$@"' in bootstrap
 
-        # Execute the bootstrap with sshd replaced by an argv probe. This
-        # verifies that values injected by srun become one SetEnv directive
-        # and that unsafe values cannot alter sshd configuration arguments.
-        probe = shlex.join([
-            sys.executable, '-c',
-            'import json,sys; print(json.dumps(sys.argv[1:]))'
-        ])
-        bootstrap = bootstrap.replace('/usr/sbin/sshd', probe, 1)
+        # Execute the bootstrap with sshd replaced by a version/argv probe.
+        # Modern servers receive one SetEnv directive, while old servers keep
+        # working without it. Unsafe values are never added to either path.
+        probe = tmp_path / 'sshd'
+        probe.write_text(f"""#!{sys.executable}
+import json
+import sys
+if sys.argv[1:] == ['-V']:
+    print('OpenSSH_{openssh_version}', file=sys.stderr)
+else:
+    print(json.dumps(sys.argv[1:]))
+""")
+        probe.chmod(0o755)
+        bootstrap = bootstrap.replace('SSHD=/usr/sbin/sshd',
+                                      f'SSHD={shlex.quote(str(probe))}', 1)
         env = {
             **os.environ,
             'CUDA_VISIBLE_DEVICES': '4,5',
@@ -58,9 +71,17 @@ class TestSrunSshdCommand:
                                 capture_output=True,
                                 text=True)
         sshd_args = json.loads(result.stdout)
-        assert sshd_args[-2:] == ['-o', 'SetEnv=CUDA_VISIBLE_DEVICES=4,5']
+        if expected_setenv is None:
+            assert not any(arg.startswith('SetEnv=') for arg in sshd_args)
+        else:
+            assert sshd_args[-2:] == ['-o', expected_setenv]
 
-    def test_dropbear_forwards_only_accelerator_environment(self):
+    @pytest.mark.parametrize('dropbear_version,expected_flag', [
+        ('2025.89', '-e'),
+        ('2020.81', ''),
+    ])
+    def test_dropbear_forwards_only_accelerator_environment(
+            self, tmp_path, dropbear_version, expected_flag):
         command = utils.srun_sshd_command(
             job_id='123',
             target_node='node-1',
@@ -70,12 +91,46 @@ class TestSrunSshdCommand:
         )
 
         bootstrap = shlex.split(command)[-1]
-        assert '"$DROPBEAR" -h 2>&1' in bootstrap
+        assert '"$DROPBEAR" -V 2>&1' in bootstrap
+        assert 'DROPBEAR_VERSION_YEAR > 2022' in bootstrap
         assert 'DROPBEAR_ENV_FLAG=(-e)' in bootstrap
         assert 'env -i "${DROPBEAR_ENV[@]}" "$DROPBEAR"' in bootstrap
         assert '"${DROPBEAR_ENV_FLAG[@]}" -F -s -R' in bootstrap
         assert ('for NAME in CUDA_VISIBLE_DEVICES ROCR_VISIBLE_DEVICES'
                 in bootstrap)
+        assert 'GPU_DEVICE_ORDINAL LD_LIBRARY_PATH' in bootstrap
+
+        probe = tmp_path / 'dropbear'
+        probe.write_text(f"""#!{sys.executable}
+import sys
+print('Dropbear v{dropbear_version}', file=sys.stderr)
+""")
+        probe.chmod(0o755)
+        setup = bootstrap.split('while :; do', 1)[0]
+        setup += ('printf "flag=<%s>\\n" "${DROPBEAR_ENV_FLAG[*]}"; '
+                  'printf "env=<%s>\\n" "${DROPBEAR_ENV[*]}"')
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ('CUDA_VISIBLE_DEVICES', 'ROCR_VISIBLE_DEVICES',
+                           'ZE_AFFINITY_MASK', 'GPU_DEVICE_ORDINAL',
+                           'LD_LIBRARY_PATH')
+        }
+        env.update({
+            'PATH': f'{tmp_path}:{env["PATH"]}',
+            'CUDA_VISIBLE_DEVICES': '4,5',
+            'LD_LIBRARY_PATH': '/opt/accelerator/lib',
+            'SLURM_JOB_ID': 'must-not-be-forwarded',
+        })
+        result = subprocess.run(['/bin/bash', '-c', setup],
+                                env=env,
+                                check=True,
+                                capture_output=True,
+                                text=True)
+        assert f'flag=<{expected_flag}>' in result.stdout
+        assert ('env=<CUDA_VISIBLE_DEVICES=4,5 '
+                'LD_LIBRARY_PATH=/opt/accelerator/lib>' in result.stdout)
+        assert 'SLURM_JOB_ID' not in result.stdout
 
 
 class TestFormatSlurmDuration:

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -60,7 +60,7 @@ class TestSrunSshdCommand:
         sshd_args = json.loads(result.stdout)
         assert sshd_args[-2:] == ['-o', 'SetEnv=CUDA_VISIBLE_DEVICES=4,5']
 
-    def test_dropbear_forwards_srun_environment(self):
+    def test_dropbear_forwards_only_accelerator_environment(self):
         command = utils.srun_sshd_command(
             job_id='123',
             target_node='node-1',
@@ -70,7 +70,12 @@ class TestSrunSshdCommand:
         )
 
         bootstrap = shlex.split(command)[-1]
-        assert '"$DROPBEAR" -e -F -s -R' in bootstrap
+        assert '"$DROPBEAR" -h 2>&1' in bootstrap
+        assert 'DROPBEAR_ENV_FLAG=(-e)' in bootstrap
+        assert 'env -i "${DROPBEAR_ENV[@]}" "$DROPBEAR"' in bootstrap
+        assert '"${DROPBEAR_ENV_FLAG[@]}" -F -s -R' in bootstrap
+        assert ('for NAME in CUDA_VISIBLE_DEVICES ROCR_VISIBLE_DEVICES'
+                in bootstrap)
 
 
 class TestFormatSlurmDuration:


### PR DESCRIPTION
## What changed

- forward Slurm-provided accelerator visibility variables into non-container OpenSSH sessions using a server-side `SetEnv` directive
- enable Dropbear environment propagation for containerized Slurm SSH sessions
- cover NVIDIA, AMD, and Intel visibility variables
- reject values that are unsafe for OpenSSH configuration parsing
- add unit coverage for both OpenSSH and Dropbear command generation

## Why

Slurm correctly assigns physical GPUs and injects visibility variables into the process launched by `srun`. However, OpenSSH and Dropbear construct a fresh environment for child sessions. Commands run through SkyPilot's Slurm SSH proxy therefore lose `CUDA_VISIBLE_DEVICES` and may observe GPUs outside their allocation.

The fix captures the values after `srun` has selected the allocation and forwards them at the SSH server boundary. It does not infer device indices from the controller, modify user dotfiles, or write shared environment files.

After an API server upgrade, new SSH connections to existing Slurm jobs receive the correct accelerator visibility environment. Existing SSH connections need to reconnect; jobs do not need to be recreated.

Fixes #10406

## Validation

- `uv run pytest tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py -q`
- `uv run pytest tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py::TestSrunSshdCommand -q`
- `PATH=.venv/bin:$PATH bash format.sh --files sky/provision/slurm/utils.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py`
- `git diff --check`
