### PR TITLE
[Slurm] Retry transiently missing jobs during status refresh

### DIFF
--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -49,6 +49,11 @@ def _sbatch_log_path(base_dir: str, job_id: str) -> str:
 
 
 POLL_INTERVAL_SECONDS = 2
+# A Slurm status query opens one SSH command per state, so keep this lower than
+# the Kubernetes equivalent. The retry is only used when an entire status
+# round returns no jobs and no stopped snapshot is found.
+_MAX_QUERY_INSTANCES_RETRIES = 2
+_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS = 0.5
 # Default KillWait is 30 seconds, so we add some buffer time here.
 _JOB_TERMINATION_TIMEOUT_SECONDS = 60
 # How long to give the batch script's TERM trap to run cleanup and exit
@@ -1284,7 +1289,7 @@ def query_instances(
     retry_if_missing: bool = False,
 ) -> Dict[str, Tuple[Optional[status_lib.ClusterStatus], Optional[str]]]:
     """See sky/provision/__init__.py"""
-    del cluster_name, retry_if_missing  # Unused for Slurm
+    del cluster_name  # Unused for Slurm
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
 
     client = _make_slurm_client(provider_config)
@@ -1306,57 +1311,77 @@ def query_instances(
         'node_fail': None,
     }
 
-    statuses: Dict[str, Tuple[Optional[status_lib.ClusterStatus],
-                              Optional[str]]] = {}
-    for state, sky_status in status_map.items():
-        jobs = client.query_jobs(
-            cluster_name_on_cloud,
-            [state],
-        )
+    attempts = 0
+    snapshot_checked = False
+    while True:
+        statuses: Dict[str, Tuple[Optional[status_lib.ClusterStatus],
+                                  Optional[str]]] = {}
+        found_any_job = False
+        for state, sky_status in status_map.items():
+            jobs = client.query_jobs(
+                cluster_name_on_cloud,
+                [state],
+            )
+            found_any_job = found_any_job or bool(jobs)
 
-        for job_id in jobs:
-            if state in ('pending', 'failed', 'node_fail', 'cancelled',
-                         'completed'):
-                reason = client.get_job_reason(job_id)
-                if non_terminated_only and sky_status is None:
-                    # TODO(kevin): For better UX, we should also find out
-                    # which node(s) exactly that failed if it's a node_fail
-                    # state.
-                    logger.debug(f'Job {job_id} is terminated, but '
-                                 'query_instances is called with '
-                                 f'non_terminated_only=True. State: {state}, '
-                                 f'Reason: {reason}')
-                    continue
-                statuses[job_id] = (sky_status, reason)
-            else:
-                nodes, _ = client.get_job_nodes(job_id)
-                for node in nodes:
-                    instance_id = slurm_utils.instance_id(job_id, node)
-                    statuses[instance_id] = (sky_status, None)
+            for job_id in jobs:
+                if state in ('pending', 'failed', 'node_fail', 'cancelled',
+                             'completed'):
+                    reason = client.get_job_reason(job_id)
+                    if non_terminated_only and sky_status is None:
+                        # TODO(kevin): For better UX, we should also find out
+                        # which node(s) exactly that failed if it's a node_fail
+                        # state.
+                        logger.debug(f'Job {job_id} is terminated, but '
+                                     'query_instances is called with '
+                                     f'non_terminated_only=True. State: '
+                                     f'{state}, Reason: {reason}')
+                        continue
+                    statuses[job_id] = (sky_status, reason)
+                else:
+                    nodes, _ = client.get_job_nodes(job_id)
+                    for node in nodes:
+                        instance_id = slurm_utils.instance_id(job_id, node)
+                        statuses[instance_id] = (sky_status, None)
 
-        # TODO(kevin): Query sacct too to get more historical job info.
-        # squeue only includes completed jobs that finished in the last
-        # MinJobAge seconds (default 300s). Or could be earlier if it
-        # reaches MaxJobCount first (default 10_000).
+            # TODO(kevin): Query sacct too to get more historical job info.
+            # squeue only includes completed jobs that finished in the last
+            # MinJobAge seconds (default 300s). Or could be earlier if it
+            # reaches MaxJobCount first (default 10_000).
 
