### PR TITLE
[Core] Let volume_refresh refresh a named subset of volumes

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2973,6 +2973,31 @@ def get_volume_names_start_with(starts_with: str) -> List[str]:
     return [row.name for row in rows]
 
 
+def _volume_record_from_row(row: Any) -> Dict[str, Any]:
+    """Builds a volume record from a volume table row.
+
+    Shared so every accessor returns the same shape: a caller that switches
+    between them must not have to check which keys it now has.
+    """
+    return {
+        'name': row.name,
+        'launched_at': row.launched_at,
+        'handle': pickle.loads(row.handle),
+        'user_hash': row.user_hash,
+        'workspace': row.workspace,
+        'last_attached_at': row.last_attached_at,
+        'last_use': row.last_use,
+        'status': status_lib.VolumeStatus[row.status],
+        'is_ephemeral': bool(row.is_ephemeral),
+        'error_message': row.error_message,
+        # Decode JSON-encoded usedby fields
+        'usedby_pods': json.loads(row.usedby_pods) if row.usedby_pods else [],
+        'usedby_clusters':
+            (json.loads(row.usedby_clusters) if row.usedby_clusters else []),
+        'creation_yaml': row.creation_yaml,
+    }
+
+
 @metrics_lib.time_me
 def get_volumes(is_ephemeral: Optional[bool] = None) -> List[Dict[str, Any]]:
     engine = _db_manager.get_engine()
@@ -2982,27 +3007,39 @@ def get_volumes(is_ephemeral: Optional[bool] = None) -> List[Dict[str, Any]]:
         else:
             rows = session.query(volume_table).filter_by(
                 is_ephemeral=int(is_ephemeral)).all()
