### PR TITLE
[Slurm] Batch inventory queries over one SSH connection

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -304,7 +304,7 @@ class SlurmClient:
             stderr_path = f'"${{snapshot_dir}}/{index}.stderr"'
             returncode_path = f'"${{snapshot_dir}}/{index}.returncode"'
             script_lines.append(
-                f'( {command} > {stdout_path} 2> {stderr_path}; '
+                f'( ( {command} ) > {stdout_path} 2> {stderr_path}; '
                 f'printf \'%s\\n\' "$?" > {returncode_path} ) &')
         batch_output_header = _BATCH_OUTPUT_HEADER.rstrip('\n')
         script_lines.extend([
@@ -353,6 +353,8 @@ class SlurmClient:
                 returncode = int(returncode_str)
                 stdout_size = int(stdout_size_str)
                 stderr_size = int(stderr_size_str)
+                if stdout_size < 0 or stderr_size < 0:
+                    raise ValueError('negative output size')
             except (UnicodeDecodeError, ValueError) as e:
                 raise RuntimeError(
                     'Unexpected output from concurrent Slurm inventory '

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -1,5 +1,7 @@
 """Slurm adaptor for SkyPilot."""
 
+import base64
+import binascii
 import ipaddress
 import logging
 import re
@@ -314,15 +316,21 @@ class SlurmClient:
         for index in range(len(commands)):
             stdout_path = f'"${{snapshot_dir}}/{index}.stdout"'
             stderr_path = f'"${{snapshot_dir}}/{index}.stderr"'
+            encoded_stdout_path = f'"${{snapshot_dir}}/{index}.stdout.b64"'
+            encoded_stderr_path = f'"${{snapshot_dir}}/{index}.stderr.b64"'
             returncode_path = f'"${{snapshot_dir}}/{index}.returncode"'
             script_lines.extend([
                 f'returncode=$(cat {returncode_path}) || exit $?',
-                f'stdout_size=$(wc -c < {stdout_path}) || exit $?',
-                f'stderr_size=$(wc -c < {stderr_path}) || exit $?',
+                # Keep the framed transport ASCII-only because command runners
+                # decode and filter subprocess output as text.
+                f'base64 < {stdout_path} > {encoded_stdout_path} || exit $?',
+                f'base64 < {stderr_path} > {encoded_stderr_path} || exit $?',
+                f'stdout_size=$(wc -c < {encoded_stdout_path}) || exit $?',
+                f'stderr_size=$(wc -c < {encoded_stderr_path}) || exit $?',
                 'printf \'%s %s %s\\n\' "$returncode" "$stdout_size" '
                 '"$stderr_size"',
-                f'cat {stdout_path} || exit $?',
-                f'cat {stderr_path} || exit $?',
+                f'cat {encoded_stdout_path} || exit $?',
+                f'cat {encoded_stderr_path} || exit $?',
             ])
 
         script = '\n'.join(script_lines)
@@ -334,7 +342,12 @@ class SlurmClient:
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
 
-        output_bytes = stdout.encode('utf-8')
+        try:
+            output_bytes = stdout.encode('ascii')
+        except UnicodeEncodeError as e:
+            raise RuntimeError('Unexpected output from concurrent Slurm '
+                               'inventory commands: non-ASCII transport '
+                               'output.') from e
         header_bytes = _BATCH_OUTPUT_HEADER.encode('ascii')
         if not output_bytes.startswith(header_bytes):
             raise RuntimeError('Unexpected output from concurrent Slurm '
@@ -346,8 +359,9 @@ class SlurmClient:
             if header_end == -1:
                 raise RuntimeError('Unexpected output from concurrent Slurm '
                                    'inventory commands: missing frame header.')
-            frame_header = output_bytes[offset:header_end].decode('ascii')
+            frame_header_bytes = output_bytes[offset:header_end]
             try:
+                frame_header = frame_header_bytes.decode('ascii')
                 returncode_str, stdout_size_str, stderr_size_str = (
                     frame_header.split())
                 returncode = int(returncode_str)
@@ -358,15 +372,31 @@ class SlurmClient:
             except (UnicodeDecodeError, ValueError) as e:
                 raise RuntimeError(
                     'Unexpected output from concurrent Slurm inventory '
-                    f'commands: invalid frame header {frame_header!r}.') from e
+                    f'commands: invalid frame header '
+                    f'{frame_header_bytes!r}.') from e
             offset = header_end + 1
             frame_end = offset + stdout_size + stderr_size
             if frame_end > len(output_bytes):
                 raise RuntimeError('Unexpected output from concurrent Slurm '
                                    'inventory commands: truncated frame.')
             stdout_end = offset + stdout_size
-            command_stdout = output_bytes[offset:stdout_end].decode('utf-8')
-            command_stderr = output_bytes[stdout_end:frame_end].decode('utf-8')
+            encoded_stdout = output_bytes[offset:stdout_end]
+            encoded_stderr = output_bytes[stdout_end:frame_end]
+            try:
+                command_stdout_bytes = base64.b64decode(b''.join(
+                    encoded_stdout.split()),
+                                                        validate=True)
+                command_stderr_bytes = base64.b64decode(b''.join(
+                    encoded_stderr.split()),
+                                                        validate=True)
+            except binascii.Error as e:
+                raise RuntimeError('Unexpected output from concurrent Slurm '
+                                   'inventory commands: invalid encoded '
+                                   'output.') from e
+            command_stdout = command_stdout_bytes.decode('utf-8',
+                                                         errors='replace')
+            command_stderr = command_stderr_bytes.decode('utf-8',
+                                                         errors='replace')
             results.append((returncode, command_stdout, command_stderr))
             offset = frame_end
         if offset != len(output_bytes):

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -91,12 +91,6 @@ class SlurmInventorySnapshot(NamedTuple):
     partitions: Optional[List[SlurmPartition]]
 
 
-class _CommandOutput(NamedTuple):
-    returncode: int
-    stdout: str
-    stderr: str
-
-
 def _parse_maxtime(line: str) -> Optional[int]:
     """Parse the maximum time a job can run from the scontrol output."""
     maxtime_match = _MAXTIME_REGEX.search(line)
@@ -294,7 +288,8 @@ class SlurmClient:
                                 separate_stderr=True,
                                 stream_logs=False)
 
-    def _run_slurm_cmds(self, commands: Sequence[str]) -> List[_CommandOutput]:
+    def _run_slurm_cmds(self,
+                        commands: Sequence[str]) -> List[Tuple[int, str, str]]:
         """Run independent commands concurrently in one remote invocation."""
         if not commands:
             return []
@@ -370,8 +365,7 @@ class SlurmClient:
             stdout_end = offset + stdout_size
             command_stdout = output_bytes[offset:stdout_end].decode('utf-8')
             command_stderr = output_bytes[stdout_end:frame_end].decode('utf-8')
-            results.append(
-                _CommandOutput(returncode, command_stdout, command_stderr))
+            results.append((returncode, command_stdout, command_stderr))
             offset = frame_end
         if offset != len(output_bytes):
             raise RuntimeError('Unexpected output from concurrent Slurm '
@@ -476,24 +470,23 @@ class SlurmClient:
             self) -> Tuple[List[NodeInfo], Dict[str, Dict[str, str]]]:
         """Get node information and details in one remote invocation."""
         outputs = self._run_slurm_cmds([_INFO_NODES_CMD, _ALL_NODE_DETAILS_CMD])
-        node_output = outputs[0]
-        details_output = outputs[1]
+        node_returncode, node_stdout, node_stderr = outputs[0]
+        details_returncode, details_stdout, details_stderr = outputs[1]
         subprocess_utils.handle_returncode(
-            node_output.returncode,
+            node_returncode,
             _INFO_NODES_CMD,
             'Failed to get Slurm node information.',
-            stderr=f'{node_output.stdout}\n{node_output.stderr}',
+            stderr=f'{node_stdout}\n{node_stderr}',
             stream_logs=False)
-        node_infos = _parse_info_nodes_output(node_output.stdout)
+        node_infos = _parse_info_nodes_output(node_stdout)
 
         node_details: Dict[str, Dict[str, str]] = {}
-        if details_output.returncode != 0:
+        if details_returncode != 0:
             logger.debug('Failed to get detailed Slurm node information: %s',
-                         details_output.stderr)
+                         details_stderr)
         else:
             try:
-                node_details = _parse_all_node_details_output(
-                    details_output.stdout)
+                node_details = _parse_all_node_details_output(details_stdout)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug(
                     'Failed to parse detailed Slurm node '
@@ -513,49 +506,46 @@ class SlurmClient:
             _ALL_JOBS_INFO_CMD,
             _PARTITIONS_INFO_CMD,
         ])
