### PR TITLE
fix(slurm): surface invalid GPU partition mappings

### DIFF
--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -322,6 +322,9 @@ class Slurm(clouds.Cloud):
             try:
                 sit = slurm_utils.SlurmInstanceType.from_instance_type(
                     instance_type)
+            except ValueError:
+                pass
+            else:
                 if sit.accelerator_type is not None:
                     mapped = slurm_utils.lookup_gpu_partition_map(
                         cluster, sit.accelerator_type)
@@ -342,6 +345,14 @@ class Slurm(clouds.Cloud):
                                                f'gpu_partition_map or omit '
                                                f'the partition from --infra.'
                                                f'{colorama.Style.RESET_ALL}')
+                            elif region is not None and available:
+                                live_partitions = sorted(available)
+                                raise ValueError(
+                                    f'None of the partitions {mapped} in '
+                                    f'gpu_partition_map for accelerator '
+                                    f'{sit.accelerator_type!r} exist on '
+                                    f'cluster {cluster!r}. Available '
+                                    f'partitions: {live_partitions}.')
                             else:
                                 logger.warning(f'{colorama.Fore.YELLOW}'
                                                f'gpu_partition_map maps '
@@ -378,8 +389,6 @@ class Slurm(clouds.Cloud):
                                 f'on cluster {cluster!r}. Please '
                                 f'double-check the partition name.'
                                 f'{colorama.Style.RESET_ALL}')
-            except ValueError:
-                pass
 
             # TODO(kevin): Batch this check to reduce number of roundtrips.
             for partition in partitions_to_check:

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -345,14 +345,6 @@ class Slurm(clouds.Cloud):
                                                f'gpu_partition_map or omit '
                                                f'the partition from --infra.'
                                                f'{colorama.Style.RESET_ALL}')
-                            elif region is not None and available:
-                                live_partitions = sorted(available)
-                                raise ValueError(
-                                    f'None of the partitions {mapped} in '
-                                    f'gpu_partition_map for accelerator '
-                                    f'{sit.accelerator_type!r} exist on '
-                                    f'cluster {cluster!r}. Available '
-                                    f'partitions: {live_partitions}.')
                             else:
                                 logger.warning(f'{colorama.Fore.YELLOW}'
                                                f'gpu_partition_map maps '
@@ -639,7 +631,9 @@ class Slurm(clouds.Cloud):
                 zone=resources.zone,
                 resources=resources)
             if not available_regions:
-                return resources_utils.FeasibleResources([], [], None)
+                hint = self._gpu_partition_map_hint(resources.instance_type,
+                                                    resources.region)
+                return resources_utils.FeasibleResources([], [], hint)
 
             # Return a single resource without region set.
             # The optimizer will call make_launchables_for_valid_region_zones()
@@ -711,11 +705,47 @@ class Slurm(clouds.Cloud):
             zone=resources.zone,
             resources=resources)
         if not available_regions:
-            hint = self._get_memory_hint(resources)
+            hint = (self._gpu_partition_map_hint(chosen_instance_type,
+                                                 resources.region) or
+                    self._get_memory_hint(resources))
             return resources_utils.FeasibleResources([], [], hint)
 
         return resources_utils.FeasibleResources(_make([chosen_instance_type]),
                                                  [], None)
+
+    @staticmethod
+    def _gpu_partition_map_hint(instance_type: str,
+                                region: Optional[str]) -> Optional[str]:
+        """Return a hint when a pinned cluster's gpu_partition_map maps the
+        requested accelerator only to partitions that do not exist there.
+
+        Returning a hint instead of raising keeps other ``any_of``/``ordered``
+        resource candidates eligible; the optimizer only surfaces the hint
+        when no candidate is feasible.
+        """
+        if region is None:
+            return None
+        try:
+            sit = slurm_utils.SlurmInstanceType.from_instance_type(
+                instance_type)
+        except ValueError:
+            return None
+        if sit.accelerator_type is None:
+            return None
+        mapped = slurm_utils.lookup_gpu_partition_map(region,
+                                                      sit.accelerator_type)
+        if mapped is None:
+            return None
+        try:
+            live_partitions = sorted(slurm_utils.get_partitions(region))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to get partitions for {region}: {e}')
+            return None
+        if not live_partitions or any(p in live_partitions for p in mapped):
+            return None
+        return (f'None of the partitions {mapped} in gpu_partition_map for '
+                f'accelerator {sit.accelerator_type!r} exist on cluster '
+                f'{region!r}. Available partitions: {live_partitions}.')
 
     @staticmethod
     def _get_memory_hint(resources: 'resources_lib.Resources') -> Optional[str]:

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+import re
 from unittest.mock import patch
 import unittest.mock as mock
 
@@ -307,16 +308,41 @@ class TestRegionsWithOfferingPartitionMap:
     @patch.object(slurm_cloud.Slurm,
                   'existing_allowed_clusters',
                   new=mock.Mock(return_value=['cluster-a']))
