### PR TITLE
Don't fail `sky status` when an instance type left the catalog

### DIFF
--- a/sky/catalog/shadeform_catalog.py
+++ b/sky/catalog/shadeform_catalog.py
@@ -4,6 +4,7 @@ This module loads pricing and instance information from the Shadeform API
 and can be used to query instance types and pricing information for Shadeform.
 """
 
+import re
 import typing
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -47,9 +48,21 @@ def _get_df():
     return _df
 
 
+# sky.catalog.common raises several different phrasings for "this row is not in
+# the catalog", and only one of them contains the literal 'not found':
+#   'Instance type <x> not found ...'      (get_instance_type_for_accelerator)
+#   'No instance type <x> found.'          (get_vcpus_mem_from_instance_type,
+#                                           get_accelerators_from_instance_type)
+#   'No <price> found for instance type <x>'
+# Matching 'not found' alone therefore defeated _call_or_default() below for the
+# most common phrasing, and the ValueError propagated out of a display path.
+_NOT_FOUND_PATTERN = re.compile(r'not found|not supported|'
+                                r'no instance type .*found|'
+                                r'no .*found for instance type')
+
+
 def _is_not_found_error(err: ValueError) -> bool:
-    msg = str(err).lower()
-    return 'not found' in msg or 'not supported' in msg
+    return _NOT_FOUND_PATTERN.search(str(err).lower()) is not None
 
 
 def _call_or_default(func, default):

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -7,6 +7,7 @@ import math
 import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+from sky import sky_logging
 from sky import skypilot_config
 from sky.skylet import constants
 from sky.utils import common_utils
@@ -16,6 +17,8 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     from sky import backends
     from sky import resources as resources_lib
+
+logger = sky_logging.init_logger(__name__)
 
 _PORT_RANGE_HINT_MSG = ('Invalid port range {}. Please use the format '
                         '"from-to", in which from <= to. e.g. "1-3".')
@@ -366,8 +369,22 @@ def format_resource(
     is_k8s = resource.cloud.canonical_name() == 'kubernetes'
     vcpu, mem = None, None
     if resource.accelerators is None or is_k8s or not simplified_only:
-        vcpu, mem = resource.cloud.get_vcpus_mem_from_instance_type(
-            resource.instance_type)
+        try:
+            vcpu, mem = resource.cloud.get_vcpus_mem_from_instance_type(
+                resource.instance_type)
+        except Exception:  # pylint: disable=broad-except
+            # An instance type can disappear from the catalog while a cluster
+            # is still running on it -- e.g. a brokered SKU that goes out of
+            # stock is dropped on the next catalog regeneration. This is a
+            # display path, so degrade to omitting cpus=/mem= rather than
+            # propagate: raising here fails the whole `sky status` request and
+            # hides every other cluster, including the live one that can no
+            # longer be rendered.
+            logger.debug(
+                f'Failed to get vCPUs/memory for instance type '
+                f'{resource.instance_type!r} on {resource.cloud}; omitting '
+                'cpus=/mem= from the resources string.',
+                exc_info=True)
 
     elements_simple = []
     elements_full = []

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -10,6 +10,7 @@ import pytest
 
 from sky import catalog
 from sky.catalog import common as catalog_common
+from sky.catalog import shadeform_catalog
 from sky.utils import annotations
 
 
@@ -806,3 +807,39 @@ def test_efa_count_duplicate_index_safe():
     df.index = [0] * len(df)
     assert catalog_common.get_efa_count_for_accelerator_impl(df, 'H100',
                                                              8) == 32
+
+
+def test_shadeform_not_found_matches_catalog_phrasings():
+    # sky.catalog.common uses several phrasings for "this row is not in the
+    # catalog". All of them must be recognised, otherwise _call_or_default()
+    # re-raises and the error escapes into callers that only wanted to render
+    # a status line.
+    assert shadeform_catalog._is_not_found_error(
+        ValueError('No instance type latitude_H100 found.'))
+    assert shadeform_catalog._is_not_found_error(
+        ValueError("Instance type 'foo' not found in catalog"))
+    assert shadeform_catalog._is_not_found_error(
+        ValueError('No Price found for instance type foo'))
+    assert shadeform_catalog._is_not_found_error(
+        ValueError('Spot instances are not supported on Shadeform'))
+
+
+def test_shadeform_not_found_does_not_swallow_real_errors():
+    # A malformed catalog row is a genuine error and must still propagate.
+    assert not shadeform_catalog._is_not_found_error(
+        ValueError('Cannot determine the number of vCPUs of the instance '
+                   'type foo.'))
+
+
+def test_shadeform_vcpus_mem_defaults_when_instance_type_vanished():
+    # A cluster can outlive its catalog row: the lookup must degrade to
+    # (None, None) rather than raise.
+    empty_df = pd.DataFrame(columns=[
+        'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
+        'MemoryGiB', 'Price', 'Region', 'GpuInfo', 'SpotPrice'
+    ])
+    with mock.patch.object(shadeform_catalog, '_get_df', return_value=empty_df):
+        assert shadeform_catalog.get_vcpus_mem_from_instance_type(
+            'latitude_H100') == (None, None)
+        assert shadeform_catalog.get_accelerators_from_instance_type(
+            'latitude_H100') is None

--- a/tests/unit_tests/test_sky/utils/test_resources_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_resources_utils.py
@@ -180,6 +180,34 @@ def test_format_resource_unmodified_pod_memory_unit_convention():
     assert 'requested' not in full
 
 
+def test_format_resource_survives_missing_catalog_entry(monkeypatch):
+    """A vanished instance type must not fail the whole render.
+
+    An instance type can drop out of the catalog while a cluster is still
+    running on it (e.g. a brokered SKU that goes out of stock). `sky status`
+    renders every cluster in a single pass, so raising here would hide all of
+    them -- including the live cluster that can no longer be rendered.
+    """
+    resource = resources_lib.Resources(cloud=clouds.AWS(),
+                                       instance_type='p4d.24xlarge')
+
+    def _vanished(self, instance_type):
+        del self  # Unused.
+        raise ValueError(f'No instance type {instance_type} found.')
+
+    monkeypatch.setattr(clouds.AWS, 'get_vcpus_mem_from_instance_type',
+                        _vanished)
+
+    simple, full = resources_utils.format_resource(resource,
+                                                   simplified_only=False)
+
+    # The cpus=/mem= fields are dropped, everything else still renders.
+    assert 'cpus=' not in full
+    assert 'mem=' not in full
+    assert 'gpus=A100:8' in simple
+    assert 'p4d.24xlarge' in full
+
+
 def test_get_readable_resources_repr_uses_cached_cluster_info():
     """Handle display prefers actual requests from cached_cluster_info."""
     cluster_info = provision_common.ClusterInfo(instances={},


### PR DESCRIPTION
Fixes #10449.

## Problem

If a cluster's instance type is no longer in the catalog, `sky status` fails **entirely** —
the request raises and *no* cluster is returned, not just the affected one. On a remote API
server this also blanks the dashboard's cluster page.

We hit this on a Shadeform-brokered cluster: `latitude_H100` was in the catalog at launch
and has since been dropped from
[`catalogs/v8/shadeform/vms.csv`](https://github.com/skypilot-org/skypilot-catalog/blob/master/catalogs/v8/shadeform/vms.csv)
(that file currently has `latitude_RTXPro6000x8` rows and zero `latitude_H100` rows). The
cluster was up and six hours into a training job the whole time — just invisible to
`sky status`, to the dashboard, and to anything built on them.

```
sky/core.py:194 in status
  → backend_utils.get_clusters                     (backend_utils.py:4006)
  → _update_records_with_handle_info               (backend_utils.py:3835)
  → resources_utils.get_readable_resources_repr
  → resources_utils.format_resource                (resources_utils.py:369)
  → sky/clouds/shadeform.py:144 get_vcpus_mem_from_instance_type
  → sky/catalog/common.py:451 get_vcpus_mem_from_instance_type_impl
ValueError: No instance type latitude_H100 found.
```

## Changes

**`sky/utils/resources_utils.py`** — `format_resource` looks up vCPUs/memory only to render
the `cpus=`/`mem=` fields, and `_format_cpu_mem_element` already omits them when the value
is `None`. Degrade to that (with a debug log) rather than propagate out of a display path.
`get_clusters` renders all records in a single pass, so one unrenderable row should not be
able to take out the response. This makes the failure mode impossible for any cloud, not
just Shadeform.

**`sky/catalog/shadeform_catalog.py`** — the interesting half. Shadeform *already* guards
its catalog lookups with `_call_or_default(...)` in five places, but the predicate was:

```python
return 'not found' in msg or 'not supported' in msg
```

while `sky.catalog.common` raises three different phrasings:

| Message | Raised by | Matched before? |
|---|---|---|
| `Instance type <x> not found ...` | `get_instance_type_for_accelerator_impl` (common.py:417) | yes |
| `No instance type <x> found.` | `get_vcpus_mem_from_instance_type_impl` (452), `get_accelerators_from_instance_type_impl` (615), `get_arch_...` (636), `get_local_disk_...` (652) | **no** |
| `No <price> found for instance type <x>` | `get_hourly_cost_impl` (432) | **no** |

`'No instance type latitude_H100 found.'` contains `found` but not `not found`, so the
guard re-raised — for the two lookups Shadeform wraps that matter most here
(`get_vcpus_mem_from_instance_type`, `get_accelerators_from_instance_type`). The existing
defensive code simply never fired. Now all three phrasings match, while genuine errors like
`Cannot determine the number of vCPUs of the instance type <x>` still propagate.

## Tests

Four new tests, all of which fail on `master` except the last (a regression guard):

- `test_format_resource_survives_missing_catalog_entry` — a vanished instance type drops
  `cpus=`/`mem=` and still renders `gpus=` and the instance type.
- `test_shadeform_not_found_matches_catalog_phrasings` — all three phrasings recognised.
- `test_shadeform_vcpus_mem_defaults_when_instance_type_vanished` — lookups return
  `(None, None)` / `None` against an empty catalog instead of raising.
- `test_shadeform_not_found_does_not_swallow_real_errors` — malformed-row errors still
  propagate.

```
$ pytest tests/unit_tests/test_sky/utils/test_resources_utils.py tests/unit_tests/test_catalog.py \
    -k "missing_catalog_entry or shadeform"
4 passed

# on master, with the same tests:
3 failed, 1 passed
```

Also ran `tests/unit_tests/test_catalog.py`, `tests/unit_tests/test_sky/utils/` and
`tests/unit_tests/test_backend_utils.py` with and without the change: the failure sets are
identical (my sandbox is missing some dev deps), so no regressions. `yapf`, `isort` and
`pylint` (10.00/10, run under 3.11) are clean on the changed files.

## Note

Both halves are string-matching or blanket-catching around what is really a typed
condition. A `CatalogEntryNotFoundError` raised by `sky/catalog/common.py` and caught by
name would be more robust than any regex, but it touches every catalog backend, so I kept
this PR to the incident fix — happy to follow up if you'd take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->