### PR TITLE
[Jobs] Step down from consolidation leadership without killing the API server

### DIFF
--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -1,15 +1,15 @@
 """Run the managed-job-status-refresh loop as a thread in the API server."""
-import os
 import pathlib
 import signal
 import threading
 import time
 import typing
-from typing import Optional
+from typing import Optional, Sequence
 
 from sky import sky_logging
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import scheduler as managed_job_scheduler
+from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
 from sky.skylet import events
@@ -22,6 +22,20 @@ logger = sky_logging.init_logger(__name__)
 
 _LOCK_PROBE_INTERVAL_SECONDS = 5
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
+
+# Step-down controller drain. On losing the lock this replica must stop its own
+# job controllers, and stepping down in place (rather than exiting) means there
+# is no container teardown afterwards to reap whatever survives a SIGTERM — so
+# we wait for them to actually exit and escalate to SIGKILL.
+#
+# The total budget must stay comfortably below
+# _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS: that wait is what separates our dying
+# controllers from the new leader's recovery sweep, and the sweep decides a job
+# needs re-adopting by checking whether its controller pid is alive *locally*
+# (see _drain_local_controllers).
+_STEP_DOWN_SIGTERM_GRACE_SECONDS = 5
+_STEP_DOWN_DRAIN_TIMEOUT_SECONDS = 10
+_STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
 
 # How long to wait after acquiring the consolidation-mode lock before running
 # recovery. During a rolling update the new leader blocks on acquire() while
@@ -57,17 +71,18 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
 
         while True:
             try:
-                self._become_leader_and_run()
-                # _become_leader_and_run only returns normally after
-                # _suicide_on_lock_loss sent SIGTERM. Re-entering would
-                # skip the lock acquire (stale local `_acquired` flag),
-                # touch the signal file, and call ha_recovery →
-                # maybe_start_controllers — which would spawn fresh
-                # controllers under a now-released lock while the new
-                # leader on another replica is doing the same. Stop the
-                # thread instead so the SIGTERM-driven drain runs to
-                # completion without further controller churn.
-                return
+                # Returns only after a step-down; the value says whether it is
+                # safe to contend for leadership again. Looping is safe because
+                # the step-down gated controller starts, confirmed our own
+                # controllers are gone, and replaced the lock object — so the
+                # next pass really does acquire() before it leads, instead of
+                # running recovery on a stale local `_acquired` flag.
+                if not self._become_leader_and_run():
+                    logger.error(
+                        'Not contending for the consolidation mode lock again; '
+                        'this replica no longer runs managed-job recovery or '
+                        'the refresh loop until it restarts')
+                    return
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
                     'managed-job refresh error; '
@@ -75,14 +90,24 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                 # If we previously held the lock and lost the session
                 # mid-recovery, retrying would run as a stale leader
                 # (local `_acquired` flag still True, server-side lock
-                # released, another replica can grab it).  Hand off via
-                # SIGTERM, same as the steady-state probe path.
+                # released, another replica can grab it). Step down first,
+                # same as the steady-state probe path.
                 if self._lock.is_locked() and not self._lock_still_held():
-                    self._suicide_on_lock_loss()
-                    return
+                    if not self._step_down_on_lock_loss():
+                        logger.error(
+                            'Not contending for the consolidation mode lock '
+                            'again; this replica no longer runs managed-job '
+                            'recovery or the refresh loop until it restarts')
+                        return
                 time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
 
-    def _become_leader_and_run(self) -> None:
+    def _become_leader_and_run(self) -> bool:
+        """Take leadership, recover, then run the refresh loop.
+
+        Returns only when this replica has lost the lock and stepped down. The
+        return value is whether it is safe to contend for leadership again (see
+        _step_down_on_lock_loss).
+        """
         assert self._lock is not None
 
         # Touch the signal file BEFORE acquiring the lock: new controllers
@@ -95,12 +120,13 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # controller-start path early-return until recovery completes.
         # NOTE: the acquire is deliberately NOT inside the try/finally that
         # wraps recovery below. The finally unlinks the signal file, but the
-        # lock-loss step-down path (_suicide_on_lock_loss) re-touches it to
-        # keep controllers gated through the shutdown drain — so that path must
-        # not be followed by an unlink. Scoping the finally to recovery only
-        # keeps those two concerns from fighting. It also means a raise from
-        # acquire() leaves the gate file in place while run() retries, which is
-        # what we want (controller starts stay gated until we hold the lock).
+        # lock-loss step-down path (_step_down_on_lock_loss) re-touches it to
+        # keep controllers gated for as long as we are not the leader — so that
+        # path must not be followed by an unlink. Scoping the finally to
+        # recovery only keeps those two concerns from fighting. It also means a
+        # raise from acquire() leaves the gate file in place while run()
+        # retries, which is what we want (controller starts stay gated until we
+        # hold the lock).
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
@@ -126,11 +152,10 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # silently stale (PostgresLock only). Re-verify we still hold the lock
         # before recovery; otherwise another replica may have taken it and
         # could be recovering concurrently, so step down rather than run a
-        # second recovery loop. _suicide_on_lock_loss re-touches the signal
-        # file and SIGTERMs the process, so leave the file in place here.
+        # second recovery loop. _step_down_on_lock_loss re-touches the signal
+        # file to keep controllers gated, so leave the file in place here.
         if not self._lock_still_held():
-            self._suicide_on_lock_loss()
-            return
+            return self._step_down_on_lock_loss()
 
         try:
             managed_job_utils.ha_recovery_for_consolidation_mode()
@@ -147,8 +172,7 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             now = time.monotonic()
             if now - last_probe >= _LOCK_PROBE_INTERVAL_SECONDS:
                 if not self._lock_still_held():
-                    self._suicide_on_lock_loss()
-                    return
+                    return self._step_down_on_lock_loss()
                 last_probe = now
             if now - last_event >= events.EVENT_CHECKING_INTERVAL_SECONDS:
                 try:
@@ -166,13 +190,87 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             return self._lock.is_session_alive()
         return True
 
