### PR TITLE
fix(slurm): respect custom task CPU demands

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6961,13 +6961,32 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         else:
             return task_codegen.RayCodeGen()
 
+    @staticmethod
+    def _get_task_demands_dict(handle: CloudVmRayResourceHandle,
+                               task: task_lib.Task) -> Dict[str, float]:
+        """Returns task demands for the handle's execution backend."""
+        resources_dict = backend_utils.get_task_demands_dict(task)
+        if (not isinstance(handle.launched_resources.cloud, clouds.Slurm) or
+                task.is_controller_task()):
+            return resources_dict
+
+        resources = task.best_resources
+        if resources is None:
+            assert len(task.resources) == 1, task.resources
+            resources = next(iter(task.resources))
+        requested_cpus = resources.cpus
+        if requested_cpus is None:
+            requested_cpus = handle.launched_resources.cpus
+        if requested_cpus is not None:
+            resources_dict['CPU'] = float(requested_cpus.rstrip('+'))
+        return resources_dict
+
     def _execute_task_one_node(self, handle: CloudVmRayResourceHandle,
                                task: task_lib.Task, job_id: int,
                                remote_log_dir: str) -> None:
         # Launch the command as a Ray task.
         log_dir = os.path.join(remote_log_dir, 'tasks')
-
-        resources_dict = backend_utils.get_task_demands_dict(task)
+        resources_dict = self._get_task_demands_dict(handle, task)
         internal_ips = handle.internal_ips()
         assert internal_ips is not None, 'internal_ips is not cached in handle'
 
@@ -6985,13 +7004,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_cmd=self._setup_cmd,
         )
 
-        codegen.add_task(
-            1,
-            bash_script=task.run,
-            env_vars=task_env_vars,
-            task_name=task.name,
-            resources_dict=backend_utils.get_task_demands_dict(task),
-            log_dir=log_dir)
+        codegen.add_task(1,
+                         bash_script=task.run,
+                         env_vars=task_env_vars,
+                         task_name=task.name,
+                         resources_dict=self._get_task_demands_dict(
+                             handle, task),
+                         log_dir=log_dir)
 
         codegen.add_epilogue()
 
@@ -7011,7 +7030,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         #   for node:
         #     submit _run_cmd(cmd) with resource {node_i: 1}
         log_dir = os.path.join(remote_log_dir, 'tasks')
-        resources_dict = backend_utils.get_task_demands_dict(task)
+        resources_dict = self._get_task_demands_dict(handle, task)
         internal_ips = handle.internal_ips()
         assert internal_ips is not None, 'internal_ips is not cached in handle'
 
@@ -7031,13 +7050,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_cmd=self._setup_cmd,
         )
 
-        codegen.add_task(
-            num_actual_nodes,
-            bash_script=task.run,
-            env_vars=task_env_vars,
-            task_name=task.name,
-            resources_dict=backend_utils.get_task_demands_dict(task),
-            log_dir=log_dir)
+        codegen.add_task(num_actual_nodes,
+                         bash_script=task.run,
+                         env_vars=task_env_vars,
+                         task_name=task.name,
+                         resources_dict=self._get_task_demands_dict(
+                             handle, task),
+                         log_dir=log_dir)
 
         codegen.add_epilogue()
         # TODO(zhanghao): Add help info for downloading logs.

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1,5 +1,6 @@
 """Slurm instance provisioning."""
 
+import math
 import os
 import shlex
 import tempfile
@@ -660,7 +661,7 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 #SBATCH --wait-all-nodes=1
 # Let the job be terminated rather than requeued implicitly.
 #SBATCH --no-requeue
-#SBATCH --cpus-per-task={int(resources["cpus"])}
+#SBATCH --cpus-per-task={math.ceil(float(resources["cpus"]))}
 {mem_directive}{gpu_directive}{extra_sbatch_directives}
 
 # Cleanup function to remove cluster dirs on job termination.

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -29,6 +29,71 @@ def test_command_length_local_shell_limit():
     assert backend_utils.is_command_length_over_limit(command, quote_levels=4)
 
 
