### PR TITLE
[Test] Don't require "Instance is up." to immediately follow "Launching on"

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -950,7 +950,12 @@ VALIDATE_LAUNCH_OUTPUT = (
     # Reset s to remove any line with FutureWarning
     's=$(echo "$s" | grep -v "FutureWarning") && '
     'echo "$s" && echo "==Validating launching==" && '
-    'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
+    # -A 5, not -A 1: the provisioner can log warnings between "Launching on"
+    # and "Instance is up.", e.g. when resuming a stopped cluster on AWS whose
+    # instance has not finished shutting down yet ("... is still in STOPPING
+    # state on AWS ... Waiting ..."). What this asserts is that the launch
+    # reported the instance/pod coming up, not that the two lines are adjacent.
+    'echo "$s" | grep -A 5 "Launching on" | grep "is up." && '
     'echo "$s" && echo "==Validating setup output==" && '
     'echo "$s" | grep -A 5 "Setup detached" | grep "Job submitted" && '
     'echo "==Validating running output hints==" && echo "$s" | '
@@ -1011,12 +1016,18 @@ def get_disk_size_and_validate_launch_output(generic_cloud: str):
     """
     if generic_cloud == 'runpod':
         disk_size_param = '--disk-size 20'
-        # Use -A 10 instead of -A 1 for "Launching on" line to handle RunPod raw_response output
+        # Use -A 10 for the "Launching on" line to handle RunPod raw_response output
         # Use -A 100 instead of -A 1 for "Job started. Streaming logs..." to handle RunPod banner output
         validate_launch_output = (VALIDATE_LAUNCH_OUTPUT.replace(
-            'grep -A 1 "Launching on"', 'grep -A 10 "Launching on"').replace(
+            'grep -A 5 "Launching on"', 'grep -A 10 "Launching on"').replace(
                 'grep -A 1 "Job started. Streaming logs..."',
                 'grep -A 100 "Job started. Streaming logs..."'))
+        # The replacements above match VALIDATE_LAUNCH_OUTPUT literally, so they
+        # silently no-op if its grep contexts are ever changed again. Fail loudly
+        # instead, otherwise RunPod quietly loses the wider context it needs.
+        assert 'grep -A 10 "Launching on"' in validate_launch_output
+        assert ('grep -A 100 "Job started. Streaming logs..."'
+                in validate_launch_output)
     else:
         disk_size_param = ''
         validate_launch_output = VALIDATE_LAUNCH_OUTPUT

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -345,10 +345,13 @@ def test_launch_fast(generic_cloud: str):
             # Second launch to test fast launch - should not reprovision
             f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --fast tests/test_yamls/minimal.yaml) && '
             ' echo "$s" && '
-            # Validate that cluster was not re-launched.
-            '! echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
-            # Validate that setup was not re-run.
-            '! echo "$s" | grep -A 1 "Running setup on" | grep "running setup" && '
+            # Validate that cluster was not re-launched. Assert the marker is
+            # absent from the whole output rather than within a line of
+            # "Launching on": a provisioner warning in between would push it out
+            # of the window and let a reprovision slip through unnoticed.
+            '! echo "$s" | grep -q "is up." && '
+            # Validate that setup was not re-run. Same reasoning as above.
+            '! echo "$s" | grep -q "running setup" && '
             # Validate that the task ran and finished.
             'echo "$s" | grep -A 1 "task run finish" | grep "Job finished (status: SUCCEEDED)"',
             f'sky logs {name} 2 --status',
@@ -983,10 +986,12 @@ def test_launch_fast_with_cluster_changes(generic_cloud: str, tmp_path):
             # Launch again - setup and provisioning should be skipped
             f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --fast tests/test_yamls/minimal.yaml) && '
             ' echo "$s" && '
-            # Validate that cluster was not re-launched.
-            '! echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
-            # Validate that setup was not re-run.
-            '! echo "$s" | grep -A 1 "Running setup on" | grep "running setup" && '
+            # Validate that cluster was not re-launched. Absence of the marker
+            # in the whole output, not within a line of "Launching on" -- see
+            # test_launch_fast.
+            '! echo "$s" | grep -q "is up." && '
+            # Validate that setup was not re-run. Same reasoning as above.
+            '! echo "$s" | grep -q "running setup" && '
             f'sky logs {name} 2 --status',
 
             # Copy current config as a base.

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -84,7 +84,9 @@ def test_ssm_private_no_ssh_proxy_command():
     VALIDATE_SSM_OUTPUT = (
         'echo "$s" && echo "==Validating launching==" && '
         f'echo "$s" | grep "{warning_message}" && '
-        'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
+        # -A 5, not -A 1, for the same reason as VALIDATE_LAUNCH_OUTPUT: the
+        # provisioner may log warnings between the two lines.
+        'echo "$s" | grep -A 5 "Launching on" | grep "is up." && '
         'echo "$s" && echo "==Validating setup output==" && '
         'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted" && '
         'echo "==Validating running output hints==" && echo "$s" | '


### PR DESCRIPTION
## Problem

Two related brittle patterns in the smoke tests, both about the launch output's *line adjacency* rather than its content.

### 1. `VALIDATE_LAUNCH_OUTPUT` fails when a warning interleaves (false failure)

The shared positive assertion is

```
echo "$s" | grep -A 1 "Launching on" | grep "is up."
```

which only holds while the two lines are adjacent. Resuming a stopped cluster on AWS breaks it: if the instance has not finished shutting down, the provisioner logs a warning in between, `is up.` falls outside the one-line window, and the whole test step exits 1.

```
⚙︎ Launching on AWS us-east-1 (us-east-1a).
W ... instance.py:446] Instance [ec2.Instance(id='i-02be4ebc439f9fb02')] is still in
  STOPPING state on AWS. It can only be resumed after it is fully STOPPED. Waiting ...
└── Instance is up.
```

The resume itself is fine — it waits for the instance and brings it up — so this is purely the test being brittle.

Landing in that window is easy:

* `query_instances` maps AWS `stopping` → `ClusterStatus.STOPPED` (`sky/provision/aws/instance.py`), and `stop_instances()` deliberately does not wait for the terminal `stopped` state.
* So a test that waits for `STOPPED` and then relaunches races the shutdown. **17 launch-validation sites** across `tests/smoke_tests/` sit behind a wait-for-`STOPPED`.
* Measured live on us-east-1 low-resource instances, `stopping → stopped` took **20 s, 30 s, and >36–38 s** in different runs. `test_hook_lifecycle_combined` allows `sleep 30`, i.e. right in the middle of that distribution: it failed three consecutive retries in one AWS nightly run, every attempt with that identical warning line, then passed on the fourth. `test_launch_fast_with_autostop_hook` already carries a 60 s sleep and a `FIXME(aylei): this can be flaky, sleep longer for now` for the same race.

### 2. The negated assertions can pass when they should fail (false pass)

`test_launch_fast` and `test_launch_fast_with_cluster_changes` check that a `--fast` launch on an already-UP cluster *skipped* provisioning and setup, expressed as `! ... grep -A 1 "Launching on" | grep "is up."`. Scoping an **absence** assertion through a window inverts the failure mode — an interleaved warning pushes the marker out of the window and the negation succeeds anyway. Over real captured output:

| input | `-A 1` | whole-output |
| --- | --- | --- |
| no reprovision — should pass | passes | passes |
| reprovisioned, no warning — should fail | fails | fails |
| reprovisioned + interleaved warning — should fail | **passes** ← reprovision unnoticed | fails |

## Fix

* **Positive assertions** → widen to `-A 5`, keeping them scoped to the launching section without pinning them to adjacency. `test_ssm.py`'s hand-rolled copy is widened to match rather than left to drift.
* **Negated assertions** → assert the marker is absent from the whole output. `"Instance is up."` / `"Pod is up."` and `minimal.yaml`'s `"running setup"` are only emitted while provisioning and running setup, so absence anywhere is both stronger and a more direct statement of intent.
* The RunPod override in `get_disk_size_and_validate_launch_output()` rewrites the grep by literal string match, so it is updated in step — and now asserts the rewrite applied, since otherwise a change like this one silently leaves RunPod without the wider context it needs.

## Tested

**CI** — all first attempt, no retries:

| build | steps |
| --- | --- |
| `-k test_hook_lifecycle_combined --aws` | 1/1 passed |
| `-k test_launch_fast --aws` | 3/3 passed (`test_launch_fast`, `_with_autostop_hook`, `_with_cluster_changes`) |
| `-k test_ssm --aws` | 5/5 passed |

**Forced the race live on AWS** at this branch — launch → `sky stop` → poll until `sky status --refresh` reports `STOPPED` (observed directly as `sky_status=STOPPED aws_state=stopping`) → relaunch 5 s later, while the instance is still shutting down. The relaunch printed the warning between the two lines, and the branch's own `VALIDATE_LAUNCH_OUTPUT` was run over that exact captured output alongside the old chain:

```
aws_state at relaunch: stopping
⚙︎ Launching on AWS us-east-1 (us-east-1a).
W ... Instance [...] is still in STOPPING state on AWS ... Waiting ...
└── Instance is up.
    NEW chain (-A 5): PASSES
    OLD chain (-A 1): FAILS   <-- the flake
```

**Negations** verified against real captured output on AWS and Kubernetes: neither marker appears in a `--fast` launch that skips provisioning (so the tighter check is not flaky), while the third row of the table above now fails as it should. `test_basic.py::test_launch_fast` also run directly on AWS: 1 passed.

`yapf`, `isort`, `mypy` clean via pre-commit.

Not included: `test_hook_lifecycle_combined`'s 30 s margin is still half of what the sibling autostop test uses. With this fix the extra warning is harmless, so raising it would only save the provisioner a short wait — happy to add it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DK2d66iuGM96viUHFsa8V
