### PR TITLE
[Test] Fix container-logs smoke tests: bare kubectl misses non-default namespace

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2077,16 +2077,21 @@ done
 def test_container_logs_multinode_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
+    # -A + custom-columns: the pods may not be in kubectl's default
+    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
+    # get pods` can silently return nothing.
+    list_pods = ('kubectl get pods -A --no-headers -o custom-columns='
+                 '"NS:.metadata.namespace,NAME:.metadata.name"')
     head_logs = (
-        'all_pods=$(kubectl get pods); echo "$all_pods"; '
+        f'all_pods=$({list_pods}); echo "$all_pods"; '
         f'echo "$all_pods" | grep {name} | '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" |  '
         'grep head | '
-        " awk '{print $1}' | xargs -I {} kubectl logs {}")
-    worker_logs = ('all_pods=$(kubectl get pods); echo "$all_pods"; '
+        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
+    worker_logs = (f'all_pods=$({list_pods}); echo "$all_pods"; '
                    f'echo "$all_pods" | grep {name} |  grep worker | '
-                   " awk '{print $1}' | xargs -I {} kubectl logs {}")
+                   """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'container_logs_multinode_kubernetes',
@@ -2110,13 +2115,17 @@ def test_container_logs_multinode_kubernetes():
 def test_container_logs_two_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
+    # -A + custom-columns: the pods may not be in kubectl's default
+    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
+    # get pods` can silently return nothing.
     pod_logs = (
-        'all_pods=$(kubectl get pods); echo "$all_pods"; '
+        'all_pods=$(kubectl get pods -A --no-headers -o custom-columns='
+        '"NS:.metadata.namespace,NAME:.metadata.name"); echo "$all_pods"; '
         f'echo "$all_pods" | grep {name} | '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" |  '
         'grep head |'
-        " awk '{print $1}' | xargs -I {} kubectl logs {}")
+        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'test_container_logs_two_jobs_kubernetes',
@@ -2140,13 +2149,17 @@ def test_container_logs_two_jobs_kubernetes():
 def test_container_logs_two_simultaneous_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml '
+    # -A + custom-columns: the pods may not be in kubectl's default
+    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
+    # get pods` can silently return nothing.
     pod_logs = (
-        'all_pods=$(kubectl get pods); echo "$all_pods"; '
+        'all_pods=$(kubectl get pods -A --no-headers -o custom-columns='
+        '"NS:.metadata.namespace,NAME:.metadata.name"); echo "$all_pods"; '
         f'echo "$all_pods" | grep {name} |  '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" |  '
         'grep head |'
-        " awk '{print $1}' | xargs -I {} kubectl logs {}")
+        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'test_container_logs_two_simultaneous_jobs_kubernetes',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2077,21 +2077,30 @@ done
 def test_container_logs_multinode_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
-    # -A + custom-columns: the pods may not be in kubectl's default
-    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
-    # get pods` can silently return nothing.
-    list_pods = ('kubectl get pods -A --no-headers -o custom-columns='
-                 '"NS:.metadata.namespace,NAME:.metadata.name"')
+    # -A + a label selector + exact match on the skypilot-cluster-name
+    # annotation (not a substring grep on the pod name): the pods may not
+    # be in kubectl's default namespace (e.g. a workspace-scoped
+    # namespace), so a bare `kubectl get pods` can silently return
+    # nothing; and -A widens the search to every namespace, so a
+    # substring match risks picking up a same-named leftover pod from
+    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
+    # exactly one pod, but plain xargs concatenates every matching
+    # "-n ns pod" line into a single invocation.
+    list_pods = ('kubectl get pods -A -l skypilot-cluster-name --no-headers '
+                 '-o custom-columns="NS:.metadata.namespace,'
+                 'NAME:.metadata.name,'
+                 'CLUSTER:.metadata.annotations.skypilot-cluster-name"')
     head_logs = (
         f'all_pods=$({list_pods}); echo "$all_pods"; '
-        f'echo "$all_pods" | grep {name} | '
+        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
         # Exclude the cloud cmd execution pod.
-        'grep -v "cloud-cmd" |  '
+        'grep -v "cloud-cmd" | '
         'grep head | '
-        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
-    worker_logs = (f'all_pods=$({list_pods}); echo "$all_pods"; '
-                   f'echo "$all_pods" | grep {name} |  grep worker | '
-                   """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
+        """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
+    worker_logs = (
+        f'all_pods=$({list_pods}); echo "$all_pods"; '
+        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | grep worker | '
+        """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'container_logs_multinode_kubernetes',
@@ -2115,17 +2124,26 @@ def test_container_logs_multinode_kubernetes():
 def test_container_logs_two_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
-    # -A + custom-columns: the pods may not be in kubectl's default
-    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
-    # get pods` can silently return nothing.
+    # -A + a label selector + exact match on the skypilot-cluster-name
+    # annotation (not a substring grep on the pod name): the pods may not
+    # be in kubectl's default namespace (e.g. a workspace-scoped
+    # namespace), so a bare `kubectl get pods` can silently return
+    # nothing; and -A widens the search to every namespace, so a
+    # substring match risks picking up a same-named leftover pod from
+    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
+    # exactly one pod, but plain xargs concatenates every matching
+    # "-n ns pod" line into a single invocation.
     pod_logs = (
-        'all_pods=$(kubectl get pods -A --no-headers -o custom-columns='
-        '"NS:.metadata.namespace,NAME:.metadata.name"); echo "$all_pods"; '
-        f'echo "$all_pods" | grep {name} | '
+        'all_pods=$(kubectl get pods -A -l skypilot-cluster-name '
+        '--no-headers -o custom-columns="NS:.metadata.namespace,'
+        'NAME:.metadata.name,'
+        'CLUSTER:.metadata.annotations.skypilot-cluster-name"); '
+        'echo "$all_pods"; '
+        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
         # Exclude the cloud cmd execution pod.
-        'grep -v "cloud-cmd" |  '
+        'grep -v "cloud-cmd" | '
         'grep head |'
-        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
+        """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'test_container_logs_two_jobs_kubernetes',
@@ -2149,17 +2167,26 @@ def test_container_logs_two_jobs_kubernetes():
 def test_container_logs_two_simultaneous_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml '
-    # -A + custom-columns: the pods may not be in kubectl's default
-    # namespace (e.g. a workspace-scoped namespace), so a bare `kubectl
-    # get pods` can silently return nothing.
+    # -A + a label selector + exact match on the skypilot-cluster-name
+    # annotation (not a substring grep on the pod name): the pods may not
+    # be in kubectl's default namespace (e.g. a workspace-scoped
+    # namespace), so a bare `kubectl get pods` can silently return
+    # nothing; and -A widens the search to every namespace, so a
+    # substring match risks picking up a same-named leftover pod from
+    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
+    # exactly one pod, but plain xargs concatenates every matching
+    # "-n ns pod" line into a single invocation.
     pod_logs = (
-        'all_pods=$(kubectl get pods -A --no-headers -o custom-columns='
-        '"NS:.metadata.namespace,NAME:.metadata.name"); echo "$all_pods"; '
-        f'echo "$all_pods" | grep {name} |  '
+        'all_pods=$(kubectl get pods -A -l skypilot-cluster-name '
+        '--no-headers -o custom-columns="NS:.metadata.namespace,'
+        'NAME:.metadata.name,'
+        'CLUSTER:.metadata.annotations.skypilot-cluster-name"); '
+        'echo "$all_pods"; '
+        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
         # Exclude the cloud cmd execution pod.
-        'grep -v "cloud-cmd" |  '
+        'grep -v "cloud-cmd" | '
         'grep head |'
-        """ awk '{print "-n " $1 " " $2}' | xargs kubectl logs""")
+        """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
             'test_container_logs_two_simultaneous_jobs_kubernetes',


### PR DESCRIPTION
## Root cause

`test_container_logs_multinode_kubernetes`, `test_container_logs_two_jobs_kubernetes`, and `test_container_logs_two_simultaneous_jobs_kubernetes` all list pods with a bare `kubectl get pods` (no `-A`, no `-n`). This only works when the target pods happen to live in kubectl's implicit default namespace.

On a server where the target workspace resolves to a **non-default Kubernetes namespace**, this silently returns zero pods — not an error, just empty output — so the retry loop in `_check_container_logs` spins for the full 60s timeout and fails.

## Evidence

Confirmed via two independent Buildkite CI runs on fresh, single-use clusters (build [smoke-tests-private-repo-feature-plugin#2240](https://buildkite.com/skypilot-1/smoke-tests-private-repo-feature-plugin/builds/2240), an internal fork's CI):
- Both runs failed identically: 12/12 retries exhausted the full 60s window with zero matching log lines, on `test_container_logs_multinode_kubernetes` and its siblings.
- The underlying job itself completed with `status: SUCCEEDED` and printed the expected `1`-`9` sequence on the worker node (visible directly in the job's own streamed logs) — so the task ran correctly; only the *verification* step's pod lookup failed.
- The `echo "$all_pods"` debug line (present in the existing code specifically to aid this kind of debugging) printed **nothing** on every single retry — not even a header row — confirming `kubectl get pods` returned zero pods, not a filtering/timing issue.
- A neighboring smoke test in a different file already handles this correctly by listing across all namespaces and passing an explicit `-n <namespace>` to the follow-up `kubectl` call.

## Fix

Switch the three `head_logs`/`worker_logs`/`pod_logs` commands from a bare `kubectl get pods` to `kubectl get pods -A --no-headers -o custom-columns="NS:.metadata.namespace,NAME:.metadata.name"`, and pass the resolved namespace through to `kubectl logs -n <namespace> <pod>` — matching the pattern already used elsewhere in the smoke suite for namespace-safe pod lookups. Verified the awk/xargs pipeline resolves correctly with a standalone sandbox test against simulated `kubectl get pods -A` output (including a `-cloud-cmd` pod name that must still be excluded).

No behavior change for servers using the default namespace — `-A` is a superset.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->