### PR TITLE
[Helm] Add API pre-start hook

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -202,8 +202,17 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         {{- end }}
+        {{- if .Values.apiService.command }}
+        command:
+          {{- toYaml .Values.apiService.command | nindent 10 }}
+        {{- else }}
         # Use tini as the init process
         command: ["tini", "--"]
+        {{- end }}
+        {{- if .Values.apiService.args }}
+        args:
+          {{- toYaml .Values.apiService.args | nindent 10 }}
+        {{- else }}
         # Start API server in foreground (if supported) to:
         # 1. Bypass the healthz check of `sky api start`, let kubernetes probes manage the lifecycle directly.
         # 2. Capture all logs in container to stdout/stderr, bypass in-container log file overhead.
@@ -322,6 +331,7 @@ spec:
           fi
           {{- end }}
           {{- end }}
+        {{- end }}
         ports:
         - containerPort: 46580
         {{- if not .Values.apiService.devMode.enabled }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -5,6 +5,9 @@
        storage mounts / ephemeral ~/.sky / env below key off this rather than
        storage.enabled alone. */ -}}
 {{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
+{{- if and (not .Values.apiService.command) .Values.apiService.args (hasPrefix "-" (first .Values.apiService.args)) }}
+{{- fail "apiService.args without apiService.command must begin with an executable because the default command is [\"tini\", \"--\"]. Set apiService.command to provide option-only args." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -5,9 +5,6 @@
        storage mounts / ephemeral ~/.sky / env below key off this rather than
        storage.enabled alone. */ -}}
 {{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
-{{- if and (not .Values.apiService.command) .Values.apiService.args (hasPrefix "-" (first .Values.apiService.args)) }}
-{{- fail "apiService.args without apiService.command must begin with an executable because the default command is [\"tini\", \"--\"]. Set apiService.command to provide option-only args." }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -205,17 +202,8 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         {{- end }}
-        {{- if .Values.apiService.command }}
-        command:
-          {{- toYaml .Values.apiService.command | nindent 10 }}
-        {{- else }}
         # Use tini as the init process
         command: ["tini", "--"]
-        {{- end }}
-        {{- if .Values.apiService.args }}
-        args:
-          {{- toYaml .Values.apiService.args | nindent 10 }}
-        {{- else }}
         # Start API server in foreground (if supported) to:
         # 1. Bypass the healthz check of `sky api start`, let kubernetes probes manage the lifecycle directly.
         # 2. Capture all logs in container to stdout/stderr, bypass in-container log file overhead.
@@ -291,6 +279,9 @@ spec:
           # developer can drive `sky api start` / `sky api stop` via kubectl exec.
           exec tail -f /dev/null
           {{- else }}
+          {{- if .Values.apiService.preStartHook }}
+          {{ .Values.apiService.preStartHook | nindent 10 }}
+          {{- end }}
           # Optional log mirror: when $SKYPILOT_SERVER_LOG_MIRROR_DIR is set,
           # also write server stdout/stderr to a per-pod, per-boot file under
           # <dir>/<HOSTNAME>/server-<UTC_ISO>.log. Survives local logrotate
@@ -334,7 +325,6 @@ spec:
           fi
           {{- end }}
           {{- end }}
-        {{- end }}
         ports:
         - containerPort: 46580
         {{- if not .Values.apiService.devMode.enabled }}

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1318,3 +1318,76 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "exec sky api start .*--host=::"
+
+  # Verifies the API container keeps the current startup command and shell
+  # arguments when command and args overrides are unset.
+  - it: should use the built-in API command and args by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - tini
+            - --
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: /bin/sh
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: -c
+
+  # Verifies a replacement command is rendered while the default startup
+  # arguments remain available when args is unset.
+  - it: should override the API container command independently
+    set:
+      apiService.command:
+        - /bin/bash
+        - /app/entrypoint.sh
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - /app/entrypoint.sh
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: /bin/sh
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: -c
+
+  # Verifies replacement arguments are rendered while the default tini
+  # command remains available when command is unset.
+  - it: should override the API container args independently
+    set:
+      apiService.args:
+        - --some-option
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - tini
+            - --
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --some-option
+
+  # Verifies a custom entrypoint and its arguments replace both container
+  # fields without retaining the generated SkyPilot startup script.
+  - it: should override the API container command and args together
+    set:
+      apiService.command:
+        - /bin/bash
+        - /app/entrypoint.sh
+      apiService.args:
+        - --some-option
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - /app/entrypoint.sh
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --some-option

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1335,70 +1335,18 @@ tests:
           path: spec.template.spec.containers[0].args[1]
           value: -c
 
-  # Verifies a replacement command is rendered while the default startup
-  # arguments remain available when args is unset.
-  - it: should override the API container command independently
+  # Verifies custom startup work runs after SkyPilot initialization and before
+  # the chart-owned API server process starts, without replacing tini.
+  - it: should run the pre-start hook before the official API server command
     set:
-      apiService.command:
-        - /bin/bash
-        - /app/entrypoint.sh
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].command
-          value:
-            - /bin/bash
-            - /app/entrypoint.sh
-      - equal:
-          path: spec.template.spec.containers[0].args[0]
-          value: /bin/sh
-      - equal:
-          path: spec.template.spec.containers[0].args[1]
-          value: -c
-
-  # Verifies an args-only override starts an executable through the default
-  # tini command when command is unset.
-  - it: should override the API container args independently
-    set:
-      apiService.args:
-        - /app/entrypoint.sh
-        - --some-option
+      apiService.preStartHook: |-
+        echo "Custom pre-start hook"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].command
           value:
             - tini
             - --
-      - equal:
-          path: spec.template.spec.containers[0].args
-          value:
-            - /app/entrypoint.sh
-            - --some-option
-
-  # Prevents option-only args from reaching tini without a command to exec.
-  - it: should reject option-only API container args without a command
-    set:
-      apiService.args:
-        - --some-option
-    asserts:
-      - failedTemplate:
-          errorMessage: "apiService.args without apiService.command must begin with an executable because the default command is [\"tini\", \"--\"]. Set apiService.command to provide option-only args."
-
-  # Verifies a custom entrypoint and its arguments replace both container
-  # fields without retaining the generated SkyPilot startup script.
-  - it: should override the API container command and args together
-    set:
-      apiService.command:
-        - /bin/bash
-        - /app/entrypoint.sh
-      apiService.args:
-        - --some-option
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].command
-          value:
-            - /bin/bash
-            - /app/entrypoint.sh
-      - equal:
-          path: spec.template.spec.containers[0].args
-          value:
-            - --some-option
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '(?s)initialize_configmap_sync_on_startup.*Custom pre-start hook.*exec sky api start'

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1355,11 +1355,12 @@ tests:
           path: spec.template.spec.containers[0].args[1]
           value: -c
 
-  # Verifies replacement arguments are rendered while the default tini
-  # command remains available when command is unset.
+  # Verifies an args-only override starts an executable through the default
+  # tini command when command is unset.
   - it: should override the API container args independently
     set:
       apiService.args:
+        - /app/entrypoint.sh
         - --some-option
     asserts:
       - equal:
@@ -1370,7 +1371,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args
           value:
+            - /app/entrypoint.sh
             - --some-option
+
+  # Prevents option-only args from reaching tini without a command to exec.
+  - it: should reject option-only API container args without a command
+    set:
+      apiService.args:
+        - --some-option
+    asserts:
+      - failedTemplate:
+          errorMessage: "apiService.args without apiService.command must begin with an executable because the default command is [\"tini\", \"--\"]. Set apiService.command to provide option-only args."
 
   # Verifies a custom entrypoint and its arguments replace both container
   # fields without retaining the generated SkyPilot startup script.

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -14,29 +14,11 @@
                         "null"
                     ]
                 },