-    def _suicide_on_lock_loss(self) -> None:
-        """SIGTERM the API server process so the pod can restart cleanly."""
-        logger.error(
-            f'Lost consolidation mode lock {self._lock}; sending SIGTERM '
-            'to the API server to step down')
-        # Re-touch the recovery signal file so no new controllers will be
-        # started
+    @staticmethod
+    def _controllers_gone(records: Sequence[
+        managed_job_state.ControllerPidRecord], timeout: float) -> bool:
+        """Poll until none of *records* is a live local process, or time out."""
+        deadline = time.time() + timeout
+        while True:
+            alive = [
+                r.pid
+                for r in records
+                if managed_job_utils.controller_process_alive(r)
+            ]
+            if not alive:
+                return True
+            if time.time() >= deadline:
+                logger.warning(
+                    f'Controllers still alive after {timeout}s: {alive}')
+                return False
+            time.sleep(_STEP_DOWN_DRAIN_POLL_SECONDS)
+
+    def _drain_local_controllers(self) -> bool:
+        """Stop this replica's job controllers and confirm they are gone.
+
+        This is the anti-split-brain mechanism of a step-down, and now that the
+        process no longer exits it is the *only* one. The new leader's recovery
+        sweep decides a job needs re-adopting by checking whether its recorded
+        controller pid is alive, and that check is a local ``psutil`` lookup
+        (``controller_process_alive``) — so it can never see another replica's
+        controllers and always concludes they are dead. If one of ours outlives
+        our leadership, that job ends up with two controllers.
+
+        Signalling is therefore not enough. Previously the process SIGTERMed
+        itself here and the container teardown that followed reaped anything
+        that ignored the signal (controllers are detached subprocesses, so the
+        parent exiting does not kill them); stepping down in place removes that
+        backstop. So: SIGTERM, wait for exit, escalate to SIGKILL, and report
+        whether they are actually gone.
+
+        Returns True iff no controller recorded for this replica is still alive.
+        """
+        records = managed_job_scheduler.get_controller_process_records()
+        if records is None:
+            # The pid file could not be read, so we can neither enumerate our
+            # controllers nor confirm their death. Report failure rather than
+            # assume there were none.
+            logger.error(
+                'Cannot read the controller pid file, so this replica cannot '
+                'confirm its job controllers are gone')
+            return False
+        if not records:
+            return True
+
+        managed_job_scheduler.kill_local_job_controllers()
+        if self._controllers_gone(records, _STEP_DOWN_SIGTERM_GRACE_SECONDS):
+            return True
+
+        logger.warning(
+            f'Job controllers survived SIGTERM for '
+            f'{_STEP_DOWN_SIGTERM_GRACE_SECONDS}s; escalating to SIGKILL')
+        managed_job_scheduler.kill_local_job_controllers(signal.SIGKILL)
+        return self._controllers_gone(
+            records,
+            _STEP_DOWN_DRAIN_TIMEOUT_SECONDS - _STEP_DOWN_SIGTERM_GRACE_SECONDS)
+
+    def _step_down_on_lock_loss(self) -> bool:
+        """Give up leadership without killing the API server process.
+
+        The API server keeps serving; only the leader role is handed over. This
+        replica gates controller starts, stops the controllers it owns, drops
+        its lock object, and returns to contending for the lock as a follower.
+
+        Returns True iff it is safe to contend for leadership again — i.e. we
+        proved our own controllers are gone. If we could not, contending again
+        risks two controllers on one job, so the caller must stop instead.
+        """
+        assert self._lock is not None
+        logger.error(f'Lost consolidation mode lock {self._lock}; stepping '
+                     'down to follower')
+
+        # 1. Gate controller starts on this replica for as long as we are not
+        #    the leader. _become_leader_and_run touches this again before its
+        #    next acquire and only unlinks it once its own recovery completes.
         try:
             signal_file = pathlib.Path(
                 constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
@@ -180,15 +278,42 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             signal_file.touch()
         except OSError:
             logger.warning('Failed to touch recovery signal file on lock-loss')
-        # The lock is already released, kill job controllers to avoid split
-        # brain, e.g. new job controllers might have been launched on the new
-        # replica during rolling-update
+
+        # 2. Stop the controllers we own and confirm it. The lock is already
+        #    released server-side, so a new leader can be recovering within
+        #    milliseconds.
         try:
-            managed_job_scheduler.kill_local_job_controllers()
+            drained = self._drain_local_controllers()
         except Exception:  # pylint: disable=broad-except
-            logger.exception('Failed to kill local controllers on lock-loss')
-        # SIGTERM to trigger graceful shutdown
-        os.kill(os.getpid(), signal.SIGTERM)
+            logger.exception('Failed to drain local controllers on lock-loss')
+            drained = False
+
+        # 3. Replace the lock object. A release() whose connection is already
+        #    dead leaves `_acquired` True — it is only cleared after a
+        #    successful unlock — and is_locked() reads exactly that flag, so
+        #    reusing this object would make the next _become_leader_and_run
+        #    skip acquire() and run recovery believing it leads. Release
+        #    best-effort first so the pooled connection is returned or
+        #    invalidated rather than leaked, then start from a clean object.
+        try:
+            self._lock.release()
+        except Exception:  # pylint: disable=broad-except
+            logger.debug('Ignoring error while releasing the lost lock',
+                         exc_info=True)
+        self._lock = locks.get_lock(
+            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
+
+        if not drained:
+            logger.error(
+                'Step-down could not confirm this replica\'s job controllers '
+                'are gone; refusing to lead again. Controller starts stay '
+                'gated on this replica, so its surviving controllers keep '
+                'their jobs and no second controller is started here, but '
+                'this replica needs a restart to become eligible again')
+        else:
+            logger.info('Stepped down cleanly; contending for the '
+                        'consolidation mode lock again as a follower')
+        return drained
 
 
 def start_managed_job_refresh_daemon() -> None:

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -10,14 +10,13 @@ from typing import Optional, Sequence
 from sky import sky_logging
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import scheduler as managed_job_scheduler
-from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
 from sky.skylet import events
 from sky.utils import locks
 
 if typing.TYPE_CHECKING:
-    pass
+    from sky.jobs import state as managed_job_state
 
 logger = sky_logging.init_logger(__name__)
 
@@ -38,7 +37,7 @@ _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 # out of _become_leader_and_run) can be arbitrarily later. So the budget below
 # buys margin on the steady-state path only:
 #
-#     5s detection + 6s drain = 11s  <  15s recovery wait
+#     5s detection + (3s SIGTERM + 3s SIGKILL) drain = 11s  <  15s recovery wait
 #
 # It does not make the exception path safe, and it is not the thing the
 # correctness of the step-down rests on. What that rests on is the drain either
@@ -46,7 +45,7 @@ _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 # _step_down_on_lock_loss, which falls back to exiting the process in the second
 # case rather than assuming the wait covered us.
 _STEP_DOWN_SIGTERM_GRACE_SECONDS = 3
-_STEP_DOWN_DRAIN_TIMEOUT_SECONDS = 6
+_STEP_DOWN_SIGKILL_GRACE_SECONDS = 3
 _STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
 
 # How long to wait after acquiring the consolidation-mode lock before running
@@ -63,6 +62,14 @@ _STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
 # file stays in place during the wait, so no controllers are started and no job
 # is marked FAILED_CONTROLLER in the meantime.
 _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS = 15
+
+# Pin the margin the step-down comment above reasons about, so retuning any one
+# of these three constants cannot silently delete it. The drain tests
+# monkeypatch the budgets to 0, so they would not catch it either.
+assert (_LOCK_PROBE_INTERVAL_SECONDS + _STEP_DOWN_SIGTERM_GRACE_SECONDS +
+        _STEP_DOWN_SIGKILL_GRACE_SECONDS < _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS
+       ), ('a step-down must be able to detect the loss and drain before the '
+           'new leader stops waiting and starts recovery')
 
 
 class ManagedJobRefreshDaemonThread(threading.Thread):
@@ -84,16 +91,14 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         while True:
             try:
                 # Returns only after a step-down; the value says whether it is
-                # safe to contend for leadership again. Looping is safe because
-                # the step-down gated controller starts, confirmed our own
-                # controllers are gone, and replaced the lock object — so the
-                # next pass really does acquire() before it leads, instead of
-                # running recovery on a stale local `_acquired` flag.
+                # safe to contend for leadership again. Looping on True is safe
+                # because the step-down confirmed our own controllers are gone
+                # and replaced the lock object — so the next pass really does
+                # acquire() before it leads, instead of running recovery on a
+                # stale local `_acquired` flag. False means the step-down
+                # already asked this process to exit (it logs why), so stop the
+                # thread and let the shutdown proceed.
                 if not self._become_leader_and_run():
-                    logger.error(
-                        'Not contending for the consolidation mode lock again; '
-                        'this replica no longer runs managed-job recovery or '
-                        'the refresh loop until it restarts')
                     return
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
@@ -106,10 +111,6 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                 # same as the steady-state probe path.
                 if self._lock.is_locked() and not self._lock_still_held():
                     if not self._step_down_on_lock_loss():
-                        logger.error(
-                            'Not contending for the consolidation mode lock '
-                            'again; this replica no longer runs managed-job '
-                            'recovery or the refresh loop until it restarts')
                         return
                 time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
 
@@ -122,23 +123,22 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         """
         assert self._lock is not None
 
-        # Touch the signal file BEFORE acquiring the lock: new controllers
-        # must not be started until recovery has run. During a rolling
-        # update we block on acquire() while the old API server still holds
-        # the lock; if a controller were started on this replica in that
-        # window, the old server's update_managed_jobs_statuses wouldn't see
-        # its process and could mark the job FAILED_CONTROLLER. The signal
-        # file makes update_managed_jobs_statuses and the scheduler's
-        # controller-start path early-return until recovery completes.
+        # Touch the signal file BEFORE acquiring the lock: it holds off the
+        # FAILED_CONTROLLER sweep (update_managed_jobs_statuses in
+        # sky/jobs/utils.py, and job_lib), and that has to be in place for the
+        # whole time we are contending, not just once we win. During a rolling
+        # update we block on acquire() while the old API server still holds the
+        # lock; jobs whose controllers are moving between replicas must not be
+        # marked FAILED_CONTROLLER for it in that window. See step 1 of
+        # _step_down_on_lock_loss for what the file does and does not gate.
         # NOTE: the acquire is deliberately NOT inside the try/finally that
         # wraps recovery below. The finally unlinks the signal file, but the
         # lock-loss step-down path (_step_down_on_lock_loss) re-touches it to
-        # keep controllers gated for as long as we are not the leader — so that
+        # hold off the sweep for as long as we are not the leader — so that
         # path must not be followed by an unlink. Scoping the finally to
         # recovery only keeps those two concerns from fighting. It also means a
-        # raise from acquire() leaves the gate file in place while run()
-        # retries, which is what we want (controller starts stay gated until we
-        # hold the lock).
+        # raise from acquire() leaves the file in place while run() retries,
+        # which is what we want.
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
@@ -151,8 +151,8 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # Wait before recovery so a prior leader (e.g. the old pod during a
         # rolling update) is fully gone first; see the comment on
         # _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS. The signal file touched above
-        # stays in place, gating controller starts and the FAILED_CONTROLLER
-        # sweep until recovery completes.
+        # stays in place, holding off the FAILED_CONTROLLER sweep until recovery
+        # completes.
         logger.info(
             f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after acquiring '
             'the consolidation mode lock before running recovery, to let any '
@@ -165,7 +165,7 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # before recovery; otherwise another replica may have taken it and
         # could be recovering concurrently, so step down rather than run a
         # second recovery loop. _step_down_on_lock_loss re-touches the signal
-        # file to keep controllers gated, so leave the file in place here.
+        # file, so leave the file in place here.
         if not self._lock_still_held():
             return self._step_down_on_lock_loss()
 
@@ -203,21 +203,28 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         return True
 
     @staticmethod
-    def _controllers_gone(records: Sequence[
-        managed_job_state.ControllerPidRecord], timeout: float) -> bool:
+    def _controllers_gone(
+            records: Sequence['managed_job_state.ControllerPidRecord'],
+            timeout: float) -> bool:
         """Poll until none of *records* is a live local process, or time out."""
-        deadline = time.time() + timeout
+        deadline = time.monotonic() + timeout
+        remaining = list(records)
         while True:
-            alive = [
-                r.pid
-                for r in records
+            # Poll only the survivors. The alive set can only shrink —
+            # controller_process_alive matches on (pid, started_at), so a record
+            # that is gone cannot come back under a recycled pid — and *records*
+            # is every pid this replica ever recorded, not the live pool: the
+            # pid file is append-only and nothing truncates it in consolidation
+            # mode.
+            remaining = [
+                r for r in remaining
                 if managed_job_utils.controller_process_alive(r)
             ]
-            if not alive:
+            if not remaining:
                 return True
-            if time.time() >= deadline:
-                logger.warning(
-                    f'Controllers still alive after {timeout}s: {alive}')
+            if time.monotonic() >= deadline:
+                logger.warning(f'Controllers still alive after {timeout}s: '
+                               f'{[r.pid for r in remaining]}')
                 return False
             time.sleep(_STEP_DOWN_DRAIN_POLL_SECONDS)
 
@@ -231,6 +238,16 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         (``controller_process_alive``) — so it can never see another replica's
         controllers and always concludes they are dead. If one of ours outlives
         our leadership, that job ends up with two controllers.
+
+        TODO(aylei): this is a local compensation for a fact that is missing
+        from the shared state, and it is the second one —
+        maybe_start_controllers already refuses to start controllers off the
+        request path for the same reason. The deeper fix is to make controller
+        ownership DB-visible (e.g.
+        record the owning replica alongside job_info's controller_pid, so
+        controller_process_alive can answer "not mine" instead of "dead"), which
+        would also let the fallback below go away. Out of scope here: schema
+        change plus every controller_process_alive call site.
 
         Signalling is therefore not enough. Previously the process SIGTERMed
         itself here and the container teardown that followed reaped anything
@@ -247,10 +264,8 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         script, so that pid becomes the controller. Verified live: a
         cmdline-based process count over the leader's pod showed exactly one
         process per controller (a surviving wrapper would have doubled it) and
-        dropped to zero after this drain. Appending anything after the
-        controller invocation in ``scheduler.py``'s ``run_cmd`` would stop bash
-        exec'ing, and this drain would then start confirming the death of a
-        wrapper while the controller kept running.
+        dropped to zero after this drain. ``scheduler.py``'s ``run_cmd`` carries
+        a matching note, since that is where the assumption can be broken.
 
         Returns True iff no controller recorded for this replica is still alive.
         """
@@ -274,16 +289,14 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             f'Job controllers survived SIGTERM for '
             f'{_STEP_DOWN_SIGTERM_GRACE_SECONDS}s; escalating to SIGKILL')
         managed_job_scheduler.kill_local_job_controllers(signal.SIGKILL)
-        return self._controllers_gone(
-            records,
-            _STEP_DOWN_DRAIN_TIMEOUT_SECONDS - _STEP_DOWN_SIGTERM_GRACE_SECONDS)
+        return self._controllers_gone(records, _STEP_DOWN_SIGKILL_GRACE_SECONDS)
 
     def _step_down_on_lock_loss(self) -> bool:
         """Give up leadership without killing the API server process.
 
         The API server keeps serving; only the leader role is handed over. This
-        replica gates controller starts, stops the controllers it owns, drops
-        its lock object, and returns to contending for the lock as a follower.
+        replica holds off the FAILED_CONTROLLER sweep, stops the controllers it
+        owns, drops its lock object, and returns to contending as a follower.
 
         Returns True iff it is safe to contend for leadership again — i.e. we
         proved our own controllers are gone. If we could not, this exits the
@@ -332,6 +345,11 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         #    skip acquire() and run recovery believing it leads. Release
         #    best-effort first so the pooled connection is returned or
         #    invalidated rather than leaked, then start from a clean object.
+        #    Same discipline as AdvisoryLockElector.release() + try_acquire() in
+        #    sky/utils/leader_election.py; this loop cannot use
+        #    that elector yet because its try_acquire is non-blocking and the
+        #    blocking acquire() above is load-bearing for the rolling-update
+        #    handoff. Keep the two in sync until they are merged.
         try:
             self._lock.release()
         except Exception:  # pylint: disable=broad-except
@@ -341,29 +359,20 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
 
         if not drained:
-            # Last resort: exit the process, which is what actually closed this
-            # hole before this change.
+            # Last resort: exit, so the container teardown reaps the survivors —
+            # which is what actually closed this hole before this change.
+            # Declining to lead instead is not equivalent, because another
+            # replica cannot see our controllers and re-adopts their jobs
+            # regardless; see _drain_local_controllers.
             #
-            # Merely declining to lead again is NOT equivalent, and it is worth
-            # being explicit about why. The new leader on another replica
-            # decides a job needs re-adopting from a *local* psutil check
-            # (controller_process_alive), so it cannot see our survivors and
-            # will re-adopt their jobs no matter what we do here — giving that
-            # job a second controller. Staying up only guarantees we do not add
-            # a *third*. The old self-SIGTERM worked because the process exiting
-            # took the container with it, and the teardown reaped whatever had
-            # ignored the signal; so ask for exactly that.
-            #
-            # It also covers the single-replica case (the chart's default
+            # Exiting also covers the single-replica case (the chart's default
             # apiService.replicas is 1): there, stopping this thread would leave
             # nobody running recovery, controller top-ups or the
             # FAILED_CONTROLLER sweep, with nothing to restart it.
             logger.error(
                 'Step-down could not confirm this replica\'s job controllers '
                 'are gone; exiting so the orchestrator restarts this replica '
-                'and its teardown reaps them. Declining to lead would not be '
-                'enough: another replica cannot see our controllers and will '
-                're-adopt their jobs regardless')
+                'and its teardown reaps them')
             os.kill(os.getpid(), signal.SIGTERM)
         else:
             logger.info('Stepped down cleanly; contending for the '

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -1,4 +1,5 @@
 """Run the managed-job-status-refresh loop as a thread in the API server."""
+import os
 import pathlib
 import signal
 import threading
@@ -28,13 +29,24 @@ _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 # is no container teardown afterwards to reap whatever survives a SIGTERM — so
 # we wait for them to actually exit and escalate to SIGKILL.
 #
-# The total budget must stay comfortably below
-# _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS: that wait is what separates our dying
-# controllers from the new leader's recovery sweep, and the sweep decides a job
-# needs re-adopting by checking whether its controller pid is alive *locally*
-# (see _drain_local_controllers).
-_STEP_DOWN_SIGTERM_GRACE_SECONDS = 5
-_STEP_DOWN_DRAIN_TIMEOUT_SECONDS = 10
+# How this races the new leader's recovery sweep, precisely, because the two
+# clocks do NOT start together: the new leader's
+# _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS (15s) starts when it ACQUIRES the lock,
+# which it can do the moment our session dies server-side. Our drain starts only
+# once we NOTICE, which on the steady-state path is up to
+# _LOCK_PROBE_INTERVAL_SECONDS (5s) later, and on the exception path (a raise
+# out of _become_leader_and_run) can be arbitrarily later. So the budget below
+# buys margin on the steady-state path only:
+#
+#     5s detection + 6s drain = 11s  <  15s recovery wait
+#
+# It does not make the exception path safe, and it is not the thing the
+# correctness of the step-down rests on. What that rests on is the drain either
+# confirming the controllers are gone or admitting it could not — see
+# _step_down_on_lock_loss, which falls back to exiting the process in the second
+# case rather than assuming the wait covered us.
+_STEP_DOWN_SIGTERM_GRACE_SECONDS = 3
+_STEP_DOWN_DRAIN_TIMEOUT_SECONDS = 6
 _STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
 
 # How long to wait after acquiring the consolidation-mode lock before running
@@ -227,6 +239,19 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         backstop. So: SIGTERM, wait for exit, escalate to SIGKILL, and report
         whether they are actually gone.
 
+        Load-bearing assumption, recorded because it is easy to break from far
+        away: the recorded pid must be the controller itself, not a shell
+        wrapper. ``launch_new_process_tree`` runs ``nohup bash -c '<export>;
+        <activate>; python -m sky.jobs.controller'`` and records ``$!``, i.e.
+        the bash pid — but bash execs the final simple command of a ``-c``
+        script, so that pid becomes the controller. Verified live: a
+        cmdline-based process count over the leader's pod showed exactly one
+        process per controller (a surviving wrapper would have doubled it) and
+        dropped to zero after this drain. Appending anything after the
+        controller invocation in ``scheduler.py``'s ``run_cmd`` would stop bash
+        exec'ing, and this drain would then start confirming the death of a
+        wrapper while the controller kept running.
+
         Returns True iff no controller recorded for this replica is still alive.
         """
         records = managed_job_scheduler.get_controller_process_records()
@@ -261,16 +286,28 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         its lock object, and returns to contending for the lock as a follower.
 
         Returns True iff it is safe to contend for leadership again — i.e. we
-        proved our own controllers are gone. If we could not, contending again
-        risks two controllers on one job, so the caller must stop instead.
+        proved our own controllers are gone. If we could not, this exits the
+        process (see below) and returns False so the caller stops the thread.
         """
         assert self._lock is not None
         logger.error(f'Lost consolidation mode lock {self._lock}; stepping '
                      'down to follower')
 
-        # 1. Gate controller starts on this replica for as long as we are not
-        #    the leader. _become_leader_and_run touches this again before its
-        #    next acquire and only unlinks it once its own recovery completes.
+        # 1. Re-touch the recovery signal file, kept for what it actually does
+        #    rather than what the surrounding comments have long claimed. It is
+        #    consulted by update_managed_jobs_statuses (sky/jobs/utils.py) and
+        #    job_lib, NOT by scheduler.maybe_start_controllers — so it does not
+        #    itself gate controller starts. What keeps a non-leader from
+        #    starting controllers in consolidation mode is
+        #    maybe_start_controllers' unconditional early return on the request
+        #    path; the leader's recovery is the only starter. The file's job
+        #    here is to hold off the FAILED_CONTROLLER sweep across the
+        #    handoff, so jobs whose controllers we are about to stop are not
+        #    marked failed for it.
+        #    Note it can be fleet-wide, not replica-local: the HA chart has a
+        #    configuration that mounts the shared state volume at ~/.sky, and
+        #    this path lives directly under it. The next leader's recovery
+        #    unlinks it (in a finally), which bounds the window.
         try:
             signal_file = pathlib.Path(
                 constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
@@ -304,12 +341,30 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
 
         if not drained:
+            # Last resort: exit the process, which is what actually closed this
+            # hole before this change.
+            #
+            # Merely declining to lead again is NOT equivalent, and it is worth
+            # being explicit about why. The new leader on another replica
+            # decides a job needs re-adopting from a *local* psutil check
+            # (controller_process_alive), so it cannot see our survivors and
+            # will re-adopt their jobs no matter what we do here — giving that
+            # job a second controller. Staying up only guarantees we do not add
+            # a *third*. The old self-SIGTERM worked because the process exiting
+            # took the container with it, and the teardown reaped whatever had
+            # ignored the signal; so ask for exactly that.
+            #
+            # It also covers the single-replica case (the chart's default
+            # apiService.replicas is 1): there, stopping this thread would leave
+            # nobody running recovery, controller top-ups or the
+            # FAILED_CONTROLLER sweep, with nothing to restart it.
             logger.error(
                 'Step-down could not confirm this replica\'s job controllers '
-                'are gone; refusing to lead again. Controller starts stay '
-                'gated on this replica, so its surviving controllers keep '
-                'their jobs and no second controller is started here, but '
-                'this replica needs a restart to become eligible again')
+                'are gone; exiting so the orchestrator restarts this replica '
+                'and its teardown reaps them. Declining to lead would not be '
+                'enough: another replica cannot see our controllers and will '
+                're-adopt their jobs regardless')
+            os.kill(os.getpid(), signal.SIGTERM)
         else:
             logger.info('Stepped down cleanly; contending for the '
                         'consolidation mode lock again as a follower')

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -23,27 +23,13 @@ logger = sky_logging.init_logger(__name__)
 _LOCK_PROBE_INTERVAL_SECONDS = 5
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 
-# Step-down controller drain. On losing the lock this replica must stop its own
-# job controllers, and stepping down in place (rather than exiting) means there
-# is no container teardown afterwards to reap whatever survives a SIGTERM — so
-# we wait for them to actually exit and escalate to SIGKILL.
-#
-# How this races the new leader's recovery sweep, precisely, because the two
-# clocks do NOT start together: the new leader's
-# _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS (15s) starts when it ACQUIRES the lock,
-# which it can do the moment our session dies server-side. Our drain starts only
-# once we NOTICE, which on the steady-state path is up to
-# _LOCK_PROBE_INTERVAL_SECONDS (5s) later, and on the exception path (a raise
-# out of _become_leader_and_run) can be arbitrarily later. So the budget below
-# buys margin on the steady-state path only:
-#
-#     5s detection + (3s SIGTERM + 3s SIGKILL) drain = 11s  <  15s recovery wait
-#
-# It does not make the exception path safe, and it is not the thing the
-# correctness of the step-down rests on. What that rests on is the drain either
-# confirming the controllers are gone or admitting it could not — see
-# _step_down_on_lock_loss, which falls back to exiting the process in the second
-# case rather than assuming the wait covered us.
+# Step-down controller drain. Stepping down in place leaves no container
+# teardown to reap controllers that ignore SIGTERM, so wait for them to exit and
+# escalate to SIGKILL. The budget (5s to detect + 3s + 3s) fits inside the new
+# leader's 15s recovery wait on the steady-state path only: the two clocks start
+# at different times, and the exception path can notice arbitrarily late. What
+# correctness rests on is the drain confirming or admitting failure, not on that
+# margin — see _step_down_on_lock_loss.
 _STEP_DOWN_SIGTERM_GRACE_SECONDS = 3
 _STEP_DOWN_SIGKILL_GRACE_SECONDS = 3
 _STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
@@ -63,9 +49,8 @@ _STEP_DOWN_DRAIN_POLL_SECONDS = 0.2
 # is marked FAILED_CONTROLLER in the meantime.
 _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS = 15
 
-# Pin the margin the step-down comment above reasons about, so retuning any one
-# of these three constants cannot silently delete it. The drain tests
-# monkeypatch the budgets to 0, so they would not catch it either.
+# Pin the margin above: retuning any one constant must not silently delete it
+# (the drain tests zero the budgets, so they would not catch it).
 assert (_LOCK_PROBE_INTERVAL_SECONDS + _STEP_DOWN_SIGTERM_GRACE_SECONDS +
         _STEP_DOWN_SIGKILL_GRACE_SECONDS < _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS
        ), ('a step-down must be able to detect the loss and drain before the '
@@ -90,25 +75,19 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
 
         while True:
             try:
-                # Returns only after a step-down; the value says whether it is
-                # safe to contend for leadership again. Looping on True is safe
-                # because the step-down confirmed our own controllers are gone
-                # and replaced the lock object — so the next pass really does
-                # acquire() before it leads, instead of running recovery on a
-                # stale local `_acquired` flag. False means the step-down
-                # already asked this process to exit (it logs why), so stop the
-                # thread and let the shutdown proceed.
+                # Returns only after a step-down. True: it confirmed our
+                # controllers are gone and replaced the lock object, so the next
+                # pass really does acquire() before leading. False: it already
+                # asked this process to exit, and logged why.
                 if not self._become_leader_and_run():
                     return
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
                     'managed-job refresh error; '
                     f'retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
-                # If we previously held the lock and lost the session
-                # mid-recovery, retrying would run as a stale leader
-                # (local `_acquired` flag still True, server-side lock
-                # released, another replica can grab it). Step down first,
-                # same as the steady-state probe path.
+                # A stale leader (local `_acquired` still True, lock released
+                # server-side) must not retry as leader; step down first, same
+                # as the steady-state probe path.
                 if self._lock.is_locked() and not self._lock_still_held():
                     if not self._step_down_on_lock_loss():
                         return
@@ -123,22 +102,14 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         """
         assert self._lock is not None
 
-        # Touch the signal file BEFORE acquiring the lock: it holds off the
-        # FAILED_CONTROLLER sweep (update_managed_jobs_statuses in
-        # sky/jobs/utils.py, and job_lib), and that has to be in place for the
-        # whole time we are contending, not just once we win. During a rolling
-        # update we block on acquire() while the old API server still holds the
-        # lock; jobs whose controllers are moving between replicas must not be
-        # marked FAILED_CONTROLLER for it in that window. See step 1 of
-        # _step_down_on_lock_loss for what the file does and does not gate.
-        # NOTE: the acquire is deliberately NOT inside the try/finally that
-        # wraps recovery below. The finally unlinks the signal file, but the
-        # lock-loss step-down path (_step_down_on_lock_loss) re-touches it to
-        # hold off the sweep for as long as we are not the leader — so that
-        # path must not be followed by an unlink. Scoping the finally to
-        # recovery only keeps those two concerns from fighting. It also means a
-        # raise from acquire() leaves the file in place while run() retries,
-        # which is what we want.
+        # Touch BEFORE acquiring: the file holds off the FAILED_CONTROLLER sweep
+        # and has to cover the whole time we contend, since acquire() can block
+        # for a long time during a rolling update. See step 1 of
+        # _step_down_on_lock_loss for what it does and does not gate.
+        # NOTE: acquire stays outside the try/finally below on purpose — the
+        # finally unlinks this file while the step-down re-touches it, so
+        # scoping the finally to recovery keeps the two from fighting, and a
+        # raise from acquire() leaves the file in place while run() retries.
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
@@ -148,24 +119,18 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             self._lock.acquire()
             logger.info('Consolidation mode lock acquired')
 
-        # Wait before recovery so a prior leader (e.g. the old pod during a
-        # rolling update) is fully gone first; see the comment on
-        # _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS. The signal file touched above
-        # stays in place, holding off the FAILED_CONTROLLER sweep until recovery
-        # completes.
+        # Let a prior leader finish shutting down first; see
+        # _RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS. The signal file stays in place.
         logger.info(
             f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after acquiring '
             'the consolidation mode lock before running recovery, to let any '
             'previous leader finish shutting down')
         time.sleep(_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS)
 
-        # The wait above widens the window between acquiring the lock and
-        # running recovery, during which the lock's underlying session could go
-        # silently stale (PostgresLock only). Re-verify we still hold the lock
-        # before recovery; otherwise another replica may have taken it and
-        # could be recovering concurrently, so step down rather than run a
-        # second recovery loop. _step_down_on_lock_loss re-touches the signal
-        # file, so leave the file in place here.
+        # The wait widens the window in which the session can go silently stale
+        # (PostgresLock only), so re-verify before recovery: another replica may
+        # hold the lock and be recovering by now. Leave the signal file in place
+        # — the step-down re-touches it.
         if not self._lock_still_held():
             return self._step_down_on_lock_loss()
 
@@ -210,12 +175,10 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         deadline = time.monotonic() + timeout
         remaining = list(records)
         while True:
-            # Poll only the survivors. The alive set can only shrink —
-            # controller_process_alive matches on (pid, started_at), so a record
-            # that is gone cannot come back under a recycled pid — and *records*
-            # is every pid this replica ever recorded, not the live pool: the
-            # pid file is append-only and nothing truncates it in consolidation
-            # mode.
+            # Poll only the survivors: the alive set can only shrink (liveness
+            # matches on (pid, started_at)), and *records* is every pid this
+            # replica ever recorded — the pid file is append-only in
+            # consolidation mode, not the live pool.
             remaining = [
                 r for r in remaining
                 if managed_job_utils.controller_process_alive(r)
@@ -231,49 +194,30 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
     def _drain_local_controllers(self) -> bool:
         """Stop this replica's job controllers and confirm they are gone.
 
-        This is the anti-split-brain mechanism of a step-down, and now that the
-        process no longer exits it is the *only* one. The new leader's recovery
-        sweep decides a job needs re-adopting by checking whether its recorded
-        controller pid is alive, and that check is a local ``psutil`` lookup
-        (``controller_process_alive``) — so it can never see another replica's
-        controllers and always concludes they are dead. If one of ours outlives
-        our leadership, that job ends up with two controllers.
+        The anti-split-brain mechanism of a step-down, and now that the process
+        no longer exits, the only one: the new leader decides a job needs
+        re-adopting from a *local* psutil check (``controller_process_alive``),
+        so it never sees another replica's controllers and always concludes they
+        are dead — a survivor of ours means two controllers on one job.
 
-        TODO(aylei): this is a local compensation for a fact that is missing
-        from the shared state, and it is the second one —
-        maybe_start_controllers already refuses to start controllers off the
-        request path for the same reason. The deeper fix is to make controller
-        ownership DB-visible (e.g.
-        record the owning replica alongside job_info's controller_pid, so
-        controller_process_alive can answer "not mine" instead of "dead"), which
-        would also let the fallback below go away. Out of scope here: schema
-        change plus every controller_process_alive call site.
+        Signalling alone is therefore not enough, because stepping down in place
+        removes the container teardown that used to reap controllers ignoring
+        SIGTERM (they are detached subprocesses): SIGTERM, wait, escalate to
+        SIGKILL, report. Assumes the recorded pid is the controller rather than
+        its shell wrapper — bash execs the final simple command of a ``-c``
+        script, and ``scheduler.py``'s ``run_cmd`` carries the matching note
+        since that is where the assumption can be broken.
 
-        Signalling is therefore not enough. Previously the process SIGTERMed
-        itself here and the container teardown that followed reaped anything
-        that ignored the signal (controllers are detached subprocesses, so the
-        parent exiting does not kill them); stepping down in place removes that
-        backstop. So: SIGTERM, wait for exit, escalate to SIGKILL, and report
-        whether they are actually gone.
-
-        Load-bearing assumption, recorded because it is easy to break from far
-        away: the recorded pid must be the controller itself, not a shell
-        wrapper. ``launch_new_process_tree`` runs ``nohup bash -c '<export>;
-        <activate>; python -m sky.jobs.controller'`` and records ``$!``, i.e.
-        the bash pid — but bash execs the final simple command of a ``-c``
-        script, so that pid becomes the controller. Verified live: a
-        cmdline-based process count over the leader's pod showed exactly one
-        process per controller (a surviving wrapper would have doubled it) and
-        dropped to zero after this drain. ``scheduler.py``'s ``run_cmd`` carries
-        a matching note, since that is where the assumption can be broken.
+        TODO(aylei): make controller ownership DB-visible (the owning replica
+        alongside job_info's controller_pid, so liveness can answer "not mine"
+        instead of "dead") and this drain's fallback can go away.
 
         Returns True iff no controller recorded for this replica is still alive.
         """
         records = managed_job_scheduler.get_controller_process_records()
         if records is None:
-            # The pid file could not be read, so we can neither enumerate our
-            # controllers nor confirm their death. Report failure rather than
-            # assume there were none.
+            # Unreadable pid file: we can neither enumerate our controllers nor
+            # confirm their death, so report failure rather than assume none.
             logger.error(
                 'Cannot read the controller pid file, so this replica cannot '
                 'confirm its job controllers are gone')
@@ -294,33 +238,26 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
     def _step_down_on_lock_loss(self) -> bool:
         """Give up leadership without killing the API server process.
 
-        The API server keeps serving; only the leader role is handed over. This
-        replica holds off the FAILED_CONTROLLER sweep, stops the controllers it
-        owns, drops its lock object, and returns to contending as a follower.
+        The server keeps serving; only the leader role moves. Holds off the
+        FAILED_CONTROLLER sweep, stops the controllers this replica owns, drops
+        the lock object, and returns to contending as a follower.
 
-        Returns True iff it is safe to contend for leadership again — i.e. we
-        proved our own controllers are gone. If we could not, this exits the
-        process (see below) and returns False so the caller stops the thread.
+        Returns True iff it is safe to lead again, i.e. we proved our
+        controllers are gone; otherwise it exits the process and returns False.
         """
         assert self._lock is not None
         logger.error(f'Lost consolidation mode lock {self._lock}; stepping '
                      'down to follower')
 
-        # 1. Re-touch the recovery signal file, kept for what it actually does
-        #    rather than what the surrounding comments have long claimed. It is
-        #    consulted by update_managed_jobs_statuses (sky/jobs/utils.py) and
-        #    job_lib, NOT by scheduler.maybe_start_controllers — so it does not
-        #    itself gate controller starts. What keeps a non-leader from
-        #    starting controllers in consolidation mode is
-        #    maybe_start_controllers' unconditional early return on the request
-        #    path; the leader's recovery is the only starter. The file's job
-        #    here is to hold off the FAILED_CONTROLLER sweep across the
-        #    handoff, so jobs whose controllers we are about to stop are not
-        #    marked failed for it.
-        #    Note it can be fleet-wide, not replica-local: the HA chart has a
-        #    configuration that mounts the shared state volume at ~/.sky, and
-        #    this path lives directly under it. The next leader's recovery
-        #    unlinks it (in a finally), which bounds the window.
+        # 1. Re-touch the recovery signal file: it holds off the
+        #    FAILED_CONTROLLER sweep (update_managed_jobs_statuses in
+        #    sky/jobs/utils.py, and job_lib) so the jobs whose controllers we
+        #    are about to stop are not marked failed across the handoff. It does
+        #    NOT gate controller starts — maybe_start_controllers never reads
+        #    it; what stops a non-leader is its own unconditional early return.
+        #    The effect can be fleet-wide rather than replica-local, since one
+        #    HA chart configuration mounts the shared state volume at ~/.sky;
+        #    the next leader's recovery unlinks it, which bounds the window.
         try:
             signal_file = pathlib.Path(
                 constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
@@ -329,27 +266,22 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         except OSError:
             logger.warning('Failed to touch recovery signal file on lock-loss')
 
-        # 2. Stop the controllers we own and confirm it. The lock is already
-        #    released server-side, so a new leader can be recovering within
-        #    milliseconds.
+        # 2. Stop the controllers we own and confirm it — the lock is already
+        #    released server-side, so a new leader can be recovering by now.
         try:
             drained = self._drain_local_controllers()
         except Exception:  # pylint: disable=broad-except
             logger.exception('Failed to drain local controllers on lock-loss')
             drained = False
 
-        # 3. Replace the lock object. A release() whose connection is already
-        #    dead leaves `_acquired` True — it is only cleared after a
-        #    successful unlock — and is_locked() reads exactly that flag, so
-        #    reusing this object would make the next _become_leader_and_run
-        #    skip acquire() and run recovery believing it leads. Release
-        #    best-effort first so the pooled connection is returned or
-        #    invalidated rather than leaked, then start from a clean object.
-        #    Same discipline as AdvisoryLockElector.release() + try_acquire() in
-        #    sky/utils/leader_election.py; this loop cannot use
-        #    that elector yet because its try_acquire is non-blocking and the
-        #    blocking acquire() above is load-bearing for the rolling-update
-        #    handoff. Keep the two in sync until they are merged.
+        # 3. Replace the lock object: a release() on a dead connection leaves
+        #    `_acquired` True (only cleared after a successful unlock) and
+        #    is_locked() reads exactly that flag, so reusing it would make the
+        #    next pass skip acquire() and run recovery believing it leads.
+        #    Release best-effort first so the pooled connection is not leaked.
+        #    Same discipline as leader_election.AdvisoryLockElector, which this
+        #    cannot use yet: its try_acquire is non-blocking, and the blocking
+        #    acquire() above is load-bearing for the rolling-update handoff.
         try:
             self._lock.release()
         except Exception:  # pylint: disable=broad-except
@@ -359,16 +291,11 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
 
         if not drained:
-            # Last resort: exit, so the container teardown reaps the survivors —
-            # which is what actually closed this hole before this change.
-            # Declining to lead instead is not equivalent, because another
-            # replica cannot see our controllers and re-adopts their jobs
-            # regardless; see _drain_local_controllers.
-            #
-            # Exiting also covers the single-replica case (the chart's default
-            # apiService.replicas is 1): there, stopping this thread would leave
-            # nobody running recovery, controller top-ups or the
-            # FAILED_CONTROLLER sweep, with nothing to restart it.
+            # Last resort: exit so the container teardown reaps the survivors,
+            # which is what closed this hole before. Declining to lead is not
+            # equivalent (see _drain_local_controllers), and with the chart's
+            # default of one replica it would leave nobody running recovery at
+            # all, with nothing to restart it.
             logger.error(
                 'Step-down could not confirm this replica\'s job controllers '
                 'are gone; exiting so the orchestrator restarts this replica '

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -176,6 +176,11 @@ def start_controller() -> None:
     # leaks permanently into the API server's os.environ and causes
     # serve_utils.is_consolidation_mode() to return True for all serve
     # requests, even when serve consolidation mode is not configured.
+    # Keep the controller invocation LAST. bash execs the final simple command
+    # of a `-c` script, so the pid recorded below is the controller itself
+    # rather than a surviving shell wrapper. Appending anything after it would
+    # break that, and the step-down drain in managed_job_refresh_thread.py would
+    # then confirm the death of a wrapper while the controller kept running.
     run_cmd = (f'export {constants.OVERRIDE_CONSOLIDATION_MODE}=true; '
                f'{activate_python_env_cmd}'
                f'{run_controller_cmd}')

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -176,11 +176,11 @@ def start_controller() -> None:
     # leaks permanently into the API server's os.environ and causes
     # serve_utils.is_consolidation_mode() to return True for all serve
     # requests, even when serve consolidation mode is not configured.
-    # Keep the controller invocation LAST. bash execs the final simple command
-    # of a `-c` script, so the pid recorded below is the controller itself
-    # rather than a surviving shell wrapper. Appending anything after it would
-    # break that, and the step-down drain in managed_job_refresh_thread.py would
-    # then confirm the death of a wrapper while the controller kept running.
+    # Keep the controller invocation LAST: bash execs the final simple command
+    # of a `-c` script, so the pid recorded below is the controller itself and
+    # not a surviving wrapper. Appending anything after it would make the
+    # step-down drain in managed_job_refresh_thread.py confirm the death of the
+    # wrapper while the controller kept running.
     run_cmd = (f'export {constants.OVERRIDE_CONSOLIDATION_MODE}=true; '
                f'{activate_python_env_cmd}'
                f'{run_controller_cmd}')

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -403,19 +403,23 @@ class PostgresLock(DistributedLock):
         This method exposes a cheap ``SELECT 1`` probe on the very connection
         that holds the lock so the holder can detect the loss and react.
 
-        Reacting by exiting the process is one option, but not the only one and
-        not the cheapest: a holder that also serves traffic takes that traffic
-        down with it. A holder can instead step down in place — stop whatever
-        work the lock guarded, prove it stopped, drop this lock object (see the
-        note below) and go back to contending. ``sky/jobs/
-        managed_job_refresh_thread.py::_step_down_on_lock_loss`` does that.
+        A holder that also serves traffic need not exit on a lost session; it
+        can step down in place, stop whatever work the lock guarded, drop this
+        lock object and go back to contending.
 
-        Note for either path: a failed ``release()`` on the dead connection
-        leaves ``self._acquired`` True, because that flag is only cleared after
-        a successful unlock — and ``is_locked()`` returns exactly that flag. A
-        holder that keeps using this object after a lost session can therefore
-        believe it still holds the lock. Build a fresh lock instead of reusing
-        one whose session died.
+        Either way, do not reuse this object afterwards: a failed ``release()``
+        on the dead connection leaves ``self._acquired`` True, because that flag
+        is only cleared after a successful unlock — and ``is_locked()`` returns
+        exactly that flag. A holder that keeps using this object after a lost
+        session can therefore believe it still holds the lock. Build a fresh
+        lock instead.
+
+        TODO(aylei): this transition belongs to this class rather than to every
+        caller's memory — an explicit ``mark_lost()``, so ``is_locked()`` stops
+        reporting a lock whose session is gone. Note that simply clearing
+        ``_acquired`` in ``release()``'s ``DatabaseError`` branch is not the
+        safe version: that branch also catches non-connection errors, where our
+        own session may still hold the lock.
 
         Returns ``False`` if the lock was never acquired, if the connection
         is missing, or if the probe raises any exception.  Returns ``True``

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -401,8 +401,21 @@ class PostgresLock(DistributedLock):
         could now hold the same lock.
 
         This method exposes a cheap ``SELECT 1`` probe on the very connection
-        that holds the lock so the holder can detect the loss and react
-        (typically by exiting and letting the orchestrator restart it).
+        that holds the lock so the holder can detect the loss and react.
+
+        Reacting by exiting the process is one option, but not the only one and
+        not the cheapest: a holder that also serves traffic takes that traffic
+        down with it. A holder can instead step down in place — stop whatever
+        work the lock guarded, prove it stopped, drop this lock object (see the
+        note below) and go back to contending. ``sky/jobs/
+        managed_job_refresh_thread.py::_step_down_on_lock_loss`` does that.
+
+        Note for either path: a failed ``release()`` on the dead connection
+        leaves ``self._acquired`` True, because that flag is only cleared after
+        a successful unlock — and ``is_locked()`` returns exactly that flag. A
+        holder that keeps using this object after a lost session can therefore
+        believe it still holds the lock. Build a fresh lock instead of reusing
+        one whose session died.
 
         Returns ``False`` if the lock was never acquired, if the connection
         is missing, or if the probe raises any exception.  Returns ``True``

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -408,18 +408,15 @@ class PostgresLock(DistributedLock):
         lock object and go back to contending.
 
         Either way, do not reuse this object afterwards: a failed ``release()``
-        on the dead connection leaves ``self._acquired`` True, because that flag
-        is only cleared after a successful unlock — and ``is_locked()`` returns
-        exactly that flag. A holder that keeps using this object after a lost
-        session can therefore believe it still holds the lock. Build a fresh
-        lock instead.
+        on a dead connection leaves ``self._acquired`` True (it is only cleared
+        after a successful unlock) and ``is_locked()`` returns that flag, so the
+        holder would believe it still holds the lock. Build a fresh one.
 
-        TODO(aylei): this transition belongs to this class rather than to every
-        caller's memory — an explicit ``mark_lost()``, so ``is_locked()`` stops
-        reporting a lock whose session is gone. Note that simply clearing
-        ``_acquired`` in ``release()``'s ``DatabaseError`` branch is not the
-        safe version: that branch also catches non-connection errors, where our
-        own session may still hold the lock.
+        TODO(aylei): that transition belongs to this class rather than to every
+        caller's memory — an explicit ``mark_lost()``. Note that simply clearing
+        ``_acquired`` in ``release()``'s ``DatabaseError`` branch is not it: the
+        branch also catches non-connection errors, where our own session may
+        still hold the lock.
 
         Returns ``False`` if the lock was never acquired, if the connection
         is missing, or if the probe raises any exception.  Returns ``True``

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -3,21 +3,17 @@
 These tests cover the state machine of the leader-elected refresh thread,
 not the full daemon loop:
 
-* ``_lock_still_held`` dispatches correctly between ``PostgresLock``
-  (probes the underlying PG session) and any other ``DistributedLock``
-  (trusts the local ``is_locked`` flag).
-* ``_step_down_on_lock_loss`` hands leadership over *without* killing the
-  API server process in the common case: it stops the job controllers
-  this replica owns, confirms they are gone, and replaces the lock object
-  so the next acquire is real. When it *cannot* confirm they are gone it
-  falls back to exiting the process, because declining to lead does not
-  stop another replica from re-adopting those jobs.
-* the outer ``run`` loop re-contends after a clean step-down, and stops
-  the thread after an unconfirmed one (where the process is exiting).
-* ``start_managed_job_refresh_daemon`` gates on consolidation mode,
-  preserving the historical ``should_skip_managed_job_status_refresh``
-  semantics now that the daemon no longer lives in
-  ``INTERNAL_REQUEST_DAEMONS``.
+* ``_lock_still_held`` probes the PG session for a ``PostgresLock`` and trusts
+  the local ``is_locked`` flag for any other ``DistributedLock``.
+* ``_step_down_on_lock_loss`` hands leadership over *without* killing the API
+  server process: it stops the controllers this replica owns, confirms they are
+  gone, and replaces the lock object so the next acquire is real. When it cannot
+  confirm, it exits the process, because declining to lead does not stop another
+  replica from re-adopting those jobs.
+* the outer ``run`` loop re-contends after a clean step-down and stops the
+  thread after an unconfirmed one (where the process is exiting).
+* ``start_managed_job_refresh_daemon`` gates on consolidation mode, preserving
+  the historical ``should_skip_managed_job_status_refresh`` semantics.
 """
 import contextlib
 import signal
@@ -122,9 +118,8 @@ class TestStepDownOnLockLoss:
     def signal_file(self, tmp_path, monkeypatch):
         """Redirect the recovery signal file, and make the drain never sleep.
 
-        Zeroing both budgets is safe for every test here: ``_controllers_gone``
-        evaluates liveness before checking its deadline, so a drain that
-        succeeds still succeeds — it just cannot wait.
+        Zeroing both budgets is safe here: ``_controllers_gone`` checks liveness
+        before its deadline, so a drain that succeeds still succeeds.
         """
         path = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
@@ -135,11 +130,10 @@ class TestStepDownOnLockLoss:
 
     @pytest.mark.parametrize('records', [[], _records(101), _records(101, 102)])
     def test_clean_drain_hands_over_without_exiting(self, records):
-        """The headline behaviour. The API server keeps serving; only the leader
-        role moves. Killing the process here takes this replica's share of the
-        Service's traffic down with it, which is a far larger blast radius than
-        the leadership change requires. SIGTERM is enough and there is no
-        escalation, whether we own no controllers, one, or several."""
+        """The headline behaviour: the server keeps serving and only the leader
+        role moves, whether we own no controllers, one, or several. Killing the
+        process here would take this replica's share of the Service's traffic
+        with it — a far larger blast radius than the handover needs."""
         thread = _thread_with_lock()
         with _drain_patched(records) as m:
             assert thread._step_down_on_lock_loss() is True
@@ -149,11 +143,10 @@ class TestStepDownOnLockLoss:
         assert m.kill.call_args_list == ([] if not records else [mock.call()])
 
     def test_touches_the_gate_file_before_draining(self, signal_file):
-        """The recovery signal file must be in place before we start killing, so
-        the FAILED_CONTROLLER sweep does not run against jobs whose controllers
-        we are in the middle of stopping. (It does not gate controller starts —
-        maybe_start_controllers never reads it; see the comment on step 1 of
-        _step_down_on_lock_loss.)"""
+        """The file must be in place before we start killing, so the
+        FAILED_CONTROLLER sweep does not run against jobs whose controllers we
+        are mid-way through stopping. (It does not gate controller starts — see
+        step 1 of _step_down_on_lock_loss.)"""
         thread = _thread_with_lock()
         order = []
 
@@ -184,22 +177,19 @@ class TestStepDownOnLockLoss:
         assert m.kill.call_args_list == [mock.call(), mock.call(signal.SIGKILL)]
 
     def test_exits_the_process_when_controllers_survive(self):
-        """An undead controller is the two-controllers-on-one-job case, and
-        merely declining to lead does not prevent it: the new leader on another
-        replica cannot see our survivors (its liveness check is a local psutil
-        lookup) and re-adopts their jobs regardless. Only the process exiting —
-        and the container teardown that follows — reaps them, so fall back to
-        that."""
+        """A survivor is the two-controllers-on-one-job case, and declining to
+        lead does not prevent it: the new leader cannot see our survivors (local
+        psutil check) and re-adopts their jobs regardless. Only exiting — and
+        the container teardown that follows — reaps them."""
         thread = _thread_with_lock()
         with _drain_patched(_records(101), alive=True) as m:
             assert thread._step_down_on_lock_loss() is False
         m.os_kill.assert_called_once_with(_PID, signal.SIGTERM)
 
     def test_exits_the_process_when_pid_file_unreadable(self):
-        """``get_controller_process_records`` returns None when the pid file
-        cannot be read. That is 'unknown', not 'none': we cannot even enumerate
-        our controllers, so nothing is signalled and the process must exit for
-        the teardown to reap whatever is there."""
+        """A None from ``get_controller_process_records`` is 'unknown', not
+        'none': we cannot even enumerate our controllers, so nothing is
+        signalled and the process must exit for the teardown to reap them."""
         thread = _thread_with_lock()
         with _drain_patched(None) as m:
             assert thread._step_down_on_lock_loss() is False
@@ -211,20 +201,18 @@ class TestStepDownOnLockLoss:
         [
             # Clean step-down.
             ([], False, None, True),
-            # Releasing a lock whose session already died routinely raises;
-            # that must not leave the stale object in place.
+            # A release() on an already-dead session routinely raises.
             ([], False, RuntimeError('conn already dead'), True),
-            # Even when we cannot prove the controllers are gone, the lock
-            # object must be dropped — otherwise a later retry could lead on a
-            # stale flag.
+            # Unconfirmed drain: the object must still be dropped, or a later
+            # retry could lead on a stale flag.
             (_records(101), True, None, False),
-            # ... including when enumerating them fails outright.
+            # ... including when enumerating the controllers fails outright.
             (RuntimeError('boom'), False, None, False),
         ])
     def test_always_replaces_the_lock_object(self, records, alive, release_exc,
                                              verdict):
-        """A release() on a dead connection leaves PostgresLock._acquired True,
-        and is_locked() returns that flag — so reusing the object would make the
+        """A release() on a dead connection leaves PostgresLock._acquired True
+        and is_locked() returns that flag, so reusing the object would make the
         next _become_leader_and_run skip acquire() and lead without the lock."""
         thread = _thread_with_lock()
         old_lock = thread._lock
@@ -385,16 +373,11 @@ class TestBecomeLeaderOrdering:
     """The recovery signal file must exist BEFORE the lock is acquired, and
     recovery must wait briefly after acquiring it.
 
-    During a rolling update we block on acquire() while the old API server
-    still holds the lock. The signal file holds off the FAILED_CONTROLLER
-    sweep, and jobs whose controllers are moving between replicas must not be
-    marked failed for it in that window — so it must be touched up-front, not
-    after we win the lock.
-
-    After acquiring the lock we also wait briefly before recovery: the old
-    pod's detached controllers can outlive the lock release by a moment, and
-    recovery resetting jobs while they are still alive lets them re-claim and
-    re-stamp soon-dead PIDs (split brain across the upgrade overlap).
+    Touched up-front because acquire() blocks for the whole rolling update while
+    the old server holds the lock, and the FAILED_CONTROLLER sweep must be held
+    off for all of it. Waiting after acquiring covers the old pod's detached
+    controllers, which outlive the lock release by a moment and would re-claim
+    the jobs recovery had just reset, stamping soon-dead PIDs back onto them.
     """
 
     def test_signal_file_touched_before_lock_acquire(self, tmp_path,

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -7,12 +7,13 @@ not the full daemon loop:
   (probes the underlying PG session) and any other ``DistributedLock``
   (trusts the local ``is_locked`` flag).
 * ``_step_down_on_lock_loss`` hands leadership over *without* killing the
-  API server process: it gates controller starts, stops the job
-  controllers this replica owns and confirms they are gone, and replaces
-  the lock object so the next acquire is real.
+  API server process in the common case: it stops the job controllers
+  this replica owns, confirms they are gone, and replaces the lock object
+  so the next acquire is real. When it *cannot* confirm they are gone it
+  falls back to exiting the process, because declining to lead does not
+  stop another replica from re-adopting those jobs.
 * the outer ``run`` loop re-contends after a clean step-down, and stops
-  only when the step-down could not prove this replica's controllers are
-  gone (contending then could put two controllers on one job).
+  the thread after an unconfirmed one (where the process is exiting).
 * ``start_managed_job_refresh_daemon`` gates on consolidation mode,
   preserving the historical ``should_skip_managed_job_status_refresh``
   semantics now that the daemon no longer lives in
@@ -90,12 +91,12 @@ class TestStepDownOnLockLoss:
             assert thread._step_down_on_lock_loss() is True
         kill_mock.assert_not_called()
 
-    def test_gates_controller_starts_before_draining(self, tmp_path,
-                                                     monkeypatch):
-        """The gate file must exist before we start killing, so an in-flight
-        submit_jobs on another worker process short-circuits
-        maybe_start_controllers instead of spawning a controller we would
-        then orphan."""
+    def test_touches_the_gate_file_before_draining(self, tmp_path, monkeypatch):
+        """The recovery signal file must be in place before we start killing, so
+        the FAILED_CONTROLLER sweep does not run against jobs whose controllers
+        we are in the middle of stopping. (It does not gate controller starts —
+        maybe_start_controllers never reads it; see the comment on step 1 of
+        _step_down_on_lock_loss.)"""
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
@@ -122,8 +123,8 @@ class TestStepDownOnLockLoss:
             assert thread._step_down_on_lock_loss() is True
 
         assert signal_file.exists(), (
-            'the gate file must survive the step-down: this replica is no '
-            'longer the leader, so it must not start controllers')
+            'the gate file must survive the step-down; the next leader\'s '
+            'recovery is what unlinks it')
         assert order == ['kill']
 
     def test_sigterm_is_enough_when_controllers_exit(self, tmp_path,
@@ -171,10 +172,14 @@ class TestStepDownOnLockLoss:
             assert thread._step_down_on_lock_loss() is True
         assert kill.call_args_list == [mock.call(), mock.call(signal.SIGKILL)]
 
-    def test_refuses_to_lead_again_when_controllers_survive(
-            self, tmp_path, monkeypatch):
-        """An undead controller plus a fresh leadership win on this replica is
-        exactly the two-controllers-on-one-job case, so report failure."""
+    def test_exits_the_process_when_controllers_survive(self, tmp_path,
+                                                        monkeypatch):
+        """An undead controller is the two-controllers-on-one-job case, and
+        merely declining to lead does not prevent it: the new leader on another
+        replica cannot see our survivors (its liveness check is a local psutil
+        lookup) and re-adopts their jobs regardless. Only the process exiting —
+        and the container teardown that follows — reaps them, so fall back to
+        that."""
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(tmp_path / 'restart_signal'))
@@ -189,14 +194,18 @@ class TestStepDownOnLockLoss:
                 mock.patch.object(mjrt.managed_job_utils,
                                   'controller_process_alive',
                                   return_value=True), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
+                mock.patch.object(mjrt.locks, 'get_lock'), \
+                mock.patch('os.kill') as kill_mock, \
+                mock.patch('os.getpid', return_value=4242):
             assert thread._step_down_on_lock_loss() is False
+        kill_mock.assert_called_once_with(4242, signal.SIGTERM)
 
-    def test_unreadable_pid_file_refuses_to_lead_again(self, tmp_path,
-                                                       monkeypatch):
+    def test_exits_the_process_when_pid_file_unreadable(self, tmp_path,
+                                                        monkeypatch):
         """``get_controller_process_records`` returns None when the pid file
-        cannot be read. That is 'unknown', not 'none' — assuming there were no
-        controllers would silently drop the only guarantee this path has."""
+        cannot be read. That is 'unknown', not 'none': we cannot even enumerate
+        our controllers, so nothing is signalled and the process must exit for
+        the teardown to reap whatever is there."""
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(tmp_path / 'restart_signal'))
@@ -206,9 +215,32 @@ class TestStepDownOnLockLoss:
                                return_value=None), \
                 mock.patch.object(mjrt.managed_job_scheduler,
                                   'kill_local_job_controllers') as kill, \
-                mock.patch.object(mjrt.locks, 'get_lock'):
+                mock.patch.object(mjrt.locks, 'get_lock'), \
+                mock.patch('os.kill') as kill_mock, \
+                mock.patch('os.getpid', return_value=4242):
             assert thread._step_down_on_lock_loss() is False
         kill.assert_not_called()
+        kill_mock.assert_called_once_with(4242, signal.SIGTERM)
+
+    def test_clean_drain_does_not_exit_the_process(self, tmp_path, monkeypatch):
+        """The whole point of the change: the common case hands over leadership
+        without costing the replica. Only an unconfirmed drain escalates."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=_records(101)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers'), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=False), \
+                mock.patch.object(mjrt.locks, 'get_lock'), \
+                mock.patch('os.kill') as kill_mock:
+            assert thread._step_down_on_lock_loss() is True
+        kill_mock.assert_not_called()
 
     def test_replaces_the_lock_object(self, tmp_path, monkeypatch):
         """A release() on a dead connection leaves PostgresLock._acquired True,
@@ -265,7 +297,8 @@ class TestStepDownOnLockLoss:
         with mock.patch.object(mjrt.managed_job_scheduler,
                                'get_controller_process_records',
                                side_effect=RuntimeError('boom')), \
-                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh):
+                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh), \
+                mock.patch('os.kill'):
             assert thread._step_down_on_lock_loss() is False
         assert thread._lock is fresh
 

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -6,8 +6,13 @@ not the full daemon loop:
 * ``_lock_still_held`` dispatches correctly between ``PostgresLock``
   (probes the underlying PG session) and any other ``DistributedLock``
   (trusts the local ``is_locked`` flag).
-* ``_suicide_on_lock_loss`` sends ``SIGTERM`` to the API server PID so
-  K8s restarts the pod and the leader is re-elected on another replica.
+* ``_step_down_on_lock_loss`` hands leadership over *without* killing the
+  API server process: it gates controller starts, stops the job
+  controllers this replica owns and confirms they are gone, and replaces
+  the lock object so the next acquire is real.
+* the outer ``run`` loop re-contends after a clean step-down, and stops
+  only when the step-down could not prove this replica's controllers are
+  gone (contending then could put two controllers on one job).
 * ``start_managed_job_refresh_daemon`` gates on consolidation mode,
   preserving the historical ``should_skip_managed_job_status_refresh``
   semantics now that the daemon no longer lives in
@@ -19,29 +24,39 @@ from unittest import mock
 import pytest
 
 from sky.jobs import managed_job_refresh_thread as mjrt
+from sky.jobs import state as managed_job_state
 from sky.utils import locks
+
+
+def _records(*pids):
+    return [
+        managed_job_state.ControllerPidRecord(pid=p, started_at=1.0)
+        for p in pids
+    ]
+
+
+def _thread_with_lock():
+    thread = mjrt.ManagedJobRefreshDaemonThread()
+    thread._lock = mock.create_autospec(locks.PostgresLock,
+                                        instance=True,
+                                        spec_set=True)
+    return thread
 
 
 class TestLockStillHeld:
     """`_lock_still_held` dispatches on lock type."""
 
     def test_postgres_lock_session_alive(self):
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _thread_with_lock()
         thread._lock.is_session_alive.return_value = True
         assert thread._lock_still_held() is True
         thread._lock.is_session_alive.assert_called_once_with()
 
     def test_postgres_lock_session_dead(self):
         """Silent PG conn loss: PostgresLock thinks acquired locally but
-        ``is_session_alive`` says otherwise.  Probe must return False so
-        the caller can SIGTERM the process."""
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        ``is_session_alive`` says otherwise. Probe must return False so
+        the caller can step down."""
+        thread = _thread_with_lock()
         thread._lock.is_session_alive.return_value = False
         assert thread._lock_still_held() is False
 
@@ -55,147 +70,270 @@ class TestLockStillHeld:
         assert thread._lock_still_held() is True
 
 
-class TestSuicideOnLockLoss:
-    """Lock-loss must SIGTERM the current process, not the thread."""
+class TestStepDownOnLockLoss:
+    """Losing the lock hands over the leader role, not the process."""
 
-    def test_sends_sigterm_to_current_pid(self):
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
-        with mock.patch.object(mjrt.os, 'kill') as kill_mock, \
-                mock.patch.object(mjrt.os, 'getpid', return_value=12345), \
+    def test_does_not_kill_the_process(self, tmp_path, monkeypatch):
+        """The headline behaviour. The API server keeps serving; only the
+        leader role moves. Killing the process here takes this replica's
+        share of the Service's traffic down with it, which is a far larger
+        blast radius than the leadership change requires."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        with mock.patch('os.kill') as kill_mock, \
                 mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers'):
-            thread._suicide_on_lock_loss()
-        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+                                  'get_controller_process_records',
+                                  return_value=[]), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is True
+        kill_mock.assert_not_called()
 
-    def test_kills_local_controllers_before_sigterm(self):
-        """Controllers must be SIGTERMed before the API server SIGTERM —
-        the lock is already released here, so a new leader can schedule
-        within milliseconds. Killing first prevents split-brain."""
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
-        call_order = []
-        with mock.patch.object(
-                mjrt.managed_job_scheduler,
-                'kill_local_job_controllers',
-                side_effect=lambda: call_order.append('kill_controllers')), \
-                mock.patch.object(
-                    mjrt.os, 'kill',
-                    side_effect=lambda *a, **kw: call_order.append('sigterm')), \
-                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
-        assert call_order == ['kill_controllers', 'sigterm']
-
-    def test_sigterm_still_sent_when_controller_kill_raises(self):
-        """A failure killing controllers must not block the SIGTERM —
-        otherwise the replica would stay up holding nothing useful."""
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
-        with mock.patch.object(
-                mjrt.managed_job_scheduler,
-                'kill_local_job_controllers',
-                side_effect=RuntimeError('boom')), \
-                mock.patch.object(mjrt.os, 'kill') as kill_mock, \
-                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
-        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
-
-    def test_touches_recovery_signal_file(self, tmp_path, monkeypatch):
-        """The signal file must be touched BEFORE we kill controllers, so
-        any in-flight submit_jobs racing this path on another worker
-        process short-circuits maybe_start_controllers rather than
-        spawning a new controller that we'd then orphan."""
+    def test_gates_controller_starts_before_draining(self, tmp_path,
+                                                     monkeypatch):
+        """The gate file must exist before we start killing, so an in-flight
+        submit_jobs on another worker process short-circuits
+        maybe_start_controllers instead of spawning a controller we would
+        then orphan."""
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(signal_file))
-
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _thread_with_lock()
         order = []
-        with mock.patch.object(
-                mjrt.managed_job_scheduler,
-                'kill_local_job_controllers',
-                side_effect=lambda: order.append('kill')), \
-                mock.patch.object(
-                    mjrt.os, 'kill',
-                    side_effect=lambda *a, **kw: order.append('sigterm')), \
-                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
 
-        assert signal_file.exists()
-        # File must be created BEFORE kill_controllers and SIGTERM,
-        # otherwise a fresh submit_jobs slipped in just before the
-        # kill could still spawn a controller.
-        assert order == ['kill', 'sigterm']
+        def on_kill(*args, **kwargs):
+            assert signal_file.exists(), (
+                'controller starts must be gated before we kill anything')
+            order.append('kill')
+            return 1
 
-    def test_signal_file_touch_failure_does_not_block_sigterm(
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=_records(101)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers',
+                                  side_effect=on_kill), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=False), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is True
+
+        assert signal_file.exists(), (
+            'the gate file must survive the step-down: this replica is no '
+            'longer the leader, so it must not start controllers')
+        assert order == ['kill']
+
+    def test_sigterm_is_enough_when_controllers_exit(self, tmp_path,
+                                                     monkeypatch):
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=_records(101, 102)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers') as kill, \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=False), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is True
+        # SIGTERM only (no signal argument), no escalation.
+        assert kill.call_args_list == [mock.call()]
+
+    def test_escalates_to_sigkill_when_sigterm_ignored(self, tmp_path,
+                                                       monkeypatch):
+        """Stepping down in place removes the container teardown that used to
+        reap controllers which ignored SIGTERM, so the drain must escalate
+        itself."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        # Zero budgets so neither phase sleeps: each phase does exactly one
+        # liveness check and then hits its deadline.
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGTERM_GRACE_SECONDS', 0)
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_DRAIN_TIMEOUT_SECONDS', 0)
+        thread = _thread_with_lock()
+        # Alive for the post-SIGTERM check, gone for the post-SIGKILL check.
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=_records(101)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers') as kill, \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  side_effect=[True, False]), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is True
+        assert kill.call_args_list == [mock.call(), mock.call(signal.SIGKILL)]
+
+    def test_refuses_to_lead_again_when_controllers_survive(
+            self, tmp_path, monkeypatch):
+        """An undead controller plus a fresh leadership win on this replica is
+        exactly the two-controllers-on-one-job case, so report failure."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGTERM_GRACE_SECONDS', 0)
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_DRAIN_TIMEOUT_SECONDS', 0)
+        thread = _thread_with_lock()
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=_records(101)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers'), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=True), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is False
+
+    def test_unreadable_pid_file_refuses_to_lead_again(self, tmp_path,
+                                                       monkeypatch):
+        """``get_controller_process_records`` returns None when the pid file
+        cannot be read. That is 'unknown', not 'none' — assuming there were no
+        controllers would silently drop the only guarantee this path has."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=None), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers') as kill, \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is False
+        kill.assert_not_called()
+
+    def test_replaces_the_lock_object(self, tmp_path, monkeypatch):
+        """A release() on a dead connection leaves PostgresLock._acquired True,
+        and is_locked() returns that flag — so reusing the object would make the
+        next _become_leader_and_run skip acquire() and lead without the lock."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        old_lock = thread._lock
+        fresh = mock.create_autospec(locks.PostgresLock,
+                                     instance=True,
+                                     spec_set=True)
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=[]), \
+                mock.patch.object(mjrt.locks, 'get_lock',
+                                  return_value=fresh) as get_lock:
+            assert thread._step_down_on_lock_loss() is True
+        old_lock.release.assert_called_once_with()
+        get_lock.assert_called_once_with(
+            mjrt.managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
+        assert thread._lock is fresh
+
+    def test_release_failure_still_replaces_the_lock(self, tmp_path,
+                                                     monkeypatch):
+        """Releasing a lock whose session already died routinely raises; that
+        must not leave the stale object in place."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        thread._lock.release.side_effect = RuntimeError('conn already dead')
+        fresh = mock.create_autospec(locks.PostgresLock,
+                                     instance=True,
+                                     spec_set=True)
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               return_value=[]), \
+                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh):
+            assert thread._step_down_on_lock_loss() is True
+        assert thread._lock is fresh
+
+    def test_drain_failure_still_replaces_the_lock(self, tmp_path, monkeypatch):
+        """Even when we cannot prove the controllers are gone, the lock object
+        must be dropped — otherwise a later retry could lead on a stale flag."""
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(tmp_path / 'restart_signal'))
+        thread = _thread_with_lock()
+        fresh = mock.create_autospec(locks.PostgresLock,
+                                     instance=True,
+                                     spec_set=True)
+        with mock.patch.object(mjrt.managed_job_scheduler,
+                               'get_controller_process_records',
+                               side_effect=RuntimeError('boom')), \
+                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh):
+            assert thread._step_down_on_lock_loss() is False
+        assert thread._lock is fresh
+
+    def test_signal_file_touch_failure_does_not_block_the_drain(
             self, monkeypatch):
-        """If the FS refuses the touch (read-only, full, etc.), proceed
-        with kill + SIGTERM anyway. Better than blocking shutdown."""
+        """If the FS refuses the touch (read-only, full), still stop the
+        controllers — that is the part that prevents split-brain."""
 
         def boom_touch(self, *args, **kwargs):  # pylint: disable=unused-argument
             raise OSError('read-only fs')
 
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _thread_with_lock()
         with mock.patch.object(mjrt.pathlib.Path, 'touch', boom_touch), \
                 mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers'), \
-                mock.patch.object(mjrt.os, 'kill') as kill_mock, \
-                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
-        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+                                  'get_controller_process_records',
+                                  return_value=_records(101)), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers') as kill, \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=False), \
+                mock.patch.object(mjrt.locks, 'get_lock'):
+            assert thread._step_down_on_lock_loss() is True
+        kill.assert_called_once_with()
 
 
-class TestOuterLoopStopsAfterSuicide:
-    """Normal return from _become_leader_and_run only happens after the
-    inner loop's probe detected lock loss and called _suicide_on_lock_loss.
-    The outer run() loop must stop the thread instead of re-entering —
-    otherwise the next iteration would skip the lock acquire (the local
-    _acquired flag is stale) and run ha_recovery_for_consolidation_mode,
-    which would spawn fresh controllers under a now-released lock while
-    the new leader on another replica is doing the same.
-    """
+class TestOuterLoopAfterStepDown:
+    """run() re-contends after a clean step-down and stops after a dirty one."""
 
-    def test_run_returns_after_become_leader_returns_normally(self):
+    def test_reenters_after_a_clean_step_down(self):
+        """A clean step-down leaves this replica eligible: controller starts are
+        gated, our controllers are gone, and the lock object was replaced — so
+        the next pass really does acquire() before leading."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
         lock = mock.create_autospec(locks.PostgresLock,
                                     instance=True,
                                     spec_set=True)
-        # If the outer loop incorrectly iterates, _become_leader_and_run
-        # would be called more than once. Use a side_effect that fails
-        # the test if that happens.
-        call_count = {'n': 0}
-
-        def normal_return(self):
-            call_count['n'] += 1
-
         with mock.patch('sky.utils.locks.get_lock', return_value=lock), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
                     '_become_leader_and_run',
-                    normal_return), \
+                    side_effect=[True, True, SystemExit()]) as become, \
+                mock.patch.object(mjrt.time, 'sleep'):
+            with pytest.raises(SystemExit):
+                thread.run()
+        assert become.call_count == 3, (
+            'run() must contend again after a clean step-down')
+
+    def test_stops_when_step_down_could_not_confirm_the_drain(self):
+        """If our controllers might still be alive, contending again could put a
+        second controller on one of their jobs. Stop the thread instead."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        with mock.patch('sky.utils.locks.get_lock', return_value=lock), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    return_value=False) as become, \
                 mock.patch.object(mjrt.time, 'sleep'):
             thread.run()
-        assert call_count['n'] == 1, (
-            'run() must not re-enter _become_leader_and_run after a '
-            'normal return — that path can only follow a suicide.')
+        assert become.call_count == 1
 
 
 class TestOuterLoopExceptionHandling:
-    """When _become_leader_and_run throws, decide between SIGTERM and retry
-    based on whether we previously held a now-dead lock."""
+    """When _become_leader_and_run throws, decide between stepping down and
+    retrying based on whether we previously held a now-dead lock."""
 
     @staticmethod
     def _patches(is_locked: bool, session_alive: bool):
@@ -208,11 +346,29 @@ class TestOuterLoopExceptionHandling:
         lock.is_session_alive.return_value = session_alive
         return mock.patch('sky.utils.locks.get_lock', return_value=lock), lock
 
-    def test_sigterm_when_was_leader_and_session_dead(self):
+    def test_steps_down_when_was_leader_and_session_dead(self):
         """Acquired the lock, then recovery threw because the underlying
         PG session died — running again would race the new leader."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=True, session_alive=False)
