### PR TITLE
DO NOT MERGE — twist to cross-verify the not-ready volume smoke tests

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -716,6 +716,9 @@ def _reject_not_ready_auto_mount_volume(volume_name: str,
     Raises:
         exceptions.VolumeNotReadyError: if the volume is not ready.
     """
+    # TWIST (do not merge): let a not-ready volume through, to prove the smoke
+    # tests actually detect the refusal.
+    return
     if record.get('status') != status_lib.VolumeStatus.NOT_READY:
         return
     error_message = (record.get('error_message') or

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -713,12 +713,6 @@ def _reject_not_ready_auto_mount_volume(volume_name: str,
                                         record: Dict[str, Any]) -> None:
     """Raises if a volume about to be auto-mounted is not usable.
 
-    Mirrors the check `VolumeMount.resolve` applies to volumes declared on a
-    task, and reads the same recorded status, so the two ways of attaching a
-    volume agree. That status can be up to one refresh interval stale; a volume
-    broken out of band within that window is caught when the pod fails to
-    schedule rather than here.
-
     Raises:
         exceptions.VolumeNotReadyError: if the volume is not ready.
     """
@@ -728,8 +722,8 @@ def _reject_not_ready_auto_mount_volume(volume_name: str,
                      'The last status refresh found it unusable.')
     raise exceptions.VolumeNotReadyError(
         f'Auto-mount volume {volume_name!r} is not ready, so it cannot be '
-        f'mounted. Error: {error_message} Check it with `sky volumes ls`, or '
-        f'remove {volume_name!r} from the auto_mounts config.')
+        f'mounted. Error: {error_message}. Check it with `sky volumes ls`, '
+        f'or remove {volume_name!r} from the auto_mounts config.')
 
 
 # TODO: too many things happening here - leaky abstraction. Refactor.
@@ -1115,6 +1109,11 @@ def write_cluster_config(
                 # just sits unschedulable or stuck in ContainerCreating -- so
                 # the launch has to be refused here, as it already is for a
                 # volume declared on the task.
+                #
+                # Keep this last: the checks above skip entries that this
+                # launch will not mount at all. Moving it earlier would refuse
+                # a launch over a volume belonging to someone else's scope, or
+                # one that would have been passed over for its access mode.
                 _reject_not_ready_auto_mount_volume(volume_name, record)
                 mount_paths = entry.get('mount_paths', [])
                 for path in mount_paths:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -709,69 +709,27 @@ def _get_volume_name(path: str, cluster_name_on_cloud: str) -> str:
     return f'{cluster_name_on_cloud}-{path_hash}'
 
 
-def _check_auto_mount_volumes_ready(mountable: List[Tuple[Dict[str, Any], Any]],
-                                    dryrun: bool = False) -> None:
-    """Raises if any volume about to be auto-mounted is not usable.
+def _reject_not_ready_auto_mount_volume(volume_name: str,
+                                        record: Dict[str, Any]) -> None:
+    """Raises if a volume about to be auto-mounted is not usable.
 
-    The recorded status can be up to one refresh interval stale, so re-check
-    against the cloud and prefer that answer. If the cloud cannot be reached,
-    fall back to the recorded status rather than blocking every launch on a
-    transient API failure.
-
-    Under dryrun the recorded status is used on its own: dryrun is expected not
-    to contact the cloud (see `adjust_resources_to_allocatable`), and a stale
-    status is an acceptable price for a check that reaches no further than the
-    local database.
+    Mirrors the check `VolumeMount.resolve` applies to volumes declared on a
+    task, and reads the same recorded status, so the two ways of attaching a
+    volume agree. That status can be up to one refresh interval stale; a volume
+    broken out of band within that window is caught when the pod fails to
+    schedule rather than here.
 
     Raises:
-        exceptions.VolumeNotReadyError: if any volume is not ready.
+        exceptions.VolumeNotReadyError: if the volume is not ready.
     """
-    if not mountable:
+    if record.get('status') != status_lib.VolumeStatus.NOT_READY:
         return
-
-    live_errors: Dict[str, Optional[str]] = {}
-    unknown: Set[str] = set()
-    if not dryrun:
-        configs_by_cloud: Dict[str, List[Any]] = {}
-        for _, record in mountable:
-            volume_config = record['handle']
-            configs_by_cloud.setdefault(volume_config.cloud,
-                                        []).append(volume_config)
-
-        for cloud, configs in configs_by_cloud.items():
-            try:
-                errors, failed = provision_lib.get_all_volumes_errors(
-                    cloud, configs)
-                live_errors.update(errors)
-                unknown.update(failed)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to check auto-mount volume status on '
-                             f'{cloud}: {e}')
-                unknown.update(config.name for config in configs)
-
-    for _, record in mountable:
-        volume_name = record['handle'].name
-        # A volume missing from both means the cloud does not implement the
-        # check at all; `unknown` means it does but could not reach the
-        # cluster. Neither is an answer.
-        answered = volume_name in live_errors and volume_name not in unknown
-        if answered:
-            # None means the cloud looked and found nothing wrong.
-            error_message = live_errors[volume_name]
-        elif record.get('status') == status_lib.VolumeStatus.NOT_READY:
-            # No answer, so go by what the last refresh recorded.
-            error_message = (record.get('error_message') or
-                             'The last status refresh found it unusable.')
-        else:
-            error_message = None
-
-        if not error_message:
-            continue
-        raise exceptions.VolumeNotReadyError(
-            f'Auto-mount volume {volume_name!r} is not ready, so it cannot '
-            f'be mounted. Error: {error_message} Check it with '
-            f'`sky volumes ls`, or remove {volume_name!r} from the '
-            f'auto_mounts config.')
+    error_message = (record.get('error_message') or
+                     'The last status refresh found it unusable.')
+    raise exceptions.VolumeNotReadyError(
+        f'Auto-mount volume {volume_name!r} is not ready, so it cannot be '
+        f'mounted. Error: {error_message} Check it with `sky volumes ls`, or '
+        f'remove {volume_name!r} from the auto_mounts config.')
 
 
 # TODO: too many things happening here - leaky abstraction. Refactor.
@@ -1113,7 +1071,6 @@ def write_cluster_config(
         if auto_mounts_config:
             home_dir = kubernetes_utils.DEFAULT_HOME_DIRECTORY
             attached_auto_mount_volumes: Set[str] = set()
-            mountable: List[Tuple[Dict[str, Any], Any]] = []
             current_user_hash = common_utils.get_current_user().id
             active_workspace = skypilot_config.get_active_workspace()
             for entry in auto_mounts_config:
@@ -1153,19 +1110,13 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
-                mountable.append((entry, record))
-
-            # Reject before any pod is created. Mounting a volume whose
-            # backing storage is not usable does not fail loudly -- the pod
-            # just sits unschedulable or stuck in ContainerCreating -- so
-            # the readiness check has to happen here, mirroring the explicit
-            # `volumes:` path in `VolumeMount.resolve`.
-            _check_auto_mount_volumes_ready(mountable, dryrun=dryrun)
-
-            for entry, record in mountable:
-                volume_name = entry['volume_name']
+                # Reject before a pod is created. Mounting a volume whose
+                # backing storage is not usable does not fail loudly -- the pod
+                # just sits unschedulable or stuck in ContainerCreating -- so
+                # the launch has to be refused here, as it already is for a
+                # volume declared on the task.
+                _reject_not_ready_auto_mount_volume(volume_name, record)
                 mount_paths = entry.get('mount_paths', [])
-                volume_config = record['handle']
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -709,8 +709,8 @@ def _get_volume_name(path: str, cluster_name_on_cloud: str) -> str:
     return f'{cluster_name_on_cloud}-{path_hash}'
 
 
-def _check_auto_mount_volumes_ready(
-        mountable: List[Tuple[Dict[str, Any], Any]]) -> None:
+def _check_auto_mount_volumes_ready(mountable: List[Tuple[Dict[str, Any], Any]],
+                                    dryrun: bool = False) -> None:
     """Raises if any volume about to be auto-mounted is not usable.
 
     The recorded status can be up to one refresh interval stale, so re-check
@@ -718,30 +718,36 @@ def _check_auto_mount_volumes_ready(
     fall back to the recorded status rather than blocking every launch on a
     transient API failure.
 
+    Under dryrun the recorded status is used on its own: dryrun is expected not
+    to contact the cloud (see `adjust_resources_to_allocatable`), and a stale
+    status is an acceptable price for a check that reaches no further than the
+    local database.
+
     Raises:
         exceptions.VolumeNotReadyError: if any volume is not ready.
     """
     if not mountable:
         return
 
-    configs_by_cloud: Dict[str, List[Any]] = {}
-    for _, record in mountable:
-        volume_config = record['handle']
-        configs_by_cloud.setdefault(volume_config.cloud,
-                                    []).append(volume_config)
-
     live_errors: Dict[str, Optional[str]] = {}
     unknown: Set[str] = set()
-    for cloud, configs in configs_by_cloud.items():
-        try:
-            errors, failed = provision_lib.get_all_volumes_errors(
-                cloud, configs)
-            live_errors.update(errors)
-            unknown.update(failed)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.debug(f'Failed to check auto-mount volume status on '
-                         f'{cloud}: {e}')
-            unknown.update(config.name for config in configs)
+    if not dryrun:
+        configs_by_cloud: Dict[str, List[Any]] = {}
+        for _, record in mountable:
+            volume_config = record['handle']
+            configs_by_cloud.setdefault(volume_config.cloud,
+                                        []).append(volume_config)
+
+        for cloud, configs in configs_by_cloud.items():
+            try:
+                errors, failed = provision_lib.get_all_volumes_errors(
+                    cloud, configs)
+                live_errors.update(errors)
+                unknown.update(failed)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Failed to check auto-mount volume status on '
+                             f'{cloud}: {e}')
+                unknown.update(config.name for config in configs)
 
     for _, record in mountable:
         volume_name = record['handle'].name
