### PR TITLE
[Kubernetes] Add gang-scheduling gate and shared pod-group plumbing (inert)

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -940,6 +940,35 @@ class Kubernetes(clouds.Cloud):
                 region=context,
                 override_configs=resources.cluster_config_overrides))
 
+        # Job Group gang scheduling (controller-internal): the jobs
+        # controller sets these per member via cluster_config_overrides;
+        # they are not meant to be set in user or tenant config files.
+        # gate_name stamps an extra scheduling gate that the controller
+        # removes only once every member of the group is admitted;
+        # pod_group_name / pod_group_total_count override the per-cluster
+        # Kueue pod group so a group's members can share one admission
+        # unit. All default to None, which renders exactly today's
+        # per-cluster behavior.
+        gang_gate_name = skypilot_config.get_effective_region_config(
+            cloud='kubernetes',
+            region=context,
+            keys=('gang_scheduling', 'gate_name'),
+            default_value=None,
+            override_configs=resources.cluster_config_overrides)
+        gang_pod_group_name = skypilot_config.get_effective_region_config(
+            cloud='kubernetes',
+            region=context,
+            keys=('gang_scheduling', 'pod_group_name'),
+            default_value=None,
+            override_configs=resources.cluster_config_overrides)
+        gang_pod_group_total_count = (
+            skypilot_config.get_effective_region_config(
+                cloud='kubernetes',
+                region=context,
+                keys=('gang_scheduling', 'pod_group_total_count'),
+                default_value=None,
+                override_configs=resources.cluster_config_overrides))
+
         # Check DWS configuration for GKE.
         (enable_flex_start, enable_flex_start_queued_provisioning,
          max_run_duration_seconds) = gcp_utils.get_dws_config(
@@ -1035,6 +1064,9 @@ class Kubernetes(clouds.Cloud):
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
+            'k8s_gang_gate_name': gang_gate_name,
+            'k8s_pod_group_name': gang_pod_group_name,
+            'k8s_pod_group_total_count': gang_pod_group_total_count,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,
             'k8s_fusermount_shared_dir': kubernetes_fuse.FUSERMOUNT_SHARED_DIR,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -944,30 +944,26 @@ class Kubernetes(clouds.Cloud):
         # controller sets these per member via cluster_config_overrides;
         # they are not meant to be set in user or tenant config files.
         # gate_name stamps an extra scheduling gate that the controller
-        # removes only once every member of the group is admitted;
-        # pod_group_name / pod_group_total_count override the per-cluster
-        # Kueue pod group so a group's members can share one admission
-        # unit. All default to None, which renders exactly today's
-        # per-cluster behavior.
+        # removes only once every member of the group is admitted.
+        # kueue_pod_group_name overrides THIS member's
+        # kueue.x-k8s.io/pod-group-name label (its Kueue admission-unit
+        # identity, normally the cluster name): the controller stamps a
+        # fresh, attempt-suffixed name on each gang retry so a new attempt
+        # never collides with the previous attempt's still-terminating
+        # Kueue Workload of the same name. Both default to None, which
+        # renders exactly today's behavior.
         gang_gate_name = skypilot_config.get_effective_region_config(
             cloud='kubernetes',
             region=context,
             keys=('gang_scheduling', 'gate_name'),
             default_value=None,
             override_configs=resources.cluster_config_overrides)
-        gang_pod_group_name = skypilot_config.get_effective_region_config(
+        gang_kueue_pod_group_name = skypilot_config.get_effective_region_config(
             cloud='kubernetes',
             region=context,
-            keys=('gang_scheduling', 'pod_group_name'),
+            keys=('gang_scheduling', 'kueue_pod_group_name'),
             default_value=None,
             override_configs=resources.cluster_config_overrides)
-        gang_pod_group_total_count = (
-            skypilot_config.get_effective_region_config(
-                cloud='kubernetes',
-                region=context,
-                keys=('gang_scheduling', 'pod_group_total_count'),
-                default_value=None,
-                override_configs=resources.cluster_config_overrides))
 
         # Check DWS configuration for GKE.
         (enable_flex_start, enable_flex_start_queued_provisioning,
@@ -1065,8 +1061,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_fuse_device_required': fuse_device_required,
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             'k8s_gang_gate_name': gang_gate_name,
-            'k8s_pod_group_name': gang_pod_group_name,
-            'k8s_pod_group_total_count': gang_pod_group_total_count,
+            'k8s_kueue_pod_group_name': gang_kueue_pod_group_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,
             'k8s_fusermount_shared_dir': kubernetes_fuse.FUSERMOUNT_SHARED_DIR,

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -299,7 +299,7 @@ available_node_types:
             {% endif %}
             {% if k8s_kueue_local_queue_name %}
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
-            kueue.x-k8s.io/pod-group-name: {{cluster_name_on_cloud}}
+            kueue.x-k8s.io/pod-group-name: {{k8s_pod_group_name or cluster_name_on_cloud}}
             {% endif %}
         annotations:
           # The skypilot-user *label* (above) sanitizes characters that are
@@ -316,7 +316,7 @@ available_node_types:
           {% endif %}
           {% if k8s_kueue_local_queue_name %}
           kueue.x-k8s.io/retriable-in-group: "false"
-          kueue.x-k8s.io/pod-group-total-count: "{{ num_nodes|string }}"
+          kueue.x-k8s.io/pod-group-total-count: "{{ (k8s_pod_group_total_count or num_nodes)|string }}"
           {% if k8s_max_run_duration_seconds %}
           provreq.kueue.x-k8s.io/maxRunDurationSeconds: "{{k8s_max_run_duration_seconds|string}}"
           {% endif %}
@@ -394,6 +394,14 @@ available_node_types:
         serviceAccountName: {{k8s_service_account_name}}
         automountServiceAccountToken: {{k8s_automount_sa_token}}
         restartPolicy: {{ "Always" if high_availability else "Never" }}
+        {% if k8s_gang_gate_name %}
+        # Held back from scheduling until the jobs controller removes this
+        # gate: no Job Group member may bind before every member of the
+        # group is admitted. Coexists with Kueue's own admission gate on
+        # the same pod; each owner removes only its own entry.
+        schedulingGates:
+          - name: {{ k8s_gang_gate_name }}
+        {% endif %}
         {% if preemption_hook_timeout is defined and preemption_hook_timeout %}
         terminationGracePeriodSeconds: {{ preemption_hook_timeout }}
         {% endif %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -299,7 +299,7 @@ available_node_types:
             {% endif %}
             {% if k8s_kueue_local_queue_name %}
             kueue.x-k8s.io/queue-name: {{k8s_kueue_local_queue_name}}
-            kueue.x-k8s.io/pod-group-name: {{k8s_pod_group_name or cluster_name_on_cloud}}
+            kueue.x-k8s.io/pod-group-name: {{k8s_kueue_pod_group_name or cluster_name_on_cloud}}
             {% endif %}
         annotations:
           # The skypilot-user *label* (above) sanitizes characters that are
@@ -316,7 +316,7 @@ available_node_types:
           {% endif %}
           {% if k8s_kueue_local_queue_name %}
           kueue.x-k8s.io/retriable-in-group: "false"
-          kueue.x-k8s.io/pod-group-total-count: "{{ (k8s_pod_group_total_count or num_nodes)|string }}"
+          kueue.x-k8s.io/pod-group-total-count: "{{ num_nodes|string }}"
           {% if k8s_max_run_duration_seconds %}
           provreq.kueue.x-k8s.io/maxRunDurationSeconds: "{{k8s_max_run_duration_seconds|string}}"
           {% endif %}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1653,11 +1653,8 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'gate_name': {
                 'type': 'string',
             },
-            'pod_group_name': {
+            'kueue_pod_group_name': {
                 'type': 'string',
-            },
-            'pod_group_total_count': {
-                'type': 'integer',
             },
         },
     },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1642,6 +1642,25 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             },
         },
     },