-                "args": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "authUserHeaderName": {
                     "type": [
                         "string",
                         "null"
                     ]
-                },
-                "command": {
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    }
                 },
                 "config": {
                     "type": [
@@ -182,6 +164,12 @@
                 },
                 "preDeployHook": {
                     "type": "string"
+                },
+                "preStartHook": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "readinessProbe": {
                     "type": [

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -14,11 +14,29 @@
                         "null"
                     ]
                 },
+                "args": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "authUserHeaderName": {
                     "type": [
                         "string",
                         "null"
                     ]
+                },
+                "command": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "config": {
                     "type": [

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -19,14 +19,6 @@ apiService:
   # Docker image to use for the API server. The default value will be updated by the release pipeline to be consistent with the SkyPilot release or nightly build.
   # Refer to https://docs.skypilot.co/en/latest/reference/api-server/helm-values-spec.html#helm-values-apiservice-image for more details.
   image: berkeleyskypilot/skypilot-nightly:latest
-  # Kubernetes command for the API server container. Set a non-empty list to
-  # replace the chart's default tini command.
-  # @schema type: [array, null]; item: string
-  command: null
-  # Kubernetes args for the API server container. Set a non-empty list to
-  # replace the chart's generated SkyPilot startup script.
-  # @schema type: [array, null]; item: string
-  args: null
   # Number of replicas to deploy - replicas > 1 is not well tested.
   replicas: 1
   # Interface the API server binds to: "0.0.0.0" for IPv4 (the default) or "::"
@@ -43,6 +35,11 @@ apiService:
 
     # echo "Installing admin policy"
     # pip install git+https://github.com/michaelvll/admin-policy-examples
+
+  # Shell commands to run after SkyPilot startup initialization and before the
+  # API server starts. The hook must exit successfully; do not use exec.
+  # @schema type: [string, null]
+  preStartHook: null
 
   # Upgrade strategy for the API server, available options are:
   # - Recreate: delete the old pod first and create a new one (has downtime).

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -19,6 +19,14 @@ apiService:
   # Docker image to use for the API server. The default value will be updated by the release pipeline to be consistent with the SkyPilot release or nightly build.
   # Refer to https://docs.skypilot.co/en/latest/reference/api-server/helm-values-spec.html#helm-values-apiservice-image for more details.
   image: berkeleyskypilot/skypilot-nightly:latest
+  # Kubernetes command for the API server container. Set a non-empty list to
+  # replace the chart's default tini command.
+  # @schema type: [array, null]; item: string
+  command: null
+  # Kubernetes args for the API server container. Set a non-empty list to
+  # replace the chart's generated SkyPilot startup script.
+  # @schema type: [array, null]; item: string
+  args: null
   # Number of replicas to deploy - replicas > 1 is not well tested.
   replicas: 1
   # Interface the API server binds to: "0.0.0.0" for IPv4 (the default) or "::"

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -36,8 +36,6 @@ Below is the available helm value keys and the default value of each key:
   :ref:`fullnameOverride <helm-values-fullnameOverride>`: null
   :ref:`apiService <helm-values-apiService>`:
     :ref:`image <helm-values-apiService-image>`: berkeleyskypilot/skypilot-nightly:latest
-    :ref:`command <helm-values-apiService-command>`: null
-    :ref:`args <helm-values-apiService-args>`: null
     :ref:`upgradeStrategy <helm-values-apiService-upgradeStrategy>`: Recreate
     :ref:`replicas <helm-values-apiService-replicas>`: 1
     :ref:`host <helm-values-apiService-host>`: "0.0.0.0"
@@ -55,6 +53,7 @@ Below is the available helm value keys and the default value of each key:
 
       # echo "Installing admin policy"
       # pip install git+https://github.com/michaelvll/admin-policy-examples
+    :ref:`preStartHook <helm-values-apiService-preStartHook>`: null
     :ref:`config <helm-values-apiService-config>`: null
     :ref:`dbConnectionSecretName <helm-values-apiService-dbConnectionSecretName>`: null
     :ref:`dbConnectionString <helm-values-apiService-dbConnectionString>`: null
@@ -405,51 +404,6 @@ To use a nightly build, find the desired nightly version on `pypi <https://pypi.
     image: berkeleyskypilot/skypilot-nightly:1.0.0.devYYYYMMDD
 
 
-.. _helm-values-apiService-command:
-
-``apiService.command``
-^^^^^^^^^^^^^^^^^^^^^^
-
-Kubernetes command for the API server container. Set a non-empty string list
-to replace the chart's default ``["tini", "--"]`` command. When unset, the
-chart retains that default; this does not inherit the image ``ENTRYPOINT``.
-
-Default: ``null``
-
-.. code-block:: yaml
-
-  apiService:
-    command:
-      - /bin/bash
-      - /app/entrypoint.sh
-
-.. _helm-values-apiService-args:
-
-``apiService.args``
-^^^^^^^^^^^^^^^^^^^
-
-Kubernetes arguments for the API server container. Set a non-empty string list
-to replace the chart's generated startup script. Replacing it also bypasses
-``preDeployHook``, SkyPilot configuration initialization, dev-mode handling,
-and the chart's ``sky api start`` command; include required setup in the
-replacement command or arguments. When unset, the generated script is kept.
-When ``apiService.command`` is unset, the default ``["tini", "--"]`` command
-executes the first ``args`` item; therefore an args-only override must begin
-with an executable, for example ``/app/entrypoint.sh``. Option-only args such
-as ``["--some-option"]`` are rejected; set ``apiService.command`` when the
-custom process needs those arguments.
-
-Default: ``null``
-
-.. code-block:: yaml
-
-  apiService:
-    command:
-      - /bin/bash
-      - /app/entrypoint.sh
-    args:
-      - --some-option
-
 .. _helm-values-apiService-imagePullPolicy:
 
 ``apiService.imagePullPolicy``
@@ -616,6 +570,30 @@ Default: see the yaml below.
       # Uncomment the following lines to install the admin policy
       # echo "Installing admin policy"
       # pip install git+https://github.com/michaelvll/admin-policy-examples
+
+.. _helm-values-apiService-preStartHook:
+
+``apiService.preStartHook``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Shell commands to run after SkyPilot initializes configuration and credentials,
+but before the API server starts. Use this for an entrypoint-style custom setup
+script that must run in the API container. The hook must exit successfully and
+must not use ``exec``: the chart retains ``tini`` and its final ``sky api
+start`` command for signal handling, health checks, logging, and normal API
+startup. The hook is not run when dev mode is enabled because that mode does
+not start the API server.
+
+Use :ref:`apiService.preDeployHook <helm-values-apiService-preDeployHook>` for
+commands that must run before SkyPilot configuration initialization.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  apiService:
+    preStartHook: |-
+      /app/custom-startup.sh --custom-option
 
 .. _helm-values-apiService-config:
 

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -433,6 +433,11 @@ to replace the chart's generated startup script. Replacing it also bypasses
 ``preDeployHook``, SkyPilot configuration initialization, dev-mode handling,
 and the chart's ``sky api start`` command; include required setup in the
 replacement command or arguments. When unset, the generated script is kept.
+When ``apiService.command`` is unset, the default ``["tini", "--"]`` command
+executes the first ``args`` item; therefore an args-only override must begin
+with an executable, for example ``/app/entrypoint.sh``. Option-only args such
+as ``["--some-option"]`` are rejected; set ``apiService.command`` when the
+custom process needs those arguments.
 
 Default: ``null``
 

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -36,6 +36,8 @@ Below is the available helm value keys and the default value of each key:
   :ref:`fullnameOverride <helm-values-fullnameOverride>`: null
   :ref:`apiService <helm-values-apiService>`:
     :ref:`image <helm-values-apiService-image>`: berkeleyskypilot/skypilot-nightly:latest
+    :ref:`command <helm-values-apiService-command>`: null
+    :ref:`args <helm-values-apiService-args>`: null
     :ref:`upgradeStrategy <helm-values-apiService-upgradeStrategy>`: Recreate
     :ref:`replicas <helm-values-apiService-replicas>`: 1
     :ref:`host <helm-values-apiService-host>`: "0.0.0.0"
@@ -402,6 +404,46 @@ To use a nightly build, find the desired nightly version on `pypi <https://pypi.
     # Replace 1.0.0.devYYYYMMDD with the desired nightly version
     image: berkeleyskypilot/skypilot-nightly:1.0.0.devYYYYMMDD
 
+
+.. _helm-values-apiService-command:
+
+``apiService.command``
+^^^^^^^^^^^^^^^^^^^^^^
+
+Kubernetes command for the API server container. Set a non-empty string list
+to replace the chart's default ``["tini", "--"]`` command. When unset, the
+chart retains that default; this does not inherit the image ``ENTRYPOINT``.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  apiService:
+    command:
+      - /bin/bash
+      - /app/entrypoint.sh
+
+.. _helm-values-apiService-args:
+
+``apiService.args``
+^^^^^^^^^^^^^^^^^^^
+
+Kubernetes arguments for the API server container. Set a non-empty string list
+to replace the chart's generated startup script. Replacing it also bypasses
+``preDeployHook``, SkyPilot configuration initialization, dev-mode handling,
+and the chart's ``sky api start`` command; include required setup in the
+replacement command or arguments. When unset, the generated script is kept.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  apiService:
+    command:
+      - /bin/bash
+      - /app/entrypoint.sh
+    args:
+      - --some-option
 
 .. _helm-values-apiService-imagePullPolicy:
 


### PR DESCRIPTION
## Summary

- Add `apiService.preStartHook` for custom startup work in the API container.
- Keep the chart-owned `tini` command and generated `sky api start` path unchanged.
- Document the hook lifecycle and add Helm rendering coverage.

## Tested

- `helm lint charts/skypilot`
- `helm unittest charts/skypilot` (154 passed, Helm 3.14)
- Regenerated `charts/skypilot/values.schema.json`.
- Rendered the API Deployment with a custom pre-start hook.

## Manual test

1. Create an override file:

   ```yaml
   apiService:
     preStartHook: |-
       /app/custom-startup.sh --custom-option
   ```

2. Run `helm template pre-start ./charts/skypilot -f values.yaml --show-only templates/api-deployment.yaml`.
3. Confirm the `skypilot-api` container retains `command: ["tini", "--"]`, the custom hook occurs after SkyPilot configuration initialization, and the rendered script still ends by starting the API server. The hook must exit successfully and must not use `exec`.
