### PR TITLE
Redact auth logs in query params and header

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -271,9 +271,9 @@ class SkyServeController:
             return responses.JSONResponse(
                 status_code=500,
                 content={
-                    'message':
-                        (f'Failed method {request.method} at URL {request.url}.'
-                         f' Exception message is {exc!r}.')
+                    'message': (f'Failed method {request.method} at URL '
+                                f'{request.url.path}.'
+                                f' Exception message is {exc!r}.')
                 },
             )
 

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -203,9 +203,11 @@ class SkyServeLoadBalancer:
                 headers=proxy_response.headers,
                 background=background.BackgroundTask(background_func))
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.error(f'Error when proxy request to {url}: '
-                         f'{common_utils.format_exception(e)}'
-                         f'\nTraceback: {traceback.format_exc()}')
+            error = serve_utils.redact_urls(common_utils.format_exception(e))
+            formatted_traceback = serve_utils.redact_urls(
+                traceback.format_exc())
+            logger.error(f'Error when proxy request to {url}: {error}'
+                         f'\nTraceback: {formatted_traceback}')
             return e
 
     async def _proxy_with_retries(

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -6,6 +6,7 @@ import typing
 from typing import Any, Dict, List, Optional
 
 from sky import sky_logging
+from sky.serve import serve_utils
 
 if typing.TYPE_CHECKING:
     import fastapi
@@ -18,11 +19,15 @@ DEFAULT_LB_POLICY = None
 
 
 def _request_repr(request: 'fastapi.Request') -> str:
-    return ('<Request '
-            f'method="{request.method}" '
-            f'url="{request.url}" '
-            f'headers={dict(request.headers)} '
-            f'query_params={dict(request.query_params)}>')
+    return (
+        '<Request '
+        f'method="{request.method}" '
+        # Do not include the query string in the URL: it may contain a
+        # secret even when the parameter name is not available here.
+        f'url="{request.url.path}" '
+        f'headers={serve_utils.redact_request_fields(request.headers)} '
+        f'query_params='
+        f'{serve_utils.redact_request_fields(request.query_params)}>')
 
 
 class LoadBalancingPolicy:

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -17,6 +17,8 @@ import traceback
 import typing
 from typing import (Any, Callable, DefaultDict, Deque, Dict, Iterator, List,
                     Mapping, Optional, Set, TextIO, Type, Union)
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 import uuid
 
 import colorama
@@ -33,6 +35,7 @@ from sky.jobs import state as managed_job_state
 from sky.serve import constants
 from sky.serve import serve_state
 from sky.serve import spot_placer
+from sky.server import common as server_common
 from sky.skylet import constants as skylet_constants
 from sky.skylet import job_lib
 from sky.utils import annotations
@@ -74,6 +77,31 @@ def redact_request_fields(fields: Mapping[str, Any]) -> Dict[str, Any]:
               if _SENSITIVE_REQUEST_FIELD_PATTERN.search(str(key)) else value)
         for key, value in fields.items()
     }
+
+
+_HTTP_URL_PATTERN = re.compile(r'https?://[^\s\'\"]+')
+
+
+def redact_urls(text: str) -> str:
+    """Remove query strings and fragments from HTTP URLs in text.
+
+    This is used for exception messages, which can contain an httpx request
+    URL even when the request itself was not logged.
+    """
+
+    def _redact_url(match: re.Match[str]) -> str:
+        url = match.group(0)
+        suffix = ''
+        while url and url[-1] in '.,;:!?)]}':
+            suffix = url[-1] + suffix
+            url = url[:-1]
+        url = server_common.redact_url_password(url)
+        parsed = urlsplit(url)
+        redacted = urlunsplit(
+            (parsed.scheme, parsed.netloc, parsed.path, '', ''))
+        return redacted + suffix
+
+    return _HTTP_URL_PATTERN.sub(_redact_url, text)
 
 
 # Retry settings for cross-pod controller HTTP calls. The DB row update of

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -16,7 +16,7 @@ import time
 import traceback
 import typing
 from typing import (Any, Callable, DefaultDict, Deque, Dict, Iterator, List,
-                    Optional, Set, TextIO, Type, Union)
+                    Mapping, Optional, Set, TextIO, Type, Union)
 import uuid
 
 import colorama
@@ -58,6 +58,23 @@ else:
     requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
+
+# Request headers and query parameters are user-controlled.  In particular,
+# serving requests commonly carry bearer tokens or API keys, so they must not
+# be included verbatim in controller/load-balancer logs.
+_SENSITIVE_REQUEST_FIELD_PATTERN = re.compile(
+    r'(?:authorization|auth|cookie|credential|password|secret|token|'
+    r'api[-_]?key|proxy[-_]?authorization)', re.IGNORECASE)
+
+
+def redact_request_fields(fields: Mapping[str, Any]) -> Dict[str, Any]:
+    """Redact sensitive request header or query parameter values."""
+    return {
+        key: ('<redacted>'
+              if _SENSITIVE_REQUEST_FIELD_PATTERN.search(str(key)) else value)
+        for key, value in fields.items()
+    }
+
 
 # Retry settings for cross-pod controller HTTP calls. The DB row update of
 # `controller_ip` is atomic w.r.t. controller readiness (sky.serve.service

--- a/tests/unit_tests/test_load_balancing_policies.py
+++ b/tests/unit_tests/test_load_balancing_policies.py
@@ -1,0 +1,29 @@
+from starlette.requests import Request
+
+from sky.serve import load_balancing_policies
+
+
+def test_request_repr_redacts_sensitive_fields():
+    request = Request({
+        'type': 'http',
+        'method': 'GET',
+        'path': '/v1/generate',
+        'query_string': (b'prompt=hello&api_key=query-secret'),
+        'headers': [
+            (b'authorization', b'Bearer header-secret'),
+            (b'x-request-id', b'request-id'),
+        ],
+        'scheme': 'https',
+        'server': ('localhost', 443),
+        'client': ('127.0.0.1', 1234),
+        'root_path': '',
+        'http_version': '1.1',
+    })
+
+    result = load_balancing_policies._request_repr(request)
+
+    assert 'header-secret' not in result
+    assert 'query-secret' not in result
+    assert "'authorization': '<redacted>'" in result
+    assert "'x-request-id': 'request-id'" in result
+    assert 'url="/v1/generate"' in result

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -33,6 +33,15 @@ def test_redact_request_fields():
     }
 
 
+def test_redact_urls():
+    text = ('Request URL: https://user:password@example.com/generate?'
+            'api_key=query-secret&prompt=hello (retrying)')
+
+    assert serve_utils.redact_urls(text) == (
+        'Request URL: https://user:<redacted>@example.com/generate '
+        '(retrying)')
+
+
 def test_task_fits():
     # Test exact fit.
     task_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -15,6 +15,24 @@ _SIGNAL_FILE_CONST = (
     'sky.jobs.constants.JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE')
 
 
+def test_redact_request_fields():
+    fields = {
+        'Authorization': 'Bearer secret-token',
+        'X-Api-Key': 'secret-api-key',
+        'Cookie': 'session=secret-cookie',
+        'X-Request-ID': 'request-id',
+        'query': 'safe-value',
+    }
+
+    assert serve_utils.redact_request_fields(fields) == {
+        'Authorization': '<redacted>',
+        'X-Api-Key': '<redacted>',
+        'Cookie': '<redacted>',
+        'X-Request-ID': 'request-id',
+        'query': 'safe-value',
+    }
+
+
 def test_task_fits():
     # Test exact fit.
     task_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())


### PR DESCRIPTION
This PR adds a log redaction, specifically in the load balancer to prevent sensitive header leakages.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->