@@ -1154,7 +1160,7 @@ def write_cluster_config(
             # just sits unschedulable or stuck in ContainerCreating -- so
             # the readiness check has to happen here, mirroring the explicit
             # `volumes:` path in `VolumeMount.resolve`.
-            _check_auto_mount_volumes_ready(mountable)
+            _check_auto_mount_volumes_ready(mountable, dryrun=dryrun)
 
             for entry, record in mountable:
                 volume_name = entry['volume_name']

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -709,6 +709,65 @@ def _get_volume_name(path: str, cluster_name_on_cloud: str) -> str:
     return f'{cluster_name_on_cloud}-{path_hash}'
 
 
+def _check_auto_mount_volumes_ready(
+        mountable: List[Tuple[Dict[str, Any], Any]]) -> None:
+    """Raises if any volume about to be auto-mounted is not usable.
+
+    The recorded status can be up to one refresh interval stale, so re-check
+    against the cloud and prefer that answer. If the cloud cannot be reached,
+    fall back to the recorded status rather than blocking every launch on a
+    transient API failure.
+
+    Raises:
+        exceptions.VolumeNotReadyError: if any volume is not ready.
+    """
+    if not mountable:
+        return
+
+    configs_by_cloud: Dict[str, List[Any]] = {}
+    for _, record in mountable:
+        volume_config = record['handle']
+        configs_by_cloud.setdefault(volume_config.cloud,
+                                    []).append(volume_config)
+
+    live_errors: Dict[str, Optional[str]] = {}
+    unknown: Set[str] = set()
+    for cloud, configs in configs_by_cloud.items():
+        try:
+            errors, failed = provision_lib.get_all_volumes_errors(
+                cloud, configs)
+            live_errors.update(errors)
+            unknown.update(failed)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to check auto-mount volume status on '
+                         f'{cloud}: {e}')
+            unknown.update(config.name for config in configs)
+
+    for _, record in mountable:
+        volume_name = record['handle'].name
+        # A volume missing from both means the cloud does not implement the
+        # check at all; `unknown` means it does but could not reach the
+        # cluster. Neither is an answer.
+        answered = volume_name in live_errors and volume_name not in unknown
+        if answered:
+            # None means the cloud looked and found nothing wrong.
+            error_message = live_errors[volume_name]
+        elif record.get('status') == status_lib.VolumeStatus.NOT_READY:
+            # No answer, so go by what the last refresh recorded.
+            error_message = (record.get('error_message') or
+                             'The last status refresh found it unusable.')
+        else:
+            error_message = None
+
+        if not error_message:
+            continue
+        raise exceptions.VolumeNotReadyError(
+            f'Auto-mount volume {volume_name!r} is not ready, so it cannot '
+            f'be mounted. Error: {error_message} Check it with '
+            f'`sky volumes ls`, or remove {volume_name!r} from the '
+            f'auto_mounts config.')
+
+
 # TODO: too many things happening here - leaky abstraction. Refactor.
 @timeline.event
 def write_cluster_config(
@@ -1048,9 +1107,9 @@ def write_cluster_config(
         if auto_mounts_config:
             home_dir = kubernetes_utils.DEFAULT_HOME_DIRECTORY
             attached_auto_mount_volumes: Set[str] = set()
+            mountable: List[Tuple[Dict[str, Any], Any]] = []
             for entry in auto_mounts_config:
                 volume_name = entry['volume_name']
-                mount_paths = entry.get('mount_paths', [])
                 record = global_user_state.get_volume_by_name(volume_name)
                 if record is None:
                     logger.warning(
@@ -1073,6 +1132,19 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
+                mountable.append((entry, record))
+
+            # Reject before any pod is created. Mounting a volume whose
+            # backing storage is not usable does not fail loudly -- the pod
+            # just sits unschedulable or stuck in ContainerCreating -- so
+            # the readiness check has to happen here, mirroring the explicit
+            # `volumes:` path in `VolumeMount.resolve`.
+            _check_auto_mount_volumes_ready(mountable)
+
+            for entry, record in mountable:
+                volume_name = entry['volume_name']
+                mount_paths = entry.get('mount_paths', [])
+                volume_config = record['handle']
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3040,6 +3040,7 @@ def add_volume(
     status: status_lib.VolumeStatus,
     is_ephemeral: bool = False,
     creation_yaml: Optional[str] = None,
+    error_message: Optional[str] = None,
 ) -> None:
     engine = _db_manager.get_engine()
     volume_launched_at = int(time.time())
@@ -3072,6 +3073,7 @@ def add_volume(
             status=status.value,
             is_ephemeral=int(is_ephemeral),
             creation_yaml=creation_yaml,
+            error_message=error_message,
         )
         do_update_stmt = insert_stmnt.on_conflict_do_nothing()
         session.execute(do_update_stmt)

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -49,6 +49,19 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
+# Launch failures that retrying cannot fix: the launch never got as far as
+# asking for resources, and trying again does not change the answer. These fail
+# the job with FAILED_PRECHECKS instead of entering the retry loop, so a job
+# does not sit there re-attempting something only an operator can resolve.
+PRECHECK_FAILURES = (
+    exceptions.InvalidClusterNameError,
+    exceptions.NoCloudAccessError,
+    exceptions.ResourcesMismatchError,
+    exceptions.StorageSpecError,
+    exceptions.StorageError,
+    exceptions.VolumeNotReadyError,
+)
+
 # Waiting time for job from INIT/PENDING to RUNNING
 # 10 * JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 10 * 5 = 50 seconds
 MAX_JOB_CHECKING_RETRY = 10
@@ -1098,11 +1111,7 @@ class StrategyExecutor:
                         logger.error('The pool no longer exists: '
                                      f'{common_utils.format_exception(e)}')
                         raise
-                    except (exceptions.InvalidClusterNameError,
-                            exceptions.NoCloudAccessError,
-                            exceptions.ResourcesMismatchError,
-                            exceptions.StorageSpecError,
-                            exceptions.StorageError) as e:
+                    except PRECHECK_FAILURES as e:
                         logger.error('Failure happened before provisioning. '
                                      f'{common_utils.format_exception(e)}')
                         if raise_on_failure:

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -308,8 +308,8 @@ def map_all_volumes_usedby(
 
 @_route_to_cloud_impl
 def get_all_volumes_errors(
-        provider_name: str,
-        configs: List[models.VolumeConfig]) -> Dict[str, Optional[str]]:
+    provider_name: str, configs: List[models.VolumeConfig]
+) -> Tuple[Dict[str, Optional[str]], Set[str]]:
     """Get error messages for all volumes.
 
     Checks if volumes have errors (e.g., pending state due to
@@ -320,11 +320,20 @@ def get_all_volumes_errors(
         configs: List of VolumeConfig objects.
 
     Returns:
-        Dictionary mapping volume name to error message (None if no error).
+        errors: Dict mapping volume name to an error message, or to None
+          when the volume is healthy.
+        failed_volume_names: Set of volume names whose status could not be
+          determined because the cloud could not be queried. A volume listed
+          here must keep its recorded status; absence from ``errors`` alone
+          does not mean healthy.
+
+        An implementation should place every input config in exactly one of
+        the two. A volume in neither means this provider does not check
+        volume errors, as with the default below.
     """
-    # Default implementation returns empty dict (no error checking)
+    # Default implementation reports no errors (no error checking)
     del provider_name, configs
-    return {}
+    return {}, set()
 
 
 @_route_to_cloud_impl

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -559,107 +559,166 @@ def map_all_volumes_usedby(
                                                   {}).get(pvc_name, []))
 
 
-def get_all_volumes_errors(
-    configs: List[models.VolumeConfig],) -> Dict[str, Optional[str]]:
-    """Gets error messages for all Kubernetes PVC volumes.
+def _first_pvc_failure_event(context: Optional[str], namespace: str,
+                             pvc_name: str) -> Optional[str]:
+    """Returns 'reason: message' for the newest failing PVC event, if any.
 
-    Checks if PVCs are in Pending state and if so, checks for access mode
-    mismatches between the PVC and the storage class's allowed access modes.
+    A failing event is the only positive evidence that a pending PVC will not
+    bind on its own; a pending PVC without one may still be mid-provisioning.
+    """
+    for event in kubernetes_utils.get_pvc_events(context, namespace, pvc_name):
+        if (event.type == WARNING_EVENT_TYPE or
+                event.reason in PVC_FAILING_EVENT_REASONS):
+            if event.message:
+                return f'{event.reason}: {event.message}'
+            return str(event.reason)
+    return None
+
+
+def _get_pvc_error(context: Optional[str], namespace: str,
+                   pvc: Any) -> Optional[str]:
+    """Returns an error message for a PVC, or None if it is healthy.
+
+    Note that a pending PVC under WaitForFirstConsumer is *not* an error: the
+    provisioner is not even triggered until a pod claims it, so there is
+    nothing to detect yet.
+    """
+    pvc_name = pvc.metadata.name
+    debug_hint = (f'To debug, run: kubectl describe pvc {pvc_name} '
+                  f'-n {namespace}')
+    pvc_phase = pvc.status.phase
+
+    if pvc_phase == 'Bound':
+        return None
+
+    if pvc_phase == 'Pending':
+        error_msg = _check_pvc_access_mode_error(context, pvc)
+        if error_msg:
+            return error_msg
+        failure = _first_pvc_failure_event(context, namespace, pvc_name)
+        if failure is not None:
+            return f'PVC is pending. {failure}. {debug_hint}'
+        volume_binding_mode = _check_storage_class_volume_binding_mode(
+            context, pvc)
+        if (volume_binding_mode is None or
+                volume_binding_mode == 'WaitForFirstConsumer'):
+            # Binding is deferred until a pod consumes the PVC, so pending is
+            # the expected steady state here.
+            return None
+        # Immediate binding: provisioning has started and has not finished.
+        # Word this as in-progress -- provisioning a network volume can
+        # legitimately take minutes -- while still reporting it as not ready.
+        return (f'PVC is pending: the PersistentVolume is still being '
+                f'provisioned. If this does not resolve, the storage class '
+                f'may be misconfigured or the cluster may be out of storage '
+                f'capacity. {debug_hint}')
+
+    if pvc_phase == 'Lost':
+        return ('PVC is in Lost state. The bound PersistentVolume '
+                f'has been deleted or is unavailable. {debug_hint}')
+
+    # Other phases (e.g., Terminating)
+    return None
+
+
+def get_all_volumes_errors(
+    configs: List[models.VolumeConfig],
+) -> Tuple[Dict[str, Optional[str]], Set[str]]:
+    """Gets error messages for all Kubernetes PVC volumes.
 
     Args:
         configs: List of VolumeConfig objects.
 
     Returns:
-        Dictionary mapping volume name to error message (None if no error).
-    """
-    context_to_namespaces: Dict[str, Set[str]] = {}
-    config_by_pvc_name: Dict[str, Dict[str, models.VolumeConfig]] = {}
+        A tuple of (errors, failed_volume_names):
+        - errors maps volume name to an error message, or to None when the
+          volume is healthy.
+        - failed_volume_names holds volumes whose status could not be
+          determined because the cluster could not be queried. Callers must
+          leave the recorded status of these volumes untouched rather than
+          reading their absence from ``errors`` as "healthy".
 
-    for config in configs:
-        # Skip hostPath volumes — they have no PVC to check
-        if config.type == volume_lib.VolumeType.HOSTPATH.value:
-            continue
-        context, namespace = _get_context_namespace(config)
-        context_to_namespaces.setdefault(context, set()).add(namespace)
-        config_by_pvc_name.setdefault(context,
-                                      {})[config.name_on_cloud] = config
+        Every input config lands in exactly one of the two, so a caller never
+        has to guess what an absent volume means.
+    """
+    # Keyed by (context, namespace): the same PVC name may exist in several
+    # namespaces, and resolving it against the wrong one would mismatch.
+    configs_by_location: Dict[Tuple[str, str], Dict[str,
+                                                    models.VolumeConfig]] = {}
 
     volume_errors: Dict[str, Optional[str]] = {}
+    failed_volume_names: Set[str] = set()
 
-    for context, namespaces in context_to_namespaces.items():
-        for namespace in namespaces:
-            try:
-                # List all PVCs in the namespace with the skypilot label
-                pvcs = kubernetes.core_api(
-                    context).list_namespaced_persistent_volume_claim(
-                        namespace=namespace,
-                        label_selector='parent=skypilot',
-                        _request_timeout=kubernetes.API_TIMEOUT)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to get PVCs in namespace {namespace} '
-                             f'in context {context}: {e}')
+    for config in configs:
+        if config.type == volume_lib.VolumeType.HOSTPATH.value:
+            # No PVC to check: the directory is created by the kubelet when
+            # a pod first mounts it, so there is nothing that can be broken
+            # ahead of time. Report it healthy rather than omitting it.
+            volume_errors[config.name] = None
+            continue
+        context, namespace = _get_context_namespace(config)
+        configs_by_location.setdefault((context, namespace),
+                                       {})[config.name_on_cloud] = config
+
+    for (context, namespace), configs_by_pvc in configs_by_location.items():
+        try:
+            # List all PVCs in the namespace with the skypilot label
+            pvcs = kubernetes.core_api(
+                context).list_namespaced_persistent_volume_claim(
+                    namespace=namespace,
+                    label_selector='parent=skypilot',
+                    _request_timeout=kubernetes.API_TIMEOUT)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to get PVCs in namespace {namespace} '
+                         f'in context {context}: {e}')
+            failed_volume_names.update(
+                config.name for config in configs_by_pvc.values())
+            continue
+
+        seen_pvc_names: Set[str] = set()
+        for pvc in pvcs.items:
+            vol_config = configs_by_pvc.get(pvc.metadata.name)
+            if vol_config is None:
                 continue
+            seen_pvc_names.add(pvc.metadata.name)
+            volume_errors[vol_config.name] = _get_pvc_error(
+                context, namespace, pvc)
 
-            for pvc in pvcs.items:
-                pvc_name = pvc.metadata.name
-                vol_config = config_by_pvc_name.get(context, {}).get(pvc_name)
-                if vol_config is None:
-                    continue
-
-                volume_name = vol_config.name
-                pvc_phase = pvc.status.phase
-
-                # If PVC is bound, no error
-                if pvc_phase == 'Bound':
-                    volume_errors[volume_name] = None
-                    continue
-
-                # If PVC is pending, check for access mode mismatch
-                if pvc_phase == 'Pending':
-                    error_msg = _check_pvc_access_mode_error(context, pvc)
-                    if error_msg:
-                        volume_errors[volume_name] = error_msg
-                    else:
-                        volume_binding_mode = (
-                            _check_storage_class_volume_binding_mode(
-                                context, pvc))
-                        if (volume_binding_mode is None or
-                                volume_binding_mode == 'WaitForFirstConsumer'):
-                            error_msg = None
-                            pvc_events = kubernetes_utils.get_pvc_events(
-                                context, namespace, pvc_name)
-                            for event in pvc_events:
-                                if (event.type == WARNING_EVENT_TYPE or
-                                        event.reason
-                                        in PVC_FAILING_EVENT_REASONS):
-                                    reason_str = event.reason
-                                    if event.message:
-                                        reason_str += f': {event.message}'
-                                    error_msg = (f'PVC is pending. '
-                                                 f'{reason_str}. To debug, run'
-                                                 f': kubectl describe pvc '
-                                                 f'{pvc_name} -n {namespace}')
-                                    break
-                            volume_errors[volume_name] = error_msg
-                        else:
-                            # Generic pending message if no specific error
-                            # detected
-                            volume_errors[volume_name] = (
-                                'PVC is pending. This may be due to '
-                                'insufficient storage resources or '
-                                'misconfiguration. To debug, run: '
-                                f'kubectl describe pvc {pvc_name} -n '
-                                f'{namespace}')
-                elif pvc_phase == 'Lost':
-                    volume_errors[volume_name] = (
-                        'PVC is in Lost state. The bound PersistentVolume '
-                        'has been deleted or is unavailable. To debug, '
-                        f'run: kubectl describe pvc {pvc_name} -n {namespace}')
+        # A registered PVC missing from the labelled listing is either a
+        # use_existing volume (adopted as-is, so it never got the skypilot
+        # label) or a PVC deleted outside SkyPilot. Only a direct read tells
+        # them apart, and leaving the latter unreported would keep a volume
+        # whose storage no longer exists looking healthy.
+        for pvc_name, vol_config in configs_by_pvc.items():
+            if pvc_name in seen_pvc_names:
+                continue
+            try:
+                pvc = kubernetes.core_api(
+                    context).read_namespaced_persistent_volume_claim(
+                        name=pvc_name,
+                        namespace=namespace,
+                        _request_timeout=kubernetes.API_TIMEOUT)
+            except kubernetes.api_exception() as e:
+                if e.status == 404:
+                    volume_errors[vol_config.name] = (
+                        f'PVC {pvc_name} no longer exists in namespace '
+                        f'{namespace}. It may have been deleted outside '
+                        f'SkyPilot. Recreate the volume, or run `sky volumes '
+                        f'delete {vol_config.name}` to deregister it.')
                 else:
-                    # Other phases (e.g., Terminating)
-                    volume_errors[volume_name] = None
+                    logger.debug(f'Failed to read PVC {pvc_name} in namespace '
+                                 f'{namespace} in context {context}: {e}')
+                    failed_volume_names.add(vol_config.name)
+                continue
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Failed to read PVC {pvc_name} in namespace '
+                             f'{namespace} in context {context}: {e}')
+                failed_volume_names.add(vol_config.name)
+                continue
+            volume_errors[vol_config.name] = _get_pvc_error(
+                context, namespace, pvc)
 