+    # Controller-internal (Job Group gang scheduling): set per member via
+    # cluster_config_overrides by the jobs controller, not in user or
+    # tenant config files.
+    'gang_scheduling': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'gate_name': {
+                'type': 'string',
+            },
+            'pod_group_name': {
+                'type': 'string',
+            },
+            'pod_group_total_count': {
+                'type': 'integer',
+            },
+        },
+    },
     # Alias of `kueue.local_queue_name`; `quota.queue` takes precedence
     # when both are set. Permissive so external schedulers (registered
     # via plugins) can layer their own sub-fields under `quota` without

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -116,6 +116,9 @@ def base_variables() -> Dict[str, Any]:
         'k8s_automount_sa_token': 'true',
         'k8s_fuse_device_required': False,
         'k8s_kueue_local_queue_name': None,
+        'k8s_gang_gate_name': None,
+        'k8s_pod_group_name': None,
+        'k8s_pod_group_total_count': None,
         'k8s_skypilot_system_namespace': 'skypilot-system',
         'k8s_fusermount_shared_dir': '/var/run/fusermount',
         'k8s_fusermount_setup_command': 'FUSERMOUNT_SETUP_COMMAND',
@@ -297,6 +300,17 @@ CASES: Dict[str, Dict[str, Any]] = {
     'kueue': {
         'k8s_kueue_local_queue_name': 'user-queue',
         'k8s_max_run_duration_seconds': 3600,
+    },
+    # Job Group gang scheduling: the controller-set overrides stamp an
+    # extra scheduling gate and point the member at a shared, group-wide
+    # Kueue pod group (name + summed total-count) instead of its own
+    # per-cluster one.
+    'gang_scheduling': {
+        'k8s_kueue_local_queue_name': 'user-queue',
+        'k8s_gang_gate_name': 'skypilot.co/gang',
+        'k8s_pod_group_name': 'my-group-a1',
+        'k8s_pod_group_total_count': 5,
+        'num_nodes': 2,
     },
     'docker_all': {
         'k8s_enable_docker_all': True,

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_ray_template_snapshot.py
@@ -117,8 +117,7 @@ def base_variables() -> Dict[str, Any]:
         'k8s_fuse_device_required': False,
         'k8s_kueue_local_queue_name': None,
         'k8s_gang_gate_name': None,
-        'k8s_pod_group_name': None,
-        'k8s_pod_group_total_count': None,
+        'k8s_kueue_pod_group_name': None,
         'k8s_skypilot_system_namespace': 'skypilot-system',
         'k8s_fusermount_shared_dir': '/var/run/fusermount',
         'k8s_fusermount_setup_command': 'FUSERMOUNT_SETUP_COMMAND',
@@ -302,14 +301,13 @@ CASES: Dict[str, Dict[str, Any]] = {
         'k8s_max_run_duration_seconds': 3600,
     },
     # Job Group gang scheduling: the controller-set overrides stamp an
-    # extra scheduling gate and point the member at a shared, group-wide
-    # Kueue pod group (name + summed total-count) instead of its own
-    # per-cluster one.
+    # extra scheduling gate and give this member's Kueue pod group a
+    # caller-controlled (attempt-suffixed) name instead of the cluster
+    # name.
     'gang_scheduling': {
         'k8s_kueue_local_queue_name': 'user-queue',
         'k8s_gang_gate_name': 'skypilot.co/gang',
-        'k8s_pod_group_name': 'my-group-a1',
-        'k8s_pod_group_total_count': 5,
+        'k8s_kueue_pod_group_name': 'my-member-a2',
         'num_nodes': 2,
     },
     'docker_all': {

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gang_scheduling.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gang_scheduling.json
@@ -10,13 +10,13 @@
         "kind": "Pod",
         "metadata": {
           "annotations": {
-            "kueue.x-k8s.io/pod-group-total-count": "5",
+            "kueue.x-k8s.io/pod-group-total-count": "2",
             "kueue.x-k8s.io/retriable-in-group": "false",
             "skypilot-user": "testuser",
             "skypilot-workspace": "default"
           },
           "labels": {
-            "kueue.x-k8s.io/pod-group-name": "my-group-a1",
+            "kueue.x-k8s.io/pod-group-name": "my-member-a2",
             "kueue.x-k8s.io/queue-name": "user-queue",
             "parent": "skypilot",
             "skypilot-cluster": "sky-cluster-abc123",

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gang_scheduling.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/gang_scheduling.json
@@ -1,0 +1,488 @@
+{
+  "auth": {
+    "ssh_private_key": "~/.ssh/sky-key",
+    "ssh_user": "sky"
+  },
+  "available_node_types": {
+    "ray_head_default": {
+      "node_config": {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "annotations": {
+            "kueue.x-k8s.io/pod-group-total-count": "5",
+            "kueue.x-k8s.io/retriable-in-group": "false",
+            "skypilot-user": "testuser",
+            "skypilot-workspace": "default"
+          },
+          "labels": {
+            "kueue.x-k8s.io/pod-group-name": "my-group-a1",
+            "kueue.x-k8s.io/queue-name": "user-queue",
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "args": "<omitted>",
+              "command": "<omitted>",
+              "env": [
+                {
+                  "name": "SKYPILOT_RAY_NODE_IP",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "status.podIP"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_NODE_TYPE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.labels['ray-node-type']"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_CPU_CORE_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.cpu"
+                    }
+                  }
+                },
+                {
+                  "name": "SKYPILOT_POD_MEMORY_BYTES_LIMIT",
+                  "valueFrom": {
+                    "resourceFieldRef": {
+                      "containerName": "ray-node",
+                      "resource": "requests.memory"
+                    }
+                  }
+                },
+                {
+                  "name": "RAY_memory_monitor_refresh_ms",
+                  "value": "0"
+                },
+                {
+                  "name": "SKYPILOT_IN_CLUSTER_CONTEXT_NAME",
+                  "value": "my-k8s-context"
+                },
+                {
+                  "name": "NVIDIA_VISIBLE_DEVICES",
+                  "value": "none"
+                }
+              ],
+              "image": "us-docker.pkg.dev/skypilot-oss/skypilot/skypilot:latest",
+              "imagePullPolicy": "Always",
+              "name": "ray-node",
+              "ports": [
+                {
+                  "containerPort": 22
+                },
+                {
+                  "containerPort": 6379
+                },
+                {
+                  "containerPort": 10001
+                },
+                {
+                  "containerPort": 8265
+                },
+                {
+                  "containerPort": 46590
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": 4,
+                  "memory": "16G"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/dev/shm",
+                  "name": "dshm"
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "schedulingGates": [
+            {
+              "name": "skypilot.co/gang"
+            }
+          ],
+          "serviceAccountName": "skypilot-service-account",
+          "volumes": [
+            {
+              "emptyDir": {
+                "medium": "Memory"
+              },
+              "name": "dshm"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "cluster_name": "sky-cluster-abc123",
+  "file_mounts": {
+    "/tmp/sky_wheels/WHEELHASH": "/tmp/local_wheel.whl",
+    "~/.sky/sky_ray.yml": "/tmp/sky_ray.yml"
+  },
+  "head_node_type": "ray_head_default",
+  "idle_timeout_minutes": 60,
+  "max_workers": 1,
+  "provider": {
+    "autoscaler_cluster_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRole",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "nodes"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "namespaces"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "clusterroles",
+            "clusterrolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "create",
+            "update",
+            "patch",
+            "delete"
+          ]
+        },
+        {
+          "apiGroups": [
+            "node.k8s.io"
+          ],
+          "resources": [
+            "runtimeclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "networking.k8s.io"
+          ],
+          "resources": [
+            "ingressclasses"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_cluster_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-cluster-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "skypilot-service-account-cluster-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_ingress_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role",
+        "namespace": "ingress-nginx"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            ""
+          ],
+          "resources": [
+            "services"
+          ],
+          "verbs": [
+            "list",
+            "get",
+            "watch"
+          ]
+        },
+        {
+          "apiGroups": [
+            "rbac.authorization.k8s.io"
+          ],
+          "resources": [
+            "roles",
+            "rolebindings"
+          ],
+          "verbs": [
+            "get",
+            "list",
+            "watch",
+            "patch"
+          ]
+        }
+      ]
+    },
+    "autoscaler_ingress_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-ingress-role-binding",
+        "namespace": "ingress-nginx"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-ingress-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account-role-binding"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "autoscaler_service_account": {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-service-account"
+      }
+    },
+    "autoscaler_skypilot_system_role": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "Role",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role",
+        "namespace": "skypilot-system"
+      },
+      "rules": [
+        {
+          "apiGroups": [
+            "*"
+          ],
+          "resources": [
+            "*"
+          ],
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    },
+    "autoscaler_skypilot_system_role_binding": {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "RoleBinding",
+      "metadata": {
+        "labels": {
+          "parent": "skypilot"
+        },
+        "name": "skypilot-system-service-account-role-binding",
+        "namespace": "skypilot-system"
+      },
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "skypilot-system-service-account-role"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "skypilot-service-account"
+        }
+      ]
+    },
+    "context": "my-k8s-context",
+    "fuse_device_required": false,
+    "module": "sky.provision.kubernetes",
+    "namespace": "default",
+    "networking_mode": "portforward",
+    "port_mode": "portforward",
+    "region": "kubernetes",
+    "services": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head-ssh"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 22,
+              "protocol": "TCP",
+              "targetPort": 22
+            }
+          ],
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-head"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-head"
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "labels": {
+            "parent": "skypilot",
+            "skypilot-cluster": "sky-cluster-abc123",
+            "skypilot-cluster-name": "sky-cluster-abc123",
+            "skypilot-user": "testuser"
+          },
+          "name": "sky-cluster-abc123-worker1"
+        },
+        "spec": {
+          "clusterIP": "None",
+          "selector": {
+            "component": "sky-cluster-abc123-worker1"
+          }
+        }
+      }
+    ],
+    "skypilot_system_namespace": "skypilot-system",
+    "timeout": 600,
+    "type": "external",
+    "use_internal_ips": true
+  },
+  "setup_commands": "<omitted>",
+  "upscaling_speed": 1
+}


