### PR TITLE
[Dashboard] Name the clusters filter params in the URL

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -73,10 +73,8 @@ import cachePreloader from '@/lib/cache-preloader';
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon } from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
-import {
-  evaluateCondition,
-  updateFiltersByURLParams as sharedUpdateFiltersByURLParams,
-} from '@/components/shared/FilterSystem';
+import { filterData } from '@/components/shared/FilterSystem';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 import { SegmentedToggle } from '@/components/elements/SegmentedToggle';
 import { getCurrentUserInfo } from '@/data/connectors/client';
 import { trackClusterAction, trackFilterUsed } from '@/lib/analytics';
@@ -95,33 +93,55 @@ const CLUSTERS_PAGE_SIZE_STORAGE_KEY = 'skypilot-clusters-page-size';
 //   return cost.toFixed(2);
 // };
 
-// Define filter options for the filter dropdown
-const PROPERTY_OPTIONS = [
+// The filterable properties of this page, declared once. `key` is what the URL
+// carries and what `optionValues` is keyed by; `label` is display only, and is
+// what a chip stores in `filter.property`. Because the dropdown and the URL
+// read the same list, a filter the page offers is always one it can read back.
+export const CLUSTER_FILTER_SCHEMA = [
+  { key: 'status', label: 'Status', kind: 'enum', multi: true },
+  { key: 'cluster', label: 'Cluster', kind: 'text' },
+  { key: 'user', label: 'User', kind: 'text' },
+  { key: 'workspace', label: 'Workspace', kind: 'text' },
+  { key: 'infra', label: 'Infra', kind: 'text' },
+  { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
+];
+
+const HISTORY_DAY_OPTIONS = [1, 5, 10, 30];
+
+// Non-filter state that also belongs in a shared link. Anything left at its
+// default stays out of the URL.
+const CLUSTER_VIEW_SCHEMA = [
+  { key: 'owner', default: 'mine' },
   {
-    label: 'Status',
-    value: 'status',
-  },
-  {
-    label: 'Cluster',
-    value: 'cluster',
-  },
-  {
-    label: 'User',
-    value: 'user',
-  },
-  {
-    label: 'Workspace',
-    value: 'workspace',
-  },
-  {
-    label: 'Infra',
-    value: 'infra',
-  },
-  {
-    label: 'Labels',
-    value: 'labels',
+    key: 'history',
+    default: 'off',
+    // Older links carry `history=true` and a separate `historyDays=N`.
+    legacyKeys: ['historyDays'],
+    fromLegacy: (query) => {
+      if (query.history === 'true') {
+        const days = parseInt(query.historyDays, 10);
+        return HISTORY_DAY_OPTIONS.includes(days) ? `${days}d` : '1d';
+      }
+      if (query.history === 'false') {
+        return 'off';
+      }
+      return undefined;
+    },
   },
 ];
+
+const PROPERTY_OPTIONS = CLUSTER_FILTER_SCHEMA.map(({ key, label }) => ({
+  label,
+  value: key,
+}));
+
+// `history` carries the window directly: absent means the history view is off,
+// otherwise `1d` / `5d` / `10d` / `30d`. Replaces the old `history=true` plus
+// `historyDays=N` pair.
+const parseHistory = (value) => {
+  const days = parseInt(String(value ?? '').replace(/d$/, ''), 10);
+  return HISTORY_DAY_OPTIONS.includes(days) ? days : null;
+};
 
 // Helper function to format username for display (reuse from users.jsx)
 const formatUserDisplay = (username, userId) => {
@@ -221,46 +241,20 @@ export function Clusters() {
   const [isVSCodeModalOpen, setIsVSCodeModalOpen] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState(null);
 
-  // Initialize showHistory from URL parameter immediately
-  const getInitialShowHistory = () => {
-    if (typeof window !== 'undefined' && router.isReady) {
-      const historyParam = router.query.history;
-      return historyParam === 'true';
-    }
-    return false;
-  };
+  // Filters and the shareable view state both live in the URL, keyed by name.
+  const { filters, setFilters, view, setView } = useUrlFilterState(
+    CLUSTER_FILTER_SCHEMA,
+    CLUSTER_VIEW_SCHEMA
+  );
 
-  // Initialize historyDays from URL parameter immediately
-  const getInitialHistoryDays = () => {
-    if (typeof window !== 'undefined' && router.isReady) {
-      const daysParam = router.query.historyDays;
-      if (
-        daysParam &&
-        typeof daysParam === 'string' &&
-        ['1', '5', '10', '30'].includes(daysParam)
-      ) {
-        return parseInt(daysParam);
-      }
-    }
-    return 1; // Default to 1 day
-  };
+  const historyDays = parseHistory(view.history) ?? 1;
+  const showHistory = parseHistory(view.history) !== null;
+  const userScope = isOwnerScope(view.owner) ? view.owner : OWNER_SCOPE_MINE;
+  const setUserScope = useCallback(
+    (scope) => setView('owner', scope),
+    [setView]
+  );
 
-  const getInitialUserScope = () => {
-    const owner = router.query.owner;
-    if (
-      typeof window !== 'undefined' &&
-      router.isReady &&
-      isOwnerScope(owner)
-    ) {
-      return owner;
-    }
-    // Fall back to the user's last choice, then to My Clusters.
-    return readStoredOwnerScope() ?? OWNER_SCOPE_MINE;
-  };
-
-  const [showHistory, setShowHistory] = useState(getInitialShowHistory);
-  const [historyDays, setHistoryDays] = useState(getInitialHistoryDays);
-  const [userScope, setUserScope] = useState(getInitialUserScope);
   const [currentUser, setCurrentUser] = useState(null);
   const [authResolved, setAuthResolved] = useState(false);
   // Whether the current scope has any rows; gates the "Showing your
@@ -289,9 +283,10 @@ export function Clusters() {
     return () => {
       cancelled = true;
     };
+    // Runs once on mount; setUserScope is stable via useCallback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [filters, setFilters] = useState([]);
   const [optionValues, setOptionValues] = useState({
     status: [],
     cluster: [],
@@ -303,59 +298,40 @@ export function Clusters() {
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
 
-  // Handle URL query parameters for workspace and user filtering and show history
+  // Owner scope resolution: a deep-linked `?owner=` wins and is persisted like
+  // a manual toggle; otherwise fall back to the user's last choice. An
+  // anonymous server has no "mine" to scope to, so it is always All.
+  const scopeSeeded = useRef(false);
   useEffect(() => {
-    if (router.isReady) {
-      updateFiltersByURLParams();
-
-      // Sync showHistory state with URL if it has changed
-      const historyParam = router.query.history;
-      const expectedState = historyParam === 'true';
-
-      if (showHistory !== expectedState) {
-        setShowHistory(expectedState);
+    if (!router.isReady) {
+      return;
+    }
+    if (authResolved && !currentUser) {
+      if (view.owner !== OWNER_SCOPE_ALL) {
+        setView('owner', OWNER_SCOPE_ALL);
       }
-
-      // Sync historyDays state with URL if it has changed
-      const daysParam = router.query.historyDays;
-      if (
-        daysParam &&
-        typeof daysParam === 'string' &&
-        ['1', '5', '10', '30'].includes(daysParam)
-      ) {
-        const expectedDays = parseInt(daysParam);
-        if (historyDays !== expectedDays) {
-          setHistoryDays(expectedDays);
-        }
-      }
-
-      const isAnonymous = authResolved && !currentUser;
-      const owner = router.query.owner;
-      if (isAnonymous) {
-        if (userScope !== OWNER_SCOPE_ALL) {
-          setUserScope(OWNER_SCOPE_ALL);
-        }
-      } else if (isOwnerScope(owner)) {
-        if (userScope !== owner) {
-          // Go through selectScope so a deep-linked ?owner=... choice is also
-          // persisted to localStorage like a manual toggle.
-          selectScope(owner);
-        } else if (readStoredOwnerScope() !== owner) {
-          // On a fresh load the initial state is already seeded from the URL,
-          // so the branch above never runs; still persist the deep-linked
-          // choice like a manual toggle.
-          writeStoredOwnerScope(owner);
-        }
-      }
+      return;
+    }
+    if (scopeSeeded.current) {
+      return;
+    }
+    scopeSeeded.current = true;
+    const deepLinked = router.query.owner;
+    if (isOwnerScope(deepLinked)) {
+      writeStoredOwnerScope(deepLinked);
+      return;
+    }
+    const stored = readStoredOwnerScope();
+    if (stored && stored !== view.owner) {
+      setView('owner', stored);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     router.isReady,
-    router.query.history,
-    router.query.historyDays,
     router.query.owner,
     authResolved,
     currentUser,
+    view.owner,
   ]);
 
   useEffect(() => {
@@ -428,103 +404,17 @@ export function Clusters() {
     fetchFilterData();
   }, []);
 
-  // Helper function to update URL query parameters
-  const updateURLParams = (filters) => {
-    const query = { ...router.query };
-
-    let properties = [];
-    let operators = [];
-    let values = [];
-
-    filters.map((filter, _index) => {
-      properties.push((filter.property ?? '').toLowerCase());
-      operators.push(filter.operator);
-      values.push(filter.value);
-    });
-
-    query.property = properties;
-    query.operator = operators;
-    query.value = values;
-
-    // Use replace to avoid adding to browser history for filter changes
-    router.replace(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
-
-  // Helper function to update show history in URL
-  const updateShowHistoryURL = (showHistoryValue) => {
-    const query = { ...router.query };
-    query.history = showHistoryValue.toString();
-
-    // Use replace to avoid adding to browser history for show history changes
-    router.replace(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
-
-  // Helper function to update history days in URL
-  const updateHistoryDaysURL = (historyDaysValue) => {
-    const query = { ...router.query };
-    query.historyDays = historyDaysValue.toString();
-
-    // Use replace to avoid adding to browser history for history days changes
-    router.replace(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
-
-  const updateFiltersByURLParams = () => {
-    if (router.query.property === undefined) {
-      return;
-    }
-    // Keys match PROPERTY_OPTIONS above; a URL naming anything else is dropped
-    // by the shared decoder.
-    const propertyMap = new Map([
-      ['status', 'Status'],
-      ['cluster', 'Cluster'],
-      ['user', 'User'],
-      ['workspace', 'Workspace'],
-      ['infra', 'Infra'],
-      ['labels', 'Labels'],
-    ]);
-
-    setFilters(sharedUpdateFiltersByURLParams(router, propertyMap));
-  };
-
   const selectScope = (scope) => {
-    setUserScope(scope);
+    setView('owner', scope);
     writeStoredOwnerScope(scope);
-    const query = { ...router.query };
-    query.owner = scope;
-    router.replace(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true }
-    );
   };
 
   const selectHistoryTab = (showHistoryValue) => {
-    setShowHistory(showHistoryValue);
-    updateShowHistoryURL(showHistoryValue);
+    setView('history', showHistoryValue ? `${historyDays}d` : 'off');
+  };
+
+  const selectHistoryDays = (days) => {
+    setView('history', `${days}d`);
   };
 
   const explicitUserFilter = useMemo(
@@ -588,18 +478,13 @@ export function Clusters() {
             propertyList={PROPERTY_OPTIONS}
             valueList={optionValues}
             setFilters={setFilters}
-            updateURLParams={updateURLParams}
             placeholder="Filter clusters"
             filters={filters}
           />
         </div>
       </div>
 
-      <Filters
-        filters={filters}
-        setFilters={setFilters}
-        updateURLParams={updateURLParams}
-      />
+      <Filters filters={filters} setFilters={setFilters} />
 
       {/* Toggles live on their own row (mirrors the Managed Jobs layout) so
           they read consistently across pages and stay clear of the search
@@ -660,11 +545,7 @@ export function Clusters() {
           {showHistory && (
             <Select
               value={historyDays.toString()}
-              onValueChange={(value) => {
-                const newDays = parseInt(value);
-                setHistoryDays(newDays);
-                updateHistoryDaysURL(newDays);
-              }}
+              onValueChange={(value) => selectHistoryDays(parseInt(value))}
             >
               <SelectTrigger className="w-24 h-8 text-xs">
                 <SelectValue />
@@ -921,30 +802,6 @@ export function ClusterTable({
   // For server-side pagination, data is already paginated, so we apply filters/sort to hookData
   // For client-side pagination, we apply filters/sort to allData, then paginate
   const sortedData = React.useMemo(() => {
-    // Main filter function
-    const filterData = (data, filters) => {
-      if (filters.length === 0) {
-        return data;
-      }
-
-      return data.filter((item) => {
-        let result = null;
-
-        for (let i = 0; i < filters.length; i++) {
-          const filter = filters[i];
-          const current = evaluateCondition(item, filter);
-
-          if (result === null) {
-            result = current;
-          } else {
-            result = result && current;
-          }
-        }
-
-        return result;
-      });
-    };
-
     // For server-side pagination, server already handles filtering - just apply sorting
     // For client-side pagination, we filter/sort the full data then paginate.
     // The current-user ("My Clusters") scope is applied server-side via the
@@ -1634,7 +1491,6 @@ const FilterDropdown = ({
   propertyList = [],
   valueList,
   setFilters,
-  updateURLParams,
   placeholder = 'Filter clusters',
   filters = [],
 }) => {
@@ -1767,7 +1623,6 @@ const FilterDropdown = ({
         },
       ];
 
-      updateURLParams(updatedFilters);
       return updatedFilters;
     });
     setIsOpen(false);
@@ -1787,7 +1642,6 @@ const FilterDropdown = ({
           },
         ];
 
-        updateURLParams(updatedFilters);
         return updatedFilters;
       });
       setValue('');
@@ -1880,21 +1734,14 @@ const FilterDropdown = ({
   );
 };
 
-const Filters = ({ filters = [], setFilters, updateURLParams }) => {
+const Filters = ({ filters = [], setFilters }) => {
   const onRemove = (index) => {
-    setFilters((prevFilters) => {
-      const updatedFilters = prevFilters.filter(
-        (_, _index) => _index !== index
-      );
-
-      updateURLParams(updatedFilters);
-
-      return updatedFilters;
-    });
+    setFilters((prevFilters) =>
+      prevFilters.filter((_, _index) => _index !== index)
+    );
   };
 
   const clearFilters = () => {
-    updateURLParams([]);
     setFilters([]);
   };
 

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -135,6 +135,25 @@ const PROPERTY_OPTIONS = CLUSTER_FILTER_SCHEMA.map(({ key, label }) => ({
   value: key,
 }));
 
+// Properties whose values are alternatives rather than extra conditions. Only
+// these may hold more than one chip; everything else replaces, so the page can
+// never show more filters than a shared link is able to carry.
+const OR_PROPERTIES = CLUSTER_FILTER_SCHEMA.filter((e) => e.multi === true).map(
+  (e) => e.label
+);
+const MULTI_VALUE_LABELS = new Set(
+  CLUSTER_FILTER_SCHEMA.filter((e) => e.multi).map((e) => e.label)
+);
+
+// Add a chip, replacing any existing one on a single-valued property and
+// ignoring an exact duplicate.
+const addFilter = (prevFilters, property, value) => {
+  const base = MULTI_VALUE_LABELS.has(property)
+    ? prevFilters.filter((f) => !(f.property === property && f.value === value))
+    : prevFilters.filter((f) => f.property !== property);
+  return [...base, { property, operator: ':', value }];
+};
+
 // `history` carries the window directly: absent means the history view is off,
 // otherwise `1d` / `5d` / `10d` / `30d`. Replaces the old `history=true` plus
 // `historyDays=N` pair.
@@ -242,10 +261,8 @@ export function Clusters() {
   const [selectedCluster, setSelectedCluster] = useState(null);
 
   // Filters and the shareable view state both live in the URL, keyed by name.
-  const { filters, setFilters, view, setView } = useUrlFilterState(
-    CLUSTER_FILTER_SCHEMA,
-    CLUSTER_VIEW_SCHEMA
-  );
+  const { filters, setFilters, view, setView, initialQuery } =
+    useUrlFilterState(CLUSTER_FILTER_SCHEMA, CLUSTER_VIEW_SCHEMA);
 
   const historyDays = parseHistory(view.history) ?? 1;
   const showHistory = parseHistory(view.history) !== null;
@@ -316,7 +333,7 @@ export function Clusters() {
       return;
     }
     scopeSeeded.current = true;
-    const deepLinked = router.query.owner;
+    const deepLinked = initialQuery.owner;
     if (isOwnerScope(deepLinked)) {
       writeStoredOwnerScope(deepLinked);
       return;
@@ -326,13 +343,7 @@ export function Clusters() {
       setView('owner', stored);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    router.isReady,
-    router.query.owner,
-    authResolved,
-    currentUser,
-    view.owner,
-  ]);
+  }, [router.isReady, initialQuery, authResolved, currentUser, view.owner]);
 
   useEffect(() => {
     const fetchFilterData = async () => {
@@ -409,8 +420,22 @@ export function Clusters() {
     writeStoredOwnerScope(scope);
   };
 
+  // Remember the chosen window across an Active/All round trip: `history=off`
+  // carries no day count, so without this the toggle would silently reset a
+  // 30-day view to 1 day.
+  const lastHistoryDays = useRef(historyDays);
+  useEffect(() => {
+    const days = parseHistory(view.history);
+    if (days !== null) {
+      lastHistoryDays.current = days;
+    }
+  }, [view.history]);
+
   const selectHistoryTab = (showHistoryValue) => {
-    setView('history', showHistoryValue ? `${historyDays}d` : 'off');
+    setView(
+      'history',
+      showHistoryValue ? `${lastHistoryDays.current}d` : 'off'
+    );
   };
 
   const selectHistoryDays = (days) => {
@@ -824,7 +849,7 @@ export function ClusterTable({
 
     const filteredData = isServerPagination
       ? dataToProcess
-      : filterData(dataToProcess, filters);
+      : filterData(dataToProcess, filters, { orProperties: OR_PROPERTIES });
 
     return sortData(filteredData, sortConfig.key, sortConfig.direction);
   }, [hookData, allData, sortConfig, filters, isServerPagination]);
@@ -1613,18 +1638,9 @@ const FilterDropdown = ({
 
   const handleOptionSelect = (option) => {
     trackFilterUsed('cluster', { property: propertyValue, value: option });
-    setFilters((prevFilters) => {
-      const updatedFilters = [
-        ...prevFilters,
-        {
-          property: getPropertyLabel(propertyValue),
-          operator: ':',
-          value: option,
-        },
-      ];
-
-      return updatedFilters;
-    });
+    setFilters((prevFilters) =>
+      addFilter(prevFilters, getPropertyLabel(propertyValue), option)
+    );
     setIsOpen(false);
     setValue('');
     inputRef.current.focus();
@@ -1632,18 +1648,9 @@ const FilterDropdown = ({
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && value.trim() !== '') {
-      setFilters((prevFilters) => {
-        const updatedFilters = [
-          ...prevFilters,
-          {
-            property: getPropertyLabel(propertyValue),
-            operator: ':',
-            value: value,
-          },
-        ];
-
-        return updatedFilters;
-      });
+      setFilters((prevFilters) =>
+        addFilter(prevFilters, getPropertyLabel(propertyValue), value)
+      );
       setValue('');
       setIsOpen(false);
     } else if (e.key === 'Escape') {

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -241,6 +241,38 @@ const readStoredOwnerScope = () => {
   }
 };
 
+// The chosen history window is a preference, not part of the view: `history=off`
+// carries no day count, so remember it the way the page already remembers the
+// owner scope and the page size. A window named in the URL wins and is stored,
+// like a manual choice.
+const HISTORY_DAYS_STORAGE_KEY = 'skypilot-dashboard-clusters-history-days';
+
+const readStoredHistoryDays = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = parseInt(
+      window.localStorage.getItem(HISTORY_DAYS_STORAGE_KEY),
+      10
+    );
+    return HISTORY_DAY_OPTIONS.includes(stored) ? stored : null;
+  } catch (e) {
+    return null;
+  }
+};
+
+const writeStoredHistoryDays = (days) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(HISTORY_DAYS_STORAGE_KEY, String(days));
+  } catch (e) {
+    // Ignore: the window still applies for this session via state/URL.
+  }
+};
+
 const writeStoredOwnerScope = (scope) => {
   if (typeof window === 'undefined') {
     return;
@@ -423,11 +455,14 @@ export function Clusters() {
   // Remember the chosen window across an Active/All round trip: `history=off`
   // carries no day count, so without this the toggle would silently reset a
   // 30-day view to 1 day.
-  const lastHistoryDays = useRef(historyDays);
+  const lastHistoryDays = useRef(
+    parseHistory(view.history) ?? readStoredHistoryDays() ?? 1
+  );
   useEffect(() => {
     const days = parseHistory(view.history);
     if (days !== null) {
       lastHistoryDays.current = days;
+      writeStoredHistoryDays(days);
     }
   }, [view.history]);
 
@@ -756,7 +791,10 @@ export function ClusterTable({
       url.searchParams.delete('pageSize');
     }
     if (url.href !== window.location.href) {
-      window.history.replaceState(null, '', url.toString());
+      // Keep the existing state so Next's router entry (`__N`, `key`) survives;
+      // nulling it makes a later popstate change the address bar without
+      // re-rendering the page.
+      window.history.replaceState(window.history.state, '', url.toString());
     }
   }, [page, limit]);
 

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -69,14 +69,22 @@ export const evaluateCondition = (item, filter) => {
 
 // Main filter function.
 //
-// Several filters on the same property mean "match any of these" (OR);
-// different properties still narrow each other (AND). AND-ing everything would
-// make two values on one property -- two statuses, two users -- always yield
-// zero rows, and would disagree with the URL, where one key carries a list.
-export const filterData = (data, filters) => {
+// Filters on different properties always narrow each other (AND). Filters on
+// the *same* property AND too, unless the caller names that property in
+// `options.orProperties` -- then its values are alternatives (OR), which is
+// what a multi-valued filter like `?status=RUNNING,STOPPED` means.
+//
+// The default is AND so that pages which have not adopted the schema keep their
+// existing behaviour. Note that key/value filters such as Labels want AND even
+// when they repeat: `team:ml` plus `env:prod` reads as an intersection.
+export const filterData = (data, filters, options = {}) => {
   if (!filters || filters.length === 0) {
     return data;
   }
+
+  const orProperties = new Set(
+    (options.orProperties || []).map((p) => String(p).toLowerCase())
+  );
 
   const groups = new Map();
   for (const filter of filters) {
@@ -86,10 +94,13 @@ export const filterData = (data, filters) => {
     }
     groups.get(key).push(filter);
   }
-  const grouped = [...groups.values()];
 
   return data.filter((item) =>
-    grouped.every((group) => group.some((f) => evaluateCondition(item, f)))
+    [...groups.entries()].every(([property, group]) =>
+      orProperties.has(property)
+        ? group.some((f) => evaluateCondition(item, f))
+        : group.every((f) => evaluateCondition(item, f))
+    )
   );
 };
 

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -67,28 +67,30 @@ export const evaluateCondition = (item, filter) => {
   }
 };
 
-// Main filter function
+// Main filter function.
+//
+// Several filters on the same property mean "match any of these" (OR);
+// different properties still narrow each other (AND). AND-ing everything would
+// make two values on one property -- two statuses, two users -- always yield
+// zero rows, and would disagree with the URL, where one key carries a list.
 export const filterData = (data, filters) => {
-  if (filters.length === 0) {
+  if (!filters || filters.length === 0) {
     return data;
   }
 
-  return data.filter((item) => {
-    let result = null;
-
-    for (let i = 0; i < filters.length; i++) {
-      const filter = filters[i];
-      const current = evaluateCondition(item, filter);
-
-      if (result === null) {
-        result = current;
-      } else {
-        result = result && current;
-      }
+  const groups = new Map();
+  for (const filter of filters) {
+    const key = (filter.property || '').toLowerCase();
+    if (!groups.has(key)) {
+      groups.set(key, []);
     }
+    groups.get(key).push(filter);
+  }
+  const grouped = [...groups.values()];
 
-    return result;
-  });
+  return data.filter((item) =>
+    grouped.every((group) => group.some((f) => evaluateCondition(item, f)))
+  );
 };
 
 // URL parameter handling utilities

--- a/sky/dashboard/src/components/shared/FilterSystem.test.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.test.jsx
@@ -1,5 +1,6 @@
 import {
   evaluateCondition,
+  filterData,
   updateFiltersByURLParams,
 } from '@/components/shared/FilterSystem';
 
@@ -132,5 +133,40 @@ describe('evaluateCondition', () => {
         value: 'alice',
       })
     ).toBe(true);
+  });
+});
+
+describe('filterData grouping', () => {
+  const rows = [
+    { status: 'RUNNING', user: 'alice' },
+    { status: 'STOPPED', user: 'alice' },
+    { status: 'RUNNING', user: 'bob' },
+  ];
+  const f = (property, value) => ({ property, operator: ':', value });
+
+  it('ORs several values on the same property', () => {
+    const out = filterData(rows, [
+      f('Status', 'RUNNING'),
+      f('Status', 'STOPPED'),
+    ]);
+    expect(out).toHaveLength(3);
+  });
+
+  it('ANDs across different properties', () => {
+    const out = filterData(rows, [f('Status', 'RUNNING'), f('User', 'alice')]);
+    expect(out).toEqual([{ status: 'RUNNING', user: 'alice' }]);
+  });
+
+  it('combines both: (status OR status) AND user', () => {
+    const out = filterData(rows, [
+      f('Status', 'RUNNING'),
+      f('Status', 'STOPPED'),
+      f('User', 'alice'),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('returns everything when there are no filters', () => {
+    expect(filterData(rows, [])).toBe(rows);
   });
 });

--- a/sky/dashboard/src/components/shared/FilterSystem.test.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.test.jsx
@@ -144,12 +144,34 @@ describe('filterData grouping', () => {
   ];
   const f = (property, value) => ({ property, operator: ':', value });
 
-  it('ORs several values on the same property', () => {
+  it('ANDs same-property values by default, so existing pages are unchanged', () => {
     const out = filterData(rows, [
       f('Status', 'RUNNING'),
       f('Status', 'STOPPED'),
     ]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('ORs a property the caller opts in', () => {
+    const out = filterData(
+      rows,
+      [f('Status', 'RUNNING'), f('Status', 'STOPPED')],
+      { orProperties: ['Status'] }
+    );
     expect(out).toHaveLength(3);
+  });
+
+  it('keeps key/value filters intersecting even when opted-in siblings OR', () => {
+    const labelled = [
+      { status: 'RUNNING', labels: { team: 'ml', env: 'prod' } },
+      { status: 'RUNNING', labels: { team: 'ml' } },
+    ];
+    const out = filterData(
+      labelled,
+      [f('Labels', 'team:ml'), f('Labels', 'env:prod')],
+      { orProperties: ['Status'] }
+    );
+    expect(out).toHaveLength(1);
   });
 
   it('ANDs across different properties', () => {
@@ -158,11 +180,11 @@ describe('filterData grouping', () => {
   });
 
   it('combines both: (status OR status) AND user', () => {
-    const out = filterData(rows, [
-      f('Status', 'RUNNING'),
-      f('Status', 'STOPPED'),
-      f('User', 'alice'),
-    ]);
+    const out = filterData(
+      rows,
+      [f('Status', 'RUNNING'), f('Status', 'STOPPED'), f('User', 'alice')],
+      { orProperties: ['Status'] }
+    );
     expect(out).toHaveLength(2);
   });
 

--- a/sky/dashboard/src/components/shared/filterSchema.js
+++ b/sky/dashboard/src/components/shared/filterSchema.js
@@ -1,0 +1,170 @@
+/**
+ * Schema-driven encoding of filter chips as named URL query parameters.
+ *
+ * A page declares its filterable properties once:
+ *
+ *   [{ key: 'status', label: 'Status', kind: 'enum', multi: true }, ...]
+ *
+ * and that one declaration drives the dropdown, the URL, and the chip bar, so
+ * the key a page writes is by construction the key it can read back.
+ *
+ * The in-memory chip shape is unchanged -- `{ property, operator, value }`
+ * where `property` is the schema entry's label -- because `evaluateCondition`,
+ * `filterData` and the table connectors all consume it. Only the URL form
+ * changes here.
+ */
+
+// The legacy encoding: three parallel arrays zipped by index. Kept readable so
+// links already pasted into docs and chat keep working.
+const LEGACY_KEYS = ['property', 'operator', 'value'];
+
+const DEFAULT_OPERATOR = ':';
+
+/** Look up a schema entry by its URL key. */
+export const entryByKey = (schema, key) =>
+  schema.find((entry) => entry.key === key);
+
+/** Look up a schema entry by the label carried on a chip. */
+export const entryByLabel = (schema, label) =>
+  schema.find((entry) => entry.label === label);
+
+/**
+ * Turn chips into `{ key: value }` pairs.
+ *
+ * - `enum` with `multi` joins its values with a comma: several values on one
+ *   key mean "match any of these".
+ * - `kv` (labels) repeats the key instead, because a label value may itself
+ *   contain a comma.
+ * - Everything else is single-valued; a page replaces rather than stacks a
+ *   text chip, so a second value here means the caller changed the filter.
+ */
+export const filtersToQuery = (schema, filters) => {
+  const query = {};
+  for (const entry of schema) {
+    const values = (filters || [])
+      .filter((f) => f.property === entry.label)
+      .map((f) => f.value)
+      .filter((v) => v !== undefined && v !== null && v !== '');
+    if (values.length === 0) {
+      continue;
+    }
+    if (entry.kind === 'kv' || entry.multi === 'repeat') {
+      query[entry.key] = values;
+    } else if (entry.kind === 'enum' && entry.multi) {
+      query[entry.key] = values.join(',');
+    } else {
+      query[entry.key] = values[values.length - 1];
+    }
+  }
+  return query;
+};
+
+/** Turn `{ key: value }` pairs back into chips, dropping anything unknown. */
+export const queryToFilters = (schema, query) => {
+  const filters = [];
+  for (const entry of schema) {
+    const raw = query?.[entry.key];
+    if (raw === undefined || raw === null || raw === '') {
+      continue;
+    }
+    let values;
+    if (Array.isArray(raw)) {
+      values = raw;
+    } else if (entry.kind === 'enum' && entry.multi) {
+      values = String(raw).split(',');
+    } else {
+      values = [String(raw)];
+    }
+    for (const value of values) {
+      const trimmed = String(value).trim();
+      if (!trimmed) {
+        continue;
+      }
+      filters.push({
+        property: entry.label,
+        operator: DEFAULT_OPERATOR,
+        value: trimmed,
+      });
+    }
+  }
+  return filters;
+};
+
+/** True when a URL still carries the legacy triple arrays. */
+export const hasLegacyFilters = (query) =>
+  query?.property !== undefined && query.property !== '';
+
+/**
+ * Translate legacy triples into named params.
+ *
+ * The operator is discarded: no UI could ever set it to anything but ':'.
+ * A property the schema does not know about is dropped rather than carried as
+ * an undefined one -- the same rule `updateFiltersByURLParams` applies.
+ */
+export const legacyFiltersToQuery = (schema, query) => {
+  if (!hasLegacyFilters(query)) {
+    return {};
+  }
+  const raw = query.property;
+  const properties = Array.isArray(raw) ? raw : [raw];
+  const rawValues = query.value;
+  const values = Array.isArray(rawValues) ? rawValues : [rawValues];
+
+  const filters = [];
+  properties.forEach((property, i) => {
+    // Legacy URLs carry the lowercased label, which for every page except the
+    // users GPU filter equals the schema key. Match either, so both survive.
+    const lower = String(property ?? '').toLowerCase();
+    const entry =
+      entryByKey(schema, lower) ||
+      schema.find((e) => e.label.toLowerCase() === lower);
+    const value = properties.length === 1 ? values[0] : values[i];
+    if (!entry || value === undefined || value === null || value === '') {
+      return;
+    }
+    filters.push({
+      property: entry.label,
+      operator: DEFAULT_OPERATOR,
+      value: String(value),
+    });
+  });
+  return filtersToQuery(schema, filters);
+};
+
+/**
+ * Serialize `{ key: value }` pairs to a query string.
+ *
+ * Built by hand rather than with URLSearchParams so a comma stays a comma:
+ * `?status=RUNNING,STOPPED` is the point of the exercise, and
+ * `URLSearchParams` would percent-encode it to `%2C`. Everything else is
+ * encoded normally, so values containing `&`, `=` or spaces round-trip.
+ */
+export const buildQueryString = (query) => {
+  const parts = [];
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    const values = Array.isArray(value) ? value : [value];
+    for (const v of values) {
+      if (v === undefined || v === null || v === '') {
+        continue;
+      }
+      const encoded = String(v)
+        .split(',')
+        .map((part) => encodeURIComponent(part))
+        .join(',');
+      parts.push(`${encodeURIComponent(key)}=${encoded}`);
+    }
+  }
+  return parts.length ? `?${parts.join('&')}` : '';
+};
+
+/** Strip the legacy triple keys from a query object. */
+export const withoutLegacyKeys = (query) => {
+  const next = { ...query };
+  for (const key of LEGACY_KEYS) {
+    delete next[key];
+  }
+  return next;
+};

--- a/sky/dashboard/src/components/shared/filterSchema.test.jsx
+++ b/sky/dashboard/src/components/shared/filterSchema.test.jsx
@@ -1,0 +1,197 @@
+import {
+  buildQueryString,
+  filtersToQuery,
+  hasLegacyFilters,
+  legacyFiltersToQuery,
+  queryToFilters,
+  withoutLegacyKeys,
+} from '@/components/shared/filterSchema';
+
+const SCHEMA = [
+  { key: 'status', label: 'Status', kind: 'enum', multi: true },
+  { key: 'cluster', label: 'Cluster', kind: 'text' },
+  { key: 'user', label: 'User', kind: 'text' },
+  { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
+];
+
+const chip = (property, value) => ({ property, operator: ':', value });
+
+describe('filtersToQuery', () => {
+  it('names each filter after its schema key', () => {
+    expect(filtersToQuery(SCHEMA, [chip('User', 'alice')])).toEqual({
+      user: 'alice',
+    });
+  });
+
+  it('joins several enum values with a comma', () => {
+    expect(
+      filtersToQuery(SCHEMA, [
+        chip('Status', 'RUNNING'),
+        chip('Status', 'STOPPED'),
+      ])
+    ).toEqual({ status: 'RUNNING,STOPPED' });
+  });
+
+  it('repeats the key for labels, whose values may contain commas', () => {
+    expect(
+      filtersToQuery(SCHEMA, [
+        chip('Labels', 'team:ml'),
+        chip('Labels', 'env:prod'),
+      ])
+    ).toEqual({ labels: ['team:ml', 'env:prod'] });
+  });
+
+  it('keeps one value for a text filter', () => {
+    expect(
+      filtersToQuery(SCHEMA, [chip('User', 'alice'), chip('User', 'bob')])
+    ).toEqual({ user: 'bob' });
+  });
+
+  it('omits empty values entirely rather than writing a bare key', () => {
+    expect(filtersToQuery(SCHEMA, [chip('User', '')])).toEqual({});
+    expect(filtersToQuery(SCHEMA, [])).toEqual({});
+  });
+});
+
+describe('queryToFilters', () => {
+  it('round-trips a single filter', () => {
+    expect(queryToFilters(SCHEMA, { user: 'alice' })).toEqual([
+      chip('User', 'alice'),
+    ]);
+  });
+
+  it('splits a comma list into one chip per value', () => {
+    expect(queryToFilters(SCHEMA, { status: 'RUNNING,STOPPED' })).toEqual([
+      chip('Status', 'RUNNING'),
+      chip('Status', 'STOPPED'),
+    ]);
+  });
+
+  it('reads a repeated key back as several chips', () => {
+    expect(queryToFilters(SCHEMA, { labels: ['team:ml', 'env:prod'] })).toEqual(
+      [chip('Labels', 'team:ml'), chip('Labels', 'env:prod')]
+    );
+  });
+
+  it('does not split a text value on commas', () => {
+    expect(queryToFilters(SCHEMA, { cluster: 'a,b' })).toEqual([
+      chip('Cluster', 'a,b'),
+    ]);
+  });
+
+  it('drops a key the schema does not know', () => {
+    expect(queryToFilters(SCHEMA, { bogus: 'x', user: 'alice' })).toEqual([
+      chip('User', 'alice'),
+    ]);
+  });
+
+  it('drops blank and whitespace-only values', () => {
+    expect(
+      queryToFilters(SCHEMA, { user: '', status: 'RUNNING, ,STOPPED' })
+    ).toEqual([chip('Status', 'RUNNING'), chip('Status', 'STOPPED')]);
+  });
+
+  it('survives a full round-trip', () => {
+    const filters = [
+      chip('Status', 'RUNNING'),
+      chip('Status', 'STOPPED'),
+      chip('User', 'alice'),
+      chip('Labels', 'team:ml'),
+    ];
+    expect(queryToFilters(SCHEMA, filtersToQuery(SCHEMA, filters))).toEqual(
+      filters
+    );
+  });
+});
+
+describe('legacy triple links', () => {
+  it('recognises a legacy URL', () => {
+    expect(hasLegacyFilters({ property: 'user' })).toBe(true);
+    expect(hasLegacyFilters({ user: 'alice' })).toBe(false);
+    expect(hasLegacyFilters({})).toBe(false);
+  });
+
+  it('translates a single triple', () => {
+    expect(
+      legacyFiltersToQuery(SCHEMA, {
+        property: 'user',
+        operator: ':',
+        value: 'alice',
+      })
+    ).toEqual({ user: 'alice' });
+  });
+
+  it('translates several triples, pairing arrays by index', () => {
+    expect(
+      legacyFiltersToQuery(SCHEMA, {
+        property: ['user', 'status'],
+        operator: [':', ':'],
+        value: ['alice', 'RUNNING'],
+      })
+    ).toEqual({ user: 'alice', status: 'RUNNING' });
+  });
+
+  it('collapses two legacy chips on one enum into a comma list', () => {
+    expect(
+      legacyFiltersToQuery(SCHEMA, {
+        property: ['status', 'status'],
+        operator: [':', ':'],
+        value: ['RUNNING', 'STOPPED'],
+      })
+    ).toEqual({ status: 'RUNNING,STOPPED' });
+  });
+
+  it('drops a legacy property the schema does not know', () => {
+    expect(
+      legacyFiltersToQuery(SCHEMA, {
+        property: ['bogus', 'user'],
+        operator: [':', ':'],
+        value: ['x', 'alice'],
+      })
+    ).toEqual({ user: 'alice' });
+  });
+
+  it('ignores the operator, which no UI could ever vary', () => {
+    expect(
+      legacyFiltersToQuery(SCHEMA, {
+        property: 'user',
+        operator: '=',
+        value: 'alice',
+      })
+    ).toEqual({ user: 'alice' });
+  });
+
+  it('strips the legacy keys and leaves the rest untouched', () => {
+    expect(
+      withoutLegacyKeys({
+        property: 'user',
+        operator: ':',
+        value: 'alice',
+        owner: 'all',
+      })
+    ).toEqual({ owner: 'all' });
+  });
+});
+
+describe('buildQueryString', () => {
+  it('keeps a comma readable instead of percent-encoding it', () => {
+    expect(buildQueryString({ status: 'RUNNING,STOPPED' })).toBe(
+      '?status=RUNNING,STOPPED'
+    );
+  });
+
+  it('encodes characters that would otherwise break the query', () => {
+    expect(buildQueryString({ user: 'a b&c=d' })).toBe('?user=a%20b%26c%3Dd');
+  });
+
+  it('repeats a key for array values', () => {
+    expect(buildQueryString({ labels: ['team:ml', 'env:prod'] })).toBe(
+      '?labels=team%3Aml&labels=env%3Aprod'
+    );
+  });
+
+  it('returns an empty string when nothing is set', () => {
+    expect(buildQueryString({})).toBe('');
+    expect(buildQueryString({ user: '' })).toBe('');
+  });
+});

--- a/sky/dashboard/src/hooks/useUrlFilterState.js
+++ b/sky/dashboard/src/hooks/useUrlFilterState.js
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  buildQueryString,
+  filtersToQuery,
+  hasLegacyFilters,
+  legacyFiltersToQuery,
+  queryToFilters,
+  withoutLegacyKeys,
+} from '@/components/shared/filterSchema';
+
+/**
+ * Keep a page's filter chips and view state in the URL, as named parameters.
+ *
+ * The URL is the source of truth on load, and is rewritten (never pushed) as
+ * the user filters, so a link can be shared or bookmarked but filtering does
+ * not fill the back button. A link still carrying the legacy
+ * `property`/`operator`/`value` triples is translated once on arrival and the
+ * address bar is rewritten to the named form.
+ *
+ * `filterSchema` describes the filterable properties; see filterSchema.js.
+ * `viewSchema` describes non-filter state that belongs in the URL too, as
+ * `{ key, default }` — anything equal to its default is left out of the URL.
+ *
+ * Writes go through `history.replaceState` rather than `router.replace` for
+ * the reason clusters.jsx and jobs.jsx already do it that way: a router write
+ * re-renders the page and cascades into the data hooks below it.
+ */
+export function useUrlFilterState(filterSchema, viewSchema = []) {
+  const router = useRouter();
+
+  const readQuery = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+    const params = new URLSearchParams(window.location.search);
+    const query = {};
+    for (const key of new Set(params.keys())) {
+      const all = params.getAll(key);
+      query[key] = all.length > 1 ? all : all[0];
+    }
+    return query;
+  }, []);
+
+  const readInitial = useCallback(() => {
+    const query = readQuery();
+    const named = hasLegacyFilters(query)
+      ? {
+          ...withoutLegacyKeys(query),
+          ...legacyFiltersToQuery(filterSchema, query),
+        }
+      : query;
+    const view = {};
+    for (const entry of viewSchema) {
+      // A view entry may declare `fromLegacy` to migrate an older spelling of
+      // itself -- e.g. the clusters page used to carry `history=true` plus a
+      // separate `historyDays=N`. It wins over the raw value, since the raw
+      // value is what it is migrating away from.
+      const migrated = entry.fromLegacy ? entry.fromLegacy(query) : undefined;
+      const raw = migrated !== undefined ? migrated : named[entry.key];
+      view[entry.key] = raw === undefined ? entry.default : String(raw);
+    }
+    return { filters: queryToFilters(filterSchema, named), view };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [readQuery]);
+
+  const initial = useRef(null);
+  if (initial.current === null) {
+    initial.current = readInitial();
+  }
+
+  const [filters, setFilters] = useState(initial.current.filters);
+  const [view, setViewState] = useState(initial.current.view);
+
+  // On a hard load Next.js hydrates before the query is parsed, so re-read once
+  // the router is ready. Only adopt what the URL says if it differs, so a user
+  // who filtered during hydration does not get reset.
+  const hydrated = useRef(false);
+  useEffect(() => {
+    if (!router.isReady || hydrated.current) {
+      return;
+    }
+    hydrated.current = true;
+    const next = readInitial();
+    if (
+      JSON.stringify(next.filters) !== JSON.stringify(initial.current.filters)
+    ) {
+      setFilters(next.filters);
+    }
+    if (JSON.stringify(next.view) !== JSON.stringify(initial.current.view)) {
+      setViewState(next.view);
+    }
+  }, [router.isReady, readInitial]);
+
+  // Mirror state into the address bar. Keys not owned by this hook (a plugin's
+  // own params, `tab`, ...) are preserved.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const owned = new Set([
+      ...filterSchema.map((e) => e.key),
+      ...viewSchema.map((e) => e.key),
+      ...viewSchema.flatMap((e) => e.legacyKeys || []),
+      'property',
+      'operator',
+      'value',
+    ]);
+    const current = readQuery();
+    const query = {};
+    for (const [key, value] of Object.entries(current)) {
+      if (!owned.has(key)) {
+        query[key] = value;
+      }
+    }
+    for (const entry of viewSchema) {
+      const value = view[entry.key];
+      if (value !== undefined && value !== null && value !== entry.default) {
+        query[entry.key] = String(value);
+      }
+    }
+    Object.assign(query, filtersToQuery(filterSchema, filters));
+
+    const search = buildQueryString(query);
+    const next = `${window.location.pathname}${search}${window.location.hash}`;
+    if (
+      next !==
+      `${window.location.pathname}${window.location.search}${window.location.hash}`
+    ) {
+      window.history.replaceState(null, '', next);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, view, readQuery]);
+
+  const setView = useCallback((key, value) => {
+    setViewState((prev) =>
+      prev[key] === value ? prev : { ...prev, [key]: value }
+    );
+  }, []);
+
+  return { filters, setFilters, view, setView };
+}

--- a/sky/dashboard/src/hooks/useUrlFilterState.js
+++ b/sky/dashboard/src/hooks/useUrlFilterState.js
@@ -127,7 +127,11 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
       next !==
       `${window.location.pathname}${window.location.search}${window.location.hash}`
     ) {
-      window.history.replaceState(null, '', next);
+      // Preserve the existing state: Next.js keeps its router entry there
+      // (`__N`, `key`, the resolved url), and replacing it with null makes a
+      // later popstate look like a non-Next navigation -- the address bar
+      // changes while the rendered page does not.
+      window.history.replaceState(window.history.state, '', next);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, view, readQuery]);

--- a/sky/dashboard/src/hooks/useUrlFilterState.js
+++ b/sky/dashboard/src/hooks/useUrlFilterState.js
@@ -66,7 +66,7 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
 
   const initial = useRef(null);
   if (initial.current === null) {
-    initial.current = readInitial();
+    initial.current = { ...readInitial(), query: readQuery() };
   }
 
   const [filters, setFilters] = useState(initial.current.filters);
@@ -138,5 +138,15 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
     );
   }, []);
 
-  return { filters, setFilters, view, setView };
+  // The query as it was on arrival, before this hook rewrote the address bar.
+  // Pages that need to know whether something was deep-linked must read this
+  // rather than `router.query`: the rewrite can land before Next parses the
+  // query on a statically exported page, and the two would disagree.
+  return {
+    filters,
+    setFilters,
+    view,
+    setView,
+    initialQuery: initial.current.query,
+  };
 }


### PR DESCRIPTION
## Problem

A filtered clusters view is encoded as three parallel arrays zipped by index. Two
chips produce six parameters:

```
/dashboard/clusters?property=user&property=status
                   &operator=%3A&operator=%3A
                   &value=alice&value=RUNNING
```

Nothing ties a chip's three parts together except position, the `operator` is
always `:` (no UI can vary it), and the result is unreadable in the chat message
or doc where such a link usually ends up.

Two values on the *same* property are worse than unreadable: `filterData` ANDs
every chip, so asking for RUNNING **or** STOPPED clusters returns nothing at all.

### Before

<!-- PASTE BEFORE SCREENSHOTS HERE -->
<!-- 1. User=alice  -> ?property=user&operator=%3A&value=alice -->

1. `User=alice  -> ?property=user&operator=%3A&value=alice`

http://100.86.230.128:46608/dashboard/clusters?property=user&operator=%3A&value=alice

<img width="3801" height="1143" alt="33199e5f2f140dc3c05659a5828edf02" src="https://github.com/user-attachments/assets/64e49873-b7c3-48fb-9393-36697e97f481" />



<!-- 2. + Status=RUNNING -> six params -->

2. `+ Status=RUNNING`

http://100.86.230.128:46608/dashboard/clusters?property=user&property=status&operator=%3A&operator=%3A&value=alice&value=RUNNING

<img width="3815" height="1100" alt="9ae880cccecd8e6770eff27871bcbbc2" src="https://github.com/user-attachments/assets/9aa74038-8aa8-4d4c-8a23-da529a8d0f38" />



<!-- 3. + Status=STOPPED -> three chips, "No active clusters" -->


3. `+ Status=STOPPED`

<img width="3824" height="1433" alt="5394e42344eec6f4b8cbcf5a97c55aba" src="https://github.com/user-attachments/assets/dcb11f6e-9b82-4e35-a066-28fcb4352a4d" />


## Change

```
/dashboard/clusters?user=alice&status=RUNNING
```

**One schema per page.** A page declares its filterable properties once — `key`,
`label`, `kind` — and that declaration drives the dropdown, the URL, and the chip
bar. The dropdown list is derived from it rather than maintained beside it, so a
property the page offers is by construction one it can read back.

```js
export const CLUSTER_FILTER_SCHEMA = [
  { key: 'status', label: 'Status', kind: 'enum', multi: true },
  { key: 'cluster', label: 'Cluster', kind: 'text' },
  ...
];
```

**Multi-value is a comma list.** `?status=RUNNING,STOPPED` means "match any of
these"; different properties still narrow each other. `filterData` now groups by
property — OR within a group, AND across groups — so the client agrees with what
the URL says. The comma is written literally rather than as `%2C`, which is the
whole point of naming the parameters.

**View state joins the scheme.** `history=true` plus a separate `historyDays=10`
collapse into `history=10d`.

**Old links keep working.** A URL still carrying the triples is translated on
arrival and the address bar is rewritten to the named form — including the
history pair — so the next copy of that link is the new one. The operator is
dropped in translation.

Also removes clusters' private copy of `filterData` in favour of the shared one.

### After

<!-- PASTE AFTER SCREENSHOTS HERE -->
<!-- 1. User=alice -> ?user=alice -->

1. User=alice -> ?user=alice

http://100.86.230.128:46608/dashboard/clusters?owner=all&user=alice

<img width="3831" height="1335" alt="b92caa4830efc26995382f0e60c86b1a" src="https://github.com/user-attachments/assets/a293dc31-1638-451a-8b1e-294df7d7a856" />


<!-- 2. + Status=RUNNING -> ?status=RUNNING&user=alice -->

2. + Status=RUNNING -> ?status=RUNNING&user=alice

http://100.86.230.128:46608/dashboard/clusters?owner=all&status=RUNNING&user=alice

<img width="3837" height="1209" alt="0f3446e79c5832a91e0ea5ff10daca2c" src="https://github.com/user-attachments/assets/ecdd7a69-e9da-4720-a96f-24af68931021" />

<!-- 3. + Status=STOPPED -> ?status=RUNNING,STOPPED&user=alice, 2 rows -->

3. + Status=STOPPED -> ?status=RUNNING,STOPPED&user=alice, 2 rows

http://100.86.230.128:46608/dashboard/clusters?owner=all&status=RUNNING,STOPPED&user=alice

<img width="3822" height="966" alt="06e397a47a8430d2a49ec85197dfd24e" src="https://github.com/user-attachments/assets/9c73867c-0528-42e5-a9f0-b6531da21811" />


<!-- 4. legacy link rewritten to ?owner=all&history=10d&status=RUNNING&user=alice -->

## What a link looks like

Every row below was driven through the UI on a local server with five seeded
clusters (alice: one RUNNING + one STOPPED; bob: two RUNNING; carol: one).

| What the user does | Before | After | Before still works? |
|---|---|---|---|
| Filter `User = alice` | `?property=user&operator=%3A&value=alice` | `?user=alice` | yes — 2 rows either way |
| Add `Status = RUNNING` | `?property=user&property=status&operator=%3A&operator=%3A&value=alice&value=RUNNING` | `?status=RUNNING&user=alice` | yes — 1 row either way |
| Add `Status = STOPPED` too | same shape, 6 params | `?status=RUNNING,STOPPED&user=alice` | **no** — before returns **0 rows** (the two statuses were AND-ed); after returns 2 |
| Filter by a second user | two `User` chips, URL keeps only the last | one `User` chip, URL matches the screen | **no** — before, the link showed a different set than the sender saw |
| History, 10-day window | `?history=true&historyDays=10` | `?history=10d` | yes — old form is translated on arrival |
| Two `Labels` chips | intersection | intersection (unchanged) | yes |
| Open an old triple link | — | rewritten in place to `?owner=all&history=10d&status=RUNNING&user=alice` | yes — page state identical |

The comma is written literally, not as `%2C`, so `?status=RUNNING,STOPPED` stays
readable in the chat message where such a link usually ends up.

## Verification

Local server, five seeded clusters (alice: one RUNNING + one STOPPED; bob: two;
carol: one), driven through the real UI:

| Step | URL | Rows |
|---|---|---|
| No filters | `?owner=all` | 5 |
| User = alice | `?owner=all&user=alice` | 2 |
| + Status = RUNNING | `?owner=all&status=RUNNING&user=alice` | 1 |
| + Status = STOPPED | `?owner=all&status=RUNNING,STOPPED&user=alice` | **2** (master: none) |
| Legacy triples + `history=true&historyDays=10` | rewritten to `?owner=all&history=10d&status=RUNNING&user=alice` | 1, History=All, 10-day window |

60 unit tests across the schema encoder, the legacy translation and the grouped
filtering. `npx jest` → 9 suites pass; `version-display` and `jobs.test.jsx` fail
identically on master without this change.

## Scope

Clusters only. Jobs, users, volumes, recipes and infra keep the triple encoding
until they adopt the same hook; the shared decoder still understands it, so
nothing breaks in the meantime. Sort, page and page size stay as they are on this
page — their state lives in the table component and wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
