### PR TITLE
[Jobs] Emergency recovery: skip per-task surgery for Job Groups

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2672,6 +2672,149 @@ class JobController:
                            'emergency teardown (continuing recovery): '
                            f'{common_utils.format_exception(e)}')
 
+    async def _emergency_bookkeeping_job_group(self) -> bool:
+        """Group-shape pre-retry bookkeeping.
+
+        Returns True to retry the job loop immediately (no backoff): the
+        group is being cancelled or every member is terminal, so the resume
+        logic owns completion. Returns False to proceed to the backoff.
+        """
+        # Job Groups: every member is concurrently mid-flight, so there
+        # is no single "latest" task to operate on, and per-task surgery
+        # is wrong in both directions: marking an arbitrary member
+        # RECOVERING instructs the retry's resume classification to tear
+        # down and relaunch a member that may be healthily RUNNING, and
+        # tearing down one member's cluster leaves its siblings running
+        # unsupervised through the backoff either way. Do neither. The
+        # retry re-enters _run_job_group, whose resume classification
+        # reconciles every member from its own status: RUNNING members
+        # get their monitors reattached untouched (a member whose
+        # cluster actually died fails its first status probe and enters
+        # recovery normally); STARTING/RECOVERING members are force-
+        # recovered (which owns cleanup-before-relaunch); PENDING
+        # members launch fresh.
+        # Known gap: no per-task RECOVERING event is emitted here, so
+        # events-based recovery metrics do not count group emergencies
+        # (the job-level budget columns still do).
+        # TODO(ishan): once gang admission lands (SKY-6224), a group
+        # whose admission barrier is still open should instead tear down
+        # all members and reset them to PENDING: mid-startup there is no
+        # progress to protect and startup is all-or-nothing.
+        statuses = [
+            await managed_job_state.get_job_status_with_task_id_async(
+                job_id=self._job_id, task_id=tid)
+            for tid in range(len(self._dag.tasks))
+        ]
+        any_cancelling = any(
+            task_status == managed_job_state.ManagedJobStatus.CANCELLING
+            for task_status in statuses)
+        all_terminal = all(
+            task_status is not None and task_status.is_terminal()
+            for task_status in statuses)
+        if any_cancelling or all_terminal:
+            # Mirror the single-task fast path below: cancellation and
+            # terminal completion are owned by the resume logic, so
+            # retry the job loop immediately (no backoff) to let it
+            # complete (re-raising CancelledError or finishing the
+            # terminal tasks cleanly).
+            logger.info(f'Job Group {self._job_id} is cancelling or terminal; '
+                        'retrying the job loop to let it complete.')
+            return True
+        return False
+
+    async def _emergency_bookkeeping_latest_task(self, error: Union[Exception,
+                                                                    SystemExit],
+                                                 attempt: int,
+                                                 max_attempts: int) -> bool:
+        """Single-job / chain-pipeline pre-retry bookkeeping.
+
+        Exactly one task can be mid-flight in these shapes, so operate on
+        the latest task: mark it RECOVERING (recovery_source=EMERGENCY) and
+        tear its cluster down early (the retry force-relaunches it, so it
+        is doomed anyway — do not leave it running through a backoff of up
+        to 30 minutes).
+
+        Returns True to retry the job loop immediately (no backoff): the
+        task is CANCELLING or terminal, so the resume logic owns completion.
+        Returns False to proceed to the backoff.
+        """
+        # 2. Determine the latest task and its status. The latest task is
+        # the only one that can be mid-flight for single jobs and chain
+        # DAGs (job groups take the branch above).
+        task_id, cur_status = (
+            await
+            managed_job_state.get_latest_task_id_status_async(self._job_id))
+        if task_id is None:
+            task_id = 0
+
+        if cur_status == managed_job_state.ManagedJobStatus.PENDING:
+            # The task never initialized (set_starting_async has not run).
+            # Do not mark it RECOVERING — that would make the retry treat it
+            # as a resume and skip initialization forever. Leave it PENDING;
+            # the retry relaunches it fresh (is_resume=False). There is no
+            # cluster to tear down yet. Fall through to the backoff so a
+            # PENDING-phase error is bounded and paced like any episode.
+            logger.info(f'Job {self._job_id} task {task_id} is PENDING; '
+                        'relaunching fresh after the emergency backoff.')
+        else:
+            # Mark the latest task RECOVERING (recovery_source=EMERGENCY on
+            # the event). Emit the event only once per escaped error, so an
+            # outer-retry re-run does not append a duplicate.
+            reason = (
+                f'Unexpected controller error (emergency recovery attempt '
+                f'{attempt}/{max_attempts}): ' +
+                common_utils.format_exception(error, use_bracket=True))
+            emit_event = not self._emergency_event_emitted
+            applied = await managed_job_state.set_emergency_recovering_async(
+                self._job_id,
+                task_id,
+                reason=reason,
+                callback_func=managed_job_utils.event_callback_func(
+                    job_id=self._job_id,
+                    task_id=task_id,
+                    task=self._dag.tasks[task_id]),
+                emit_event=emit_event)
+            if applied and emit_event:
+                self._emergency_event_emitted = True
+            if not applied:
+                # The task is CANCELLING or already terminal — those paths
+                # own the task now. Retry the job loop immediately (no
+                # backoff): the resume logic completes the cancellation
+                # (re-raising CancelledError) or finishes the terminal task
+                # cleanly.
+                logger.info(f'Job {self._job_id} task {task_id} is cancelling '
+                            'or terminal; retrying the job loop to let it '
+                            'complete.')
+                return True
+
+            # 3. Tear down the task's cluster now (best-effort) instead of
+            # leaving it to the retry's forced recovery: the retry always
+            # relaunches from scratch, so the cluster is doomed anyway —
+            # don't leave it running (and billing) through a backoff that can
+            # be up to 30 minutes. terminate_cluster is idempotent and the
+            # retry's forced recovery runs the same cleanup again, so a
+            # failure here only delays the teardown. Pool jobs keep their
+            # shared cluster (no dedicated cluster to tear down) — the
+            # retry's forced recovery cancels the stale pool submission and
+            # runs the hook, so nothing to do here.
+            task_name = self._dag.tasks[task_id].name
+            if self._pool is None and task_name is not None:
+                cluster_name = (
+                    managed_job_utils.generate_managed_job_cluster_name(
+                        task_name, self._job_id))
+                # Give the runtime a chance to snapshot the run's logs before
+                # we tear the cluster down.
+                await self._emergency_before_teardown_hook(
+                    task_id, cluster_name)
+                try:
+                    await self._cleanup_cluster(cluster_name)
+                except Exception as cleanup_error:  # pylint: disable=broad-except
+                    logger.warning(
+                        'Best-effort cluster teardown before the emergency '
+                        'backoff failed; the retry will clean up instead: '
+                        f'{common_utils.format_exception(cleanup_error)}')
+        return False
+
     async def _attempt_emergency_recovery(
             self, error: Union[Exception, SystemExit]) -> Optional[str]:
         """One round of the emergency-recovery bookkeeping.
@@ -2723,128 +2866,18 @@ class JobController:
         # Free the launching slot for the whole backoff (see helper).
         await self._release_launch_slot()
 
+        # 2./3. Shape-specific bookkeeping (see each helper's docstring).
         if self._dag.is_job_group():
-            # Job Groups: every member is concurrently mid-flight, so there
-            # is no single "latest" task to operate on, and per-task surgery
-            # is wrong in both directions: marking an arbitrary member
-            # RECOVERING instructs the retry's resume classification to tear
-            # down and relaunch a member that may be healthily RUNNING, and
-            # tearing down one member's cluster leaves its siblings running
-            # unsupervised through the backoff either way. Do neither. The
-            # retry re-enters _run_job_group, whose resume classification
-            # reconciles every member from its own status: RUNNING members
-            # get their monitors reattached untouched (a member whose
-            # cluster actually died fails its first status probe and enters
-            # recovery normally); STARTING/RECOVERING members are force-
-            # recovered (which owns cleanup-before-relaunch); PENDING
-            # members launch fresh.
-            # Known gap: no per-task RECOVERING event is emitted here, so
-            # events-based recovery metrics do not count group emergencies
-            # (the job-level budget columns still do).
-            # TODO(ishan): once gang admission lands (SKY-6224), a group
-            # whose admission barrier is still open should instead tear down
-            # all members and reset them to PENDING: mid-startup there is no
-            # progress to protect and startup is all-or-nothing.
-            statuses = [
-                await managed_job_state.get_job_status_with_task_id_async(
-                    job_id=self._job_id, task_id=tid)
-                for tid in range(len(self._dag.tasks))
-            ]
-            any_cancelling = any(
-                task_status == managed_job_state.ManagedJobStatus.CANCELLING
-                for task_status in statuses)
-            all_terminal = all(
-                task_status is not None and task_status.is_terminal()
-                for task_status in statuses)
-            if any_cancelling or all_terminal:
-                # Mirror the single-task fast path below: cancellation and
-                # terminal completion are owned by the resume logic, so
-                # retry the job loop immediately (no backoff) to let it
-                # complete (re-raising CancelledError or finishing the
-                # terminal tasks cleanly).
-                logger.info(
-                    f'Job Group {self._job_id} is cancelling or terminal; '
-                    'retrying the job loop to let it complete.')
-                await asyncio.to_thread(self._load_dag)
-                return None
+            fast_retry = await self._emergency_bookkeeping_job_group()
         else:
-            # 2. Determine the latest task and its status. The latest task is
-            # the only one that can be mid-flight for single jobs and chain
-            # DAGs (job groups take the branch above).
-            task_id, cur_status = (
-                await
-                managed_job_state.get_latest_task_id_status_async(self._job_id))
-            if task_id is None:
-                task_id = 0
-
-            if cur_status == managed_job_state.ManagedJobStatus.PENDING:
-                # The task never initialized (set_starting_async has not run).
-                # Do not mark it RECOVERING — that would make the retry treat it
-                # as a resume and skip initialization forever. Leave it PENDING;
-                # the retry relaunches it fresh (is_resume=False). There is no
-                # cluster to tear down yet. Fall through to the backoff so a
-                # PENDING-phase error is bounded and paced like any episode.
-                logger.info(f'Job {self._job_id} task {task_id} is PENDING; '
-                            'relaunching fresh after the emergency backoff.')
-            else:
-                # Mark the latest task RECOVERING (recovery_source=EMERGENCY on
-                # the event). Emit the event only once per escaped error, so an
-                # outer-retry re-run does not append a duplicate.
-                reason = (
-                    f'Unexpected controller error (emergency recovery attempt '
-                    f'{attempt}/{max_attempts}): ' +
-                    common_utils.format_exception(error, use_bracket=True))
-                emit_event = not self._emergency_event_emitted
-                applied = await managed_job_state.set_emergency_recovering_async(
-                    self._job_id,
-                    task_id,
-                    reason=reason,
-                    callback_func=managed_job_utils.event_callback_func(
-                        job_id=self._job_id,
-                        task_id=task_id,
-                        task=self._dag.tasks[task_id]),
-                    emit_event=emit_event)
-                if applied and emit_event:
-                    self._emergency_event_emitted = True
-                if not applied:
-                    # The task is CANCELLING or already terminal — those paths
-                    # own the task now. Retry the job loop immediately (no
-                    # backoff): the resume logic completes the cancellation
-                    # (re-raising CancelledError) or finishes the terminal task
-                    # cleanly.
-                    logger.info(
-                        f'Job {self._job_id} task {task_id} is cancelling '
-                        'or terminal; retrying the job loop to let it '
-                        'complete.')
-                    await asyncio.to_thread(self._load_dag)
-                    return None
-
-                # 3. Tear down the task's cluster now (best-effort) instead of
-                # leaving it to the retry's forced recovery: the retry always
-                # relaunches from scratch, so the cluster is doomed anyway —
-                # don't leave it running (and billing) through a backoff that can
-                # be up to 30 minutes. terminate_cluster is idempotent and the
-                # retry's forced recovery runs the same cleanup again, so a
-                # failure here only delays the teardown. Pool jobs keep their
-                # shared cluster (no dedicated cluster to tear down) — the
-                # retry's forced recovery cancels the stale pool submission and
-                # runs the hook, so nothing to do here.
-                task_name = self._dag.tasks[task_id].name
-                if self._pool is None and task_name is not None:
-                    cluster_name = (
-                        managed_job_utils.generate_managed_job_cluster_name(
-                            task_name, self._job_id))
-                    # Give the runtime a chance to snapshot the run's logs before
-                    # we tear the cluster down.
-                    await self._emergency_before_teardown_hook(
-                        task_id, cluster_name)
-                    try:
-                        await self._cleanup_cluster(cluster_name)
-                    except Exception as cleanup_error:  # pylint: disable=broad-except
-                        logger.warning(
-                            'Best-effort cluster teardown before the emergency '
-                            'backoff failed; the retry will clean up instead: '
-                            f'{common_utils.format_exception(cleanup_error)}')
+            fast_retry = await self._emergency_bookkeeping_latest_task(
+                error, attempt, max_attempts)
+        if fast_retry:
+            # Cancellation and terminal completion are owned by the resume
+            # logic; retry the job loop immediately so it can complete
+            # (re-raising CancelledError or finishing terminal tasks).
+            await asyncio.to_thread(self._load_dag)
+            return None
 
         # 4. If the error escaped mid-launch, the job may be stuck in a
         # launch-adjacent schedule state (LAUNCHING / ALIVE_WAITING /

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2720,86 +2720,131 @@ class JobController:
         await managed_job_state.record_emergency_recovery_attempt_async(
             self._job_id, attempt, now)
 
-        # 2. Determine the latest task and its status. Use the latest task
-        # (it is the only one that can be mid-flight in a chain DAG; for job
-        # groups the resume classification handles the other tasks from
-        # their raw statuses).
-        task_id, cur_status = (
-            await
-            managed_job_state.get_latest_task_id_status_async(self._job_id))
-        if task_id is None:
-            task_id = 0
-
         # Free the launching slot for the whole backoff (see helper).
         await self._release_launch_slot()
 
-        if cur_status == managed_job_state.ManagedJobStatus.PENDING:
-            # The task never initialized (set_starting_async has not run).
-            # Do not mark it RECOVERING — that would make the retry treat it
-            # as a resume and skip initialization forever. Leave it PENDING;
-            # the retry relaunches it fresh (is_resume=False). There is no
-            # cluster to tear down yet. Fall through to the backoff so a
-            # PENDING-phase error is bounded and paced like any episode.
-            logger.info(f'Job {self._job_id} task {task_id} is PENDING; '
-                        'relaunching fresh after the emergency backoff.')
-        else:
-            # Mark the latest task RECOVERING (recovery_source=EMERGENCY on
-            # the event). Emit the event only once per escaped error, so an
-            # outer-retry re-run does not append a duplicate.
-            reason = (
-                f'Unexpected controller error (emergency recovery attempt '
-                f'{attempt}/{max_attempts}): ' +
-                common_utils.format_exception(error, use_bracket=True))
-            emit_event = not self._emergency_event_emitted
-            applied = await managed_job_state.set_emergency_recovering_async(
-                self._job_id,
-                task_id,
-                reason=reason,
-                callback_func=managed_job_utils.event_callback_func(
-                    job_id=self._job_id,
-                    task_id=task_id,
-                    task=self._dag.tasks[task_id]),
-                emit_event=emit_event)
-            if applied and emit_event:
-                self._emergency_event_emitted = True
-            if not applied:
-                # The task is CANCELLING or already terminal — those paths
-                # own the task now. Retry the job loop immediately (no
-                # backoff): the resume logic completes the cancellation
-                # (re-raising CancelledError) or finishes the terminal task
-                # cleanly.
-                logger.info(f'Job {self._job_id} task {task_id} is cancelling '
-                            'or terminal; retrying the job loop to let it '
-                            'complete.')
+        if self._dag.is_job_group():
+            # Job Groups: every member is concurrently mid-flight, so there
+            # is no single "latest" task to operate on, and per-task surgery
+            # is wrong in both directions: marking an arbitrary member
+            # RECOVERING instructs the retry's resume classification to tear
+            # down and relaunch a member that may be healthily RUNNING, and
+            # tearing down one member's cluster leaves its siblings running
+            # unsupervised through the backoff either way. Do neither. The
+            # retry re-enters _run_job_group, whose resume classification
+            # reconciles every member from its own status: RUNNING members
+            # get their monitors reattached untouched (a member whose
+            # cluster actually died fails its first status probe and enters
+            # recovery normally); STARTING/RECOVERING members are force-
+            # recovered (which owns cleanup-before-relaunch); PENDING
+            # members launch fresh.
+            # Known gap: no per-task RECOVERING event is emitted here, so
+            # events-based recovery metrics do not count group emergencies
+            # (the job-level budget columns still do).
+            # TODO(ishan): once gang admission lands (SKY-6224), a group
+            # whose admission barrier is still open should instead tear down
+            # all members and reset them to PENDING: mid-startup there is no
+            # progress to protect and startup is all-or-nothing.
+            statuses = [
+                await managed_job_state.get_job_status_with_task_id_async(
+                    job_id=self._job_id, task_id=tid)
+                for tid in range(len(self._dag.tasks))
+            ]
+            any_cancelling = any(
+                task_status == managed_job_state.ManagedJobStatus.CANCELLING
+                for task_status in statuses)
+            all_terminal = all(
+                task_status is not None and task_status.is_terminal()
+                for task_status in statuses)
+            if any_cancelling or all_terminal:
+                # Mirror the single-task fast path below: cancellation and
+                # terminal completion are owned by the resume logic, so
+                # retry the job loop immediately (no backoff) to let it
+                # complete (re-raising CancelledError or finishing the
+                # terminal tasks cleanly).
+                logger.info(
+                    f'Job Group {self._job_id} is cancelling or terminal; '
+                    'retrying the job loop to let it complete.')
                 await asyncio.to_thread(self._load_dag)
                 return None
+        else:
+            # 2. Determine the latest task and its status. The latest task is
+            # the only one that can be mid-flight for single jobs and chain
+            # DAGs (job groups take the branch above).
+            task_id, cur_status = (
+                await
+                managed_job_state.get_latest_task_id_status_async(self._job_id))
+            if task_id is None:
+                task_id = 0
 
-            # 3. Tear down the task's cluster now (best-effort) instead of
-            # leaving it to the retry's forced recovery: the retry always
-            # relaunches from scratch, so the cluster is doomed anyway —
-            # don't leave it running (and billing) through a backoff that can
-            # be up to 30 minutes. terminate_cluster is idempotent and the
-            # retry's forced recovery runs the same cleanup again, so a
-            # failure here only delays the teardown. Pool jobs keep their
-            # shared cluster (no dedicated cluster to tear down) — the
-            # retry's forced recovery cancels the stale pool submission and
-            # runs the hook, so nothing to do here.
-            task_name = self._dag.tasks[task_id].name
-            if self._pool is None and task_name is not None:
-                cluster_name = (
-                    managed_job_utils.generate_managed_job_cluster_name(
-                        task_name, self._job_id))
-                # Give the runtime a chance to snapshot the run's logs before
-                # we tear the cluster down.
-                await self._emergency_before_teardown_hook(
-                    task_id, cluster_name)
-                try:
-                    await self._cleanup_cluster(cluster_name)
-                except Exception as cleanup_error:  # pylint: disable=broad-except
-                    logger.warning(
-                        'Best-effort cluster teardown before the emergency '
-                        'backoff failed; the retry will clean up instead: '
-                        f'{common_utils.format_exception(cleanup_error)}')
+            if cur_status == managed_job_state.ManagedJobStatus.PENDING:
+                # The task never initialized (set_starting_async has not run).
+                # Do not mark it RECOVERING — that would make the retry treat it
+                # as a resume and skip initialization forever. Leave it PENDING;
+                # the retry relaunches it fresh (is_resume=False). There is no
+                # cluster to tear down yet. Fall through to the backoff so a
+                # PENDING-phase error is bounded and paced like any episode.
+                logger.info(f'Job {self._job_id} task {task_id} is PENDING; '
+                            'relaunching fresh after the emergency backoff.')
+            else:
+                # Mark the latest task RECOVERING (recovery_source=EMERGENCY on
+                # the event). Emit the event only once per escaped error, so an
+                # outer-retry re-run does not append a duplicate.
+                reason = (
+                    f'Unexpected controller error (emergency recovery attempt '
+                    f'{attempt}/{max_attempts}): ' +
+                    common_utils.format_exception(error, use_bracket=True))
+                emit_event = not self._emergency_event_emitted
+                applied = await managed_job_state.set_emergency_recovering_async(
+                    self._job_id,
+                    task_id,
+                    reason=reason,
+                    callback_func=managed_job_utils.event_callback_func(
+                        job_id=self._job_id,
+                        task_id=task_id,
+                        task=self._dag.tasks[task_id]),
+                    emit_event=emit_event)
+                if applied and emit_event:
+                    self._emergency_event_emitted = True
+                if not applied:
+                    # The task is CANCELLING or already terminal — those paths
+                    # own the task now. Retry the job loop immediately (no
+                    # backoff): the resume logic completes the cancellation
+                    # (re-raising CancelledError) or finishes the terminal task
+                    # cleanly.
+                    logger.info(
+                        f'Job {self._job_id} task {task_id} is cancelling '
+                        'or terminal; retrying the job loop to let it '
+                        'complete.')
+                    await asyncio.to_thread(self._load_dag)
+                    return None
+
+                # 3. Tear down the task's cluster now (best-effort) instead of
+                # leaving it to the retry's forced recovery: the retry always
+                # relaunches from scratch, so the cluster is doomed anyway —
+                # don't leave it running (and billing) through a backoff that can
+                # be up to 30 minutes. terminate_cluster is idempotent and the
+                # retry's forced recovery runs the same cleanup again, so a
+                # failure here only delays the teardown. Pool jobs keep their
+                # shared cluster (no dedicated cluster to tear down) — the
+                # retry's forced recovery cancels the stale pool submission and
+                # runs the hook, so nothing to do here.
+                task_name = self._dag.tasks[task_id].name
+                if self._pool is None and task_name is not None:
+                    cluster_name = (
+                        managed_job_utils.generate_managed_job_cluster_name(
+                            task_name, self._job_id))
+                    # Give the runtime a chance to snapshot the run's logs before
+                    # we tear the cluster down.
+                    await self._emergency_before_teardown_hook(
+                        task_id, cluster_name)
+                    try:
+                        await self._cleanup_cluster(cluster_name)
+                    except Exception as cleanup_error:  # pylint: disable=broad-except
+                        logger.warning(
+                            'Best-effort cluster teardown before the emergency '
+                            'backoff failed; the retry will clean up instead: '
+                            f'{common_utils.format_exception(cleanup_error)}')
 
         # 4. If the error escaped mid-launch, the job may be stuck in a
         # launch-adjacent schedule state (LAUNCHING / ALIVE_WAITING /

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2679,26 +2679,26 @@ class JobController:
         group is being cancelled or every member is terminal, so the resume
         logic owns completion. Returns False to proceed to the backoff.
         """