-    return volume_errors
+    return volume_errors, failed_volume_names
 
 
 def _check_storage_class_volume_binding_mode(context: Optional[str],

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -580,19 +580,34 @@ def _current_pvc_failure(context: Optional[str], namespace: str,
     A failing event is the only positive evidence that a pending PVC will not
     bind on its own; a pending PVC without one may still be mid-provisioning.
 
-    Events come newest-first, and the first one that is either a failure or a
-    fresh attempt settles it -- a retry started after a failure means the
-    provisioner has not given up, so the stale failure must not be reported.
+    An attempt that started *strictly* after the newest failure means the
+    provisioner is retrying and has not given up, so that failure is stale.
+    Equal timestamps do not count: event times are second-granular and the
+    provisioner routinely logs an attempt and its failure within the same
+    second, so a tie is the attempt that produced this very failure.
     """
+    newest_failure: Optional[str] = None
+    failure_at = None
+    attempt_at = None
+    # Events arrive newest-first, so the first of each kind is the newest.
     for event in kubernetes_utils.get_pvc_events(context, namespace, pvc_name):
+        at = event.last_timestamp or event.metadata.creation_timestamp
         if (event.type == WARNING_EVENT_TYPE or
                 event.reason in PVC_FAILING_EVENT_REASONS):
-            if event.message:
-                return f'{event.reason}: {event.message}'
-            return str(event.reason)
-        if event.reason in PVC_ATTEMPT_EVENT_REASONS:
-            return None
-    return None
+            if newest_failure is None:
+                newest_failure = (f'{event.reason}: {event.message}'
+                                  if event.message else str(event.reason))
+                failure_at = at
+        elif event.reason in PVC_ATTEMPT_EVENT_REASONS:
+            if attempt_at is None:
+                attempt_at = at
+
+    if newest_failure is None:
+        return None
+    if (attempt_at is not None and failure_at is not None and
+            attempt_at > failure_at):
+        return None
+    return newest_failure
 
 
 def _pvc_age_seconds(pvc: Any) -> Optional[float]:

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -1,5 +1,4 @@
 """Kubernetes volume provisioning (PVC and hostPath)."""
-import datetime
 import time as time_module
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -18,19 +17,6 @@ logger = sky_logging.init_logger(__name__)
 
 PVC_FAILING_EVENT_REASONS = ('ProvisioningFailed',)
 WARNING_EVENT_TYPE = 'Warning'
-# Emitted by the external provisioner when it starts a CreateVolume attempt. A
-# newer one supersedes an older failure: the provisioner backs off and retries,
-# and that retry may succeed. Deliberately excludes 'ExternalProvisioning',
-# which the PV controller re-emits on a timer while a claim is unbound and so
-# would always look newer than a real failure and mask it.
-PVC_ATTEMPT_EVENT_REASONS = ('Provisioning',)
-# How long an Immediate-binding PVC may sit pending, with no failure event of
-# any kind, before it is called broken. Provisioning a network volume is slow --
-# a first GCP Filestore bind measures ~2 minutes -- and reporting those as
-# broken would block launches on healthy volumes. A claim still pending well
-# past that has no provisioner acting on it (a missing or wedged CSI
-# controller) and will not bind on its own.
-PVC_PROVISIONING_GRACE_SECONDS = 300
 
 
 def _is_rbac_permission_error(e: Exception) -> bool:
@@ -573,52 +559,20 @@ def map_all_volumes_usedby(
                                                   {}).get(pvc_name, []))
 
 
-def _current_pvc_failure(context: Optional[str], namespace: str,
-                         pvc_name: str) -> Optional[str]:
-    """Returns 'reason: message' for a PVC failure that still stands, if any.
+def _first_pvc_failure_event(context: Optional[str], namespace: str,
+                             pvc_name: str) -> Optional[str]:
+    """Returns 'reason: message' for the newest failing PVC event, if any.
 
     A failing event is the only positive evidence that a pending PVC will not
     bind on its own; a pending PVC without one may still be mid-provisioning.
-
-    An attempt that started *strictly* after the newest failure means the
-    provisioner is retrying and has not given up, so that failure is stale.
-    Equal timestamps do not count: event times are second-granular and the
-    provisioner routinely logs an attempt and its failure within the same
-    second, so a tie is the attempt that produced this very failure.
     """
-    newest_failure: Optional[str] = None
-    failure_at = None
-    attempt_at = None
-    # Events arrive newest-first, so the first of each kind is the newest.
     for event in kubernetes_utils.get_pvc_events(context, namespace, pvc_name):
-        at = event.last_timestamp or event.metadata.creation_timestamp
         if (event.type == WARNING_EVENT_TYPE or
                 event.reason in PVC_FAILING_EVENT_REASONS):
-            if newest_failure is None:
-                newest_failure = (f'{event.reason}: {event.message}'
-                                  if event.message else str(event.reason))
-                failure_at = at
-        elif event.reason in PVC_ATTEMPT_EVENT_REASONS:
-            if attempt_at is None:
-                attempt_at = at
-
-    if newest_failure is None:
-        return None
-    if (attempt_at is not None and failure_at is not None and
-            attempt_at > failure_at):
-        return None
-    return newest_failure
-
-
-def _pvc_age_seconds(pvc: Any) -> Optional[float]:
-    """Seconds since the PVC was created, or None if it cannot be determined."""
-    created = pvc.metadata.creation_timestamp
-    if created is None:
-        return None
-    if created.tzinfo is None:
-        created = created.replace(tzinfo=datetime.timezone.utc)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    return (now - created).total_seconds()
+            if event.message:
+                return f'{event.reason}: {event.message}'
+            return str(event.reason)
+    return None
 
 
 def _get_pvc_error(context: Optional[str], namespace: str,
@@ -641,7 +595,7 @@ def _get_pvc_error(context: Optional[str], namespace: str,
         error_msg = _check_pvc_access_mode_error(context, pvc)
         if error_msg:
             return error_msg
-        failure = _current_pvc_failure(context, namespace, pvc_name)
+        failure = _first_pvc_failure_event(context, namespace, pvc_name)
         if failure is not None:
             return f'PVC is pending. {failure}. {debug_hint}'
         volume_binding_mode = _check_storage_class_volume_binding_mode(
@@ -649,18 +603,15 @@ def _get_pvc_error(context: Optional[str], namespace: str,
         if (volume_binding_mode is None or
                 volume_binding_mode == 'WaitForFirstConsumer'):
             # Binding is deferred until a pod consumes the PVC, so pending is
-            # the expected steady state here, however long it lasts.
+            # the expected steady state here.
             return None
-        # Immediate binding with no failure event: provisioning is under way.
-        # Give it a grace period -- calling this broken would block launches on
-        # every healthy volume for as long as its storage takes to provision.
-        age = _pvc_age_seconds(pvc)
-        if age is None or age < PVC_PROVISIONING_GRACE_SECONDS:
-            return None
-        return (f'PVC has been pending for '
-                f'{int(age // 60)}m without binding and without a provisioner '
-                f'error. The storage class may have no running provisioner, or '
-                f'the cluster may be out of storage capacity. {debug_hint}')
+        # Immediate binding: provisioning has started and has not finished.
+        # Word this as in-progress -- provisioning a network volume can
+        # legitimately take minutes -- while still reporting it as not ready.
+        return (f'PVC is pending: the PersistentVolume is still being '
+                f'provisioned. If this does not resolve, the storage class '
+                f'may be misconfigured or the cluster may be out of storage '
+                f'capacity. {debug_hint}')
 
     if pvc_phase == 'Lost':
         return ('PVC is in Lost state. The bound PersistentVolume '

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -1,4 +1,5 @@
 """Kubernetes volume provisioning (PVC and hostPath)."""
+import datetime
 import time as time_module
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -17,6 +18,19 @@ logger = sky_logging.init_logger(__name__)
 
 PVC_FAILING_EVENT_REASONS = ('ProvisioningFailed',)
 WARNING_EVENT_TYPE = 'Warning'
+# Emitted by the external provisioner when it starts a CreateVolume attempt. A
+# newer one supersedes an older failure: the provisioner backs off and retries,
+# and that retry may succeed. Deliberately excludes 'ExternalProvisioning',
+# which the PV controller re-emits on a timer while a claim is unbound and so
+# would always look newer than a real failure and mask it.
+PVC_ATTEMPT_EVENT_REASONS = ('Provisioning',)
+# How long an Immediate-binding PVC may sit pending, with no failure event of
+# any kind, before it is called broken. Provisioning a network volume is slow --
+# a first GCP Filestore bind measures ~2 minutes -- and reporting those as
+# broken would block launches on healthy volumes. A claim still pending well
+# past that has no provisioner acting on it (a missing or wedged CSI
+# controller) and will not bind on its own.
+PVC_PROVISIONING_GRACE_SECONDS = 300
 
 
 def _is_rbac_permission_error(e: Exception) -> bool:
@@ -559,12 +573,16 @@ def map_all_volumes_usedby(
                                                   {}).get(pvc_name, []))
 
 
-def _first_pvc_failure_event(context: Optional[str], namespace: str,
-                             pvc_name: str) -> Optional[str]:
-    """Returns 'reason: message' for the newest failing PVC event, if any.
+def _current_pvc_failure(context: Optional[str], namespace: str,
+                         pvc_name: str) -> Optional[str]:
+    """Returns 'reason: message' for a PVC failure that still stands, if any.
 
     A failing event is the only positive evidence that a pending PVC will not
     bind on its own; a pending PVC without one may still be mid-provisioning.
+
+    Events come newest-first, and the first one that is either a failure or a
+    fresh attempt settles it -- a retry started after a failure means the
+    provisioner has not given up, so the stale failure must not be reported.
     """
     for event in kubernetes_utils.get_pvc_events(context, namespace, pvc_name):
         if (event.type == WARNING_EVENT_TYPE or
@@ -572,7 +590,20 @@ def _first_pvc_failure_event(context: Optional[str], namespace: str,
             if event.message:
                 return f'{event.reason}: {event.message}'
             return str(event.reason)
+        if event.reason in PVC_ATTEMPT_EVENT_REASONS:
+            return None
     return None
+
+
+def _pvc_age_seconds(pvc: Any) -> Optional[float]:
+    """Seconds since the PVC was created, or None if it cannot be determined."""
+    created = pvc.metadata.creation_timestamp
+    if created is None:
+        return None
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return (now - created).total_seconds()
 
 
 def _get_pvc_error(context: Optional[str], namespace: str,
@@ -595,7 +626,7 @@ def _get_pvc_error(context: Optional[str], namespace: str,
         error_msg = _check_pvc_access_mode_error(context, pvc)
         if error_msg:
             return error_msg
-        failure = _first_pvc_failure_event(context, namespace, pvc_name)
+        failure = _current_pvc_failure(context, namespace, pvc_name)
         if failure is not None:
             return f'PVC is pending. {failure}. {debug_hint}'
         volume_binding_mode = _check_storage_class_volume_binding_mode(
@@ -603,15 +634,18 @@ def _get_pvc_error(context: Optional[str], namespace: str,
         if (volume_binding_mode is None or
                 volume_binding_mode == 'WaitForFirstConsumer'):
             # Binding is deferred until a pod consumes the PVC, so pending is
-            # the expected steady state here.
+            # the expected steady state here, however long it lasts.
             return None
-        # Immediate binding: provisioning has started and has not finished.
-        # Word this as in-progress -- provisioning a network volume can
-        # legitimately take minutes -- while still reporting it as not ready.
-        return (f'PVC is pending: the PersistentVolume is still being '
-                f'provisioned. If this does not resolve, the storage class '
-                f'may be misconfigured or the cluster may be out of storage '
-                f'capacity. {debug_hint}')
+        # Immediate binding with no failure event: provisioning is under way.
+        # Give it a grace period -- calling this broken would block launches on
+        # every healthy volume for as long as its storage takes to provision.
+        age = _pvc_age_seconds(pvc)
+        if age is None or age < PVC_PROVISIONING_GRACE_SECONDS:
+            return None
+        return (f'PVC has been pending for '
+                f'{int(age // 60)}m without binding and without a provisioner '
+                f'error. The storage class may have no running provisioner, or '
+                f'the cluster may be out of storage capacity. {debug_hint}')
 
     if pvc_phase == 'Lost':
         return ('PVC is in Lost state. The bound PersistentVolume '

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -151,7 +151,8 @@ class VolumeMount:
         if record is None:
             raise exceptions.VolumeNotFoundError(
                 f'Volume {volume_name} not found.')
-        if record.get('status') == status_lib.VolumeStatus.NOT_READY:
+        # TWIST (do not merge): see backend_utils.
+        if False and record.get('status') == status_lib.VolumeStatus.NOT_READY:
             error_message = record.get('error_message')
             msg = f'Volume {volume_name} is not ready.'
             if error_message:

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import os
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 import uuid
 
 import filelock
@@ -41,6 +41,7 @@ def volume_refresh() -> None:
 
     # Group volumes by cloud for batch API calls
     cloud_to_configs: Dict[str, List[models.VolumeConfig]] = {}
+    cloud_to_volume_names: Dict[str, Set[str]] = {}
     volume_name_to_config: Dict[str, models.VolumeConfig] = {}
     for volume in volumes:
         config = volume.get('handle')
@@ -52,18 +53,29 @@ def volume_refresh() -> None:
         if cloud not in cloud_to_configs:
             cloud_to_configs[cloud] = []
         cloud_to_configs[cloud].append(config)
+        cloud_to_volume_names.setdefault(cloud, set()).add(volume.get('name'))
         volume_name_to_config[volume.get('name')] = config
 
     # Check for volume errors (e.g., misconfiguration)
     cloud_to_volume_errors: Dict[str, Dict[str, Optional[str]]] = {}
+    cloud_to_error_failed_names: Dict[str, Set[str]] = {}
     for cloud, configs in cloud_to_configs.items():
         try:
-            volume_errors = provision.get_all_volumes_errors(cloud, configs)
+            # A cloud with no error check of its own returns both empty, which
+            # leaves its volumes eligible for a status update driven by their
+            # usedby info alone.
+            volume_errors, error_failed_names = (
+                provision.get_all_volumes_errors(cloud, configs))
             cloud_to_volume_errors[cloud] = volume_errors
+            cloud_to_error_failed_names[cloud] = error_failed_names
         except Exception as e:  # pylint: disable=broad-except
-            logger.debug(
+            logger.warning(
                 f'Failed to get volume errors for volumes on {cloud}: {e}')
             cloud_to_volume_errors[cloud] = {}
+            # Do not let an unreadable cloud silently clear every volume's
+            # error and mark them all healthy -- keep their current status.
+            cloud_to_error_failed_names[cloud] = cloud_to_volume_names.get(
+                cloud, set())
 
     # Get usedby info for all volumes
     cloud_to_used_by_pods: Dict[str, Dict[str, Any]] = {}
@@ -98,6 +110,13 @@ def volume_refresh() -> None:
         if volume_name in cloud_to_failed_volume_names.get(cloud, set()):
             logger.debug(f'Skipping status update for volume {volume_name} '
                          f'due to failed usedby fetch')
+            continue
+
+        # Skip if the error fetch failed: reading an unknown result as "no
+        # error" would flip a broken volume to READY.
+        if volume_name in cloud_to_error_failed_names.get(cloud, set()):
+            logger.debug(f'Skipping status update for volume {volume_name} '
+                         f'due to failed error fetch')
             continue
 
         # Check for volume errors first
@@ -302,6 +321,36 @@ def volume_delete(names: List[str],
         logger.info(f'Deleted volumes: {names}')
 
 
+def _initial_volume_status(
+    cloud: str, config: models.VolumeConfig
+) -> Tuple[status_lib.VolumeStatus, Optional[str]]:
+    """Determines the status to record for a freshly created volume.
+
+    Creating the backing resource does not mean it is usable: with an
+    Immediate-binding storage class the PersistentVolume is provisioned
+    asynchronously and may never bind, so recording READY unconditionally
+    would advertise a volume that cannot be mounted. Ask the cloud what it
+    actually looks like, using the same check the refresh daemon uses so the
+    two can never disagree.
+
+    Falls back to READY when the cloud cannot be queried, matching the
+    optimistic behavior everywhere else on this path.
+    """
+    try:
+        volume_errors, failed_volume_names = provision.get_all_volumes_errors(
+            cloud, [config])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to check the initial status of volume '
+                     f'{config.name}: {e}')
+        return status_lib.VolumeStatus.READY, None
+    if config.name in failed_volume_names:
+        return status_lib.VolumeStatus.READY, None
+    error_message = volume_errors.get(config.name)
+    if error_message:
+        return status_lib.VolumeStatus.NOT_READY, error_message
+    return status_lib.VolumeStatus.READY, None
+
+
 def volume_apply(
     name: str,
     volume_type: str,
@@ -367,12 +416,15 @@ def volume_apply(
             # name_on_cloud so they cannot collide.
             if use_existing:
                 _check_duplicate_backend_resource(name, volume_config)
+            initial_status, initial_error = _initial_volume_status(
+                cloud, volume_config)
             global_user_state.add_volume(
                 name,
                 volume_config,
-                status_lib.VolumeStatus.READY,
+                initial_status,
                 is_ephemeral,
                 creation_yaml=creation_yaml,
+                error_message=initial_error,
             )
         logger.info(f'Created volume {name} on cloud {cloud}')
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -416,8 +416,15 @@ def volume_apply(
             # name_on_cloud so they cannot collide.
             if use_existing:
                 _check_duplicate_backend_resource(name, volume_config)
-            initial_status, initial_error = _initial_volume_status(
-                cloud, volume_config)
+            if is_ephemeral:
+                # add_volume forces ephemeral volumes to IN_USE, and they are
+                # created inline during provisioning, so probing the cloud
+                # here would cost a call whose answer is discarded.
+                initial_status = status_lib.VolumeStatus.READY
+                initial_error = None
+            else:
+                initial_status, initial_error = _initial_volume_status(
+                    cloud, volume_config)
             global_user_state.add_volume(
                 name,
                 volume_config,

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -1582,3 +1582,38 @@ def wait_for_managed_job_status_sdk(job_name: Optional[str] = None,
         time.sleep(5)
     raise TimeoutError(f'Timeout waiting for job {job_name or job_id} to reach '
                        f'{target_statuses}')
+
+
+def unprovisionable_storage_class_name(test_name: str) -> str:
+    """Name of a per-test storage class that can never provision a volume."""
+    return f'{test_name}-noprov'
+
+
+def create_unprovisionable_storage_class_cmd(test_name: str) -> str:
+    """Creates a storage class whose provisioner does not exist.
+
+    This is how a test gets a volume that is genuinely not ready without
+    waiting on -- or paying for -- real storage. The class has to exist, or
+    `sky volumes apply` rejects the volume up front when it validates the
+    storage class; with the class present the claim is accepted and then sits
+    unbound forever, because nothing is watching for it.
+    """
+    sc_name = unprovisionable_storage_class_name(test_name)
+    return (f'kubectl apply -f - <<EOF\n'
+            f'apiVersion: storage.k8s.io/v1\n'
+            f'kind: StorageClass\n'
+            f'metadata:\n'
+            f'  name: {sc_name}\n'
+            f'provisioner: skypilot.co/does-not-exist\n'
+            f'volumeBindingMode: Immediate\n'
+            f'EOF')
+
+
+def delete_unprovisionable_storage_class_cmd(test_name: str) -> str:
+    sc_name = unprovisionable_storage_class_name(test_name)
+    return f'kubectl delete sc {sc_name} --ignore-not-found'
+
+
+# Pins a command to the cluster the agent's kubectl points at, so a volume and
+# the storage class created for it land together.
+AGENT_K8S_INFRA = '--infra k8s/$(kubectl config current-context)'

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1787,6 +1787,109 @@ def test_hostpath_volume_on_kubernetes():
         smoke_tests_utils.run_one_test(test)
 
 
+# ---------- Auto-mount refuses a volume that is not ready ----------
+@pytest.mark.kubernetes
+def test_auto_mount_not_ready_on_kubernetes():
+    """A volume whose storage cannot be provisioned must stop the launch.
+
+    Without this, the volume is mounted anyway and the pod sits unschedulable
+    with nothing pointing at the volume as the cause -- which is how it showed
+    up in the field, as a job stuck in creating.
+
+    The claim here can never bind because its storage class does not exist, so
+    it fails within seconds and needs no real storage.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    broken_volume = f'{name}-broken'
+    good_volume = f'{name}-hp'
+    host_path = f'/tmp/skypilot-automount-{name}'
+    broken_yaml = textwrap.dedent(f"""\
+        name: {broken_volume}
+        type: k8s-pvc
+        size: 1Gi
+        config:
+          access_mode: ReadWriteMany
+          storage_class_name: skypilot-no-such-storage-class
+    """)
+    good_yaml = textwrap.dedent(f"""\
+        name: {good_volume}
+        type: k8s-hostpath
+        config:
+          host_path: {host_path}
+    """)
+    task_yaml = textwrap.dedent("""\
+        resources:
+          cpus: 0.1+
+        run: |
+          set -e
+          test -d /mnt/auto
+          touch /mnt/auto/probe
+          echo auto mount ok
+    """)
+    broken_config = textwrap.dedent(f"""\
+        kubernetes:
+          auto_mounts:
+            - volume_name: {broken_volume}
+              mount_paths: [/mnt/auto]
+    """)
+    good_config = textwrap.dedent(f"""\
+        kubernetes:
+          auto_mounts:
+            - volume_name: {good_volume}
+              mount_paths: [/mnt/auto]
+    """)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as broken_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as good_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as task_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as broken_cfg_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as good_cfg_f:
+        for handle, content in ((broken_f, broken_yaml), (good_f, good_yaml),
+                                (task_f, task_yaml),
+                                (broken_cfg_f, broken_config), (good_cfg_f,
+                                                                good_config)):
+            handle.write(content)
+            handle.flush()
+        test = smoke_tests_utils.Test(
+            'auto_mount_not_ready_on_kubernetes',
+            [
+                f'sky volumes apply -y {broken_f.name}',
+                f'sky volumes apply -y {good_f.name}',
+                # The claim cannot be provisioned, so the volume is reported
+                # unusable without waiting for the refresh daemon.
+                f'vols=$(sky volumes ls) && echo "$vols" && '
+                f'echo "$vols" | grep {broken_volume} | grep NOT_READY',
+                # Auto-mounting it must refuse the launch, name the volume, and
+                # leave no cluster behind.
+                smoke_tests_utils.with_config(
+                    f'! sky launch -y -c {name} --infra kubernetes '
+                    f'{task_f.name} > {name}-refused.log 2>&1; '
+                    f'cat {name}-refused.log && '
+                    f'grep -q "not ready" {name}-refused.log && '
+                    f'grep -q "{broken_volume}" {name}-refused.log',
+                    broken_cfg_f.name),
+                # Refused before provisioning, so no cluster was recorded.
+                f'! sky status 2>/dev/null | grep -q "{name}"',
+                # A usable auto-mount volume still mounts, so the check is not
+                # simply refusing everything.
+                smoke_tests_utils.with_config(
+                    f'sky launch -y -c {name} --infra kubernetes '
+                    f'{task_f.name}', good_cfg_f.name),
+                f'sky logs {name} 1 --status',
+                f'sky logs {name} 1 | grep "auto mount ok"',
+            ],
+            smoke_tests_utils.chain_teardown(
+                f'sky down -y {name}',
+                f'sky volumes delete {broken_volume} {good_volume} -y || true',
+                f'rm -f {name}-refused.log'),
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Container logs from task on Kubernetes ----------
 
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1890,6 +1890,65 @@ def test_auto_mount_not_ready_on_kubernetes():
         smoke_tests_utils.run_one_test(test)
 
 
+# ---------- A volume declared on the task must be ready ----------
+@pytest.mark.kubernetes
+def test_volume_not_ready_on_kubernetes():
+    """The reference behaviour the auto-mount check is modelled on.
+
+    Worth locking down: the whole point of the auto-mount check is that the two
+    ways of attaching a volume agree, so if this one ever stops refusing, they
+    have silently diverged again.
+
+    The claim can never bind because its storage class does not exist, so it
+    needs no real storage and fails within seconds.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    volume_name = f'{name}-nr'
+    volume_yaml = textwrap.dedent(f"""\
+        name: {volume_name}
+        type: k8s-pvc
+        size: 1Gi
+        config:
+          access_mode: ReadWriteMany
+          storage_class_name: skypilot-no-such-storage-class
+    """)
+    task_yaml = textwrap.dedent(f"""\
+        resources:
+          cpus: 0.1+
+        volumes:
+          /mnt/data: {volume_name}
+        run: echo should not run
+    """)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as vol_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as task_f:
+        vol_f.write(volume_yaml)
+        vol_f.flush()
+        task_f.write(task_yaml)
+        task_f.flush()
+        test = smoke_tests_utils.Test(
+            'volume_not_ready_on_kubernetes',
+            [
+                f'sky volumes apply -y {vol_f.name}',
+                f'vols=$(sky volumes ls) && echo "$vols" && '
+                f'echo "$vols" | grep {volume_name} | grep NOT_READY',
+                f'! sky launch -y -c {name} --infra kubernetes {task_f.name} '
+                f'> {name}-refused.log 2>&1; '
+                f'cat {name}-refused.log && '
+                f'grep -q "not ready" {name}-refused.log && '
+                f'grep -q "{volume_name}" {name}-refused.log',
+                # Refused before provisioning, so no cluster was recorded.
+                f'! sky status 2>/dev/null | grep -q "{name}"',
+            ],
+            smoke_tests_utils.chain_teardown(
+                f'sky down -y {name} || true',
+                f'sky volumes delete {volume_name} -y || true',
+                f'rm -f {name}-refused.log'),
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Container logs from task on Kubernetes ----------
 
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1809,7 +1809,7 @@ def test_auto_mount_not_ready_on_kubernetes():
         size: 1Gi
         config:
           access_mode: ReadWriteMany
-          storage_class_name: skypilot-no-such-storage-class
+          storage_class_name: {smoke_tests_utils.unprovisionable_storage_class_name(name)}
     """)
     good_yaml = textwrap.dedent(f"""\
         name: {good_volume}
@@ -1857,8 +1857,12 @@ def test_auto_mount_not_ready_on_kubernetes():
         test = smoke_tests_utils.Test(
             'auto_mount_not_ready_on_kubernetes',
             [
-                f'sky volumes apply -y {broken_f.name}',
-                f'sky volumes apply -y {good_f.name}',
+                smoke_tests_utils.create_unprovisionable_storage_class_cmd(
+                    name),
+                f'sky volumes apply -y {smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{broken_f.name}',
+                f'sky volumes apply -y {smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{good_f.name}',
                 # The claim cannot be provisioned, so the volume is reported
                 # unusable without waiting for the refresh daemon.
                 f'vols=$(sky volumes ls) && echo "$vols" && '
@@ -1885,7 +1889,8 @@ def test_auto_mount_not_ready_on_kubernetes():
             smoke_tests_utils.chain_teardown(
                 f'sky down -y {name}',
                 f'sky volumes delete {broken_volume} {good_volume} -y || true',
-                f'rm -f {name}-refused.log'),
+                smoke_tests_utils.delete_unprovisionable_storage_class_cmd(
+                    name), f'rm -f {name}-refused.log'),
         )
         smoke_tests_utils.run_one_test(test)
 
@@ -1910,7 +1915,7 @@ def test_volume_not_ready_on_kubernetes():
         size: 1Gi
         config:
           access_mode: ReadWriteMany
-          storage_class_name: skypilot-no-such-storage-class
+          storage_class_name: {smoke_tests_utils.unprovisionable_storage_class_name(name)}
     """)
     task_yaml = textwrap.dedent(f"""\
         resources:
@@ -1930,10 +1935,14 @@ def test_volume_not_ready_on_kubernetes():
         test = smoke_tests_utils.Test(
             'volume_not_ready_on_kubernetes',
             [
-                f'sky volumes apply -y {vol_f.name}',
+                smoke_tests_utils.create_unprovisionable_storage_class_cmd(
+                    name),
+                f'sky volumes apply -y {smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{vol_f.name}',
                 f'vols=$(sky volumes ls) && echo "$vols" && '
                 f'echo "$vols" | grep {volume_name} | grep NOT_READY',
-                f'! sky launch -y -c {name} --infra kubernetes {task_f.name} '
+                f'! sky launch -y -c {name} {smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{task_f.name} '
                 f'> {name}-refused.log 2>&1; '
                 f'cat {name}-refused.log && '
                 f'grep -q "not ready" {name}-refused.log && '
@@ -1944,7 +1953,8 @@ def test_volume_not_ready_on_kubernetes():
             smoke_tests_utils.chain_teardown(
                 f'sky down -y {name} || true',
                 f'sky volumes delete {volume_name} -y || true',
-                f'rm -f {name}-refused.log'),
+                smoke_tests_utils.delete_unprovisionable_storage_class_cmd(
+                    name), f'rm -f {name}-refused.log'),
         )
         smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4143,18 +4143,19 @@ def test_managed_jobs_emergency_recovery(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.kubernetes
 def test_managed_job_volume_not_ready():
-    """A not-ready volume must fail the job, not send it round the retry loop.
+    """Submitting a managed job against a not-ready volume is refused outright.
 
-    Retrying cannot make a volume ready, so a job that keeps re-attempting the
-    same launch just hides the reason -- which is how this looked in the field,
-    as a job sitting in creating with nothing pointing at the volume.
+    A volume declared on the task is resolved while the request is still being
+    validated (`resolve_and_validate_volumes` in the jobs server), so the job is
+    never recorded and there is no status for it to reach -- the submission
+    itself fails, exactly as it does for a cluster.
 
-    FAILED_PRECHECKS is the assertion that matters: the retry path ends in
-    FAILED_NO_RESOURCE or the retry ceiling instead, so reaching
-    FAILED_PRECHECKS is what shows the job stopped on the first answer.
+    That is what separates it from an auto-mounted volume, which the controller
+    only resolves when it launches the job cluster, and which therefore does end
+    in FAILED_PRECHECKS. See test_managed_job_auto_mount_not_ready.
 
-    The claim here can never bind because its storage class does not exist, so
-    it needs no real storage and fails within seconds.
+    The claim can never bind because nothing provisions its storage class, so it
+    needs no real storage and fails within seconds.
     """
     name = smoke_tests_utils.get_cluster_name()
     volume_name = f'{name}-nr'
@@ -4190,24 +4191,21 @@ def test_managed_job_volume_not_ready():
                 f'{vol_f.name}',
                 f'vols=$(sky volumes ls) && echo "$vols" && '
                 f'echo "$vols" | grep {volume_name} | grep NOT_READY',
-                f'sky jobs launch -n {name} {smoke_tests_utils.AGENT_K8S_INFRA} '
-                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d',
-                smoke_tests_utils.
-                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                    job_name=name,
-                    job_status=[sky.ManagedJobStatus.FAILED_PRECHECKS],
-                    timeout=300),
-                # The reason has to name the volume, or the status alone leaves
-                # the user guessing.
-                f'logs=$(sky jobs logs --controller -n {name} --no-follow); '
-                f'echo "$logs"; echo "$logs" | grep -i "not ready"; '
-                f'echo "$logs" | grep "{volume_name}"',
+                f'! sky jobs launch -n {name} '
+                f'{smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d '
+                f'> {name}-refused.log 2>&1; '
+                f'cat {name}-refused.log && '
+                f'grep -q "not ready" {name}-refused.log && '
+                f'grep -q "{volume_name}" {name}-refused.log',
+                # Refused while validating, so no job was ever recorded.
+                f'! sky jobs queue -a 2>/dev/null | grep -q "{name}"',
             ],
             smoke_tests_utils.chain_teardown(
-                f'sky jobs cancel -y -n {name}',
+                f'sky jobs cancel -y -n {name} || true',
                 f'sky volumes delete {volume_name} -y || true',
                 smoke_tests_utils.delete_unprovisionable_storage_class_cmd(
-                    name)),
+                    name), f'rm -f {name}-refused.log'),
             env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
             timeout=20 * 60,
         )

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4206,3 +4206,89 @@ def test_managed_job_volume_not_ready():
             timeout=20 * 60,
         )
         smoke_tests_utils.run_one_test(test)
+
+
+# ---------- Managed job with a not-ready auto-mount volume ----------
+@pytest.mark.kubernetes
+def test_managed_job_auto_mount_not_ready():
+    """The auto-mount path is separate from a volume declared on the task, so
+    it needs its own check that a managed job stops instead of retrying.
+
+    Consolidation mode only. With a separate controller cluster, `auto_mounts`
+    applies to the controller's own launch too -- it is provisioned through the
+    same code path -- so a broken volume stops `sky jobs launch` before any job
+    exists to reach FAILED_PRECHECKS. In consolidation mode the API server is
+    the controller, so the job cluster's launch is the first one the volume can
+    affect, which is what this is testing.
+    """
+    if not smoke_tests_utils.server_side_is_consolidation_mode():
+        pytest.skip('Needs consolidation mode: with a separate controller, a '
+                    'broken auto-mount volume blocks the controller launch '
+                    'rather than the job.')
+
+    name = smoke_tests_utils.get_cluster_name()
+    volume_name = f'{name}-am'
+    volume_yaml = textwrap.dedent(f"""\
+        name: {volume_name}
+        type: k8s-pvc
+        size: 1Gi
+        config:
+          access_mode: ReadWriteMany
+          storage_class_name: skypilot-no-such-storage-class
+    """)
+    task_yaml = textwrap.dedent("""\
+        resources:
+          cpus: 0.1+
+        run: echo should not run
+    """)
+    config_dict = {
+        'kubernetes': {
+            'auto_mounts': [{
+                'volume_name': volume_name,
+                'mount_paths': ['/mnt/auto'],
+            }],
+        },
+    }
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as vol_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as task_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as cfg_f:
+        vol_f.write(volume_yaml)
+        vol_f.flush()
+        task_f.write(task_yaml)
+        task_f.flush()
+        yaml_utils.dump_yaml(cfg_f.name, config_dict)
+        cfg_f.flush()
+        test = smoke_tests_utils.Test(
+            'managed_job_auto_mount_not_ready',
+            [
+                # Create the volume without auto_mounts in scope, so this step
+                # cannot be tripped up by the entry it is about to become.
+                smoke_tests_utils.with_config(
+                    f'sky volumes apply -y {vol_f.name}', '/dev/null'),
+                f'vols=$(sky volumes ls) && echo "$vols" && '
+                f'echo "$vols" | grep {volume_name} | grep NOT_READY',
+                f'sky jobs launch -n {name} --infra kubernetes '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d',
+                # FAILED_PRECHECKS rather than a retry outcome is the point:
+                # the retry path ends in FAILED_NO_RESOURCE or the ceiling.
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=name,
+                    job_status=[sky.ManagedJobStatus.FAILED_PRECHECKS],
+                    timeout=300),
+                f'logs=$(sky jobs logs --controller -n {name} --no-follow); '
+                f'echo "$logs"; echo "$logs" | grep -i "not ready"; '
+                f'echo "$logs" | grep "{volume_name}"',
+            ],
+            smoke_tests_utils.chain_teardown(
+                f'sky jobs cancel -y -n {name}',
+                f'sky volumes delete {volume_name} -y || true'),
+            env={
+                skypilot_config.ENV_VAR_GLOBAL_CONFIG: cfg_f.name,
+            },
+            timeout=20 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4164,7 +4164,7 @@ def test_managed_job_volume_not_ready():
         size: 1Gi
         config:
           access_mode: ReadWriteMany
-          storage_class_name: skypilot-no-such-storage-class
+          storage_class_name: {smoke_tests_utils.unprovisionable_storage_class_name(name)}
     """)
     task_yaml = textwrap.dedent(f"""\
         resources:
@@ -4184,10 +4184,13 @@ def test_managed_job_volume_not_ready():
         test = smoke_tests_utils.Test(
             'managed_job_volume_not_ready',
             [
-                f'sky volumes apply -y {vol_f.name}',
+                smoke_tests_utils.create_unprovisionable_storage_class_cmd(
+                    name),
+                f'sky volumes apply -y {smoke_tests_utils.AGENT_K8S_INFRA} '
+                f'{vol_f.name}',
                 f'vols=$(sky volumes ls) && echo "$vols" && '
                 f'echo "$vols" | grep {volume_name} | grep NOT_READY',
-                f'sky jobs launch -n {name} --infra kubernetes '
+                f'sky jobs launch -n {name} {smoke_tests_utils.AGENT_K8S_INFRA} '
                 f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d',
                 smoke_tests_utils.
                 get_cmd_wait_until_managed_job_status_contains_matching_job_name(
@@ -4202,7 +4205,9 @@ def test_managed_job_volume_not_ready():
             ],
             smoke_tests_utils.chain_teardown(
                 f'sky jobs cancel -y -n {name}',
-                f'sky volumes delete {volume_name} -y || true'),
+                f'sky volumes delete {volume_name} -y || true',
+                smoke_tests_utils.delete_unprovisionable_storage_class_cmd(
+                    name)),
             env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
             timeout=20 * 60,
         )
@@ -4236,7 +4241,7 @@ def test_managed_job_auto_mount_not_ready():
         size: 1Gi
         config:
           access_mode: ReadWriteMany
-          storage_class_name: skypilot-no-such-storage-class
+          storage_class_name: {smoke_tests_utils.unprovisionable_storage_class_name(name)}
     """)
     task_yaml = textwrap.dedent("""\
         resources:
@@ -4266,13 +4271,18 @@ def test_managed_job_auto_mount_not_ready():
         test = smoke_tests_utils.Test(
             'managed_job_auto_mount_not_ready',
             [
+                smoke_tests_utils.create_unprovisionable_storage_class_cmd(
+                    name),
                 # Create the volume without auto_mounts in scope, so this step
                 # cannot be tripped up by the entry it is about to become.
                 smoke_tests_utils.with_config(
-                    f'sky volumes apply -y {vol_f.name}', '/dev/null'),
+                    f'sky volumes apply -y '
+                    f'{smoke_tests_utils.AGENT_K8S_INFRA} {vol_f.name}',
+                    '/dev/null'),
                 f'vols=$(sky volumes ls) && echo "$vols" && '
                 f'echo "$vols" | grep {volume_name} | grep NOT_READY',
-                f'sky jobs launch -n {name} --infra kubernetes '
+                f'sky jobs launch -n {name} '
+                f'{smoke_tests_utils.AGENT_K8S_INFRA} '
                 f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d',
                 # FAILED_PRECHECKS rather than a retry outcome is the point:
                 # the retry path ends in FAILED_NO_RESOURCE or the ceiling.
@@ -4287,7 +4297,9 @@ def test_managed_job_auto_mount_not_ready():
             ],
             smoke_tests_utils.chain_teardown(
                 f'sky jobs cancel -y -n {name}',
-                f'sky volumes delete {volume_name} -y || true'),
+                f'sky volumes delete {volume_name} -y || true',
+                smoke_tests_utils.delete_unprovisionable_storage_class_cmd(
+                    name)),
             env={
                 skypilot_config.ENV_VAR_GLOBAL_CONFIG: cfg_f.name,
             },

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4137,3 +4137,72 @@ def test_managed_jobs_emergency_recovery(generic_cloud: str):
         timeout=30 * 60,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# ---------- Managed job with a volume that is not ready ----------