-    non_terminated_statuses = {
-        instance_id: status_and_reason
-        for instance_id, status_and_reason in statuses.items()
-        if status_and_reason[0] is not None
-    }
-    if non_terminated_statuses:
-        return non_terminated_statuses
-    login_node_runner = _make_login_node_runner(provider_config)
-    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
-    snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
-    manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
-    if manifest is not None:
-        return {
-            f'snapshot-rank-{rank}': (status_lib.ClusterStatus.STOPPED, None)
-            for rank in range(len(manifest['nodes']))
+        non_terminated_statuses = {
+            instance_id: status_and_reason
+            for instance_id, status_and_reason in statuses.items()
+            if status_and_reason[0] is not None
         }
+        if non_terminated_statuses:
+            return non_terminated_statuses
 
-    return statuses
+        if not snapshot_checked:
+            # A snapshot is the stopped steady state. Check it before retrying
+            # so stopped clusters do not pay for additional Slurm queries.
+            login_node_runner = _make_login_node_runner(provider_config)
+            sky_base_dir = _resolve_sky_base_dir(client, provider_config)
+            snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+            manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
+            snapshot_checked = True
+            if manifest is not None:
+                return {
+                    f'snapshot-rank-{rank}':
+                    (status_lib.ClusterStatus.STOPPED, None)
+                    for rank in range(len(manifest['nodes']))
+                }
+
+        if (found_any_job or not retry_if_missing or
+                attempts >= _MAX_QUERY_INSTANCES_RETRIES):
+            return statuses
+
+        attempts += 1
+        logger.debug(
+            f'No Slurm jobs found for {cluster_name_on_cloud}; retrying '
+            f'{attempts}/{_MAX_QUERY_INSTANCES_RETRIES} after '
+            f'{_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS} seconds.')
+        time.sleep(_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS)
 
 
 def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1253,6 +1253,8 @@ class TestQueryInstances:
         manifest = _snapshot_manifest(num_nodes=2)
         read_manifest = mock.MagicMock(return_value=manifest)
         monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
         provider_config = {
             **_PROVIDER_CONFIG,
             'sky_base_dir': '/home/test',
@@ -1260,7 +1262,8 @@ class TestQueryInstances:
 
         statuses = instance.query_instances('test-cluster',
                                             _CLUSTER,
-                                            provider_config=provider_config)
+                                            provider_config=provider_config,
+                                            retry_if_missing=True)
 
         assert statuses == {
             'snapshot-rank-0':
@@ -1270,6 +1273,8 @@ class TestQueryInstances:
         }
         read_manifest.assert_called_once_with(
             login_runner, '/home/test/.sky_snapshots/test-cluster')
+        assert client.query_jobs.call_count == 7
+        sleep.assert_not_called()
         get_config.assert_not_called()
 
     def test_running_job_ignores_recent_terminal_allocation(self, monkeypatch):
@@ -1301,3 +1306,93 @@ class TestQueryInstances:
                 (instance.status_lib.ClusterStatus.UP, None)
         }
         read_manifest.assert_not_called()
+
+    def test_retries_missing_job(self, mock_client, monkeypatch):
+        running_queries = 0
+
+        def query_jobs(job_name, state_filters):
+            nonlocal running_queries
+            assert job_name == _CLUSTER
+            if state_filters == ['running']:
+                running_queries += 1
+                if running_queries == 2:
+                    return ['386700']
+            return []
+
+        mock_client.query_jobs.side_effect = query_jobs
+        mock_client.get_job_nodes.return_value = (['node-a'], None)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest',
+                            mock.MagicMock(return_value=None))
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=True)
+
+        assert result == {
+            'job386700-node-a': (instance.status_lib.ClusterStatus.UP, None)
+        }
+        assert running_queries == 2
+        sleep.assert_called_once_with(
+            instance._QUERY_INSTANCES_RETRY_INTERVAL_SECONDS)
+
+    def test_does_not_retry_when_terminal_job_is_found(self, mock_client,
+                                                       monkeypatch):
+
+        def query_jobs(job_name, state_filters):
+            assert job_name == _CLUSTER
+            if state_filters == ['completed']:
+                return ['386700']
+            return []
+
+        mock_client.query_jobs.side_effect = query_jobs
+        mock_client.get_job_reason.return_value = 'Completed'
+        read_manifest = mock.MagicMock(return_value=None)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=True)
+
+        assert not result
+        assert mock_client.query_jobs.call_count == 7
+        mock_client.get_job_reason.assert_called_once_with('386700')
+        read_manifest.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_does_not_retry_by_default(self, mock_client, monkeypatch):
+        mock_client.query_jobs.return_value = []
+        monkeypatch.setattr(instance, '_read_snapshot_manifest',
+                            mock.MagicMock(return_value=None))
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=False)
+
+        assert not result
+        assert mock_client.query_jobs.call_count == 7
+        sleep.assert_not_called()
+
+    def test_retry_exhaustion_returns_empty(self, mock_client, monkeypatch):
+        mock_client.query_jobs.return_value = []
+        read_manifest = mock.MagicMock(return_value=None)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+        monkeypatch.setattr(instance.time, 'sleep', mock.MagicMock())
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=True)
+
+        assert not result
+        expected_rounds = 1 + instance._MAX_QUERY_INSTANCES_RETRIES
+        assert mock_client.query_jobs.call_count == 7 * expected_rounds
+        read_manifest.assert_called_once()


### PR DESCRIPTION
## Summary

- honor `retry_if_missing` in the Slurm provisioner's `query_instances()`
- retry a completely empty Slurm status round before treating an allocation as terminated
- check the snapshot manifest before retrying so stopped clusters return immediately
- add regression coverage for recovery, terminal-only results, disabled retries, retry exhaustion, and stopped clusters

## Root cause

The observed incident started with a connection disruption to the Slurm cluster. During a status refresh around that disruption, SkyPilot observed no jobs and removed the local cluster metadata even though the Slurm allocation was still running. That left an orphaned allocation which could no longer be managed through `sky status`, `sky ssh`, or `sky down`.

The Slurm implementation accepted `retry_if_missing` but explicitly discarded it, so the first completely empty status round was treated as authoritative. Transport and `squeue` command failures already raise and are retried by `@common_utils.retry`; this change covers the separate case where the status commands complete but the round observes no jobs during a transient disruption. The available incident information does not identify why that round completed empty.

The retry count is intentionally lower than Kubernetes because one Slurm status round opens one SSH command per queried state. If any job is observed, including a terminal job, the result is not retried. A stopped snapshot is checked before retrying and returned immediately.

Fixes #10457.

## Test plan

- `PATH=.venv/bin:$PATH bash format.sh --files sky/provision/slurm/instance.py tests/unit_tests/test_sky/provision/slurm/test_instance.py`
  - YAPF and isort passed
  - mypy passed
  - pylint reported only warnings already present on `master`
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/unit_tests/test_sky/provision/slurm/test_instance.py`
  - passed
