### PR TITLE
[API] Redact the basic-auth password at the remaining URL display sites

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -232,8 +232,11 @@ def _get_kubernetes_hint(reason: str,
     if '{dashboard_url}' in hint:
         try:
             starting_page = (f'infra/{context}' if context else 'infra')
-            dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(), starting_page=starting_page)
+            # Substituted into a user-facing hint, so mask any basic-auth
+            # password in the URL.
+            dashboard_url = server_common.redact_url_password(
+                server_common.get_dashboard_url(server_common.get_server_url(),
+                                                starting_page=starting_page))
         except Exception:  # pylint: disable=broad-except
             dashboard_url = 'the SkyPilot dashboard infra page'
         hint = hint.replace('{dashboard_url}', dashboard_url)

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1516,9 +1516,12 @@ def launch(
                                        follow=True)
         cluster_dashboard_url = None
         if not server_common.is_api_server_local():
-            cluster_dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(),
-                starting_page=f'clusters/{handle.get_cluster_name()}')
+            # This URL is only printed as a hint, so mask any basic-auth
+            # password in it. Use `sky dashboard` to open it in a browser.
+            cluster_dashboard_url = server_common.redact_url_password(
+                server_common.get_dashboard_url(
+                    server_common.get_server_url(),
+                    starting_page=f'clusters/{handle.get_cluster_name()}'))
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.CLUSTER_JOB,
                                            job_id, handle.get_cluster_name(),
@@ -5948,8 +5951,10 @@ def jobs_launch(
                                                 controller=False)
         job_dashboard_url = None
         if not server_common.is_api_server_local():
-            job_dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(), starting_page=f'jobs/{job_id}')
+            # Printed as a hint only; mask any basic-auth password.
+            job_dashboard_url = server_common.redact_url_password(
+                server_common.get_dashboard_url(server_common.get_server_url(),
+                                                starting_page=f'jobs/{job_id}'))
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.MANAGED_JOB,
                                            job_id=str(job_id),
@@ -5974,8 +5979,10 @@ def jobs_launch(
             else:
                 starting_page = 'jobs'
                 show_jobs_label = 'Show all jobs:'
-            dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(), starting_page=starting_page)
+            # Printed as a hint only; mask any basic-auth password.
+            dashboard_url = server_common.redact_url_password(
+                server_common.get_dashboard_url(server_common.get_server_url(),
+                                                starting_page=starting_page))
             dashboard_hint = (f'\n{ux_utils.INDENT_SYMBOL}{show_jobs_label}'
                               f'\t\t{ux_utils.BOLD}{dashboard_url}'
                               f'{ux_utils.RESET_BOLD}')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2795,12 +2795,13 @@ def api_start(
     if not is_local_api_server:
         server_url = server_common.get_server_url()
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'Unable to start local API server: '
-                             f'server endpoint is set to {server_url}. '
-                             'To start a local API server, remove the endpoint '
-                             'from the config file and/or unset the '
-                             'SKYPILOT_API_SERVER_ENDPOINT environment '
-                             'variable.')
+            raise ValueError(
+                f'Unable to start local API server: server endpoint is set to '
+                f'{server_common.redact_url_password(server_url)}. '
+                'To start a local API server, remove the endpoint '
+                'from the config file and/or unset the '
+                'SKYPILOT_API_SERVER_ENDPOINT environment '
+                'variable.')
     server_common.check_server_healthy_or_start_fn(deploy, host, foreground,
                                                    metrics, metrics_port,
                                                    enable_basic_auth)
@@ -2809,7 +2810,7 @@ def api_start(
         logger.info('API server is already running:')
     api_server_url = server_common.get_server_url(host)
     logger.info(f'{ux_utils.INDENT_SYMBOL}SkyPilot API server and dashboard: '
-                f'{api_server_url}\n'
+                f'{server_common.redact_url_password(api_server_url)}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}'
                 f'View API server logs at: {constants.API_SERVER_LOGS}')
     local_port = server_common.get_local_api_server_port()
@@ -2835,8 +2836,9 @@ def api_stop() -> None:
     if not server_common.is_api_server_local():
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
-                f'Cannot kill the API server at {server_url} because it is not '
-                f'the default SkyPilot API server started locally.')
+                'Cannot kill the API server at '
+                f'{server_common.redact_url_password(server_url)} because it '
+                'is not the default SkyPilot API server started locally.')
 
     # Acquire the api server creation lock to prevent multiple processes from
     # stopping and starting the API server at the same time.
