### PR TITLE
[Dashboard] Name the managed-jobs filter params in the URL

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -229,6 +229,28 @@ const JOB_VIEW_SCHEMA = [
 
 const STATUS_GROUP_NAMES = Object.keys(statusGroups);
 
+const KNOWN_STATUSES = new Set([...PRIMARY_STATUSES, ...OTHER_STATUSES]);
+
+// Everything the status UI needs, derived from the single `status` param: a
+// group name, an explicit list of pills, or neither. Values we do not
+// recognise are dropped, the same way the filter decoders drop unknown
+// properties -- a hand-edited link must not leave the pill bar highlighting
+// a group that does not exist.
+export function deriveStatusView(statusParam) {
+  const value = statusParam || '';
+  const statusGroupName = STATUS_GROUP_NAMES.includes(value) ? value : null;
+  const selectedStatuses =
+    statusGroupName || !value
+      ? []
+      : value.split(',').filter((s) => KNOWN_STATUSES.has(s));
+  return {
+    statusGroupName,
+    selectedStatuses,
+    // Neither segment is highlighted while specific pills narrow the view.
+    activeTab: statusGroupName || (selectedStatuses.length > 0 ? null : 'all'),
+  };
+}
+
 const PROPERTY_OPTIONS = JOB_FILTER_SCHEMA.map(({ key, label }) => ({
   label,
   value: key,
@@ -570,15 +592,9 @@ export function ManagedJobsTable({
   // `view.status` is the single source of truth; the pill bar and the
   // Active/All segments are both views of it. A group name means the group.
   const statusParam = view.status || '';
-  const statusGroupName = STATUS_GROUP_NAMES.includes(statusParam)
-    ? statusParam
-    : null;
-  const selectedStatuses = React.useMemo(
-    () =>
-      statusGroupName || !statusParam
-        ? []
-        : statusParam.split(',').filter(Boolean),
-    [statusParam, statusGroupName]
+  const { statusGroupName, selectedStatuses, activeTab } = React.useMemo(
+    () => deriveStatusView(statusParam),
+    [statusParam]
   );
   const setSelectedStatuses = React.useCallback(
     (next) => setView('status', (next || []).join(',')),
@@ -590,8 +606,6 @@ export function ManagedJobsTable({
   const [controllerStopped, setControllerStopped] = useState(false);
   const [controllerLaunching, setControllerLaunching] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
-  // Neither segment is highlighted while specific pills narrow the view.
-  const activeTab = statusGroupName || (statusParam ? null : 'all');
   // Default to scoping the table to the current user's jobs. Flips to
   // 'all' when the user clicks the Everyone toggle, or implicitly when
   // they pick a different user via the FilterDropdown (explicit user

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -633,7 +633,10 @@ export function ManagedJobsTable({
       url.searchParams.delete('pageSize');
     }
     if (url.href !== window.location.href) {
-      window.history.replaceState(null, '', url.toString());
+      // Keep the existing state: Next.js keeps its router entry there
+      // (`__N`, `key`, the resolved url), and nulling it makes a later
+      // popstate change the address bar without re-rendering the page.
+      window.history.replaceState(window.history.state, '', url.toString());
     }
   }, [currentPage, pageSize]);
 

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -444,6 +444,7 @@ export function ManagedJobs() {
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}
             setFilters={setFilters}
+            addFilter={addFilter}
             onFilterAdd={trackNewFilter}
             placeholder="Filter jobs"
           />

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -86,11 +86,10 @@ import {
 import {
   FilterDropdown,
   Filters,
-  updateURLParams as sharedUpdateURLParams,
-  updateFiltersByURLParams as sharedUpdateFiltersByURLParams,
   buildFilterUrl,
   evaluateCondition,
 } from '@/components/shared/FilterSystem';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 import { trackJobAction, trackFilterUsed } from '@/lib/analytics';
 
 // Page-size ("rows per page") options for the managed jobs queue, and the
@@ -202,32 +201,51 @@ export function getAggregatedStatus(tasks) {
 // Define filter options for the filter dropdown
 // Name is first so it's the default when users open the dropdown —
 // users typically search by job name, not ID.
-const PROPERTY_OPTIONS = [
-  {
-    label: 'Name',
-    value: 'name',
-  },
-  {
-    label: 'ID',
-    value: 'id',
-  },
-  {
-    label: 'User',
-    value: 'user',
-  },
-  {
-    label: 'Workspace',
-    value: 'workspace',
-  },
-  {
-    label: 'Pool',
-    value: 'pool',
-  },
-  {
-    label: 'Labels',
-    value: 'labels',
-  },
+// The filterable properties of this page, declared once: `key` is what the URL
+// carries, `label` is display only and is what a chip stores in
+// `filter.property`. The dropdown is derived from this list, so a property the
+// page offers is by construction one it can read back.
+export const JOB_FILTER_SCHEMA = [
+  { key: 'name', label: 'Name', kind: 'text' },
+  { key: 'id', label: 'ID', kind: 'text' },
+  { key: 'user', label: 'User', kind: 'text' },
+  { key: 'workspace', label: 'Workspace', kind: 'text' },
+  { key: 'pool', label: 'Pool', kind: 'text' },
+  { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
 ];
+
+// Non-filter state that belongs in a shared link too.
+//
+// `status` is the single source of truth for which statuses the table shows,
+// and the pill bar plus the Active/All segments are two views of it:
+//   absent              -> every status ("All")
+//   'active'/'finished' -> that group, named rather than expanded so the link
+//                          stays short and keeps meaning the group
+//   'FAILED,CANCELLED'  -> exactly those, which is what clicking pills builds
+const JOB_VIEW_SCHEMA = [
+  { key: 'owner', default: 'mine' },
+  { key: 'status', default: '' },
+];
+
+const STATUS_GROUP_NAMES = Object.keys(statusGroups);
+
+const PROPERTY_OPTIONS = JOB_FILTER_SCHEMA.map(({ key, label }) => ({
+  label,
+  value: key,
+}));
+
+// Properties that may hold several chips; the rest replace, so the page can
+// never show more filters than the URL is able to carry.
+const MULTI_VALUE_LABELS = new Set(
+  JOB_FILTER_SCHEMA.filter((e) => e.multi).map((e) => e.label)
+);
+
+const addFilter = (prevFilters, property, value) => {
+  const base = MULTI_VALUE_LABELS.has(property)
+    ? prevFilters.filter((f) => !(f.property === property && f.value === value))
+    : prevFilters.filter((f) => f.property !== property);
+  return [...base, { property, operator: ':', value }];
+};
 
 // Helper function to filter jobs by name
 export function filterJobsByName(jobs, nameFilter) {
@@ -306,7 +324,11 @@ export function ManagedJobs() {
   const jobsRefreshRef = React.useRef(null);
   const poolsRefreshRef = React.useRef(null);
   const [poolsData, setPoolsData] = useState([]);
-  const [filters, setFilters] = useState([]);
+  // Filters and the shareable view state both live in the URL, keyed by name.
+  const { filters, setFilters, view, setView } = useUrlFilterState(
+    JOB_FILTER_SCHEMA,
+    JOB_VIEW_SCHEMA
+  );
   const [valueList, setValueList] = useState({
     name: [],
     user: [],
@@ -382,11 +404,6 @@ export function ManagedJobs() {
     });
   };
 
-  // Helper function to update URL query parameters
-  const updateURLParams = (filters) => {
-    sharedUpdateURLParams(router, filters);
-  };
-
   // Track only the newly added filter (called from FilterDropdown callbacks)
   const trackNewFilter = (property, value) => {
     trackFilterUsed('job', { property, value });
@@ -398,42 +415,11 @@ export function ManagedJobs() {
   const handleUserFilterClick = React.useCallback(
     (username) => {
       if (!username) return;
-      setFilters((prevFilters) => {
-        const withoutUser = prevFilters.filter(
-          (f) => (f.property || '').toLowerCase() !== 'user'
-        );
-        const updatedFilters = [
-          ...withoutUser,
-          { property: 'User', operator: ':', value: username },
-        ];
-        sharedUpdateURLParams(router, updatedFilters);
-        return updatedFilters;
-      });
+      setFilters((prevFilters) => addFilter(prevFilters, 'User', username));
       trackFilterUsed('job', { property: 'User', value: username });
     },
-    [router]
+    [setFilters]
   );
-
-  const updateFiltersByURLParams = React.useCallback(() => {
-    const propertyMap = new Map();
-    propertyMap.set('id', 'ID');
-    propertyMap.set('status', 'Status');
-    propertyMap.set('name', 'Name');
-    propertyMap.set('user', 'User');
-    propertyMap.set('workspace', 'Workspace');
-    propertyMap.set('pool', 'Pool');
-    propertyMap.set('labels', 'Labels');
-
-    const urlFilters = sharedUpdateFiltersByURLParams(router, propertyMap);
-    setFilters(urlFilters);
-  }, [router, setFilters]);
-
-  // Handle URL query parameters for tab selection and filters
-  useEffect(() => {
-    if (router.isReady) {
-      updateFiltersByURLParams();
-    }
-  }, [router.isReady, router.query.tab, updateFiltersByURLParams]);
 
   return (
     <>
@@ -458,24 +444,21 @@ export function ManagedJobs() {
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}
             setFilters={setFilters}
-            updateURLParams={updateURLParams}
             onFilterAdd={trackNewFilter}
             placeholder="Filter jobs"
           />
         </div>
       </div>
 
-      <Filters
-        filters={filters}
-        setFilters={setFilters}
-        updateURLParams={updateURLParams}
-      />
+      <Filters filters={filters} setFilters={setFilters} />
 
       <ManagedJobsTable
         refreshInterval={REFRESH_INTERVAL}
         setLoading={setLoading}
         refreshDataRef={jobsRefreshRef}
         filters={filters}
+        view={view}
+        setView={setView}
         onUserFilter={handleUserFilterClick}
         onRefresh={handleRefresh}
         poolsData={poolsData}
@@ -538,6 +521,8 @@ export function ManagedJobsTable({
   setLoading,
   refreshDataRef,
   filters,
+  view,
+  setView,
   onUserFilter,
   onRefresh,
   poolsData,
@@ -581,20 +566,40 @@ export function ManagedJobsTable({
   const [expandedRowId, setExpandedRowId] = useState(null);
   const expandedRowRef = useRef(null);
   const [expandedJobGroups, setExpandedJobGroups] = useState(new Set());
-  const [selectedStatuses, setSelectedStatuses] = useState([]);
+  // `view.status` is the single source of truth; the pill bar and the
+  // Active/All segments are both views of it. A group name means the group.
+  const statusParam = view.status || '';
+  const statusGroupName = STATUS_GROUP_NAMES.includes(statusParam)
+    ? statusParam
+    : null;
+  const selectedStatuses = React.useMemo(
+    () =>
+      statusGroupName || !statusParam
+        ? []
+        : statusParam.split(',').filter(Boolean),
+    [statusParam, statusGroupName]
+  );
+  const setSelectedStatuses = React.useCallback(
+    (next) => setView('status', (next || []).join(',')),
+    [setView]
+  );
   const [statusCounts, setStatusCounts] = useState({});
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const moreMenuRef = useRef(null);
   const [controllerStopped, setControllerStopped] = useState(false);
   const [controllerLaunching, setControllerLaunching] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
-  const [activeTab, setActiveTab] = useState('all');
-  const [showAllMode, setShowAllMode] = useState(true);
+  // Neither segment is highlighted while specific pills narrow the view.
+  const activeTab = statusGroupName || (statusParam ? null : 'all');
   // Default to scoping the table to the current user's jobs. Flips to
   // 'all' when the user clicks the Everyone toggle, or implicitly when
   // they pick a different user via the FilterDropdown (explicit user
   // filter wins; see effectiveUserMatch in fetchData).
-  const [userScope, setUserScope] = useState('mine');
+  const userScope = view.owner || 'mine';
+  const setUserScope = React.useCallback(
+    (scope) => setView('owner', scope),
+    [setView]
+  );
   const [currentUser, setCurrentUser] = useState(null);
   // True once the /users/role lookup has resolved (with a real user, with
   // the 'local'/anonymous sentinel, or by erroring out). Used to gate the
@@ -638,27 +643,12 @@ export function ManagedJobsTable({
   const [totalNoFilter, setTotalNoFilter] = useState(0);
   const [hookControllerStopped, setHookControllerStopped] = useState(false);
 
-  // Compute statuses based on UI state for filtering
-  const computedStatuses = React.useMemo(() => {
-    // If specific statuses are selected, use those
-    if (selectedStatuses.length > 0) {
-      return selectedStatuses;
-    }
-    // If not in "show all" mode but no specific statuses selected, show no jobs
-    if (!showAllMode) {
-      return [];
-    }
-    // Show all active jobs
-    if (activeTab === 'active') {
-      return statusGroups.active;
-    }
-    // Show all finished jobs
-    if (activeTab === 'finished') {
-      return statusGroups.finished;
-    }
-    // For activeTab === 'all' and showAllMode === true, show all jobs
-    return [];
-  }, [selectedStatuses, showAllMode, activeTab]);
+  // An empty list means "every status", which is what the server treats a
+  // missing `statuses` param as.
+  const computedStatuses = React.useMemo(
+    () => (statusGroupName ? statusGroups[statusGroupName] : selectedStatuses),
+    [statusGroupName, selectedStatuses]
+  );
 
   // Convert sortConfig to API format
   const sortBy = React.useMemo(
@@ -934,13 +924,13 @@ export function ManagedJobsTable({
     }
   }, [filters, pageSize, fetchData, preloadingComplete]);
 
-  // Fetch on status filter changes (activeTab, selectedStatuses, showAllMode)
-  // Skip on initial fetch (these have default values)
+  // Fetch when the status selection changes.
+  // Skip on initial fetch (it has a default value)
   React.useEffect(() => {
     if (!isInitialFetch.current && preloadingComplete) {
       fetchData({ includeStatus: true });
     }
-  }, [activeTab, selectedStatuses, showAllMode, fetchData, preloadingComplete]);
+  }, [statusParam, fetchData, preloadingComplete]);
 
   // Fetch on sort config changes for server-side sorting
   // Skip on initial fetch (sortConfig has default value)
@@ -997,24 +987,20 @@ export function ManagedJobsTable({
     setCurrentPage(1);
   }, [activeTab, filters, pageSize, sortConfig]);
 
-  // Reset status filter when activeTab changes
-  useEffect(() => {
-    setSelectedStatuses([]);
-    setShowAllMode(true); // Default to show all mode when changing tabs
-  }, [activeTab]);
-
   // Switch ownership scope (My Jobs vs All Jobs). Resets status narrowing
   // so a status chip selected in one scope (e.g. RUNNING in My Jobs)
   // doesn't carry over and silently empty the table under the new scope.
   // Leaves `activeTab` alone — Active/All is orthogonal to ownership.
-  const selectScope = React.useCallback((scope) => {
-    React.startTransition(() => {
-      setUserScope(scope);
-      setSelectedStatuses([]);
-      setShowAllMode(true);
-      setCurrentPage(1);
-    });
-  }, []);
+  const selectScope = React.useCallback(
+    (scope) => {
+      React.startTransition(() => {
+        setUserScope(scope);
+        setSelectedStatuses([]);
+        setCurrentPage(1);
+      });
+    },
+    [setUserScope, setSelectedStatuses]
+  );
 
   // Populate valueList for filter dropdown
   useEffect(() => {
@@ -1325,6 +1311,8 @@ export function ManagedJobsTable({
     return () => {
       cancelled = true;
     };
+    // Runs once on mount; setUserScope is stable via useCallback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // When the Mine view comes up empty, fire a one-shot probe for the
@@ -1396,31 +1384,13 @@ export function ManagedJobsTable({
     return () => document.removeEventListener('mousedown', onPointerDown);
   }, [moreMenuOpen]);
 
-  // Handle status selection
+  // Toggle one status. Clicking a pill while a group is selected narrows to
+  // exactly that status; deselecting the last one returns to every status.
   const handleStatusClick = (status) => {
-    // Toggle the clicked status without affecting others
-    if (selectedStatuses.includes(status)) {
-      // If the status is already selected, unselect it
-      const newSelectedStatuses = selectedStatuses.filter((s) => s !== status);
-
-      if (newSelectedStatuses.length === 0) {
-        // When deselecting the last selected status, go back to "show all" mode
-        // for the current active tab (active/finished)
-        setShowAllMode(true);
-        setSelectedStatuses([]);
-      } else {
-        setSelectedStatuses(newSelectedStatuses);
-        // We're not in "show all" mode if there are specific statuses selected
-        setShowAllMode(false);
-      }
-    } else {
-      // Add the clicked status to the selected statuses
-      setSelectedStatuses([...selectedStatuses, status]);
-      // We're not in "show all" mode if there are specific statuses selected
-      setShowAllMode(false);
-    }
-
-    // Reset to first page when changing status filters
+    const next = selectedStatuses.includes(status)
+      ? selectedStatuses.filter((s) => s !== status)
+      : [...selectedStatuses, status];
+    setSelectedStatuses(next);
     setCurrentPage(1);
   };
 
@@ -2195,15 +2165,15 @@ export function ManagedJobsTable({
               {(() => {
                 const selectTab = (tab) => {
                   React.startTransition(() => {
-                    setActiveTab(tab);
-                    setSelectedStatuses([]);
-                    setShowAllMode(true);
+                    // 'all' is the default and stays out of the URL; a group
+                    // is named rather than expanded.
+                    setView('status', tab === 'all' ? '' : tab);
                     setCurrentPage(1);
                   });
                 };
-                // Neither segment is highlighted while a status chip
-                // narrows the view (showAllMode=false).
-                const activityValue = showAllMode ? activeTab : null;
+                // Neither segment is highlighted while specific pills narrow
+                // the view.
+                const activityValue = activeTab;
                 return (
                   <SegmentedToggle
                     ariaLabel="Filter jobs by activity"
@@ -2506,7 +2476,6 @@ export function ManagedJobsTable({
                         (userScope === 'mine' &&
                         currentUser &&
                         activeTab === 'all' &&
-                        showAllMode &&
                         everyoneTotal > 0 ? (
                           <div className="flex flex-col items-center space-y-2 max-w-md">
                             <p className="text-gray-700">
@@ -2524,7 +2493,6 @@ export function ManagedJobsTable({
                                 React.startTransition(() => {
                                   setUserScope('all');
                                   setSelectedStatuses([]);
-                                  setShowAllMode(true);
                                   setCurrentPage(1);
                                 });
                               }}

--- a/sky/dashboard/src/components/jobs.statusview.test.jsx
+++ b/sky/dashboard/src/components/jobs.statusview.test.jsx
@@ -1,0 +1,63 @@
+// `data/connectors/jobs` imports the plugin data-enhancement module, which
+// imports back into it through the cache preloader. Loading that cycle from a
+// test entry point hits the temporal-dead-zone error that already breaks
+// `data/connectors/jobs.test.jsx`; the pure function under test needs none of
+// it, so cut the edge here.
+jest.mock('@/plugins/dataEnhancement', () => ({
+  applyEnhancements: async (data) => data,
+}));
+
+import { deriveStatusView, statusGroups } from '@/components/jobs';
+
+// The Managed Jobs page keeps its whole status UI -- the Active/All segments
+// and the pill bar -- in one `status` query param. These cover the values a
+// hand-edited or stale link can carry, because an unrecognised one used to
+// leave `activeTab` pointing at a group that does not exist and crashed the
+// page on render.
+describe('deriveStatusView', () => {
+  it('treats a missing status as "every status", with All highlighted', () => {
+    expect(deriveStatusView('')).toEqual({
+      statusGroupName: null,
+      selectedStatuses: [],
+      activeTab: 'all',
+    });
+    expect(deriveStatusView(undefined).activeTab).toBe('all');
+  });
+
+  it('recognises a group name and highlights that segment', () => {
+    expect(deriveStatusView('active')).toEqual({
+      statusGroupName: 'active',
+      selectedStatuses: [],
+      activeTab: 'active',
+    });
+    expect(deriveStatusView('finished').statusGroupName).toBe('finished');
+  });
+
+  it('reads a comma list as pills, with neither segment highlighted', () => {
+    expect(deriveStatusView('RUNNING,SUCCEEDED')).toEqual({
+      statusGroupName: null,
+      selectedStatuses: ['RUNNING', 'SUCCEEDED'],
+      activeTab: null,
+    });
+  });
+
+  it('drops values that name no known status', () => {
+    expect(deriveStatusView('RUNNINGG')).toEqual({
+      statusGroupName: null,
+      selectedStatuses: [],
+      activeTab: 'all',
+    });
+    expect(deriveStatusView('RUNNING,RUNNINGG').selectedStatuses).toEqual([
+      'RUNNING',
+    ]);
+  });
+
+  it('never leaves activeTab naming a group that does not exist', () => {
+    // `?status=,` is the minimal reproduction: truthy param, no usable
+    // statuses. `statusGroups[activeTab]` must stay dereferenceable.
+    for (const value of [',', ',,', ' ', 'ACTIVE', 'RUNNINGG']) {
+      const { activeTab } = deriveStatusView(value);
+      expect(activeTab === 'all' || statusGroups[activeTab]).toBeTruthy();
+    }
+  });
+});

--- a/sky/dashboard/src/components/shared/FilterDropdown.test.jsx
+++ b/sky/dashboard/src/components/shared/FilterDropdown.test.jsx
@@ -1,0 +1,122 @@
+/**
+ * Contract tests for the shared filter widgets.
+ *
+ * These exist because a page removed the `updateURLParams` prop while the
+ * shared components still called it unconditionally: every add/remove/clear
+ * threw `TypeError: updateURLParams is not a function` and took the page down
+ * with it. Lint and `next build` cannot see that -- a missing prop is a
+ * runtime fact -- so the guard has to be a rendered interaction.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FilterDropdown, Filters } from '@/components/shared/FilterSystem';
+
+const PROPERTIES = [
+  { label: 'Name', value: 'name' },
+  { label: 'User', value: 'user' },
+];
+
+const typeAndEnter = (text) => {
+  const input = screen.getByPlaceholderText('Filter items');
+  fireEvent.change(input, { target: { value: text } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+};
+
+describe('FilterDropdown without an updateURLParams prop', () => {
+  it('adds a filter instead of throwing', () => {
+    let filters = [];
+    const setFilters = (updater) => {
+      filters = typeof updater === 'function' ? updater(filters) : updater;
+    };
+
+    render(
+      <FilterDropdown
+        propertyList={PROPERTIES}
+        valueList={{ name: [], user: [] }}
+        setFilters={setFilters}
+      />
+    );
+
+    expect(() => typeAndEnter('alice')).not.toThrow();
+    expect(filters).toEqual([
+      { property: 'Name', operator: ':', value: 'alice' },
+    ]);
+  });
+
+  it('routes the addition through a page-supplied addFilter', () => {
+    // A page whose URL carries one value per property replaces rather than
+    // stacks, so the chips can never say more than the address bar does.
+    const addFilter = (prev, property, value) => [
+      ...prev.filter((f) => f.property !== property),
+      { property, operator: ':', value },
+    ];
+    let filters = [{ property: 'Name', operator: ':', value: 'alice' }];
+    const setFilters = (updater) => {
+      filters = typeof updater === 'function' ? updater(filters) : updater;
+    };
+
+    render(
+      <FilterDropdown
+        propertyList={PROPERTIES}
+        valueList={{ name: [], user: [] }}
+        setFilters={setFilters}
+        addFilter={addFilter}
+      />
+    );
+
+    typeAndEnter('bob');
+    expect(filters).toEqual([
+      { property: 'Name', operator: ':', value: 'bob' },
+    ]);
+  });
+
+  it('still calls updateURLParams when a page passes one', () => {
+    const updateURLParams = jest.fn();
+    render(
+      <FilterDropdown
+        propertyList={PROPERTIES}
+        valueList={{ name: [], user: [] }}
+        setFilters={(u) => (typeof u === 'function' ? u([]) : u)}
+        updateURLParams={updateURLParams}
+      />
+    );
+
+    typeAndEnter('alice');
+    expect(updateURLParams).toHaveBeenCalledWith([
+      { property: 'Name', operator: ':', value: 'alice' },
+    ]);
+  });
+});
+
+describe('Filters chip bar without an updateURLParams prop', () => {
+  const chips = [
+    { property: 'Name', operator: ':', value: 'alice' },
+    { property: 'User', operator: ':', value: 'bob' },
+  ];
+
+  it('removes one chip instead of throwing', () => {
+    let filters = chips;
+    const setFilters = (updater) => {
+      filters = typeof updater === 'function' ? updater(filters) : updater;
+    };
+
+    render(<Filters filters={chips} setFilters={setFilters} />);
+    const [firstRemove] = screen.getAllByTitle('Clear filter');
+    expect(() => fireEvent.click(firstRemove)).not.toThrow();
+    expect(filters).toEqual([chips[1]]);
+  });
+
+  it('clears every chip instead of throwing', () => {
+    let filters = chips;
+    const setFilters = (updater) => {
+      filters = typeof updater === 'function' ? updater(filters) : updater;
+    };
+
+    render(<Filters filters={chips} setFilters={setFilters} />);
+    expect(() =>
+      fireEvent.click(screen.getByText('Clear filters'))
+    ).not.toThrow();
+    expect(filters).toEqual([]);
+  });
+});

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -182,8 +182,15 @@ export const FilterDropdown = ({
   propertyList = [],
   valueList,
   setFilters,
+  // Optional: pages that mirror filter state into the URL themselves (via
+  // useUrlFilterState) pass neither of these.
   updateURLParams,
   onFilterAdd,
+  // Optional: how a chip joins the existing ones. Defaults to appending, which
+  // is what pages without a filter schema expect. A page whose URL can only
+  // carry one value per property passes a helper that replaces instead, so the
+  // chips and the address bar cannot disagree.
+  addFilter,
   placeholder = 'Filter items',
 }) => {
   const inputRef = useRef(null);
@@ -271,16 +278,11 @@ export const FilterDropdown = ({
   const handleOptionSelect = (option) => {
     const property = getPropertyLabel(propertyValue);
     setFilters((prevFilters) => {
-      const updatedFilters = [
-        ...prevFilters,
-        {
-          property,
-          operator: ':',
-          value: option,
-        },
-      ];
+      const updatedFilters = addFilter
+        ? addFilter(prevFilters, property, option)
+        : [...prevFilters, { property, operator: ':', value: option }];
 
-      updateURLParams(updatedFilters);
+      updateURLParams?.(updatedFilters);
       return updatedFilters;
     });
     if (onFilterAdd) onFilterAdd(property, option);
@@ -293,16 +295,11 @@ export const FilterDropdown = ({
     if (e.key === 'Enter' && value.trim() !== '') {
       const property = getPropertyLabel(propertyValue);
       setFilters((prevFilters) => {
-        const updatedFilters = [
-          ...prevFilters,
-          {
-            property,
-            operator: ':',
-            value: value,
-          },
-        ];
+        const updatedFilters = addFilter
+          ? addFilter(prevFilters, property, value)
+          : [...prevFilters, { property, operator: ':', value }];
 
-        updateURLParams(updatedFilters);
+        updateURLParams?.(updatedFilters);
         return updatedFilters;
       });
       if (onFilterAdd) onFilterAdd(property, value);
@@ -410,14 +407,14 @@ export const Filters = ({ filters = [], setFilters, updateURLParams }) => {
         (_, _index) => _index !== index
       );
 
-      updateURLParams(updatedFilters);
+      updateURLParams?.(updatedFilters);
 
       return updatedFilters;
     });
   };
 
   const clearFilters = () => {
-    updateURLParams([]);
+    updateURLParams?.([]);
     setFilters([]);
   };
 

--- a/sky/dashboard/src/hooks/useUrlFilterState.js
+++ b/sky/dashboard/src/hooks/useUrlFilterState.js
@@ -72,25 +72,32 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
   const [filters, setFilters] = useState(initial.current.filters);
   const [view, setViewState] = useState(initial.current.view);
 
-  // On a hard load Next.js hydrates before the query is parsed, so re-read once
-  // the router is ready. Only adopt what the URL says if it differs, so a user
-  // who filtered during hydration does not get reset.
-  const hydrated = useRef(false);
+  // Adopt the query whenever it changes from outside this hook. Two cases:
+  // a hard load, where a statically exported page hydrates before Next parses
+  // the query; and a same-route navigation carrying filters, e.g. a link built
+  // by `buildFilterUrl` pointing back at the page it is rendered on.
+  //
+  // Writes this hook makes go through `history.replaceState`, which leaves
+  // `router.asPath` alone, so remembering what we last wrote is what tells our
+  // own writes apart from someone else's navigation.
+  const lastWritten = useRef(null);
   useEffect(() => {
-    if (!router.isReady || hydrated.current) {
+    if (!router.isReady || typeof window === 'undefined') {
       return;
     }
-    hydrated.current = true;
+    if (window.location.search === lastWritten.current) {
+      return;
+    }
     const next = readInitial();
-    if (
-      JSON.stringify(next.filters) !== JSON.stringify(initial.current.filters)
-    ) {
-      setFilters(next.filters);
-    }
-    if (JSON.stringify(next.view) !== JSON.stringify(initial.current.view)) {
-      setViewState(next.view);
-    }
-  }, [router.isReady, readInitial]);
+    setFilters((prev) =>
+      JSON.stringify(prev) === JSON.stringify(next.filters)
+        ? prev
+        : next.filters
+    );
+    setViewState((prev) =>
+      JSON.stringify(prev) === JSON.stringify(next.view) ? prev : next.view
+    );
+  }, [router.isReady, router.asPath, readInitial]);
 
   // Mirror state into the address bar. Keys not owned by this hook (a plugin's
   // own params, `tab`, ...) are preserved.
@@ -122,6 +129,10 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
     Object.assign(query, filtersToQuery(filterSchema, filters));
 
     const search = buildQueryString(query);
+    // Record it either way: when the URL already matches, our state and the
+    // address bar agree, and the adopt-external effect must not treat that as
+    // someone else's navigation.
+    lastWritten.current = search;
     const next = `${window.location.pathname}${search}${window.location.hash}`;
     if (
       next !==


### PR DESCRIPTION
> Builds on the hook and schema from #10455, now merged — this PR is one file (`jobs.jsx`).

## Problem

The jobs page kept its most-used filter entirely out of the URL. Clicking
**Active**, then **RUNNING**, then **SUCCEEDED** produces three different views
and leaves the address bar at `/dashboard/jobs` throughout — so "hey, look at all
the failed jobs here: …" is a link that shows the recipient the default page.

The chip filters were in the URL, but as positional triples
(`?property=user&operator=%3A&value=alice`).

## What a link looks like

Driven through the UI on a local server with twelve seeded managed jobs across
six statuses and three users. **Row counts are identical at every step — only the
URL changes.**

| What the user does | Before | After | Rows |
|---|---|---|---|
| Open the page | `/dashboard/jobs` | `?owner=all` | 10 |
| Click **Active** | `/dashboard/jobs` — unchanged | `?owner=all&status=active` | 6 |
| Click the **RUNNING** pill | `/dashboard/jobs` — unchanged | `?owner=all&status=RUNNING` | 4 |
| Also click **SUCCEEDED** | `/dashboard/jobs` — unchanged | `?owner=all&status=RUNNING,SUCCEEDED` | 6 |
| Filter `User = alice` | `?property=user&operator=%3A&value=alice` | `?user=alice` | — |
| Open `?owner=all&status=FAILED,CANCELLED` | not expressible | opens on exactly those jobs | 4 |

That last row is the ticket's original ask, and it is the one that could not be
built at all before.

### Before

<!-- PASTE BEFORE SCREENSHOTS HERE -->
<!-- 1. initial: /dashboard/jobs, 6 rows -->

1. initial: /dashboard/jobs, 6 rows  `http://100.86.230.128:46621/dashboard/jobs`

<img width="3024" height="1810" alt="image" src="https://github.com/user-attachments/assets/01a99785-14d7-4d4d-8160-c637cc883239" />


<!-- 2. Active: 3 rows, address bar STILL empty -->

2. Active: 3 rows, address bar STILL empty `http://100.86.230.128:46621/dashboard/jobs`

<img width="3024" height="1818" alt="image" src="https://github.com/user-attachments/assets/5b56ba48-62a6-4a9b-8fea-db985b316d54" />


<!-- 3. RUNNING pill: 2 rows, address bar STILL empty -->

3. RUNNING pill: 2 rows, address bar STILL empty `http://100.86.230.128:46621/dashboard/jobs`

<img width="3014" height="1776" alt="image" src="https://github.com/user-attachments/assets/e28a295e-a644-456b-956a-2f8c0dad2499" />


<!-- 4. + SUCCEEDED pill: 3 rows, address bar STILL empty -->

4. + SUCCEEDED pill: 3 rows, address bar STILL empty `http://100.86.230.128:46621/dashboard/jobs`

<img width="3014" height="1382" alt="image" src="https://github.com/user-attachments/assets/295aaab8-a917-4390-bc96-0b47ed214696" />



### After

<!-- PASTE AFTER SCREENSHOTS HERE -->
<!-- 1. ?owner=all -->

1. initial: /dashboard/jobs, 10 rows  `http://100.86.230.128:46623/dashboard/jobs?owner=all`

<img width="3008" height="1816" alt="image" src="https://github.com/user-attachments/assets/f19bf333-51f4-42d4-bf9e-2b4e84c6dfc1" />

<!-- 2. ?owner=all&status=active -->

2. Active: 3 rows `http://100.86.230.128:46623/dashboard/jobs?owner=all&status=active`

<img width="3022" height="1536" alt="image" src="https://github.com/user-attachments/assets/e69eeee7-8649-485a-b6f4-4d8a64cf9f8b" />


<!-- 3. ?owner=all&status=RUNNING -->

3. RUNNING pill: 2 rows, address bar STILL empty `http://100.86.230.128:46623/dashboard/jobs?owner=all&status=RUNNING`

<img width="3024" height="1328" alt="image" src="https://github.com/user-attachments/assets/cc866e2c-79af-4d4e-b500-7f728b9f59dc" />


<!-- 4. ?owner=all&status=RUNNING,SUCCEEDED -->

4. + SUCCEEDED pill: 3 rows, `http://100.86.230.128:46623/dashboard/jobs?owner=all&status=RUNNING,SUCCEEDED`

<img width="3024" height="1462" alt="image" src="https://github.com/user-attachments/assets/f5338fff-72e4-4736-b097-c44f2bdac46c" />


<!-- 5. pasting ?owner=all&status=FAILED,CANCELLED opens on those 4 jobs -->

## Change

`status` becomes the single source of truth for which statuses the table shows;
the pill bar and the Active/All segments are two views of it:

```
absent               every status
active / finished    that group, named rather than expanded, so the link stays
                     short and keeps meaning "the active ones" rather than
                     freezing today's membership of the group
FAILED,CANCELLED     exactly those, which is what clicking pills builds
```

This retires `showAllMode`, which existed only to mark "a pill narrowed the view,
so highlight neither segment" — now derivable from `status` itself. Its other
documented state ("show no jobs") was unreachable: deselecting the last pill
always reset it.

`owner` (My Jobs / All Jobs) joins the same scheme, and clicking a user in the
table replaces rather than stacks a `User` chip, so the page cannot show more
filters than a link is able to carry.

One deliberate behaviour change falls out of this. Deselecting the last pill
clears `status`, which means every status. On master it restored `activeTab`,
which defaults to `'all'` — so the common flow (arrive, click RUNNING, click it
again) is unchanged, but a user who first clicked **Active** now widens to every
status instead of returning to Active. Recovering that needs the group and the
pills to be separate pieces of state, which is what the URL is replacing; and it
is not silent — the **All** segment lights up as the finished jobs appear.

A `status` value the page cannot interpret is ignored rather than trusted, the
same way the filter decoders already drop unknown properties: unknown status
names are filtered out, and the tab falls back to **All** whenever no pill
narrows the view. Without that, `?status=,` rendered an error page and
`?status=RUNNINGG` drew a fake zero-count status chip.

Sort, page and page size stay as they are, matching #10455: their state lives in
the table component and wants its own change.

## Verification

Statuses reach the server through the existing `statuses` parameter, which this
PR does not change: it only changes how the same list is spelled in the address
bar. Checked on a running server that each link in the table above returns the
rows it names, including `?owner=all&status=FAILED,CANCELLED` arriving cold in a
fresh tab.

Two new suites cover the paths that had none, and both fail against the previous
code:

- `shared/FilterDropdown.test.jsx` drives chip add / remove / clear through the
  real components. These widgets take the URL writer as an optional prop, and
  calling it unconditionally crashed every page that does not pass one.
- `jobs.statusview.test.jsx` covers the `status` values a hand-edited or stale
  link can carry, and asserts the invariant that the activity tab is either
  `all` or a key that exists in `statusGroups`.

`npx jest` → 11 suites pass. `version-display` and `jobs.test.jsx` fail identically
on master without this change; the latter is a module cycle between
`data/connectors/jobs` and `plugins/dataEnhancement`, which is also why the new
jobs test has to cut that edge with `jest.mock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


