### PR TITLE
[API] Process client task YAMLs in memory

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -20,7 +20,6 @@ from typing import (Any, Callable, cast, Dict, Generic, List, Literal, Optional,
                     Tuple, TypeVar, Union)
 import urllib.parse
 from urllib.request import Request
-import uuid
 
 import cachetools
 import click
@@ -1172,16 +1171,7 @@ def process_mounts_in_task_on_api_server(
 
     user_hash = env_vars.get(constants.USER_ID_ENV_VAR, 'unknown')
 
-    # We should not use int(time.time()) as there can be multiple requests at
-    # the same second.
-    task_id = str(uuid.uuid4().hex)
     client_dir = (API_SERVER_CLIENT_DIR.expanduser().resolve() / user_hash)
-    client_task_dir = client_dir / 'tasks'
-    client_task_dir.mkdir(parents=True, exist_ok=True)
-
-    client_task_path = client_task_dir / f'{task_id}.yaml'
-    client_task_path.write_text(task)
-
     client_file_mounts_dir = client_dir / 'file_mounts'
     client_file_mounts_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1198,7 +1188,7 @@ def process_mounts_in_task_on_api_server(
         return str(file_mounts_base /
                    file_mounts_mapping[original_path].lstrip('/'))
 
-    task_configs = yaml_utils.read_yaml_all(str(client_task_path))
+    task_configs = yaml_utils.read_yaml_all_str(task)
     for task_config in task_configs:
         if task_config is None:
             continue
@@ -1247,13 +1237,8 @@ def process_mounts_in_task_on_api_server(
                         tls[key] = _get_client_file_mounts_path(
                             tls[key], file_mounts_mapping)
 
-    # We can switch to using string, but this is to make it easier to debug, by
-    # persisting the translated task yaml file.
-    translated_client_task_path = client_dir / f'{task_id}_translated.yaml'
-    yaml_utils.dump_yaml(str(translated_client_task_path), task_configs)
-
-    dag = dag_utils.load_dag_from_yaml(str(translated_client_task_path))
-    return dag
+    translated_task = yaml_utils.dump_yaml_str(task_configs)
+    return dag_utils.load_dag_from_yaml_str(translated_task)
 
 
 def api_server_user_logs_dir_prefix(

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -632,6 +632,7 @@ def test_process_mounts_removes_file_mounts_mapping(tmp_path, monkeypatch):
     task is submitted again (e.g., in jobs scenarios).
     """
     from sky.skylet import constants as skylet_constants
+    from sky.utils import dag_utils
     from sky.utils import yaml_utils
 
     # Mock the API_SERVER_CLIENT_DIR to use tmp_path
@@ -663,19 +664,8 @@ run: python /remote/script.py
                                                       env_vars=env_vars,
                                                       workdir_only=False)
 
-    # Find the translated YAML file
-    user_hash = 'test-user'
-    client_dir = api_server_dir / user_hash
-
-    # Find the translated file (it has _translated.yaml suffix)
-    translated_files = list(client_dir.glob('**/*_translated.yaml'))
-    assert len(translated_files) == 1, \
-        f'Expected 1 translated file, found {len(translated_files)}'
-
-    translated_file = translated_files[0]
-
-    # Read the translated YAML and verify file_mounts_mapping is removed
-    translated_configs = yaml_utils.read_yaml_all(str(translated_file))
+    translated_yaml = dag_utils.dump_dag_to_yaml_str(dag)
+    translated_configs = yaml_utils.read_yaml_all_str(translated_yaml)
 
     for task_config in translated_configs:
         if task_config is None:
@@ -701,6 +691,8 @@ run: python /remote/script.py
                     if isinstance(source, str):
                         assert 'uploaded/' in source, \
                             f'file_mount source should be translated: {source}'
+
+    assert not list(api_server_dir.rglob('*.yaml'))
 
 
 def test_process_mounts_without_mapping(tmp_path, monkeypatch):
@@ -733,6 +725,7 @@ run: echo "hello world"
     # Verify the dag was created successfully
     assert dag is not None
     assert len(dag.tasks) == 1
+    assert not list(api_server_dir.rglob('*.yaml'))
 
 
 def _fake_response(status_code, json_body=None, json_raises=False):


### PR DESCRIPTION
Supersedes [#10430](https://github.com/skypilot-org/skypilot/pull/10430).

## Summary

- Parse the submitted task YAML directly from its string.
- Load the translated task DAG from its serialized string.
- Stop creating original and translated task YAML artifacts under `~/.sky/api_server/clients/<user_hash>/`.

## Why

#10430 proposed retaining the existing file-backed flow and periodically deleting old YAMLs by scanning every client directory and calling `stat()` on each match. Testing that approach against an API server's RWX PVC with approximately 24,000 YAML files showed that iterating the two globs took about 97 ms, while the full glob plus per-file `stat()` loop took 24.3 seconds median. Every API server replica would independently repeat that metadata walk against the shared filesystem.

The files are only intermediates for YAML parsing. SkyPilot already provides string-based equivalents for each operation, so this PR removes the source of the accumulation instead of adding a permanent filesystem GC. In a pod-side analog benchmark, the existing file-backed flow took 38.3 ms/request median and the string-backed flow took 10.8 ms/request median, with identical serialized DAG output.

## Test plan

- `python -m pytest -n0 tests/unit_tests/test_sky/server/test_common.py::test_process_mounts_removes_file_mounts_mapping tests/unit_tests/test_sky/server/test_common.py::test_process_mounts_without_mapping` (`2 passed`)
- `bash format.sh --files sky/server/common.py tests/unit_tests/test_sky/server/test_common.py` (YAPF and isort completed; mypy passed; pylint exited on existing warnings in `test_common.py`)
- Compared the current file-backed path with the proposed string-backed operations inside an API server pod for simple and mapped tasks; serialized DAG outputs matched, and the string-backed analog created no task YAML files.
