### PR TITLE
[SERVE] Load balancing least_load policy replica decrement bug and rotation issue

### DIFF
--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -33,8 +33,8 @@ class _CleanupStreamingResponse(fastapi.responses.StreamingResponse):
             await super().__call__(scope, receive, send)
         finally:
             # This covers a client disconnect before the response body
-            # iterator is started. The iterator also invokes this callback in
-            # its own finally block for errors during streaming.
+            # iterator is started, as well as errors and disconnects during
+            # streaming.
             await self._cleanup()
 
 
@@ -189,7 +189,6 @@ class SkyServeLoadBalancer:
             encountered if anything goes wrong.
         """
         logger.info(f'Proxy request to {url}')
-        self._load_balancing_policy.pre_execute_hook(url, request)
         load_released = False
 
         def release_load() -> None:
@@ -201,6 +200,7 @@ class SkyServeLoadBalancer:
 
         response_returned = False
         try:
+            self._load_balancing_policy.pre_execute_hook(url, request)
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
             # entering this function. In that case we will return an error here

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -198,9 +198,11 @@ class SkyServeLoadBalancer:
             load_released = True
             self._load_balancing_policy.post_execute_hook(url, request)
 
+        load_incremented = False
         response_returned = False
         try:
             self._load_balancing_policy.pre_execute_hook(url, request)
+            load_incremented = True
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
             # entering this function. In that case we will return an error here
@@ -243,7 +245,7 @@ class SkyServeLoadBalancer:
             # response body cleanup cannot run to release the load. This also
             # covers a replica disappearing from the client pool between
             # selection and proxying.
-            if not response_returned:
+            if load_incremented and not response_returned:
                 release_load()
 
     async def _proxy_with_retries(

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -173,6 +173,7 @@ class SkyServeLoadBalancer:
         """
         logger.info(f'Proxy request to {url}')
         self._load_balancing_policy.pre_execute_hook(url, request)
+        release_load_immediately = True
         try:
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
@@ -194,19 +195,31 @@ class SkyServeLoadBalancer:
             proxy_response = await client.send(proxy_request, stream=True)
 
             async def background_func():
-                await proxy_response.aclose()
-                self._load_balancing_policy.post_execute_hook(url, request)
+                try:
+                    await proxy_response.aclose()
+                finally:
+                    self._load_balancing_policy.post_execute_hook(url, request)
 
-            return fastapi.responses.StreamingResponse(
+            response = fastapi.responses.StreamingResponse(
                 content=proxy_response.aiter_raw(),
                 status_code=proxy_response.status_code,
                 headers=proxy_response.headers,
                 background=background.BackgroundTask(background_func))
+            # Keep the load counted until the streaming response has finished.
+            release_load_immediately = False
+            return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error(f'Error when proxy request to {url}: '
                          f'{common_utils.format_exception(e)}'
                          f'\nTraceback: {traceback.format_exc()}')
             return e
+        finally:
+            # If proxying failed before a StreamingResponse was returned, the
+            # background task above cannot run to release the load. This also
+            # covers a replica disappearing from the client pool between
+            # selection and proxying.
+            if release_load_immediately:
+                self._load_balancing_policy.post_execute_hook(url, request)
 
     async def _proxy_with_retries(
             self, request: fastapi.Request) -> fastapi.responses.Response:

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -31,7 +31,16 @@ class _CleanupStreamingResponse(fastapi.responses.StreamingResponse):
     async def __call__(self, scope, receive, send):
         try:
             await super().__call__(scope, receive, send)
-        finally:
+        except BaseException:  # pylint: disable=broad-except
+            try:
+                await self._cleanup()
+            except BaseException:  # pylint: disable=broad-except
+                # Preserve the original response error if cleanup also fails.
+                logger.exception(
+                    'Error cleaning up streaming response; preserving the '
+                    'original response error.')
+            raise
+        else:
             # This covers a client disconnect before the response body
             # iterator is started, as well as errors and disconnects during
             # streaming.
@@ -225,6 +234,9 @@ class SkyServeLoadBalancer:
             async def cleanup_response() -> None:
                 try:
                     await proxy_response.aclose()
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception(
+                        f'Error closing proxied response to {url}.')
                 finally:
                     release_load()
 

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -4,7 +4,7 @@ import logging
 import os
 import threading
 import traceback
-from typing import Dict, List, Optional, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Union
 
 import aiohttp
 import fastapi
@@ -18,6 +18,24 @@ from sky.serve import serve_utils
 from sky.utils import common_utils
 
 logger = sky_logging.init_logger(__name__)
+
+
+class _CleanupStreamingResponse(fastapi.responses.StreamingResponse):
+    """Streaming response that always runs its cleanup callback."""
+
+    def __init__(self, *response_args, cleanup: Callable[[], Awaitable[None]],
+                 **kwargs) -> None:
+        super().__init__(*response_args, **kwargs)
+        self._cleanup = cleanup
+
+    async def __call__(self, scope, receive, send):
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            # This covers a client disconnect before the response body
+            # iterator is started. The iterator also invokes this callback in
+            # its own finally block for errors during streaming.
+            await self._cleanup()
 
 
 class SkyServeLoadBalancer:
@@ -202,23 +220,17 @@ class SkyServeLoadBalancer:
                 timeout=self._stream_timeout_seconds)
             proxy_response = await client.send(proxy_request, stream=True)
 
-            async def response_body():
+            async def cleanup_response() -> None:
                 try:
-                    async for chunk in proxy_response.aiter_raw():
-                        yield chunk
+                    await proxy_response.aclose()
                 finally:
-                    try:
-                        await proxy_response.aclose()
-                    finally:
-                        release_load()
+                    release_load()
 
-            response = fastapi.responses.StreamingResponse(
-                content=response_body(),
+            response = _CleanupStreamingResponse(
+                content=proxy_response.aiter_raw(),
                 status_code=proxy_response.status_code,
-                headers=proxy_response.headers)
-            # TODO(jgsweets): Wrap the response ASGI call in a finally block
-            # so a client disconnect before body iteration also closes the
-            # upstream response and releases the load.
+                headers=proxy_response.headers,
+                cleanup=cleanup_response)
             response_returned = True
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -216,6 +216,9 @@ class SkyServeLoadBalancer:
                 content=response_body(),
                 status_code=proxy_response.status_code,
                 headers=proxy_response.headers)
+            # TODO(jgsweets): Wrap the response ASGI call in a finally block
+            # so a client disconnect before body iteration also closes the
+            # upstream response and releases the load.
             response_returned = True
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Union
 import aiohttp
 import fastapi
 import httpx
-from starlette import background
 import uvicorn
 
 from sky import sky_logging