+def test_non_slurm_cpu_demand_uses_ray_default():
+    handle = MagicMock()
+    handle.launched_resources = resources.Resources(cloud=clouds.Kubernetes())
+    test_task = task.Task(resources=resources.Resources(cpus=1.5))
+
+    demands = (cloud_vm_ray_backend.CloudVmRayBackend._get_task_demands_dict(
+        handle, test_task))
+
+    assert demands['CPU'] == backend_utils.DEFAULT_TASK_CPU_DEMAND
+
+
+def test_slurm_controller_cpu_demand_uses_controller_default():
+    handle = MagicMock()
+    handle.launched_resources = resources.Resources(cloud=clouds.Slurm())
+    test_task = task.Task(resources=resources.Resources(cpus=4))
+    test_task.service_name = 'service'
+
+    demands = (cloud_vm_ray_backend.CloudVmRayBackend._get_task_demands_dict(
+        handle, test_task))
+
+    assert (
+        demands['CPU'] == backend_utils.constants.CONTROLLER_PROCESS_CPU_DEMAND)
+
+
+def test_slurm_cpu_demand_uses_allocated_cpus():
+    allocated = resources.Resources(cloud=clouds.Slurm(),
+                                    instance_type='2CPU--2GB')
+    handle = MagicMock()
+    handle.launched_resources = allocated
+    test_task = task.Task(resources=resources.Resources(cpus=0.25))
+    test_task.best_resources = allocated
+
+    demands = (cloud_vm_ray_backend.CloudVmRayBackend._get_task_demands_dict(
+        handle, test_task))
+
+    assert demands['CPU'] == 2.0
+
+
+def test_slurm_gpu_cpu_demand_uses_allocated_cpus():
+    allocated = resources.Resources(cloud=clouds.Slurm(),
+                                    instance_type='4CPU--16GB--H200:1')
+    handle = MagicMock()
+    handle.launched_resources = allocated
+    test_task = task.Task(resources=resources.Resources(
+        accelerators={'H200': 1}))
+    test_task.best_resources = allocated
+
+    demands = (cloud_vm_ray_backend.CloudVmRayBackend._get_task_demands_dict(
+        handle, test_task))
+
+    assert demands['CPU'] == 4.0
+
+
+def test_slurm_exec_cpu_demand_uses_cluster_allocation():
+    handle = MagicMock()
+    handle.launched_resources = resources.Resources(cloud=clouds.Slurm(),
+                                                    instance_type='8CPU--32GB')
+    test_task = task.Task(resources=resources.Resources())
+
+    demands = (cloud_vm_ray_backend.CloudVmRayBackend._get_task_demands_dict(
+        handle, test_task))
+
+    assert demands['CPU'] == 8.0
+
+
 class TestCloudVmRayBackendTaskRedaction:
     """Tests for CloudVmRayBackend usage of redacted task configs."""
 

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1166,6 +1166,35 @@ class TestCreateVirtualInstance:
         assert written_script is not None, 'Script was not written'
         return written_script
 
+    @staticmethod
+    def _make_non_container_config(cpus):
+        from sky.provision import common
+
+        return common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'root',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'cpus',
+                'provision_timeout': 300,
+                'slurm_user': 'alice',
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': cpus,
+                'memory': 8,
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
     @patch('sky.provision.slurm.instance._wait_for_job_nodes')
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
     @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
@@ -1225,42 +1254,38 @@ class TestCreateVirtualInstance:
                                          mock_get_proctrack_type,
                                          mock_wait_for_job_nodes):
         """Test that sbatch provision script without containers is correct."""
-        from sky.provision import common
-
         self._setup_mocks(mock_ssh_runner, mock_slurm_client,
                           mock_get_partition_info, 'cpus')
         mock_get_proctrack_type.return_value = 'cgroup'
 
-        config = common.ProvisionConfig(
-            provider_config={
-                'ssh': {
-                    'hostname': 'login.example.com',
-                    'port': '22',
-                    'user': 'root',
-                    'private_key': '/path/to/key',
-                },
-                'cluster': 'test-slurm',
-                'partition': 'cpus',
-                'provision_timeout': 300,
-                'slurm_user': 'alice',
-            },
-            authentication_config={},
-            docker_config={},
-            node_config={
-                'cpus': 2,
-                'memory': 8,
-            },
-            count=1,
-            tags={},
-            resume_stopped_nodes=False,
-            ports_to_open_on_launch=None,
-        )
-
+        config = self._make_non_container_config(cpus=2)
         written_script = self._run_and_capture_script(
             'test-cluster-no-container', config)
+
         assert_sbatch_matches_snapshot('basic', written_script)
         assert mock_slurm_client.call_args.kwargs['slurm_user'] == 'alice'
         assert mock_ssh_runner.call_args.kwargs['slurm_user'] == 'alice'
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_fractional_cpus_are_rounded_up(self, mock_ssh_runner,
+                                            mock_slurm_client,
+                                            mock_get_partition_info,
+                                            mock_get_proctrack_type,
+                                            mock_wait_for_job_nodes):
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'cpus')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = self._make_non_container_config(cpus=1.5)
+        written_script = self._run_and_capture_script(
+            'test-cluster-fractional-cpus', config)
+
+        assert '#SBATCH --cpus-per-task=2' in written_script
 
     @pytest.mark.parametrize('memory_gb,expected_mem_mb', [
         (0.5, 512),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
pass resource.cpu to slurm


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x ] Any manual or new tests for this PR (please specify below)
- [x ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->