-        # Job Groups: every member is concurrently mid-flight, so there
-        # is no single "latest" task to operate on, and per-task surgery
-        # is wrong in both directions: marking an arbitrary member
-        # RECOVERING instructs the retry's resume classification to tear
-        # down and relaunch a member that may be healthily RUNNING, and
-        # tearing down one member's cluster leaves its siblings running
-        # unsupervised through the backoff either way. Do neither. The
-        # retry re-enters _run_job_group, whose resume classification
-        # reconciles every member from its own status: RUNNING members
-        # get their monitors reattached untouched (a member whose
-        # cluster actually died fails its first status probe and enters
-        # recovery normally); STARTING/RECOVERING members are force-
-        # recovered (which owns cleanup-before-relaunch); PENDING
-        # members launch fresh.
+        # Policy: no per-member surgery — reconcile on re-entry instead,
+        # exactly like a controller restart (_run_job_group's resume
+        # classification judges each member from its own status; a member
+        # whose cluster actually died fails its first monitor probe and
+        # recovers normally). The considered alternative is generalizing
+        # the single-task policy to all N live members: mark each
+        # RECOVERING and tear its cluster down (symmetric reset). Rejected
+        # as the default because the error is evidence about the
+        # controller, not about any member — a reset's cost scales with N
+        # while its justification does not — and because neither a
+        # controller restart nor a real preemption of one member restarts
+        # the group; an internal error should not be more destructive than
+        # infrastructure failure. The symmetric reset is a two-line policy
+        # flip here if experience disagrees.
         # Known gap: no per-task RECOVERING event is emitted here, so
         # events-based recovery metrics do not count group emergencies
         # (the job-level budget columns still do).
         # TODO(ishan): once gang admission lands (SKY-6224), a group