@@ -173,7 +172,16 @@ class SkyServeLoadBalancer:
         """
         logger.info(f'Proxy request to {url}')
         self._load_balancing_policy.pre_execute_hook(url, request)
-        release_load_immediately = True
+        load_released = False
+
+        def release_load() -> None:
+            nonlocal load_released
+            if load_released:
+                return
+            load_released = True
+            self._load_balancing_policy.post_execute_hook(url, request)
+
+        response_returned = False
         try:
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
@@ -194,19 +202,21 @@ class SkyServeLoadBalancer:
                 timeout=self._stream_timeout_seconds)
             proxy_response = await client.send(proxy_request, stream=True)
 
-            async def background_func():
+            async def response_body():
                 try:
-                    await proxy_response.aclose()
+                    async for chunk in proxy_response.aiter_raw():
+                        yield chunk
                 finally:
-                    self._load_balancing_policy.post_execute_hook(url, request)
+                    try:
+                        await proxy_response.aclose()
+                    finally:
+                        release_load()
 
             response = fastapi.responses.StreamingResponse(
-                content=proxy_response.aiter_raw(),
+                content=response_body(),
                 status_code=proxy_response.status_code,
-                headers=proxy_response.headers,
-                background=background.BackgroundTask(background_func))
-            # Keep the load counted until the streaming response has finished.
-            release_load_immediately = False
+                headers=proxy_response.headers)
+            response_returned = True
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error(f'Error when proxy request to {url}: '
@@ -215,11 +225,11 @@ class SkyServeLoadBalancer:
             return e
         finally:
             # If proxying failed before a StreamingResponse was returned, the
-            # background task above cannot run to release the load. This also
+            # response body cleanup cannot run to release the load. This also
             # covers a replica disappearing from the client pool between
             # selection and proxying.
-            if release_load_immediately:
-                self._load_balancing_policy.post_execute_hook(url, request)
+            if not response_returned:
+                release_load()
 
     async def _proxy_with_retries(
             self, request: fastapi.Request) -> fastapi.responses.Response:

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -1,5 +1,6 @@
 """LoadBalancer: Distribute any incoming request to all ready replicas."""
 import asyncio
+import functools
 import logging
 import os
 import threading
@@ -198,20 +199,10 @@ class SkyServeLoadBalancer:
             encountered if anything goes wrong.
         """
         logger.info(f'Proxy request to {url}')
-        load_released = False
-
-        def release_load() -> None:
-            nonlocal load_released
-            if load_released:
-                return
-            load_released = True
-            self._load_balancing_policy.post_execute_hook(url, request)
-
-        load_incremented = False
-        response_returned = False
+        release_load: Optional[Callable[[], None]] = None
         try:
-            self._load_balancing_policy.pre_execute_hook(url, request)
-            load_incremented = True
+            release_load = self._load_balancing_policy.begin_request(
+                url, request)
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
             # entering this function. In that case we will return an error here
@@ -231,7 +222,8 @@ class SkyServeLoadBalancer:
                 timeout=self._stream_timeout_seconds)
             proxy_response = await client.send(proxy_request, stream=True)
 
-            async def cleanup_response() -> None:
+            async def cleanup_response(
+                    release_load: Callable[[], None]) -> None:
                 try:
                     await proxy_response.aclose()
                 except Exception:  # pylint: disable=broad-except
@@ -240,12 +232,14 @@ class SkyServeLoadBalancer:
                 finally:
                     release_load()
 
+            assert release_load is not None
             response = _CleanupStreamingResponse(
                 content=proxy_response.aiter_raw(),
                 status_code=proxy_response.status_code,
                 headers=proxy_response.headers,
-                cleanup=cleanup_response)
-            response_returned = True
+                cleanup=functools.partial(cleanup_response, release_load))
+            # Transfer release ownership to the streaming response.
+            release_load = None
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error(f'Error when proxy request to {url}: '
@@ -253,12 +247,12 @@ class SkyServeLoadBalancer:
                          f'\nTraceback: {traceback.format_exc()}')
             return e
         finally:
-            # If proxying failed before a StreamingResponse was returned, the
-            # response body cleanup cannot run to release the load. This also
-            # covers a replica disappearing from the client pool between
-            # selection and proxying.
-            if load_incremented and not response_returned:
-                release_load()
+            # If proxying failed before release ownership was transferred to
+            # a StreamingResponse, release the load here. This also covers a
+            # replica disappearing from the client pool between selection and
+            # proxying.
+            if release_load is not None:
+                release_load()  # pylint: disable=not-callable
 
     async def _proxy_with_retries(
             self, request: fastapi.Request) -> fastapi.responses.Response:

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -122,7 +122,10 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         with self.lock:
             self.ready_replicas = ready_replicas
             for r in list(self.load_map.keys()):
-                if r not in ready_replicas:
+                # Keep the accounting for retired replicas until their
+                # in-flight requests finish. Otherwise a late completion can
+                # recreate the entry with a negative load.
+                if (r not in ready_replicas and self.load_map[r] <= 0):
                     del self.load_map[r]
             for replica in ready_replicas:
                 self.load_map[replica] = self.load_map.get(replica, 0)
@@ -145,7 +148,14 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
                           request: 'fastapi.Request') -> None:
         del request  # Unused.
         with self.lock:
-            self.load_map[replica_url] -= 1
+            current_load = self.load_map.get(replica_url)
+            if current_load is None:
+                return
+            current_load = max(0, current_load - 1)
+            if current_load == 0 and replica_url not in self.ready_replicas:
+                del self.load_map[replica_url]
+            else:
+                self.load_map[replica_url] = current_load
 
 
 class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
@@ -170,7 +180,7 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
             self.ready_replicas = ready_replicas
             # Clean up load map for removed replicas
             for r in list(self.load_map.keys()):
-                if r not in ready_replicas:
+                if (r not in ready_replicas and self.load_map[r] <= 0):
                     del self.load_map[r]
             # Initialize load for new replicas
             for replica in ready_replicas:

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -115,6 +115,7 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         super().__init__()
         self.load_map: Dict[str, int] = collections.defaultdict(int)
         self.lock = threading.Lock()
+        self._tie_breaker_index = 0
 
     def set_ready_replicas(self, ready_replicas: List[str]) -> None:
         if set(self.ready_replicas) == set(ready_replicas):
@@ -135,8 +136,32 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         if not self.ready_replicas:
             return None
         with self.lock:
-            return min(self.ready_replicas,
-                       key=lambda replica: self.load_map.get(replica, 0))
+            min_load = min(
+                self.load_map.get(replica, 0)
+                for replica in self.ready_replicas)
+            tied_replicas = [
+                replica for replica in self.ready_replicas
+                if self.load_map.get(replica, 0) == min_load
+            ]
+            return self._select_tied_replica(tied_replicas)
+
+    def _select_tied_replica(self, replicas: List[str]) -> Optional[str]:
+        """Select among tied replicas without favoring the first one.
+
+        The cursor is relative to all ready replicas, so changes to the set
+        of tied replicas do not cause the same endpoint to win repeatedly.
+        """
+        if not replicas or not self.ready_replicas:
+            return None
+        tied_replicas = set(replicas)
+        for offset in range(len(self.ready_replicas)):
+            index = (self._tie_breaker_index + offset) % len(
+                self.ready_replicas)
+            replica = self.ready_replicas[index]
+            if replica in tied_replicas:
+                self._tie_breaker_index = (index + 1) % len(self.ready_replicas)
+                return replica
+        return None
 
     def pre_execute_hook(self, replica_url: str,
                          request: 'fastapi.Request') -> None:
@@ -263,8 +288,12 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
                 normalized_load = self._get_normalized_load(replica)
                 replica_loads.append((replica, normalized_load))
 
-            # Select replica with minimum normalized load
-            selected_replica = min(replica_loads, key=lambda x: x[1])[0]
+            # Select a minimum-load replica, rotating among ties.
+            min_load = min(load for _, load in replica_loads)
+            tied_replicas = [
+                replica for replica, load in replica_loads if load == min_load
+            ]
+            selected_replica = self._select_tied_replica(tied_replicas)
             logger.debug('Available replicas and loads: %s', replica_loads)
             logger.debug('Selected replica: %s', selected_replica)
             return selected_replica

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -198,20 +198,6 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
         self.target_qps_per_accelerator: Dict[str, float] = {
         }  # accelerator_type -> target_qps
 
-    def set_ready_replicas(self, ready_replicas: List[str]) -> None:
-        if set(self.ready_replicas) == set(ready_replicas):
-            return
-        with self.lock:
-            self.ready_replicas = ready_replicas
-            # Clean up load map for removed replicas
-            for r in list(self.load_map.keys()):
-                if (r not in ready_replicas and self.load_map[r] <= 0):
-                    del self.load_map[r]
-            # Initialize load for new replicas
-            for replica in ready_replicas:
-                if replica not in self.load_map:
-                    self.load_map[replica] = 0
-
     def set_replica_info(self, replica_info: Dict[str, Dict[str, Any]]) -> None:
         """Set replica information including accelerator types.
 
@@ -298,4 +284,5 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
             logger.debug('Selected replica: %s', selected_replica)
             return selected_replica
 
-    # pre_execute_hook and post_execute_hook are inherited from LeastLoadPolicy
+    # set_ready_replicas, pre_execute_hook, and post_execute_hook are inherited
+    # from LeastLoadPolicy.

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -118,7 +118,8 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         self._tie_breaker_index = 0
 
     def set_ready_replicas(self, ready_replicas: List[str]) -> None:
-        if set(self.ready_replicas) == set(ready_replicas):
+        ready_replica_set = set(ready_replicas)
+        if set(self.ready_replicas) == ready_replica_set:
             return
         with self.lock:
             self.ready_replicas = ready_replicas
@@ -126,7 +127,7 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
                 # Keep the accounting for retired replicas until their
                 # in-flight requests finish. Otherwise a late completion can
                 # recreate the entry with a negative load.
-                if (r not in ready_replicas and self.load_map[r] <= 0):
+                if r not in ready_replica_set and self.load_map[r] <= 0:
                     del self.load_map[r]
             for replica in ready_replicas:
                 self.load_map[replica] = self.load_map.get(replica, 0)
@@ -145,14 +146,14 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
             ]
             return self._select_tied_replica(tied_replicas)
 
-    def _select_tied_replica(self, replicas: List[str]) -> Optional[str]:
+    def _select_tied_replica(self, replicas: List[str]) -> str:
         """Select among tied replicas without favoring the first one.
 
         The cursor is relative to all ready replicas, so changes to the set
         of tied replicas do not cause the same endpoint to win repeatedly.
         """
-        if not replicas or not self.ready_replicas:
-            return None
+        assert replicas and self.ready_replicas, (
+            'Cannot select from empty replica lists.')
         tied_replicas = set(replicas)
         for offset in range(len(self.ready_replicas)):
             index = (self._tie_breaker_index + offset) % len(
@@ -161,7 +162,7 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
             if replica in tied_replicas:
                 self._tie_breaker_index = (index + 1) % len(self.ready_replicas)
                 return replica
-        return None
+        raise RuntimeError('No tied replica found among ready replicas.')
 
     def pre_execute_hook(self, replica_url: str,
                          request: 'fastapi.Request') -> None:

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -311,5 +311,5 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
             logger.debug('Selected replica: %s', selected_replica)
             return selected_replica
 
-    # set_ready_replicas, pre_execute_hook, and post_execute_hook are inherited
-    # from LeastLoadPolicy.
+    # set_ready_replicas, begin_request, pre_execute_hook, and
+    # post_execute_hook are inherited from LeastLoadPolicy.

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -3,7 +3,7 @@ import collections
 import random
 import threading
 import typing
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from sky import sky_logging
 
@@ -72,6 +72,12 @@ class LoadBalancingPolicy:
     # compatible with all frameworks.
     def _select_replica(self, request: 'fastapi.Request') -> Optional[str]:
         raise NotImplementedError
+
+    def begin_request(self, replica_url: str,
+                      request: 'fastapi.Request') -> Callable[[], None]:
+        """Begin request accounting and return a release callback."""
+        del replica_url, request
+        return lambda: None
 
     def pre_execute_hook(self, replica_url: str,
                          request: 'fastapi.Request') -> None:
@@ -149,6 +155,20 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
                 if self.load_map.get(replica, 0) == min_load
             ]
             return self._select_tied_replica(tied_replicas)
+
+    def begin_request(self, replica_url: str,
+                      request: 'fastapi.Request') -> Callable[[], None]:
+        self.pre_execute_hook(replica_url, request)
+        load_released = False
+
+        def release_load() -> None:
+            nonlocal load_released
+            if load_released:
+                return
+            load_released = True
+            self.post_execute_hook(replica_url, request)
+
+        return release_load
 
     def _select_tied_replica(self, replicas: List[str]) -> str:
         """Select among tied replicas without favoring the first one.

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -158,7 +158,6 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
 
     def begin_request(self, replica_url: str,
                       request: 'fastapi.Request') -> Callable[[], None]:
-        self.pre_execute_hook(replica_url, request)
         load_released = False
 
         def release_load() -> None:
@@ -168,6 +167,11 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
             load_released = True
             self.post_execute_hook(replica_url, request)
 
+        # Keep this as the last operation before returning the release
+        # callback. It increments load_map; a potentially-raising operation
+        # after it would leak the increment before the callback is handed to
+        # the caller.
+        self.pre_execute_hook(replica_url, request)
         return release_load
 
     def _select_tied_replica(self, replicas: List[str]) -> str:

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -124,10 +124,14 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         with self.lock:
             self.ready_replicas = ready_replicas
             for r in list(self.load_map.keys()):
-                # Keep the accounting for retired replicas until their
-                # in-flight requests finish. Otherwise a late completion can
-                # recreate the entry with a negative load.
-                if r not in ready_replica_set and self.load_map[r] <= 0:
+                # Delete retired replicas immediately. A late completion is
+                # ignored by post_execute_hook() instead of recreating the
+                # entry. This favors avoiding phantom load if a URL is reused
+                # over preserving accounting across a readiness flap. A URL
+                # that re-enters before an old request finishes can still be
+                # affected by that late completion; stable replica identity
+                # would be needed to eliminate that ambiguity.
+                if r not in ready_replica_set:
                     del self.load_map[r]
             for replica in ready_replicas:
                 self.load_map[replica] = self.load_map.get(replica, 0)
@@ -176,6 +180,8 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
         with self.lock:
             current_load = self.load_map.get(replica_url)
             if current_load is None:
+                # Do not recreate an entry for a completion from a retired
+                # replica.
                 return
             current_load = max(0, current_load - 1)
             if current_load == 0 and replica_url not in self.ready_replicas:

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -25,6 +25,26 @@ def _make_load_balancer():
         load_balancing_policy_name='least_load')
 
 
+async def _run_response_with_client_disconnect(response, spec_version):
+
+    async def receive():
+        if spec_version == '2.3':
+            return {'type': 'http.disconnect'}
+        raise AssertionError('The request should not be received.')
+
+    async def send(message):
+        del message
+        if spec_version == '2.4':
+            raise OSError('client disconnected')
+
+    scope = {'type': 'http', 'asgi': {'spec_version': spec_version}}
+    if spec_version == '2.4':
+        with pytest.raises(Exception):
+            await response(scope, receive, send)
+    else:
+        await response(scope, receive, send)
+
+
 @pytest.mark.asyncio
 async def test_proxy_error_releases_least_load_accounting():
     lb = _make_load_balancer()
@@ -172,35 +192,138 @@ async def test_client_disconnect_before_streaming_releases_load_accounting(
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
-    async def receive():
-        if spec_version == '2.3':
-            return {'type': 'http.disconnect'}
-        raise AssertionError('The request should not be received.')
-
-    async def send(message):
-        del message
-        if spec_version == '2.4':
-            raise OSError('client disconnected')
-
-    if spec_version == '2.4':
-        with pytest.raises(Exception):
-            await response(
-                {
-                    'type': 'http',
-                    'asgi': {
-                        'spec_version': spec_version
-                    }
-                }, receive, send)
-    else:
-        await response({
-            'type': 'http',
-            'asgi': {
-                'spec_version': spec_version
-            }
-        }, receive, send)
+    await _run_response_with_client_disconnect(response, spec_version)
 
     assert lb._load_balancing_policy.load_map[replica_url] == 0
     proxy_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
+@pytest.mark.asyncio
+async def test_proxy_retries_spread_load_after_failure_and_disconnect(
+        spec_version, monkeypatch):
+    lb = _make_load_balancer()
+    replica_urls = [
+        'http://failing-replica',
+        'http://healthy-replica-1',
+        'http://healthy-replica-2',
+    ]
+    failing_url = replica_urls[0]
+    healthy_responses = []
+
+    def make_proxy_response():
+
+        async def response_body():
+            await asyncio.Event().wait()
+            yield b'unreachable'
+
+        proxy_response = mock.MagicMock()
+        proxy_response.aiter_raw.return_value = response_body()
+        proxy_response.status_code = 200
+        proxy_response.headers = {}
+        proxy_response.aclose = mock.AsyncMock()
+        healthy_responses.append(proxy_response)
+        return proxy_response
+
+    async def send_to_healthy_replica(proxy_request, **kwargs):
+        del proxy_request, kwargs
+        return make_proxy_response()
+
+    for replica_url in replica_urls:
+        client = mock.MagicMock()
+        client.build_request.return_value = mock.sentinel.proxy_request
+        if replica_url == failing_url:
+            client.send = mock.AsyncMock(
+                side_effect=httpx.ReadTimeout('timed out'))
+        else:
+            client.send = mock.AsyncMock(side_effect=send_to_healthy_replica)
+        lb._client_pool[replica_url] = client
+
+    policy = lb._load_balancing_policy
+    policy.set_ready_replicas(replica_urls)
+    request = _make_request()
+    request.is_disconnected = mock.AsyncMock(return_value=False)
+    monkeypatch.setattr(load_balancer.asyncio, 'sleep', mock.AsyncMock())
+
+    # The failed attempt and every disconnected response must release its
+    # load before the next request is selected.
+    for _ in range(4):
+        response = await lb._proxy_with_retries(request)
+        await _run_response_with_client_disconnect(response, spec_version)
+        assert all(
+            policy.load_map[replica_url] == 0 for replica_url in replica_urls)
+
+    assert [
+        lb._client_pool[replica_url].send.await_count
+        for replica_url in replica_urls
+    ] == [2, 2, 2]
+    assert all(
+        response.aclose.await_count == 1 for response in healthy_responses)
+
+
+@pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
+@pytest.mark.asyncio
+async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load(
+        spec_version):
+    lb = _make_load_balancer()
+    replica_urls = [
+        'http://failing-replica',
+        'http://healthy-replica-1',
+        'http://healthy-replica-2',
+    ]
+    healthy_responses = []
+
+    def make_proxy_response():
+
+        async def response_body():
+            await asyncio.Event().wait()
+            yield b'unreachable'
+
+        proxy_response = mock.MagicMock()
+        proxy_response.aiter_raw.return_value = response_body()
+        proxy_response.status_code = 200
+        proxy_response.headers = {}
+        proxy_response.aclose = mock.AsyncMock()
+        healthy_responses.append(proxy_response)
+        return proxy_response
+
+    async def send_to_healthy_replica(proxy_request, **kwargs):
+        del proxy_request, kwargs
+        return make_proxy_response()
+
+    clients = {}
+    for replica_url in replica_urls:
+        client = mock.MagicMock()
+        client.build_request.return_value = mock.sentinel.proxy_request
+        if replica_url == replica_urls[0]:
+            client.send = mock.AsyncMock(
+                side_effect=httpx.ReadTimeout('timed out'))
+        else:
+            client.send = mock.AsyncMock(side_effect=send_to_healthy_replica)
+        clients[replica_url] = client
+        lb._client_pool[replica_url] = client
+
+    policy = lb._load_balancing_policy
+    policy.set_ready_replicas(replica_urls)
+    request = _make_request()
+    request.is_disconnected = mock.AsyncMock(return_value=True)
+
+    result_statuses = []
+    for _ in range(4):
+        result = await lb._proxy_with_retries(request)
+        result_statuses.append(result.status_code)
+        if result.status_code != 499:
+            await _run_response_with_client_disconnect(result, spec_version)
+        assert all(
+            policy.load_map[replica_url] == 0 for replica_url in replica_urls)
+
+    assert result_statuses == [499, 200, 200, 499]
+    assert request.is_disconnected.await_count == 2
+    assert [
+        clients[replica_url].send.await_count for replica_url in replica_urls
+    ] == [2, 1, 1]
+    assert all(
+        response.aclose.await_count == 1 for response in healthy_responses)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -50,6 +50,8 @@ async def _run_response_with_client_disconnect(response, spec_version):
 async def test_proxy_error_releases_least_load_accounting():
     lb = _make_load_balancer()
     replica_url = 'http://replica'
+    policy = lb._load_balancing_policy
+    policy.set_ready_replicas([replica_url])
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
     client.send = mock.AsyncMock(side_effect=httpx.ReadTimeout('timed out'))
@@ -58,7 +60,7 @@ async def test_proxy_error_releases_least_load_accounting():
     result = await lb._proxy_request_to(replica_url, _make_request())
 
     assert isinstance(result, httpx.ReadTimeout)
-    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert policy.load_map.get(replica_url) == 0
 
 
 @pytest.mark.asyncio
@@ -79,7 +81,7 @@ async def test_pre_execute_error_preserves_least_load_accounting():
     with pytest.raises(RuntimeError, match='pre-execute failed'):
         await lb._proxy_request_to(replica_url, request)
 
-    assert policy.load_map[replica_url] == 1
+    assert policy.load_map.get(replica_url) == 1
 
 
 @pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
@@ -101,10 +103,11 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
     proxy_response.aclose = mock.AsyncMock()
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica_url])
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
-    assert lb._load_balancing_policy.load_map[replica_url] == 1
+    assert lb._load_balancing_policy.load_map.get(replica_url) == 1
     messages = []
 
     receive_event = asyncio.Event()