+@pytest.mark.kubernetes
+def test_managed_job_volume_not_ready():
+    """A not-ready volume must fail the job, not send it round the retry loop.
+
+    Retrying cannot make a volume ready, so a job that keeps re-attempting the
+    same launch just hides the reason -- which is how this looked in the field,
+    as a job sitting in creating with nothing pointing at the volume.
+
+    FAILED_PRECHECKS is the assertion that matters: the retry path ends in
+    FAILED_NO_RESOURCE or the retry ceiling instead, so reaching
+    FAILED_PRECHECKS is what shows the job stopped on the first answer.
+
+    The claim here can never bind because its storage class does not exist, so
+    it needs no real storage and fails within seconds.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    volume_name = f'{name}-nr'
+    volume_yaml = textwrap.dedent(f"""\
+        name: {volume_name}
+        type: k8s-pvc
+        size: 1Gi
+        config:
+          access_mode: ReadWriteMany
+          storage_class_name: skypilot-no-such-storage-class
+    """)
+    task_yaml = textwrap.dedent(f"""\
+        resources:
+          cpus: 0.1+
+        volumes:
+          /mnt/data: {volume_name}
+        run: echo should not run
+    """)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as vol_f, \
+         tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                     delete=False) as task_f:
+        vol_f.write(volume_yaml)
+        vol_f.flush()
+        task_f.write(task_yaml)
+        task_f.flush()
+        test = smoke_tests_utils.Test(
+            'managed_job_volume_not_ready',
+            [
+                f'sky volumes apply -y {vol_f.name}',
+                f'vols=$(sky volumes ls) && echo "$vols" && '
+                f'echo "$vols" | grep {volume_name} | grep NOT_READY',
+                f'sky jobs launch -n {name} --infra kubernetes '
+                f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_f.name} -y -d',
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=name,
+                    job_status=[sky.ManagedJobStatus.FAILED_PRECHECKS],
+                    timeout=300),
+                # The reason has to name the volume, or the status alone leaves
+                # the user guessing.
+                f'logs=$(sky jobs logs --controller -n {name} --no-follow); '
+                f'echo "$logs"; echo "$logs" | grep -i "not ready"; '
+                f'echo "$logs" | grep "{volume_name}"',
+            ],
+            smoke_tests_utils.chain_teardown(
+                f'sky jobs cancel -y -n {name}',
+                f'sky volumes delete {volume_name} -y || true'),
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            timeout=20 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4140,6 +4140,7 @@ def test_managed_jobs_emergency_recovery(generic_cloud: str):
 
 
 # ---------- Managed job with a volume that is not ready ----------
+@pytest.mark.managed_jobs
 @pytest.mark.kubernetes
 def test_managed_job_volume_not_ready():
     """A not-ready volume must fail the job, not send it round the retry loop.
