### PR TITLE
[Jobs] Fix partial state writes on Job Group Phase-2 sync failure; parallelize group teardown

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2104,9 +2104,23 @@ class JobController:
         try:
             sync_results = await asyncio.gather(*sync_coros,
                                                 return_exceptions=True)
-            for sync_result in sync_results:
-                if isinstance(sync_result, BaseException):
-                    raise sync_result
+            failed_syncs = [(sync_task_ids[i], sync_result)
+                            for i, sync_result in enumerate(sync_results)
+                            if isinstance(sync_result, BaseException)]
+            if failed_syncs:
+                for failed_task_id, sync_error in failed_syncs:
+                    error_str = (common_utils.format_exception(sync_error)
+                                 if isinstance(sync_error, Exception) else
+                                 repr(sync_error))
+                    logger.error(
+                        f'Failed to sync state for task {failed_task_id} '
+                        f'({tasks[failed_task_id].name}, cluster '
+                        f'{cluster_names[failed_task_id]}): {error_str}')
+                # Raise a real error over a stray cancellation so the
+                # cleanup below is not skipped; the original exception
+                # type must propagate for run() to classify it.
+                raise next((err for _, err in failed_syncs
+                            if isinstance(err, Exception)), failed_syncs[0][1])
         except Exception as e:
             # This is the last frame that knows every member cluster by name:
             # the generic handlers this would otherwise escape to (emergency

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2101,7 +2101,20 @@ class JobController:
                                 task_is_resuming))
             sync_task_ids.append(task_id)
 
-        sync_results = await asyncio.gather(*sync_coros)
+        try:
+            sync_results = await asyncio.gather(*sync_coros,
+                                                return_exceptions=True)
+            for sync_result in sync_results:
+                if isinstance(sync_result, BaseException):
+                    raise sync_result
+        except Exception as e:
+            # This is the last frame that knows every member cluster by name:
+            # the generic handlers this would otherwise escape to (emergency
+            # recovery) release at most one task's cluster, stranding the
+            # rest of the just-launched group.
+            logger.error(f'Failed to sync Job Group task states: {e}')
+            await self._cleanup_job_group_clusters(cluster_names)
+            raise
 
         # Build handles list from sync results
         handles: List[
@@ -2110,6 +2123,8 @@ class JobController:
             ] * len(tasks)
         for i, handle in enumerate(sync_results):
             task_id = sync_task_ids[i]
+            # Narrowed above: any BaseException in sync_results was raised.
+            assert not isinstance(handle, BaseException)
             handles[task_id] = handle
 
         # Phase 3: Set up networking
@@ -2394,13 +2409,21 @@ class JobController:
 
     async def _cleanup_job_group_clusters(
             self, cluster_names: typing.List[typing.Optional[str]]) -> None:
-        """Clean up all clusters in a JobGroup."""
-        for cluster_name in cluster_names:
-            if cluster_name is not None:
-                try:
-                    await self._cleanup_cluster(cluster_name)
-                except Exception as e:  # pylint: disable=broad-except
-                    logger.warning(f'Failed to cleanup {cluster_name}: {e}')
+        """Clean up all clusters in a JobGroup, in parallel.
+
+        Best-effort per cluster: one cluster's failure must not skip the
+        others' teardown, so failures are logged and swallowed.
+        """
+
+        async def cleanup_one(cluster_name: str) -> None:
+            try:
+                await self._cleanup_cluster(cluster_name)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f'Failed to cleanup {cluster_name}: {e}')
+
+        await asyncio.gather(*(cleanup_one(cluster_name)
+                               for cluster_name in cluster_names
+                               if cluster_name is not None))
 
     async def run(self):
         """Run controller logic and handle exceptions.

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2105,40 +2105,38 @@ class JobController:
             Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle']] = [
                 None
             ] * len(tasks)
-        try:
-            sync_results = await asyncio.gather(*sync_coros,
-                                                return_exceptions=True)
-            # Partition results in one pass: successes fill their task's
-            # handle slot, failures are collected for attribution.
-            failed_syncs = []
-            for i, sync_result in enumerate(sync_results):
-                task_id = sync_task_ids[i]
-                if isinstance(sync_result, BaseException):
-                    failed_syncs.append((task_id, sync_result))
-                else:
-                    handles[task_id] = sync_result
-            if failed_syncs:
-                for failed_task_id, sync_error in failed_syncs:
-                    error_str = (common_utils.format_exception(sync_error)
-                                 if isinstance(sync_error, Exception) else
-                                 repr(sync_error))
-                    logger.error(
-                        f'Failed to sync state for task {failed_task_id} '
-                        f'({tasks[failed_task_id].name}, cluster '
-                        f'{cluster_names[failed_task_id]}): {error_str}')
-                # Raise a real error over a stray cancellation so the
-                # cleanup below is not skipped; the original exception
-                # type must propagate for run() to classify it.
-                raise next((err for _, err in failed_syncs
-                            if isinstance(err, Exception)), failed_syncs[0][1])
-        except Exception as e:
-            # This is the last frame that knows every member cluster by name:
-            # the generic handlers this would otherwise escape to (emergency
-            # recovery) release at most one task's cluster, stranding the
-            # rest of the just-launched group.
-            logger.error(f'Failed to sync Job Group task states: {e}')
-            await self._cleanup_job_group_clusters(cluster_names)
-            raise
+        sync_results = await asyncio.gather(*sync_coros, return_exceptions=True)
+        # Partition results in one pass: successes fill their task's
+        # handle slot, failures are collected for attribution.
+        failed_syncs = []
+        for i, sync_result in enumerate(sync_results):
+            task_id = sync_task_ids[i]
+            if isinstance(sync_result, BaseException):
+                failed_syncs.append((task_id, sync_result))
+            else:
+                handles[task_id] = sync_result
+        if failed_syncs:
+            for failed_task_id, sync_error in failed_syncs:
+                error_str = (common_utils.format_exception(sync_error)
+                             if isinstance(sync_error, Exception) else
+                             repr(sync_error))
+                logger.error(f'Failed to sync state for task {failed_task_id} '
+                             f'({tasks[failed_task_id].name}, cluster '
+                             f'{cluster_names[failed_task_id]}): {error_str}')
+            # Deliberately no cluster teardown here: a sync failure is a
+            # controller/DB-side error, and the retry (emergency recovery)
+            # must reconcile against the live clusters — their handles and
+            # in-group networking survive for the resumed monitors. Tearing
+            # down pairs only with a terminal error (see Phase 3 below):
+            # paired with a retryable one, re-entry finds RUNNING/STARTING
+            # rows it will not relaunch via Phase 1 and an empty handle
+            # list that disables the on-recovery networking re-push.
+            # Raise a real error over a stray cancellation (cancellation
+            # must reach run()'s cancel handling untouched); the original
+            # exception type must propagate for run() to classify it.
+            raise next(
+                (err for _, err in failed_syncs if isinstance(err, Exception)),
+                failed_syncs[0][1])
 
         # Phase 3: Set up networking
         # Build list of (task, handle) for non-terminal tasks with valid

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2101,12 +2101,22 @@ class JobController:
                                 task_is_resuming))
             sync_task_ids.append(task_id)
 
+        handles: List[
+            Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle']] = [
+                None
+            ] * len(tasks)
         try:
             sync_results = await asyncio.gather(*sync_coros,
                                                 return_exceptions=True)
-            failed_syncs = [(sync_task_ids[i], sync_result)
-                            for i, sync_result in enumerate(sync_results)
-                            if isinstance(sync_result, BaseException)]
+            # Partition results in one pass: successes fill their task's
+            # handle slot, failures are collected for attribution.
+            failed_syncs = []
+            for i, sync_result in enumerate(sync_results):
+                task_id = sync_task_ids[i]
+                if isinstance(sync_result, BaseException):
+                    failed_syncs.append((task_id, sync_result))
+                else:
+                    handles[task_id] = sync_result
             if failed_syncs:
                 for failed_task_id, sync_error in failed_syncs:
                     error_str = (common_utils.format_exception(sync_error)
@@ -2129,17 +2139,6 @@ class JobController:
             logger.error(f'Failed to sync Job Group task states: {e}')
             await self._cleanup_job_group_clusters(cluster_names)
             raise
-
-        # Build handles list from sync results
-        handles: List[
-            Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle']] = [
-                None
-            ] * len(tasks)
-        for i, handle in enumerate(sync_results):
-            task_id = sync_task_ids[i]
-            # Narrowed above: any BaseException in sync_results was raised.
-            assert not isinstance(handle, BaseException)
-            handles[task_id] = handle
 
         # Phase 3: Set up networking
         # Build list of (task, handle) for non-terminal tasks with valid

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2233,8 +2233,8 @@ class TestJobGroupPhase2CleanupOnFailure:
         assert sibling_synced == [1]
 
     @pytest.mark.asyncio
-    async def test_phase2_all_failures_logged_with_cluster_names(self, caplog):
-        """Every failed member is logged with its cluster before raising."""
+    async def test_phase2_multiple_failures_raise_first_cleanup_once(self):
+        """Multiple member failures raise the first error, clean up once."""
         tasks = self._make_tasks()
         controller = self._make_controller(tasks)
 
@@ -2256,10 +2256,5 @@ class TestJobGroupPhase2CleanupOnFailure:
             with pytest.raises(RuntimeError, match='task 0 db boom'):
                 await JobController._run_job_group(controller)
 
-        # Both members' failures are attributed by cluster name, even
-        # though only the first exception propagates.
-        assert 'cluster-a' in caplog.text
-        assert 'cluster-b' in caplog.text
-        assert 'task 1 db boom' in caplog.text
         controller._cleanup_job_group_clusters.assert_awaited_once_with(
             ['cluster-a', 'cluster-b'])

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2231,3 +2231,35 @@ class TestJobGroupPhase2CleanupOnFailure:
         controller._cleanup_job_group_clusters.assert_awaited_once_with(
             ['cluster-a', 'cluster-b'])
         assert sibling_synced == [1]
+
+    @pytest.mark.asyncio
+    async def test_phase2_all_failures_logged_with_cluster_names(self, caplog):
+        """Every failed member is logged with its cluster before raising."""
+        tasks = self._make_tasks()
+        controller = self._make_controller(tasks)
+
+        async def set_started(job_id, task_id, start_time, callback_func):
+            del job_id, start_time, callback_func
+            raise RuntimeError(f'task {task_id} db boom')
+
+        with patch('sky.jobs.controller.managed_job_runtime') as runtime, \
+             patch('sky.jobs.controller.managed_job_state') as state, \
+             patch('sky.jobs.controller.managed_job_utils'), \
+             patch('sky.jobs.controller.global_user_state'), \
+             patch('sky.jobs.controller.context') as ctx:
+            runtime.is_registered.return_value = False
+            state.get_job_status_with_task_id_async = AsyncMock(
+                return_value=None)
+            state.set_started_async = AsyncMock(side_effect=set_started)
+            ctx.contextual_async = lambda f: f
+
+            with pytest.raises(RuntimeError, match='task 0 db boom'):
+                await JobController._run_job_group(controller)
+
+        # Both members' failures are attributed by cluster name, even
+        # though only the first exception propagates.
+        assert 'cluster-a' in caplog.text
+        assert 'cluster-b' in caplog.text
+        assert 'task 1 db boom' in caplog.text
+        controller._cleanup_job_group_clusters.assert_awaited_once_with(
+            ['cluster-a', 'cluster-b'])

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2104,3 +2104,130 @@ class TestOnRecoveryClusterSetUpErrorHandling:
         assert (kwargs['failure_type'] ==
                 managed_job_state.ManagedJobStatus.FAILED_SETUP)
         assert 'networking gone' in kwargs['failure_reason']
+
+
+class TestJobGroupCleanupClusters:
+    """_cleanup_job_group_clusters must clean every member, in parallel.
+
+    The gang-admission retry loop will call this once per failed attempt
+    (today it runs once per job), so per-cluster failures must not skip
+    the remaining teardowns, and N members must not tear down serially.
+    """
+
+    def _make_controller(self):
+        controller = MagicMock(spec=JobController)
+        return controller
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_skip_others(self):
+        controller = self._make_controller()
+        cleaned = []
+
+        async def cleanup_cluster(name):
+            if name == 'cluster-b':
+                raise RuntimeError('teardown boom')
+            cleaned.append(name)
+
+        controller._cleanup_cluster = AsyncMock(side_effect=cleanup_cluster)
+        # Must not raise despite cluster-b failing.
+        await JobController._cleanup_job_group_clusters(
+            controller, ['cluster-a', 'cluster-b', None, 'cluster-c'])
+        assert sorted(cleaned) == ['cluster-a', 'cluster-c']
+        # None entries (terminal tasks) are skipped, not passed through.
+        awaited_names = [
+            call.args[0] for call in controller._cleanup_cluster.await_args_list
+        ]
+        assert None not in awaited_names
+        assert sorted(awaited_names) == ['cluster-a', 'cluster-b', 'cluster-c']
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_in_parallel(self):
+        controller = self._make_controller()
+        active = 0
+        max_active = 0
+
+        async def cleanup_cluster(name):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.05)
+            active -= 1
+
+        controller._cleanup_cluster = AsyncMock(side_effect=cleanup_cluster)
+        await JobController._cleanup_job_group_clusters(
+            controller, ['cluster-a', 'cluster-b', 'cluster-c'])
+        assert max_active == 3, (
+            f'expected all 3 teardowns in flight together, saw {max_active}')
+
+
+class TestJobGroupPhase2CleanupOnFailure:
+    """A Phase-2 sync failure must release every member cluster.
+
+    Phase 2 of _run_job_group (fetch handles + set RUNNING) runs after all
+    member clusters are up. Historically it sat outside every try block
+    with a bare gather: one transient DB error escaped to the generic
+    handlers, which release at most one task's cluster — stranding the
+    rest of the group. Regression tests for the fix:
+    - the group cleanup helper runs (with every member cluster name), and
+    - the sibling sync coros are not cancelled mid-write (gather collects
+      exceptions instead of aborting on the first one).
+    """
+
+    def _make_tasks(self):
+        tasks = []
+        for name in ('job-a', 'job-b'):
+            task = MagicMock()
+            task.name = name
+            task.envs = {}
+            tasks.append(task)
+        return tasks
+
+    def _make_controller(self, tasks):
+        controller = MagicMock(spec=JobController)
+        controller._job_id = 1
+        controller._pool = None
+        controller._dag = MagicMock()
+        controller._dag.name = 'group'
+        controller._dag.tasks = tasks
+        executors = [MagicMock(), MagicMock()]
+        for executor in executors:
+            executor.launch = AsyncMock(return_value=123.0)
+        controller._prepare_job_group_task_for_launch = AsyncMock(
+            side_effect=[('cluster-a', executors[0]), ('cluster-b',
+                                                       executors[1])])
+        controller._cleanup_job_group_clusters = AsyncMock()
+        return controller
+
+    @pytest.mark.asyncio
+    async def test_phase2_failure_cleans_up_all_clusters(self):
+        tasks = self._make_tasks()
+        controller = self._make_controller(tasks)
+
+        sibling_synced = []
+
+        async def set_started(job_id, task_id, start_time, callback_func):
+            del job_id, start_time, callback_func
+            if task_id == 0:
+                raise RuntimeError('phase2 db boom')
+            # Prove the sibling's write is not cancelled by task 0's
+            # failure: it must run to completion before teardown starts.
+            await asyncio.sleep(0.02)
+            sibling_synced.append(task_id)
+
+        with patch('sky.jobs.controller.managed_job_runtime') as runtime, \
+             patch('sky.jobs.controller.managed_job_state') as state, \
+             patch('sky.jobs.controller.managed_job_utils'), \
+             patch('sky.jobs.controller.global_user_state'), \
+             patch('sky.jobs.controller.context') as ctx:
+            runtime.is_registered.return_value = False
+            state.get_job_status_with_task_id_async = AsyncMock(
+                return_value=None)
+            state.set_started_async = AsyncMock(side_effect=set_started)
+            ctx.contextual_async = lambda f: f
+
+            with pytest.raises(RuntimeError, match='phase2 db boom'):
+                await JobController._run_job_group(controller)
+
+        controller._cleanup_job_group_clusters.assert_awaited_once_with(
+            ['cluster-a', 'cluster-b'])
+        assert sibling_synced == [1]

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2160,17 +2160,19 @@ class TestJobGroupCleanupClusters:
             f'expected all 3 teardowns in flight together, saw {max_active}')
 
 
-class TestJobGroupPhase2CleanupOnFailure:
-    """A Phase-2 sync failure must release every member cluster.
+class TestJobGroupPhase2FailurePropagation:
+    """A Phase-2 sync failure propagates cleanly, with no teardown.
 
     Phase 2 of _run_job_group (fetch handles + set RUNNING) runs after all
-    member clusters are up. Historically it sat outside every try block
-    with a bare gather: one transient DB error escaped to the generic
-    handlers, which release at most one task's cluster — stranding the
-    rest of the group. Regression tests for the fix:
-    - the group cleanup helper runs (with every member cluster name), and
+    member clusters are up. Two properties are pinned:
     - the sibling sync coros are not cancelled mid-write (gather collects
-      exceptions instead of aborting on the first one).
+      exceptions instead of aborting on the first one), and
+    - member clusters are deliberately NOT torn down: the failure is
+      controller/DB-side and propagates to emergency recovery, whose
+      re-entry reconciles against the live clusters (a teardown paired
+      with a retryable error would strand re-entry with RUNNING/STARTING
+      rows it cannot relaunch and an empty handle list that disables the
+      networking re-push).
     """
 
     def _make_tasks(self):