-    records = []
-    for row in rows:
-        # Decode JSON-encoded usedby fields
-        usedby_pods = json.loads(row.usedby_pods) if row.usedby_pods else []
-        usedby_clusters = (json.loads(row.usedby_clusters)
-                           if row.usedby_clusters else [])
-        records.append({
-            'name': row.name,
-            'launched_at': row.launched_at,
-            'handle': pickle.loads(row.handle),
-            'user_hash': row.user_hash,
-            'workspace': row.workspace,
-            'last_attached_at': row.last_attached_at,
-            'last_use': row.last_use,
-            'status': status_lib.VolumeStatus[row.status],
-            'is_ephemeral': bool(row.is_ephemeral),
-            'error_message': row.error_message,
-            'usedby_pods': usedby_pods,
-            'usedby_clusters': usedby_clusters,
-            'creation_yaml': row.creation_yaml,
-        })
+    return [_volume_record_from_row(row) for row in rows]
+
+
+@metrics_lib.time_me
+def get_volumes_from_names(
+        volume_names: List[str],
+        is_ephemeral: Optional[bool] = None) -> List[Dict[str, Any]]:
+    """Batched ``get_volume_by_name`` for many volume names at once.
+
+    Returns records in the same shape as ``get_volumes``. Names with no row
+    are simply absent from the result, so the caller sees the same thing it
+    would from a filtered ``get_volumes``.
+
+    Args:
+        volume_names: Volume names to look up.
+        is_ephemeral: If given, keep only volumes with this ephemerality,
+            matching ``get_volumes``.
+    """
+    if not volume_names:
+        return []
+    engine = _db_manager.get_engine()
+    # Chunk the IN list for the same reason as _CLUSTER_IN_QUERY_CHUNK_SIZE:
+    # SQLite caps bound parameters and PostgreSQL plans huge IN clauses badly.
+    records: List[Dict[str, Any]] = []
+    with orm.Session(engine) as session:
+        for offset in range(0, len(volume_names), _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = volume_names[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            query = session.query(volume_table).filter(
+                volume_table.c.name.in_(batch))
+            if is_ephemeral is not None:
+                query = query.filter(
+                    volume_table.c.is_ephemeral == int(is_ephemeral))
+            records.extend(_volume_record_from_row(row) for row in query.all())
     return records
 
 
@@ -3012,24 +3049,7 @@ def get_volume_by_name(name: str) -> Optional[Dict[str, Any]]:
     with orm.Session(engine) as session:
         row = session.query(volume_table).filter_by(name=name).first()
     if row:
-        # Decode JSON-encoded usedby fields
-        usedby_pods = json.loads(row.usedby_pods) if row.usedby_pods else []
-        usedby_clusters = (json.loads(row.usedby_clusters)
-                           if row.usedby_clusters else [])
-        return {
-            'name': row.name,
-            'launched_at': row.launched_at,
-            'handle': pickle.loads(row.handle),
-            'user_hash': row.user_hash,
-            'workspace': row.workspace,
-            'last_attached_at': row.last_attached_at,
-            'last_use': row.last_use,
-            'status': status_lib.VolumeStatus[row.status],
-            'error_message': row.error_message,
-            'usedby_pods': usedby_pods,
-            'usedby_clusters': usedby_clusters,
-            'creation_yaml': row.creation_yaml,
-        }
+        return _volume_record_from_row(row)
     return None
 
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -26,7 +26,7 @@ VOLUME_LOCK_PATH = os.path.expanduser('~/.sky/.{volume_name}.lock')
 VOLUME_LOCK_TIMEOUT_SECONDS = 20
 
 
-def volume_refresh() -> None:
+def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
     """Refreshes volume status by querying cloud APIs.
 
     This is called by the background daemon to update volume state.
@@ -36,8 +36,21 @@ def volume_refresh() -> None:
     - NOT_READY: Volume has errors (e.g., pending due to misconfiguration)
     - IN_USE: Volume is healthy and in use
     - READY: Volume is healthy and not in use
+
+    Args:
+        volume_names: Refresh only these volumes instead of every one. A
+            caller waiting on a single volume it just created would otherwise
+            take a file lock and a database round-trip per volume in the
+            table on every poll, contending with concurrent volume
+            operations for the same locks. Names with no row are ignored.
+            Cloud calls are per (context, namespace) rather than per volume,
+            so this narrows the database work, not necessarily the API calls.
     """
-    volumes = global_user_state.get_volumes(is_ephemeral=False)
+    if volume_names is None:
+        volumes = global_user_state.get_volumes(is_ephemeral=False)
+    else:
+        volumes = global_user_state.get_volumes_from_names(volume_names,
+                                                           is_ephemeral=False)
 
     # Group volumes by cloud for batch API calls
     cloud_to_configs: Dict[str, List[models.VolumeConfig]] = {}

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2107,3 +2107,85 @@ class TestEphemeralVolumeSkipsStatusProbe:
                           is_ephemeral=True)
 
         mock_get_errors.assert_not_called()
+
+
+class TestVolumeRefreshScopedToNames:
+    """A caller waiting on one volume must not pay for the whole table.
+
+    volume_refresh takes a file lock and a database round-trip per volume it
+    walks, and those are the same locks concurrent volume operations take, so
+    polling it unscoped puts the whole table in the poll loop's path.
+    """
+
+    def _volume(self, name):
+        return {
+            'name': name,
+            'launched_at': 1234567890,
+            'user_hash': 'user123',
+            'workspace': 'default',
+            'last_attached_at': None,
+            'last_use': None,
+            'handle': mock.MagicMock(name=name,
+                                     cloud='kubernetes',
+                                     type='k8s-pvc',
+                                     region='my-context',
+                                     zone=None,
+                                     size='1Gi',
+                                     config={},
+                                     name_on_cloud=f'{name}-on-cloud',
+                                     spec=models.VolumeConfig),
+            'status': status_lib.VolumeStatus.NOT_READY,
+            'is_ephemeral': False,
+        }
+
+    def _patch_common(self, monkeypatch, wanted):
+        monkeypatch.setattr(provision, 'get_all_volumes_errors',
+                            mock.MagicMock(return_value=({}, set())))
+        monkeypatch.setattr(provision, 'get_all_volumes_usedby',
+                            mock.MagicMock(return_value=({}, {}, set())))
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock.MagicMock(return_value=([], [])))
+        monkeypatch.setattr(
+            provision, 'refresh_volume_config',
+            mock.MagicMock(side_effect=lambda cloud, c: (False, c)))
+        monkeypatch.setattr(
+            global_user_state, 'get_volume_by_name',
+            mock.MagicMock(side_effect=lambda n: self._volume(n)))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr(global_user_state, 'update_volume_status',
+                            mock_update)
+        mock_scoped = mock.MagicMock(
+            return_value=[self._volume(n) for n in wanted])
+        monkeypatch.setattr(global_user_state, 'get_volumes_from_names',
+                            mock_scoped)
+        mock_all = mock.MagicMock(
+            return_value=[self._volume(n) for n in ('vol-a', 'vol-b')])
+        monkeypatch.setattr(global_user_state, 'get_volumes', mock_all)
+        return mock_all, mock_scoped, mock_update
+
+    def test_only_the_named_volume_is_touched(self, monkeypatch):
+        mock_all, mock_scoped, mock_update = self._patch_common(
+            monkeypatch, ['vol-a'])
+
+        core.volume_refresh(volume_names=['vol-a'])
+
+        mock_all.assert_not_called()
+        mock_scoped.assert_called_once_with(['vol-a'], is_ephemeral=False)
+        # vol-b is never locked, read, or written.
+        assert [c.args[0] for c in mock_update.call_args_list] == ['vol-a']
+
+    def test_no_names_still_refreshes_everything(self, monkeypatch):
+        """The daemon and `sky volumes ls --refresh` pass nothing and must
+        keep their existing behavior."""
+        mock_all, mock_scoped, mock_update = self._patch_common(
+            monkeypatch, ['vol-a'])
+
+        core.volume_refresh()
+
+        mock_all.assert_called_once_with(is_ephemeral=False)
+        mock_scoped.assert_not_called()
+        assert sorted(c.args[0] for c in mock_update.call_args_list) == [
+            'vol-a', 'vol-b'
+        ]