-        # whose admission barrier is still open should instead tear down
-        # all members and reset them to PENDING: mid-startup there is no
+        # whose admission barrier is still open should take the symmetric
+        # reset (tear down all, reset to PENDING): mid-startup there is no
         # progress to protect and startup is all-or-nothing.
         statuses = [
             await managed_job_state.get_job_status_with_task_id_async(

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2700,17 +2700,16 @@ class JobController:
         # whose admission barrier is still open should take the symmetric
         # reset (tear down all, reset to PENDING): mid-startup there is no
         # progress to protect and startup is all-or-nothing.
-        statuses = [
-            await managed_job_state.get_job_status_with_task_id_async(
-                job_id=self._job_id, task_id=tid)
-            for tid in range(len(self._dag.tasks))
-        ]
+        id_statuses = await managed_job_state.get_all_task_ids_statuses_async(
+            self._job_id)
+        statuses = [task_status for _, task_status in id_statuses]
         any_cancelling = any(
             task_status == managed_job_state.ManagedJobStatus.CANCELLING
             for task_status in statuses)
-        all_terminal = all(
-            task_status is not None and task_status.is_terminal()
-            for task_status in statuses)
+        # Guarded on every member having a row: a missing row must never
+        # count toward "all terminal".
+        all_terminal = (len(statuses) == len(self._dag.tasks) and all(
+            task_status.is_terminal() for task_status in statuses))
         if any_cancelling or all_terminal:
             # Mirror the single-task fast path below: cancellation and
             # terminal completion are owned by the resume logic, so

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2696,7 +2696,7 @@ class JobController:
         # Known gap: no per-task RECOVERING event is emitted here, so
         # events-based recovery metrics do not count group emergencies
         # (the job-level budget columns still do).
-        # TODO(ishan): once gang admission lands (SKY-6224), a group
+        # TODO(ishan): once gang admission for job groups lands, a group
         # whose admission barrier is still open should take the symmetric
         # reset (tear down all, reset to PENDING): mid-startup there is no
         # progress to protect and startup is all-or-nothing.

--- a/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
+++ b/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
@@ -552,15 +552,12 @@ class _RetryLoopHarness:
         if task_statuses is None:
             task_statuses = [state.ManagedJobStatus.RUNNING] * num_tasks
 
-        async def _get_task_status(job_id, task_id):
-            del job_id
-            return task_statuses[task_id]
-
-        self.get_task_status = AsyncMock(side_effect=_get_task_status)
+        self.get_task_statuses = AsyncMock(
+            return_value=list(enumerate(task_statuses)))
 
         mjs = 'sky.jobs.controller.managed_job_state'
-        monkeypatch.setattr(f'{mjs}.get_job_status_with_task_id_async',
-                            self.get_task_status)
+        monkeypatch.setattr(f'{mjs}.get_all_task_ids_statuses_async',
+                            self.get_task_statuses)
         monkeypatch.setattr(f'{mjs}.get_emergency_recovery_budget_async',
                             self.get_budget)
         monkeypatch.setattr(f'{mjs}.record_emergency_recovery_attempt_async',
@@ -1141,4 +1138,4 @@ class TestJobGroupEmergencyRecovery:
         h.set_emergency.assert_awaited_once()
         h.jc._cleanup_cluster.assert_awaited_once()
         # The group-only bulk status probe is never used on this path.
-        h.get_task_status.assert_not_awaited()
+        h.get_task_statuses.assert_not_awaited()

--- a/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
+++ b/tests/unit_tests/test_sky/jobs/test_emergency_recovery.py
@@ -491,19 +491,33 @@ class TestEmergencyRecoveryState:
 class _RetryLoopHarness:
     """Drives the real JobController.run() with mocked collaborators."""
 
-    def __init__(self, monkeypatch, body_effects):
-        """body_effects: side_effect list for _run_one_task."""
+    def __init__(self,
+                 monkeypatch,
+                 body_effects,
+                 is_job_group=False,
+                 num_tasks=1,
+                 task_statuses=None):
+        """body_effects: side_effect list for the job body.
+
+        Drives _run_one_task for single jobs, _run_job_group when
+        is_job_group is set. task_statuses feeds the group branch's
+        per-member status probe (defaults to all RUNNING).
+        """
         jc = controller.JobController.__new__(controller.JobController)
         jc._job_id = 1
-        task = MagicMock()
-        task.name = 'task0'
+        tasks = []
+        for i in range(num_tasks):
+            task = MagicMock()
+            task.name = f'task{i}'
+            tasks.append(task)
         dag = MagicMock()
-        dag.is_job_group.return_value = False
-        dag.tasks = [task]
+        dag.is_job_group.return_value = is_job_group
+        dag.tasks = tasks
         jc._dag = dag
         jc._pool = None
         jc._emergency_backoff_seconds = None
         jc._run_one_task = AsyncMock(side_effect=body_effects)
+        jc._run_job_group = AsyncMock(side_effect=body_effects)
         jc._update_failed_task_state = AsyncMock()
         jc._cleanup_cluster = AsyncMock()
         # Shared launching-slot primitives (real JobController gets these from
@@ -535,7 +549,18 @@ class _RetryLoopHarness:
         async def _fake_sleep(seconds):
             self.sleeps.append(seconds)
 
+        if task_statuses is None:
+            task_statuses = [state.ManagedJobStatus.RUNNING] * num_tasks
+
+        async def _get_task_status(job_id, task_id):
+            del job_id
+            return task_statuses[task_id]
+
+        self.get_task_status = AsyncMock(side_effect=_get_task_status)
+
         mjs = 'sky.jobs.controller.managed_job_state'
+        monkeypatch.setattr(f'{mjs}.get_job_status_with_task_id_async',
+                            self.get_task_status)
         monkeypatch.setattr(f'{mjs}.get_emergency_recovery_budget_async',
                             self.get_budget)
         monkeypatch.setattr(f'{mjs}.record_emergency_recovery_attempt_async',
@@ -1025,3 +1050,95 @@ class TestTaskPrepFailureIsTerminal:
         h.get_budget.assert_not_awaited()
         h.record_attempt.assert_not_awaited()
         assert not h.sleeps
+
+
+class TestJobGroupEmergencyRecovery:
+    """Group-mode emergency recovery does no per-task surgery.
+
+    For job groups, every member is concurrently mid-flight, so "the
+    latest task" is an arbitrary member: marking it RECOVERING would
+    force-recover (tear down + relaunch) a possibly-healthy RUNNING
+    member on re-entry, and tearing down its cluster leaves siblings
+    running unsupervised through the backoff. The group branch skips
+    both and leaves reconciliation to the retry's resume classification,
+    keeping only the job-level bookkeeping (budget, launch slot,
+    schedule-state normalization, backoff).
+    """
+
+    @pytest.mark.asyncio
+    async def test_group_skips_per_task_surgery(self, monkeypatch):
+        h = _RetryLoopHarness(monkeypatch, [RuntimeError('boom'), True],
+                              is_job_group=True,
+                              num_tasks=3)
+
+        await h.jc.run()
+
+        assert h.jc._run_job_group.call_count == 2
+        h.jc._update_failed_task_state.assert_not_called()
+        # Budget is still spent and the episode paced like any other.
+        h.record_attempt.assert_awaited_once()
+        assert h.record_attempt.await_args.args[1] == 1
+        _assert_jittered(
+            h.sleeps, [jobs_constants.EMERGENCY_RECOVERY_BACKOFF_BASE_SECONDS])
+        # No per-task surgery: no member marked RECOVERING, no member's
+        # cluster torn down, no "latest task" resolution at all.
+        h.set_emergency.assert_not_awaited()
+        h.jc._cleanup_cluster.assert_not_awaited()
+        h.get_latest_task.assert_not_awaited()
+        # Job-level bookkeeping still runs.
+        h.normalize.assert_awaited_once()
+        assert 1 not in h.jc.starting  # launch slot released
+
+    @pytest.mark.asyncio
+    async def test_group_cancelling_member_retries_without_backoff(
+            self, monkeypatch):
+        h = _RetryLoopHarness(monkeypatch,
+                              [RuntimeError('boom'),
+                               asyncio.CancelledError()],
+                              is_job_group=True,
+                              num_tasks=2,
+                              task_statuses=[
+                                  state.ManagedJobStatus.RUNNING,
+                                  state.ManagedJobStatus.CANCELLING,
+                              ])
+
+        with pytest.raises(asyncio.CancelledError):
+            await h.jc.run()
+
+        assert h.jc._run_job_group.call_count == 2
+        assert not h.sleeps  # no backoff for the cancellation handoff
+        h.set_emergency.assert_not_awaited()
+        h.jc._cleanup_cluster.assert_not_awaited()
+        # Cancellation ordering mirrors the single-task fast path.
+        h.set_cancelling.assert_awaited_once()
+        h.set_cancelled.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_group_all_terminal_retries_without_backoff(
+            self, monkeypatch):
+        h = _RetryLoopHarness(monkeypatch, [RuntimeError('boom'), True],
+                              is_job_group=True,
+                              num_tasks=2,
+                              task_statuses=[
+                                  state.ManagedJobStatus.SUCCEEDED,
+                                  state.ManagedJobStatus.FAILED,
+                              ])
+
+        await h.jc.run()
+
+        assert h.jc._run_job_group.call_count == 2
+        assert not h.sleeps
+        h.set_emergency.assert_not_awaited()
+        h.jc._cleanup_cluster.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_single_task_surgery_unchanged(self, monkeypatch):
+        """Regression pin: single jobs keep the mark + early teardown."""
+        h = _RetryLoopHarness(monkeypatch, [RuntimeError('boom'), True])
+
+        await h.jc.run()
+
+        h.set_emergency.assert_awaited_once()
+        h.jc._cleanup_cluster.assert_awaited_once()
+        # The group-only bulk status probe is never used on this path.
+        h.get_task_status.assert_not_awaited()


### PR DESCRIPTION
## Summary

**Stacked on #10415** (Phase-2 hardening) — review this diff against that base, not master.

Emergency recovery (#9868) does pre-retry bookkeeping built for shapes with exactly one mid-flight task: resolve "the latest task", mark it RECOVERING (`recovery_source=EMERGENCY`), and tear its cluster down early ("doomed anyway" — the retry force-relaunches it, so don't bill through a ≤30-min backoff). For **job groups**, all N members are concurrently mid-flight, so "latest" picks an arbitrary member, and both halves of the surgery misfire:

- **The mark is the sneakier harm**: a task's status is an instruction to the retry's resume classification — RECOVERING means "tear down and relaunch on re-entry." Marking an arbitrary member converts a healthily RUNNING workload into one sentenced to teardown, for an error that escaped from *controller* code, not from that member.
- **The early teardown's premise is false for groups**: group re-entry does *not* relaunch running members from scratch, so their clusters aren't doomed — shooting one just leaves its N−1 siblings running unsupervised through the backoff.

For groups this PR keeps only the job-level bookkeeping (budget spend, launch-slot release, schedule-state normalization, jittered backoff) and defers member fate entirely to re-entry's evidence-based reconciliation: RUNNING → monitor reattaches untouched (a member whose cluster actually died fails its first probe and enters recovery *normally*); STARTING/RECOVERING → forced recovery (which owns cleanup-before-relaunch); PENDING → fresh launch. Net effect: a group emergency behaves exactly like a controller restart, minus the crash.

## Code pointers for review

- `sky/jobs/controller.py` — `_attempt_emergency_recovery`: the new `is_job_group()` branch. Note the launch-slot release is hoisted above the branch (it was between the latest-task read and the mark; order is not load-bearing — the release is an idempotent `discard`).
- **The cancellation fast path is preserved by an explicit probe.** For single tasks, the mark doubles as cancellation *detection*: the guarded write returns `applied=False` when the task is CANCELLING/terminal, and the code retries immediately (no backoff) so the cancel completes promptly. Groups skip the mark, so they get an honest read instead: any member CANCELLING (or all terminal) → immediate retry. Same behavior, no side-effect coupling.
- `TODO(SKY-6224)` marks where gang admission's future branch slots in: a group whose admission *barrier is still open* should tear down all members symmetrically (mid-startup there is no progress to protect).

## Judgment calls (please review explicitly)

**1. Reconcile-on-re-entry vs symmetric group reset.** The honest alternative to this PR is generalizing the single-task policy to all N live members: mark each RECOVERING + tear each cluster down (a deterministic, symmetric reset — one code path, one outcome). We chose reconciliation as the default because the escaped error is evidence about the *controller*, not about any member — a reset costs N members' progress on one process's confusion — and because neither a controller restart nor a real preemption of one member restarts a group today; an internal error should not be more destructive than infrastructure failure. The reset is a two-line flip inside the group helper if reviewers prefer symmetric semantics, and it *is* the right behavior for the future barrier-open startup case (the TODO in the group helper). Known corner of the chosen policy: a member that completes during the unsupervised backoff window and gets idle-autodowned can have its success go unobserved and be re-run on re-entry (phantom-preemption shape) — strictly narrower than the previous behavior, which unconditionally relaunched the shot member, but real.

**2. Group emergencies are invisible to the events-based recovery metrics.** The RECOVERING mark is also what emits the `recovery_source=EMERGENCY` job-event that the Prometheus recovery collector counts. Groups skipping the mark → no event row. The episode is still counted in the job-level budget columns (`emergency_recovery_count`), and it's loudly logged. We chose *not* to build an event-write-without-status-mutation path just to feed the collector — flagging instead so whoever owns those dashboards can veto. If required, an event-only write is a small follow-up.

## Tests

`tests/unit_tests/test_sky/jobs/test_emergency_recovery.py` — extends the existing `_RetryLoopHarness` (drives the real `run()`) with group mode:
- group emergency → **no** mark, **no** teardown, **no** latest-task resolution; budget spent, slot released, schedule normalized, jittered backoff — then retry succeeds. **Red on the base branch** (mark + teardown both fire there).
- group + CANCELLING member → immediate retry, no backoff, cancellation ordering preserved. **Red on base.**
- group all-terminal → immediate retry, no backoff. **Red on base.**
- single-task regression pin: mark + early teardown unchanged, and the group-only bulk status probe is never used on the single path.

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_emergency_recovery.py tests/unit_tests/test_sky/jobs/test_controller.py` — 111 passed.
- Red/green verified: all three group tests fail on the base branch.
- `bash format.sh` clean.
- e2e: triggering an emergency requires injecting an unexpected error into controller internals; unit tests drive the real `run()` loop instead (same rationale as #10415).

Part of the gang-admission pre-work for SKY-6224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