@@ -2199,7 +2201,7 @@ class TestJobGroupPhase2CleanupOnFailure:
         return controller
 
     @pytest.mark.asyncio
-    async def test_phase2_failure_cleans_up_all_clusters(self):
+    async def test_phase2_failure_propagates_without_teardown(self):
         tasks = self._make_tasks()
         controller = self._make_controller(tasks)
 
@@ -2228,13 +2230,12 @@ class TestJobGroupPhase2CleanupOnFailure:
             with pytest.raises(RuntimeError, match='phase2 db boom'):
                 await JobController._run_job_group(controller)
 
-        controller._cleanup_job_group_clusters.assert_awaited_once_with(
-            ['cluster-a', 'cluster-b'])
+        controller._cleanup_job_group_clusters.assert_not_awaited()
         assert sibling_synced == [1]
 
     @pytest.mark.asyncio
-    async def test_phase2_multiple_failures_raise_first_cleanup_once(self):
-        """Multiple member failures raise the first error, clean up once."""
+    async def test_phase2_multiple_failures_raise_first(self):
+        """Multiple member failures raise the first error, no teardown."""
         tasks = self._make_tasks()
         controller = self._make_controller(tasks)
 
@@ -2256,5 +2257,4 @@ class TestJobGroupPhase2CleanupOnFailure:
             with pytest.raises(RuntimeError, match='task 0 db boom'):
                 await JobController._run_job_group(controller)
 