@@ -122,7 +125,7 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
         }
     }, receive, send)
 
-    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
     assert any(message.get('body') == b'response' for message in messages)
     proxy_response.aclose.assert_awaited_once()
 
@@ -148,6 +151,7 @@ async def test_streaming_response_error_releases_least_load_accounting(
         side_effect=RuntimeError('aclose failed'))
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica_url])
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
@@ -166,7 +170,7 @@ async def test_streaming_response_error_releases_least_load_accounting(
                 'spec_version': spec_version
             }
         }, receive, send)
-    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
     proxy_response.aclose.assert_awaited_once()
 
 
@@ -190,12 +194,13 @@ async def test_client_disconnect_before_streaming_releases_load_accounting(
     proxy_response.aclose = mock.AsyncMock()
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica_url])
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
     await _run_response_with_client_disconnect(response, spec_version)
 
-    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
     proxy_response.aclose.assert_awaited_once()
 
 
@@ -252,7 +257,8 @@ async def test_proxy_retries_spread_load_after_failure_and_disconnect(
         response = await lb._proxy_with_retries(request)
         await _run_response_with_client_disconnect(response, spec_version)
         assert all(
-            policy.load_map[replica_url] == 0 for replica_url in replica_urls)
+            policy.load_map.get(replica_url) == 0
+            for replica_url in replica_urls)
 
     assert [
         lb._client_pool[replica_url].send.await_count
@@ -316,7 +322,8 @@ async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load
         if result.status_code != 499:
             await _run_response_with_client_disconnect(result, spec_version)
         assert all(
-            policy.load_map[replica_url] == 0 for replica_url in replica_urls)
+            policy.load_map.get(replica_url) == 0
+            for replica_url in replica_urls)
 
     assert result_statuses == [499, 200, 200, 499]
     assert request.is_disconnected.await_count == 2
@@ -331,11 +338,13 @@ async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load
 async def test_missing_client_releases_least_load_accounting():
     lb = _make_load_balancer()
     replica_url = 'http://replica'
+    policy = lb._load_balancing_policy
+    policy.set_ready_replicas([replica_url])
 
     result = await lb._proxy_request_to(replica_url, _make_request())
 
     assert isinstance(result, RuntimeError)
-    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert policy.load_map.get(replica_url) == 0
 
 
 def test_retired_replica_load_is_removed_after_inflight_request_finishes():
@@ -346,13 +355,13 @@ def test_retired_replica_load_is_removed_after_inflight_request_finishes():
     policy.set_ready_replicas([replica_url])
     policy.pre_execute_hook(replica_url, request)
     policy.set_ready_replicas([])
-    assert policy.load_map[replica_url] == 1
+    assert policy.load_map.get(replica_url) == 1
     policy.set_ready_replicas([replica_url])
-    assert policy.load_map[replica_url] == 1
+    assert policy.load_map.get(replica_url) == 1
 
     policy.post_execute_hook(replica_url, request)
 
-    assert policy.load_map[replica_url] == 0
+    assert policy.load_map.get(replica_url) == 0
     policy.set_ready_replicas([])
     assert replica_url not in policy.load_map
 

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from sky.serve import load_balancer
+from sky.serve import load_balancing_policies
 
 
 def _make_request():
@@ -338,7 +339,7 @@ async def test_missing_client_releases_least_load_accounting():
 
 
 def test_retired_replica_load_is_removed_after_inflight_request_finishes():
-    policy = load_balancer.lb_policies.LeastLoadPolicy()
+    policy = load_balancing_policies.LeastLoadPolicy()
     replica_url = 'http://replica'
     request = _make_request()
 
@@ -357,7 +358,7 @@ def test_retired_replica_load_is_removed_after_inflight_request_finishes():
 
 
 def test_least_load_rotates_equal_load_ties():
-    policy = load_balancer.lb_policies.LeastLoadPolicy()
+    policy = load_balancing_policies.LeastLoadPolicy()
     replicas = ['http://replica-1', 'http://replica-2', 'http://replica-3']
     policy.set_ready_replicas(replicas)
 
@@ -367,7 +368,7 @@ def test_least_load_rotates_equal_load_ties():
 
 
 def test_instance_aware_least_load_rotates_equal_load_ties():
-    policy = load_balancer.lb_policies.InstanceAwareLeastLoadPolicy()
+    policy = load_balancing_policies.InstanceAwareLeastLoadPolicy()
     replicas = ['http://replica-1', 'http://replica-2']
     policy.set_ready_replicas(replicas)
 

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -60,8 +60,38 @@ async def test_streaming_response_releases_least_load_accounting_on_close():
     response = await lb._proxy_request_to(replica_url, _make_request())
 
     assert lb._load_balancing_policy.load_map[replica_url] == 1
-    await response.background()
+    assert await response.body_iterator.__anext__() == b'response'
+    with pytest.raises(StopAsyncIteration):
+        await response.body_iterator.__anext__()
     assert lb._load_balancing_policy.load_map[replica_url] == 0
+    proxy_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_error_releases_least_load_accounting():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+    client = mock.MagicMock()
+    client.build_request.return_value = mock.sentinel.proxy_request
+
+    async def response_body():
+        raise httpx.ReadTimeout('timed out')
+        yield b'unreachable'
+
+    proxy_response = mock.MagicMock()
+    proxy_response.aiter_raw.return_value = response_body()
+    proxy_response.status_code = 200
+    proxy_response.headers = {}
+    proxy_response.aclose = mock.AsyncMock()
+    client.send = mock.AsyncMock(return_value=proxy_response)
+    lb._client_pool[replica_url] = client
+
+    response = await lb._proxy_request_to(replica_url, _make_request())
+
+    with pytest.raises(httpx.ReadTimeout):
+        await response.body_iterator.__anext__()
+    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    proxy_response.aclose.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -73,3 +103,22 @@ async def test_missing_client_releases_least_load_accounting():
 
     assert isinstance(result, RuntimeError)
     assert lb._load_balancing_policy.load_map[replica_url] == 0
+
+
+def test_retired_replica_load_is_removed_after_inflight_request_finishes():
+    policy = load_balancer.lb_policies.LeastLoadPolicy()
+    replica_url = 'http://replica'
+    request = _make_request()
+
+    policy.set_ready_replicas([replica_url])
+    policy.pre_execute_hook(replica_url, request)
+    policy.set_ready_replicas([])
+    assert policy.load_map[replica_url] == 1
+    policy.set_ready_replicas([replica_url])
+    assert policy.load_map[replica_url] == 1
+
+    policy.post_execute_hook(replica_url, request)
+
+    assert policy.load_map[replica_url] == 0
+    policy.set_ready_replicas([])
+    assert replica_url not in policy.load_map

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -40,6 +40,27 @@ async def test_proxy_error_releases_least_load_accounting():
 
 
 @pytest.mark.asyncio
