### PR TITLE
[Jobs] Keep the local log copy when external delivery is unconfirmed

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -57,6 +57,7 @@ from sky.utils import status_lib
 from sky.utils import ux_utils
 from sky.utils.plugin_extensions import ExternalClusterFailure
 from sky.utils.plugin_extensions import ExternalFailureSource
+from sky.utils.plugin_extensions import LogDeliverySource
 
 if typing.TYPE_CHECKING:
     import psutil
@@ -339,15 +340,31 @@ class JobController:
         logs are forwarded but there is no reader to read them back (e.g. a
         write-only logging store), we still keep the local copy so ``sky jobs
         logs`` can serve a finished job's logs.
+
+        Being configured is not the same as having worked: the agent may never
+        have run on the cluster this job landed on. A registered
+        ``LogDeliverySource`` (the component that deploys the agent) can report
+        that, and we then keep the local copy instead of leaving the job with no
+        readable logs anywhere.
         """
         if (logs.is_logging_agent_configured() and
                 logs.get_log_reader() is not None):
-            logger.info(
-                f'Logging agent and log reader are configured for job '
-                f'{self._job_id}; logs are forwarded to the external store and '
-                'read back on demand. Skipping downloading and streaming the '
-                'logs to the controller.')
-            return
+            undelivered_reason = None
+            if handle is not None:
+                undelivered_reason = LogDeliverySource.undelivered_reason(
+                    cluster_name=handle.cluster_name,
+                    cluster_name_on_cloud=handle.cluster_name_on_cloud)
+            if undelivered_reason is None:
+                logger.info(
+                    f'Logging agent and log reader are configured for job '
+                    f'{self._job_id}; logs are forwarded to the external store '
+                    'and read back on demand. Skipping downloading and '
+                    'streaming the logs to the controller.')
+                return
+            logger.warning(
+                f'Logs of job {self._job_id} are not confirmed to have reached '
+                f'the external log store ({undelivered_reason}); keeping a '
+                'copy on the controller so they stay readable.')
         if handle is None:
             logger.info(f'Cluster for job {self._job_id} is not found. '
                         'Skipping downloading and streaming the logs.')

--- a/sky/utils/plugin_extensions/__init__.py
+++ b/sky/utils/plugin_extensions/__init__.py
@@ -7,6 +7,7 @@ from sky.utils.plugin_extensions.external_failure_source import (
     ExternalClusterFailure)
 from sky.utils.plugin_extensions.external_failure_source import (
     ExternalFailureSource)
+from sky.utils.plugin_extensions.log_delivery_source import LogDeliverySource
 from sky.utils.plugin_extensions.node_info_source import NodeInfoSource
 from sky.utils.plugin_extensions.pod_info_source import PodInfoSource
 from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
@@ -14,6 +15,7 @@ from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
 __all__ = [
     'ExternalClusterFailure',
     'ExternalFailureSource',
+    'LogDeliverySource',
     'NodeInfoSource',
     'PodInfoSource',
     'RecipeValidator',

--- a/sky/utils/plugin_extensions/log_delivery_source.py
+++ b/sky/utils/plugin_extensions/log_delivery_source.py
@@ -58,6 +58,14 @@ class LogDeliverySource:
     as "no reason to doubt delivery" and preserves the previous behavior,
     so a broken source degrades to today's semantics rather than making
     every job download its logs again.
+
+    Implementations must answer quickly and must not block. The check runs
+    once per managed job task, on the job-finalization path, in a worker
+    thread drawn from a pool the rest of the controller shares -- so a
+    source that hangs does not just delay one job, it holds a thread others
+    are waiting for. Exceptions are contained (see below); a hang is not.
+    A local lookup of something recorded earlier is the intended shape; a
+    round trip that can stall indefinitely is not.
     """
 
     _undelivered_reason_func: Optional[UndeliveredReasonFunc] = None
@@ -71,7 +79,8 @@ class LogDeliverySource:
         Args:
             undelivered_reason: Function returning a human-readable reason
                 why the cluster's logs did not reach the external store, or
-                None when there is no evidence against delivery.
+                None when there is no evidence against delivery. Must return
+                promptly and must not block -- see the class docstring.
                 Signature: (cluster_name: Optional[str],
                             cluster_name_on_cloud: Optional[str])
                            -> Optional[str]

