### PR TITLE
[Slurm] Fail fast when a task exits nonzero

### DIFF
--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -289,12 +289,13 @@ def main():
                                            stream_logs=True,
                                            streaming_prefix=prefix)
 
-    # For multi-node Slurm jobs (one task per node), we need to wait for all
-    # tasks to complete before any task exits, because Slurm's proctrack/cgroup
-    # kills all processes in a task's cgroup when that task's main process
-    # exits. If one task exits early, child processes (e.g., Ray workers) get
-    # killed even while other tasks are still running.
-    # This ensures all tasks wait until every task has completed before exiting.
+    # For successful tasks in multi-node Slurm jobs (one task per node), wait
+    # for all tasks to complete before exiting, because Slurm's
+    # proctrack/cgroup kills all processes in a task's cgroup when that task's
+    # main process exits. If one task exits early, child processes (e.g., Ray
+    # workers) get killed even while other tasks are still running. Failed
+    # tasks must exit immediately so srun's --kill-on-bad-exit can terminate
+    # the other tasks.
     # Only needed when proctrack/cgroup is enabled.
     # https://slurm.schedmd.com/cgroups.html#proctrack
     # Use the shared filesystem home for cross-node coordination.
@@ -303,8 +304,8 @@ def main():
     shared_home = (args.cluster_home_dir
                    if args.cluster_home_dir else os.path.expanduser('~'))
 
-    if num_nodes > 1 and not args.is_setup and _is_proctrack_cgroup_enabled(
-            shared_home):
+    if (returncode == 0 and num_nodes > 1 and not args.is_setup and
+            _is_proctrack_cgroup_enabled(shared_home)):
         slurm_job_id = os.environ['SLURM_JOB_ID']
         slurm_step_id = os.environ['SLURM_STEP_ID']
         run_done_dir = os.path.join(

--- a/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
+++ b/tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py
@@ -229,3 +229,36 @@ def test_barrier_leaves_the_done_directory_in_place(tmp_path, monkeypatch):
     assert exit_info.value.code == 0
     assert run_done_dir.is_dir(), 'the barrier directory was removed'
     assert sorted(p.name for p in run_done_dir.iterdir()) == ['0', '1']
+
+
+def test_failed_task_skips_barrier(tmp_path, monkeypatch):
+    cluster_home = tmp_path / 'cluster_home'
+    cluster_home.mkdir()
+    (cluster_home / constants.SLURM_PROCTRACK_TYPE_FILE).write_text('cgroup')
+    log_dir = tmp_path / 'logs'
+    log_dir.mkdir()
+
+    monkeypatch.setenv('SLURM_PROCID', '1')
+    monkeypatch.setenv('SLURM_NNODES', '3')
+    monkeypatch.setenv('SLURM_JOB_ID', '42')
+    monkeypatch.setenv('SLURM_STEP_ID', '7')
+    monkeypatch.setattr(slurm, '_get_ip_address', lambda: '10.0.0.2')
+    monkeypatch.setattr(slurm, '_get_job_node_ips',
+                        lambda: '10.0.0.1\n10.0.0.2\n10.0.0.3')
+    monkeypatch.setattr(slurm, 'run_bash_command_with_log', lambda *a, **kw: 1)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError('failed task entered the completion barrier')
+
+    monkeypatch.setattr(slurm, '_wait_for_all_ranks', fail_if_called)
+    monkeypatch.setattr(sys, 'argv', [
+        'slurm.py', '--script', 'exit 1', '--log-dir',
+        str(log_dir), '--cluster-num-nodes', '3', '--cluster-ips',
+        '10.0.0.1,10.0.0.2,10.0.0.3', '--cluster-home-dir',
+        str(cluster_home)
+    ])
+
+    with pytest.raises(SystemExit) as exit_info:
+        slurm.main()
+
+    assert exit_info.value.code == 1


### PR DESCRIPTION
## Summary

- Skip Slurm's run-completion barrier when a task exits nonzero.
- Preserve the barrier for successful multi-node tasks using `proctrack/cgroup`.
- Add regression coverage ensuring failed tasks exit immediately.

## Problem

On Slurm clusters using `proctrack/cgroup`, each task waits for every rank's completion marker before exiting. If one rank's user command fails while peers continue running, the failed task remains in the barrier instead of returning its nonzero status to `srun`.

Consequently, `srun --kill-on-bad-exit` cannot terminate the remaining tasks and the job can hang indefinitely.

## Test plan

- `pytest tests/unit_tests/test_sky/skylet/executor/test_slurm_executor.py -n0`
  - 8 passed.
- Ran `format.sh` on both changed files.
  - mypy passed.
  - pylint: 10.00/10.
  - Dashboard lint passed.
- Started a local API server from the modified checkout and launched the existing three-node failure task on a `proctrack/cgroup` Slurm cluster.
  - Rank 1 exited with code 1.
  - Slurm immediately cancelled the step and terminated ranks 0 and 2.
  - SkyPilot marked the job `FAILED` and returned code 100.
  - Confirmed no `sleep 10000` process remained on any allocated node.