+async def test_pre_execute_error_releases_least_load_accounting():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+    request = _make_request()
+    policy = lb._load_balancing_policy
+    policy.set_ready_replicas([replica_url])
+
+    def increment_then_raise(replica_url_arg, request_arg):
+        del request_arg
+        policy.load_map[replica_url_arg] += 1
+        raise RuntimeError('pre-execute failed')
+
+    policy.pre_execute_hook = increment_then_raise
+
+    with pytest.raises(RuntimeError, match='pre-execute failed'):
+        await lb._proxy_request_to(replica_url, request)
+
+    assert policy.load_map[replica_url] == 0
+
+
+@pytest.mark.asyncio
 async def test_streaming_response_releases_least_load_accounting_on_close():
     lb = _make_load_balancer()
     replica_url = 'http://replica'

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -60,10 +60,23 @@ async def test_streaming_response_releases_least_load_accounting_on_close():
     response = await lb._proxy_request_to(replica_url, _make_request())
 
     assert lb._load_balancing_policy.load_map[replica_url] == 1
-    assert await response.body_iterator.__anext__() == b'response'
-    with pytest.raises(StopAsyncIteration):
-        await response.body_iterator.__anext__()
+    messages = []
+
+    async def receive():
+        return {'type': 'http.request'}
+
+    async def send(message):
+        messages.append(message)
+
+    await response({
+        'type': 'http',
+        'asgi': {
+            'spec_version': '2.4'
+        }
+    }, receive, send)
+
     assert lb._load_balancing_policy.load_map[replica_url] == 0
+    assert any(message.get('body') == b'response' for message in messages)
     proxy_response.aclose.assert_awaited_once()
 
 
@@ -88,8 +101,59 @@ async def test_streaming_response_error_releases_least_load_accounting():
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
+    async def receive():
+        return {'type': 'http.request'}
+
+    async def send(message):
+        del message
+
     with pytest.raises(httpx.ReadTimeout):
-        await response.body_iterator.__anext__()
+        await response({
+            'type': 'http',
+            'asgi': {
+                'spec_version': '2.4'
+            }
+        }, receive, send)
+    assert lb._load_balancing_policy.load_map[replica_url] == 0
+    proxy_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_before_streaming_releases_load_accounting():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+    client = mock.MagicMock()
+    client.build_request.return_value = mock.sentinel.proxy_request
+
+    async def response_body():
+        raise AssertionError('The response body should not be iterated.')
+        yield b'unreachable'
+
+    proxy_response = mock.MagicMock()
+    proxy_response.aiter_raw.return_value = response_body()
+    proxy_response.status_code = 200
+    proxy_response.headers = {}
+    proxy_response.aclose = mock.AsyncMock()
+    client.send = mock.AsyncMock(return_value=proxy_response)
+    lb._client_pool[replica_url] = client
+
+    response = await lb._proxy_request_to(replica_url, _make_request())
+
+    async def receive():
+        raise AssertionError('The request should not be received.')
+
+    async def send(message):
+        del message
+        raise OSError('client disconnected')
+
+    with pytest.raises(Exception):
+        await response({
+            'type': 'http',
+            'asgi': {
+                'spec_version': '2.4'
+            }
+        }, receive, send)
+
     assert lb._load_balancing_policy.load_map[replica_url] == 0
     proxy_response.aclose.assert_awaited_once()
 

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -1,0 +1,75 @@
+"""Tests for SkyServe load balancer request accounting."""
+from unittest import mock
+
+import httpx
+import pytest
+
+from sky.serve import load_balancer
+
+
+def _make_request():
+    request = mock.MagicMock()
+    request.method = 'GET'
+    request.url.path = '/'
+    request.url.query = ''
+    request.headers.raw = []
+    request.body = mock.AsyncMock(return_value=b'')
+    return request
+
+
+def _make_load_balancer():
+    return load_balancer.SkyServeLoadBalancer(
+        controller_url='http://controller',
+        load_balancer_port=30001,
+        load_balancing_policy_name='least_load')
+
+
+@pytest.mark.asyncio
+async def test_proxy_error_releases_least_load_accounting():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+    client = mock.MagicMock()
+    client.build_request.return_value = mock.sentinel.proxy_request
+    client.send = mock.AsyncMock(side_effect=httpx.ReadTimeout('timed out'))
+    lb._client_pool[replica_url] = client
+
+    result = await lb._proxy_request_to(replica_url, _make_request())
+
+    assert isinstance(result, httpx.ReadTimeout)
+    assert lb._load_balancing_policy.load_map[replica_url] == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_releases_least_load_accounting_on_close():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+    client = mock.MagicMock()
+    client.build_request.return_value = mock.sentinel.proxy_request
+
+    async def response_body():
+        yield b'response'
+
+    proxy_response = mock.MagicMock()
+    proxy_response.aiter_raw.return_value = response_body()
+    proxy_response.status_code = 200
+    proxy_response.headers = {}
+    proxy_response.aclose = mock.AsyncMock()
+    client.send = mock.AsyncMock(return_value=proxy_response)
+    lb._client_pool[replica_url] = client
+
+    response = await lb._proxy_request_to(replica_url, _make_request())
+
+    assert lb._load_balancing_policy.load_map[replica_url] == 1
+    await response.background()
+    assert lb._load_balancing_policy.load_map[replica_url] == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_client_releases_least_load_accounting():
+    lb = _make_load_balancer()
+    replica_url = 'http://replica'
+
+    result = await lb._proxy_request_to(replica_url, _make_request())
+
+    assert isinstance(result, RuntimeError)
+    assert lb._load_balancing_policy.load_map[replica_url] == 0

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -122,3 +122,23 @@ def test_retired_replica_load_is_removed_after_inflight_request_finishes():
     assert policy.load_map[replica_url] == 0
     policy.set_ready_replicas([])
     assert replica_url not in policy.load_map
+
+
+def test_least_load_rotates_equal_load_ties():
+    policy = load_balancer.lb_policies.LeastLoadPolicy()
+    replicas = ['http://replica-1', 'http://replica-2', 'http://replica-3']
+    policy.set_ready_replicas(replicas)
+
+    selected_replicas = [policy._select_replica(None) for _ in range(6)]
+
+    assert selected_replicas == replicas * 2
+
+
+def test_instance_aware_least_load_rotates_equal_load_ties():
+    policy = load_balancer.lb_policies.InstanceAwareLeastLoadPolicy()
+    replicas = ['http://replica-1', 'http://replica-2']
+    policy.set_ready_replicas(replicas)
+
+    selected_replicas = [policy._select_replica(None) for _ in range(4)]
+
+    assert selected_replicas == replicas * 2

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -1,4 +1,5 @@
 """Tests for SkyServe load balancer request accounting."""
+import asyncio
 from unittest import mock
 
 import httpx