--- a/sky/utils/plugin_extensions/log_delivery_source.py
+++ b/sky/utils/plugin_extensions/log_delivery_source.py
@@ -1,0 +1,112 @@
+"""External log delivery source interface for plugins.
+
+When a logging agent forwards job logs to an external store and a reader
+can stream them back, the store is the durable copy and the controller
+skips keeping a local one. That decision is made from the server's own
+config -- it only knows that *a* logging agent is configured, not that this
+particular job's logs actually reached the store. An agent that could not
+be deployed on the target cluster, or that was still starting when a short
+job finished, leaves the job with no readable logs at all: none in the
+store, and none on the controller either.
+
+This extension point lets whatever component deploys and operates the
+logging agent report, per cluster, whether it is actually delivering that
+cluster's logs. Core SkyPilot consults it before dropping the local copy:
+an unconfirmed delivery keeps the copy (and logs why), a confirmed one is
+skipped as before. Not registering a source keeps the previous behavior.
+
+Example usage in a plugin:
+    from sky.utils.plugin_extensions import LogDeliverySource
+
+    # Register a custom delivery source
+    LogDeliverySource.register(undelivered_reason=my_undelivered_reason)
+
+Example usage in core SkyPilot:
+    from sky.utils.plugin_extensions import LogDeliverySource
+
+    reason = LogDeliverySource.undelivered_reason(
+        cluster_name='my-cluster', cluster_name_on_cloud='my-cluster-abcd')
+    if reason is not None:
+        ...  # keep a local copy of the logs
+"""
+from typing import Optional, Protocol
+
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
+
+class UndeliveredReasonFunc(Protocol):
+    """Protocol for the undelivered_reason function."""
+
+    def __call__(self,
+                 cluster_name: Optional[str] = None,
+                 cluster_name_on_cloud: Optional[str] = None) -> Optional[str]:
+        ...
+
+
+class LogDeliverySource:
+    """Singleton class for the external log delivery source.
+
+    A plugin registers its implementation during install(); core SkyPilot
+    asks it whether a cluster's logs reached the external store without
+    knowing which plugin (if any) provides the answer.
+
+    The answer is deliberately one-sided: a source reports only the case it
+    can prove -- that the logs did *not* make it. Everything else (no source
+    registered, no record for the cluster, the check itself failing) reads
+    as "no reason to doubt delivery" and preserves the previous behavior,
+    so a broken source degrades to today's semantics rather than making
+    every job download its logs again.
+    """
+
+    _undelivered_reason_func: Optional[UndeliveredReasonFunc] = None
+
+    @classmethod
+    def register(cls, undelivered_reason: UndeliveredReasonFunc) -> None:
+        """Register an external log delivery source implementation.
+
+        Only one delivery source can be registered at a time.
+
+        Args:
+            undelivered_reason: Function returning a human-readable reason
+                why the cluster's logs did not reach the external store, or
+                None when there is no evidence against delivery.
+                Signature: (cluster_name: Optional[str],
+                            cluster_name_on_cloud: Optional[str])
+                           -> Optional[str]
+        """
+        cls._undelivered_reason_func = undelivered_reason
+        logger.debug('Registered external log delivery source')
+
+    @classmethod
+    def is_registered(cls) -> bool:
+        """Check if a log delivery source is registered."""
+        return cls._undelivered_reason_func is not None
+
+    @classmethod
+    def undelivered_reason(
+            cls,
+            cluster_name: Optional[str] = None,
+            cluster_name_on_cloud: Optional[str] = None) -> Optional[str]:
+        """Why the cluster's logs did not reach the external log store.
+
+        Args:
+            cluster_name: Display name of the cluster the job ran on.
+            cluster_name_on_cloud: Provider-side name of that cluster.
+
+        Returns:
+            A human-readable reason, or None if the logs are believed to
+            have been delivered -- which is also what an unregistered or
+            failing source returns.
+        """
+        if cls._undelivered_reason_func is None:
+            return None
+        try:
+            # pylint: disable=not-callable
+            return cls._undelivered_reason_func(
+                cluster_name=cluster_name,
+                cluster_name_on_cloud=cluster_name_on_cloud)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to check external log delivery: {e}')
+            return None

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -31,6 +31,7 @@ from sky.jobs.controller import JobController
 from sky.skylet import job_lib
 from sky.utils import common
 from sky.utils import status_lib
+from sky.utils.plugin_extensions import LogDeliverySource
 
 
 class TestNormalJobRecovery:
@@ -1167,6 +1168,26 @@ class TestDownloadLogAndStreamLoggingAgentGate:
         _, _, mock_cutils = self._run(agent_configured=True,
                                       reader=MagicMock(),
                                       undelivered_reason=None)
