### PR TITLE
Revert "[Kubernetes] Let a new volume settle before recording it as not ready"

### DIFF
--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import os
-import time
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 import uuid
 
@@ -322,22 +321,6 @@ def volume_delete(names: List[str],
         logger.info(f'Deleted volumes: {names}')
 
 
-# How long to let a freshly created volume settle before recording it as not
-# ready. Creating the backing resource only starts provisioning: with an
-# Immediate-binding storage class the PersistentVolume is created
-# asynchronously, so the claim is Pending until the provisioner finishes.
-# Judging it the moment after creation would report every functioning
-# Immediate-binding storage class as not ready.
-#
-# Covered by unit tests only. Reaching this case end to end needs a storage
-# class that binds immediately *and* a provisioner that can serve it, and the
-# Kubernetes smoke lane has neither: local-path defers to the scheduler, so a
-# claim on it is pending by design. Such a test would have to run against a
-# cloud CSI driver.
-_INITIAL_STATUS_SETTLE_SECONDS = 10
-_INITIAL_STATUS_POLL_SECONDS = 0.5
-
-
 def _initial_volume_status(
     cloud: str, config: models.VolumeConfig
 ) -> Tuple[status_lib.VolumeStatus, Optional[str]]:
@@ -353,25 +336,19 @@ def _initial_volume_status(
     Falls back to READY when the cloud cannot be queried, matching the
     optimistic behavior everywhere else on this path.
     """
-    deadline = time.time() + _INITIAL_STATUS_SETTLE_SECONDS
-    while True:
-        try:
-            volume_errors, failed_volume_names = (
-                provision.get_all_volumes_errors(cloud, [config]))
-        except Exception as e:  # pylint: disable=broad-except
-            logger.debug(f'Failed to check the initial status of volume '
-                         f'{config.name}: {e}')
-            return status_lib.VolumeStatus.READY, None
-        if config.name in failed_volume_names:
-            return status_lib.VolumeStatus.READY, None
-        error_message = volume_errors.get(config.name)
-        if not error_message:
-            return status_lib.VolumeStatus.READY, None
-        if time.time() >= deadline:
-            # Still not usable after a full settle window: whatever is wrong
-            # is not the provisioner merely being mid-flight.
-            return status_lib.VolumeStatus.NOT_READY, error_message
-        time.sleep(_INITIAL_STATUS_POLL_SECONDS)
+    try:
+        volume_errors, failed_volume_names = provision.get_all_volumes_errors(
+            cloud, [config])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to check the initial status of volume '
+                     f'{config.name}: {e}')
+        return status_lib.VolumeStatus.READY, None
+    if config.name in failed_volume_names:
+        return status_lib.VolumeStatus.READY, None
+    error_message = volume_errors.get(config.name)
+    if error_message:
+        return status_lib.VolumeStatus.NOT_READY, error_message
+    return status_lib.VolumeStatus.READY, None
 
 
 def volume_apply(

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -1881,51 +1881,6 @@ class TestInitialVolumeStatus:
         """Creating a PVC does not provision the PersistentVolume, so a
         just-created volume must not be advertised as usable."""
         config = _make_volume_config()
-        monkeypatch.setattr(core, '_INITIAL_STATUS_SETTLE_SECONDS', 0)
-        monkeypatch.setattr(
-            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
-                'test-vol': 'PVC is pending.'
-            }, set()))
-
-        status, error = core._initial_volume_status('Kubernetes', config)
-
-        assert status == status_lib.VolumeStatus.NOT_READY
-        assert error == 'PVC is pending.'
-
-    def test_volume_that_binds_during_the_settle_window_is_ready(
-            self, monkeypatch):
-        """A claim still provisioning is not a claim that failed to provision.
-
-        Creating the backing resource only starts provisioning, so the first
-        look at a just-created volume finds it pending on any storage class
-        that binds immediately. Judging it there reports every functioning
-        Immediate-binding storage class as not ready.
-        """
-        config = _make_volume_config()
-        monkeypatch.setattr(core, '_INITIAL_STATUS_POLL_SECONDS', 0)
-        calls = []
-
-        def _pending_then_bound(cloud, configs):
-            calls.append(cloud)
-            if len(calls) == 1:
-                return {'test-vol': 'PVC is pending.'}, set()
-            return {'test-vol': None}, set()
-
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            _pending_then_bound)
-
-        status, error = core._initial_volume_status('Kubernetes', config)
-
-        assert status == status_lib.VolumeStatus.READY
-        assert error is None
-        assert len(calls) == 2, 'expected a re-check after the first pending'
-
-    def test_settle_window_is_bounded(self, monkeypatch):
-        """A volume that never binds must still be reported, not waited on
-        forever."""
-        config = _make_volume_config()
-        monkeypatch.setattr(core, '_INITIAL_STATUS_SETTLE_SECONDS', 0.05)
-        monkeypatch.setattr(core, '_INITIAL_STATUS_POLL_SECONDS', 0.01)
         monkeypatch.setattr(
             provision, 'get_all_volumes_errors', lambda cloud, configs: ({
                 'test-vol': 'PVC is pending.'


### PR DESCRIPTION
Reverts skypilot-org/skypilot#10443
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->