### PR TITLE
[Dashboard] Drop unknown filter properties from the URL instead of crashing

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -73,7 +73,10 @@ import cachePreloader from '@/lib/cache-preloader';
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
-import { evaluateCondition } from '@/components/shared/FilterSystem';
+import {
+  evaluateCondition,
+  updateFiltersByURLParams as sharedUpdateFiltersByURLParams,
+} from '@/components/shared/FilterSystem';
 import { SegmentedToggle } from '@/components/elements/SegmentedToggle';
 import { getCurrentUserInfo } from '@/data/connectors/client';
 import { trackClusterAction, trackFilterUsed } from '@/lib/analytics';
@@ -434,7 +437,7 @@ export function Clusters() {
     let values = [];
 
     filters.map((filter, _index) => {
-      properties.push(filter.property.toLowerCase() ?? '');
+      properties.push((filter.property ?? '').toLowerCase());
       operators.push(filter.operator);
       values.push(filter.value);
     });
@@ -487,45 +490,21 @@ export function Clusters() {
   };
 
   const updateFiltersByURLParams = () => {
-    const query = { ...router.query };
-
-    const properties = query.property;
-    const operators = query.operator;
-    const values = query.value;
-
-    if (properties === undefined) {
+    if (router.query.property === undefined) {
       return;
     }
+    // Keys match PROPERTY_OPTIONS above; a URL naming anything else is dropped
+    // by the shared decoder.
+    const propertyMap = new Map([
+      ['status', 'Status'],
+      ['cluster', 'Cluster'],
+      ['user', 'User'],
+      ['workspace', 'Workspace'],
+      ['infra', 'Infra'],
+      ['labels', 'Labels'],
+    ]);
 
-    let filters = [];
-
-    const length = Array.isArray(properties) ? properties.length : 1;
-
-    const propertyMap = new Map();
-    propertyMap.set('', '');
-    propertyMap.set('status', 'Status');
-    propertyMap.set('cluster', 'Cluster');
-    propertyMap.set('user', 'User');
-    propertyMap.set('workspace', 'Workspace');
-    propertyMap.set('infra', 'Infra');
-
-    if (length === 1) {
-      filters.push({
-        property: propertyMap.get(properties),
-        operator: operators,
-        value: values,
-      });
-    } else {
-      for (let i = 0; i < length; i++) {
-        filters.push({
-          property: propertyMap.get(properties[i]),
-          operator: operators[i],
-          value: values[i],
-        });
-      }
-    }
-
-    setFilters(filters);
+    setFilters(sharedUpdateFiltersByURLParams(router, propertyMap));
   };
 
   const selectScope = (scope) => {

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -411,7 +411,6 @@ export function ManagedJobs() {
 
   const updateFiltersByURLParams = React.useCallback(() => {
     const propertyMap = new Map();
-    propertyMap.set('', '');
     propertyMap.set('id', 'ID');
     propertyMap.set('status', 'Status');
     propertyMap.set('name', 'Name');

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -13,13 +13,10 @@ export const evaluateCondition = (item, filter) => {
 
   if (!value) return true; // skip empty filters
 
-  // Global search: check all values
-  if (!property) {
-    const strValue = value.toLowerCase();
-    return Object.values(item).some((val) =>
-      val?.toString().toLowerCase().includes(strValue)
-    );
-  }
+  // A filter without a property cannot be evaluated. The decoders drop these
+  // before they reach the filter list, so this is a guard, not a code path:
+  // skip the filter rather than throwing on the lookup below.
+  if (!property) return true;
 
   const propertyLower = property.toLowerCase();
 
@@ -103,7 +100,7 @@ export const updateURLParams = (router, filters) => {
   let values = [];
 
   filters.map((filter, _index) => {
-    properties.push(filter.property.toLowerCase() ?? '');
+    properties.push((filter.property ?? '').toLowerCase());
     operators.push(filter.operator);
     values.push(filter.value);
   });
@@ -138,20 +135,20 @@ export const updateFiltersByURLParams = (router, propertyMap) => {
 
   const length = Array.isArray(properties) ? properties.length : 1;
 
-  if (length === 1) {
-    filters.push({
-      property: propertyMap.get(properties),
-      operator: operators,
-      value: values,
-    });
-  } else {
-    for (let i = 0; i < length; i++) {
-      filters.push({
-        property: propertyMap.get(properties[i]),
-        operator: operators[i],
-        value: values[i],
-      });
+  for (let i = 0; i < length; i++) {
+    const rawProperty = length === 1 ? properties : properties[i];
+    const property = propertyMap.get(rawProperty);
+    // A property the page does not know about cannot be filtered on. Drop it:
+    // keeping it would render a chip labeled `undefined` that filters nothing
+    // it claims to, and a URL is user-editable input, not trusted state.
+    if (!property) {
+      continue;
     }
+    filters.push({
+      property,
+      operator: length === 1 ? operators : operators[i],
+      value: length === 1 ? values : values[i],
+    });
   }
 
   return filters;

--- a/sky/dashboard/src/components/shared/FilterSystem.test.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.test.jsx
@@ -1,0 +1,136 @@
+import {
+  evaluateCondition,
+  updateFiltersByURLParams,
+} from '@/components/shared/FilterSystem';
+
+const PROPERTY_MAP = new Map([
+  ['status', 'Status'],
+  ['cluster', 'Cluster'],
+  ['user', 'User'],
+  ['labels', 'Labels'],
+]);
+
+const routerWith = (query) => ({ query });
+
+describe('updateFiltersByURLParams', () => {
+  it('decodes a single filter', () => {
+    const filters = updateFiltersByURLParams(
+      routerWith({ property: 'status', operator: ':', value: 'UP' }),
+      PROPERTY_MAP
+    );
+    expect(filters).toEqual([
+      { property: 'Status', operator: ':', value: 'UP' },
+    ]);
+  });
+
+  it('decodes multiple filters, pairing each array by index', () => {
+    const filters = updateFiltersByURLParams(
+      routerWith({
+        property: ['status', 'user'],
+        operator: [':', ':'],
+        value: ['UP', 'alice'],
+      }),
+      PROPERTY_MAP
+    );
+    expect(filters).toEqual([
+      { property: 'Status', operator: ':', value: 'UP' },
+      { property: 'User', operator: ':', value: 'alice' },
+    ]);
+  });
+
+  it('returns no filters when the URL carries none', () => {
+    expect(updateFiltersByURLParams(routerWith({}), PROPERTY_MAP)).toEqual([]);
+  });
+
+  // A URL is user-editable input. A property this page cannot filter on must
+  // not survive as a filter with no property: that used to render a chip
+  // labeled `undefined`, silently turn the filter into a full-text search, and
+  // then throw on the next chip removal.
+  it('drops a property the page does not know about', () => {
+    const filters = updateFiltersByURLParams(
+      routerWith({
+        property: ['bogus', 'status'],
+        operator: [':', ':'],
+        value: ['x', 'UP'],
+      }),
+      PROPERTY_MAP
+    );
+    expect(filters).toEqual([
+      { property: 'Status', operator: ':', value: 'UP' },
+    ]);
+  });
+
+  it('drops an empty property', () => {
+    const filters = updateFiltersByURLParams(
+      routerWith({ property: '', operator: ':', value: 'alice' }),
+      PROPERTY_MAP
+    );
+    expect(filters).toEqual([]);
+  });
+
+  it('keeps a labels filter, which the clusters page offers', () => {
+    const filters = updateFiltersByURLParams(
+      routerWith({ property: 'labels', operator: ':', value: 'team:ml' }),
+      PROPERTY_MAP
+    );
+    expect(filters).toEqual([
+      { property: 'Labels', operator: ':', value: 'team:ml' },
+    ]);
+  });
+});
+
+describe('evaluateCondition', () => {
+  const item = { status: 'UP', cluster: 'train-a100', user: 'alice' };
+
+  it('matches a substring with the : operator', () => {
+    expect(
+      evaluateCondition(item, {
+        property: 'Cluster',
+        operator: ':',
+        value: 'train',
+      })
+    ).toBe(true);
+  });
+
+  it('requires equality with the = operator', () => {
+    expect(
+      evaluateCondition(item, {
+        property: 'Cluster',
+        operator: '=',
+        value: 'train',
+      })
+    ).toBe(false);
+    expect(
+      evaluateCondition(item, {
+        property: 'Cluster',
+        operator: '=',
+        value: 'train-a100',
+      })
+    ).toBe(true);
+  });
+
+  it('skips a filter with no value', () => {
+    expect(
+      evaluateCondition(item, { property: 'Cluster', operator: ':', value: '' })
+    ).toBe(true);
+  });
+
+  // Guard, not a code path: the decoders drop these. It must skip the filter
+  // rather than throw on the property lookup.
+  it('skips a filter with no property instead of throwing', () => {
+    expect(() =>
+      evaluateCondition(item, {
+        property: undefined,
+        operator: ':',
+        value: 'alice',
+      })
+    ).not.toThrow();
+    expect(
+      evaluateCondition(item, {
+        property: undefined,
+        operator: ':',
+        value: 'alice',
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The clusters page offers a "Labels" filter in its dropdown, but its URL decoder has
no entry for it. Opening a shared link that carries a labels filter therefore
produces a filter with no property, which then:

1. renders as a chip literally labeled `undefined : team:ml`;
2. silently becomes a match-any-field text search, so the recipient of the link sees
   different rows than the sender;
3. throws `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` as
   soon as any filter is added or removed afterwards, replacing the page with
   "Application error: a client-side exception has occurred".

Reproduced against master on a local server with five clusters, two of them labeled
`team=ml`:

| Step | Result on master |
|---|---|
| Filter `Labels : team:ml` in my own browser | 5 rows → 2 rows, works |
| Open that same URL in a new tab | chip reads `undefined : team:ml`, table reads **"No active clusters"** |
| Add any second filter on that page | white screen, `TypeError` in the console |

### Before

<!-- PASTE BEFORE SCREENSHOTS HERE -->
<!-- 1. own browser: chip "Labels : team:ml", 2 rows -->

1. own browser: chip "Labels : team:ml", 2 rows

<img width="3822" height="1089" alt="6906f3605fa54b172b6154b1a71d44a1" src="https://github.com/user-attachments/assets/1c7db51b-a1a2-47ef-b50a-683eb2124dc8" />

<!-- 2. same URL in a new tab: chip "undefined : team:ml", "No active clusters" -->

2. same URL in a new tab: chip "undefined : team:ml", "No active clusters"

<img width="3794" height="1086" alt="72216f909d4d4b828a9173b33e3bc0ca" src="https://github.com/user-attachments/assets/e9c904ce-910d-4a15-ac39-c72000ee242b" />


<!-- 3. after adding a second filter: "Application error" white screen -->

3. after adding a second filter: "Application error" white screen

<img width="3810" height="1593" alt="5696e8eb321f60a0b28543c21cb1dfdd" src="https://github.com/user-attachments/assets/f57f8b12-93b1-4742-91d4-623f9b92e834" />


## Fix

- `updateFiltersByURLParams` drops any property the page does not know about. A URL
  is user-editable input; a filter with no property can only misreport what it is
  filtering on.
- The clusters page gains the missing `labels` entry, so its Labels filter survives a
  reload, and drops its private copy of the decoder in favour of the shared one.
- `evaluateCondition`'s empty-property branch is removed. No dropdown can produce an
  empty property — all three seed a non-empty one — so its only caller was this failed
  decode. It is replaced by a guard that skips the filter instead of throwing on the
  property lookup below it.
- `filter.property.toLowerCase() ?? ''` in both URL writers becomes
  `(filter.property ?? '').toLowerCase()`; the `??` applied after the method call and
  so never guarded anything — that is the line that threw.
- The decoder's duplicated single-filter and multi-filter branches fold into one loop.

## After

| Step | Result with this change |
|---|---|
| Open the shared URL in a new tab | chip reads `Labels : team:ml`, same 2 rows as the sender |
| Add a second filter | no crash, both chips apply, 1 row |
| URL naming an unknown property | dropped silently, the known filters still apply |

<!-- PASTE AFTER SCREENSHOTS HERE -->
<!-- 1. same URL in a new tab: chip "Labels : team:ml", 2 rows -->

1. same URL in a new tab: chip "Labels : team:ml", 2 rows

<img width="3812" height="1121" alt="f043ca90fa5457bd80e7d043eed5ff45" src="https://github.com/user-attachments/assets/dd59e1f3-a39e-4839-a541-a84a4b03d574" />


<!-- 2. after adding a second filter: both chips, 1 row, no crash -->

2. after adding a second filter: both chips, 1 row, no crash

<img width="3807" height="1208" alt="2857068b4c2ab806ce9e9782bfe6de32" src="https://github.com/user-attachments/assets/5233fbfa-85f5-42c5-8ca6-72de725126f9" />


3. after adding a second filter: no error

<img width="3572" height="1280" alt="e518bb1575eda80e26fcb8aa887b0618" src="https://github.com/user-attachments/assets/8b241853-0efd-4897-ac9d-244f5bfef103" />



## Tests

Adds `FilterSystem.test.jsx`; this code had no coverage. Ten cases: single- and
multi-filter decode, unknown property dropped, empty property dropped, labels kept,
and `evaluateCondition` skipping rather than throwing on a property-less filter.

```
npx jest src/components/shared/FilterSystem.test.jsx   # 10 passed
```

Full dashboard suite: 8 suites pass. `version-display` and `jobs.test.jsx` fail
identically on master without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->