-    def test_fixed_region_partition_mismatch_raises(self):
-        with pytest.raises(
-                ValueError,
-                match='gpu_partition_map.*H100.*cluster-a.*cpu.*live-gpu'):
-            slurm_cloud.Slurm.regions_with_offering(
-                instance_type='64CPU--256GB--H100:1',
-                accelerators=None,
-                use_spot=False,
-                region='cluster-a',
-                zone=None)
+    def test_fixed_region_partition_mismatch_returns_no_regions(self):
+        regions = slurm_cloud.Slurm.regions_with_offering(
+            instance_type='64CPU--256GB--H100:1',
+            accelerators=None,
+            use_spot=False,
+            region='cluster-a',
+            zone=None)
+
+        assert regions == []
+
+    @patch('sky.clouds.slurm.slurm_utils.lookup_gpu_partition_map',
+           new=mock.Mock(return_value=['configured-gpu']))
+    @patch('sky.clouds.slurm.slurm_utils.get_partitions',
+           new=mock.Mock(return_value=['live-gpu', 'cpu']))
+    @patch.object(slurm_cloud.Slurm,
+                  'existing_allowed_clusters',
+                  new=mock.Mock(return_value=['cluster-a']))
+    def test_fixed_region_partition_mismatch_surfaces_hint(self):
+        """The diagnostic must flow through the FeasibleResources hint, not
+        an exception, so other any_of/ordered candidates stay eligible."""
+        resources = mock.MagicMock(unsafe=True)
+        resources.instance_type = '64CPU--256GB--H100:1'
+        resources.region = 'cluster-a'
+        resources.zone = None
+        resources.use_spot = False
+        resources.is_launchable.return_value = True
+        resources.get_required_cloud_features.return_value = set()
+
+        feasible = slurm_cloud.Slurm()._get_feasible_launchable_resources(
+            resources)
+
+        assert feasible.resources_list == []
+        assert re.search(
+            r"gpu_partition_map.*'H100'.*'cluster-a'.*cpu.*live-gpu",
+            feasible.hint)
 
     @patch('sky.clouds.slurm.slurm_utils.check_instance_fits',
            new=mock.Mock(return_value=(True, None)))

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -297,6 +297,50 @@ class TestCheckInstanceFits:
             assert reason is None
 
 
+class TestRegionsWithOfferingPartitionMap:
+    """Test configured partition validation against live partitions."""
+
+    @patch('sky.clouds.slurm.slurm_utils.lookup_gpu_partition_map',
+           new=mock.Mock(return_value=['configured-gpu']))
+    @patch('sky.clouds.slurm.slurm_utils.get_partitions',
+           new=mock.Mock(return_value=['live-gpu', 'cpu']))
+    @patch.object(slurm_cloud.Slurm,
+                  'existing_allowed_clusters',
+                  new=mock.Mock(return_value=['cluster-a']))
+    def test_fixed_region_partition_mismatch_raises(self):
+        with pytest.raises(
+                ValueError,
+                match='gpu_partition_map.*H100.*cluster-a.*cpu.*live-gpu'):
+            slurm_cloud.Slurm.regions_with_offering(
+                instance_type='64CPU--256GB--H100:1',
+                accelerators=None,
+                use_spot=False,
+                region='cluster-a',
+                zone=None)
+
+    @patch('sky.clouds.slurm.slurm_utils.check_instance_fits',
+           new=mock.Mock(return_value=(True, None)))
+    @patch('sky.clouds.slurm.slurm_utils.lookup_gpu_partition_map',
+           new=mock.Mock(return_value=['gpu']))
+    @patch('sky.clouds.slurm.slurm_utils.get_partitions',
+           new=mock.Mock(side_effect=lambda cluster: {
+               'cluster-a': ['cpu'],
+               'cluster-b': ['gpu'],
+           }[cluster]))
+    @patch.object(slurm_cloud.Slurm,
+                  'existing_allowed_clusters',
+                  new=mock.Mock(return_value=['cluster-a', 'cluster-b']))
+    def test_unspecified_region_continues_after_partition_mismatch(self):
+        regions = slurm_cloud.Slurm.regions_with_offering(
+            instance_type='64CPU--256GB--H100:1',
+            accelerators=None,
+            use_spot=False,
+            region=None,
+            zone=None)
+
+        assert [region.name for region in regions] == ['cluster-b']
+
+
 class TestLookupGpuPartitionMap:
     """Test slurm_utils.lookup_gpu_partition_map()."""
 


### PR DESCRIPTION
Surface invalid `gpu_partition_map` entries directly when a task pins one Slurm cluster. Preserve fallback across clusters when no cluster is pinned.

## Summary

- Raise a concrete error containing configured and live partition names for a fixed-cluster mismatch.

## Refs

- Follow-up to #9237.

Tested (run the relevant ones):

- [x] Code formatting: `PATH="$PWD/.venv/bin:$PATH" bash format.sh`
- [x] New focused tests: `.venv/bin/python -m pytest -n 0 -o addopts='' tests/unit_tests/test_sky/clouds/test_slurm.py::TestRegionsWithOfferingPartitionMap -q`
- [x] Slurm unit suite: `.venv/bin/python -m pytest -n 0 -o addopts='' tests/unit_tests/test_sky/clouds/test_slurm.py -q`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)