### PR TITLE
feat(slurm): support host path volume mounts

### DIFF
--- a/agent/skills/skypilot/references/yaml-spec.md
+++ b/agent/skills/skypilot/references/yaml-spec.md
@@ -1042,7 +1042,8 @@ See Nested SkyPilot from managed jobs for details.
 
 ### ``volumes``
 
-SkyPilot supports managing persistent and ephemeral volumes for tasks or jobs on Kubernetes clusters. Refer to volumes on Kubernetes for more details.
+SkyPilot supports managed persistent and ephemeral volumes on Kubernetes, plus host path bind mounts for Slurm containers.
+Refer to volumes on Kubernetes for managed volume details.
 
 Example:
 
@@ -1053,8 +1054,27 @@ volumes:
   # Ephemeral volume
   /mnt/cache:
     size: 100Gi
-
 ```
+
+For Slurm tasks using Pyxis/Enroot, mount an existing absolute host path directly:
+
+```yaml
+resources:
+  cloud: slurm
+  image_id: docker:ubuntu:24.04
+
+volumes:
+  /data:
+    host_path: /shared/datasets
+    mode: ro  # Optional; defaults to ro. Use rw for a writable mount.
+```
+
+Host and container paths must use safe POSIX path characters.
+Host paths may contain simple environment variable expansions such as `$SLURM_JOB_ID`.
+
+Administrators can also declare cluster-wide binds applied to every containerized job; see
+slurm.container_mounts.
+
 
 
 ### ``file_mounts``

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -150,6 +150,8 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`gpu_partition_map <config-yaml-slurm-gpu-partition-map>`:
       H100: h100-partition
     :ref:`cpu_partition <config-yaml-slurm-cpu-partition>`: cpu-batch
+    :ref:`container_mounts <config-yaml-slurm-container-mounts>`:
+      /datasets: /shared/datasets
     :ref:`cluster_configs <config-yaml-slurm-cluster-configs>`:
       mycluster1:
         submit_as_user: true
@@ -2394,6 +2396,37 @@ Example:
 using the ``config:`` block in a task YAML. Per-cluster values override
 global values.
 
+.. _config-yaml-slurm-container-mounts:
+
+``slurm.container_mounts``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Host path bind mounts applied to every containerized (Pyxis/Enroot) Slurm job
+(optional).
+
+Each entry maps a container path to either a host path string, mounted
+read-only, or a mapping with ``host_path`` and an optional ``mode``
+(``ro``, the default, or ``rw``).
+
+Jobs without a container image ignore these mounts. If a task YAML
+:ref:`volume <yaml-spec-new-volumes>` binds the same container path, the task
+YAML entry wins.
+
+Example:
+
+.. code-block:: yaml
+
+  slurm:
+    container_mounts:
+      /datasets: /shared/datasets
+      /scratch:
+        host_path: /nvme/$SLURM_JOB_ID
+        mode: rw
+
+``container_mounts`` can also be set per-cluster using
+:ref:`cluster_configs <config-yaml-slurm-cluster-configs>`. Entries are merged
+per container path, with per-cluster values overriding global values.
+
 .. _config-yaml-slurm-cluster-configs:
 
 ``slurm.cluster_configs``
@@ -2430,6 +2463,11 @@ Supported fields:
 - ``cpu_partition``:
   :ref:`CPU partition <config-yaml-slurm-cpu-partition>` override at the
   cluster level. Per-cluster values override the global value.
+
+- ``container_mounts``:
+  :ref:`Container mounts <config-yaml-slurm-container-mounts>` overrides at
+  the cluster level. Entries are merged per container path, with per-cluster
+  values overriding global values.
 
 Example:
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -535,7 +535,7 @@ Units supported (case-insensitive):
    On **Kubernetes**, this sets the ``resources.requests.ephemeral-storage`` field in the pod spec.
    When :ref:`set_pod_resource_limits <config-yaml-kubernetes-set-pod-resource-limits>` is configured in the SkyPilot config, it also sets
    ``resources.limits.ephemeral-storage`` using the multiplier defined there.
-  
+
    With this, the disk size will be rounded down (floored) to the nearest gigabyte. For example, ``1500MB`` will be rounded to ``1GB``.
 
 .. code-block:: yaml
@@ -1097,7 +1097,8 @@ See :ref:`Nested SkyPilot from managed jobs <nested-skypilot-managed-jobs>` for 
 ``volumes``
 ~~~~~~~~~~~
 
-SkyPilot supports managing persistent and ephemeral volumes for tasks or jobs on Kubernetes clusters. Refer to :ref:`volumes on Kubernetes <volumes-on-kubernetes>` for more details.
+SkyPilot supports managed persistent and ephemeral volumes on Kubernetes, plus host path bind mounts for Slurm containers.
+Refer to :ref:`volumes on Kubernetes <volumes-on-kubernetes>` for managed volume details.
 
 Example:
 
@@ -1109,6 +1110,25 @@ Example:
     # Ephemeral volume
     /mnt/cache:
       size: 100Gi
+
+For Slurm tasks using Pyxis/Enroot, mount an existing absolute host path directly:
+
+.. code-block:: yaml
+
+  resources:
+    cloud: slurm
+    image_id: docker:ubuntu:24.04
+
+  volumes:
+    /data:
+      host_path: /shared/datasets
+      mode: ro  # Optional; defaults to ro. Use rw for a writable mount.
+
+Host and container paths must use safe POSIX path characters.
+Host paths may contain simple environment variable expansions such as ``$SLURM_JOB_ID``.
+
+Administrators can also declare cluster-wide binds applied to every containerized job; see
+:ref:`slurm.container_mounts <config-yaml-slurm-container-mounts>`.
 
 
 .. _yaml-spec-file-mounts:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6411,6 +6411,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             if task.volume_mounts:
                 # Get existing cluster's volume mounts from cluster yaml
                 existing_volume_names = set()
+                existing_slurm_host_mounts = set()
                 try:
                     if cluster_yaml_obj is not None:
                         # Extract volume names from existing cluster
@@ -6459,6 +6460,17 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                 vol_name = vol_mount.get('VolumeNameOnCloud')
                                 if vol_name:
                                     existing_volume_names.add(vol_name)
+                        elif isinstance(to_provision.cloud, clouds.Slurm):
+                            for vol_mount in node_config.get(
+                                    'volume_mounts', []):
+                                config = vol_mount.get('volume_config',
+                                                       {}).get('config', {})
+                                host_path = config.get('host_path')
+                                mount_path = vol_mount.get('path')
+                                if host_path and mount_path:
+                                    existing_slurm_host_mounts.add(
+                                        (host_path, mount_path,
+                                         config.get('mode')))
                 except Exception as e:  # pylint: disable=broad-except
                     # If we can't get the existing volume mounts, log debug
                     # and skip the warning check
@@ -6469,10 +6481,17 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 new_ephemeral_volumes = []
                 new_persistent_volumes = []
                 for volume_mount in task.volume_mounts:
+                    config = volume_mount.volume_config.config
                     # Compare using volume_name for user-facing name
                     if volume_mount.is_ephemeral:
                         if volume_mount.path not in existing_volume_names:
                             new_ephemeral_volumes.append(volume_mount.path)
+                    elif (isinstance(to_provision.cloud, clouds.Slurm) and
+                          config.get('host_path')):
+                        identity = (config['host_path'], volume_mount.path,
+                                    config.get('mode'))
+                        if identity not in existing_slurm_host_mounts:
+                            new_persistent_volumes.append(volume_mount.path)
                     elif (volume_mount.volume_name not in existing_volume_names
                           and volume_mount.volume_config.name_on_cloud
                           not in existing_volume_names):

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -428,6 +428,23 @@ def kubernetes_label_gpus(
     return server_common.get_request_id(response)
 
 
+def _check_slurm_host_path_volume_api_version(dag: 'sky.Dag') -> None:
+    if not any(
+            isinstance(volume_config, dict) and 'host_path' in volume_config
+            for task in dag.tasks
+            for volume_config in task.volumes.values()):
+        return
+    remote_api_version = versions.get_remote_api_version()
+    if (remote_api_version is None or remote_api_version <
+            server_constants.MIN_SLURM_HOST_PATH_VOLUME_API_VERSION):
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.APINotSupportedError(
+                'Slurm host_path volumes are not supported by this API '
+                'server. Please upgrade the API server to a version that '
+                f'supports API_VERSION >= '
+                f'{server_constants.MIN_SLURM_HOST_PATH_VOLUME_API_VERSION}.')
+
+
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
@@ -456,6 +473,7 @@ def optimize(
             for a task.
         exceptions.NoCloudAccessError: if no public clouds are enabled.
     """
+    _check_slurm_host_path_volume_api_version(dag)
     dag_str = dag_utils.dump_dag_to_yaml_str(dag)
 
     body = payloads.OptimizeBody(dag=dag_str,
@@ -588,6 +606,7 @@ def validate(
             validation. This is only required when a admin policy is in use,
             see: https://docs.skypilot.co/en/latest/cloud-setup/policy.html
     """
+    _check_slurm_host_path_volume_api_version(dag)
     remote_api_version = versions.get_remote_api_version()
 
     def _omit(version: int) -> bool:

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -474,7 +474,7 @@ class Slurm(clouds.Cloud):
         dryrun: bool = False,
         volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
     ) -> Dict[str, Any]:
-        del cluster_name, dryrun, volume_mounts  # Unused.
+        del cluster_name, dryrun  # Unused.
         if region is not None:
             cluster = region.name
         else:
@@ -542,6 +542,15 @@ class Slurm(clouds.Cloud):
                     f'Error: {common_utils.format_exception(e)}')
 
         image_id = resources.extract_docker_image()
+        if volume_mounts:
+            for mount in volume_mounts:
+                if mount.volume_config.config.get('host_path') is None:
+                    raise ValueError(
+                        f'Slurm only supports inline host_path volume '
+                        f'mounts; {mount.path!r} does not bind a host path.')
+            if image_id is None:
+                raise ValueError(
+                    'Slurm host_path volume mounts require a container image.')
 
         provision_timeout = skypilot_config.get_effective_region_config(
             cloud='slurm',
@@ -583,6 +592,43 @@ class Slurm(clouds.Cloud):
         if task_sbatch is not None:
             sbatch_options.update(task_sbatch)
 
+        # Read admin-declared container mounts with two-level merge:
+        # global < cluster. Each entry maps a container path to either a
+        # host path string (read-only) or {host_path: ..., mode: ro|rw}.
+        container_mounts: Dict[str, Any] = {}
+        for config_keys in [
+            ('slurm', 'container_mounts'),
+            ('slurm', 'cluster_configs', cluster, 'container_mounts'),
+        ]:
+            level_config = skypilot_config.get_nested(config_keys,
+                                                      default_value=None)
+            if level_config is not None:
+                container_mounts.update(level_config)
+
+        volume_mount_vars = []
+        if container_mounts:
+            if image_id is None:
+                logger.debug(f'Ignoring configured container_mounts for '
+                             f'cluster {cluster!r}: the task does not use a '
+                             f'container image.')
+            else:
+                # pylint: disable-next=import-outside-toplevel
+                from sky.utils import volume
+                task_mount_paths = {mount.path for mount in volume_mounts or []}
+                for dst_path, mount_config in sorted(container_mounts.items()):
+                    if dst_path in task_mount_paths:
+                        logger.debug(
+                            f'Configured container mount {dst_path!r} is '
+                            f'overridden by the task YAML volume.')
+                        continue
+                    if isinstance(mount_config, str):
+                        mount_config = {'host_path': mount_config}
+                    mount = volume.VolumeMount.resolve_host_path_config(
+                        dst_path, mount_config)
+                    volume_mount_vars.append(mount.to_yaml_config())
+        volume_mount_vars.extend(
+            mount.to_yaml_config() for mount in volume_mounts or [])
+
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -611,6 +657,9 @@ class Slurm(clouds.Cloud):
                 (constants.SKY_CLUSTER_NAME_ENV_VAR_KEY),
             'image_id': image_id,
             'sbatch_options': sbatch_options,
+            # 'volume_mounts' is reserved by write_cluster_config(), which
+            # overwrites it with generic VolumeInfo objects.
+            'slurm_volume_mounts': volume_mount_vars,
         }
 
         return deploy_vars

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '56';
+export const CLIENT_API_VERSION = '57';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1,6 +1,7 @@
 """Slurm instance provisioning."""
 
 import os
+import re
 import shlex
 import tempfile
 import threading
@@ -71,6 +72,19 @@ _SBATCH_PROTECTED_OPTIONS = frozenset({
     'gres',
     'partition',
 })
+
+_PYXIS_MOUNT_PATH_PATTERN = re.compile(
+    r'/(?:[A-Za-z0-9._~+@%=/\-]|\$[A-Za-z_][A-Za-z0-9_]*)*')
+
+
+def _validate_pyxis_mount_path(path: str, field: str) -> None:
+    """Validate a path before interpolating it into --container-mounts."""
+    if not (isinstance(path, str) and
+            _PYXIS_MOUNT_PATH_PATTERN.fullmatch(path)):
+        raise ValueError(
+            f'Invalid Pyxis container mount {field} path {path!r}. Paths must '
+            'be absolute and contain only safe POSIX path characters or '
+            'simple $VARNAME expansions.')
 
 
 def _build_custom_sbatch_directives(sbatch_options: Dict[str, Any]) -> str:
@@ -577,6 +591,17 @@ def _create_virtual_instance(
         # it so the container can access sky_cluster_home_dir.
         if workdir is not None and workdir != remote_home_dir:
             mount_paths.append(f'{workdir}:{workdir}')
+        for volume_mount in resources.get('volume_mounts', []) or []:
+            dst_path = volume_mount['path']
+            volume_config = volume_mount['volume_config']
+            host_path = volume_config['config']['host_path']
+            _validate_pyxis_mount_path(host_path, 'source')
+            _validate_pyxis_mount_path(dst_path, 'destination')
+            mount = f'{host_path}:{dst_path}'
+            # Fail closed: anything but an explicit 'rw' mounts read-only.
+            if volume_config['config'].get('mode') != 'rw':
+                mount += ':ro'
+            mount_paths.append(mount)
         container_mounts = ','.join(mount_paths)
         # Add sudo alias to bashrc since we're already root in the container.
         # This allows scripts with 'sudo' commands to work without modification.

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 56  # resize field on LaunchBody
+API_VERSION = 57  # Slurm inline host path volume mounts
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):
@@ -50,6 +50,7 @@ MIN_BATCH_API_VERSION = 49
 # launch response. Lets the CLI skip the follow-up /status round-trip that
 # only exists to fetch credentials for SSH config setup.
 MIN_LAUNCH_CREDENTIALS_API_VERSION = 50
+MIN_SLURM_HOST_PATH_VOLUME_API_VERSION = 57
 
 # Servers >= this version omit the bulky pickled `handle` from each replica
 # in serve/pool status responses, shipping pre-computed `infra` /

--- a/sky/task.py
+++ b/sky/task.py
@@ -1076,11 +1076,22 @@ class Task:
                     # External volume with 'name' field
                     volume_mount = volume_lib.VolumeMount.resolve(
                         dst_path, vol['name'], sub_path=vol.get('sub_path'))
+                elif 'host_path' in vol:
+                    if not self.resources or not all(
+                            isinstance(resource.cloud, clouds.Slurm)
+                            for resource in self.resources):
+                        raise ValueError(
+                            'Inline host_path volumes are only supported for '
+                            'tasks explicitly targeting Slurm.')
+                    volume_mount = (
+                        volume_lib.VolumeMount.resolve_host_path_config(
+                            dst_path, vol))
                 else:
                     raise ValueError(
                         f'Invalid volume config: {dst_path}: {vol}. '
-                        'Either "size" (for ephemeral volume) or "name" '
-                        '(for external volume) must be set.')
+                        'One of "size" (for an ephemeral volume), "name" '
+                        '(for an external volume), or "host_path" (for a '
+                        'Slurm host bind) must be set.')
             else:
                 raise ValueError(f'Invalid volume config: {dst_path}: {vol}')
             volume_mounts.append(volume_mount)

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -55,6 +55,9 @@ available_node_types:
 {% if sbatch_options is defined and sbatch_options %}
       sbatch_options: {{sbatch_options | tojson}}
 {% endif %}
+{% if slurm_volume_mounts is defined and slurm_volume_mounts %}
+      volume_mounts: {{slurm_volume_mounts | tojson}}
+{% endif %}
 
       # TODO: more configs that is required by the provisioner to create new
       # instances on the FluffyCloud:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1505,6 +1505,31 @@ _GPU_PARTITION_MAP_SCHEMA = {
     },
 }
 
+_CONTAINER_MOUNTS_SCHEMA = {
+    'type': 'object',
+    'required': [],
+    # Maps a container path to a host path string (read-only) or
+    # {host_path: ..., mode: ro|rw}.
+    'additionalProperties': {
+        'anyOf': [{
+            'type': 'string',
+        }, {
+            'type': 'object',
+            'required': ['host_path'],
+            'additionalProperties': False,
+            'properties': {
+                'host_path': {
+                    'type': 'string',
+                },
+                'mode': {
+                    'type': 'string',
+                    'enum': ['ro', 'rw'],
+                },
+            },
+        }],
+    },
+}
+
 _PRICING_SCHEMA = {
     'type': 'object',
     'required': [],
@@ -2106,6 +2131,7 @@ def get_config_schema():
                 'cpu_partition': {
                     'type': 'string',
                 },
+                'container_mounts': _CONTAINER_MOUNTS_SCHEMA,
                 'cluster_configs': {
                     'type': 'object',
                     'required': [],
@@ -2130,6 +2156,7 @@ def get_config_schema():
                             'cpu_partition': {
                                 'type': 'string',
                             },
+                            'container_mounts': _CONTAINER_MOUNTS_SCHEMA,
                             'partition_configs': {
                                 'type': 'object',
                                 'required': [],

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -25,6 +25,12 @@ class VolumeAccessMode(enum.Enum):
     READ_ONLY_MANY = 'ReadOnlyMany'
 
 
+class VolumeMountMode(enum.Enum):
+    """Per-mount permission for host path bind mounts."""
+    RO = 'ro'
+    RW = 'rw'
+
+
 class VolumeType(enum.Enum):
     """Volume type."""
     PVC = 'k8s-pvc'
@@ -119,8 +125,8 @@ class VolumeMount:
 
     def pre_mount(self) -> None:
         """Update the volume status before actual mounting."""
-        # Skip pre_mount for ephemeral volumes as they don't exist yet
-        if self.is_ephemeral:
+        # Inline and ephemeral volumes have no global volume record.
+        if not self.volume_name:
             return
         # TODO(aylei): for ReadWriteOnce volume, we also need to queue the
         # mount request if the target volume is already mounted to another
@@ -160,6 +166,37 @@ class VolumeMount:
         assert 'handle' in record, 'Volume handle is None.'
         volume_config: models.VolumeConfig = record['handle']
         return cls(path, volume_name, volume_config, sub_path=sub_path)
+
+    @classmethod
+    def resolve_host_path_config(cls, path: str,
+                                 config: Dict[str, Any]) -> 'VolumeMount':
+        """Create a non-provisioned host path mount from inline config."""
+        host_path = config.get('host_path')
+        if not isinstance(host_path, str) or not host_path.startswith('/'):
+            raise ValueError(
+                f'host_path must be an absolute path, got: {host_path!r}')
+        if host_path == '/':
+            raise ValueError('host_path must not be the root directory \'/\'')
+        mode = config.get('mode', VolumeMountMode.RO.value)
+        if mode not in (VolumeMountMode.RO.value, VolumeMountMode.RW.value):
+            raise ValueError(f'Invalid host_path volume mode {mode!r}. '
+                             'Supported modes are "ro" and "rw".')
+        unexpected_fields = set(config) - {'host_path', 'mode'}
+        if unexpected_fields:
+            raise ValueError(f'Invalid host_path volume config fields: '
+                             f'{sorted(unexpected_fields)}')
+        volume_config = models.VolumeConfig(name='',
+                                            type='',
+                                            cloud='Slurm',
+                                            region=None,
+                                            zone=None,
+                                            name_on_cloud=host_path,
+                                            size=None,
+                                            config={
+                                                'host_path': host_path,
+                                                'mode': mode,
+                                            })
+        return cls(path, '', volume_config)
 
     @classmethod
     def from_yaml_config(cls, config: Dict[str, Any]) -> 'VolumeMount':

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -699,6 +699,52 @@ def test_sdk_launch_no_resize_skips_version_guard(_stub_launch_preamble,
         sdk.launch(task, cluster_name='my-cluster', resize=False)
 
 
+@pytest.mark.parametrize('api_version', [None, 24, 56])
+def test_sdk_validate_slurm_host_path_errors_on_old_server(
+        api_version, monkeypatch):
+    """sdk.validate should error for host_path volumes if remote API
+    version < 57."""
+    import sky
+    from sky.client import sdk
+
+    monkeypatch.setattr('sky.client.sdk.versions.get_remote_api_version',
+                        lambda: api_version)
+    task = sky.Task(resources=sky.Resources(cloud=clouds.Slurm()),
+                    volumes={'/data': {
+                        'host_path': '/shared/data'
+                    }})
+    with sky.Dag() as dag:
+        dag.add(task)
+
+    with pytest.raises(exceptions.APINotSupportedError,
+                       match='Slurm host_path volumes'):
+        sdk.validate(dag)
+
+
+def test_sdk_validate_slurm_host_path_allowed_on_new_server(monkeypatch):
+    """sdk.validate should pass the guard for host_path volumes when remote
+    API version >= 57. We short-circuit the server request with a sentinel
+    so reaching it proves the guard didn't raise."""
+    import sky
+    from sky.client import sdk
+
+    monkeypatch.setattr('sky.client.sdk.versions.get_remote_api_version',
+                        lambda: 57)
+    sentinel = RuntimeError('reached server request')
+    monkeypatch.setattr(
+        'sky.client.sdk.server_common.make_authenticated_request',
+        mock.Mock(side_effect=sentinel))
+    task = sky.Task(resources=sky.Resources(cloud=clouds.Slurm()),
+                    volumes={'/data': {
+                        'host_path': '/shared/data'
+                    }})
+
+    with sky.Dag() as dag:
+        dag.add(task)
+    with pytest.raises(RuntimeError, match='reached server request'):
+        sdk.validate(dag)
+
+
 def test_launch_body_accepts_resize_field():
     """New server should accept resize=True in the request body."""
     from sky.server.requests import payloads

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -95,13 +95,17 @@ class TestSlurmClientSubmitUser:
 class TestSubmitUserDeployVariables:
 
     @staticmethod
-    def _make_deploy_variables(submit_user, ssh_user='root'):
+    def _make_deploy_variables(submit_user,
+                               ssh_user='root',
+                               volume_mounts=None,
+                               image_id=None,
+                               config_container_mounts=None):
         cloud = slurm_cloud.Slurm()
         resources = mock.MagicMock(unsafe=True)
         resources.zone = 'gpu'
         resources.instance_type = '4CPU--16GB'
         resources.assert_launchable.return_value = resources
-        resources.extract_docker_image.return_value = None
+        resources.extract_docker_image.return_value = image_id
         resources.cluster_config_overrides = {}
 
         region = mock.MagicMock()
@@ -116,12 +120,21 @@ class TestSubmitUserDeployVariables:
             'identityfile': ['/root/.ssh/id_ed25519'],
         }
 
+        def _get_nested(keys, default_value=None, **_):
+            if (keys == ('slurm', 'cluster_configs', 'my-cluster',
+                         'container_mounts') and
+                    config_container_mounts is not None):
+                return config_container_mounts
+            return default_value
+
         with patch('sky.clouds.slurm.slurm_utils.get_slurm_ssh_config',
                    return_value=ssh_config), \
              patch('sky.clouds.slurm.slurm_utils.get_submit_user',
                    return_value=submit_user), \
              patch('sky.clouds.slurm.slurm_utils.get_partitions',
                    return_value=['gpu']), \
+             patch('sky.clouds.slurm.skypilot_config.get_nested',
+                   side_effect=_get_nested), \
              patch('sky.clouds.slurm.skypilot_config.'
                    'get_effective_region_config', return_value=None):
             return cloud.make_deploy_resources_variables(
@@ -129,7 +142,8 @@ class TestSubmitUserDeployVariables:
                 cluster_name=mock.MagicMock(),
                 region=region,
                 zones=[zone],
-                num_nodes=1)
+                num_nodes=1,
+                volume_mounts=volume_mounts)
 
     def test_submit_user_persisted(self):
         deploy_vars = self._make_deploy_variables('alice')
@@ -146,6 +160,106 @@ class TestSubmitUserDeployVariables:
 
         assert deploy_vars['ssh_user'] == 'ubuntu'
         assert deploy_vars['slurm_user'] == 'alice'
+
+    def test_volume_mounts_serialized(self):
+        mount = mock.MagicMock()
+        mount.volume_config.config = {'host_path': '/host/data'}
+        mount.to_yaml_config.return_value = {
+            'path': '/data',
+            'volume_name': '',
+            'volume_config': {
+                'config': {
+                    'host_path': '/host/data',
+                    'mode': 'ro',
+                },
+            },
+            'is_ephemeral': False,
+        }
+
+        deploy_vars = self._make_deploy_variables(None,
+                                                  volume_mounts=[mount],
+                                                  image_id='ubuntu:22.04')
+
+        assert deploy_vars['slurm_volume_mounts'] == [
+            mount.to_yaml_config.return_value
+        ]
+
+    @pytest.mark.parametrize(
+        'config,image_id,error',
+        [
+            ({}, 'ubuntu:22.04', r"only supports inline host_path.*'/mnt'"),
+            ({
+                'host_path': '/host/data'
+            }, None, 'require a container image'),
+        ],
+    )
+    def test_volume_mounts_validate_slurm_support(self, config, image_id,
+                                                  error):
+        mount = mock.MagicMock()
+        mount.path = '/mnt'
+        mount.volume_config.config = config
+
+        with pytest.raises(ValueError, match=error):
+            self._make_deploy_variables(None,
+                                        volume_mounts=[mount],
+                                        image_id=image_id)
+
+    def test_config_container_mounts_serialized(self):
+        deploy_vars = self._make_deploy_variables(
+            None,
+            image_id='ubuntu:22.04',
+            config_container_mounts={
+                '/blob': '/data/blob',
+                '/scratch': {
+                    'host_path': '/nvme/$SLURM_JOB_ID',
+                    'mode': 'rw',
+                },
+            })
+
+        mounts = {
+            m['path']: m['volume_config']['config']
+            for m in deploy_vars['slurm_volume_mounts']
+        }
+        assert mounts == {
+            '/blob': {
+                'host_path': '/data/blob',
+                'mode': 'ro',
+            },
+            '/scratch': {
+                'host_path': '/nvme/$SLURM_JOB_ID',
+                'mode': 'rw',
+            },
+        }
+
+    def test_config_container_mounts_yield_to_task_volume(self):
+        mount = mock.MagicMock()
+        mount.path = '/data'
+        mount.volume_config.config = {'host_path': '/host/data'}
+        mount.to_yaml_config.return_value = {
+            'path': '/data',
+            'volume_config': {
+                'config': {
+                    'host_path': '/host/data',
+                    'mode': 'ro',
+                },
+            },
+        }
+
+        deploy_vars = self._make_deploy_variables(
+            None,
+            volume_mounts=[mount],
+            image_id='ubuntu:22.04',
+            config_container_mounts={'/data': '/config/data'})
+
+        assert deploy_vars['slurm_volume_mounts'] == [
+            mount.to_yaml_config.return_value
+        ]
+
+    def test_config_container_mounts_skipped_without_image(self):
+        deploy_vars = self._make_deploy_variables(
+            None, config_container_mounts={'/blob': '/data/blob'})
+
+        assert deploy_vars['slurm_volume_mounts'] == []
 
 
 class TestSubmitUserTemplate:
@@ -186,6 +300,17 @@ class TestSubmitUserTemplate:
                 'accelerator_type': None,
                 'accelerator_count': 0,
                 'sbatch_options': {},
+                'slurm_volume_mounts': [{
+                    'path': '/data',
+                    'volume_name': '',
+                    'volume_config': {
+                        'config': {
+                            'host_path': '/host/data',
+                            'mode': 'ro',
+                        },
+                    },
+                    'is_ephemeral': False,
+                }],
                 'sky_ray_yaml_remote_path': '/tmp/ray.yaml',
                 'sky_ray_yaml_local_path': '/tmp/ray.yaml',
                 'sky_remote_path': '/tmp/sky',
@@ -209,6 +334,8 @@ class TestSubmitUserTemplate:
             assert config['provider']['slurm_user'] == slurm_user
         assert config['provider']['ssh']['user'] == transport_user
         assert config['auth']['ssh_user'] == expected_ssh_user
+        assert config['available_node_types']['ray_head_default'][
+            'node_config']['volume_mounts'][0]['path'] == '/data'
 
 
 class TestCheckInstanceFits:
@@ -1212,6 +1339,63 @@ class TestCreateVirtualInstance:
 
         written_script = self._run_and_capture_script('test-cluster', config)
         assert_sbatch_matches_snapshot('containers', written_script)
+
+        config.node_config['volume_mounts'] = [
+            {
+                'path': '/data',
+                'volume_name': '',
+                'volume_config': {
+                    'config': {
+                        'host_path': '/host/data',
+                        'mode': 'ro',
+                    },
+                },
+                'is_ephemeral': False,
+            },
+            {
+                'path': '/scratch',
+                'volume_name': '',
+                'volume_config': {
+                    'config': {
+                        'host_path': '/nvme/$SLURM_JOB_ID',
+                        'mode': 'rw',
+                    },
+                },
+                'is_ephemeral': False,
+            },
+            {
+                # No 'mode': must fail closed to read-only.
+                'path': '/models',
+                'volume_name': '',
+                'volume_config': {
+                    'config': {
+                        'host_path': '/host/models',
+                    },
+                },
+                'is_ephemeral': False,
+            },
+        ]
+        mounted_script = self._run_and_capture_script('test-cluster-mounted',
+                                                      config)
+        assert ('--container-mounts="/home/testuser:/home/testuser,'
+                '/tmp/ccache_$(id -u):/var/cache/ccache,'
+                '/host/data:/data:ro,/nvme/$SLURM_JOB_ID:/scratch,'
+                '/host/models:/models:ro"' in mounted_script)
+
+    @pytest.mark.parametrize('path', [
+        '/host/data,other',
+        '/host/data:/other',
+        '/host/data with-space',
+        '/host/"data"',
+        '/host/`id`',
+        '/host/$(id)',
+        '/host/${HOME}',
+        '/host/data\nmalicious',
+        'relative/path',
+    ])
+    def test_container_mount_rejects_unsafe_paths(self, path):
+        with pytest.raises(ValueError, match='Invalid Pyxis container mount'):
+            slurm_instance._validate_pyxis_mount_path(path, 'source')
 
     @patch('sky.provision.slurm.instance._wait_for_job_nodes')
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -859,6 +859,49 @@ def test_resolve_volumes_dict_volume_success():
             assert r.cloud == registry.CLOUD_REGISTRY.from_str('aws')
 
 
+def test_resolve_volumes_inline_slurm_host_path():
+    t = task.Task.from_yaml_str("""
+resources:
+  cloud: slurm
+volumes:
+  /data:
+    host_path: /host/data
+  /scratch:
+    host_path: /host/scratch
+    mode: rw
+""")
+
+    t.resolve_and_validate_volumes()
+
+    assert t.volume_mounts is not None
+    assert [(mount.path, mount.volume_config.name_on_cloud,
+             mount.volume_config.config) for mount in t.volume_mounts] == [
+                 ('/data', '/host/data', {
+                     'host_path': '/host/data',
+                     'mode': 'ro',
+                 }),
+                 ('/scratch', '/host/scratch', {
+                     'host_path': '/host/scratch',
+                     'mode': 'rw',
+                 }),
+             ]
+
+
+@pytest.mark.parametrize('host_path,mode,error', [
+    ('relative/path', 'ro', 'absolute path'),
+    ('/', 'ro', 'root directory'),
+    ('/host/data', 'read-only', 'Supported modes'),
+])
+def test_resolve_volumes_inline_slurm_host_path_validation(
+        host_path, mode, error):
+    t = task.Task(resources=resources_lib.Resources(
+        cloud=registry.CLOUD_REGISTRY.from_str('slurm')))
+    t._volumes = {'/data': {'host_path': host_path, 'mode': mode}}
+
+    with pytest.raises(ValueError, match=error):
+        t.resolve_and_validate_volumes()
+
+
 def test_resolve_volumes_topology_conflict_between_volumes():
     t = task.Task()
     t._volumes = {'/mnt1': 'vol1', '/mnt2': 'vol2'}
@@ -965,14 +1008,15 @@ def test_resolve_volumes_dict_with_name_and_size():
         mock_resolve.assert_not_called()
 
 
-def test_resolve_volumes_invalid_dict_no_size_no_name():
-    """Test dict without 'size' or 'name' raises ValueError."""
+def test_resolve_volumes_invalid_dict_no_source():
+    """Test a dict without a supported volume source raises ValueError."""
     t = task.Task()
     t._volumes = {'/mnt': {'type': 'pd-standard'}}
     t.resources = [make_mock_resource()]
 
-    with pytest.raises(ValueError,
-                       match='Invalid volume config.*Either "size".*or "name"'):
+    with pytest.raises(
+            ValueError,
+            match='Invalid volume config.*"size".*"name".*"host_path"'):
         t.resolve_and_validate_volumes()
 
 
@@ -982,8 +1026,9 @@ def test_resolve_volumes_invalid_dict_empty():
     t._volumes = {'/mnt': {}}
     t.resources = [make_mock_resource()]
 
-    with pytest.raises(ValueError,
-                       match='Invalid volume config.*Either "size".*or "name"'):
+    with pytest.raises(
+            ValueError,
+            match='Invalid volume config.*"size".*"name".*"host_path"'):
         t.resolve_and_validate_volumes()
 
 

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -525,6 +525,47 @@ class TestVolumeMount:
         assert volume_mount.volume_config == mock_volume_config
         assert volume_mount.is_ephemeral is False
 
+    @mock.patch('sky.global_user_state.update_volume')
+    def test_pre_mount_inline_host_path_skips_state_update(self, mock_update):
+        volume_config = models.VolumeConfig(name='',
+                                            type='',
+                                            cloud='slurm',
+                                            region=None,
+                                            zone=None,
+                                            name_on_cloud='/host/data',
+                                            size=None,
+                                            config={
+                                                'host_path': '/host/data',
+                                                'mode': 'ro',
+                                            })
+        volume_mount = volume.VolumeMount('/data', '', volume_config)
+
+        volume_mount.pre_mount()
+
+        mock_update.assert_not_called()
+
+    @mock.patch('sky.global_user_state.update_volume')
+    def test_pre_mount_named_host_path_updates_state(self, mock_update):
+        volume_config = models.VolumeConfig(name='host-volume',
+                                            type='k8s-hostpath',
+                                            cloud='kubernetes',
+                                            region=None,
+                                            zone=None,
+                                            name_on_cloud='host-volume',
+                                            size=None,
+                                            config={
+                                                'host_path': '/host/data',
+                                                'access_mode': 'ReadOnlyMany',
+                                            })
+        volume_mount = volume.VolumeMount('/data', 'host-volume', volume_config)
+
+        volume_mount.pre_mount()
+
+        mock_update.assert_called_once_with(
+            'host-volume',
+            last_attached_at=mock.ANY,
+            status=status_lib.VolumeStatus.IN_USE)
+
 
 PVC_TYPE = 'k8s-pvc'
 HOSTPATH_TYPE = 'k8s-hostpath'


### PR DESCRIPTION
Slurm clusters are on-prem machines with shared filesystems (datasets, caches, scratch NVMe), but there is currently no way to make those paths visible inside a Pyxis/Enroot container. This adds host path bind mounts for Slurm, declared either per-task or cluster-wide.

## Summary

Per-task, in task YAML:

```yaml
resources:
  cloud: slurm
  image_id: docker:ubuntu:24.04