-        node_output = outputs[0]
-        details_output = outputs[1]
-        jobs_output = outputs[2]
-        partitions_output = outputs[3]
+        node_returncode, node_stdout, node_stderr = outputs[0]
+        details_returncode, details_stdout, details_stderr = outputs[1]
+        jobs_returncode, jobs_stdout, jobs_stderr = outputs[2]
+        partitions_returncode, partitions_stdout, partitions_stderr = outputs[3]
         subprocess_utils.handle_returncode(
-            node_output.returncode,
+            node_returncode,
             _INFO_NODES_CMD,
             'Failed to get Slurm node information.',
-            stderr=f'{node_output.stdout}\n{node_output.stderr}',
+            stderr=f'{node_stdout}\n{node_stderr}',
             stream_logs=False)
-        node_infos = _parse_info_nodes_output(node_output.stdout)
+        node_infos = _parse_info_nodes_output(node_stdout)
 
         node_details: Dict[str, Dict[str, str]] = {}
-        if details_output.returncode != 0:
+        if details_returncode != 0:
             logger.debug('Failed to get detailed Slurm node information: %s',
-                         details_output.stderr)
+                         details_stderr)
         else:
             try:
-                node_details = _parse_all_node_details_output(
-                    details_output.stdout)
+                node_details = _parse_all_node_details_output(details_stdout)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug(
                     'Failed to parse detailed Slurm node '
                     'information: %s', e)
 
         jobs = None
-        if jobs_output.returncode != 0:
-            logger.debug('Failed to get running Slurm jobs: %s',
-                         jobs_output.stderr)
+        if jobs_returncode != 0:
+            logger.debug('Failed to get running Slurm jobs: %s', jobs_stderr)
         else:
             try:
-                jobs = _parse_all_jobs_info_output(jobs_output.stdout)
+                jobs = _parse_all_jobs_info_output(jobs_stdout)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Failed to parse running Slurm jobs: %s', e)
 
         partitions = None
-        if partitions_output.returncode != 0:
+        if partitions_returncode != 0:
             logger.debug('Failed to get Slurm partitions: %s',
-                         partitions_output.stderr)
+                         partitions_stderr)
         else:
             try:
-                partitions = _parse_partitions_info_output(
-                    partitions_output.stdout)
+                partitions = _parse_partitions_info_output(partitions_stdout)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Failed to parse Slurm partitions: %s', e)
 

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -4,7 +4,7 @@ import ipaddress
 import logging
 import re
 import shlex
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 from sky.adaptors import common
 from sky.utils import command_runner
@@ -16,6 +16,14 @@ logger = logging.getLogger(__name__)
 # ASCII Unit Separator (\x1f) to handle values with spaces
 # and other special characters.
 SEP = r'\x1f'
+
+_INFO_NODES_CMD = (f'sinfo -h --Node -o '
+                   f'"%N{SEP}%t{SEP}%G{SEP}%c{SEP}%m{SEP}%P"')
+_ALL_NODE_DETAILS_CMD = 'scontrol show node -o'
+_ALL_JOBS_INFO_CMD = (f'squeue -h --states=running,completing '
+                      f'-o "%i{SEP}%j{SEP}%u{SEP}%N{SEP}%b"')
+_PARTITIONS_INFO_CMD = 'scontrol show partitions -o'
+_BATCH_OUTPUT_HEADER = 'SKYPILOT_SLURM_BATCH\n'
 
 # Regex pattern to extract partition names from scontrol output
 # Matches PartitionName=<name> and captures until the next field
@@ -75,6 +83,20 @@ class JobGresInfo(NamedTuple):
     gres_str: str
 
 
+class SlurmInventorySnapshot(NamedTuple):
+    """Cluster-wide Slurm inventory collected in one remote invocation."""
+    node_infos: List[NodeInfo]
+    node_details: Dict[str, Dict[str, str]]
+    jobs: Optional[Dict[str, List[JobGresInfo]]]
+    partitions: Optional[List[SlurmPartition]]
+
+
+class _CommandOutput(NamedTuple):
+    returncode: int
+    stdout: str
+    stderr: str
+
+
 def _parse_maxtime(line: str) -> Optional[int]:
     """Parse the maximum time a job can run from the scontrol output."""
     maxtime_match = _MAXTIME_REGEX.search(line)
@@ -125,6 +147,82 @@ def _parse_scontrol_node_output(output: str) -> Dict[str, str]:
             value = value.strip('\'"')
             node_info[key] = value
     return node_info