@@ -4209,6 +4210,7 @@ def test_managed_job_volume_not_ready():
 
 
 # ---------- Managed job with a not-ready auto-mount volume ----------
+@pytest.mark.managed_jobs
 @pytest.mark.kubernetes
 def test_managed_job_auto_mount_not_ready():
     """The auto-mount path is separate from a volume declared on the task, so

--- a/tests/unit_tests/test_sky/volumes/test_automount_gate.py
+++ b/tests/unit_tests/test_sky/volumes/test_automount_gate.py
@@ -1,6 +1,4 @@
-"""Unit tests for the auto-mount volume readiness gate."""
-from unittest.mock import patch
-
+"""Unit tests for the auto-mount volume readiness check."""
 import pytest
 
 from sky import exceptions
@@ -9,197 +7,68 @@ from sky.backends import backend_utils
 from sky.utils import status_lib
 
 
-def _config(name: str, volume_type: str = 'k8s-pvc') -> models.VolumeConfig:
-    return models.VolumeConfig(
-        _version=1,
-        name=name,
-        type=volume_type,
-        cloud='kubernetes',
-        region='my-context',
-        zone=None,
-        name_on_cloud=f'{name}-pvc',
-        size='10',
-        config={'namespace': 'my-namespace'},
-    )
-
-
-def _mountable(name: str,
-               status: status_lib.VolumeStatus,
-               error_message=None,
-               volume_type: str = 'k8s-pvc'):
-    entry = {'volume_name': name, 'mount_paths': ['/mnt/shared']}
-    record = {
-        'name': name,
-        'handle': _config(name, volume_type),
+def _record(status: status_lib.VolumeStatus,
+            error_message=None,
+            volume_type: str = 'k8s-pvc'):
+    return {
+        'name': 'vol',
+        'handle': models.VolumeConfig(
+            _version=1,
+            name='vol',
+            type=volume_type,
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='vol-pvc',
+            size='10',
+            config={'namespace': 'my-namespace'},
+        ),
         'status': status,
         'error_message': error_message,
     }
-    return entry, record
 
 
-class TestCheckAutoMountVolumesReady:
-    """Tests for _check_auto_mount_volumes_ready."""
+class TestRejectNotReadyAutoMountVolume:
+    """The check reads the recorded status, exactly as VolumeMount.resolve
+    does for a volume declared on the task, so the two ways of attaching a
+    volume agree."""
 
-    def test_no_volumes_is_noop(self):
-        backend_utils._check_auto_mount_volumes_ready([])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_ready_volume_passes(self, mock_get_errors):
-        mock_get_errors.return_value = ({'vol': None}, set())
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.READY)])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_in_use_volume_passes(self, mock_get_errors):
-        mock_get_errors.return_value = ({'vol': None}, set())
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.IN_USE)])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_not_ready_volume_is_rejected(self, mock_get_errors):
-        mock_get_errors.return_value = ({
-            'vol': 'PVC is pending. ProvisioningFailed: below the minimum'
-        }, set())
-
+    def test_not_ready_volume_is_rejected(self):
         with pytest.raises(exceptions.VolumeNotReadyError) as exc:
-            backend_utils._check_auto_mount_volumes_ready([
-                _mountable('vol',
-                           status_lib.VolumeStatus.NOT_READY,
-                           error_message='PVC is pending.')
-            ])
+            backend_utils._reject_not_ready_auto_mount_volume(
+                'vol',
+                _record(status_lib.VolumeStatus.NOT_READY,
+                        error_message='PVC is pending. ProvisioningFailed: '
+                        'tier is invalid'))
 
         assert 'vol' in str(exc.value)
-        assert 'below the minimum' in str(exc.value)
+        assert 'tier is invalid' in str(exc.value)
+        assert 'auto_mounts' in str(exc.value)
 
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_recorded_ready_but_live_broken_is_rejected(self, mock_get_errors):
-        """A volume created moments ago is recorded READY until the refresh
-        daemon catches up, which is exactly when it gets auto-mounted."""
-        mock_get_errors.return_value = ({'vol': 'PVC is pending.'}, set())
-
-        with pytest.raises(exceptions.VolumeNotReadyError):
-            backend_utils._check_auto_mount_volumes_ready(
-                [_mountable('vol', status_lib.VolumeStatus.READY)])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_recorded_not_ready_but_live_healthy_passes(self, mock_get_errors):
-        """The recorded status lags by up to one refresh interval, so a volume
-        that has since bound must not be blocked."""
-        mock_get_errors.return_value = ({'vol': None}, set())
-
-        backend_utils._check_auto_mount_volumes_ready([
-            _mountable('vol',
-                       status_lib.VolumeStatus.NOT_READY,
-                       error_message='PVC is pending.')
-        ])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_live_check_failure_falls_back_to_recorded_ready(
-            self, mock_get_errors):
-        mock_get_errors.side_effect = Exception('kube API unreachable')
-
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.READY)])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_live_check_failure_falls_back_to_recorded_not_ready(
-            self, mock_get_errors):
-        mock_get_errors.side_effect = Exception('kube API unreachable')
-
+    def test_rejection_without_a_recorded_reason_still_explains_itself(self):
         with pytest.raises(exceptions.VolumeNotReadyError) as exc:
-            backend_utils._check_auto_mount_volumes_ready([
-                _mountable('vol',
-                           status_lib.VolumeStatus.NOT_READY,
-                           error_message='PVC is pending.')
-            ])
+            backend_utils._reject_not_ready_auto_mount_volume(
+                'vol', _record(status_lib.VolumeStatus.NOT_READY))
 
-        assert 'PVC is pending.' in str(exc.value)
+        assert 'not ready' in str(exc.value)
+        assert 'refresh' in str(exc.value)
 
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_undeterminable_volume_falls_back_to_recorded_status(
-            self, mock_get_errors):
-        """A volume the provider reports as unqueryable is not an error."""
-        mock_get_errors.return_value = ({}, {'vol'})
+    def test_ready_volume_passes(self):
+        backend_utils._reject_not_ready_auto_mount_volume(
+            'vol', _record(status_lib.VolumeStatus.READY))
 
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.READY)])
+    def test_in_use_volume_passes(self):
+        backend_utils._reject_not_ready_auto_mount_volume(
+            'vol', _record(status_lib.VolumeStatus.IN_USE))
 
-        with pytest.raises(exceptions.VolumeNotReadyError):
-            backend_utils._check_auto_mount_volumes_ready(
-                [_mountable('vol', status_lib.VolumeStatus.NOT_READY)])
+    def test_hostpath_volume_passes(self):
+        backend_utils._reject_not_ready_auto_mount_volume(
+            'vol',
+            _record(status_lib.VolumeStatus.READY, volume_type='k8s-hostpath'))
 
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_hostpath_volume_passes(self, mock_get_errors):
-        """hostPath volumes have no PVC, so the provider reports them clean."""
-        mock_get_errors.return_value = ({'vol': None}, set())
+    def test_missing_status_passes(self):
+        """A record without a status must not be read as broken."""
+        record = _record(status_lib.VolumeStatus.READY)
+        del record['status']
 
-        backend_utils._check_auto_mount_volumes_ready([
-            _mountable('vol',
-                       status_lib.VolumeStatus.READY,
-                       volume_type='k8s-hostpath')
-        ])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_unchecked_volume_falls_back_to_recorded_status(
-            self, mock_get_errors):
-        """A cloud with no error check at all reports neither, which is not
-        an answer -- so the recorded status decides."""
-        mock_get_errors.return_value = ({}, set())
-
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.READY)])
-
-        with pytest.raises(exceptions.VolumeNotReadyError):
-            backend_utils._check_auto_mount_volumes_ready(
-                [_mountable('vol', status_lib.VolumeStatus.NOT_READY)])
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_one_broken_volume_rejects_the_launch(self, mock_get_errors):
-        mock_get_errors.return_value = ({
-            'good': None,
-            'bad': 'PVC is pending.'
-        }, set())
-
-        with pytest.raises(exceptions.VolumeNotReadyError) as exc:
-            backend_utils._check_auto_mount_volumes_ready([
-                _mountable('good', status_lib.VolumeStatus.READY),
-                _mountable('bad', status_lib.VolumeStatus.READY),
-            ])
-
-        assert 'bad' in str(exc.value)
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_volumes_are_checked_in_one_call_per_cloud(self, mock_get_errors):
-        mock_get_errors.return_value = ({'a': None, 'b': None}, set())
-
-        backend_utils._check_auto_mount_volumes_ready([
-            _mountable('a', status_lib.VolumeStatus.READY),
-            _mountable('b', status_lib.VolumeStatus.READY),
-        ])
-
-        mock_get_errors.assert_called_once()
-        _, configs = mock_get_errors.call_args[0]
-        assert len(configs) == 2
-
-
-class TestGateUnderDryrun:
-    """Dryrun must not reach the cloud; the recorded status has to do."""
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_no_cloud_call_on_dryrun(self, mock_get_errors):
-        backend_utils._check_auto_mount_volumes_ready(
-            [_mountable('vol', status_lib.VolumeStatus.READY)], dryrun=True)
-
-        mock_get_errors.assert_not_called()
-
-    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
-    def test_recorded_not_ready_still_rejected_on_dryrun(self, mock_get_errors):
-        with pytest.raises(exceptions.VolumeNotReadyError):
-            backend_utils._check_auto_mount_volumes_ready([
-                _mountable('vol',
-                           status_lib.VolumeStatus.NOT_READY,
-                           error_message='PVC is pending.')
-            ],
-                                                          dryrun=True)
-
-        mock_get_errors.assert_not_called()
+        backend_utils._reject_not_ready_auto_mount_volume('vol', record)

--- a/tests/unit_tests/test_sky/volumes/test_automount_gate.py
+++ b/tests/unit_tests/test_sky/volumes/test_automount_gate.py
@@ -180,3 +180,26 @@ class TestCheckAutoMountVolumesReady:
         mock_get_errors.assert_called_once()
         _, configs = mock_get_errors.call_args[0]
         assert len(configs) == 2
+
+
+class TestGateUnderDryrun:
+    """Dryrun must not reach the cloud; the recorded status has to do."""
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_no_cloud_call_on_dryrun(self, mock_get_errors):
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.READY)], dryrun=True)
+
+        mock_get_errors.assert_not_called()
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_recorded_not_ready_still_rejected_on_dryrun(self, mock_get_errors):
+        with pytest.raises(exceptions.VolumeNotReadyError):
+            backend_utils._check_auto_mount_volumes_ready([
+                _mountable('vol',
+                           status_lib.VolumeStatus.NOT_READY,
+                           error_message='PVC is pending.')
+            ],
+                                                          dryrun=True)
+
+        mock_get_errors.assert_not_called()

--- a/tests/unit_tests/test_sky/volumes/test_automount_gate.py
+++ b/tests/unit_tests/test_sky/volumes/test_automount_gate.py
@@ -1,0 +1,182 @@
+"""Unit tests for the auto-mount volume readiness gate."""
+from unittest.mock import patch
+
+import pytest
+
+from sky import exceptions
+from sky import models
+from sky.backends import backend_utils
+from sky.utils import status_lib
+
+
+def _config(name: str, volume_type: str = 'k8s-pvc') -> models.VolumeConfig:
+    return models.VolumeConfig(
+        _version=1,
+        name=name,
+        type=volume_type,
+        cloud='kubernetes',
+        region='my-context',
+        zone=None,
+        name_on_cloud=f'{name}-pvc',
+        size='10',
+        config={'namespace': 'my-namespace'},
+    )
+
+
+def _mountable(name: str,
+               status: status_lib.VolumeStatus,
+               error_message=None,
+               volume_type: str = 'k8s-pvc'):
+    entry = {'volume_name': name, 'mount_paths': ['/mnt/shared']}
+    record = {
+        'name': name,
+        'handle': _config(name, volume_type),
+        'status': status,
+        'error_message': error_message,
+    }
+    return entry, record
+
+
+class TestCheckAutoMountVolumesReady:
+    """Tests for _check_auto_mount_volumes_ready."""
+
+    def test_no_volumes_is_noop(self):
+        backend_utils._check_auto_mount_volumes_ready([])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_ready_volume_passes(self, mock_get_errors):
+        mock_get_errors.return_value = ({'vol': None}, set())
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.READY)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_in_use_volume_passes(self, mock_get_errors):
+        mock_get_errors.return_value = ({'vol': None}, set())
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.IN_USE)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_not_ready_volume_is_rejected(self, mock_get_errors):
+        mock_get_errors.return_value = ({
+            'vol': 'PVC is pending. ProvisioningFailed: below the minimum'
+        }, set())
+
+        with pytest.raises(exceptions.VolumeNotReadyError) as exc:
+            backend_utils._check_auto_mount_volumes_ready([
+                _mountable('vol',
+                           status_lib.VolumeStatus.NOT_READY,
+                           error_message='PVC is pending.')
+            ])
+
+        assert 'vol' in str(exc.value)
+        assert 'below the minimum' in str(exc.value)
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_recorded_ready_but_live_broken_is_rejected(self, mock_get_errors):
+        """A volume created moments ago is recorded READY until the refresh
+        daemon catches up, which is exactly when it gets auto-mounted."""
+        mock_get_errors.return_value = ({'vol': 'PVC is pending.'}, set())
+
+        with pytest.raises(exceptions.VolumeNotReadyError):
+            backend_utils._check_auto_mount_volumes_ready(
+                [_mountable('vol', status_lib.VolumeStatus.READY)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_recorded_not_ready_but_live_healthy_passes(self, mock_get_errors):
+        """The recorded status lags by up to one refresh interval, so a volume
+        that has since bound must not be blocked."""
+        mock_get_errors.return_value = ({'vol': None}, set())
+
+        backend_utils._check_auto_mount_volumes_ready([
+            _mountable('vol',
+                       status_lib.VolumeStatus.NOT_READY,
+                       error_message='PVC is pending.')
+        ])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_live_check_failure_falls_back_to_recorded_ready(
+            self, mock_get_errors):
+        mock_get_errors.side_effect = Exception('kube API unreachable')
+
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.READY)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_live_check_failure_falls_back_to_recorded_not_ready(
+            self, mock_get_errors):
+        mock_get_errors.side_effect = Exception('kube API unreachable')
+
+        with pytest.raises(exceptions.VolumeNotReadyError) as exc:
+            backend_utils._check_auto_mount_volumes_ready([
+                _mountable('vol',
+                           status_lib.VolumeStatus.NOT_READY,
+                           error_message='PVC is pending.')
+            ])
+
+        assert 'PVC is pending.' in str(exc.value)
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_undeterminable_volume_falls_back_to_recorded_status(
+            self, mock_get_errors):
+        """A volume the provider reports as unqueryable is not an error."""
+        mock_get_errors.return_value = ({}, {'vol'})
+
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.READY)])
+
+        with pytest.raises(exceptions.VolumeNotReadyError):
+            backend_utils._check_auto_mount_volumes_ready(
+                [_mountable('vol', status_lib.VolumeStatus.NOT_READY)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_hostpath_volume_passes(self, mock_get_errors):
+        """hostPath volumes have no PVC, so the provider reports them clean."""
+        mock_get_errors.return_value = ({'vol': None}, set())
+
+        backend_utils._check_auto_mount_volumes_ready([
+            _mountable('vol',
+                       status_lib.VolumeStatus.READY,
+                       volume_type='k8s-hostpath')
+        ])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_unchecked_volume_falls_back_to_recorded_status(
+            self, mock_get_errors):
+        """A cloud with no error check at all reports neither, which is not
+        an answer -- so the recorded status decides."""
+        mock_get_errors.return_value = ({}, set())
+
+        backend_utils._check_auto_mount_volumes_ready(
+            [_mountable('vol', status_lib.VolumeStatus.READY)])
+
+        with pytest.raises(exceptions.VolumeNotReadyError):
+            backend_utils._check_auto_mount_volumes_ready(
+                [_mountable('vol', status_lib.VolumeStatus.NOT_READY)])
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_one_broken_volume_rejects_the_launch(self, mock_get_errors):
+        mock_get_errors.return_value = ({
+            'good': None,
+            'bad': 'PVC is pending.'
+        }, set())
+
+        with pytest.raises(exceptions.VolumeNotReadyError) as exc:
+            backend_utils._check_auto_mount_volumes_ready([
+                _mountable('good', status_lib.VolumeStatus.READY),
+                _mountable('bad', status_lib.VolumeStatus.READY),
+            ])
+
+        assert 'bad' in str(exc.value)
+
+    @patch('sky.backends.backend_utils.provision_lib.get_all_volumes_errors')
+    def test_volumes_are_checked_in_one_call_per_cloud(self, mock_get_errors):
+        mock_get_errors.return_value = ({'a': None, 'b': None}, set())
+
+        backend_utils._check_auto_mount_volumes_ready([
+            _mountable('a', status_lib.VolumeStatus.READY),
+            _mountable('b', status_lib.VolumeStatus.READY),
+        ])
+
+        mock_get_errors.assert_called_once()
+        _, configs = mock_get_errors.call_args[0]
+        assert len(configs) == 2

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -14,6 +14,18 @@ from sky.utils import status_lib
 from sky.volumes.server import core
 
 
+@pytest.fixture
+def mock_no_volume_errors(monkeypatch):
+    """Reports every volume as error-free.
+
+    volume_refresh holds a volume's status when the error check cannot reach
+    the cloud, so a test that asserts on the refresh outcome has to say what
+    the check found.
+    """
+    monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                        mock.MagicMock(return_value=({}, set())))
+
+
 class TestVolumeCore:
     """Test cases for volume core functions."""
 
@@ -1325,7 +1337,7 @@ class TestVolumeCore:
         assert result[1]['usedby_clusters'] == ['cluster-b']
 
     def test_volume_refresh_with_config_refresh_multiple_volumes(
-            self, monkeypatch):
+            self, monkeypatch, mock_no_volume_errors):
         """Test volume_refresh with multiple volumes, some needing refresh."""
         # Mock volume data
         mock_handle1 = mock.MagicMock(
@@ -1481,8 +1493,9 @@ class TestVolumeCore:
 
         # Mock get_all_volumes_errors to return an error
         error_msg = 'PVC access mode mismatch: PVC requests ReadWriteOnce'
-        mock_get_errors = mock.MagicMock(
-            return_value={'test-volume': error_msg})
+        mock_get_errors = mock.MagicMock(return_value=({
+            'test-volume': error_msg
+        }, set()))
         monkeypatch.setattr(provision, 'get_all_volumes_errors',
                             mock_get_errors)
 
@@ -1847,3 +1860,214 @@ class TestVolumeStatus:
         """Test that NOT_READY status exists."""
         assert hasattr(status_lib.VolumeStatus, 'NOT_READY')
         assert status_lib.VolumeStatus.NOT_READY.value == 'NOT_READY'
+
+
+class TestInitialVolumeStatus:
+    """Tests for _initial_volume_status."""
+
+    def test_bound_volume_is_ready(self, monkeypatch):
+        config = _make_volume_config()
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            lambda cloud, configs: ({
+                                'test-vol': None
+                            }, set()))
+
+        status, error = core._initial_volume_status('Kubernetes', config)
+
+        assert status == status_lib.VolumeStatus.READY
+        assert error is None
+
+    def test_unbound_volume_is_not_ready(self, monkeypatch):
+        """Creating a PVC does not provision the PersistentVolume, so a
+        just-created volume must not be advertised as usable."""
+        config = _make_volume_config()
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+                'test-vol': 'PVC is pending.'
+            }, set()))
+
+        status, error = core._initial_volume_status('Kubernetes', config)
+
+        assert status == status_lib.VolumeStatus.NOT_READY
+        assert error == 'PVC is pending.'
+
+    def test_unqueryable_volume_is_ready(self, monkeypatch):
+        config = _make_volume_config()
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            lambda cloud, configs: ({}, {'test-vol'}))
+
+        status, error = core._initial_volume_status('Kubernetes', config)
+
+        assert status == status_lib.VolumeStatus.READY
+        assert error is None
+
+    def test_check_failure_is_ready(self, monkeypatch):
+        """A creation must not fail just because the status probe did."""
+
+        def _raise(cloud, configs):
+            raise RuntimeError('kube API unreachable')
+
+        config = _make_volume_config()
+        monkeypatch.setattr(provision, 'get_all_volumes_errors', _raise)
+
+        status, error = core._initial_volume_status('Kubernetes', config)
+
+        assert status == status_lib.VolumeStatus.READY
+        assert error is None
+
+
+class TestVolumeRefreshErrorFetchFailure:
+    """A failed error check must not be read as "no error"."""
+
+    @staticmethod
+    def _setup(monkeypatch, recorded_status, recorded_error):
+        mock_handle = mock.MagicMock(cloud='kubernetes',
+                                     type='k8s-pvc',
+                                     region='my-context',
+                                     zone=None,
+                                     size='100Gi',
+                                     config={},
+                                     name_on_cloud='test-pvc',
+                                     spec=models.VolumeConfig)
+        mock_handle.name = 'test-volume'
+        mock_volumes = [{
+            'name': 'test-volume',
+            'launched_at': 1234567890,
+            'user_hash': 'user123',
+            'workspace': 'default',
+            'last_attached_at': None,
+            'last_use': None,
+            'handle': mock_handle,
+            'status': recorded_status,
+            'is_ephemeral': False,
+            'error_message': recorded_error,
+            'usedby_pods': [],
+            'usedby_clusters': [],
+        }]
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=mock_volumes))
+        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                            mock.MagicMock(return_value=mock_volumes[0]))
+        monkeypatch.setattr(provision, 'get_all_volumes_usedby',
+                            mock.MagicMock(return_value=({}, {}, set())))
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock.MagicMock(return_value=([], [])))
+        monkeypatch.setattr(provision, 'refresh_volume_config',
+                            mock.MagicMock(return_value=(False, mock_handle)))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        mock_update_status = mock.MagicMock()
+        monkeypatch.setattr(global_user_state, 'update_volume_status',
+                            mock_update_status)
+        return mock_update_status
+
+    def test_broken_volume_keeps_its_status(self, monkeypatch):
+        mock_update_status = self._setup(monkeypatch,
+                                         status_lib.VolumeStatus.NOT_READY,
+                                         'PVC is pending.')
+
+        def _raise(cloud, configs):
+            raise RuntimeError('kube API unreachable')
+
+        monkeypatch.setattr(provision, 'get_all_volumes_errors', _raise)
+
+        core.volume_refresh()
+
+        mock_update_status.assert_not_called()
+
+    def test_cloud_without_error_check_still_updates(self, monkeypatch):
+        """A cloud that does not implement the check returns both empty; its
+        volumes must not get frozen by the failed-fetch guard."""
+        mock_update_status = self._setup(monkeypatch,
+                                         status_lib.VolumeStatus.READY, None)
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            lambda cloud, configs: ({}, set()))
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock.MagicMock(return_value=(['pod-a'], [])))
+
+        core.volume_refresh()
+
+        mock_update_status.assert_called_once()
+        assert mock_update_status.call_args[1][
+            'status'] == status_lib.VolumeStatus.IN_USE
+
+    def test_unreported_volume_still_updates(self, monkeypatch):
+        """Only volumes the provider flags as unqueryable are held back."""
+        mock_update_status = self._setup(monkeypatch,
+                                         status_lib.VolumeStatus.READY, None)
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+                'test-volume': 'PVC is pending.'
+            }, set()))
+
+        core.volume_refresh()
+
+        mock_update_status.assert_called_once()
+        assert mock_update_status.call_args[1][
+            'status'] == status_lib.VolumeStatus.NOT_READY
+
+
+class TestVolumeApplyRecordsInitialStatus:
+    """volume_apply must record what the volume actually looks like."""
+
+    @staticmethod
+    def _setup(monkeypatch):
+        mock_cloud = mock.MagicMock()
+        mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.validate_region_zone.return_value = ('my-context', None)
+        mock_cloud_registry = mock.MagicMock()
+        mock_cloud_registry.from_str.return_value = mock_cloud
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
+                            mock_cloud_registry)
+        monkeypatch.setattr(
+            'sky.volumes.server.core.common_utils.make_cluster_name_on_cloud',
+            mock.MagicMock(return_value='test-vol'))
+        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                            mock.MagicMock(return_value=None))
+        monkeypatch.setattr(provision, 'apply_volume',
+                            mock.MagicMock(side_effect=lambda cloud, c: c))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        mock_add_volume = mock.MagicMock()
+        monkeypatch.setattr(global_user_state, 'add_volume', mock_add_volume)
+        return mock_add_volume
+
+    def test_unbound_volume_is_recorded_not_ready(self, monkeypatch):
+        mock_add_volume = self._setup(monkeypatch)
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+                'test-vol': 'PVC is pending.'
+            }, set()))
+
+        core.volume_apply(name='test-vol',
+                          volume_type='k8s-pvc',
+                          cloud='kubernetes',
+                          region='my-context',
+                          zone=None,
+                          size='1000',
+                          config={})
+
+        mock_add_volume.assert_called_once()
+        assert mock_add_volume.call_args[0][
+            2] == status_lib.VolumeStatus.NOT_READY
+        assert mock_add_volume.call_args[1][
+            'error_message'] == 'PVC is pending.'
+
+    def test_bound_volume_is_recorded_ready(self, monkeypatch):
+        mock_add_volume = self._setup(monkeypatch)
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            lambda cloud, configs: ({
+                                'test-vol': None
+                            }, set()))
+
+        core.volume_apply(name='test-vol',
+                          volume_type='k8s-pvc',
+                          cloud='kubernetes',
+                          region='my-context',
+                          zone=None,
+                          size='1000',
+                          config={})
+
+        mock_add_volume.assert_called_once()
+        assert mock_add_volume.call_args[0][2] == status_lib.VolumeStatus.READY
+        assert mock_add_volume.call_args[1]['error_message'] is None

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2071,3 +2071,39 @@ class TestVolumeApplyRecordsInitialStatus:
         mock_add_volume.assert_called_once()
         assert mock_add_volume.call_args[0][2] == status_lib.VolumeStatus.READY
         assert mock_add_volume.call_args[1]['error_message'] is None
+
+
+class TestEphemeralVolumeSkipsStatusProbe:
+    """add_volume forces ephemeral volumes to IN_USE, so probing is waste."""
+
+    def test_probe_is_not_called(self, monkeypatch):
+        mock_cloud = mock.MagicMock()
+        mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.validate_region_zone.return_value = ('my-context', None)
+        mock_registry = mock.MagicMock()
+        mock_registry.from_str.return_value = mock_cloud
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY', mock_registry)
+        monkeypatch.setattr(
+            'sky.volumes.server.core.common_utils.make_cluster_name_on_cloud',
+            mock.MagicMock(return_value='eph-vol'))
+        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                            mock.MagicMock(return_value=None))
+        monkeypatch.setattr(provision, 'apply_volume',
+                            mock.MagicMock(side_effect=lambda cloud, c: c))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        monkeypatch.setattr(global_user_state, 'add_volume', mock.MagicMock())
+        mock_get_errors = mock.MagicMock(return_value=({}, set()))
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            mock_get_errors)
+
+        core.volume_apply(name='eph-vol',
+                          volume_type='k8s-pvc',
+                          cloud='kubernetes',
+                          region='my-context',
+                          zone=None,
+                          size='10',
+                          config={},
+                          is_ephemeral=True)
+
+        mock_get_errors.assert_not_called()

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -2181,6 +2181,85 @@ class TestGetAllVolumesErrors:
         assert 'ProvisioningFailed' in errors['test-vol']
         assert 'below the 1Ti minimum' in errors['test-vol']
 
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_same_pvc_name_in_two_namespaces_is_not_confused(
+            self, mock_core_api, mock_get_context):
+        """Claims are resolved per (context, namespace): the same claim name in
+        another namespace belongs to a different volume, and reading one's phase
+        as the other's would report the wrong volume broken."""
+        by_volume = {'vol-a': ('ctx', 'ns-a'), 'vol-b': ('ctx', 'ns-b')}
+        mock_get_context.side_effect = lambda cfg: by_volume[cfg.name]
+
+        bound = MockPVC('shared-name', 'ns-a')
+        bound.status.phase = 'Bound'
+        lost = MockPVC('shared-name', 'ns-b')
+        lost.status.phase = 'Lost'
+
+        def _list(namespace, **kwargs):
+            del kwargs
+            result = Mock()
+            result.items = [bound] if namespace == 'ns-a' else [lost]
+            return result
+
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.side_effect = _list
+
+        def _config(name):
+            return models.VolumeConfig(
+                _version=1,
+                name=name,
+                type='k8s-pvc',
+                cloud='kubernetes',
+                region='ctx',
+                zone=None,
+                name_on_cloud='shared-name',
+                size='10',
+                config={},
+            )
+
+        errors, failed = k8s_volume.get_all_volumes_errors(
+            [_config('vol-a'), _config('vol-b')])
+
+        assert failed == set()
+        assert errors['vol-a'] is None
+        assert errors['vol-b'] is not None
+        assert 'Lost' in errors['vol-b']
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_one_broken_volume_among_several_is_reported(
+            self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        good = MockPVC('good-pvc', 'my-namespace')
+        good.status.phase = 'Bound'
+        bad = MockPVC('bad-pvc', 'my-namespace')
+        bad.status.phase = 'Lost'
+
+        listing = Mock()
+        listing.items = [good, bad]
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = listing
+
+        def _config(name, pvc):
+            return models.VolumeConfig(
+                _version=1,
+                name=name,
+                type='k8s-pvc',
+                cloud='kubernetes',
+                region='my-context',
+                zone=None,
+                name_on_cloud=pvc,
+                size='10',
+                config={'namespace': 'my-namespace'},
+            )
+
+        errors, _ = k8s_volume.get_all_volumes_errors(
+            [_config('good-vol', 'good-pvc'),
+             _config('bad-vol', 'bad-pvc')])
+
+        assert errors['good-vol'] is None
+        assert errors['bad-vol'] is not None
+
 
 class TestFindPVCByNameOrLabel:
     """Tests for _find_pvc_by_name_or_label function."""

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -8,6 +8,7 @@ import pytest
 
 from sky import global_user_state
 from sky import models
+from sky.adaptors import kubernetes
 from sky.provision import constants
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
@@ -1756,7 +1757,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         assert errors.get('test-vol') is None
 
@@ -1799,7 +1800,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         assert 'test-vol' in errors
         assert errors['test-vol'] is not None
@@ -1845,7 +1846,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         assert 'test-vol' in errors
         assert 'access mode mismatch' in errors['test-vol'].lower()
@@ -1893,7 +1894,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         # Should be None for WaitForFirstConsumer
         assert errors.get('test-vol') is None
@@ -1937,7 +1938,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         # Should be None when storage class read fails
         assert errors.get('test-vol') is None
@@ -1976,7 +1977,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         # Should be None when storage class read fails
         assert errors.get('test-vol') is None
@@ -2007,7 +2008,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors = k8s_volume.get_all_volumes_errors([config])
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
 
         assert 'test-vol' in errors
         assert 'Lost' in errors['test-vol']
@@ -2035,9 +2036,150 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        # Should not raise, just return empty dict
-        errors = k8s_volume.get_all_volumes_errors([config])
+        # Should not raise. The volume must be reported as failed rather than
+        # simply omitted -- an omitted volume reads as healthy to the caller.
+        errors, failed = k8s_volume.get_all_volumes_errors([config])
         assert errors == {}
+        assert failed == {'test-vol'}
+
+    def test_hostpath_volume_reported_clean(self):
+        """hostPath volumes have no PVC, but they still have to appear in the
+        result -- a caller cannot tell "omitted" from "unknown"."""
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-hostpath',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-vol',
+            size='10',
+            config={'host_path': '/mnt/data'},
+        )
+
+        errors, failed = k8s_volume.get_all_volumes_errors([config])
+
+        assert errors == {'test-vol': None}
+        assert failed == set()
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_pvc_deleted_outside_skypilot_reports_error(self, mock_core_api,
+                                                        mock_get_context):
+        """A registered volume whose PVC is gone must not read as healthy."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        empty_list = Mock()
+        empty_list.items = []
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = empty_list
+
+        not_found = kubernetes.api_exception()(status=404, reason='Not Found')
+        mock_core_api.return_value.read_namespaced_persistent_volume_claim.side_effect = not_found
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='10',
+            config={'namespace': 'my-namespace'},
+        )
+
+        errors, failed = k8s_volume.get_all_volumes_errors([config])
+
+        assert 'test-vol' not in failed
+        assert errors['test-vol'] is not None
+        assert 'no longer exists' in errors['test-vol']
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_unlabelled_pvc_is_read_directly(self, mock_core_api,
+                                             mock_get_context):
+        """use_existing PVCs lack the skypilot label, so the listing misses
+        them; a direct read must still find and evaluate them."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        empty_list = Mock()
+        empty_list.items = []
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = empty_list
+
+        adopted_pvc = MockPVC('adopted-pvc', 'my-namespace')
+        adopted_pvc.status.phase = 'Bound'
+        mock_core_api.return_value.read_namespaced_persistent_volume_claim.return_value = adopted_pvc
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='adopted-pvc',
+            size='10',
+            config={
+                'namespace': 'my-namespace',
+                'use_existing': True
+            },
+        )
+
+        errors, failed = k8s_volume.get_all_volumes_errors([config])
+
+        assert failed == set()
+        assert errors['test-vol'] is None
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    @patch('sky.adaptors.kubernetes.storage_api')
+    def test_pvc_pending_immediate_surfaces_csi_message(self, mock_storage_api,
+                                                        mock_core_api,
+                                                        mock_get_context,
+                                                        mock_get_events):
+        """The provisioner's rejection reason is what identifies the fault,
+        so it has to reach the error message verbatim."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        mock_pvc = MockPVC('test-pvc', 'my-namespace')
+        mock_pvc.status.phase = 'Pending'
+        mock_pvc.spec.storage_class_name = 'standard'
+
+        mock_pvc_list = Mock()
+        mock_pvc_list.items = [mock_pvc]
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = mock_pvc_list
+
+        mock_pv_list = Mock()
+        mock_pv_list.items = []
+        mock_core_api.return_value.list_persistent_volume.return_value = mock_pv_list
+
+        mock_storage_class = Mock()
+        mock_storage_class.volume_binding_mode = 'Immediate'
+        mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
+
+        event = Mock()
+        event.type = 'Warning'
+        event.reason = 'ProvisioningFailed'
+        event.message = 'requested size is below the 1Ti minimum'
+        mock_get_events.return_value = [event]
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='1000',
+            config={'namespace': 'my-namespace'},
+        )
+
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
+
+        assert 'ProvisioningFailed' in errors['test-vol']
+        assert 'below the 1Ti minimum' in errors['test-vol']
 
 
 class TestFindPVCByNameOrLabel:

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -2288,18 +2288,22 @@ class TestCurrentPVCFailure:
     """Tests for _current_pvc_failure."""
 
     @staticmethod
-    def _event(reason, etype='Normal', message='m'):
+    def _event(reason, etype='Normal', message='m', at=0):
         e = Mock()
         e.reason = reason
         e.type = etype
         e.message = message
+        e.last_timestamp = _ago(at)
         return e
 
     @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
     def test_reports_a_standing_failure(self, mock_get_events):
         mock_get_events.return_value = [
-            self._event('ProvisioningFailed', 'Warning', 'tier is invalid'),
-            self._event('Provisioning'),
+            self._event('ProvisioningFailed',
+                        'Warning',
+                        'tier is invalid',
+                        at=10),
+            self._event('Provisioning', at=20),
         ]
 
         result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
@@ -2312,8 +2316,11 @@ class TestCurrentPVCFailure:
         """The provisioner backs off and retries; a retry in flight means the
         earlier failure no longer stands."""
         mock_get_events.return_value = [
-            self._event('Provisioning'),
-            self._event('ProvisioningFailed', 'Warning', 'transient blip'),
+            self._event('Provisioning', at=10),
+            self._event('ProvisioningFailed',
+                        'Warning',
+                        'transient blip',
+                        at=60),
         ]
 
         assert k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc') is None
@@ -2323,8 +2330,30 @@ class TestCurrentPVCFailure:
         """The PV controller re-emits ExternalProvisioning on a timer, so it
         would otherwise always look newer than a real failure and mask it."""
         mock_get_events.return_value = [
-            self._event('ExternalProvisioning'),
-            self._event('ProvisioningFailed', 'Warning', 'tier is invalid'),
+            self._event('ExternalProvisioning', at=5),
+            self._event('ProvisioningFailed',
+                        'Warning',
+                        'tier is invalid',
+                        at=60),
+        ]
+
+        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
+
+        assert result is not None
+        assert 'tier is invalid' in result
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    def test_attempt_at_the_same_second_does_not_supersede(
+            self, mock_get_events):
+        """Event times are second-granular and the provisioner logs an attempt
+        and its failure within the same second, so a tie is that very attempt.
+        Treating it as a retry would report a broken volume as healthy."""
+        mock_get_events.return_value = [
+            self._event('Provisioning', at=30),
+            self._event('ProvisioningFailed',
+                        'Warning',
+                        'tier is invalid',
+                        at=30),
         ]
 
         result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1,5 +1,4 @@
 """Unit tests for Kubernetes volume provisioning."""
-import datetime
 from typing import Any, Dict, List
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -15,12 +14,6 @@ from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import volume as k8s_volume
 from sky.utils import volume as volume_lib
-
-
-def _ago(seconds: float) -> datetime.datetime:
-    """A tz-aware timestamp `seconds` in the past."""
-    return (datetime.datetime.now(datetime.timezone.utc) -
-            datetime.timedelta(seconds=seconds))
 
 
 class MockPVC:
@@ -42,8 +35,6 @@ class MockPVC:
         self.spec.access_modes = access_modes or ['ReadWriteOnce']
         self.spec.resources = Mock()
         self.spec.resources.requests = {'storage': size}
-
-        self.metadata.creation_timestamp = _ago(1)
 
         self.status = Mock()
         self.status.capacity = {'storage': size}
@@ -1797,10 +1788,6 @@ class TestGetAllVolumesErrors:
         mock_storage_class.volume_binding_mode = 'Immediate'
         mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
 
-        # Past the provisioning grace period: nothing is acting on this claim.
-        mock_pvc.metadata.creation_timestamp = _ago(
-            k8s_volume.PVC_PROVISIONING_GRACE_SECONDS + 60)
-
         config = models.VolumeConfig(
             _version=1,
             name='test-vol',
@@ -2193,178 +2180,6 @@ class TestGetAllVolumesErrors:
 
         assert 'ProvisioningFailed' in errors['test-vol']
         assert 'below the 1Ti minimum' in errors['test-vol']
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    @patch('sky.adaptors.kubernetes.storage_api')
-    def test_pvc_pending_immediate_within_grace_is_not_an_error(
-            self, mock_storage_api, mock_core_api, mock_get_context,
-            mock_get_events):
-        """Provisioning a network volume takes minutes; calling that broken
-        would block launches on every healthy volume."""
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-
-        mock_pvc = MockPVC('test-pvc', 'my-namespace')
-        mock_pvc.status.phase = 'Pending'
-        mock_pvc.spec.storage_class_name = 'standard'
-        mock_pvc.metadata.creation_timestamp = _ago(30)
-
-        mock_pvc_list = Mock()
-        mock_pvc_list.items = [mock_pvc]
-        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = mock_pvc_list
-        mock_pv_list = Mock()
-        mock_pv_list.items = []
-        mock_core_api.return_value.list_persistent_volume.return_value = mock_pv_list
-
-        mock_storage_class = Mock()
-        mock_storage_class.volume_binding_mode = 'Immediate'
-        mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
-        mock_get_events.return_value = []
-
-        config = models.VolumeConfig(
-            _version=1,
-            name='test-vol',
-            type='k8s-pvc',
-            cloud='kubernetes',
-            region='my-context',
-            zone=None,
-            name_on_cloud='test-pvc',
-            size='10',
-            config={'namespace': 'my-namespace'},
-        )
-
-        errors, failed = k8s_volume.get_all_volumes_errors([config])
-
-        assert errors['test-vol'] is None
-        assert failed == set()
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    @patch('sky.adaptors.kubernetes.storage_api')
-    def test_pvc_pending_wffc_never_ages_out(self, mock_storage_api,
-                                             mock_core_api, mock_get_context,
-                                             mock_get_events):
-        """A deferred-binding claim may sit unconsumed indefinitely; age says
-        nothing about its health."""
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-
-        mock_pvc = MockPVC('test-pvc', 'my-namespace')
-        mock_pvc.status.phase = 'Pending'
-        mock_pvc.spec.storage_class_name = 'standard-rwx'
-        mock_pvc.metadata.creation_timestamp = _ago(30 * 24 * 3600)
-
-        mock_pvc_list = Mock()
-        mock_pvc_list.items = [mock_pvc]
-        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = mock_pvc_list
-        mock_pv_list = Mock()
-        mock_pv_list.items = []
-        mock_core_api.return_value.list_persistent_volume.return_value = mock_pv_list
-
-        mock_storage_class = Mock()
-        mock_storage_class.volume_binding_mode = 'WaitForFirstConsumer'
-        mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
-        mock_get_events.return_value = []
-
-        config = models.VolumeConfig(
-            _version=1,
-            name='test-vol',
-            type='k8s-pvc',
-            cloud='kubernetes',
-            region='my-context',
-            zone=None,
-            name_on_cloud='test-pvc',
-            size='10',
-            config={'namespace': 'my-namespace'},
-        )
-
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
-
-        assert errors['test-vol'] is None
-
-
-class TestCurrentPVCFailure:
-    """Tests for _current_pvc_failure."""
-
-    @staticmethod
-    def _event(reason, etype='Normal', message='m', at=0):
-        e = Mock()
-        e.reason = reason
-        e.type = etype
-        e.message = message
-        e.last_timestamp = _ago(at)
-        return e
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    def test_reports_a_standing_failure(self, mock_get_events):
-        mock_get_events.return_value = [
-            self._event('ProvisioningFailed',
-                        'Warning',
-                        'tier is invalid',
-                        at=10),
-            self._event('Provisioning', at=20),
-        ]
-
-        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
-
-        assert result is not None
-        assert 'tier is invalid' in result
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    def test_newer_attempt_supersedes_an_older_failure(self, mock_get_events):
-        """The provisioner backs off and retries; a retry in flight means the
-        earlier failure no longer stands."""
-        mock_get_events.return_value = [
-            self._event('Provisioning', at=10),
-            self._event('ProvisioningFailed',
-                        'Warning',
-                        'transient blip',
-                        at=60),
-        ]
-
-        assert k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc') is None
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    def test_external_provisioning_does_not_supersede(self, mock_get_events):
-        """The PV controller re-emits ExternalProvisioning on a timer, so it
-        would otherwise always look newer than a real failure and mask it."""
-        mock_get_events.return_value = [
-            self._event('ExternalProvisioning', at=5),
-            self._event('ProvisioningFailed',
-                        'Warning',
-                        'tier is invalid',
-                        at=60),
-        ]
-
-        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
-
-        assert result is not None
-        assert 'tier is invalid' in result
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    def test_attempt_at_the_same_second_does_not_supersede(
-            self, mock_get_events):
-        """Event times are second-granular and the provisioner logs an attempt
-        and its failure within the same second, so a tie is that very attempt.
-        Treating it as a retry would report a broken volume as healthy."""
-        mock_get_events.return_value = [
-            self._event('Provisioning', at=30),
-            self._event('ProvisioningFailed',
-                        'Warning',
-                        'tier is invalid',
-                        at=30),
-        ]
-
-        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
-
-        assert result is not None
-        assert 'tier is invalid' in result
-
-    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
-    def test_no_events_is_no_failure(self, mock_get_events):
-        mock_get_events.return_value = []
-        assert k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc') is None
 
 
 class TestFindPVCByNameOrLabel:

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1,4 +1,5 @@
 """Unit tests for Kubernetes volume provisioning."""
+import datetime
 from typing import Any, Dict, List
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -14,6 +15,12 @@ from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import volume as k8s_volume
 from sky.utils import volume as volume_lib
+
+
+def _ago(seconds: float) -> datetime.datetime:
+    """A tz-aware timestamp `seconds` in the past."""
+    return (datetime.datetime.now(datetime.timezone.utc) -
+            datetime.timedelta(seconds=seconds))
 
 
 class MockPVC:
@@ -35,6 +42,8 @@ class MockPVC:
         self.spec.access_modes = access_modes or ['ReadWriteOnce']
         self.spec.resources = Mock()
         self.spec.resources.requests = {'storage': size}
+
+        self.metadata.creation_timestamp = _ago(1)
 
         self.status = Mock()
         self.status.capacity = {'storage': size}
@@ -1788,6 +1797,10 @@ class TestGetAllVolumesErrors:
         mock_storage_class.volume_binding_mode = 'Immediate'
         mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
 
+        # Past the provisioning grace period: nothing is acting on this claim.
+        mock_pvc.metadata.creation_timestamp = _ago(
+            k8s_volume.PVC_PROVISIONING_GRACE_SECONDS + 60)
+
         config = models.VolumeConfig(
             _version=1,
             name='test-vol',
@@ -2180,6 +2193,149 @@ class TestGetAllVolumesErrors:
 
         assert 'ProvisioningFailed' in errors['test-vol']
         assert 'below the 1Ti minimum' in errors['test-vol']
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    @patch('sky.adaptors.kubernetes.storage_api')
+    def test_pvc_pending_immediate_within_grace_is_not_an_error(
+            self, mock_storage_api, mock_core_api, mock_get_context,
+            mock_get_events):
+        """Provisioning a network volume takes minutes; calling that broken
+        would block launches on every healthy volume."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        mock_pvc = MockPVC('test-pvc', 'my-namespace')
+        mock_pvc.status.phase = 'Pending'
+        mock_pvc.spec.storage_class_name = 'standard'
+        mock_pvc.metadata.creation_timestamp = _ago(30)
+
+        mock_pvc_list = Mock()
+        mock_pvc_list.items = [mock_pvc]
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = mock_pvc_list
+        mock_pv_list = Mock()
+        mock_pv_list.items = []
+        mock_core_api.return_value.list_persistent_volume.return_value = mock_pv_list
+
+        mock_storage_class = Mock()
+        mock_storage_class.volume_binding_mode = 'Immediate'
+        mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
+        mock_get_events.return_value = []
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='10',
+            config={'namespace': 'my-namespace'},
+        )
+
+        errors, failed = k8s_volume.get_all_volumes_errors([config])
+
+        assert errors['test-vol'] is None
+        assert failed == set()
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    @patch('sky.adaptors.kubernetes.storage_api')
+    def test_pvc_pending_wffc_never_ages_out(self, mock_storage_api,
+                                             mock_core_api, mock_get_context,
+                                             mock_get_events):
+        """A deferred-binding claim may sit unconsumed indefinitely; age says
+        nothing about its health."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        mock_pvc = MockPVC('test-pvc', 'my-namespace')
+        mock_pvc.status.phase = 'Pending'
+        mock_pvc.spec.storage_class_name = 'standard-rwx'
+        mock_pvc.metadata.creation_timestamp = _ago(30 * 24 * 3600)
+
+        mock_pvc_list = Mock()
+        mock_pvc_list.items = [mock_pvc]
+        mock_core_api.return_value.list_namespaced_persistent_volume_claim.return_value = mock_pvc_list
+        mock_pv_list = Mock()
+        mock_pv_list.items = []
+        mock_core_api.return_value.list_persistent_volume.return_value = mock_pv_list
+
+        mock_storage_class = Mock()
+        mock_storage_class.volume_binding_mode = 'WaitForFirstConsumer'
+        mock_storage_api.return_value.read_storage_class.return_value = mock_storage_class
+        mock_get_events.return_value = []
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='10',
+            config={'namespace': 'my-namespace'},
+        )
+
+        errors, _ = k8s_volume.get_all_volumes_errors([config])
+
+        assert errors['test-vol'] is None
+
+
+class TestCurrentPVCFailure:
+    """Tests for _current_pvc_failure."""
+
+    @staticmethod
+    def _event(reason, etype='Normal', message='m'):
+        e = Mock()
+        e.reason = reason
+        e.type = etype
+        e.message = message
+        return e
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    def test_reports_a_standing_failure(self, mock_get_events):
+        mock_get_events.return_value = [
+            self._event('ProvisioningFailed', 'Warning', 'tier is invalid'),
+            self._event('Provisioning'),
+        ]
+
+        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
+
+        assert result is not None
+        assert 'tier is invalid' in result
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    def test_newer_attempt_supersedes_an_older_failure(self, mock_get_events):
+        """The provisioner backs off and retries; a retry in flight means the
+        earlier failure no longer stands."""
+        mock_get_events.return_value = [
+            self._event('Provisioning'),
+            self._event('ProvisioningFailed', 'Warning', 'transient blip'),
+        ]
+
+        assert k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc') is None
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    def test_external_provisioning_does_not_supersede(self, mock_get_events):
+        """The PV controller re-emits ExternalProvisioning on a timer, so it
+        would otherwise always look newer than a real failure and mask it."""
+        mock_get_events.return_value = [
+            self._event('ExternalProvisioning'),
+            self._event('ProvisioningFailed', 'Warning', 'tier is invalid'),
+        ]
+
+        result = k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc')
+
+        assert result is not None
+        assert 'tier is invalid' in result
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.get_pvc_events')
+    def test_no_events_is_no_failure(self, mock_get_events):
+        mock_get_events.return_value = []
+        assert k8s_volume._current_pvc_failure('ctx', 'ns', 'pvc') is None
 
 
 class TestFindPVCByNameOrLabel:

--- a/tests/unit_tests/test_sky/volumes/test_not_ready_is_terminal.py
+++ b/tests/unit_tests/test_sky/volumes/test_not_ready_is_terminal.py
@@ -1,0 +1,33 @@
+"""A not-ready volume must fail a managed job, not send it round the retry loop.
+
+Retrying cannot make a volume ready: either its storage is broken and an
+operator has to fix it, or it is still provisioning and the job should be
+resubmitted once it is. Either way the job is better off failing with a reason
+than re-attempting the same launch until it hits the retry ceiling.
+"""
+from sky import exceptions
+from sky.jobs import recovery_strategy
+
+
+class TestVolumeNotReadyIsTerminal:
+
+    def test_listed_as_a_precheck_failure(self):
+        assert exceptions.VolumeNotReadyError in (
+            recovery_strategy.PRECHECK_FAILURES)
+
+    def test_caught_by_the_precheck_handler(self):
+        """What the `except` clause actually evaluates."""
+        assert isinstance(exceptions.VolumeNotReadyError('not ready'),
+                          recovery_strategy.PRECHECK_FAILURES)
+
+    def test_sits_with_the_other_storage_failures(self):
+        """Storage problems were already terminal; a volume is the same kind of
+        thing, so the two should not diverge."""
+        assert exceptions.StorageError in recovery_strategy.PRECHECK_FAILURES
+        assert exceptions.StorageSpecError in (
+            recovery_strategy.PRECHECK_FAILURES)
+
+    def test_resource_unavailability_is_not_a_precheck_failure(self):
+        """That one has to keep retrying -- capacity comes and goes."""
+        assert exceptions.ResourcesUnavailableError not in (
+            recovery_strategy.PRECHECK_FAILURES)


### PR DESCRIPTION
**Throwaway. Do not merge, do not review.** Close and delete once the smoke run reports.

Cross-verification for the smoke tests added in #10402. Everything here is #10402 plus one commit that disables both places a not-ready volume is refused:

- the auto-mount check in `write_cluster_config`
- the check for a volume declared on a task, in `VolumeMount.resolve`

The recorded status is deliberately left alone, so each test still sees `NOT_READY` at its second step and can only fail on the refusal it claims to assert. That is what makes the result meaningful: a test that stays green here is not testing anything.

Expected outcome — **all four red**:

| test | how it should fail |
|---|---|
| `test_volume_not_ready_on_kubernetes` | `! sky launch` inverts: the launch now succeeds |
| `test_auto_mount_not_ready_on_kubernetes` | same, and a cluster is left where none should exist |
| `test_managed_job_volume_not_ready` | submission succeeds, so the job turns up in the queue |
| `test_managed_job_auto_mount_not_ready` | never reaches FAILED_PRECHECKS, times out |

Locally the twist already fails the two unit tests that assert the refusal (`test_not_ready_volume_is_rejected`, `test_rejection_without_a_recorded_reason_still_explains_itself`), which is the same property at the unit level.

Trigger:

```
/smoke-test --jobs-consolidation --kubernetes -k not_ready
```