--- a/tests/unit_tests/test_sky/volumes/test_get_volumes_from_names.py
+++ b/tests/unit_tests/test_sky/volumes/test_get_volumes_from_names.py
@@ -1,0 +1,118 @@
+"""Looking up a few volumes must not read the whole volume table."""
+
+import pytest
+import sqlalchemy
+
+from sky import global_user_state
+from sky import models
+from sky.utils import status_lib
+
+
+@pytest.fixture()
+def isolated_database(tmp_path):
+    """A real database: these tests are about the query, not about mocks."""
+    global_user_state._db_manager._engine = sqlalchemy.create_engine(
+        f'sqlite:///{tmp_path / "state.db"}')
+    global_user_state.create_table(global_user_state._db_manager.get_engine())
+    yield
+    global_user_state._db_manager._engine = None
+
+
+def _add(name: str, is_ephemeral: bool = False) -> None:
+    global_user_state.add_volume(
+        name,
+        models.VolumeConfig(
+            name=name,
+            cloud='kubernetes',
+            type='k8s-pvc',
+            region='my-context',
+            zone=None,
+            size='1Gi',
+            config={},
+            name_on_cloud=f'{name}-on-cloud',
+        ),
+        status_lib.VolumeStatus.READY,
+        is_ephemeral=is_ephemeral,
+    )
+
+
+def test_returns_only_the_named_volumes(isolated_database):
+    for name in ('vol-a', 'vol-b', 'vol-c'):
+        _add(name)
+
+    records = global_user_state.get_volumes_from_names(['vol-a', 'vol-c'])
+
+    assert sorted(r['name'] for r in records) == ['vol-a', 'vol-c']
+
+
+def _comparable(record):
+    """The record minus its handle, which is a pydantic model whose __eq__
+    recurses on nested config."""
+    record = dict(record)
+    handle = record.pop('handle')
+    record['handle_name_on_cloud'] = handle.name_on_cloud
+    return record
+
+
+def test_shape_matches_get_volumes(isolated_database):
+    """Callers switching between the two accessors must not have to check
+    which keys they now have."""
+    _add('vol-a')
+
+    from_names = global_user_state.get_volumes_from_names(['vol-a'])[0]
+    from_all = global_user_state.get_volumes()[0]
+
+    assert _comparable(from_names) == _comparable(from_all)
+
+
+def test_get_volume_by_name_shape_matches_too(isolated_database):
+    """get_volume_by_name used to omit is_ephemeral, so a caller that
+    filtered on it against that record silently dropped the filter."""
+    _add('vol-a', is_ephemeral=True)
+
+    by_name = global_user_state.get_volume_by_name('vol-a')
+
+    assert by_name['is_ephemeral'] is True
+    assert _comparable(by_name) == _comparable(
+        global_user_state.get_volumes()[0])
+
+
+def test_unknown_names_are_absent_not_an_error(isolated_database):
+    _add('vol-a')
+
+    records = global_user_state.get_volumes_from_names(['vol-a', 'nope'])
+
+    assert [r['name'] for r in records] == ['vol-a']
+
+
+def test_empty_input_does_not_query(isolated_database):
+    _add('vol-a')
+
+    assert global_user_state.get_volumes_from_names([]) == []
+
+
+@pytest.mark.parametrize('is_ephemeral', [True, False])
+def test_filters_by_ephemerality_like_get_volumes(isolated_database,
+                                                  is_ephemeral):
+    _add('vol-persistent', is_ephemeral=False)
+    _add('vol-ephemeral', is_ephemeral=True)
+    names = ['vol-persistent', 'vol-ephemeral']
+
+    records = global_user_state.get_volumes_from_names(
+        names, is_ephemeral=is_ephemeral)
+
+    expected = 'vol-ephemeral' if is_ephemeral else 'vol-persistent'
+    assert [r['name'] for r in records] == [expected]
+
+
+def test_more_names_than_one_chunk(isolated_database, monkeypatch):
+    """The IN list is chunked to stay under SQLite's bound-parameter cap, so
+    a lookup spanning chunks must still return every match."""
+    monkeypatch.setattr(global_user_state, '_CLUSTER_IN_QUERY_CHUNK_SIZE', 2)
+    names = [f'vol-{i}' for i in range(5)]
+    for name in names:
+        _add(name)
+
+    records = global_user_state.get_volumes_from_names(names)
+
+    assert sorted(r['name'] for r in records) == sorted(names)