+
+
+def _parse_info_nodes_output(stdout: str) -> List[NodeInfo]:
+    nodes = []
+    for line in stdout.splitlines():
+        parts = line.split(SEP)
+        if len(parts) != 6:
+            raise RuntimeError(f'Unexpected output format from sinfo: {line!r}')
+        try:
+            node_info = NodeInfo(node=parts[0],
+                                 state=parts[1],
+                                 gres=parts[2],
+                                 cpus=int(parts[3]),
+                                 memory_gb=int(parts[4]) / 1024.0,
+                                 partition=parts[5])
+            nodes.append(node_info)
+        except ValueError as e:
+            raise RuntimeError(
+                f'Failed to parse node info from line: {line!r}. '
+                f'Error: {e}') from e
+    return nodes
+
+
+def _parse_all_node_details_output(stdout: str) -> Dict[str, Dict[str, str]]:
+    details: Dict[str, Dict[str, str]] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        node_info = _parse_scontrol_node_output(line)
+        node_name = node_info.get('NodeName')
+        if node_name:
+            details[node_name] = node_info
+    return details
+
+
+def _parse_all_jobs_info_output(stdout: str) -> Dict[str, List[JobGresInfo]]:
+    nodes_to_jobs: Dict[str, List[JobGresInfo]] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(SEP)
+        if len(parts) != 5:
+            continue
+        job_id, job_name, user, nodelist_str, gres_str = parts
+        if not gres_str or gres_str == 'N/A':
+            continue
+
+        job_info = JobGresInfo(job_id=job_id,
+                               job_name=job_name,
+                               user=user,
+                               gres_str=gres_str)
+        for node in hostlist.expand_hostlist(nodelist_str):
+            nodes_to_jobs.setdefault(node, []).append(job_info)
+    return nodes_to_jobs
+
+
+def _parse_partitions_info_output(stdout: str) -> List[SlurmPartition]:
+    partitions = []
+    for line in stdout.strip().splitlines():
+        is_default = False
+        match = _PARTITION_NAME_REGEX.search(line)
+        if 'Default=YES' in line:
+            is_default = True
+        maxtime = _parse_maxtime(line)
+        default_time = _parse_default_time(line)
+        if match:
+            partition = match.group(1).strip()
+            if partition:
+                partitions.append(
+                    SlurmPartition(name=partition,
+                                   is_default=is_default,
+                                   maxtime=maxtime,
+                                   default_time=default_time))
+    return partitions
 
 
 class SlurmClient:
@@ -195,6 +293,90 @@ class SlurmClient:
                                 require_outputs=True,
                                 separate_stderr=True,
                                 stream_logs=False)