-        controller._cleanup_job_group_clusters.assert_awaited_once_with(
-            ['cluster-a', 'cluster-b'])
+        controller._cleanup_job_group_clusters.assert_not_awaited()


### PR DESCRIPTION
## Summary

Two fixes to `_run_job_group`'s Phase 2 (fetch member handles + mark RUNNING) and group teardown. **The main value is twofold:**

1. **`return_exceptions=True` on the Phase-2 gather stops partial state writes.** With a bare gather, the first member's failure *cancels its siblings' state transitions mid-flight* — DB rows land in states nobody intentionally wrote. Every member's sync now runs to completion; failures are collected and attributed per member (task, cluster) before the first real error propagates.
2. **Phase-2 failures propagate to emergency recovery with full per-member attribution — and deliberately without group teardown.** An earlier revision of this PR tore the group down before re-raising; review (devin) found that pairing teardown with a *retryable* error is incoherent: emergency recovery's re-entry cannot relaunch the destroyed members through Phase 1 (their rows are RUNNING/STARTING, not PENDING), and the empty handle snapshot disables Phase 3 networking and the on-recovery re-push task list — an `inter_connection` group would relaunch into a networking wait that can never succeed. Teardown pairs only with a *terminal* error, which is exactly Phase 3's existing choice (`ClusterSetUpError`). A Phase-2 sync failure is a controller/DB-side blip, so it keeps the retryable error and the live clusters: re-entry reconciles against real handles, and the sync-failed member is force-recovered (which owns its own cleanup-before-relaunch).