### PR DESCRIPTION
## Summary

- `volume_refresh` gains an optional `volume_names` scope, so a caller waiting on one volume no longer pays for the whole table on every poll.
- New `global_user_state.get_volumes_from_names`: one chunked `IN` query instead of a lookup per name.
- Extract `_volume_record_from_row`, fixing a shape drift between the two existing volume accessors.

## Why

`volume_refresh` walks every volume in the table, and for each one takes a `filelock.FileLock` and a database round-trip. That is the right shape for the 60s daemon, but not for a caller polling on a single volume it just created — waiting for a PVC to finish binding on an `Immediate`-binding StorageClass, for example. Such a caller pays for the entire table on every poll, and the locks it takes are the same ones `volume_apply` / `volume_delete` take, so polling puts the whole table in contention with real volume operations.

`volume_names` narrows that to the volumes the caller actually cares about. Both existing callers — the refresh daemon and `sky volumes ls --refresh` — pass nothing and are unchanged.

Worth being precise about what this does *not* buy: the cloud probes underneath are per `(context, namespace)`, not per volume (`get_all_volumes_errors` lists PVCs per namespace, `get_all_volumes_usedby` lists pods per namespace). So on a single-namespace deployment the Kubernetes API traffic is the same either way. This narrows the database work — locks and round-trips — and the docstring says so rather than leaving the next reader to assume it cuts API calls.

## Drive-by: the two volume accessors had drifted

The row-to-record mapping was duplicated between `get_volumes` and `get_volume_by_name`, and the copies were not identical: `get_volume_by_name` omitted `is_ephemeral`. Anything that filtered on `is_ephemeral` against a `get_volume_by_name` record silently dropped the filter rather than failing. Both now share `_volume_record_from_row`, and a test pins the accessors to the same shape so they cannot drift again.

## Test plan

New `tests/unit_tests/test_sky/volumes/test_get_volumes_from_names.py` — 7 tests against a **real SQLite database** rather than a mocked session, since the point is the query:

- only the named volumes come back; unknown names are absent rather than an error
- empty input short-circuits
- the record shape matches `get_volumes` exactly, and `get_volume_by_name` now matches too (the `is_ephemeral` regression above)
- the `is_ephemeral` filter behaves like `get_volumes`, parameterized both ways
- a lookup spanning more names than one chunk still returns every match (chunk size monkeypatched to 2)

New `TestVolumeRefreshScopedToNames` in `tests/unit_tests/test_sky/volumes/test_core.py`:

- with `volume_names`, `get_volumes` is never called and only the named volume is locked, read, and written
- without it, the daemon path still walks everything

Both were checked against the unfixed code: reverting the `volume_refresh` branch fails `test_only_the_named_volume_is_touched`, so the assertion is bound to the change rather than passing vacuously.

```console
$ pytest tests/unit_tests/test_sky/volumes/
320 passed

$ pytest tests/unit_tests/test_sky/server/test_role_filter.py \
         tests/unit_tests/test_sky/utils/test_volume_utils.py \
         tests/unit_tests/test_sky/test_task.py
133 passed
```

Manual verification against a real database, covering the exact call a scoped caller makes:

```console
$ python -c "
import sqlalchemy, tempfile
from sky import global_user_state as gus, models
from sky.utils import status_lib
from sky.volumes.server import core

d = tempfile.mkdtemp()
gus._db_manager._engine = sqlalchemy.create_engine(f'sqlite:///{d}/s.db')
gus.create_table(gus._db_manager.get_engine())
for n in ('vol-a', 'vol-b'):
    gus.add_volume(n, models.VolumeConfig(name=n, cloud='kubernetes', type='k8s-pvc',
        region='ctx', zone=None, size='1Gi', config={}, name_on_cloud=n + '-oc'),
        status_lib.VolumeStatus.READY)
print([r['name'] for r in gus.get_volumes_from_names(['vol-a'])])
print('is_ephemeral' in gus.get_volume_by_name('vol-a'))
core.volume_refresh(volume_names=['vol-a'])
"
['vol-a']
True
```

`format.sh` equivalents pass (isort, mypy, yapf, pylint all green via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->