### PR TITLE
[Test] container-logs: don't require cluster-scoped pod list

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2022,6 +2022,53 @@ def test_volume_not_ready_on_kubernetes():
 
 # ---------- Container logs from task on Kubernetes ----------
 
+_POD_COLUMNS = ('--no-headers -o custom-columns="NS:.metadata.namespace,'
+                'NAME:.metadata.name,'
+                'CLUSTER:.metadata.annotations.skypilot-cluster-name"')
+
+
+def _set_cluster_pods(name):
+    """Shell snippet setting `$all_pods` to the `NS NAME CLUSTER` rows.
+
+    Rows are selected by an exact match on the `skypilot-cluster-name`
+    annotation rather than a substring grep on the pod name, because a
+    substring also matches the `-cloud-cmd` helper pod and any same-prefixed
+    leftover from another run.
+
+    `smoke_tests_utils.run_cloud_cmd_on_cluster` dispatches these commands to
+    one of two places, and kubectl runs with a different identity in each:
+
+    - against a local API server, the command runs verbatim on the test
+      machine, against the local kubeconfig. That credential is typically
+      cluster-wide, but its default namespace is whatever the kubeconfig
+      context says, which need not be the namespace SkyPilot placed the pods
+      in (a `kubernetes.namespace` override, or a workspace-scoped namespace).
+      Only a cluster-scoped list is guaranteed to find them.
+
+    - on a `--remote-server` run, the command goes through `sky exec` into the
+      cloud-cmd pod, where kubectl authenticates as the least-privilege
+      `skypilot-service-account`. That account has full access within its own
+      namespace -- which is the namespace the cluster's pods are in, so a
+      namespace-scoped list finds them -- but no cluster-scoped access to
+      pods, so `kubectl get pods -A` is rejected outright::
+
+        pods is forbidden: User
+        "system:serviceaccount:<ns>:skypilot-service-account" cannot list
+        resource "pods" in API group "" at the cluster scope
+
+    So neither form works in both places: `-A` is the only one that reliably
+    finds the pods in the first case, and the only one that is refused in the
+    second. Hence namespace-scoped first, widening to `-A` only when that
+    returned nothing. Errors are discarded on both attempts -- a denied or
+    empty lookup just leaves `$all_pods` empty and the caller's retry loop
+    tries again.
+    """
+    get = f'kubectl get pods -l skypilot-cluster-name {_POD_COLUMNS}'
+    match = f'awk -v n="{name}" \'$3==n\''
+    return (f'all_pods=$({get} 2>/dev/null | {match}); '
+            f'if [ -z "$all_pods" ]; then '
+            f'all_pods=$({get} -A 2>/dev/null | {match}); fi')
+
 
 def _check_container_logs(name, logs, total_lines, count, timeout=60):
     """Check if the container logs contain the expected number of logging lines.
@@ -2077,29 +2124,19 @@ done
 def test_container_logs_multinode_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
-    # -A + a label selector + exact match on the skypilot-cluster-name
-    # annotation (not a substring grep on the pod name): the pods may not
-    # be in kubectl's default namespace (e.g. a workspace-scoped
-    # namespace), so a bare `kubectl get pods` can silently return
-    # nothing; and -A widens the search to every namespace, so a
-    # substring match risks picking up a same-named leftover pod from
-    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
-    # exactly one pod, but plain xargs concatenates every matching
-    # "-n ns pod" line into a single invocation.
-    list_pods = ('kubectl get pods -A -l skypilot-cluster-name --no-headers '
-                 '-o custom-columns="NS:.metadata.namespace,'
-                 'NAME:.metadata.name,'
-                 'CLUSTER:.metadata.annotations.skypilot-cluster-name"')
+    # xargs -r -L1 (not plain xargs): kubectl logs takes exactly one pod, but
+    # plain xargs concatenates every matching pod into a single invocation,
+    # and -r skips the call entirely when nothing matched.
     head_logs = (
-        f'all_pods=$({list_pods}); echo "$all_pods"; '
-        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
+        f'{_set_cluster_pods(name)}; echo "$all_pods"; '
+        'echo "$all_pods" | '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" | '
         'grep head | '
         """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
     worker_logs = (
-        f'all_pods=$({list_pods}); echo "$all_pods"; '
-        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | grep worker | '
+        f'{_set_cluster_pods(name)}; echo "$all_pods"; '
+        'echo "$all_pods" | grep worker | '
         """ awk '{print "-n " $1 " " $2}' | xargs -r -L1 kubectl logs""")
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test = smoke_tests_utils.Test(
@@ -2124,22 +2161,12 @@ def test_container_logs_multinode_kubernetes():
 def test_container_logs_two_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml'
-    # -A + a label selector + exact match on the skypilot-cluster-name
-    # annotation (not a substring grep on the pod name): the pods may not
-    # be in kubectl's default namespace (e.g. a workspace-scoped
-    # namespace), so a bare `kubectl get pods` can silently return
-    # nothing; and -A widens the search to every namespace, so a
-    # substring match risks picking up a same-named leftover pod from
-    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
-    # exactly one pod, but plain xargs concatenates every matching
-    # "-n ns pod" line into a single invocation.
+    # xargs -r -L1 (not plain xargs): kubectl logs takes exactly one pod, but
+    # plain xargs concatenates every matching pod into a single invocation,
+    # and -r skips the call entirely when nothing matched.
     pod_logs = (
-        'all_pods=$(kubectl get pods -A -l skypilot-cluster-name '
-        '--no-headers -o custom-columns="NS:.metadata.namespace,'
-        'NAME:.metadata.name,'
-        'CLUSTER:.metadata.annotations.skypilot-cluster-name"); '
-        'echo "$all_pods"; '
-        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
+        f'{_set_cluster_pods(name)}; echo "$all_pods"; '
+        'echo "$all_pods" | '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" | '
         'grep head |'
@@ -2167,22 +2194,12 @@ def test_container_logs_two_jobs_kubernetes():
 def test_container_logs_two_simultaneous_jobs_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
     task_yaml = 'tests/test_yamls/test_k8s_logs.yaml '
-    # -A + a label selector + exact match on the skypilot-cluster-name
-    # annotation (not a substring grep on the pod name): the pods may not
-    # be in kubectl's default namespace (e.g. a workspace-scoped
-    # namespace), so a bare `kubectl get pods` can silently return
-    # nothing; and -A widens the search to every namespace, so a
-    # substring match risks picking up a same-named leftover pod from
-    # another run. xargs -r -L1 (not plain xargs): kubectl logs takes
-    # exactly one pod, but plain xargs concatenates every matching
-    # "-n ns pod" line into a single invocation.
+    # xargs -r -L1 (not plain xargs): kubectl logs takes exactly one pod, but
+    # plain xargs concatenates every matching pod into a single invocation,
+    # and -r skips the call entirely when nothing matched.
     pod_logs = (
-        'all_pods=$(kubectl get pods -A -l skypilot-cluster-name '
-        '--no-headers -o custom-columns="NS:.metadata.namespace,'
-        'NAME:.metadata.name,'
-        'CLUSTER:.metadata.annotations.skypilot-cluster-name"); '
-        'echo "$all_pods"; '
-        f'echo "$all_pods" | awk -v n="{name}" \'$3==n\' | '
+        f'{_set_cluster_pods(name)}; echo "$all_pods"; '
+        'echo "$all_pods" | '
         # Exclude the cloud cmd execution pod.
         'grep -v "cloud-cmd" | '
         'grep head |'


### PR DESCRIPTION
## What regressed

#10420 (`65b950f70`, merged Aug 11) changed how the three container-logs Kubernetes smoke
tests find their pods:

```diff
-'all_pods=$(kubectl get pods); ...'
+'all_pods=$(kubectl get pods -A -l skypilot-cluster-name ...); ...'
```

The nightly `--remote-server --kubernetes` lane went red on the first run that contained it, and
has failed deterministically since:

| Nightly | Commit | Contains `65b950f70`? | Result |
|---|---|---|---|
| Aug 11 | `80c9be26` | no | pass |
| — | **`65b950f70` merges** | — | — |
| Aug 12 | `654f1c60` | yes | **fail** — all 3 container-logs tests |

Confirmed with `git merge-base --is-ancestor 65b950f70 <commit>`: no for `80c9be26`, yes for
`654f1c60`. The three tests failed identically across three retries each, so this is not a flake.

## Why `-A` cannot work here

These commands run **inside the cloud-cmd pod** via `sky exec`, where kubectl authenticates as
the least-privilege `skypilot-service-account`. Per `sky/templates/kubernetes-ray.yml.j2`:

- the namespaced Role `skypilot-service-account-role` grants `apiGroups/resources/verbs: ["*"]`
  — so a namespace-scoped `kubectl get pods` works;
- the `ClusterRole` `skypilot-service-account-cluster-role` grants cluster scope only for
  `nodes`, `namespaces`, `clusterroles`/`clusterrolebindings`, `runtimeclasses` and
  `ingressclasses` — **`pods` is deliberately not in it**.

`-A` turns the namespace-scoped list into a cluster-scoped one, which that account may never
issue, so every iteration of the check loop is rejected:

```
Error from server (Forbidden): pods is forbidden: User
"system:serviceaccount:<ns>:skypilot-service-account" cannot list resource "pods"
in API group "" at the cluster scope
```

…until the loop gives up:

```
Waiting for container logs to be ready...   (x12)
Timeout after 60 seconds waiting for container logs
```

The workload under test was fine throughout — both `sky launch` jobs finished `SUCCEEDED` and
the container logs were written correctly. Only the test's own verification command was
unauthorized.

**Why it passes in some environments:** where the caller holds cluster-wide read, `-A` is
allowed. That is the case on a cluster-admin credential, and the difference is why the plain
`--kubernetes` lane stayed green on the exact commit where `--remote-server` failed. Any
deployment using a least-privilege service account — what
`sky/utils/kubernetes/generate_kubeconfig.sh` produces without `SUPER_USER=1` — hits the failure
on every run.

## Fix

Look the pods up **namespace-scoped first, and widen to `-A` only when that came back empty**.

Simply reverting to a bare `kubectl get pods` was rejected as an option: it would trade one
broken case for another, re-breaking the case `-A` was added for. The combinations:

| Identity | Pods' namespace | `-A` only (today) | plain revert | this PR |
|---|---|---|---|---|
| least-privilege SA | kubectl's default | ❌ Forbidden | ✅ | ✅ |
| cluster-wide read | kubectl's default | ✅ | ✅ | ✅ |
| cluster-wide read | another namespace | ✅ | ❌ finds nothing | ✅ |
| least-privilege SA | another namespace | ❌ Forbidden | ❌ Forbidden | ❌ |

- least-privilege account, pods in its own namespace — the namespace-scoped list is permitted
  and finds them; the `-A` retry is never reached;
- cluster-wide read, pods in another namespace — the namespace-scoped list finds nothing and the
  `-A` retry finds them.

Errors are discarded on both attempts, so a denied or empty lookup just leaves `$all_pods` empty
and the existing retry loop tries again. The namespace is carried through to
`kubectl logs -n <ns> <pod>`, so the log fetch stays correct in the cross-namespace case.

The last row is out of reach and must be: a least-privilege account holds no rights in the other
namespace, so no in-pod query can read those pods. That would need an RBAC change or a host-side
kubectl, not a different query.

Behaviour otherwise preserved from #10420: the `-l skypilot-cluster-name` label selector, the
exact match on the `skypilot-cluster-name` annotation instead of a substring grep on the pod
name (a substring also matches the `-cloud-cmd` helper pod and same-prefixed leftovers), and
`xargs -r -L1` so `kubectl logs` runs once per pod and not at all on empty input. The command
was identical in all three tests, so it is hoisted into one helper.

## Testing

The generated shell was run against a fake `kubectl` simulating each row of the table above. The
helper is loaded out of the test file itself, so this exercises the real code rather than a copy:

```
[OK ] least-priv SA, pods in own ns      -> LOGS_FROM ns=default pod=t-foo-head-abc
[OK ] broad identity, pods in default ns -> LOGS_FROM ns=default pod=t-foo-head-abc
[OK ] broad identity, pods in another ns -> LOGS_FROM ns=team-a  pod=t-foo-head-abc
[OK ] least-priv SA, pods in another ns  -> (nothing, as expected)
```

The fixture also covers the selector's edge cases: a same-prefixed cluster (`t-foobar`) and the
`-cloud-cmd` helper pod are both correctly excluded.

Both lanes pass, on the head commit:

| Lane | Command | Result |
|---|---|---|
| least-privilege (the lane that regressed) | `pytest tests/smoke_tests/test_cluster_job.py -k test_container_logs --kubernetes --remote-server` | ✅ 3/3 |
| cluster-admin | `pytest tests/smoke_tests/test_cluster_job.py -k test_container_logs --kubernetes` | ✅ 3/3 |

The second lane matters as a guard: it is the one that exercises the `-A` fallback, so it would
catch a regression of the case #10420 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