@@ -3141,8 +3143,10 @@ def api_login(endpoint: Optional[str] = None,
         """Show the logged in message."""
         if server_status != server_common.ApiServerStatus.HEALTHY:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Cannot log in API server at '
-                                 f'{endpoint} (status: {server_status.value})')
+                raise ValueError(
+                    'Cannot log in API server at '
+                    f'{server_common.redact_url_password(endpoint)} '
+                    f'(status: {server_status.value})')
 
         identity_info = f'\n{ux_utils.INDENT_SYMBOL}{colorama.Fore.GREEN}User: '
         if user:
@@ -3194,7 +3198,8 @@ def api_login(endpoint: Optional[str] = None,
         except exceptions.ApiServerConnectionError as e:
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(
-                    f'Failed to connect to API server at {endpoint}: {e}'
+                    'Failed to connect to API server at '
+                    f'{server_common.redact_url_password(endpoint)}: {e}'
                 ) from e
         except Exception as e:  # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -663,7 +663,10 @@ def dashboard(starting_page: Optional[str] = None) -> None:
     api_server_url = server_common.get_server_url()
     url = server_common.get_dashboard_url(api_server_url,
                                           starting_page=starting_page)
-    logger.info(f'Opening dashboard in browser: {url}')
+    # The browser needs the real URL for basic auth to complete, but the log
+    # line is just for the user to read, so mask the password there.
+    logger.info('Opening dashboard in browser: '
+                f'{server_common.redact_url_password(url)}')
     common_utils.open_browser(url)
 
 
@@ -3151,9 +3154,11 @@ def api_login(endpoint: Optional[str] = None,
                 identity_info += user_id
         else:
             identity_info = ''
-        dashboard_msg = f'Dashboard: {dashboard_url}'
+        dashboard_msg = (
+            f'Dashboard: {server_common.redact_url_password(dashboard_url)}')
         click.secho(
-            f'Logged into SkyPilot API server at: {endpoint}'
+            'Logged into SkyPilot API server at: '
+            f'{server_common.redact_url_password(endpoint)}'
             f'{identity_info}'
             f'\n{ux_utils.INDENT_LAST_SYMBOL}{colorama.Fore.GREEN}'
             f'{dashboard_msg}',

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -692,9 +692,9 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
                                     latest_version=latest_version)
         if api_version is None or version is None or commit is None:
             server_url = endpoint if endpoint is not None else get_server_url()
-            logger.warning(f'API server response missing '
-                           f'version info. {server_url} may '
-                           f'not be running SkyPilot API server.')
+            logger.warning('API server response missing version info. '
+                           f'{redact_url_password(server_url)} may '
+                           'not be running SkyPilot API server.')
             server_info.status = ApiServerStatus.UNHEALTHY
         version_info = versions.check_compatibility_at_client(response.headers)
         if version_info is None:
@@ -840,7 +840,8 @@ def _start_api_server(deploy: bool = False,
     with rich_utils.client_status('Starting SkyPilot API server, '
                                   f'view logs at {constants.API_SERVER_LOGS}'):
         logger.info(f'{colorama.Style.DIM}Failed to connect to '
-                    f'SkyPilot API server at {server_url}. '
+                    'SkyPilot API server at '
+                    f'{redact_url_password(server_url)}. '
                     'Starting a local server.'
                     f'{colorama.Style.RESET_ALL}')
         if not is_api_server_local():

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -782,8 +782,8 @@ def get_request_id(response: 'requests.Response') -> RequestId[T]:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
                 'Failed to get request ID from SkyPilot API server at '
-                f'{get_server_url()}. Response: {response.status_code} '
-                f'{response.text}')
+                f'{redact_url_password(get_server_url())}. '
+                f'Response: {response.status_code} {response.text}')
     return RequestId[T](request_id)
 
 
@@ -844,8 +844,9 @@ def _start_api_server(deploy: bool = False,
                     'Starting a local server.'
                     f'{colorama.Style.RESET_ALL}')
         if not is_api_server_local():
-            raise RuntimeError(f'Cannot start API server: {get_server_url()} '
-                               'is not a local URL')
+            raise RuntimeError(
+                'Cannot start API server: '
+                f'{redact_url_password(get_server_url())} is not a local URL')
 
         # At this point, we cannot reliably tell if we will be using
         # consolidation mode, because that requires accessing the db

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -820,6 +820,26 @@ def test_redact_url_password_non_url_is_unchanged():
     assert common.redact_url_password('') == ''
 
 
+def test_redact_url_password_masks_dashboard_urls():
+    """Dashboard URLs inherit the endpoint's credentials, so display sites
+    that print them must redact.
+
+    get_dashboard_url() itself keeps the password on purpose -- `sky dashboard`
+    hands the real URL to the browser so basic auth still completes. Only the
+    printed form is masked, and the /dashboard path must survive.
+    """
+    dashboard_url = common.get_dashboard_url(
+        server_url='https://user:s3cr3t@example.com:8080',
+        starting_page='clusters/my-cluster')
+    # The constructor keeps credentials (the browser needs them)...
+    assert 's3cr3t' in dashboard_url
+    # ...and the printed form does not.
+    redacted = common.redact_url_password(dashboard_url)
+    assert 's3cr3t' not in redacted
+    assert redacted == ('https://user:<redacted>@example.com:8080'
+                        '/dashboard/clusters/my-cluster')
+
+
 def test_redact_url_password_bad_port_is_returned_unchanged():
     """A malformed port must not raise, even with a password present.
 


### PR DESCRIPTION
Follow-up to #10286, which added `redact_url_password()` and used it on the `sky check` and `sky api info` banners.

The same credentialed URL still gets printed in a number of other places, so an agent subprocess can still pick the password up. The most visible one is the dashboard link in the `sky launch` / `sky jobs launch` end summary, which @taxfree-python called out in #9529.

What this covers:

- the cluster and managed-job dashboard hints in `sky/client/cli/command.py`
- the "Show all jobs" hint in the same file
- the provision-failure hint that substitutes `{dashboard_url}` in `sky/backends/cloud_vm_ray_backend.py`
- `sky api login` output, both the endpoint line and the dashboard line, in `sky/client/sdk.py`
- the "Opening dashboard in browser" log line
- two API-server error messages in `sky/server/common.py`

What I left alone, and why:

`get_dashboard_url()` still returns the URL with credentials in it. `sky dashboard` passes that straight to the browser so basic auth completes without the user typing anything, and there is already a test asserting the credentials survive. The SSH ProxyCommand needs the real URL too. Only the strings we print are masked.

One implementation note: the redaction happens at the call sites rather than inside `ux_utils.command_hint_messages`, which would have been the tidier spot. `sky/server/common.py` already imports `ux_utils`, so importing it back the other way would be a circular import.

Testing:

- [x] Code formatting: yapf, isort, pylint all pass (pylint 10.00/10). mypy is clean on the files it covers; `sdk.py` and `cloud_vm_ray_backend.py` are not in `tests/mypy_files.txt` and their existing errors also show up on an unmodified master.
- [x] Unit tests: `pytest tests/unit_tests/test_sky/server/test_common.py -k "redact or dashboard_url"`, 8 passing. Added a case covering the dashboard URL specifically: the constructor keeps the password, the printed form masks it, and the `/dashboard/...` path survives.
- [ ] Smoke tests: not applicable, this only changes printed strings.

Happy to adjust the scope if you'd rather some of these stay verbatim.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->