+        get_lock_p, _ = self._patches(is_locked=True, session_alive=False)
+        with get_lock_p, \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    side_effect=[RuntimeError('recovery boom'),
+                                 SystemExit()]), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_step_down_on_lock_loss',
+                    return_value=True) as step_down, \
+                mock.patch.object(mjrt.time, 'sleep'):
+            with pytest.raises(SystemExit):
+                thread.run()
+        step_down.assert_called_once()
+
+    def test_stops_when_step_down_says_unsafe(self):
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        get_lock_p, _ = self._patches(is_locked=True, session_alive=False)
         with get_lock_p, \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
@@ -220,16 +376,17 @@ class TestOuterLoopExceptionHandling:
                     side_effect=RuntimeError('recovery boom')), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_step_down_on_lock_loss',
+                    return_value=False) as step_down, \
                 mock.patch.object(mjrt.time, 'sleep'):
             thread.run()
-        suicide.assert_called_once()
+        step_down.assert_called_once()
 
     def test_retry_when_acquire_threw(self):
         """acquire() itself failed (e.g. another replica holds the lock,
         or transient PG hiccup); is_locked stays False, just retry."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=False, session_alive=False)
+        get_lock_p, _ = self._patches(is_locked=False, session_alive=False)
         with get_lock_p, \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
@@ -239,17 +396,17 @@ class TestOuterLoopExceptionHandling:
                                  SystemExit()]), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_step_down_on_lock_loss') as step_down, \
                 mock.patch.object(mjrt.time, 'sleep'):
             with pytest.raises(SystemExit):
                 thread.run()
-        suicide.assert_not_called()
+        step_down.assert_not_called()
 
     def test_retry_when_lock_still_held(self):
         """Recovery threw on transient error but our lock session is
         still alive — keep retrying as leader."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=True, session_alive=True)