+
+    def _run_slurm_cmds(self, commands: Sequence[str]) -> List[_CommandOutput]:
+        """Run independent commands concurrently in one remote invocation."""
+        if not commands:
+            return []
+
+        script_lines = [
+            'snapshot_dir=$(mktemp -d) || exit $?',
+            'cleanup_snapshot() { rm -rf -- "${snapshot_dir:?}"; }',
+            'trap cleanup_snapshot EXIT',
+        ]
+        for index, command in enumerate(commands):
+            stdout_path = f'"${{snapshot_dir}}/{index}.stdout"'
+            stderr_path = f'"${{snapshot_dir}}/{index}.stderr"'
+            returncode_path = f'"${{snapshot_dir}}/{index}.returncode"'
+            script_lines.append(
+                f'( {command} > {stdout_path} 2> {stderr_path}; '
+                f'printf \'%s\\n\' "$?" > {returncode_path} ) &')
+        batch_output_header = _BATCH_OUTPUT_HEADER.rstrip('\n')
+        script_lines.extend([
+            'wait',
+            f'printf \'%s\\n\' {shlex.quote(batch_output_header)}',
+        ])
+        for index in range(len(commands)):
+            stdout_path = f'"${{snapshot_dir}}/{index}.stdout"'
+            stderr_path = f'"${{snapshot_dir}}/{index}.stderr"'
+            returncode_path = f'"${{snapshot_dir}}/{index}.returncode"'
+            script_lines.extend([
+                f'returncode=$(cat {returncode_path}) || exit $?',
+                f'stdout_size=$(wc -c < {stdout_path}) || exit $?',
+                f'stderr_size=$(wc -c < {stderr_path}) || exit $?',
+                'printf \'%s %s %s\\n\' "$returncode" "$stdout_size" '
+                '"$stderr_size"',
+                f'cat {stdout_path} || exit $?',
+                f'cat {stderr_path} || exit $?',
+            ])
+
+        script = '\n'.join(script_lines)
+        rc, stdout, stderr = self._run_slurm_cmd(script)
+        subprocess_utils.handle_returncode(
+            rc,
+            'concurrent Slurm inventory commands',
+            'Failed to run concurrent Slurm inventory commands.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+
+        output_bytes = stdout.encode('utf-8')
+        header_bytes = _BATCH_OUTPUT_HEADER.encode('ascii')
+        if not output_bytes.startswith(header_bytes):
+            raise RuntimeError('Unexpected output from concurrent Slurm '
+                               'inventory commands: missing header.')
+        offset = len(header_bytes)
+        results = []
+        for _ in commands:
+            header_end = output_bytes.find(b'\n', offset)
+            if header_end == -1:
+                raise RuntimeError('Unexpected output from concurrent Slurm '
+                                   'inventory commands: missing frame header.')
+            frame_header = output_bytes[offset:header_end].decode('ascii')
+            try:
+                returncode_str, stdout_size_str, stderr_size_str = (
+                    frame_header.split())
+                returncode = int(returncode_str)
+                stdout_size = int(stdout_size_str)
+                stderr_size = int(stderr_size_str)
+            except (UnicodeDecodeError, ValueError) as e:
+                raise RuntimeError(
+                    'Unexpected output from concurrent Slurm inventory '
+                    f'commands: invalid frame header {frame_header!r}.') from e
+            offset = header_end + 1
+            frame_end = offset + stdout_size + stderr_size
+            if frame_end > len(output_bytes):
+                raise RuntimeError('Unexpected output from concurrent Slurm '
+                                   'inventory commands: truncated frame.')
+            stdout_end = offset + stdout_size
+            command_stdout = output_bytes[offset:stdout_end].decode('utf-8')
+            command_stderr = output_bytes[stdout_end:frame_end].decode('utf-8')
+            results.append(
+                _CommandOutput(returncode, command_stdout, command_stderr))
+            offset = frame_end
+        if offset != len(output_bytes):
+            raise RuntimeError('Unexpected output from concurrent Slurm '
+                               'inventory commands: trailing data.')
+        return results
 
     def query_jobs(
         self,
@@ -279,8 +461,7 @@ class SlurmClient:
         Returns node names, states, GRES (generic resources like GPUs),
         CPUs, memory (MB), and partitions.
         """
-        cmd = (f'sinfo -h --Node -o '
-               f'"%N{SEP}%t{SEP}%G{SEP}%c{SEP}%m{SEP}%P"')
+        cmd = _INFO_NODES_CMD
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(
             rc,
@@ -289,26 +470,99 @@ class SlurmClient:
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
 
-        nodes = []
-        for line in stdout.splitlines():
-            parts = line.split(SEP)
-            if len(parts) != 6:
-                raise RuntimeError(
-                    f'Unexpected output format from sinfo: {line!r}')
-            try:
-                node_info = NodeInfo(node=parts[0],
-                                     state=parts[1],
-                                     gres=parts[2],
-                                     cpus=int(parts[3]),
-                                     memory_gb=int(parts[4]) / 1024.0,
-                                     partition=parts[5])
-                nodes.append(node_info)
-            except ValueError as e:
-                raise RuntimeError(
-                    f'Failed to parse node info from line: {line!r}. '
-                    f'Error: {e}') from e
+        return _parse_info_nodes_output(stdout)
 
-        return nodes
+    def get_node_inventory(
+            self) -> Tuple[List[NodeInfo], Dict[str, Dict[str, str]]]:
+        """Get node information and details in one remote invocation."""
+        outputs = self._run_slurm_cmds([_INFO_NODES_CMD, _ALL_NODE_DETAILS_CMD])
+        node_output = outputs[0]
+        details_output = outputs[1]
+        subprocess_utils.handle_returncode(
+            node_output.returncode,
+            _INFO_NODES_CMD,
+            'Failed to get Slurm node information.',
+            stderr=f'{node_output.stdout}\n{node_output.stderr}',
+            stream_logs=False)
+        node_infos = _parse_info_nodes_output(node_output.stdout)
+
+        node_details: Dict[str, Dict[str, str]] = {}
+        if details_output.returncode != 0:
+            logger.debug('Failed to get detailed Slurm node information: %s',
+                         details_output.stderr)
+        else:
+            try:
+                node_details = _parse_all_node_details_output(
+                    details_output.stdout)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(
+                    'Failed to parse detailed Slurm node '
+                    'information: %s', e)
+        return node_infos, node_details
+
+    def get_inventory_snapshot(self) -> SlurmInventorySnapshot:
+        """Get cluster-wide nodes, jobs, and partitions in one SSH call.
+
+        Node information is required. Node details, running jobs, and
+        partitions are best-effort and use empty or None values when their
+        individual Slurm commands fail.
+        """
+        outputs = self._run_slurm_cmds([
+            _INFO_NODES_CMD,
+            _ALL_NODE_DETAILS_CMD,
+            _ALL_JOBS_INFO_CMD,
+            _PARTITIONS_INFO_CMD,
+        ])
+        node_output = outputs[0]
+        details_output = outputs[1]
+        jobs_output = outputs[2]
+        partitions_output = outputs[3]
+        subprocess_utils.handle_returncode(
+            node_output.returncode,
+            _INFO_NODES_CMD,
+            'Failed to get Slurm node information.',
+            stderr=f'{node_output.stdout}\n{node_output.stderr}',
+            stream_logs=False)
+        node_infos = _parse_info_nodes_output(node_output.stdout)
+
+        node_details: Dict[str, Dict[str, str]] = {}
+        if details_output.returncode != 0:
+            logger.debug('Failed to get detailed Slurm node information: %s',
+                         details_output.stderr)
+        else:
+            try:
+                node_details = _parse_all_node_details_output(
+                    details_output.stdout)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(
+                    'Failed to parse detailed Slurm node '
+                    'information: %s', e)
+
+        jobs = None
+        if jobs_output.returncode != 0:
+            logger.debug('Failed to get running Slurm jobs: %s',
+                         jobs_output.stderr)
+        else:
+            try:
+                jobs = _parse_all_jobs_info_output(jobs_output.stdout)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug('Failed to parse running Slurm jobs: %s', e)
+
+        partitions = None
+        if partitions_output.returncode != 0:
+            logger.debug('Failed to get Slurm partitions: %s',
+                         partitions_output.stderr)
+        else:
+            try:
+                partitions = _parse_partitions_info_output(
+                    partitions_output.stdout)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug('Failed to parse Slurm partitions: %s', e)
+
+        return SlurmInventorySnapshot(node_infos=node_infos,
+                                      node_details=node_details,
+                                      jobs=jobs,
+                                      partitions=partitions)
 
     def node_details(self, node_name: str) -> Dict[str, str]:
         """Get detailed Slurm node information.
@@ -338,7 +592,7 @@ class SlurmClient:
         Returns:
             A dictionary mapping node name to its attribute dictionary.
         """
-        cmd = 'scontrol show node -o'
+        cmd = _ALL_NODE_DETAILS_CMD
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(
             rc,
@@ -346,16 +600,7 @@ class SlurmClient:
             'Failed to get detailed node information.',
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
-        details: Dict[str, Dict[str, str]] = {}
-        for line in stdout.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            node_info = _parse_scontrol_node_output(line)
-            node_name = node_info.get('NodeName')
-            if node_name:
-                details[node_name] = node_info
-        return details
+        return _parse_all_node_details_output(stdout)
 
     def get_jobs_gres(self, node_name: str) -> List[str]:
         """Get the list of jobs GRES for a given node name.
@@ -420,8 +665,7 @@ class SlurmClient:
             Dict mapping node_name -> list of JobGresInfo for jobs on that
             node.
         """
-        cmd = (f'squeue -h --states=running,completing '
-               f'-o "%i{SEP}%j{SEP}%u{SEP}%N{SEP}%b"')
+        cmd = _ALL_JOBS_INFO_CMD
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(rc,
                                            cmd,
@@ -429,27 +673,7 @@ class SlurmClient:
                                            stderr=f'{stdout}\n{stderr}',
                                            stream_logs=False)
 
-        nodes_to_jobs: Dict[str, List[JobGresInfo]] = {}
-        for line in stdout.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split(SEP)
-            if len(parts) != 5:
-                # We should never reach here, but just in case.
-                continue
-            job_id, job_name, user, nodelist_str, gres_str = parts
-            if not gres_str or gres_str == 'N/A':
-                continue
-
-            job_info = JobGresInfo(job_id=job_id,
-                                   job_name=job_name,
-                                   user=user,
-                                   gres_str=gres_str)
-            for node in hostlist.expand_hostlist(nodelist_str):
-                nodes_to_jobs.setdefault(node, []).append(job_info)
-
-        return nodes_to_jobs
+        return _parse_all_jobs_info_output(stdout)
 
     def get_job_state(self, job_id: str) -> Optional[str]:
         """Get the state of a Slurm job.
@@ -694,7 +918,7 @@ class SlurmClient:
         Returns:
             List of SlurmPartition objects.
         """
-        cmd = 'scontrol show partitions -o'
+        cmd = _PARTITIONS_INFO_CMD
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(rc,
                                            cmd,
@@ -702,23 +926,7 @@ class SlurmClient:
                                            stderr=f'{stdout}\n{stderr}',
                                            stream_logs=False)
 
-        partitions = []
-        for line in stdout.strip().splitlines():
-            is_default = False
-            match = _PARTITION_NAME_REGEX.search(line)
-            if 'Default=YES' in line:
-                is_default = True
-            maxtime = _parse_maxtime(line)
-            default_time = _parse_default_time(line)
-            if match:
-                partition = match.group(1).strip()
-                if partition:
-                    partitions.append(
-                        SlurmPartition(name=partition,
-                                       is_default=is_default,
-                                       maxtime=maxtime,
-                                       default_time=default_time))
-        return partitions
+        return _parse_partitions_info_output(stdout)
 
     def get_default_partition(self) -> Optional[str]:
         """Get the default partition name for the Slurm cluster.

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from paramiko.config import SSHConfig
 
@@ -54,6 +54,13 @@ _SLURM_PROCTRACK_TYPE_CACHE_TTL = 24 * 60 * 60
 _SLURM_PYXIS_CHECK_CACHE_TTL = 24 * 60 * 60
 # FUSE availability is unlikely to change frequently.
 _SLURM_FUSE_CHECK_CACHE_TTL = 24 * 60 * 60
+
+
+class SlurmClusterInventory(NamedTuple):
+    """Cluster-wide node, job, and partition inventory."""
+    nodes: List[Dict[str, Any]]
+    jobs: Dict[str, List[slurm.JobGresInfo]]
+    default_partition: Optional[str]
 
 
 def expand_path_vars(path: str, env: Dict[str, str]) -> str:
@@ -1033,6 +1040,22 @@ def _parse_float_or_none(value: Optional[str]) -> Optional[float]:
         return None
 
 
+def _get_slurm_inventory_client(slurm_cluster_name: str) -> 'slurm.SlurmClient':
+    slurm_config = get_slurm_ssh_config()
+    slurm_config_dict = slurm_config.lookup(slurm_cluster_name)
+    logger.debug(f'Slurm config dict: {slurm_config_dict}')
+    return slurm.SlurmClient(
+        slurm_config_dict['hostname'],
+        int(slurm_config_dict.get('port', 22)),
+        slurm_config_dict['user'],
+        get_identity_file(slurm_config_dict),
+        ssh_proxy_command=slurm_config_dict.get('proxycommand', None),
+        ssh_proxy_jump=slurm_config_dict.get('proxyjump', None),
+        identities_only=get_identities_only(slurm_config_dict),
+        slurm_user=None,
+    )
+
+
 def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     """Gathers detailed information about each node in the Slurm cluster.
 
@@ -1047,42 +1070,26 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         exceptions.CommandError: If a Slurm command fails on the cluster, e.g.
             because the login node is unreachable.
     """
-    # 1. Get node state and GRES using sinfo
+    slurm_client = _get_slurm_inventory_client(slurm_cluster_name)
+    node_infos, node_details_by_name = slurm_client.get_node_inventory()
+    return _build_slurm_node_info_list(slurm_cluster_name, slurm_client,
+                                       node_infos, node_details_by_name)
 
-    # can raise FileNotFoundError if config file does not exist.
-    slurm_config = get_slurm_ssh_config()
-    slurm_config_dict = slurm_config.lookup(slurm_cluster_name)
-    logger.debug(f'Slurm config dict: {slurm_config_dict}')
-    slurm_client = slurm.SlurmClient(
-        slurm_config_dict['hostname'],
-        int(slurm_config_dict.get('port', 22)),
-        slurm_config_dict['user'],
-        get_identity_file(slurm_config_dict),
-        ssh_proxy_command=slurm_config_dict.get('proxycommand', None),
-        ssh_proxy_jump=slurm_config_dict.get('proxyjump', None),
-        identities_only=get_identities_only(slurm_config_dict),
-        # The SSH transport identity gives cluster-wide inventory callers one
-        # consistent view of monitoring and capacity data.
-        slurm_user=None,
-    )
-    node_infos = slurm_client.info_nodes()
+
+def _build_slurm_node_info_list(
+    slurm_cluster_name: str,
+    slurm_client: 'slurm.SlurmClient',
+    node_infos: List[slurm.NodeInfo],
+    node_details_by_name: Dict[str, Dict[str, str]],
+    jobs_gres_by_node: Optional[Dict[str, List[str]]] = None,
+) -> List[Dict[str, Any]]:
+    """Build node inventory from cluster-wide Slurm query results."""
 
     if not node_infos:
         logger.warning(
             f'`sinfo -N` returned no output on cluster {slurm_cluster_name}. '
             f'No nodes found?')
         return []
-
-    # Best-effort enrichment with per-node scontrol attributes (CPU/memory
-    # allocation from the scheduler plus actual load/free-memory sampled
-    # by slurmd) — sinfo's format codes cannot express these. A failure
-    # here must not break basic node info.
-    try:
-        node_details_by_name = slurm_client.get_all_node_details()
-    except Exception as e:  # pylint: disable=broad-except
-        logger.debug(f'Could not fetch scontrol node details on cluster '
-                     f'{slurm_cluster_name}: {e}')
-        node_details_by_name = {}
 
     # 2. Process each node, aggregating partitions per node
     slurm_nodes_info: Dict[str, Dict[str, Any]] = {}
@@ -1135,7 +1142,11 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
             # TODO(zhwu): move to enum
             if state in ('alloc', 'mix', 'drain', 'drng', 'drained', 'resv',
                          'comp'):
-                jobs_gres = _get_all_jobs_gres(slurm_client).get(node_name, [])
+                if jobs_gres_by_node is None:
+                    jobs_gres = _get_all_jobs_gres(slurm_client).get(
+                        node_name, [])
+                else:
+                    jobs_gres = jobs_gres_by_node.get(node_name, [])
                 if jobs_gres:
                     for job_line in jobs_gres:
                         _, job_gpu_count = get_gpu_type_and_count(job_line)
@@ -1198,6 +1209,35 @@ def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
         node_info['partition'] = ','.join(str(p) for p in partitions)
 
     return list(slurm_nodes_info.values())
+
+
+def get_slurm_cluster_inventory(
+        slurm_cluster_name: str) -> SlurmClusterInventory:
+    """Get nodes, running GPU jobs, and the default partition for a cluster.
+
+    The underlying Slurm commands run concurrently in one remote invocation.
+    Node information is required; jobs and partition metadata are best-effort.
+    """
+    slurm_client = _get_slurm_inventory_client(slurm_cluster_name)
+    snapshot = slurm_client.get_inventory_snapshot()
+    jobs_gres_by_node: Dict[str, List[str]] = {}
+    if snapshot.jobs is not None:
+        jobs_gres_by_node = {
+            node_name: [job.gres_str for job in jobs
+                       ] for node_name, jobs in snapshot.jobs.items()
+        }
+    nodes = _build_slurm_node_info_list(slurm_cluster_name, slurm_client,
+                                        snapshot.node_infos,
+                                        snapshot.node_details,
+                                        jobs_gres_by_node)
+    default_partition = None
+    if snapshot.partitions is not None:
+        default_partition = next((partition.name
+                                  for partition in snapshot.partitions
+                                  if partition.is_default), None)
+    return SlurmClusterInventory(nodes=nodes,
+                                 jobs=snapshot.jobs or {},
+                                 default_partition=default_partition)
 
 
 def slurm_cluster_names() -> List[str]:

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1220,7 +1220,7 @@ def get_slurm_cluster_inventory(
     """
     slurm_client = _get_slurm_inventory_client(slurm_cluster_name)
     snapshot = slurm_client.get_inventory_snapshot()
-    jobs_gres_by_node: Dict[str, List[str]] = {}
+    jobs_gres_by_node: Optional[Dict[str, List[str]]] = None
     if snapshot.jobs is not None:
         jobs_gres_by_node = {
             node_name: [job.gres_str for job in jobs

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -1,5 +1,6 @@
 """Unit tests for Slurm adaptor."""
 
+import base64
 import unittest.mock as mock
 
 import pytest
@@ -12,9 +13,11 @@ from sky.utils import command_runner as command_runner_lib
 def _batch_output(*outputs):
     framed = ['SKYPILOT_SLURM_BATCH\n']
     for returncode, stdout, stderr in outputs:
+        encoded_stdout = base64.b64encode(stdout.encode()).decode()
+        encoded_stderr = base64.b64encode(stderr.encode()).decode()
         framed.append(
-            f'{returncode} {len(stdout.encode())} {len(stderr.encode())}\n')
-        framed.extend([stdout, stderr])
+            f'{returncode} {len(encoded_stdout)} {len(encoded_stderr)}\n')
+        framed.extend([encoded_stdout, encoded_stderr])
     return ''.join(framed)
 
 
@@ -39,11 +42,35 @@ class TestRunSlurmCmds:
         client._runner = command_runner_lib.LocalProcessCommandRunner()
 
         results = client._run_slurm_cmds([
-            "sleep 0.1; printf 'first\\nnœud\\n'",
-            "printf 'second error\\n' >&2; exit 7",
+            'sleep 0.1; printf \'first\\nnœud\\n\'',
+            'printf \'second error\\n\' >&2; exit 7',
         ])
 
         assert results == [(0, 'first\nnœud\n', ''), (7, '', 'second error\n')]
+
+    def test_transport_preserves_frames_after_invalid_utf8_replacement(self):
+        client = self._client()
+        client._runner = command_runner_lib.LocalProcessCommandRunner()
+
+        results = client._run_slurm_cmds([
+            'python3 -c \'import os; os.write(1, bytes([255])); '
+            'os.write(2, bytes([254]))\'',
+            'printf \'second\'',
+        ])
+
+        assert results == [(0, '\ufffd', '\ufffd'), (0, 'second', '')]
+
+    def test_transport_preserves_lines_filtered_by_command_runner(self):
+        client = self._client()
+        client._runner = command_runner_lib.LocalProcessCommandRunner()
+        warning = 'bash: cannot set terminal process group\n'
+
+        results = client._run_slurm_cmds([
+            f'printf {warning!r}',
+            f'printf {warning!r} >&2',
+        ])
+
+        assert results == [(0, warning, ''), (0, '', warning)]
 
     def test_byte_lengths_preserve_arbitrary_text_and_input_order(self):
         client = self._client()
@@ -63,14 +90,31 @@ class TestRunSlurmCmds:
         assert script.count(' ) &') == 2
         assert script.index('\nwait\n') < script.index('SKYPILOT_SLURM_BATCH')
 
+    def test_parser_accepts_line_wrapped_base64_frames(self):
+        client = self._client()
+        expected = 'nœud\n' * 40
+        encoded = base64.b64encode(expected.encode()).decode()
+        wrapped = '\n'.join(encoded[offset:offset + 76]
+                            for offset in range(0, len(encoded), 76))
+        output = (f'SKYPILOT_SLURM_BATCH\n0 {len(wrapped)} 0\n'
+                  f'{wrapped}')
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, output, '')
+
+            results = client._run_slurm_cmds(['command'])
+
+        assert results == [(0, expected, '')]
+
     @pytest.mark.parametrize(('output', 'error'), [
         ('', 'missing header'),
         ('not-the-protocol\n', 'missing header'),
+        ('SKYPILOT_SLURM_BATCH\n\ufffd', 'non-ASCII transport output'),
         ('SKYPILOT_SLURM_BATCH\n', 'missing frame header'),
         ('SKYPILOT_SLURM_BATCH\ninvalid\n', 'invalid frame header'),
         ('SKYPILOT_SLURM_BATCH\n0 1\nx', 'invalid frame header'),
         ('SKYPILOT_SLURM_BATCH\n0 -1 0\n', 'invalid frame header'),
         ('SKYPILOT_SLURM_BATCH\n0 2 0\nx', 'truncated frame'),
+        ('SKYPILOT_SLURM_BATCH\n0 1 0\n?', 'invalid encoded output'),
         ('SKYPILOT_SLURM_BATCH\n0 0 0\nextra', 'trailing data'),
     ])
     def test_rejects_malformed_framing(self, output, error):

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -200,10 +200,10 @@ class TestInventorySnapshot:
                                    ssh_user='root',
                                    ssh_key=None)
         with mock.patch.object(client._runner, 'run') as mock_run:
-            mock_run.return_value = (
-                0,
-                _batch_output((1, '', 'sinfo failed'), (0, '', ''),
-                              (0, '', ''), (0, '', '')), '')
+            mock_run.return_value = (0,
+                                     _batch_output((1, '', 'sinfo failed'),
+                                                   (0, '', ''), (0, '', ''),
+                                                   (0, '', '')), '')
 
             with pytest.raises(exceptions.CommandError) as exc_info:
                 client.get_inventory_snapshot()

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -6,6 +6,7 @@ import pytest
 
 from sky import exceptions
 from sky.adaptors import slurm
+from sky.utils import command_runner as command_runner_lib
 
 
 def _batch_output(*outputs):
@@ -15,6 +16,80 @@ def _batch_output(*outputs):
             f'{returncode} {len(stdout.encode())} {len(stderr.encode())}\n')
         framed.extend([stdout, stderr])
     return ''.join(framed)
+
+
+class TestRunSlurmCmds:
+    """Tests for the concurrent command transport and framing protocol."""
+
+    @staticmethod
+    def _client():
+        return slurm.SlurmClient(ssh_host='localhost',
+                                 ssh_port=22,
+                                 ssh_user='root',
+                                 ssh_key=None)
+
+    def test_empty_command_list_skips_remote_invocation(self):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            assert not client._run_slurm_cmds([])
+        mock_run.assert_not_called()
+
+    def test_generated_script_and_parser_round_trip(self):
+        client = self._client()
+        client._runner = command_runner_lib.LocalProcessCommandRunner()
+
+        results = client._run_slurm_cmds([
+            "sleep 0.1; printf 'first\\nnœud\\n'",
+            "printf 'second error\\n' >&2; exit 7",
+        ])
+
+        assert results == [(0, 'first\nnœud\n', ''), (7, '', 'second error\n')]
+
+    def test_byte_lengths_preserve_arbitrary_text_and_input_order(self):
+        client = self._client()
+        outputs = [
+            (23, 'line 1\n0 2 3\nSKYPILOT_SLURM_BATCH\nnœud\x00',
+             'warning\nstill warning'),
+            (0, '', ''),
+        ]
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, _batch_output(*outputs), '')
+
+            results = client._run_slurm_cmds(['slow command', 'fast command'])
+
+        assert results == outputs
+        script = mock_run.call_args.args[0]
+        assert script.index('slow command') < script.index('fast command')
+        assert script.count(' ) &') == 2
+        assert script.index('\nwait\n') < script.index('SKYPILOT_SLURM_BATCH')
+
+    @pytest.mark.parametrize(('output', 'error'), [
+        ('', 'missing header'),
+        ('not-the-protocol\n', 'missing header'),
+        ('SKYPILOT_SLURM_BATCH\n', 'missing frame header'),
+        ('SKYPILOT_SLURM_BATCH\ninvalid\n', 'invalid frame header'),
+        ('SKYPILOT_SLURM_BATCH\n0 1\nx', 'invalid frame header'),
+        ('SKYPILOT_SLURM_BATCH\n0 -1 0\n', 'invalid frame header'),
+        ('SKYPILOT_SLURM_BATCH\n0 2 0\nx', 'truncated frame'),
+        ('SKYPILOT_SLURM_BATCH\n0 0 0\nextra', 'trailing data'),
+    ])
+    def test_rejects_malformed_framing(self, output, error):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, output, '')
+
+            with pytest.raises(RuntimeError, match=error):
+                client._run_slurm_cmds(['command'])
+
+    def test_outer_command_failure_is_not_parsed_as_a_frame(self):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (255, '', 'connection lost')
+
+            with pytest.raises(exceptions.CommandError) as exc_info:
+                client._run_slurm_cmds(['command'])
+
+        assert exc_info.value.returncode == 255
 
 
 class TestGetPartitions:

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -4,7 +4,17 @@ import unittest.mock as mock
 
 import pytest
 
+from sky import exceptions
 from sky.adaptors import slurm
+
+
+def _batch_output(*outputs):
+    framed = ['SKYPILOT_SLURM_BATCH\n']
+    for returncode, stdout, stderr in outputs:
+        framed.append(
+            f'{returncode} {len(stdout.encode())} {len(stderr.encode())}\n')
+        framed.extend([stdout, stderr])
+    return ''.join(framed)
 
 
 class TestGetPartitions:
@@ -86,6 +96,119 @@ class TestInfoNodes:
             assert result[2].cpus == 4
             assert result[2].memory_gb == 32
             assert result[2].partition == 'tpu nodes'
+
+
+class TestInventorySnapshot:
+    """Tests for batched Slurm inventory collection."""
+
+    def test_get_node_inventory_uses_one_remote_invocation(self):
+        client = slurm.SlurmClient(ssh_host='localhost',
+                                   ssh_port=22,
+                                   ssh_user='root',
+                                   ssh_key=None)
+        sinfo_output = (f'nœud1{slurm.SEP}mix{slurm.SEP}gpu:h100:8{slurm.SEP}64'
+                        f'{slurm.SEP}819200{slurm.SEP}gpu\n')
+        details_output = ('NodeName=nœud1 CPUAlloc=32 CPUTot=64 '
+                          'CfgTRES=gres/gpu=8 AllocTRES=gres/gpu=4\n')
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0,
+                                     _batch_output((0, sinfo_output, ''),
+                                                   (0, details_output, '')), '')
+
+            node_infos, node_details = client.get_node_inventory()
+
+        mock_run.assert_called_once()
+        script = mock_run.call_args.args[0]
+        assert 'sinfo -h --Node' in script
+        assert 'scontrol show node -o' in script
+        assert script.count(' ) &') == 2
+        assert node_infos[0].node == 'nœud1'
+        assert node_details['nœud1']['CPUAlloc'] == '32'
+
+    def test_get_inventory_snapshot_parses_all_sections(self):
+        client = slurm.SlurmClient(ssh_host='localhost',
+                                   ssh_port=22,
+                                   ssh_user='root',
+                                   ssh_key=None)
+        sinfo_output = (f'node1{slurm.SEP}mix{slurm.SEP}gpu:h100:8'
+                        f'{slurm.SEP}64{slurm.SEP}819200{slurm.SEP}gpu\n')
+        details_output = ('NodeName=node1 CPUAlloc=32 CPUTot=64 '
+                          'CfgTRES=gres/gpu=8 AllocTRES=gres/gpu=4\n')
+        jobs_output = (f'123{slurm.SEP}train{slurm.SEP}alice{slurm.SEP}'
+                       f'node1{slurm.SEP}gpu:h100:4\n')
+        partitions_output = ('PartitionName=gpu Default=YES '
+                             'DefaultTime=01:00:00 MaxTime=UNLIMITED\n')
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0,
+                                     _batch_output(
+                                         (0, sinfo_output, ''),
+                                         (0, details_output, ''),
+                                         (0, jobs_output, ''),
+                                         (0, partitions_output, '')), '')
+
+            snapshot = client.get_inventory_snapshot()
+
+        mock_run.assert_called_once()
+        script = mock_run.call_args.args[0]
+        for command in ('sinfo -h --Node', 'scontrol show node -o',
+                        'squeue -h --states=running,completing',
+                        'scontrol show partitions -o'):
+            assert command in script
+        assert script.count(' ) &') == 4
+        assert snapshot.node_infos[0].node == 'node1'
+        assert snapshot.node_details['node1']['CPUAlloc'] == '32'
+        assert snapshot.jobs == {
+            'node1': [
+                slurm.JobGresInfo(job_id='123',
+                                  job_name='train',
+                                  user='alice',
+                                  gres_str='gpu:h100:4')
+            ]
+        }
+        assert snapshot.partitions == [
+            slurm.SlurmPartition(name='gpu',
+                                 is_default=True,
+                                 maxtime=None,
+                                 default_time='01:00:00')
+        ]
+
+    def test_get_inventory_snapshot_keeps_optional_failures_isolated(self):
+        client = slurm.SlurmClient(ssh_host='localhost',
+                                   ssh_port=22,
+                                   ssh_user='root',
+                                   ssh_key=None)
+        sinfo_output = (f'node1{slurm.SEP}idle{slurm.SEP}(null)'
+                        f'{slurm.SEP}4{slurm.SEP}16384{slurm.SEP}cpu\n')
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0,
+                                     _batch_output(
+                                         (0, sinfo_output, ''),
+                                         (1, '', 'scontrol failed'),
+                                         (1, '', 'squeue failed'),
+                                         (1, '', 'partitions failed')), '')
+
+            snapshot = client.get_inventory_snapshot()
+
+        assert len(snapshot.node_infos) == 1
+        assert snapshot.node_details == {}
+        assert snapshot.jobs is None
+        assert snapshot.partitions is None
+
+    def test_get_inventory_snapshot_requires_node_information(self):
+        client = slurm.SlurmClient(ssh_host='localhost',
+                                   ssh_port=22,
+                                   ssh_user='root',
+                                   ssh_key=None)
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (
+                0,
+                _batch_output((1, '', 'sinfo failed'), (0, '', ''),
+                              (0, '', ''), (0, '', '')), '')
+
+            with pytest.raises(exceptions.CommandError) as exc_info:
+                client.get_inventory_snapshot()
+
+        assert exc_info.value.returncode == 1
 
 
 class TestCheckJobHasNodes:

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -420,6 +420,11 @@ class _FakeSlurmClient:
             raise self._details_error
         return self._node_details
 
+    def get_node_inventory(self):
+        if self._details_error is not None:
+            return self._node_infos, {}
+        return self._node_infos, self._node_details
+
     def get_all_jobs_gres(self):
         self.jobs_gres_calls += 1
         return self._jobs_gres
@@ -597,7 +602,7 @@ class TestGetSlurmNodeInfoListEnrichment:
         from sky.adaptors import slurm as slurm_adaptor
 
         client = mock.Mock()
-        client.info_nodes.return_value = [
+        node_infos = [
             slurm_adaptor.NodeInfo(node='node1',
                                    state='mix',
                                    gres='gpu:gh200:1',
@@ -607,9 +612,10 @@ class TestGetSlurmNodeInfoListEnrichment:
         ]
         client.get_all_jobs_gres.return_value = {}
         if isinstance(node_details_result, Exception):
-            client.get_all_node_details.side_effect = node_details_result
+            client.get_node_inventory.return_value = (node_infos, {})
         else:
-            client.get_all_node_details.return_value = node_details_result
+            client.get_node_inventory.return_value = (node_infos,
+                                                      node_details_result)
 
         ssh_config = mock.Mock()
         ssh_config.lookup.return_value = {
@@ -684,3 +690,66 @@ class TestGetSlurmNodeInfoListEnrichment:
         assert node['node_name'] == 'node1'
         assert node['free_vcpus'] is None
         assert node['cpu_load'] is None
+
+
+class TestGetSlurmClusterInventory:
+    """Tests for the cluster-wide Slurm inventory API."""
+
+    def test_reuses_snapshot_jobs_for_gpu_accounting(self, monkeypatch):
+        node_info = slurm_adaptor.NodeInfo(node='node1',
+                                           state='mix',
+                                           gres='gpu:h100:8',
+                                           cpus=64,
+                                           memory_gb=800.0,
+                                           partition='gpu*')
+        job = slurm_adaptor.JobGresInfo(job_id='123',
+                                        job_name='train',
+                                        user='alice',
+                                        gres_str='gpu:h100:2')
+        snapshot = slurm_adaptor.SlurmInventorySnapshot(
+            node_infos=[node_info],
+            node_details={},
+            jobs={'node1': [job]},
+            partitions=[
+                slurm_adaptor.SlurmPartition(name='gpu',
+                                             is_default=True,
+                                             maxtime=None,
+                                             default_time=None)
+            ])
+        client = mock.Mock()
+        client.get_inventory_snapshot.return_value = snapshot
+        client.get_all_jobs_gres.side_effect = AssertionError(
+            'snapshot jobs should satisfy GPU accounting')
+        monkeypatch.setattr(utils, '_get_slurm_inventory_client',
+                            mock.Mock(return_value=client))
+
+        inventory = utils.get_slurm_cluster_inventory('cluster-a')
+
+        client.get_inventory_snapshot.assert_called_once_with()
+        assert inventory.nodes[0]['free_gpus'] == 6
+        assert inventory.jobs == {'node1': [job]}
+        assert inventory.default_partition == 'gpu'
+
+    def test_optional_snapshot_failures_keep_node_inventory(self, monkeypatch):
+        node_info = slurm_adaptor.NodeInfo(node='node1',
+                                           state='mix',
+                                           gres='gpu:h100:8',
+                                           cpus=8,
+                                           memory_gb=32.0,
+                                           partition='gpu')
+        snapshot = slurm_adaptor.SlurmInventorySnapshot(node_infos=[node_info],
+                                                        node_details={},
+                                                        jobs=None,
+                                                        partitions=None)
+        client = mock.Mock()
+        client.get_inventory_snapshot.return_value = snapshot
+        monkeypatch.setattr(utils, '_get_slurm_inventory_client',
+                            mock.Mock(return_value=client))
+
+        inventory = utils.get_slurm_cluster_inventory('cluster-a')
+
+        assert len(inventory.nodes) == 1
+        assert inventory.nodes[0]['free_gpus'] == 8
+        assert inventory.jobs == {}
+        assert inventory.default_partition is None
+        client.get_all_jobs_gres.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -730,7 +730,8 @@ class TestGetSlurmClusterInventory:
         assert inventory.jobs == {'node1': [job]}
         assert inventory.default_partition == 'gpu'
 
-    def test_optional_snapshot_failures_keep_node_inventory(self, monkeypatch):
+    def test_failed_snapshot_jobs_fall_back_for_gpu_accounting(
+            self, monkeypatch):
         node_info = slurm_adaptor.NodeInfo(node='node1',
                                            state='mix',
                                            gres='gpu:h100:8',
@@ -743,13 +744,63 @@ class TestGetSlurmClusterInventory:
                                                         partitions=None)
         client = mock.Mock()
         client.get_inventory_snapshot.return_value = snapshot
+        client.get_all_jobs_gres.return_value = {'node1': ['gpu:h100:2']}
         monkeypatch.setattr(utils, '_get_slurm_inventory_client',
                             mock.Mock(return_value=client))
 
         inventory = utils.get_slurm_cluster_inventory('cluster-a')
 
         assert len(inventory.nodes) == 1
-        assert inventory.nodes[0]['free_gpus'] == 8
+        assert inventory.nodes[0]['free_gpus'] == 6
         assert inventory.jobs == {}
         assert inventory.default_partition is None
+        client.get_all_jobs_gres.assert_called_once_with()
+
+    def test_failed_snapshot_jobs_do_not_fall_back_when_tres_is_complete(
+            self, monkeypatch):
+        node_info = slurm_adaptor.NodeInfo(node='node1',
+                                           state='mix',
+                                           gres='gpu:h100:8',
+                                           cpus=64,
+                                           memory_gb=800.0,
+                                           partition='gpu')
+        snapshot = slurm_adaptor.SlurmInventorySnapshot(
+            node_infos=[node_info],
+            node_details={
+                'node1': {
+                    'CfgTRES': 'cpu=64,gres/gpu=8',
+                    'AllocTRES': 'cpu=32,gres/gpu=4',
+                }
+            },
+            jobs=None,
+            partitions=None)
+        client = mock.Mock()
+        client.get_inventory_snapshot.return_value = snapshot
+        monkeypatch.setattr(utils, '_get_slurm_inventory_client',
+                            mock.Mock(return_value=client))
+
+        inventory = utils.get_slurm_cluster_inventory('cluster-a')
+
+        assert inventory.nodes[0]['free_gpus'] == 4
+        assert inventory.jobs == {}
         client.get_all_jobs_gres.assert_not_called()
+
+    def test_failed_snapshot_and_fallback_jobs_propagate(self, monkeypatch):
+        node_info = slurm_adaptor.NodeInfo(node='node1',
+                                           state='mix',
+                                           gres='gpu:h100:8',
+                                           cpus=64,
+                                           memory_gb=800.0,
+                                           partition='gpu')
+        snapshot = slurm_adaptor.SlurmInventorySnapshot(node_infos=[node_info],
+                                                        node_details={},
+                                                        jobs=None,
+                                                        partitions=None)
+        client = mock.Mock()
+        client.get_inventory_snapshot.return_value = snapshot
+        client.get_all_jobs_gres.side_effect = RuntimeError('squeue failed')
+        monkeypatch.setattr(utils, '_get_slurm_inventory_client',
+                            mock.Mock(return_value=client))
+
+        with pytest.raises(RuntimeError, match='squeue failed'):
+            utils.get_slurm_cluster_inventory('cluster-a')


### PR DESCRIPTION
## Summary

- run independent Slurm inventory commands concurrently in one SSH invocation
- add a cluster inventory snapshot containing node, job, and partition data
- reuse the batched node queries in the existing node inventory path

This removes avoidable SSH round trips from cluster-wide Slurm inventory reads while keeping optional enrichment data best-effort.

## Test plan

- `pytest -n0 tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py` (128 passed)
