### PR TITLE
fix(kubernetes): fall back to catalog EFA sizing

### DIFF
--- a/docs/superpowers/plans/2026-08-10-efa-detection.md
+++ b/docs/superpowers/plans/2026-08-10-efa-detection.md
@@ -1,0 +1,50 @@
+# EFA detection fallback implementation plan
+
+> **For implementation:** Use `superpowers:executing-plans` and test first.
+
+**Goal:** On autoscaling AWS Kubernetes clusters, `network_tier: best` must request catalog-sized EFA when a currently running matching GPU node does not advertise an EFA resource.
+
+**Architecture:** `_detect_network_type()` already scans nodes for a live EFA allocation and has a catalog fallback for cold AWS clusters. A matching non-EFA GPU node currently returns too early, bypassing that fallback. Continue the scan instead; live EFA remains authoritative, while the existing AWS/autoscaler/catalog gates govern the fallback.
+
+**Tech Stack:** Python, pytest/unittest mocks.
+
+### Task 1: Continue past non-EFA AWS GPU nodes
+
+**Files:**
+- Modify: `sky/clouds/kubernetes.py:1679-1698`
+- Modify: `tests/unit_tests/test_sky/clouds/test_kubernetes.py:4085-4109`
+- Modify: `tests/unit_tests/test_sky/clouds/test_kubernetes.py:4339-4351`
+
+**Step 1: Write the failing tests**
+
+Add a `TestDetectNetworkTypeEfaScaleFromZero` case with a matching AWS H100 GPU node that lacks `vpc.amazonaws.com/efa`, a configured autoscaler, and `derived_efa=32`; expect `AWS_EFA` with `{'efa_count': 32}`. Change the existing static-node test so its expected result is `NONE, None`, because an unschedulable static cluster cannot request EFA from a catalog.
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+`uv run pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py -k "aws_efa_detection_node_without_efa_resource or matching_gpu_without_efa_uses_catalog" -q`
+
+Expected: the new autoscaling-node case fails because `_detect_network_type()` returns `AWS_EFA, None` before the catalog fallback.
+
+**Step 3: Implement the smallest fix**
+
+In `_detect_network_type()`, replace the post-EFA `return (network_type, metadata)` for a matching AWS GPU node with `continue`. Do not change the live `efa_count > 0` return or the AWS/autoscaler/catalog fallback conditions.
+
+**Step 4: Run focused verification**
+
+Run:
+`uv run pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py -k "aws_efa_detection_node_without_efa_resource or matching_gpu_without_efa_uses_catalog or warm_node_scan_wins" -q`
+
+Expected: all selected tests pass; live EFA sizing still wins over the catalog.
+
+**Step 5: Run the EFA regression suite**
+
+Run:
+`uv run pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py -k "Efa or efa" -q`
+
+**Step 6: Commit**
+
+```bash
+git add sky/clouds/kubernetes.py tests/unit_tests/test_sky/clouds/test_kubernetes.py
+git commit -m "fix(kubernetes): fall back to catalog EFA sizing"
+```

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1695,7 +1695,7 @@ class Kubernetes(clouds.Cloud):
                                     metadata = {'efa_count': efa_count}
                                     return (network_type, metadata)
                             # No EFA available, but it's an AWS node
-                            return (network_type, metadata)
+                            continue
 
                     # Check for GKE clusters with specific GPUDirect variants
                     machine_family = node.metadata.labels.get(

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4102,7 +4102,8 @@ class TestKubernetesDetectNetworkType(unittest.TestCase):
                 network_tier=resources_utils.NetworkTier.BEST,
                 k8s_acc_label_key='nvidia.com/gpu.product',
                 k8s_resource_key='nvidia.com/gpu',
-                acc_count=8)
+                acc_count=8,
+                acc_type='H100')
 
         self.assertEqual(
             result,
@@ -4151,12 +4152,15 @@ class TestKubernetesDetectNetworkType(unittest.TestCase):
             })
         mock_get_nodes.return_value = [mock_node]
 