+        get_lock_p, _ = self._patches(is_locked=True, session_alive=True)
         with get_lock_p, \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
@@ -258,11 +415,11 @@ class TestOuterLoopExceptionHandling:
                                  SystemExit()]), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_step_down_on_lock_loss') as step_down, \
                 mock.patch.object(mjrt.time, 'sleep'):
             with pytest.raises(SystemExit):
                 thread.run()
-        suicide.assert_not_called()
+        step_down.assert_not_called()
 
 
 class TestBecomeLeaderOrdering:
@@ -368,8 +525,8 @@ class TestBecomeLeaderOrdering:
     def test_steps_down_if_lock_lost_during_wait(self, tmp_path, monkeypatch):
         """If the lock session goes stale during the post-acquire wait, we
         must NOT run recovery — another replica may now hold the lock. Step
-        down via _suicide_on_lock_loss and leave the gate file in place (the
-        suicide path re-touches it to keep controllers gated)."""
+        down and leave the gate file in place (the step-down path re-touches it
+        to keep controllers gated), and propagate its verdict to run()."""
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
@@ -390,14 +547,45 @@ class TestBecomeLeaderOrdering:
                     'ha_recovery_for_consolidation_mode') as recovery, \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide:
-            thread._become_leader_and_run()
+                    '_step_down_on_lock_loss',
+                    return_value=True) as step_down:
+            assert thread._become_leader_and_run() is True
 
-        suicide.assert_called_once()
+        step_down.assert_called_once()
         recovery.assert_not_called()
-        # The gate file is NOT removed on the step-down path; the suicide
-        # routine owns re-touching it for the shutdown drain.
+        # The gate file is NOT removed on the step-down path; the step-down
+        # routine owns re-touching it while this replica is not the leader.
         assert signal_file.exists()
+
+    def test_lock_lost_in_event_loop_propagates_step_down_verdict(
+            self, tmp_path, monkeypatch):
+        """The steady-state probe path must return the step-down's verdict too,
+        so an unconfirmed drain stops the thread instead of re-contending."""
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        lock.is_locked.return_value = False
+        # Alive for the post-acquire re-check, dead at the first loop probe.
+        lock.is_session_alive.side_effect = [True, False]
+        thread._lock = lock
+
+        with mock.patch.object(mjrt.time, 'sleep'), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'ha_recovery_for_consolidation_mode'), \
+                mock.patch.object(mjrt.events, 'ManagedJobEvent'), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_step_down_on_lock_loss',
+                    return_value=False) as step_down:
+            assert thread._become_leader_and_run() is False
+
+        step_down.assert_called_once()
 
 
 class TestStart:

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -19,7 +19,9 @@ not the full daemon loop:
   semantics now that the daemon no longer lives in
   ``INTERNAL_REQUEST_DAEMONS``.
 """
