### PR TITLE
[Core] Accept every writable store scheme in jobs.bucket / serve.bucket

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1815,7 +1815,14 @@ def get_config_schema():
             },
             'bucket': {
                 'type': 'string',
-                'pattern': '^(https|s3|gs|r2|cos)://.+',
+                # This module cannot import sky.data.storage to derive the
+                # scheme list (storage.py imports this module), so the
+                # alternation is spelled out. It must cover every writable
+                # StoreType prefix; read-only stores (hf://) and volumes are
+                # deliberately absent. Kept in sync by
+                # tests/unit_tests/test_sky/utils/test_schemas.py::
+                # TestControllerBucketSchema.
+                'pattern': '^(https|s3|gs|r2|cos|oci|nebius|cw|vastdata)://.+',
                 'required': [],
             },
             'force_disable_cloud_bucket': {

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -1596,5 +1596,55 @@ class TestDashboardConfigUrlTemplateValidation(unittest.TestCase):
             config, 'test_config')
 
 
+class TestControllerBucketSchema(unittest.TestCase):
+    """Tests for jobs.bucket / serve.bucket URL scheme validation."""
+
+    def setUp(self):
+        self.config_schema = schemas.get_config_schema()
+
+    def _validate(self, config):
+        jsonschema.validate(instance=config, schema=self.config_schema)
+
+    def test_accepts_all_writable_store_schemes(self):
+        for scheme in ('s3', 'gs', 'https', 'r2', 'cos', 'oci', 'nebius', 'cw',
+                       'vastdata'):
+            for section in ('jobs', 'serve'):
+                self._validate(
+                    {section: {
+                        'bucket': f'{scheme}://my-bucket/sub/path'
+                    }})
+
+    def test_rejects_unsupported_schemes(self):
+        # hf:// is read-only and volumes are not buckets; neither can serve
+        # as a staging bucket. ftp:// and bare paths are plain invalid.
+        for bucket in ('hf://org/repo', 'volume://vol1', 'ftp://host/bucket',
+                       'my-bucket/path', 's3:/missing-slash'):
+            for section in ('jobs', 'serve'):
+                with self.assertRaises(jsonschema.exceptions.ValidationError):
+                    self._validate({section: {'bucket': bucket}})
+
+    def test_pattern_covers_every_writable_store_prefix(self):
+        """Fails when a store is added without extending the bucket pattern.
+
+        schemas.py cannot import sky.data.storage (circular import), so the
+        scheme alternation there is a literal. This test derives the ground
+        truth from the store registry and catches drift.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from sky.data import storage
+        read_only_or_non_bucket = {
+            storage.StoreType.HF, storage.StoreType.VOLUME
+        }
+        for store_type in storage.StoreType:
+            if store_type in read_only_or_non_bucket:
+                continue
+            prefix = store_type.store_prefix()
+            for section in ('jobs', 'serve'):
+                self._validate(
+                    {section: {
+                        'bucket': f'{prefix}my-bucket/sub/path'
+                    }})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #10387

## Problem

The config schema pattern for `jobs.bucket` / `serve.bucket` predates the S3-compatible store abstraction and only allows `(https|s3|gs|r2|cos)://`. The runtime resolves bucket URLs through `StoreType.get_fields_from_store_url()`, which also handles `oci://`, `nebius://`, `cw://`, and `vastdata://` — so a staging-bucket URL the runtime fully supports, e.g.

```yaml
jobs:
  bucket: nebius://skypilot-bucket/jobs
```

is rejected at config validation before the runtime ever sees it:

```
Invalid SkyPilot configuration: 'nebius://skypilot-bucket/jobs' does not match
'^(https|s3|gs|r2|cos)://.+'. Check problematic field(s): $.jobs.bucket
```

As the issue notes, this cannot be worked around: `_validate_config` runs on every config load, so the jobs controller re-rejects the config the API server hands it. On clouds where an `s3://` staging bucket is unreachable from the worker, this is the difference between working and broken managed jobs.

## Fix

Extend the pattern to every writable store scheme:

```
^(https|s3|gs|r2|cos|oci|nebius|cw|vastdata)://.+
```

**Why a literal rather than deriving from the store registry** (the issue's preferred suggestion): `sky/data/storage.py` imports `sky/utils/schemas.py`, so `schemas.py` cannot import the registry without a circular import. Instead, a new unit test (`test_pattern_covers_every_writable_store_prefix`) derives the ground truth from `StoreType.store_prefix()` at test time and fails if a future store is registered without extending the pattern — same coverage guarantee, no import cycle.

Read-only stores (`hf://`) and volumes are deliberately still rejected: neither can serve as a writable staging bucket, and rejecting them at validation is clearer than a later upload failure.

## Tests

New `TestControllerBucketSchema` in `tests/unit_tests/test_sky/utils/test_schemas.py`:

- every writable scheme accepted for both `jobs.bucket` and `serve.bucket`
- `hf://`, `volume://`, `ftp://`, bare paths, and malformed URLs rejected
- drift guard: pattern must accept `store_prefix()` of every writable `StoreType`

Verified the issue's minimal repro passes after the change:

```python
from sky.utils import schemas, common_utils
common_utils.validate_schema({'jobs': {'bucket': 'nebius://my-bucket/jobs'}},
                             schemas.get_config_schema(), '', skip_none=False)
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/unit_tests/test_sky/utils/test_schemas.py` — 104 passed (3 new)
  - Issue's minimal repro script (above) — passes
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->