@@ -60,8 +61,10 @@ async def test_pre_execute_error_preserves_least_load_accounting():
     assert policy.load_map[replica_url] == 1
 
 
+@pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
 @pytest.mark.asyncio
-async def test_streaming_response_releases_least_load_accounting_on_close():
+async def test_streaming_response_releases_least_load_accounting_on_close(
+        spec_version):
     lb = _make_load_balancer()
     replica_url = 'http://replica'
     client = mock.MagicMock()
@@ -83,8 +86,10 @@ async def test_streaming_response_releases_least_load_accounting_on_close():
     assert lb._load_balancing_policy.load_map[replica_url] == 1
     messages = []
 
+    receive_event = asyncio.Event()
+
     async def receive():
-        return {'type': 'http.request'}
+        await receive_event.wait()
 
     async def send(message):
         messages.append(message)
@@ -92,7 +97,7 @@ async def test_streaming_response_releases_least_load_accounting_on_close():
     await response({
         'type': 'http',
         'asgi': {
-            'spec_version': '2.4'
+            'spec_version': spec_version
         }
     }, receive, send)
 
@@ -101,8 +106,10 @@ async def test_streaming_response_releases_least_load_accounting_on_close():
     proxy_response.aclose.assert_awaited_once()
 
 
+@pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
 @pytest.mark.asyncio
-async def test_streaming_response_error_releases_least_load_accounting():
+async def test_streaming_response_error_releases_least_load_accounting(
+        spec_version):
     lb = _make_load_balancer()
     replica_url = 'http://replica'
     client = mock.MagicMock()
@@ -123,8 +130,10 @@ async def test_streaming_response_error_releases_least_load_accounting():
 
     response = await lb._proxy_request_to(replica_url, _make_request())
 
+    receive_event = asyncio.Event()
+
     async def receive():
-        return {'type': 'http.request'}
+        await receive_event.wait()
 
     async def send(message):
         del message
@@ -133,22 +142,24 @@ async def test_streaming_response_error_releases_least_load_accounting():
         await response({
             'type': 'http',
             'asgi': {
-                'spec_version': '2.4'
+                'spec_version': spec_version
             }
         }, receive, send)
     assert lb._load_balancing_policy.load_map[replica_url] == 0
     proxy_response.aclose.assert_awaited_once()
 
 
+@pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
 @pytest.mark.asyncio
-async def test_client_disconnect_before_streaming_releases_load_accounting():
+async def test_client_disconnect_before_streaming_releases_load_accounting(
+        spec_version):
     lb = _make_load_balancer()
     replica_url = 'http://replica'
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
 
     async def response_body():
-        raise AssertionError('The response body should not be iterated.')
+        await asyncio.Event().wait()
         yield b'unreachable'
 
     proxy_response = mock.MagicMock()
@@ -162,17 +173,29 @@ async def test_client_disconnect_before_streaming_releases_load_accounting():
     response = await lb._proxy_request_to(replica_url, _make_request())
 
     async def receive():
+        if spec_version == '2.3':
+            return {'type': 'http.disconnect'}
         raise AssertionError('The request should not be received.')
 
     async def send(message):
         del message
-        raise OSError('client disconnected')
+        if spec_version == '2.4':
+            raise OSError('client disconnected')
 
-    with pytest.raises(Exception):
+    if spec_version == '2.4':
+        with pytest.raises(Exception):
+            await response(
+                {
+                    'type': 'http',
+                    'asgi': {
+                        'spec_version': spec_version
+                    }
+                }, receive, send)
+    else:
         await response({
             'type': 'http',
             'asgi': {
-                'spec_version': '2.4'
+                'spec_version': spec_version
             }
         }, receive, send)
 

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -116,7 +116,8 @@ async def test_streaming_response_error_releases_least_load_accounting():
     proxy_response.aiter_raw.return_value = response_body()
     proxy_response.status_code = 200
     proxy_response.headers = {}
-    proxy_response.aclose = mock.AsyncMock()
+    proxy_response.aclose = mock.AsyncMock(
+        side_effect=RuntimeError('aclose failed'))
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
 
@@ -128,7 +129,7 @@ async def test_streaming_response_error_releases_least_load_accounting():
     async def send(message):
         del message
 