+import contextlib
 import signal
+import types
 from unittest import mock
 
 import pytest
@@ -27,6 +29,8 @@ import pytest
 from sky.jobs import managed_job_refresh_thread as mjrt
 from sky.jobs import state as managed_job_state
 from sky.utils import locks
+
+_PID = 4242
 
 
 def _records(*pids):
@@ -36,12 +40,52 @@ def _records(*pids):
     ]
 
 
+def _autospec_lock():
+    return mock.create_autospec(locks.PostgresLock,
+                                instance=True,
+                                spec_set=True)
+
+
 def _thread_with_lock():
     thread = mjrt.ManagedJobRefreshDaemonThread()
-    thread._lock = mock.create_autospec(locks.PostgresLock,
-                                        instance=True,
-                                        spec_set=True)
+    thread._lock = _autospec_lock()
     return thread
+
+
+@contextlib.contextmanager
+def _drain_patched(records, alive=False, fresh_lock=None):
+    """Patch every collaborator of ``_step_down_on_lock_loss``.
+
+    ``records`` is what ``get_controller_process_records`` returns, or an
+    exception to raise from it; ``alive`` is the ``controller_process_alive``
+    result, or a list of per-call results. Yields the mocks worth asserting on.
+    """
+    exc = isinstance(records, Exception)
+    alive_kwargs = ({
+        'side_effect': alive
+    } if isinstance(alive, list) else {
+        'return_value': alive
+    })
+    with mock.patch.object(mjrt.managed_job_scheduler,
+                           'get_controller_process_records',
+                           **({
+                               'side_effect': records
+                           } if exc else {
+                               'return_value': records
+                           })), \
+            mock.patch.object(mjrt.managed_job_scheduler,
+                              'kill_local_job_controllers') as kill, \
+            mock.patch.object(mjrt.managed_job_utils,
+                              'controller_process_alive',
+                              **alive_kwargs), \
+            mock.patch.object(mjrt.locks, 'get_lock',
+                              return_value=fresh_lock or
+                              mock.MagicMock()) as get_lock, \
+            mock.patch('os.kill') as os_kill, \
+            mock.patch('os.getpid', return_value=_PID):
+        yield types.SimpleNamespace(kill=kill,
+                                    get_lock=get_lock,
+                                    os_kill=os_kill)
 
 
 class TestLockStillHeld:
@@ -74,52 +118,54 @@ class TestLockStillHeld:
 class TestStepDownOnLockLoss:
     """Losing the lock hands over the leader role, not the process."""
 
-    def test_does_not_kill_the_process(self, tmp_path, monkeypatch):
-        """The headline behaviour. The API server keeps serving; only the
-        leader role moves. Killing the process here takes this replica's
-        share of the Service's traffic down with it, which is a far larger
-        blast radius than the leadership change requires."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        thread = _thread_with_lock()
-        with mock.patch('os.kill') as kill_mock, \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'get_controller_process_records',
-                                  return_value=[]), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
-            assert thread._step_down_on_lock_loss() is True
-        kill_mock.assert_not_called()
+    @pytest.fixture(autouse=True)
+    def signal_file(self, tmp_path, monkeypatch):
+        """Redirect the recovery signal file, and make the drain never sleep.
 
-    def test_touches_the_gate_file_before_draining(self, tmp_path, monkeypatch):
+        Zeroing both budgets is safe for every test here: ``_controllers_gone``
+        evaluates liveness before checking its deadline, so a drain that
+        succeeds still succeeds — it just cannot wait.
+        """
+        path = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE', str(path))
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGTERM_GRACE_SECONDS', 0)
+        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGKILL_GRACE_SECONDS', 0)
+        return path
+
+    @pytest.mark.parametrize('records', [[], _records(101), _records(101, 102)])
+    def test_clean_drain_hands_over_without_exiting(self, records):
+        """The headline behaviour. The API server keeps serving; only the leader
+        role moves. Killing the process here takes this replica's share of the
+        Service's traffic down with it, which is a far larger blast radius than
+        the leadership change requires. SIGTERM is enough and there is no
+        escalation, whether we own no controllers, one, or several."""
+        thread = _thread_with_lock()
+        with _drain_patched(records) as m:
+            assert thread._step_down_on_lock_loss() is True
+        m.os_kill.assert_not_called()
+        # SIGTERM only (no signal argument), and nothing to signal when we own
+        # no controllers.
+        assert m.kill.call_args_list == ([] if not records else [mock.call()])
+
+    def test_touches_the_gate_file_before_draining(self, signal_file):
         """The recovery signal file must be in place before we start killing, so
         the FAILED_CONTROLLER sweep does not run against jobs whose controllers
         we are in the middle of stopping. (It does not gate controller starts —
         maybe_start_controllers never reads it; see the comment on step 1 of
         _step_down_on_lock_loss.)"""
-        signal_file = tmp_path / 'restart_signal'
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(signal_file))
         thread = _thread_with_lock()
         order = []
 
         def on_kill(*args, **kwargs):
             assert signal_file.exists(), (
-                'controller starts must be gated before we kill anything')
+                'the FAILED_CONTROLLER sweep must be held off before we kill '
+                'anything')
             order.append('kill')
             return 1
 
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=_records(101)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers',
-                                  side_effect=on_kill), \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  return_value=False), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
+        with _drain_patched(_records(101)) as m:
+            m.kill.side_effect = on_kill
             assert thread._step_down_on_lock_loss() is True
 
         assert signal_file.exists(), (
@@ -127,183 +173,71 @@ class TestStepDownOnLockLoss:
             'recovery is what unlinks it')
         assert order == ['kill']
 
-    def test_sigterm_is_enough_when_controllers_exit(self, tmp_path,
-                                                     monkeypatch):
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        thread = _thread_with_lock()
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=_records(101, 102)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers') as kill, \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  return_value=False), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
-            assert thread._step_down_on_lock_loss() is True
-        # SIGTERM only (no signal argument), no escalation.
-        assert kill.call_args_list == [mock.call()]
-
-    def test_escalates_to_sigkill_when_sigterm_ignored(self, tmp_path,
-                                                       monkeypatch):
+    def test_escalates_to_sigkill_when_sigterm_ignored(self):
         """Stepping down in place removes the container teardown that used to
         reap controllers which ignored SIGTERM, so the drain must escalate
         itself."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        # Zero budgets so neither phase sleeps: each phase does exactly one
