### PR TITLE
[Test] Give optimizer dryrun launches unique cluster names

### DIFF
--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -4,6 +4,7 @@ import tempfile
 import textwrap
 import time
 from typing import Callable, Optional, Set
+import uuid
 
 from click import testing as cli_testing
 import pytest
@@ -73,7 +74,21 @@ def _test_resources(
         assert expected_cloud.is_same_cloud(resources.cloud)
 
 
+def _unique_cluster_name() -> str:
+    """A per-call unique cluster name for dryrun launches.
+
+    An unnamed launch falls back to the default cluster name, which is
+    deterministic per user -- so under pytest-xdist every unnamed dryrun
+    test in this file contends for the SAME cluster status lock, and a
+    loser surfaces ExecutionPausedError ("locked by another operation")
+    as a spurious failure. Unique names make the tests lock-disjoint.
+    """
+    return f'dryrun-{uuid.uuid4().hex[:8]}'
+
+
 def _test_resources_from_yaml(spec: str, cluster_name: str = None):
+    if cluster_name is None:
+        cluster_name = _unique_cluster_name()
     resources = sky.Resources.from_yaml_config(spec)
     with sky.Dag() as dag:
         task = sky.Task('test_task')
@@ -86,6 +101,8 @@ def _test_resources_launch(*resources_args,
                            cluster_name: str = None,
                            **resources_kwargs):
     """This function is testing for the core functions on client side."""
+    if cluster_name is None:
+        cluster_name = _unique_cluster_name()
     resources = _make_resources(*resources_args, **resources_kwargs)
     resources.validate()
     with sky.Dag() as dag:
@@ -749,7 +766,9 @@ def test_ordered_resources(enable_all_clouds):
             ])
         dag = sky.optimize(dag)
         cli_runner = cli_testing.CliRunner()
-        request_id = sky.launch(task, dryrun=True)
+        request_id = sky.launch(task,
+                                dryrun=True,
+                                cluster_name=_unique_cluster_name())
         result = cli_runner.invoke(command.api_logs, [request_id])
         assert not result.exit_code
 
@@ -946,7 +965,8 @@ def test_candidate_logging(enable_all_clouds, capfd):
             sky.Resources(accelerators={'H200': 1}, use_spot=True),
         ])
     sky.optimize(dag)
-    sky.stream_and_get(sky.launch(dag, dryrun=True))
+    sky.stream_and_get(
+        sky.launch(dag, dryrun=True, cluster_name=_unique_cluster_name()))
     stdout, _ = capfd.readouterr()
     l4_section = any(
         'L4:1' in line and '✔' in line for line in stdout.splitlines())


### PR DESCRIPTION
## Summary

Fixes a CI flake class in `tests/test_optimizer_dryruns.py`: an unnamed `sky.launch(dryrun=True)` falls back to the **default cluster name, which is deterministic per user** — so under pytest-xdist (16 workers), every unnamed dryrun test in this file targets the *same* cluster name and therefore the *same* cluster status lock (`_provision` acquires it for dryruns too). When two workers overlap, the loser hits the lock timeout and — because tests run in a request context — surfaces `ExecutionPausedError: Cluster 'sky-09c4-runner' is locked by another operation` as a spurious failure.

Fix: a `_unique_cluster_name()` helper; both test helpers default to it when no name is passed, and the two direct unnamed `sky.launch` call sites get explicit unique names. Tests become lock-disjoint; the flake class dies for this file.

Observed instance: `test_resources_gcp` failing on an unrelated PR's CI (run 31629340257).

## Note on the deeper question

Arguably a dryrun should not take the cluster status lock at all — it mutates nothing, and taking the lock means dryruns can contend with (and be blocked by) real operations on the same cluster. That's a production-locking change deserving its own careful PR; this one just makes the tests stop colliding with each other.

## Test plan

- `pytest tests/test_optimizer_dryruns.py -k 'test_resources_gcp or test_resources_aws'` — 2 passed locally.
- `bash format.sh` clean.
- The change is test-only; CI on this PR runs the whole file under xdist as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->