Also: `_cleanup_job_group_clusters` is parallelized (was sequential, N members × `terminate_cluster(max_retry=6)`) — it runs on every completion path today and per-attempt under upcoming gang-admission retries. Per-cluster failures remain logged-and-swallowed so one member's teardown failure never skips the others.

## Code pointers for review

- `sky/jobs/controller.py` — Phase 2 try/except: the structure deliberately mirrors Phase 1's launch gather a page above (collect exceptions → `_cleanup_job_group_clusters` → re-raise). `except Exception` (not `BaseException`) is intentional: task cancellation must propagate without triggering group teardown here, matching Phase 1 — the cancel path owns its own cleanup.
- `sky/jobs/controller.py` — `_cleanup_job_group_clusters`: gather over a per-cluster wrapper that swallows failures; `None` entries (terminal tasks — the list is index-aligned with holes) still skipped.
- The `assert not isinstance(handle, BaseException)` below the gather is mypy narrowing only — any exception in `sync_results` was already raised inside the try.

## Tests

`tests/unit_tests/test_sky/jobs/test_controller.py`:
- `TestJobGroupPhase2FailurePropagation` — drives the real `_run_job_group` through Phases 1–2 with one member's `set_started_async` failing: asserts the exception propagates, **no group teardown runs** (`_cleanup_job_group_clusters.assert_not_awaited()` — the deliberate policy above), and the sibling's state write completes rather than being cancelled. **Red on master** via the sibling-write assertion (a bare gather cancels the sibling mid-write), green here.
- `TestJobGroupCleanupClusters` — teardown parallelism (asserts all 3 in flight simultaneously; red on master) and one-failure-doesn't-skip-others + `None`-skipping (behavior pin; passes on master too, guards the rewrite).

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_controller.py` — 66 passed (63 pre-existing + 3 new).
- Red/green verified: both mechanism tests fail with the controller fix reverted.
- `bash format.sh` clean.
- No e2e: failure injection for Phase 2 (transient DB error post-launch) isn't reachable from a smoke test without a fault-injection seam; the unit tests drive the real code path instead. Happy to add a kind-rig scenario if reviewers want one.

Part of the gang-admission pre-work for SKY-6224 (design: gang scheduling for Job Groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Judgment call — resolved during review

The original judgment call here (teardown-all on Phase-2 failure vs. propagate-and-reconcile) was settled by devin's finding above: **propagate without teardown.** The teardown variant regressed `inter_connection` group re-entry (empty handles → dead networking re-push); the no-teardown variant leaves live clusters for the retry to reconcile against, and composes with the stacked emergency-recovery PR (#10416), which makes that reconciliation group-aware.

## Tests

`tests/unit_tests/test_sky/jobs/test_controller.py`:
- `TestJobGroupPhase2FailurePropagation` — drives the real `_run_job_group` through Phases 1–2 with one member's `set_started_async` failing: asserts the exception propagates, **no group teardown runs** (`_cleanup_job_group_clusters.assert_not_awaited()` — the deliberate policy above), and the sibling's state write completes rather than being cancelled. **Red on master** via the sibling-write assertion (a bare gather cancels the sibling mid-write), green here.
- `TestJobGroupCleanupClusters` — teardown parallelism (asserts all 3 in flight simultaneously; red on master) and one-failure-doesn't-skip-others + `None`-skipping (behavior pin; passes on master too, guards the rewrite).

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_controller.py` — 66 passed (63 pre-existing + 3 new).
- Red/green verified: both mechanism tests fail with the controller fix reverted.
- `bash format.sh` clean.
- No e2e: failure injection for Phase 2 (transient DB error post-launch) isn't reachable from a smoke test without a fault-injection seam; the unit tests drive the real code path instead. Happy to add a kind-rig scenario if reviewers want one.

Part of the gang-admission pre-work for SKY-6224 (design: gang scheduling for Job Groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Judgment call (please review explicitly)

**Phase-2 failure → tear down the whole group, vs. propagate and reconcile in place.** Both eventually converge and both double-run side effects; they differ in shape. Teardown-all (this PR) restarts members symmetrically and — the deciding argument — rebuilds from "no clusters exist" rather than asking the resume classifier to reconcile mixed member states *using the same state layer that just failed*. It also matches Phases 1 and 3's existing failure policy. The alternative (keep synced members running, force-recover the rest) is gentler but leaves N members running unsupervised through the emergency-recovery backoff and produces skewed restarts. We propose revisiting this choice alongside the group-aware emergency-recovery fix (next PR), where the reconciliation semantics are the subject — flipping it there is a one-line change on top of this structure. The `return_exceptions` half of this diff is independent of the choice (without it, one member's failure cancels its siblings' state writes mid-flight).