-        # liveness check and then hits its deadline.
-        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGTERM_GRACE_SECONDS', 0)
-        monkeypatch.setattr(mjrt, '_STEP_DOWN_DRAIN_TIMEOUT_SECONDS', 0)
         thread = _thread_with_lock()
         # Alive for the post-SIGTERM check, gone for the post-SIGKILL check.
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=_records(101)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers') as kill, \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  side_effect=[True, False]), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
+        with _drain_patched(_records(101), alive=[True, False]) as m:
             assert thread._step_down_on_lock_loss() is True
-        assert kill.call_args_list == [mock.call(), mock.call(signal.SIGKILL)]
+        assert m.kill.call_args_list == [mock.call(), mock.call(signal.SIGKILL)]
 
-    def test_exits_the_process_when_controllers_survive(self, tmp_path,
-                                                        monkeypatch):
+    def test_exits_the_process_when_controllers_survive(self):
         """An undead controller is the two-controllers-on-one-job case, and
         merely declining to lead does not prevent it: the new leader on another
         replica cannot see our survivors (its liveness check is a local psutil
         lookup) and re-adopts their jobs regardless. Only the process exiting —
         and the container teardown that follows — reaps them, so fall back to
         that."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        monkeypatch.setattr(mjrt, '_STEP_DOWN_SIGTERM_GRACE_SECONDS', 0)
-        monkeypatch.setattr(mjrt, '_STEP_DOWN_DRAIN_TIMEOUT_SECONDS', 0)
         thread = _thread_with_lock()
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=_records(101)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers'), \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  return_value=True), \
-                mock.patch.object(mjrt.locks, 'get_lock'), \
-                mock.patch('os.kill') as kill_mock, \
-                mock.patch('os.getpid', return_value=4242):
+        with _drain_patched(_records(101), alive=True) as m:
             assert thread._step_down_on_lock_loss() is False
-        kill_mock.assert_called_once_with(4242, signal.SIGTERM)
+        m.os_kill.assert_called_once_with(_PID, signal.SIGTERM)
 
-    def test_exits_the_process_when_pid_file_unreadable(self, tmp_path,
-                                                        monkeypatch):
+    def test_exits_the_process_when_pid_file_unreadable(self):
         """``get_controller_process_records`` returns None when the pid file
         cannot be read. That is 'unknown', not 'none': we cannot even enumerate
         our controllers, so nothing is signalled and the process must exit for
         the teardown to reap whatever is there."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
         thread = _thread_with_lock()
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=None), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers') as kill, \
-                mock.patch.object(mjrt.locks, 'get_lock'), \
-                mock.patch('os.kill') as kill_mock, \
-                mock.patch('os.getpid', return_value=4242):
+        with _drain_patched(None) as m:
             assert thread._step_down_on_lock_loss() is False