volumes:
  /data:
    host_path: /shared/datasets   # ro by default; mode: rw for writable
```

Cluster-wide, in server config (global and `cluster_configs.<cluster>` levels, merged like `sbatch_options`), applied to every containerized job on the cluster:

```yaml
slurm:
  cluster_configs:
    my-cluster:
      container_mounts:
        /datasets: /shared/datasets
        /scratch:
          host_path: /nvme/$SLURM_JOB_ID
          mode: rw
```

Both forms share one validation and rendering path into `--container-mounts`.

Contracts:

- A mount only exists inside a container: task YAML mounts without a container image are rejected with a clear error; config mounts are skipped for uncontainerized jobs.
- Task YAML wins over config on a duplicate container path.
- Paths must be absolute, non-root, and free of shell/Pyxis delimiter characters; simple `$VARNAME` expansion (e.g. `$SLURM_JOB_ID`) is allowed by design.
- Reusing an existing Slurm cluster warns when the requested host mounts differ from the cluster's.
- `API_VERSION` 57: `validate`/`optimize` raise `APINotSupportedError` for task YAML `host_path` against older servers. Config mounts resolve server-side and need no client support.

## Tests

- [x] Code formatting and lint: `.venv/bin/pre-commit run --files <changed files>`
- [x] Affected unit suites: `.venv/bin/python -m pytest tests/unit_tests/test_core.py tests/unit_tests/test_api_version_consistency.py tests/unit_tests/test_sky/clouds/test_slurm.py tests/unit_tests/test_sky/test_task.py tests/unit_tests/test_sky/utils/test_volume_utils.py -q`
- [x] Native-only mount contract tests with an empty `SKYPILOT_CONFIG`
- [ ] Slurm cloud smoke test

## Refs

- Pyxis mount syntax: https://github.com/NVIDIA/pyxis/wiki/Usage#--container-mounts