### PR DESCRIPTION
## Summary

Mechanism-only plumbing for Job Group gang admission via Kubernetes scheduling gates — **inert by construction**: three new deploy variables, all defaulting to `None`, with nothing in the codebase setting them yet. The consumer (a gang coordinator in the jobs controller, feature-flagged off) comes in a follow-up.

The three knobs ride `cluster_config_overrides` — the same certified route the Kueue queue name already travels (`clouds/kubernetes.py`) — and are controller-internal: set per member by the jobs controller, not intended for user or tenant config files (schema block added so they validate, comment marks intent).

| Override | Renders as | Purpose |
|---|---|---|
| `kubernetes.gang_scheduling.gate_name` | `spec.schedulingGates: [{name: …}]` | Pod held unschedulable until the controller removes the gate — i.e., until every member of the group is admitted. Coexists with Kueue's own admission gate on the same pod; each owner removes only its own entry (verified against Kueue v0.18.4 in a spike: Kueue admits pod-group Workloads normally with a foreign gate present, removes only its gates, quota reserved while parked). |
| `kubernetes.gang_scheduling.kueue_pod_group_name` | `kueue.x-k8s.io/pod-group-name` label (falls back to `cluster_name_on_cloud`, today's value) | Overrides **this member's** Kueue admission-unit identity (its pod group / Workload name). The coordinator stamps a fresh, attempt-suffixed name (`<cluster>-a2`) on each gang retry, so a new attempt never collides with the previous attempt's still-terminating Workload of the same name. Per-member semantics — members do **not** share this value in the committed design. |

(A third override — a group-wide total-count enabling all members to merge into one shared Kueue admission unit — was in an earlier revision and is deliberately trimmed: its only consumer is a demoted future optimization. If that revives, it returns as `job_group_pod_total_count`, named for its actual across-members semantics.)

## Inertness proof

The template snapshot suite (`test_kubernetes_ray_template_snapshot.py`) pins the rendered manifest for 49 input permutations: **all 49 existing goldens pass unchanged** with this diff — the fallbacks render byte-identical manifests for every existing input. One new golden (`gang_scheduling.json`) pins the gang case: gate present, caller-named pod group, and `retriable-in-group: "false"` still stamped (load-bearing: without it, deleting a parked member's pods leaves a Workload holding quota indefinitely — verified in the spike).

## Notes for review

- The gate block is deliberately independent of the Kueue guard in the template: the gate mechanism itself has no Kueue dependency (a future no-Kueue gang path could reuse it); the *pairing* policy (only gate where an admission signal exists) belongs to the coordinator, which is also where the feature flag lands with its first consumer.
- No user-facing knob or docs by design: gang scheduling will not be advertised as conditional; ineligible shapes will log degradation (coordinator PR).

## Test plan

- `pytest tests/unit_tests/test_sky/clouds/ tests/unit_tests/test_task_overrideable_config_keys.py` — 417 passed (includes the 50-case snapshot suite).
- `git diff` on `testdata/kubernetes_ray_template/`: only the new golden added; zero churn in existing ones.
- `bash format.sh` clean.
- No smoke needed: no code path sets the new variables, so no launched-cluster behavior can change.

Part of the Job Group gang-scheduling work (pre-work: #10415, #10416; design + spike results in the tracking notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