-        kill.assert_not_called()
-        kill_mock.assert_called_once_with(4242, signal.SIGTERM)
+        m.kill.assert_not_called()
+        m.os_kill.assert_called_once_with(_PID, signal.SIGTERM)
 
-    def test_clean_drain_does_not_exit_the_process(self, tmp_path, monkeypatch):
-        """The whole point of the change: the common case hands over leadership
-        without costing the replica. Only an unconfirmed drain escalates."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        thread = _thread_with_lock()
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=_records(101)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers'), \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  return_value=False), \
-                mock.patch.object(mjrt.locks, 'get_lock'), \
-                mock.patch('os.kill') as kill_mock:
-            assert thread._step_down_on_lock_loss() is True
-        kill_mock.assert_not_called()
-
-    def test_replaces_the_lock_object(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        'records,alive,release_exc,verdict',
+        [
+            # Clean step-down.
+            ([], False, None, True),
+            # Releasing a lock whose session already died routinely raises;
+            # that must not leave the stale object in place.
+            ([], False, RuntimeError('conn already dead'), True),
+            # Even when we cannot prove the controllers are gone, the lock
+            # object must be dropped — otherwise a later retry could lead on a
+            # stale flag.
+            (_records(101), True, None, False),
+            # ... including when enumerating them fails outright.
+            (RuntimeError('boom'), False, None, False),
+        ])
+    def test_always_replaces_the_lock_object(self, records, alive, release_exc,
+                                             verdict):
         """A release() on a dead connection leaves PostgresLock._acquired True,
         and is_locked() returns that flag — so reusing the object would make the
         next _become_leader_and_run skip acquire() and lead without the lock."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
         thread = _thread_with_lock()
         old_lock = thread._lock
-        fresh = mock.create_autospec(locks.PostgresLock,
-                                     instance=True,
-                                     spec_set=True)
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=[]), \
-                mock.patch.object(mjrt.locks, 'get_lock',
-                                  return_value=fresh) as get_lock:
-            assert thread._step_down_on_lock_loss() is True
+        old_lock.release.side_effect = release_exc
+        fresh = _autospec_lock()
+        with _drain_patched(records, alive=alive, fresh_lock=fresh) as m:
+            assert thread._step_down_on_lock_loss() is verdict
         old_lock.release.assert_called_once_with()
-        get_lock.assert_called_once_with(
+        m.get_lock.assert_called_once_with(
             mjrt.managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
         assert thread._lock is fresh
 
-    def test_release_failure_still_replaces_the_lock(self, tmp_path,
-                                                     monkeypatch):
-        """Releasing a lock whose session already died routinely raises; that
-        must not leave the stale object in place."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        thread = _thread_with_lock()
-        thread._lock.release.side_effect = RuntimeError('conn already dead')
-        fresh = mock.create_autospec(locks.PostgresLock,
-                                     instance=True,
-                                     spec_set=True)
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               return_value=[]), \
-                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh):
-            assert thread._step_down_on_lock_loss() is True
-        assert thread._lock is fresh
-
-    def test_drain_failure_still_replaces_the_lock(self, tmp_path, monkeypatch):
-        """Even when we cannot prove the controllers are gone, the lock object
-        must be dropped — otherwise a later retry could lead on a stale flag."""
-        monkeypatch.setattr(mjrt.constants,
-                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
-                            str(tmp_path / 'restart_signal'))
-        thread = _thread_with_lock()
-        fresh = mock.create_autospec(locks.PostgresLock,
-                                     instance=True,
-                                     spec_set=True)
-        with mock.patch.object(mjrt.managed_job_scheduler,
-                               'get_controller_process_records',
-                               side_effect=RuntimeError('boom')), \
-                mock.patch.object(mjrt.locks, 'get_lock', return_value=fresh), \
-                mock.patch('os.kill'):
-            assert thread._step_down_on_lock_loss() is False
-        assert thread._lock is fresh
-
-    def test_signal_file_touch_failure_does_not_block_the_drain(
-            self, monkeypatch):
+    def test_signal_file_touch_failure_does_not_block_the_drain(self):
         """If the FS refuses the touch (read-only, full), still stop the
         controllers — that is the part that prevents split-brain."""
 
@@ -312,26 +246,18 @@ class TestStepDownOnLockLoss:
 
         thread = _thread_with_lock()
         with mock.patch.object(mjrt.pathlib.Path, 'touch', boom_touch), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'get_controller_process_records',
-                                  return_value=_records(101)), \
-                mock.patch.object(mjrt.managed_job_scheduler,
-                                  'kill_local_job_controllers') as kill, \
-                mock.patch.object(mjrt.managed_job_utils,
-                                  'controller_process_alive',
-                                  return_value=False), \
-                mock.patch.object(mjrt.locks, 'get_lock'):
+                _drain_patched(_records(101)) as m:
             assert thread._step_down_on_lock_loss() is True
-        kill.assert_called_once_with()
+        m.kill.assert_called_once_with()
 
 
 class TestOuterLoopAfterStepDown:
     """run() re-contends after a clean step-down and stops after a dirty one."""
 
     def test_reenters_after_a_clean_step_down(self):
-        """A clean step-down leaves this replica eligible: controller starts are
-        gated, our controllers are gone, and the lock object was replaced — so
-        the next pass really does acquire() before leading."""
+        """A clean step-down leaves this replica eligible: our controllers are
+        confirmed gone and the lock object was replaced — so the next pass
+        really does acquire() before leading."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
         lock = mock.create_autospec(locks.PostgresLock,
                                     instance=True,
@@ -460,11 +386,10 @@ class TestBecomeLeaderOrdering:
     recovery must wait briefly after acquiring it.
 
     During a rolling update we block on acquire() while the old API server
-    still holds the lock. If the gate file is missing in that window, a
-    controller started on this replica would be invisible to the old
-    server's update_managed_jobs_statuses, which could mark the job
-    FAILED_CONTROLLER. The signal file gates controller starts, so it must
-    be touched up-front, not after we win the lock.
+    still holds the lock. The signal file holds off the FAILED_CONTROLLER
+    sweep, and jobs whose controllers are moving between replicas must not be
+    marked failed for it in that window — so it must be touched up-front, not
+    after we win the lock.
 
     After acquiring the lock we also wait briefly before recovery: the old
     pod's detached controllers can outlive the lock release by a moment, and
@@ -559,7 +484,7 @@ class TestBecomeLeaderOrdering:
         """If the lock session goes stale during the post-acquire wait, we
         must NOT run recovery — another replica may now hold the lock. Step
         down and leave the gate file in place (the step-down path re-touches it
-        to keep controllers gated), and propagate its verdict to run()."""
+        to hold off the sweep), and propagate its verdict to run()."""
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',


### PR DESCRIPTION
On losing its consolidation-mode advisory lock, the managed-job refresh thread SIGTERMs its own process. That works, but the blast radius is much larger than the event requires: the process is also an API server replica, so a leadership change takes that replica's share of the Service's traffic down with it and fails whatever was in flight on it. Nothing about handing over the leader role requires the server to stop serving.

This steps down in place instead. The thread gates controller starts, stops the job controllers this replica owns, drops its lock object, and goes back to contending for the lock as a follower.

**The part the SIGTERM was silently providing.** Recovery on the new leader decides a job needs re-adopting by checking whether its recorded controller pid is alive, and that check is a local `psutil` lookup (`controller_process_alive`) — so it can never see another replica's controllers and always concludes they are dead. If one of ours outlives our leadership, that job gets a second controller.

Job controllers are detached subprocesses (`start_new_session=True`), so the parent exiting never killed them; what reaped anything that ignored SIGTERM was the container teardown that followed. Stepping down in place removes that backstop, so signalling is no longer enough. The drain now waits for the controllers to actually exit, escalates to SIGKILL, and reports whether they are gone.

If it cannot prove they are gone — including when the controller pid file cannot be read, which is *unknown*, not *none* — the thread refuses to lead again and stops, leaving controller starts gated on this replica. That preserves the old guarantee (never two controllers on one job) in the one case where stepping down cannot establish it, at the cost of needing a restart to become eligible again.

**The lock object is replaced, not reused.** A `release()` whose connection is already dead leaves `PostgresLock._acquired` True, because that flag is only cleared after a successful unlock — and `is_locked()` returns exactly that flag. Reusing the object would make the next pass skip `acquire()` and run recovery believing it leads. So the step-down releases best-effort (to return or invalidate the pooled connection) and then builds a fresh lock. Documented on `is_session_alive()`, whose docstring previously suggested exiting as *the* way to react to a lost session.

**Tradeoffs.** Removing the process exit converts "the process is gone, so its controllers certainly cannot act" into "we killed them and confirmed it"; the confirmation is what makes that sound, and the refuse-to-lead-again path covers the case where it cannot be established. A stronger fence — recording the owning replica alongside the controller pid, so recovery could distinguish "pid dead" from "pid belongs to another replica" — would remove the need to reason about the drain at all, and is the natural follow-up. The drain budget (5s to SIGTERM, 10s total) is deliberately well inside `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS` (15s), which is what separates our dying controllers from the new leader's recovery sweep; those constants are now coupled and the comment says so. And a replica that cannot confirm its drain stops running the refresh loop until it restarts — it keeps serving API traffic and its controller starts stay gated, but the fleet is down one eligible leader until a rollout replaces it. Failing closed there seemed clearly better than risking two controllers on one job.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New/changed tests: `tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py`, 25 tests, rewritten around the new semantics. The headline case asserts `os.kill` is never called. Others cover: controller starts gated before anything is killed and still gated after the step-down; SIGTERM alone when controllers exit; escalation to SIGKILL when they do not; refusing to lead again when they survive or when the pid file cannot be read; the lock object being replaced (including when `release()` raises, and when the drain fails); and the outer loop re-contending after a clean step-down but stopping after an unconfirmed one. `yapf`, `pylint` (10.00/10 on the changed files) and `mypy` all clean via pre-commit.

Manual test: exercised end-to-end on a 2-replica HA deployment with a chaos case that cuts every replica off from Postgres for 30s while a managed job and a `sky launch` are in flight, sampling `/api/health` through the Service and the controller processes per pod throughout. Before this change, one 30s DB blackout measured: the leader's container restarting; ~71s with zero job controllers fleet-wide (the old leader kills its controllers and dies, then the new leader waits `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS` before recovery); and ~10s in which the dying pod was still `Ready`, so still receiving traffic, while its own `/api/health` timed out — visible to clients as 502s and a 21s unanswerable gap. No split-brain in either case; that invariant is checked by sampling the controller processes across the handoff, since the lock-holder count cannot see this failure mode (the old leader *releases* its lock, so the count stays 1, while its detached controllers may keep running).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->