-        result = kubernetes.Kubernetes._detect_network_type(
-            context='test-context',
-            network_tier=resources_utils.NetworkTier.BEST,
-            k8s_acc_label_key='nvidia.com/gpu.product',
-            k8s_resource_key='nvidia.com/gpu',
-            acc_count=8)
+        with patch('sky.skypilot_config.get_effective_region_config',
+                   return_value=None):
+            result = kubernetes.Kubernetes._detect_network_type(
+                context='test-context',
+                network_tier=resources_utils.NetworkTier.BEST,
+                k8s_acc_label_key='nvidia.com/gpu.product',
+                k8s_resource_key='nvidia.com/gpu',
+                acc_count=8,
+                acc_type='H100')
 
         self.assertEqual(
             result,

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4095,18 +4095,18 @@ class TestKubernetesDetectNetworkType(unittest.TestCase):
                         })
         mock_get_nodes.return_value = [mock_node]
 
-        result = kubernetes.Kubernetes._detect_network_type(
-            context='test-context',
-            network_tier=resources_utils.NetworkTier.BEST,
-            k8s_acc_label_key='nvidia.com/gpu.product',
-            k8s_resource_key='nvidia.com/gpu',
-            acc_count=8)
+        with patch('sky.skypilot_config.get_effective_region_config',
+                   return_value=None):
+            result = kubernetes.Kubernetes._detect_network_type(
+                context='test-context',
+                network_tier=resources_utils.NetworkTier.BEST,
+                k8s_acc_label_key='nvidia.com/gpu.product',
+                k8s_resource_key='nvidia.com/gpu',
+                acc_count=8)
 
-        # Should return AWS_EFA type but without efa_count metadata
         self.assertEqual(
             result,
-            (kubernetes_utils.KubernetesHighPerformanceNetworkType.AWS_EFA,
-             None))
+            (kubernetes_utils.KubernetesHighPerformanceNetworkType.NONE, None))
 
     @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
     def test_aws_efa_detection_node_without_gpu_label(self, mock_get_nodes):
@@ -4158,11 +4158,9 @@ class TestKubernetesDetectNetworkType(unittest.TestCase):
             k8s_resource_key='nvidia.com/gpu',
             acc_count=8)
 
-        # EFA count is 0, so AWS_EFA is still returned but without efa_count metadata
         self.assertEqual(
             result,
-            (kubernetes_utils.KubernetesHighPerformanceNetworkType.AWS_EFA,
-             None))
+            (kubernetes_utils.KubernetesHighPerformanceNetworkType.NONE, None))
 
 
 class TestKubernetesCheckSingleContextForwardsCloud(unittest.TestCase):
@@ -4311,6 +4309,17 @@ class TestDetectNetworkTypeEfaScaleFromZero(unittest.TestCase):
             net, kubernetes.KubernetesHighPerformanceNetworkType.AWS_EFA)
         self.assertIsNotNone(meta)
         self.assertEqual(meta['efa_count'], 32)
+
+    def test_matching_gpu_without_efa_uses_catalog(self):
+        node = self._node(
+            {
+                **self._AWS_SYSTEM_NODE_LABELS,
+                'nvidia.com/gpu.product': 'H100',
+            }, {'nvidia.com/gpu': '8'})
+        net, meta = self._detect([node], 8, 'H100', derived_efa=32)
+        self.assertEqual(
+            net, kubernetes.KubernetesHighPerformanceNetworkType.AWS_EFA)
+        self.assertEqual(meta, {'efa_count': 32})
 
     def test_cold_aws_node_no_autoscaler_gets_no_efa(self):
         # A static cluster (no autoscaler) with no GPU node can never schedule


### PR DESCRIPTION
## What changed

Allow Kubernetes EFA detection to continue to the AWS autoscaler catalog when a matching static GPU node has no EFA resource or reports zero EFA.

## Why

An EFA-capable instance type can require catalog-derived EFA sizing before the device plugin advertises the extended resource. Returning early incorrectly treated that node as non-EFA.

## Validation

- Focused Kubernetes EFA unit suite: passed
- Added static no-resource, zero-resource, and catalog-fallback coverage
- No cluster or cloud-resource actions