+        mock_cutils.download_and_stream_job_log.assert_not_called()
+
+    def test_no_delivery_source_registered_is_inert(self):
+        # The compatibility property of the extension point: with nothing
+        # registered, the check must not change behavior at all. Unlike the
+        # cases above, this exercises the real LogDeliverySource rather than
+        # patching its lookup, so a future default other than None is caught.
+        assert not LogDeliverySource.is_registered()
+        controller = self._make_controller()
+        with patch('sky.jobs.controller.logs.is_logging_agent_configured',
+                   return_value=True), \
+             patch('sky.jobs.controller.logs.get_log_reader',
+                   return_value=MagicMock()), \
+             patch('sky.jobs.controller.managed_job_state') as mock_state, \
+             patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
+             patch('sky.jobs.controller.controller_utils') as mock_cutils:
+            mock_runtime.is_registered.return_value = False
+            controller.download_log_and_stream(0, MagicMock(), None)
+        mock_state.set_local_log_file.assert_not_called()
+        mock_runtime.download_logs.assert_not_called()
         mock_cutils.download_and_stream_job_log.assert_not_called()
 
 

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1115,13 +1115,15 @@ class TestDownloadLogAndStreamLoggingAgentGate:
                 controller, JobController))
         return controller
 
-    def _run(self, agent_configured, reader):
+    def _run(self, agent_configured, reader, undelivered_reason=None):
         controller = self._make_controller()
         handle = MagicMock()
         with patch('sky.jobs.controller.logs.is_logging_agent_configured',
                    return_value=agent_configured), \
              patch('sky.jobs.controller.logs.get_log_reader',
                    return_value=reader), \
+             patch('sky.jobs.controller.LogDeliverySource.undelivered_reason',
+                   return_value=undelivered_reason), \
              patch('sky.jobs.controller.managed_job_state') as mock_state, \
              patch('sky.jobs.controller.managed_job_runtime') as mock_runtime, \
              patch('sky.jobs.controller.controller_utils') as mock_cutils:
@@ -1148,6 +1150,24 @@ class TestDownloadLogAndStreamLoggingAgentGate:
     def test_downloads_when_no_logging_agent(self):
         _, _, mock_cutils = self._run(agent_configured=False, reader=None)
         mock_cutils.download_and_stream_job_log.assert_called_once()
+
+    def test_downloads_when_delivery_source_reports_undelivered(self):
+        # Agent and reader are configured, but the component operating the
+        # agent knows it never delivered this cluster's logs -> the local copy
+        # is the only copy that will exist, so it must be kept.
+        _, _, mock_cutils = self._run(
+            agent_configured=True,
+            reader=MagicMock(),
+            undelivered_reason='logging agent was not deployed on the cluster')
+        mock_cutils.download_and_stream_job_log.assert_called_once()
+
+    def test_skips_download_when_delivery_source_confirms(self):
+        # A registered source with no evidence against delivery must not
+        # change the skip behavior.
+        _, _, mock_cutils = self._run(agent_configured=True,
+                                      reader=MagicMock(),
+                                      undelivered_reason=None)
+        mock_cutils.download_and_stream_job_log.assert_not_called()
 
 
 class TestJobGroupResumeDoesNotReissueStarting:


### PR DESCRIPTION
## Summary

With a logging agent and a log reader configured, the jobs controller skips downloading a managed job's logs, treating the external store as the durable copy. That decision comes purely from server config, which only says *an* agent is configured — not that this job's logs reached the store. If the agent could not be deployed on the cluster the job landed on, or was still starting when a short job finished, the job ends up with no readable logs anywhere: none in the store, none on the controller.

This adds a `LogDeliverySource` plugin extension point (same shape as the existing `ExternalFailureSource`) so whatever component deploys and operates the logging agent can report, per cluster, that it did not deliver. When it does, the controller keeps the local copy and logs the reason.

The answer is deliberately one-sided: no source registered, no record for the cluster, or a failing check all read as "no reason to doubt delivery", so behavior is unchanged unless a source positively reports a miss.

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_controller.py` — 65 passed, including two new cases in `TestDownloadLogAndStreamLoggingAgentGate`: a reported reason makes the controller download the logs, and a registered source with no reason still skips.
- Manual: with an agent + reader configured and no source registered, a managed job still skips the local copy (unchanged); with a source returning a reason, the controller logs `not confirmed to have reached the external log store (...)` and `sky jobs logs <id>` serves the local copy.

https://claude.ai/code/session_01TPaG9z4mk1kcKRLTtdTGvq