### PR TITLE
[API] GC stale per-task YAML files on the API server

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -5,6 +5,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
+import itertools
 import os
 import pathlib
 import shutil
@@ -1356,6 +1357,54 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
                 f'older than {retention_seconds} seconds')
 
 
+async def clean_stale_client_task_yamls(retention_seconds: int) -> None:
+    """Delete stale per-task YAML files under the client directories.
+
+    ``sky.server.common.process_mounts_in_task_on_api_server`` persists two
+    YAML files per submitted task under
+    ``~/.sky/api_server/clients/<user_hash>/``: the original task in
+    ``tasks/<task_id>.yaml`` and the translated task in
+    ``<task_id>_translated.yaml``. Both are read back right after being
+    written and are only kept for debugging afterwards, but nothing deletes
+    them while the server is running, so a long-running API server
+    accumulates two files per submitted task indefinitely. Age them out with
+    the same retention that is applied to the request records they were
+    created for.
+
+    Args:
+        retention_seconds: Files whose mtime is older than this many seconds
+            will be deleted.
+    """
+    cutoff = time.time() - retention_seconds
+
+    def _clean() -> int:
+        clients_dir = server_common.API_SERVER_CLIENT_DIR.expanduser()
+        if not clients_dir.exists():
+            return 0
+        deleted = 0
+        for user_dir in clients_dir.iterdir():
+            if not user_dir.is_dir():
+                continue
+            yaml_paths = itertools.chain(user_dir.glob('*_translated.yaml'),
+                                         user_dir.glob('tasks/*.yaml'))
+            for path in yaml_paths:
+                try:
+                    if path.stat().st_mtime < cutoff:
+                        path.unlink()
+                        deleted += 1
+                except OSError:
+                    # Best-effort: the file may be deleted concurrently, e.g.
+                    # by the GC of another API server instance sharing the
+                    # same client directory.
+                    pass
+        return deleted
+
+    deleted = await asyncio.to_thread(_clean)
+    if deleted:
+        logger.info(f'Cleaned up {deleted} stale task YAML files older than '
+                    f'{retention_seconds} seconds')
+
+
 async def requests_gc_daemon():
     """Garbage collect finished requests periodically."""
     while True:
@@ -1369,6 +1418,7 @@ async def requests_gc_daemon():
             # Negative value disables the requests GC
             if retention_seconds >= 0:
                 await clean_finished_requests_with_retention(retention_seconds)
+                await clean_stale_client_task_yamls(retention_seconds)
         except asyncio.CancelledError:
             logger.info('Requests GC daemon cancelled')
             break

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import os
 import pathlib
 import time
 from typing import List, Optional
@@ -492,6 +493,49 @@ async def test_clean_finished_requests_with_retention_all_statuses(
     mock_logger.info.assert_called_once()
     log_message = mock_logger.info.call_args[0][0]
     assert 'Cleaned up 3 finished requests' in log_message
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_client_task_yamls(tmp_path):
+    """Test that stale per-task YAMLs are deleted and fresh ones are kept."""
+    clients_dir = tmp_path / 'clients'
+    user_dir = clients_dir / 'test-user'
+    tasks_dir = user_dir / 'tasks'
+    tasks_dir.mkdir(parents=True)
+    file_mounts_dir = user_dir / 'file_mounts'
+    file_mounts_dir.mkdir()
+
+    old_translated = user_dir / 'old-task_translated.yaml'
+    old_task = tasks_dir / 'old-task.yaml'
+    recent_translated = user_dir / 'recent-task_translated.yaml'
+    recent_task = tasks_dir / 'recent-task.yaml'
+    # File mounts have their own reference-aware GC and must not be touched
+    # here, regardless of age.
+    old_file_mount = file_mounts_dir / 'old-file-mount.yaml'
+
+    for path in (old_translated, old_task, recent_translated, recent_task,
+                 old_file_mount):
+        path.write_text('run: echo hi')
+    old_mtime = time.time() - 7200
+    for path in (old_translated, old_task, old_file_mount):
+        os.utime(path, (old_mtime, old_mtime))
+
+    with mock.patch('sky.server.common.API_SERVER_CLIENT_DIR', clients_dir):
+        await requests.clean_stale_client_task_yamls(retention_seconds=3600)
+
+    assert not old_translated.exists()
+    assert not old_task.exists()
+    assert recent_translated.exists()
+    assert recent_task.exists()
+    assert old_file_mount.exists()
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_client_task_yamls_missing_dir(tmp_path):
+    """Test that a missing clients directory is a no-op, not an error."""
+    with mock.patch('sky.server.common.API_SERVER_CLIENT_DIR',
+                    tmp_path / 'nonexistent'):
+        await requests.clean_stale_client_task_yamls(retention_seconds=3600)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extends the requests GC daemon to clean up the per-task YAML files that `process_mounts_in_task_on_api_server` persists under `~/.sky/api_server/clients/<user_hash>/` — the original task in `tasks/<task_id>.yaml` and the translated task in `<task_id>_translated.yaml`.

Both files are read back immediately after being written and are only kept for debugging afterwards (see the comment in `sky/server/common.py`), but nothing deletes them while the server is running — they are only wiped by `reset_on_startup()`. A long-running API server therefore accumulates two small files per submitted task indefinitely, and on deployments where the clients directory lives on persistent storage (e.g. the helm chart mounts it on the state volume when using `RollingUpdate`), they survive restarts as well and grow without bound.

This PR ages them out by mtime in the hourly requests GC daemon, reusing `api_server.requests_retention_hours` (default 24h) so these debugging artifacts live exactly as long as the request records and logs they belong to. A negative retention still disables the GC entirely, as before. File mounts are deliberately untouched: their lifecycle is already owned by the reference-aware blob GC (`cleanup_unreferenced_file_mounts`).

An mtime TTL is used (rather than tying deletion to request completion) because the files are named by a standalone `task_id` UUID with no link to a `request_id`. Since both files are consumed within the same function call that writes them, any TTL ≥ 1h is safe. Deletion is best-effort and tolerates concurrent deletion by another server instance sharing the client directory.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Added `test_clean_stale_client_task_yamls` (stale YAMLs deleted; fresh YAMLs and `file_mounts/` contents kept) and `test_clean_stale_client_task_yamls_missing_dir` (missing clients dir is a no-op). Full `tests/unit_tests/test_sky/server/requests/test_requests.py`: 72 passed.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJcjGWerAvibJp8qs8XW2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01W94iVRm6AM32VpA8madjHP)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->