### PR TITLE
[API] Validate the client-supplied user id before it becomes a cluster owner

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -30,6 +30,7 @@ import time
 import typing
 from typing import Any, Callable, Dict, Generator, List, Optional, TextIO, Tuple
 
+import fastapi
 import psutil
 import setproctitle
 
@@ -1070,6 +1071,23 @@ async def prepare_request_async(
         # Fallback to legacy environment variable based identity if no
         # authentication is set.
         user_id = request_body.env_vars[constants.USER_ID_ENV_VAR]
+        # This identity comes straight from the client and is stored as the
+        # owner of any cluster the request creates, so reject a malformed one
+        # here. A well-formed id is an invariant elsewhere in the codebase
+        # (controller_utils asserts it), and a client that somehow persisted a
+        # corrupted ~/.sky/user_hash would otherwise create clusters owned by
+        # an identity that matches no user and can never be filtered back to
+        # them. See #9621. get_user_hash() regenerates a valid id on the
+        # client, so a healthy client never trips this.
+        # Skipped for system requests, whose id is replaced below anyway.
+        if (not is_skypilot_system and
+                not common_utils.is_valid_user_hash(user_id)):
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Invalid user id: {user_id!r}. Remove '
+                '~/.sky/user_hash (a new one is generated automatically) or '
+                f'unset {constants.USER_ID_ENV_VAR} if it is set to an '
+                'invalid value.')
     if is_skypilot_system:
         user_id = constants.SKYPILOT_SYSTEM_USER_ID
         global_user_state.add_or_update_user(

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -10,9 +10,11 @@ import time
 from typing import List
 from unittest import mock
 
+import fastapi
 import pytest
 
 from sky import exceptions
+from sky import models
 from sky import skypilot_config
 from sky.server import config as server_config
 from sky.server import constants as server_constants
@@ -1451,3 +1453,68 @@ def test_saturating_request_executor_does_not_block_auth():
             except Exception:  # pylint: disable=broad-except
                 pass
         _reset_thread_executors()
+
+
+class TestClientUserIdValidation:
+    """The client-supplied user id is validated before it becomes an owner.
+
+    Regression tests for #9621: a corrupted ~/.sky/user_hash used to be stored
+    verbatim as a cluster's owner, producing an identity that matches no user.
+    """
+
+    def _body(self, user_id: str) -> payloads.RequestBody:
+        body = payloads.RequestBody()
+        body.env_vars[constants.USER_ID_ENV_VAR] = user_id
+        body.env_vars[constants.USER_ENV_VAR] = 'someone'
+        return body
+
+    async def _prepare(self, user_id: str, auth_user=None):
+        # Everything after the identity check needs the requests DB, which is
+        # not what these tests are about.
+        with mock.patch.object(executor.api_requests,
+                               'create_if_not_exists_async',
+                               new=mock.AsyncMock(return_value=True)), \
+             mock.patch.object(executor.workspace_access,
+                               'for_current_request',
+                               return_value=None), \
+             mock.patch.object(pathlib.Path, 'touch'):
+            return await executor.prepare_request_async(
+                request_id='req-9621',
+                request_name='test.identity',
+                request_body=self._body(user_id),
+                func=lambda: None,
+                schedule_type=requests_lib.ScheduleType.SHORT,
+                auth_user=auth_user)
+
+    @pytest.mark.asyncio
+    async def test_malformed_user_id_is_rejected(self):
+        """The '%' from the issue must not reach the request record."""
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await self._prepare('abc%123')
+        assert exc_info.value.status_code == 400
+        assert 'Invalid user id' in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_user_id_is_rejected(self):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await self._prepare('')
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_valid_user_id_passes_through(self):
+        request = await self._prepare('abcdef12')
+        assert request.user_id == 'abcdef12'
+
+    @pytest.mark.asyncio
+    async def test_service_account_id_still_accepted(self):
+        """Service-account ids use hyphens and must keep working."""
+        request = await self._prepare('sa-abc123-token-xyz')
+        assert request.user_id == 'sa-abc123-token-xyz'
+
+    @pytest.mark.asyncio
+    async def test_authenticated_identity_bypasses_client_value(self):
+        """With auth on, the server's identity wins and the bad client value
+        is overwritten rather than rejected."""
+        auth_user = models.User(id='authuser1', name='auth-user')
+        request = await self._prepare('bad%id', auth_user=auth_user)
+        assert request.user_id == 'authuser1'


### PR DESCRIPTION
Closes #9621.

When no authentication is configured, `prepare_request_async` takes the user id straight out of the request body and stores it as the owner of whatever the request creates:

```python
else:
    # Fallback to legacy environment variable based identity if no
    # authentication is set.
    user_id = request_body.env_vars[constants.USER_ID_ENV_VAR]
```

The reporter had a stray `%` in `~/.sky/user_hash`, so their clusters ended up owned by an identity that matches no real user, and the owner filter in `get_clusters()` could never associate those clusters back with them.

A well-formed id is already treated as an invariant everywhere else. `common_utils.get_user_hash()` regenerates one on the client when the file is corrupt (that has been there since #5486), and `controller_utils` asserts `is_valid_user_hash()`. The API boundary was the one place that trusted the value, and `is_valid_user_hash` appeared nowhere under `sky/server/` or `sky/users/`.

This rejects a malformed id with a 400 that tells the user how to fix it. A healthy client never trips it, since `get_user_hash()` only ever returns a valid id.

Two paths are deliberately left alone:

- SkyPilot system requests, whose id is replaced with `SKYPILOT_SYSTEM_USER_ID` on the next line anyway.
- The authenticated path, where the server already overrides the client value with the authenticated identity.

One note on the issue title. As far as I can tell clusters are not scoped per-user in the first place: `StatusBody` defaults to `all_users=True`, `sky status` shows a USER column, and access is scoped by workspace. So other workspace members seeing the cluster looks like intended behavior, and the real defect is that an invalid identity could be persisted as an owner at all. Happy to be corrected if I have the model wrong.

If you would rather this fall back to a server-generated id instead of returning a 400, that is a small change and I am glad to switch it.

Testing:

- [x] Code formatting: yapf, isort, pylint pass (pylint 10.00/10).
- [x] Unit tests: `pytest tests/unit_tests/test_sky/server/requests/test_executor.py -k ClientUserIdValidation`, 5 cases covering a malformed id, an empty id, a normal id, a service-account id (`sa-...`, which uses hyphens and must keep working), and the authenticated override still winning over a bad client value.
- [x] `test_workspace_access.py` and `test_payloads.py` still pass (39 tests), since they exercise the same request-preparation path.
- [ ] Smoke tests: not run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->