### PR TITLE
[Test] Make cancel-pytorch smoke test work on H100

### DIFF
--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -11,8 +11,11 @@ setup: |
     source .venv/bin/activate
     git clone https://github.com/michaelzhiluo/pytorch-distributed-resnet
     cd pytorch-distributed-resnet
-    # SkyPilot's default image on AWS/GCP has CUDA 11.6 (Azure 11.5).
-    uv pip install -r requirements.txt numpy==1.26.4 torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+    # The cu118 build ships kernels for sm_70 (V100) through sm_90 (H100), so
+    # this example runs on both older and Hopper GPUs. Do not downgrade to
+    # torch 1.12.1+cu113: it only goes up to sm_86 and fails on H100 with
+    # "no kernel image is available for execution on the device".
+    uv pip install -r requirements.txt numpy==1.26.4 torch==2.7.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
     mkdir -p data  && mkdir -p saved_models
     # Check if working directory is on a shared filesystem (NFS, Lustre, etc.)
     # If shared, only download on rank 0 to avoid race conditions
@@ -41,6 +44,10 @@ run: |
 
     num_nodes=`echo "$SKYPILOT_NODE_IPS" | wc -l`
     master_addr=`echo "$SKYPILOT_NODE_IPS" | head -n1`
-    python3 -m torch.distributed.launch --nproc_per_node=1 \
+    # resnet_ddp.py takes the local rank as --local_rank, but torch>=2.0's
+    # launcher passes the hyphenated --local-rank, which its argparse rejects.
+    # nproc_per_node is 1, so the local rank is always 0: pass it explicitly and
+    # use torchrun (which does not inject a rank flag of its own).
+    torchrun --nproc_per_node=1 \
     --nnodes=$num_nodes --node_rank=${SKYPILOT_NODE_RANK} --master_addr=$master_addr \
-    --master_port=8008 resnet_ddp.py --num_epochs 20
+    --master_port=8008 resnet_ddp.py --local_rank=0 --num_epochs 20

--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -48,6 +48,11 @@ run: |
     # launcher passes the hyphenated --local-rank, which its argparse rejects.
     # nproc_per_node is 1, so the local rank is always 0: pass it explicitly and
     # use torchrun (which does not inject a rank flag of its own).
+    #
+    # num_epochs is deliberately generous: test_cancel_pytorch cancels this job
+    # ~2.5min in and then asserts the GPU went idle, so the run has to still be
+    # alive at that point. 20 epochs finishes in under 4min on 2xH100, which
+    # left the cancel almost nothing to cancel.
     torchrun --nproc_per_node=1 \
     --nnodes=$num_nodes --node_rank=${SKYPILOT_NODE_RANK} --master_addr=$master_addr \
-    --master_port=8008 resnet_ddp.py --local_rank=0 --num_epochs 20
+    --master_port=8008 resnet_ddp.py --local_rank=0 --num_epochs 60


### PR DESCRIPTION
`examples/resnet_distributed_torch.yaml` pinned `torch==1.12.1+cu113`, whose wheels only ship kernels up to sm_86, so `test_cancel_pytorch` fails on H100 (sm_90) with `no kernel image is available for execution on the device`.

- Bump to `torch==2.7.1+cu118`. The CUDA 11.8 build's arch list is `5.0;6.0;7.0;7.5;8.0;8.6;3.7;9.0`, so it adds sm_90 without dropping sm_70 (V100) or sm_75 (the `T4` fallback). Same pin `examples/distributed-pytorch/train.yaml` already uses; cu118 also keeps the driver floor low, unlike cu12x.
- Switch `torch.distributed.launch` → `torchrun` and pass `--local_rank=0` explicitly. torch>=2.0 injects the hyphenated `--local-rank`, which upstream `resnet_ddp.py`'s argparse (`--local_rank`) rejects with exit 2. `nproc_per_node` is 1, so the local rank is always 0.
- `--num_epochs` 20 → 60. On 2xH100 the 20-epoch run finishes in 3m54s while the test cancels ~2m35s after RUNNING, leaving <100s of margin. On faster accelerators the job finishes first, which either makes the cancel a no-op or fails the preceding "GPU is busy" check.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual: replicated every step of `test_cancel_pytorch` by hand on 2xH100 80GB (Kubernetes, driver 570.148.08):

- setup installs `torch==2.7.1+cu118` / `torchvision==0.22.1+cu118` on both nodes; both DDP ranks start with no CUDA arch error and no argparse error
- GPU utilization peaks at 94% / 96% with 1987MiB allocated — training genuinely runs, NCCL is healthy across nodes
- unmodified 20-epoch run SUCCEEDED in 3m54s
- "GPU is busy" assertion: python process visible on both nodes
- `sky cancel` against a job that had been RUNNING for 2m3s → CANCELLED
- "GPU is idle" assertion 60s later: `No running processes found` on both nodes

Also verified away from hardware: `uv pip compile` resolves the new pin cleanly for linux/py3.10 (`torch==2.7.1+cu118`, `torchvision==0.22.1+cu118`), and `sky.Task.from_yaml` parses the YAML.

Only exercised on Kubernetes/H100 — the AWS/GCP/DO paths in the parametrization use different base images, so `/smoke-test -k test_cancel_pytorch` is still worth running before merge.

https://claude.ai/code/session_01KwymZaYmM9qGnGd4nG1K3Y

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->