### PR TITLE
[Helm] Reserve the API server's listen ports from the ephemeral port range

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -60,7 +60,50 @@ spec:
     spec:
       automountServiceAccountToken: {{ .Values.kubernetesCredentials.useApiServerCluster }}
       serviceAccountName: {{ include "skypilot.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
+      {{- /* Reserve this pod's fixed listen ports from the kernel's ephemeral
+             port allocator: 46580 (the API server, sky/server/common.py),
+             50011 (the multiprocessing queue manager,
+             sky/server/requests/queues/mp_queue.py), and 46581, reserved
+             alongside them for the auxiliary listener that runs in this pod in
+             some deployments. All three sit inside Linux's default ephemeral
+             port range (net.ipv4.ip_local_port_range, 32768-60999), so any
+             process sharing this pod's network namespace — for example a
+             sidecar opening an outbound connection — can be handed one of them
+             as an ephemeral *source* port, after which the API server's bind()
+             fails with "Address already in use". The failure is sticky: the
+             network namespace belongs to the pod sandbox and outlives container
+             restarts, so the container crash-loops until the pod is recreated.
+             net.ipv4.ip_local_reserved_ports removes the ports from automatic
+             assignment (connect(), bind(0)) while leaving our own explicit
+             bind() working.
+
+             Version gate: this sysctl only joined kubelet's safe-sysctl
+             allowlist in Kubernetes 1.27, and an older kubelet rejects the pod
+             outright with SysctlForbidden — strictly worse than the bug being
+             prevented. .Capabilities.KubeVersion is the *control plane*
+             version, but the allowlist is enforced by the kubelet on the node,
+             and the version skew policy lets a kubelet run up to three minor
+             versions behind kube-apiserver. So the gate is >=1.30: that is the
+             lowest control-plane version at which every kubelet the skew policy
+             permits is already >=1.27. Below it the chart renders exactly what
+             it rendered before this default existed. Note helm only knows the
+             real cluster version when it can reach the cluster — `helm
+             template` without --kube-version falls back to the helm binary's
+             built-in version, so pass --kube-version when rendering offline for
+             an older cluster.
+
+             Setting podSecurityContext.sysctls to any value, including [],
+             replaces this default entirely. merge's destination is a freshly
+             built dict, so .Values is never mutated. */}}
+      {{- $kubeMajorVersion := .Capabilities.KubeVersion.Major | trimSuffix "+" | int }}
+      {{- $kubeMinorVersion := .Capabilities.KubeVersion.Minor | trimSuffix "+" | int }}
+      {{- $sysctlSafe := or (gt $kubeMajorVersion 1) (and (eq $kubeMajorVersion 1) (ge $kubeMinorVersion 30)) }}
+      {{- $podSecurityContext := default (dict) .Values.podSecurityContext }}
+      {{- if and $sysctlSafe (not (hasKey $podSecurityContext "sysctls")) }}
+      {{- $reservedPorts := list (dict "name" "net.ipv4.ip_local_reserved_ports" "value" "46580,46581,50011") }}
+      {{- $podSecurityContext = merge (dict "sysctls" $reservedPorts) $podSecurityContext }}
+      {{- end }}
+      {{- with $podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1318,3 +1318,140 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "exec sky api start .*--host=::"
+
+  # Tests for the default net.ipv4.ip_local_reserved_ports sysctl.
+  # NOTE: helm-unittest renders with KubeVersion v1.20.0 unless a test sets
+  # `capabilities`, so the >=1.30 cases below MUST declare it explicitly.
+  # The gate is 1.30, not 1.27: the sysctl is allowlisted by the kubelet from
+  # 1.27, but the chart only sees the control plane version and the version
+  # skew policy lets a kubelet trail kube-apiserver by three minor versions.
+  - it: should reserve the API server listen ports via sysctl on Kubernetes >= 1.30
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: net.ipv4.ip_local_reserved_ports
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].value
+          value: "46580,46581,50011"
+      - lengthEqual:
+          path: spec.template.spec.securityContext.sysctls
+          count: 1
+
+  - it: should not render a pod securityContext at all on Kubernetes 1.29
+    # 1.29 is the skew boundary: a supported cluster here may still run 1.26
+    # kubelets, which reject the pod with SysctlForbidden.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should not render a pod securityContext at all on Kubernetes < 1.27
+    # Older kubelets reject the pod with SysctlForbidden, so these clusters
+    # must render exactly what they rendered before this default existed.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 26
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should keep a user-supplied podSecurityContext alongside the default sysctl
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      podSecurityContext:
+        runAsUser: 1000
+        fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: net.ipv4.ip_local_reserved_ports
+
+  - it: should render a user-supplied podSecurityContext unchanged below the gate
+    capabilities:
+      majorVersion: 1
+      minorVersion: 26
+    set:
+      podSecurityContext:
+        fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - notExists:
+          path: spec.template.spec.securityContext.sysctls
+
+  - it: should let a user-supplied sysctls override the default reservation
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      podSecurityContext:
+        sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "32768 46579"
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: net.ipv4.ip_local_port_range
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].value
+          value: "32768 46579"
+      - lengthEqual:
+          path: spec.template.spec.securityContext.sysctls
+          count: 1
+
+  - it: should let an unrelated user-supplied sysctl replace the default reservation
+    # Any sysctls value replaces the default wholesale, so a user tuning an
+    # unrelated sysctl drops the port reservation. Documented in values.yaml.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      podSecurityContext:
+        sysctls:
+          - name: net.core.somaxconn
+            value: "1024"
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: net.core.somaxconn
+      - lengthEqual:
+          path: spec.template.spec.securityContext.sysctls
+          count: 1
+
+  - it: should render no sysctls when podSecurityContext.sysctls is set to an empty list
+    # The knob-free opt-out for clusters with exotic admission policies.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      podSecurityContext:
+        sysctls: []
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.securityContext.sysctls
+          count: 0
+
+  - it: should still apply the default sysctl when podSecurityContext is explicitly null
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      podSecurityContext: null
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.sysctls[0].name
+          value: net.ipv4.ip_local_reserved_ports

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -696,6 +696,14 @@ slurmCredentials:
 extraInitContainers: null
 
 # Set securityContext for the api pod
+# On Kubernetes >= 1.30 the chart adds a default
+# `net.ipv4.ip_local_reserved_ports` sysctl covering the API server's listen
+# ports, so that other processes in the pod's network namespace cannot be
+# assigned them as ephemeral source ports (which makes the server fail to bind
+# with "Address already in use" until the pod is recreated). Setting `sysctls`
+# here — to any value, including `[]` — replaces that default. See the
+# `podSecurityContext` section of the Helm values reference for the version
+# gate, the offline-rendering caveat, and Pod Security Admission notes.
 # @schema type: [object, null]
 podSecurityContext: {}
 

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -2472,6 +2472,57 @@ Default: ``null``
 
 Security context for the API server pod. Usually left empty to use defaults. Refer to `set the security context for Pod <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod>`_ for more details.
 
+On Kubernetes 1.30 and later, the chart merges a default ``sysctls`` entry into
+this security context:
+
+.. code-block:: yaml
+
+  sysctls:
+    - name: net.ipv4.ip_local_reserved_ports
+      value: "46580,46581,50011"
+
+The ports are 46580 (the API server itself), 50011 (the multiprocessing queue
+manager), and 46581, reserved alongside them for the auxiliary listener that
+runs in the API server pod in some deployments. All three fall inside Linux's default
+ephemeral port range (``net.ipv4.ip_local_port_range``, ``32768-60999``), so
+another process in the pod's network namespace can be assigned one of them as an
+ephemeral source port. The API server then fails to bind with ``Address already
+in use`` and keeps failing across container restarts, because the network
+namespace outlives the container. Reserving the ports excludes them from
+automatic port assignment only; explicit binds are unaffected.
+
+Setting ``sysctls`` here replaces the default entirely, including when the entry
+you set is unrelated (such as ``net.core.somaxconn``) and including ``[]``, which
+is the way to opt out. All other keys you set are merged with the default rather
+than replacing it.
+
+Version gate and compatibility notes:
+
+- The sysctl only joined the kubelet's safe-sysctl allowlist in Kubernetes 1.27,
+  and an older kubelet rejects the pod with ``SysctlForbidden``. The chart can
+  only see the *control plane* version, while the allowlist is enforced by the
+  kubelet on the node, and the Kubernetes version skew policy allows a kubelet to
+  run up to three minor versions behind ``kube-apiserver``. The default is
+  therefore gated at 1.30, the lowest control plane version at which every
+  permitted kubelet is already 1.27 or newer. Below 1.30 nothing is added. If you
+  run 1.27-1.29 with all nodes on 1.27 or newer, you can set the ``sysctls``
+  entry above explicitly.
+- Helm only knows the real cluster version when it can reach the cluster.
+  ``helm install`` and ``helm upgrade`` do; ``helm template`` without
+  ``--kube-version`` falls back to the Helm binary's built-in version, which is
+  1.29 or newer. If you render manifests offline for a cluster older than 1.30,
+  pass ``--kube-version <your cluster version>``, otherwise the rendered pod
+  carries a sysctl the target kubelet may reject.
+- If the release namespace enforces Pod Security Admission with
+  ``pod-security.kubernetes.io/enforce-version`` pinned below ``v1.27``, the pod
+  is rejected with ``forbidden sysctls (net.ipv4.ip_local_reserved_ports)`` even
+  on a newer cluster, because the ``baseline`` and ``restricted`` profiles only
+  allowed this sysctl from v1.27. Set ``sysctls: []`` in that case, or unpin
+  ``enforce-version``.
+- Because the sysctl is part of the pod template, upgrading to the first chart
+  version that adds it replaces the API server pod once. Under the default
+  ``apiService.upgradeStrategy: Recreate`` that is a brief outage.
+
 Default: ``{}``
 
 .. code-block:: yaml


### PR DESCRIPTION
## Problem

The API server pod can end up in a permanent `CrashLoopBackOff` with

```
ERROR:    [Errno 98] Address already in use
```

while binding `0.0.0.0:46580` — even though nothing in the pod is listening on that port.

The cause is that 46580 sits *inside* Linux's default ephemeral port range (`net.ipv4.ip_local_port_range` = `32768 60999`). All containers in a pod share one network namespace, so any process in the pod that opens an outbound connection — a sidecar, a metrics scraper, the API server's own pre-bind calls out to a cloud or the Kubernetes API — can be handed 46580 as its ephemeral **source** port. Once that happens, the API server can no longer bind the wildcard address.

Two properties make this much worse than a transient race:

- **Restarting the container does not clear it.** The network namespace belongs to the pod sandbox, not to any container, so the conflicting socket survives every container restart. The container crash-loops until the *pod* itself is deleted.
- **`SO_REUSEADDR` does not rescue it.** uvicorn already sets `SO_REUSEADDR` on its bind. The conflicting socket does not set it and is not in `LISTEN`, so `inet_csk_bind_conflict` reports a conflict regardless.

### Socket-level signature

This is easy to misdiagnose as a stale listener, so it's worth recording the fingerprint. Reproduced against an `ESTABLISHED` outbound socket bound to a non-loopback local address and *not* listening:

```
connect() 127.0.0.1:<port>                                 -> ECONNREFUSED  (nothing is listening)
bind()    localhost:<port>  SO_REUSEADDR                   -> OK            (loopback is free)
bind()    0.0.0.0:<port>    SO_REUSEADDR                   -> EADDRINUSE (98)
bind()    0.0.0.0:<port>    SO_REUSEADDR|SO_REUSEPORT      -> EADDRINUSE (98)
```

No "a leftover server is still bound" hypothesis reproduces all of these at once — a listener would have answered the `connect()`, and would have failed the loopback bind. That combination is the fingerprint of an ephemeral *source*-port collision. Consistent with it: Linux hands even-numbered ports to `connect()` and odd-numbered ones to `bind(0)` (measured 400/400 each on 5.15), and 46580 is even.

## Fix

Reserve the pod's fixed listen ports from the kernel's automatic allocator, with a pod-level sysctl on the API server deployment:

```yaml
securityContext:
  sysctls:
    - name: net.ipv4.ip_local_reserved_ports
      value: "46580,46581,50011"
```

Per `Documentation/networking/ip-sysctl.rst`, reserved ports "will not be used by automatic port assignments (e.g. when calling connect() or bind() with port number 0). Explicit port allocation behavior is unchanged." That is exactly the property needed: the allocator skips these ports while our own explicit `bind()` still succeeds.

The ports are 46580 (the API server), 50011 (the multiprocessing queue manager, `sky/server/requests/queues/mp_queue.py`), and 46581, reserved alongside them for an auxiliary listener that runs in this pod in some deployments. All three fall inside `32768-60999`. Ports outside that range (metrics on 9090, oauth2-proxy on 4180, redis on 6379) are not stealable this way and need no reservation.

The sysctl is deliberately **pod-level**: `sysctls` is a field of `PodSecurityContext` only. That is also what makes it correct — it applies to the pod sandbox's network namespace, so it covers every container in the pod (including sidecars, which is where the conflicting connection typically lives) and is in force before any container starts. It also survives container restarts, verified on a live cluster.

## Why this is gated on Kubernetes >= 1.30

`net.ipv4.ip_local_reserved_ports` joined kubelet's **safe sysctl** allowlist in Kubernetes 1.27. On an older kubelet, without `--allowed-unsafe-sysctls`, the pod is admitted by the API server and then rejected by the *node* with `SysctlForbidden`.

That failure mode is worse than it sounds, and it's why the gate is conservative. Because the pod `CREATE` succeeds, the ReplicaSet never observes a create failure and never backs off — it just keeps replacing the rejected pod. Measured against a real 1.26.15 kubelet: **424 `Failed` pods in 171s (~2.5/s and still climbing)**, with the Deployment stuck at `0/1 AVAILABLE`. That is a hard outage plus an API-server/etcd churn loop — strictly worse than the intermittent crash-loop this change prevents.

The chart declares no `kubeVersion` and the docs claim support back to v1.20, so an unconditional sysctl would hand that to those users. The gate therefore has to be safe, and 1.27 is *not* safe: the chart can only see the **control plane** version through `.Capabilities`, while the allowlist is enforced by the **kubelet on each node**, and the [version skew policy](https://kubernetes.io/releases/version-skew-policy/) permits a kubelet to trail `kube-apiserver` by three minor versions. A 1.27 control plane may legally have 1.24 kubelets.

**1.30 is the lowest control plane version at which every kubelet the skew policy permits is already >= 1.27.** Below it, the chart renders byte-identical output to before this PR.

Operators on 1.27–1.29 whose nodes are all >= 1.27 can opt in by setting the `sysctls` entry explicitly.

No new values knob is introduced — Helm already knows the cluster version, and the escape hatch already exists.

## Overriding / opting out

`podSecurityContext` is the override, and a user-supplied `sysctls` wins:

```yaml
# replace the reservation
podSecurityContext:
  sysctls:
    - name: net.ipv4.ip_local_port_range
      value: "32768 46579"

# or opt out entirely
podSecurityContext:
  sysctls: []
```

The check is `hasKey`, not truthiness, specifically so `sysctls: []` is honored as an opt-out instead of silently falling back to the default (an empty list is falsy in Go templates). Other keys — `runAsUser`, `fsGroup`, … — merge with the default rather than replacing it.

Note the trade-off this implies, which is intentional but worth knowing: setting `sysctls` for an *unrelated* reason (say `net.core.somaxconn`) replaces the reservation wholesale and reopens the exposure. It's documented in `values.yaml` and pinned by a test.

## Known caveats

- **Offline `helm template`.** Without `--kube-version`, Helm falls back to the binary's built-in version (1.29 on Helm 3.14, 1.34 on 3.19). On Helm 3.19 a manifest rendered offline and applied to a pre-1.30 cluster still carries the sysctl. `helm install`/`upgrade` and anything rendering against a live cluster see the real version. Pass `--kube-version` when rendering offline for an older cluster.
- **PSA `enforce-version` pins.** A namespace pinning `pod-security.kubernetes.io/enforce-version` below `v1.27` rejects the pod even on a new cluster, since `baseline`/`restricted` only allowed this sysctl from v1.27. Use `sysctls: []` there, or unpin.
- **One pod replacement on upgrade.** The sysctl is part of the pod template, so the first upgrade carrying it replaces the API server pod once. Under the default `apiService.upgradeStrategy: Recreate` that is a brief restart.

## Testing

- 9 new cases in `charts/skypilot/tests/deployment_test.yaml`: sysctl present at >= 1.30; nothing rendered at 1.29 and at 1.26; merge with a user-supplied `podSecurityContext`; user context rendered unchanged below the gate; user `sysctls` overrides; an unrelated user sysctl replaces the default; `sysctls: []` opts out; `podSecurityContext: null` still works.
- `helm lint` + `helm unittest`: **8 suites, 161 tests pass**, on both Helm 3.19 and the CI-pinned Helm 3.14 + helm-unittest commit.
- **No-op proof below the gate**: rendered before/after at `--kube-version` 1.20.0 / 1.24.0 / 1.26.0 / 1.26.15 / 1.29.0 across `podSecurityContext` combinations (unset, populated, explicitly null, `sysctls: []`) — byte-identical. At and above 1.30 the only delta in the entire rendered chart is the 4-line `securityContext`/`sysctls` block.
- **Real-world version strings** exercised, since build suffixes parse as semver prereleases: `v1.30.5-gke.1443001` (on), `v1.29.8-eks-a737599` (off), `v1.28.9-aliyun.1` (off), `v1.27.16+rke2r1` (off).
- **Mutation-tested** rather than trusting a green run: dropping the version gate, inverting merge precedence, changing the port list, and dropping the `with` guard each turn the suite red.
- **Live cluster (v1.34.4)**: the rendered `securityContext` is admitted; `/proc/sys/net/ipv4/ip_local_reserved_ports` carries all three ports in *both* containers of the pod; the reservation survives a container restart (`restartCount=1`); the allocator never hands out a reserved port across many `connect()`/`bind(0)` calls; an explicit `bind()+listen()` on `0.0.0.0:46580` still succeeds; `ip_local_port_range` is untouched.

## Follow-up (not in this PR)

`sky api start` currently fail-fast-checks the port by binding `localhost`, which passes in exactly this scenario — so the real failure only surfaces minutes later, at the uvicorn bind, after full server init. Binding the actual serve address instead, and logging the `/proc/net/tcp` entry for the port on `EADDRINUSE`, would turn a multi-minute mystery into a one-line diagnosis. Worth doing separately.

-Claude