-    with pytest.raises(httpx.ReadTimeout):
+    with pytest.raises(httpx.ReadTimeout, match='timed out'):
         await response({
             'type': 'http',
             'asgi': {

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -40,24 +40,24 @@ async def test_proxy_error_releases_least_load_accounting():
 
 
 @pytest.mark.asyncio
-async def test_pre_execute_error_releases_least_load_accounting():
+async def test_pre_execute_error_preserves_least_load_accounting():
     lb = _make_load_balancer()
     replica_url = 'http://replica'
     request = _make_request()
     policy = lb._load_balancing_policy
     policy.set_ready_replicas([replica_url])
+    policy.pre_execute_hook(replica_url, request)
 
-    def increment_then_raise(replica_url_arg, request_arg):
-        del request_arg
-        policy.load_map[replica_url_arg] += 1
+    def raise_before_increment(replica_url_arg, request_arg):
+        del replica_url_arg, request_arg
         raise RuntimeError('pre-execute failed')
 
-    policy.pre_execute_hook = increment_then_raise
+    policy.pre_execute_hook = raise_before_increment
 
     with pytest.raises(RuntimeError, match='pre-execute failed'):
         await lb._proxy_request_to(replica_url, request)
 
-    assert policy.load_map[replica_url] == 0
+    assert policy.load_map[replica_url] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -46,6 +46,47 @@ async def _run_response_with_client_disconnect(response, spec_version):
         await response(scope, receive, send)
 
 
+def _make_streaming_response(response_body, aclose_side_effect=None):
+    proxy_response = mock.MagicMock()
+    proxy_response.aiter_raw.return_value = response_body
+    proxy_response.status_code = 200
+    proxy_response.headers = {}
+    proxy_response.aclose = mock.AsyncMock(side_effect=aclose_side_effect)
+    return proxy_response
+
+
+def _configure_multi_replica_clients(lb, replica_urls, failing_url):
+    healthy_responses = []
+
+    def make_proxy_response():
+
+        async def response_body():
+            await asyncio.Event().wait()
+            yield b'unreachable'
+
+        proxy_response = _make_streaming_response(response_body())
+        healthy_responses.append(proxy_response)
+        return proxy_response
+
+    async def send_to_healthy_replica(proxy_request, **kwargs):
+        del proxy_request, kwargs
+        return make_proxy_response()
+
+    clients = {}
+    for replica_url in replica_urls:
+        client = mock.MagicMock()
+        client.build_request.return_value = mock.sentinel.proxy_request
+        if replica_url == failing_url:
+            client.send = mock.AsyncMock(
+                side_effect=httpx.ReadTimeout('timed out'))
+        else:
+            client.send = mock.AsyncMock(side_effect=send_to_healthy_replica)
+        clients[replica_url] = client
+        lb._client_pool[replica_url] = client
+
+    return clients, healthy_responses
+
+
 @pytest.mark.asyncio
 async def test_proxy_error_releases_least_load_accounting():
     lb = _make_load_balancer()
@@ -96,11 +137,7 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
     async def response_body():
         yield b'response'
 
-    proxy_response = mock.MagicMock()
-    proxy_response.aiter_raw.return_value = response_body()
-    proxy_response.status_code = 200
-    proxy_response.headers = {}
-    proxy_response.aclose = mock.AsyncMock()
+    proxy_response = _make_streaming_response(response_body())
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
     lb._load_balancing_policy.set_ready_replicas([replica_url])
@@ -143,12 +180,8 @@ async def test_streaming_response_error_releases_least_load_accounting(
         raise httpx.ReadTimeout('timed out')
         yield b'unreachable'
 
-    proxy_response = mock.MagicMock()
-    proxy_response.aiter_raw.return_value = response_body()
-    proxy_response.status_code = 200
-    proxy_response.headers = {}
-    proxy_response.aclose = mock.AsyncMock(
-        side_effect=RuntimeError('aclose failed'))
+    proxy_response = _make_streaming_response(
+        response_body(), aclose_side_effect=RuntimeError('aclose failed'))
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
     lb._load_balancing_policy.set_ready_replicas([replica_url])
@@ -187,11 +220,7 @@ async def test_client_disconnect_before_streaming_releases_load_accounting(
         await asyncio.Event().wait()
         yield b'unreachable'
 
-    proxy_response = mock.MagicMock()
-    proxy_response.aiter_raw.return_value = response_body()
-    proxy_response.status_code = 200
-    proxy_response.headers = {}
-    proxy_response.aclose = mock.AsyncMock()
+    proxy_response = _make_streaming_response(response_body())
     client.send = mock.AsyncMock(return_value=proxy_response)
     lb._client_pool[replica_url] = client
     lb._load_balancing_policy.set_ready_replicas([replica_url])
@@ -215,35 +244,8 @@ async def test_proxy_retries_spread_load_after_failure_and_disconnect(
         'http://healthy-replica-2',
     ]
     failing_url = replica_urls[0]
-    healthy_responses = []
-
-    def make_proxy_response():
-
-        async def response_body():
-            await asyncio.Event().wait()
-            yield b'unreachable'
-
-        proxy_response = mock.MagicMock()
-        proxy_response.aiter_raw.return_value = response_body()
-        proxy_response.status_code = 200
-        proxy_response.headers = {}
-        proxy_response.aclose = mock.AsyncMock()
-        healthy_responses.append(proxy_response)
-        return proxy_response
-
-    async def send_to_healthy_replica(proxy_request, **kwargs):
-        del proxy_request, kwargs
-        return make_proxy_response()
-
-    for replica_url in replica_urls:
-        client = mock.MagicMock()
-        client.build_request.return_value = mock.sentinel.proxy_request
-        if replica_url == failing_url:
-            client.send = mock.AsyncMock(
-                side_effect=httpx.ReadTimeout('timed out'))
-        else:
-            client.send = mock.AsyncMock(side_effect=send_to_healthy_replica)
-        lb._client_pool[replica_url] = client
+    _, healthy_responses = _configure_multi_replica_clients(
+        lb, replica_urls, failing_url)
 
     policy = lb._load_balancing_policy
     policy.set_ready_replicas(replica_urls)
@@ -278,37 +280,8 @@ async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load
         'http://healthy-replica-1',
         'http://healthy-replica-2',
     ]
-    healthy_responses = []
-
-    def make_proxy_response():
-
-        async def response_body():
-            await asyncio.Event().wait()
-            yield b'unreachable'
-
-        proxy_response = mock.MagicMock()
-        proxy_response.aiter_raw.return_value = response_body()
-        proxy_response.status_code = 200
-        proxy_response.headers = {}
-        proxy_response.aclose = mock.AsyncMock()
-        healthy_responses.append(proxy_response)
-        return proxy_response
-
-    async def send_to_healthy_replica(proxy_request, **kwargs):
-        del proxy_request, kwargs
-        return make_proxy_response()
-
-    clients = {}
-    for replica_url in replica_urls:
-        client = mock.MagicMock()
-        client.build_request.return_value = mock.sentinel.proxy_request
-        if replica_url == replica_urls[0]:
-            client.send = mock.AsyncMock(
-                side_effect=httpx.ReadTimeout('timed out'))
-        else:
-            client.send = mock.AsyncMock(side_effect=send_to_healthy_replica)
-        clients[replica_url] = client
-        lb._client_pool[replica_url] = client
+    clients, healthy_responses = _configure_multi_replica_clients(
+        lb, replica_urls, replica_urls[0])
 
     policy = lb._load_balancing_policy
     policy.set_ready_replicas(replica_urls)

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -347,7 +347,7 @@ async def test_missing_client_releases_least_load_accounting():
     assert policy.load_map.get(replica_url) == 0
 
 
-def test_retired_replica_load_is_removed_after_inflight_request_finishes():
+def test_late_completion_does_not_recreate_retired_replica_load():
     policy = load_balancing_policies.LeastLoadPolicy()
     replica_url = 'http://replica'
     request = _make_request()
@@ -355,14 +355,10 @@ def test_retired_replica_load_is_removed_after_inflight_request_finishes():
     policy.set_ready_replicas([replica_url])
     policy.pre_execute_hook(replica_url, request)
     policy.set_ready_replicas([])
-    assert policy.load_map.get(replica_url) == 1
-    policy.set_ready_replicas([replica_url])
-    assert policy.load_map.get(replica_url) == 1
+    assert replica_url not in policy.load_map
 
     policy.post_execute_hook(replica_url, request)
 
-    assert policy.load_map.get(replica_url) == 0
-    policy.set_ready_replicas([])
     assert replica_url not in policy.load_map
 
 

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -64,7 +64,7 @@ async def test_proxy_error_releases_least_load_accounting():
 
 
 @pytest.mark.asyncio
-async def test_pre_execute_error_preserves_least_load_accounting():
+async def test_begin_request_error_preserves_least_load_accounting():
     lb = _make_load_balancer()
     replica_url = 'http://replica'
     request = _make_request()
@@ -72,13 +72,13 @@ async def test_pre_execute_error_preserves_least_load_accounting():
     policy.set_ready_replicas([replica_url])
     policy.pre_execute_hook(replica_url, request)
 
-    def raise_before_increment(replica_url_arg, request_arg):
+    def raise_begin_request(replica_url_arg, request_arg):
         del replica_url_arg, request_arg
-        raise RuntimeError('pre-execute failed')
+        raise RuntimeError('begin request failed')
 
-    policy.pre_execute_hook = raise_before_increment
+    policy.begin_request = raise_begin_request
 
-    with pytest.raises(RuntimeError, match='pre-execute failed'):
+    with pytest.raises(RuntimeError, match='begin request failed'):
         await lb._proxy_request_to(replica_url, request)
 
     assert policy.load_map.get(replica_url) == 1


### PR DESCRIPTION
Load balancing with least_load has bugs where certain errors prevent the decrement of load on the replica. This may cause all load to only be sent to a single replica. Additionally, in times of ties, the same replica is always chosen, this adds an additional cycle. 

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

Smoke tests and launches will need to be ran to evaluate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->