### PR TITLE
[Kubernetes] Bound the wait for pods to run, and say why a pod went missing

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -113,6 +113,30 @@ _MOUNT_FAILURE_EVENT_REASONS = ('FailedMount', 'FailedAttachVolume')
 # deadline they would hang provisioning forever with only a spinner update.
 _MOUNT_FAILURE_TIMEOUT_SECONDS = 600
 
+# Synthetic pending reason used when a pod is bound to a node but the kubelet
+# has not reported anything yet (the uninformative 'ContainerCreating' waiting
+# state with no event).
+_CONTAINER_CREATION_REASON = 'container creation'
+# Prefix of the synthetic pending reasons describing a running init container.
+_INIT_CONTAINER_REASON_PREFIX = 'init container '
+# Pending reasons that can legitimately persist, unchanged, for a very long
+# time, and so must not count towards the no-progress deadline below:
+#   - the allow-listed Normal events (pulling a large image, an external CSI
+#     provisioner creating a volume, a late-binding storage class),
+#   - 'container creation', which is also what a pod reports while pulling an
+#     image whose 'Pulling' event has already aged out of the event window,
+#   - a running init container, which may be doing arbitrary user work.
+_STALL_EXEMPT_PENDING_REASONS = frozenset(
+    _PENDING_REASON_NORMAL_EVENT_ALLOWLIST | {_CONTAINER_CREATION_REASON})
+# How long a pod may keep reporting the same non-exempt pending reason before
+# provisioning is failed. Every pod reaching _wait_for_pods_to_run is already
+# bound to a node (_wait_for_pods_to_schedule only returns once all pods are
+# scheduled), so no queue-admission or autoscaling wait remains: what is left
+# is kubelet-side work, and any of it stuck on the same reason for this long is
+# not going to resolve. Without this deadline such a pod hangs the launch
+# forever behind a 'Launching' spinner, with no error, ever.
+_POD_RUN_STALL_TIMEOUT_SECONDS = 600
+
 # Pattern to extract SSH user from command output, handling MOTD contamination
 _SSH_USER_PATTERN = re.compile(r'SKYPILOT_SSH_USER: ([^\s\n]+)')
 
@@ -901,6 +925,27 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
             f'Error: {common_utils.format_exception(e)}') from None
 
 
+def _reason_is_exempt_from_stall(reason: Optional[str]) -> bool:
+    """Whether a pending reason is allowed to persist indefinitely.
+
+    A reason of None is not exempt: a pod that is neither running nor able to
+    say why is exactly the case the no-progress deadline exists to catch.
+    """
+    if reason is None:
+        return False
+    if reason in _STALL_EXEMPT_PENDING_REASONS:
+        return True
+    return reason.startswith(_INIT_CONTAINER_REASON_PREFIX)
+
+
+def _stall_timeout_seconds(reason: Optional[str]) -> int:
+    """The no-progress deadline for a pending reason, in seconds."""
+    if reason in _MOUNT_FAILURE_EVENT_REASONS:
+        # Mount failures get their own window; see the constant.
+        return _MOUNT_FAILURE_TIMEOUT_SECONDS
+    return _POD_RUN_STALL_TIMEOUT_SECONDS
+
+
 @timeline.event
 def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     """Wait for pods and their containers to be ready.
@@ -991,10 +1036,12 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                             running_init = _check_init_containers(pod)
                             if running_init is not None:
                                 name, idx, total = running_init
-                                init_reason = (f'init container {name!r} '
-                                               f'running ({idx}/{total})')
+                                init_reason = (
+                                    f'{_INIT_CONTAINER_REASON_PREFIX}{name!r} '
+                                    f'running ({idx}/{total})')
                             else:
-                                init_reason = 'init container running'
+                                init_reason = (
+                                    f'{_INIT_CONTAINER_REASON_PREFIX}running')
                         elif waiting.reason != 'ContainerCreating':
                             msg = waiting.message if (
                                 waiting.message) else str(waiting)
@@ -1035,7 +1082,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                 # creation)') instead of a bare 'Launching'. Gate on
                 # _pod_is_scheduled so an unbound pod still waiting for
                 # capacity is not mislabeled as creating a container.
-                reason = 'container creation'
+                reason = _CONTAINER_CREATION_REASON
             if reason is not None:
                 log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
                 if event_message:
@@ -1048,23 +1095,34 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
         # returned (False, None) silently, masking OOMKilled etc.
         return False, container_reason
 
-    # First time each pod was seen continuously reporting a mount-failure
-    # event, keyed by pod name. Cleared when the pod's pending reason moves
-    # on (the kubelet retry succeeded).
-    mount_failure_first_seen: Dict[str, float] = {}
+    # The pending reason each pod is currently being timed against, and when
+    # that reason was first seen, keyed by pod name. Reset whenever the reason
+    # changes (progress) or the pod starts running, so a deadline is always
+    # measured from the most recent onset of a single reason.
+    stalled_since: Dict[str, Tuple[Optional[str], float]] = {}
 
-    def _raise_mount_failure(pod_name: str, reason: str) -> None:
+    def _raise_stalled(pod_name: str, reason: Optional[str]) -> None:
         # Re-fetch the newest event for the full kubelet message — the wait
         # loop only tracks the bare reason (e.g. 'FailedMount').
         detail = ''
         pending_reason = _get_pod_pending_reason(context, namespace, pod_name)
-        if (pending_reason is not None and
-                pending_reason[0] in _MOUNT_FAILURE_EVENT_REASONS):
+        if pending_reason is not None and pending_reason[0] == reason:
             detail = f': {pending_reason[1]}'
+        minutes = _stall_timeout_seconds(reason) // 60
+        if reason in _MOUNT_FAILURE_EVENT_REASONS:
+            raise config_lib.KubernetesError(
+                f'Pod {pod_name} has failed to attach or mount volumes for '
+                f'over {minutes} minutes: {reason}{detail}')
+        if reason is None:
+            raise config_lib.KubernetesError(
+                f'Pod {pod_name} has not started running after {minutes} '
+                'minutes and reports no reason why. Run '
+                f'`sky logs --provision {cluster_name}` and '
+                f'`kubectl describe pod {pod_name}` for more details.')
         raise config_lib.KubernetesError(
-            f'Pod {pod_name} has failed to attach or mount volumes for over '
-            f'{_MOUNT_FAILURE_TIMEOUT_SECONDS // 60} minutes: '
-            f'{reason}{detail}')
+            f'Pod {pod_name} has been stuck on the same condition for over '
+            f'{minutes} minutes: {reason}{detail}. Run '
+            f'`sky logs --provision {cluster_name}` for more details.')
 
     missing_pods_retry = 0
     transport_error_since: Optional[float] = None
@@ -1106,17 +1164,31 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             # instead of hardcoding the number of retries?
             if missing_pods_retry >= _MAX_MISSING_PODS_RETRIES:
                 first_pod = True
-                for pod_name in missing_pod_names:
+                missing_pod_reasons: List[str] = []
+                for pod_name in sorted(missing_pod_names):
                     reason = _get_pod_missing_reason(context, namespace,
                                                      cluster_name, pod_name,
                                                      first_pod)
                     logger.warning(f'Pod {pod_name} missing: {reason}')
+                    if reason is not None:
+                        missing_pod_reasons.append(f'{pod_name}: {reason}')
                     first_pod = False
+                # Surface whatever the events said. Without this the only
+                # signal is the generic sentence below, which reads the same
+                # whether the pod was evicted, deleted by another controller,
+                # or rejected by the API server before it ever started.
+                if missing_pod_reasons:
+                    missing_detail = '; '.join(missing_pod_reasons)
+                else:
+                    missing_detail = (
+                        f'{sorted(missing_pod_names)} may have been terminated '
+                        'or failed unexpectedly, and no events were found for '
+                        'them — the pod was likely deleted, or rejected by the '
+                        'API server before it started')
                 raise config_lib.KubernetesError(
                     f'Failed to get all pods after {missing_pods_retry} '
-                    f'retries. Some pods may have been terminated or failed '
-                    f'unexpectedly. Run `sky logs --provision {cluster_name}` '
-                    'for more details.')
+                    f'retries: {missing_detail}. Run '
+                    f'`sky logs --provision {cluster_name}` for more details.')
             logger.info('Retrying running pods check: '
                         f'Missing pods: {missing_pod_names}')
             time.sleep(0.5)
@@ -1141,19 +1213,24 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             if pending_reason is not None:
                 pending_reasons_count[pending_reason] = (
                     pending_reasons_count.get(pending_reason, 0) + 1)
-            # Escalate a sustained volume attach/mount failure to a
-            # provisioning error. Unlike other kubelet-level failures (which
-            # show up in containerStatuses and raise in _inspect_pod_status),
-            # a mount failure leaves the container in 'ContainerCreating'
-            # indefinitely — without this deadline the loop would spin
-            # forever with only a spinner update.
+            # Escalate a pod that keeps reporting the same condition to a
+            # provisioning error. Some kubelet-level failures raise from
+            # _inspect_pod_status as soon as they are seen, but the ones that
+            # only leave the container in 'ContainerCreating' (a mount
+            # failure, a pod sandbox that cannot be created) or that are
+            # normal in isolation (a container restart) are invisible there —
+            # without this deadline such a pod spins here forever with only a
+            # spinner update.
             pod_name = pod.metadata.name
-            if pending_reason in _MOUNT_FAILURE_EVENT_REASONS:
-                first_seen = mount_failure_first_seen.setdefault(pod_name, now)
-                if now - first_seen >= _MOUNT_FAILURE_TIMEOUT_SECONDS:
-                    _raise_mount_failure(pod_name, pending_reason)
+            if is_running or _reason_is_exempt_from_stall(pending_reason):
+                stalled_since.pop(pod_name, None)
             else:
-                mount_failure_first_seen.pop(pod_name, None)
+                previous = stalled_since.get(pod_name)
+                if previous is None or previous[0] != pending_reason:
+                    stalled_since[pod_name] = (pending_reason, now)
+                elif (now - previous[1] >=
+                      _stall_timeout_seconds(pending_reason)):
+                    _raise_stalled(pod_name, pending_reason)
 
         if all_pods_running:
             break

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -139,7 +139,8 @@ _POD_INITIALIZATION_REASON = 'pod initialization'
 #     image whose 'Pulling' event has already aged out of the event window,
 #   - a running init container, which may be doing arbitrary user work, and an
 #     init container the kubelet is still creating, which may be pulling a
-#     large image of its own.
+#     large image of its own -- the latter only reaches this exemption when no
+#     live Warning event contradicts it, see _inspect_pod_status.
 _STALL_EXEMPT_PENDING_REASONS = frozenset(
     _PENDING_REASON_NORMAL_EVENT_ALLOWLIST | {_CONTAINER_CREATION_REASON})
 # How long a pod may keep reporting the same non-exempt pending reason before
@@ -955,6 +956,11 @@ def _reason_is_exempt_from_stall(reason: Optional[str]) -> bool:
 
     A reason of None is not exempt: a pod that is neither running nor able to
     say why is exactly the case the no-progress deadline exists to catch.
+
+    The _INIT_CONTAINER_REASON_PREFIX exemption is only as good as the reason
+    reaching it: an init container the kubelet is failing to start looks
+    exactly like one it is slowly starting, so _inspect_pod_status resolves
+    that ambiguity against the pod's events before a reason gets here.
     """
     if reason is None:
         return False
@@ -1063,6 +1069,9 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             # via _unmask_crashloopbackoff_reason when the waiting state is
             # CrashLoopBackOff. msg body (waiting.message) is always preserved.
             init_reason: Optional[str] = None
+            # Whether init_reason is an assumption about what the kubelet is
+            # doing rather than something it reported -- see below.
+            init_reason_is_assumed = False
             if container_statuses is not None:
                 for container_status in container_statuses:
                     if not container_status.state:
@@ -1079,6 +1088,8 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                                     f'{init_progress.name!r} {verb} '
                                     f'({init_progress.position}/'
                                     f'{init_progress.total})')
+                                init_reason_is_assumed = (
+                                    not init_progress.running)
                             else:
                                 # PodInitializing, yet no init container is
                                 # running or being created -- they have all
@@ -1117,6 +1128,26 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             if reason is None:
                 pending_reason = _get_pod_pending_reason(
                     context, namespace, pod.metadata.name)
+                if pending_reason is not None:
+                    reason, event_message = pending_reason
+            elif init_reason_is_assumed:
+                # 'init container ... starting' says only that the kubelet has
+                # not started the container yet; that this is legitimately slow
+                # work (an image pull of its own) is an assumption, and it is
+                # the assumption that makes the reason stall-exempt. The same
+                # state is what a pod shows when the kubelet cannot get as far
+                # as starting the container at all -- a sandbox it cannot
+                # create, a volume it cannot mount -- which is reported only
+                # through events. So let a live Warning, one the pod has not
+                # already moved past, replace the assumption: it is both the
+                # truer reason and, unlike the init label, bounded by the
+                # no-progress deadline. An allow-listed Normal is not consulted
+                # -- it is exempt either way, and the init label names which
+                # container the pod is waiting on.
+                pending_reason = _get_pod_pending_reason(context,
+                                                         namespace,
+                                                         pod.metadata.name,
+                                                         warnings_only=True)
                 if pending_reason is not None:
                     reason, event_message = pending_reason
             if reason is None and _pod_is_scheduled(pod):
@@ -3239,8 +3270,11 @@ def _get_pod_pending_reason_from_container_status(pod: Any) -> Optional[str]:
     return None
 
 
-def _get_pod_pending_reason(context: Optional[str], namespace: str,
-                            pod_name: str) -> Optional[Tuple[str, str]]:
+def _get_pod_pending_reason(
+        context: Optional[str],
+        namespace: str,
+        pod_name: str,
+        warnings_only: bool = False) -> Optional[Tuple[str, str]]:
     """Get the reason why a pod is pending from its events.
 
     Two-pass scan over the event list (sorted newest-first by _get_pod_events):
@@ -3271,6 +3305,12 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
     Warning being re-emitted survives both checks, and an event that cannot be
     dated is never treated as stale. Ordering *within* a tier is left to
     _get_pod_events' newest-first creation order.
+
+    With warnings_only, tier 3 is answered with None rather than the Normal
+    event: the caller has a reason already and is asking the narrower question
+    of whether the pod is actively failing. The tiering still runs in full --
+    a Normal that demotes a stale Warning under (b) must still demote it here,
+    or the caller would be handed the very Warning the pod has moved past.
 
     Returns a (reason, message) tuple, or None if neither pass matches.
     """
@@ -3313,6 +3353,8 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
                 normal_at > warning_at):
             chosen = normal
     if chosen is None:
+        return None
+    if warnings_only and chosen.type != 'Warning':
         return None
     return chosen.reason or 'Unknown', chosen.message or ''
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -5,8 +5,8 @@ import json
 import re
 import sys
 import time
-from typing import (Any, Callable, Dict, List, Mapping, Optional, Set, Tuple,
-                    TYPE_CHECKING, Union)
+from typing import (Any, Callable, Dict, List, Mapping, NamedTuple, Optional,
+                    Set, Tuple, TYPE_CHECKING, Union)
 
 from sky import exceptions
 from sky import global_user_state
@@ -113,19 +113,33 @@ _MOUNT_FAILURE_EVENT_REASONS = ('FailedMount', 'FailedAttachVolume')
 # deadline they would hang provisioning forever with only a spinner update.
 _MOUNT_FAILURE_TIMEOUT_SECONDS = 600
 
+# Reason of the Normal event the scheduler emits when it binds a pod to a node
+# ('Successfully assigned <ns>/<pod> to <node>'). Marks the boundary between
+# the scheduler's warnings and the kubelet's.
+_POD_BOUND_EVENT_REASON = 'Scheduled'
+
 # Synthetic pending reason used when a pod is bound to a node but the kubelet
 # has not reported anything yet (the uninformative 'ContainerCreating' waiting
 # state with no event).
 _CONTAINER_CREATION_REASON = 'container creation'
-# Prefix of the synthetic pending reasons describing a running init container.
+# Prefix of the synthetic pending reasons describing an init container that is
+# running, or that the kubelet is still creating.
 _INIT_CONTAINER_REASON_PREFIX = 'init container '
+# Synthetic pending reason for a pod that reports 'PodInitializing' while no
+# init container is running or being created -- i.e. they have all terminated
+# successfully and the kubelet has not moved on to the main containers. Kept
+# distinct from the reasons above precisely so it is *not* stall-exempt: there
+# is no legitimately-slow work behind it to wait for.
+_POD_INITIALIZATION_REASON = 'pod initialization'
 # Pending reasons that can legitimately persist, unchanged, for a very long
 # time, and so must not count towards the no-progress deadline below:
 #   - the allow-listed Normal events (pulling a large image, an external CSI
 #     provisioner creating a volume, a late-binding storage class),
 #   - 'container creation', which is also what a pod reports while pulling an
 #     image whose 'Pulling' event has already aged out of the event window,
-#   - a running init container, which may be doing arbitrary user work.
+#   - a running init container, which may be doing arbitrary user work, and an
+#     init container the kubelet is still creating, which may be pulling a
+#     large image of its own.
 _STALL_EXEMPT_PENDING_REASONS = frozenset(
     _PENDING_REASON_NORMAL_EVENT_ALLOWLIST | {_CONTAINER_CREATION_REASON})
 # How long a pod may keep reporting the same non-exempt pending reason before
@@ -139,6 +153,17 @@ _POD_RUN_STALL_TIMEOUT_SECONDS = 600
 
 # Pattern to extract SSH user from command output, handling MOTD contamination
 _SSH_USER_PATTERN = re.compile(r'SKYPILOT_SSH_USER: ([^\s\n]+)')
+
+
+class _InitContainerProgress(NamedTuple):
+    """The init container currently holding up a pod's initialization."""
+    name: str
+    position: int  # 1-based, for display against `total`.
+    total: int
+    # True if the container is running its own work; False if the kubelet is
+    # still creating it (typically pulling its image).
+    running: bool
+
 
 logger = sky_logging.init_logger(__name__)
 
@@ -959,16 +984,19 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     # Create a set of pod names we're waiting for
     expected_pod_names = {pod.metadata.name for pod in new_pods}
 
-    def _check_init_containers(pod) -> Optional[Tuple[str, int, int]]:
-        """Check init containers for errors and return running container info.
+    def _check_init_containers(pod) -> Optional[_InitContainerProgress]:
+        """Check init containers for errors and return the one holding up pod
+        initialization.
 
-        Returns (name, 1-based index, total) of the currently running init
-        container, or None if none is running.
+        Returns the first init container that is running, else the first one
+        the kubelet is still creating (pulling its image), else None -- no
+        init container accounts for the pod being uninitialized.
         Raises KubernetesError if any init container failed.
         """
         init_statuses = pod.status.init_container_statuses
         total = len(init_statuses)
-        running_info: Optional[Tuple[str, int, int]] = None
+        running_info: Optional[_InitContainerProgress] = None
+        starting_info: Optional[_InitContainerProgress] = None
         for idx, init_status in enumerate(init_statuses):
             init_terminated = init_status.state.terminated
             if init_terminated:
@@ -980,22 +1008,31 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                         f'{pod.metadata.name}. Error details: {msg}.')
                 continue
             if (init_status.state.running is not None and running_info is None):
-                running_info = (init_status.name, idx + 1, total)
+                running_info = _InitContainerProgress(init_status.name, idx + 1,
+                                                      total, True)
             init_waiting = init_status.state.waiting
-            if (init_waiting is not None and init_waiting.reason
-                    not in ['ContainerCreating', 'PodInitializing']):
-                # TODO(romilb): There may be more states to check for. Add
-                #  them as needed.
-                msg = init_waiting.message if (
-                    init_waiting.message) else str(init_waiting)
-                unmasked = _unmask_crashloopbackoff_reason(init_status)
-                reason_text = (unmasked if unmasked is not None else
-                               (init_waiting.reason or 'Unknown'))
-                raise config_lib.KubernetesError(
-                    f'Failed to create init container for pod '
-                    f'{pod.metadata.name}. Error details: '
-                    f'{reason_text}: {msg}.')
-        return running_info
+            if init_waiting is not None:
+                if init_waiting.reason in ('ContainerCreating',
+                                           'PodInitializing'):
+                    # The kubelet is creating it -- most often pulling its
+                    # image, which is legitimately slow. Recorded so the
+                    # no-progress deadline does not mistake it for a stall.
+                    if starting_info is None:
+                        starting_info = _InitContainerProgress(
+                            init_status.name, idx + 1, total, False)
+                else:
+                    # TODO(romilb): There may be more states to check for. Add
+                    #  them as needed.
+                    msg = init_waiting.message if (
+                        init_waiting.message) else str(init_waiting)
+                    unmasked = _unmask_crashloopbackoff_reason(init_status)
+                    reason_text = (unmasked if unmasked is not None else
+                                   (init_waiting.reason or 'Unknown'))
+                    raise config_lib.KubernetesError(
+                        f'Failed to create init container for pod '
+                        f'{pod.metadata.name}. Error details: '
+                        f'{reason_text}: {msg}.')
+        return running_info if running_info is not None else starting_info
 
     def _inspect_pod_status(pod):
         # Check if pod is terminated/preempted/failed (unchanged).
@@ -1033,15 +1070,24 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     waiting = container_status.state.waiting
                     if waiting is not None:
                         if waiting.reason == 'PodInitializing':
-                            running_init = _check_init_containers(pod)
-                            if running_init is not None:
-                                name, idx, total = running_init
+                            init_progress = _check_init_containers(pod)
+                            if init_progress is not None:
+                                verb = ('running' if init_progress.running else
+                                        'starting')
                                 init_reason = (
-                                    f'{_INIT_CONTAINER_REASON_PREFIX}{name!r} '
-                                    f'running ({idx}/{total})')
+                                    f'{_INIT_CONTAINER_REASON_PREFIX}'
+                                    f'{init_progress.name!r} {verb} '
+                                    f'({init_progress.position}/'
+                                    f'{init_progress.total})')
                             else:
-                                init_reason = (
-                                    f'{_INIT_CONTAINER_REASON_PREFIX}running')
+                                # PodInitializing, yet no init container is
+                                # running or being created -- they have all
+                                # terminated successfully and the kubelet has
+                                # simply not moved on to the main containers.
+                                # Nothing here is legitimately slow, so unlike
+                                # the two branches above this reason is not
+                                # exempt from the no-progress deadline.
+                                init_reason = _POD_INITIALIZATION_REASON
                         elif waiting.reason != 'ContainerCreating':
                             msg = waiting.message if (
                                 waiting.message) else str(waiting)
@@ -1180,11 +1226,16 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                 if missing_pod_reasons:
                     missing_detail = '; '.join(missing_pod_reasons)
                 else:
+                    # A reason of None does not mean the pod had no events:
+                    # _get_pod_missing_reason also returns None when the events
+                    # were all seen on an earlier pass, and when they simply do
+                    # not name one of the causes it recognises. Say only what
+                    # was established -- that no cause could be derived.
                     missing_detail = (
                         f'{sorted(missing_pod_names)} may have been terminated '
-                        'or failed unexpectedly, and no events were found for '
-                        'them — the pod was likely deleted, or rejected by the '
-                        'API server before it started')
+                        'or failed unexpectedly, and no cause could be derived '
+                        'from their events — the pod may have been deleted, or '
+                        'rejected by the API server before it started')
                 raise config_lib.KubernetesError(
                     f'Failed to get all pods after {missing_pods_retry} '
                     f'retries: {missing_detail}. Run '
@@ -3198,20 +3249,28 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
          _PENDING_REASON_NORMAL_EVENT_ALLOWLIST.
     A Warning beats an allow-listed Normal -- a FailedScheduling Warning is a
     more truthful pending reason than a Pulling Normal from a doomed retry --
-    *unless* the Normal was observed more recently, in which case the Warning
-    describes a condition the pod has already moved past. Kubernetes keeps
-    events for the API server's event TTL (~1h), so a resolved Warning outlives
-    the condition that produced it by a long way: a pod that waited on an
-    autoscaler still carries its FailedScheduling long after it was bound, and
-    a mount that the kubelet retried successfully still carries its FailedMount
-    while the image pull that follows it is under way. Reporting the stale
-    Warning there is not just a mislabeled spinner -- the reason never changes
-    while the pod makes progress, which is exactly what the no-progress
-    deadline in _wait_for_pods_to_run reads as a stall.
+    but only while the Warning still describes the pod. Kubernetes keeps events
+    for the API server's event TTL (~1h), so a resolved Warning outlives the
+    condition that produced it by a long way, and reporting a stale one is not
+    just a mislabeled spinner: the reason then never changes while the pod
+    makes progress, which is exactly what the no-progress deadline in
+    _wait_for_pods_to_run reads as a stall. Two independent checks demote one:
 
-    Timestamp ordering *within* a tier is left to _get_pod_events' newest-first
-    creation order; only the cross-tier choice consults the last-observed time,
-    since that is the only place staleness can mislead.
+      a. A Warning last observed before the pod was bound cannot describe what
+         the kubelet is doing, because every caller of this function observes
+         the pod only after the bind. This covers the pod that waited on an
+         autoscaler and carries a FailedScheduling for the next hour, whether
+         or not any Normal event follows it.
+      b. A Warning observed less recently than the allow-listed Normal has
+         been overtaken by it -- e.g. a mount the kubelet retried successfully,
+         whose FailedMount predates the image pull now under way.
+
+    Both compare last-observed times, not creation times: kubernetes folds a
+    repeated event back into the original object, bumping count/last_timestamp
+    while creation_timestamp stays pinned to the first occurrence. So a live
+    Warning being re-emitted survives both checks, and an event that cannot be
+    dated is never treated as stale. Ordering *within* a tier is left to
+    _get_pod_events' newest-first creation order.
 
     Returns a (reason, message) tuple, or None if neither pass matches.
     """
@@ -3224,18 +3283,32 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
     if not pod_events:
         return None
 
+    # (a) The bind, read from the pod's own events. Absent once it has aged
+    # out of the event window -- by which point every pre-bind Warning has
+    # aged out ahead of it, so there is nothing left to demote.
+    bound_at = next((_event_last_observed(e)
+                     for e in pod_events
+                     if e.reason == _POD_BOUND_EVENT_REASON), None)
+
+    def _describes_pod_now(event: Any) -> bool:
+        if bound_at is None:
+            return True
+        observed_at = _event_last_observed(event)
+        return observed_at is None or observed_at >= bound_at
+
     # Tier 2: Warning events.
-    warning = next((e for e in pod_events if e.type == 'Warning'), None)
+    warning = next((
+        e for e in pod_events if e.type == 'Warning' and _describes_pod_now(e)),
+                   None)
     # Tier 3: allow-listed Normal events.
     normal = next((e for e in pod_events
                    if e.reason in _PENDING_REASON_NORMAL_EVENT_ALLOWLIST), None)
 
     chosen = warning if warning is not None else normal
+    # (b) Cross-tier recency.
     if warning is not None and normal is not None:
         warning_at = _event_last_observed(warning)
         normal_at = _event_last_observed(normal)
-        # Fall back to the Warning when either side is undated -- an event the
-        # API server left without any timestamp cannot be shown to be stale.
         if (warning_at is not None and normal_at is not None and
                 normal_at > warning_at):
             chosen = normal

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1221,6 +1221,10 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             # normal in isolation (a container restart) are invisible there —
             # without this deadline such a pod spins here forever with only a
             # spinner update.
+            # This reads "the reason did not change" as "the pod made no
+            # progress", which holds only because _get_pod_pending_reason will
+            # not keep reporting a Warning the pod has already moved past; see
+            # its docstring.
             pod_name = pod.metadata.name
             if is_running or _reason_is_exempt_from_stall(pending_reason):
                 stalled_since.pop(pod_name, None)
@@ -2850,6 +2854,29 @@ def _condensed_pod_reason(pod: 'V1Pod') -> str:
     return kubernetes_utils.get_condensed_pod_reason(pod)
 
 
+def _event_last_observed(event: Any) -> Optional[float]:
+    """When ``event`` was last observed, in unix seconds; None if unknown.
+
+    Prefers the last-observed time over the creation time. Kubernetes folds a
+    repeated event back into the original object -- bumping ``count`` and
+    ``last_timestamp`` (``series.last_observed_time`` on the events.k8s.io
+    path) while ``metadata.creation_timestamp`` stays pinned to the first
+    occurrence -- so the creation time says when a condition started, and only
+    the last-observed time says whether it is still happening.
+    """
+    series = getattr(event, 'series', None)
+    ts = (getattr(series, 'last_observed_time', None) or
+          getattr(event, 'last_timestamp', None) or
+          getattr(event, 'event_time', None) or
+          getattr(getattr(event, 'metadata', None), 'creation_timestamp', None))
+    if not isinstance(ts, datetime.datetime):
+        # Absent, or a field the API server did not populate.
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.timezone.utc)
+    return ts.timestamp()
+
+
 def _get_pod_events(context: Optional[str], namespace: str,
                     pod_name: str) -> List[Any]:
     """Get the events for a pod, sorted by timestamp, most recent first."""
@@ -3166,12 +3193,25 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
     """Get the reason why a pod is pending from its events.
 
     Two-pass scan over the event list (sorted newest-first by _get_pod_events):
-      1. Tier 2 -- return the newest event with event.type == 'Warning'.
-      2. Tier 3 -- return the newest event whose reason is in
+      1. Tier 2 -- the newest event with event.type == 'Warning'.
+      2. Tier 3 -- the newest event whose reason is in
          _PENDING_REASON_NORMAL_EVENT_ALLOWLIST.
-    Warnings always beat allow-listed Normals, regardless of timestamp ordering
-    in the event window -- a FailedScheduling Warning is a more truthful pending
-    reason than a Pulling Normal from a doomed retry.
+    A Warning beats an allow-listed Normal -- a FailedScheduling Warning is a
+    more truthful pending reason than a Pulling Normal from a doomed retry --
+    *unless* the Normal was observed more recently, in which case the Warning
+    describes a condition the pod has already moved past. Kubernetes keeps
+    events for the API server's event TTL (~1h), so a resolved Warning outlives
+    the condition that produced it by a long way: a pod that waited on an
+    autoscaler still carries its FailedScheduling long after it was bound, and
+    a mount that the kubelet retried successfully still carries its FailedMount
+    while the image pull that follows it is under way. Reporting the stale
+    Warning there is not just a mislabeled spinner -- the reason never changes
+    while the pod makes progress, which is exactly what the no-progress
+    deadline in _wait_for_pods_to_run reads as a stall.
+
+    Timestamp ordering *within* a tier is left to _get_pod_events' newest-first
+    creation order; only the cross-tier choice consults the last-observed time,
+    since that is the only place staleness can mislead.
 
     Returns a (reason, message) tuple, or None if neither pass matches.
     """
@@ -3185,16 +3225,23 @@ def _get_pod_pending_reason(context: Optional[str], namespace: str,
         return None
 
     # Tier 2: Warning events.
-    for event in pod_events:
-        if event.type == 'Warning':
-            return event.reason or 'Unknown', event.message or ''
-
+    warning = next((e for e in pod_events if e.type == 'Warning'), None)
     # Tier 3: allow-listed Normal events.
-    for event in pod_events:
-        if event.reason in _PENDING_REASON_NORMAL_EVENT_ALLOWLIST:
-            return event.reason, event.message or ''
+    normal = next((e for e in pod_events
+                   if e.reason in _PENDING_REASON_NORMAL_EVENT_ALLOWLIST), None)
 
-    return None
+    chosen = warning if warning is not None else normal
+    if warning is not None and normal is not None:
+        warning_at = _event_last_observed(warning)
+        normal_at = _event_last_observed(normal)
+        # Fall back to the Warning when either side is undated -- an event the
+        # API server left without any timestamp cannot be shown to be stale.
+        if (warning_at is not None and normal_at is not None and
+                normal_at > warning_at):
+            chosen = normal
+    if chosen is None:
+        return None
+    return chosen.reason or 'Unknown', chosen.message or ''
 
 
 def _format_pod_missing_reason(

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2,6 +2,7 @@
 
 import datetime
 import re
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -2896,16 +2897,85 @@ class TestGetPodPendingReasonFromContainerStatus:
             pod) is None
 
 
-class TestGetPodPendingReasonTieredEventFilter:
-    """Two-pass scan: Warning events first (regardless of timestamp),
-    then a small allow-list of slow Normal events."""
+class TestEventLastObserved:
+    """The last-observed time of an event, which is what says whether the
+    condition behind it is still happening."""
 
     @staticmethod
-    def _event(reason: str, event_type: str = 'Normal', message: str = ''):
+    def _ts(unix: int):
+        return datetime.datetime.fromtimestamp(unix, datetime.timezone.utc)
+
+    @staticmethod
+    def _event(**fields):
+        ev = mock.MagicMock()
+        for name in ('series', 'last_timestamp', 'event_time'):
+            setattr(ev, name, fields.get(name))
+        ev.metadata.creation_timestamp = fields.get('creation_timestamp')
+        return ev
+
+    def test_series_last_observed_time_wins(self):
+        """The events.k8s.io path records repeats in a series, whose
+        last_observed_time is the only field that moves."""
+        ev = self._event(
+            series=mock.MagicMock(last_observed_time=self._ts(3000)),
+            last_timestamp=self._ts(2000),
+            creation_timestamp=self._ts(1000))
+        assert instance._event_last_observed(ev) == 3000
+
+    def test_last_timestamp_beats_creation_timestamp(self):
+        """A repeated event is folded into the original object: creation_
+        timestamp stays at the first occurrence, last_timestamp moves."""
+        ev = self._event(last_timestamp=self._ts(2000),
+                         creation_timestamp=self._ts(1000))
+        assert instance._event_last_observed(ev) == 2000
+
+    def test_event_time_used_when_no_last_timestamp(self):
+        ev = self._event(event_time=self._ts(2000),
+                         creation_timestamp=self._ts(1000))
+        assert instance._event_last_observed(ev) == 2000
+
+    def test_creation_timestamp_is_the_last_resort(self):
+        ev = self._event(creation_timestamp=self._ts(1000))
+        assert instance._event_last_observed(ev) == 1000
+
+    def test_naive_timestamp_is_read_as_utc(self):
+        """Not as local time, which would shift it by the host's offset and
+        misorder it against a tz-aware sibling event."""
+        naive = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        expected = naive.replace(tzinfo=datetime.timezone.utc).timestamp()
+        assert instance._event_last_observed(
+            self._event(last_timestamp=naive)) == expected
+
+    def test_undated_event_returns_none(self):
+        assert instance._event_last_observed(self._event()) is None
+
+    def test_non_datetime_field_returns_none(self):
+        """Guards against a mock or a field the API server left as a string:
+        an undatable event must be reported as such, not compared."""
+        assert instance._event_last_observed(
+            self._event(last_timestamp='2026-01-01T00:00:00Z')) is None
+
+
+class TestGetPodPendingReasonTieredEventFilter:
+    """Two-pass scan: Warning events first, then a small allow-list of slow
+    Normal events -- except where the Warning is demonstrably stale."""
+
+    @staticmethod
+    def _event(reason: str,
+               event_type: str = 'Normal',
+               message: str = '',
+               last_observed: Optional[int] = None):
+        """An event; `last_observed` is a unix timestamp, None for undated."""
         ev = mock.MagicMock()
         ev.reason = reason
         ev.type = event_type
         ev.message = message
+        ev.series = None
+        ev.event_time = None
+        ev.last_timestamp = (None if last_observed is None else
+                             datetime.datetime.fromtimestamp(
+                                 last_observed, datetime.timezone.utc))
+        ev.metadata.creation_timestamp = None
         return ev
 
     def _patch_events(self, monkeypatch, events):
@@ -2916,9 +2986,10 @@ class TestGetPodPendingReasonTieredEventFilter:
         self._patch_events(monkeypatch, [])
         assert instance._get_pod_pending_reason('ctx', 'ns', 'pod-0') is None
 
-    def test_warning_wins_over_normal_regardless_of_age(self, monkeypatch):
+    def test_warning_wins_over_undated_normal(self, monkeypatch):
         # Newest event (index 0) is a Normal Pulling, older event is a
-        # Warning FailedScheduling. Warning must win.
+        # Warning FailedScheduling. With nothing to date either by, the
+        # Warning must win.
         events = [
             self._event('Pulling', 'Normal', 'Pulling image "foo:bar"'),
             self._event('FailedScheduling', 'Warning',
@@ -2929,6 +3000,96 @@ class TestGetPodPendingReasonTieredEventFilter:
             'FailedScheduling',
             '0/3 nodes are available: insufficient cpu.',
         )
+
+    def test_warning_wins_over_an_older_normal(self, monkeypatch):
+        """The doomed-retry case the Warning tier exists for: the pull came
+        first and the Warning is the newer, live condition."""
+        events = [
+            self._event('FailedScheduling',
+                        'Warning',
+                        '0/3 nodes are available: insufficient cpu.',
+                        last_observed=2000),
+            self._event('Pulling',
+                        'Normal',
+                        'Pulling image "foo:bar"',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') == (
+            'FailedScheduling',
+            '0/3 nodes are available: insufficient cpu.',
+        )
+
+    def test_more_recent_normal_beats_a_stale_warning(self, monkeypatch):
+        """A pod that waited on the autoscaler keeps its FailedScheduling for
+        the event TTL (~1h) after being bound. Once the kubelet starts pulling,
+        the pull is the pod's real pending reason -- reporting the resolved
+        Warning instead would also make the no-progress deadline in
+        _wait_for_pods_to_run count a healthy pull as a stall."""
+        events = [
+            self._event('Pulling',
+                        'Normal',
+                        'Pulling image "foo:bar"',
+                        last_observed=2000),
+            self._event('FailedScheduling',
+                        'Warning',
+                        '0/3 nodes are available: insufficient cpu.',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
+
+    def test_resolved_mount_failure_loses_to_the_pull_that_followed_it(
+            self, monkeypatch):
+        """The kubelet retries a mount until it succeeds, then pulls. The
+        FailedMount from the failed attempts must not outrank the pull, or a
+        transient mount hiccup would fail an otherwise healthy launch."""
+        events = [
+            self._event('Pulling',
+                        'Normal',
+                        'Pulling image "foo:bar"',
+                        last_observed=2000),
+            self._event('FailedMount',
+                        'Warning',
+                        'Unable to attach or mount volumes',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
+
+    def test_ties_go_to_the_warning(self, monkeypatch):
+        events = [
+            self._event('Pulling',
+                        'Normal',
+                        'Pulling image "foo:bar"',
+                        last_observed=1000),
+            self._event('FailedMount',
+                        'Warning',
+                        'Unable to attach or mount volumes',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns',
+            'p') == ('FailedMount', 'Unable to attach or mount volumes')
+
+    def test_undated_warning_is_never_treated_as_stale(self, monkeypatch):
+        """Only a Warning that can be shown to be older than the Normal loses.
+        An event the API server left undated cannot be, so it keeps winning."""
+        events = [
+            self._event('Pulling',
+                        'Normal',
+                        'Pulling image "foo:bar"',
+                        last_observed=2000),
+            self._event('FailedMount', 'Warning',
+                        'Unable to attach or mount volumes'),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns',
+            'p') == ('FailedMount', 'Unable to attach or mount volumes')
 
     def test_allow_listed_normal_returned_when_no_warning(self, monkeypatch):
         events = [self._event('Pulling', 'Normal', 'Pulling image "foo:bar"')]
@@ -3483,6 +3644,7 @@ class TestWaitForPodsToRunStallEscalation:
                   *,
                   pod,
                   pending_reasons=(None,),
+                  pod_events=None,
                   clock_step=301.0,
                   healthy_after=None,
                   max_iterations=500):
@@ -3496,6 +3658,10 @@ class TestWaitForPodsToRunStallEscalation:
         past that the harness fails the test rather than hanging, so a
         regression that makes the wait unbounded again shows up as a failure
         and not as a stuck CI job.
+
+        Pass `pod_events` instead of `pending_reasons` to drive the real
+        _get_pod_pending_reason off a fixed event list, so the tiering between
+        Warning and Normal events is exercised end to end rather than stubbed.
         """
         healthy_pod = self._make_running_pod()
         iteration = {'n': -1}
@@ -3518,16 +3684,21 @@ class TestWaitForPodsToRunStallEscalation:
         monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
                             lambda *a, **kw: core_api)
 
-        def _pending_reason(context, namespace, pod_name):
-            del context, namespace, pod_name  # unused
-            idx = min(max(iteration['n'], 0), len(pending_reasons) - 1)
-            reason = pending_reasons[idx]
-            if reason is None:
-                return None
-            return reason, self._EVENT_MSG
+        if pod_events is not None:
+            monkeypatch.setattr(instance, '_get_pod_events',
+                                lambda *a, **kw: pod_events)
+        else:
 
-        monkeypatch.setattr(instance, '_get_pod_pending_reason',
-                            _pending_reason)
+            def _pending_reason(context, namespace, pod_name):
+                del context, namespace, pod_name  # unused
+                idx = min(max(iteration['n'], 0), len(pending_reasons) - 1)
+                reason = pending_reasons[idx]
+                if reason is None:
+                    return None
+                return reason, self._EVENT_MSG
+
+            monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                                _pending_reason)
 
         clock = {'t': 1000.0}
         monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
@@ -3601,6 +3772,59 @@ class TestWaitForPodsToRunStallEscalation:
         msg = str(exc_info.value)
         assert 'reports no reason why' in msg
         assert 'pod-0' in msg
+
+    @pytest.mark.parametrize('stale_warning',
+                             ['FailedScheduling', 'FailedMount'])
+    def test_a_resolved_warning_does_not_fail_a_healthy_pull(
+            self, monkeypatch, stale_warning):
+        """The regression this deadline is most exposed to: kubernetes keeps
+        events for ~1h, so a pod that waited on the autoscaler, or whose mount
+        the kubelet retried successfully, still carries that Warning while it
+        pulls its image. A stale Warning never changes, so counting it would
+        fail a launch that was making progress the whole time. Driven through
+        the real _get_pod_pending_reason: 200 iterations at 301s is ~16
+        simulated hours of pulling.
+        """
+        events = [
+            TestGetPodPendingReasonTieredEventFilter._event(
+                'Pulling',
+                'Normal',
+                'Pulling image "foo:bar"',
+                last_observed=2000),
+            TestGetPodPendingReasonTieredEventFilter._event(
+                stale_warning,
+                'Warning',
+                'resolved a while ago',
+                last_observed=1000),
+        ]
+        self._run_wait(monkeypatch,
+                       pod=self._make_pending_pod(),
+                       pod_events=events,
+                       healthy_after=200)
+
+    def test_a_live_warning_still_escalates_over_an_older_pull(
+            self, monkeypatch):
+        """The other side of the same tiering: a Warning that is newer than the
+        pull is the pod's live condition and must still fail the launch."""
+        events = [
+            TestGetPodPendingReasonTieredEventFilter._event(
+                'FailedCreatePodSandBox',
+                'Warning',
+                self._EVENT_MSG,
+                last_observed=2000),
+            TestGetPodPendingReasonTieredEventFilter._event(
+                'Pulling',
+                'Normal',
+                'Pulling image "foo:bar"',
+                last_observed=1000),
+        ]
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(monkeypatch,
+                           pod=self._make_pending_pod(),
+                           pod_events=events)
+        msg = str(exc_info.value)
+        assert 'FailedCreatePodSandBox' in msg
+        assert self._EVENT_MSG in msg
 
     def test_timer_resets_when_reason_changes(self, monkeypatch):
         """Two different non-exempt reasons in sequence: the deadline is

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2897,272 +2897,185 @@ class TestGetPodPendingReasonFromContainerStatus:
             pod) is None
 
 
+def _utc(unix: int) -> datetime.datetime:
+    return datetime.datetime.fromtimestamp(unix, datetime.timezone.utc)
+
+
+def _make_pod_event(reason: str = 'Pulling',
+                    event_type: str = 'Normal',
+                    message: str = '',
+                    last_observed: Optional[int] = None,
+                    series=None,
+                    last_timestamp=None,
+                    event_time=None,
+                    creation_timestamp=None):
+    """A mock pod event.
+
+    `last_observed` is the sugar for the usual case: a unix timestamp on
+    last_timestamp, None for an event with no timestamp at all. The individual
+    timestamp fields are for exercising the precedence between them.
+    """
+    if last_observed is not None:
+        last_timestamp = _utc(last_observed)
+    ev = mock.MagicMock()
+    ev.reason = reason
+    ev.type = event_type
+    ev.message = message
+    ev.series = series
+    ev.last_timestamp = last_timestamp
+    ev.event_time = event_time
+    ev.metadata.creation_timestamp = creation_timestamp
+    return ev
+
+
 class TestEventLastObserved:
     """The last-observed time of an event, which is what says whether the
     condition behind it is still happening."""
 
-    @staticmethod
-    def _ts(unix: int):
-        return datetime.datetime.fromtimestamp(unix, datetime.timezone.utc)
-
-    @staticmethod
-    def _event(**fields):
-        ev = mock.MagicMock()
-        for name in ('series', 'last_timestamp', 'event_time'):
-            setattr(ev, name, fields.get(name))
-        ev.metadata.creation_timestamp = fields.get('creation_timestamp')
-        return ev
-
-    def test_series_last_observed_time_wins(self):
-        """The events.k8s.io path records repeats in a series, whose
-        last_observed_time is the only field that moves."""
-        ev = self._event(
-            series=mock.MagicMock(last_observed_time=self._ts(3000)),
-            last_timestamp=self._ts(2000),
-            creation_timestamp=self._ts(1000))
-        assert instance._event_last_observed(ev) == 3000
-
-    def test_last_timestamp_beats_creation_timestamp(self):
-        """A repeated event is folded into the original object: creation_
-        timestamp stays at the first occurrence, last_timestamp moves."""
-        ev = self._event(last_timestamp=self._ts(2000),
-                         creation_timestamp=self._ts(1000))
-        assert instance._event_last_observed(ev) == 2000
-
-    def test_event_time_used_when_no_last_timestamp(self):
-        ev = self._event(event_time=self._ts(2000),
-                         creation_timestamp=self._ts(1000))
-        assert instance._event_last_observed(ev) == 2000
-
-    def test_creation_timestamp_is_the_last_resort(self):
-        ev = self._event(creation_timestamp=self._ts(1000))
-        assert instance._event_last_observed(ev) == 1000
+    @pytest.mark.parametrize(
+        'fields,expected',
+        [
+            # Kubernetes folds a repeated event back into the original object,
+            # so the fields that move outrank the one pinned to the first
+            # occurrence. The events.k8s.io path records the repeat in a
+            # series instead of on last_timestamp.
+            pytest.param(
+                {
+                    'series': mock.MagicMock(last_observed_time=_utc(3000)),
+                    'last_timestamp': _utc(2000),
+                    'creation_timestamp': _utc(1000),
+                },
+                3000,
+                id='series-beats-last-timestamp'),
+            pytest.param(
+                {
+                    'last_timestamp': _utc(2000),
+                    'creation_timestamp': _utc(1000),
+                },
+                2000,
+                id='last-timestamp-beats-creation'),
+            pytest.param(
+                {
+                    'event_time': _utc(2000),
+                    'creation_timestamp': _utc(1000),
+                },
+                2000,
+                id='event-time-beats-creation'),
+            pytest.param({'creation_timestamp': _utc(1000)},
+                         1000,
+                         id='creation-is-the-last-resort'),
+            pytest.param({}, None, id='undated'),
+            # A field the API server left as a string, or a bare mock: an
+            # undatable event must be reported as such, not compared.
+            pytest.param({'last_timestamp': '2026-01-01T00:00:00Z'},
+                         None,
+                         id='not-a-datetime'),
+        ])
+    def test_precedence(self, fields, expected):
+        assert instance._event_last_observed(
+            _make_pod_event(**fields)) == expected
 
     def test_naive_timestamp_is_read_as_utc(self):
         """Not as local time, which would shift it by the host's offset and
         misorder it against a tz-aware sibling event."""
         naive = datetime.datetime(2026, 1, 1, 0, 0, 0)
-        expected = naive.replace(tzinfo=datetime.timezone.utc).timestamp()
         assert instance._event_last_observed(
-            self._event(last_timestamp=naive)) == expected
-
-    def test_undated_event_returns_none(self):
-        assert instance._event_last_observed(self._event()) is None
-
-    def test_non_datetime_field_returns_none(self):
-        """Guards against a mock or a field the API server left as a string:
-        an undatable event must be reported as such, not compared."""
-        assert instance._event_last_observed(
-            self._event(last_timestamp='2026-01-01T00:00:00Z')) is None
+            _make_pod_event(last_timestamp=naive)) == naive.replace(
+                tzinfo=datetime.timezone.utc).timestamp()
 
 
 class TestGetPodPendingReasonTieredEventFilter:
     """Two-pass scan: Warning events first, then a small allow-list of slow
     Normal events -- except where the Warning is demonstrably stale."""
 
-    @staticmethod
-    def _event(reason: str,
-               event_type: str = 'Normal',
-               message: str = '',
-               last_observed: Optional[int] = None):
-        """An event; `last_observed` is a unix timestamp, None for undated."""
-        ev = mock.MagicMock()
-        ev.reason = reason
-        ev.type = event_type
-        ev.message = message
-        ev.series = None
-        ev.event_time = None
-        ev.last_timestamp = (None if last_observed is None else
-                             datetime.datetime.fromtimestamp(
-                                 last_observed, datetime.timezone.utc))
-        ev.metadata.creation_timestamp = None
-        return ev
+    # (reason, type, message) of the two events the cross-tier choice is
+    # between. The code does not branch on the reason, so one of each is
+    # enough to pin the tiering down.
+    _WARNING = ('FailedMount', 'Warning', 'Unable to attach or mount volumes')
+    _NORMAL = ('Pulling', 'Normal', 'Pulling image "foo:bar"')
+    _SCHEDULED = ('Scheduled', 'Normal', 'Successfully assigned ns/p to node-1')
+
+    _event = staticmethod(_make_pod_event)
 
     def _patch_events(self, monkeypatch, events):
         monkeypatch.setattr(instance, '_get_pod_events',
                             lambda *a, **kw: events)
 
+    @staticmethod
+    def _expected(event_spec):
+        """The (reason, message) _get_pod_pending_reason returns for a spec."""
+        return event_spec[0], event_spec[2]
+
     def test_no_events_returns_none(self, monkeypatch):
         self._patch_events(monkeypatch, [])
         assert instance._get_pod_pending_reason('ctx', 'ns', 'pod-0') is None
 
-    def test_warning_wins_over_undated_normal(self, monkeypatch):
-        # Newest event (index 0) is a Normal Pulling, older event is a
-        # Warning FailedScheduling. With nothing to date either by, the
-        # Warning must win.
-        events = [
-            self._event('Pulling', 'Normal', 'Pulling image "foo:bar"'),
-            self._event('FailedScheduling', 'Warning',
-                        '0/3 nodes are available: insufficient cpu.'),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') == (
-            'FailedScheduling',
-            '0/3 nodes are available: insufficient cpu.',
-        )
+    @pytest.mark.parametrize('warning_at,normal_at,warning_wins', [
+        pytest.param(None, None, True, id='both-undated'),
+        pytest.param(2000, 1000, True, id='warning-is-newer'),
+        pytest.param(1000, 1000, True, id='same-instant'),
+        pytest.param(None, 2000, True, id='warning-undated'),
+        pytest.param(1000, None, True, id='normal-undated'),
+        pytest.param(1000, 2000, False, id='normal-is-newer'),
+    ])
+    def test_cross_tier_recency(self, monkeypatch, warning_at, normal_at,
+                                warning_wins):
+        """A Warning is the more truthful pending reason -- a FailedScheduling
+        beats a Pulling from a doomed retry -- right up until the Normal
+        overtakes it, at which point the Warning describes a condition the pod
+        has already moved past: a mount the kubelet retried successfully, say,
+        before the image pull now under way. Only a Warning that can be *shown*
+        to be older loses, so an undated event on either side keeps it.
 
-    def test_warning_wins_over_an_older_normal(self, monkeypatch):
-        """The doomed-retry case the Warning tier exists for: the pull came
-        first and the Warning is the newer, live condition."""
-        events = [
-            self._event('FailedScheduling',
-                        'Warning',
-                        '0/3 nodes are available: insufficient cpu.',
-                        last_observed=2000),
-            self._event('Pulling',
-                        'Normal',
-                        'Pulling image "foo:bar"',
-                        last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') == (
-            'FailedScheduling',
-            '0/3 nodes are available: insufficient cpu.',
-        )
-
-    def test_more_recent_normal_beats_a_stale_warning(self, monkeypatch):
-        """A pod that waited on the autoscaler keeps its FailedScheduling for
-        the event TTL (~1h) after being bound. Once the kubelet starts pulling,
-        the pull is the pod's real pending reason -- reporting the resolved
-        Warning instead would also make the no-progress deadline in
-        _wait_for_pods_to_run count a healthy pull as a stall."""
-        events = [
-            self._event('Pulling',
-                        'Normal',
-                        'Pulling image "foo:bar"',
-                        last_observed=2000),
-            self._event('FailedScheduling',
-                        'Warning',
-                        '0/3 nodes are available: insufficient cpu.',
-                        last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
+        The Normal is first in the list (newest by creation order) throughout,
+        so this also pins down that list position does not decide the choice.
+        """
+        self._patch_events(monkeypatch, [
+            self._event(*self._NORMAL, last_observed=normal_at),
+            self._event(*self._WARNING, last_observed=warning_at),
+        ])
         assert instance._get_pod_pending_reason(
-            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
+            'ctx', 'ns', 'p') == self._expected(
+                self._WARNING if warning_wins else self._NORMAL)
 
-    def test_resolved_mount_failure_loses_to_the_pull_that_followed_it(
-            self, monkeypatch):
-        """The kubelet retries a mount until it succeeds, then pulls. The
-        FailedMount from the failed attempts must not outrank the pull, or a
-        transient mount hiccup would fail an otherwise healthy launch."""
-        events = [
-            self._event('Pulling',
-                        'Normal',
-                        'Pulling image "foo:bar"',
-                        last_observed=2000),
-            self._event('FailedMount',
-                        'Warning',
-                        'Unable to attach or mount volumes',
-                        last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason(
-            'ctx', 'ns', 'p') == ('Pulling', 'Pulling image "foo:bar"')
-
-    def test_ties_go_to_the_warning(self, monkeypatch):
-        events = [
-            self._event('Pulling',
-                        'Normal',
-                        'Pulling image "foo:bar"',
-                        last_observed=1000),
-            self._event('FailedMount',
-                        'Warning',
-                        'Unable to attach or mount volumes',
-                        last_observed=1000),
-        ]
+    @pytest.mark.parametrize('bind_at,warning_survives', [
+        pytest.param(2000, False, id='warning-predates-the-bind'),
+        pytest.param(None, True, id='bind-no-longer-in-the-event-window'),
+    ])
+    def test_warning_predating_the_bind_is_dropped(self, monkeypatch, bind_at,
+                                                   warning_survives):
+        """Everything this function observes happens after the pod was bound,
+        so a Warning older than the bind cannot describe it -- the pod that
+        waited on an autoscaler carries its FailedScheduling for the event TTL
+        even with no Normal event to overtake it (image already cached, a slow
+        volume attach that emits nothing yet). Once the Scheduled event itself
+        ages out of the window, every pre-bind Warning has aged out ahead of
+        it and there is nothing left to demote.
+        """
+        stale = ('FailedScheduling', 'Warning', 'insufficient cpu')
+        events = [self._event(*stale, last_observed=1000)]
+        if bind_at is not None:
+            events.insert(0, self._event(*self._SCHEDULED,
+                                         last_observed=bind_at))
         self._patch_events(monkeypatch, events)
         assert instance._get_pod_pending_reason(
             'ctx', 'ns',
-            'p') == ('FailedMount', 'Unable to attach or mount volumes')
-
-    def test_warning_from_before_the_bind_is_dropped(self, monkeypatch):
-        """The autoscaler case with nothing to overtake it: the pod carries a
-        FailedScheduling for the event TTL and no allow-listed Normal follows
-        (image already cached, a slow volume attach that emits nothing yet).
-        Everything this function observes happens after the bind, so a Warning
-        older than the Scheduled event cannot describe the pod now."""
-        events = [
-            self._event('Scheduled',
-                        'Normal',
-                        'Successfully assigned ns/p to node-1',
-                        last_observed=2000),
-            self._event('FailedScheduling',
-                        'Warning',
-                        '0/3 nodes are available: insufficient cpu.',
-                        last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
-
-    def test_warning_after_the_bind_is_kept(self, monkeypatch):
-        """The kubelet's own warnings all postdate the bind and must survive
-        the same check."""
-        events = [
-            self._event('FailedCreatePodSandBox',
-                        'Warning',
-                        'plugin not initialized',
-                        last_observed=3000),
-            self._event('Scheduled',
-                        'Normal',
-                        'Successfully assigned ns/p to node-1',
-                        last_observed=2000),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason(
-            'ctx', 'ns',
-            'p') == ('FailedCreatePodSandBox', 'plugin not initialized')
+            'p') == (self._expected(stale) if warning_survives else None)
 
     def test_a_pre_bind_warning_does_not_hide_a_live_one(self, monkeypatch):
         """Dropping the stale Warning must fall through to the next Warning,
-        not abandon the tier."""
-        events = [
-            self._event('FailedMount',
-                        'Warning',
-                        'Unable to attach or mount volumes',
-                        last_observed=3000),
-            self._event('Scheduled',
-                        'Normal',
-                        'Successfully assigned ns/p to node-1',
-                        last_observed=2000),
+        not abandon the tier -- and the kubelet's own warnings, which all
+        postdate the bind, must survive the check."""
+        self._patch_events(monkeypatch, [
+            self._event(*self._WARNING, last_observed=3000),
+            self._event(*self._SCHEDULED, last_observed=2000),
             self._event('FailedScheduling',
                         'Warning',
                         'insufficient cpu',
                         last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
+        ])
         assert instance._get_pod_pending_reason(
-            'ctx', 'ns',
-            'p') == ('FailedMount', 'Unable to attach or mount volumes')
-
-    def test_no_scheduled_event_leaves_warnings_alone(self, monkeypatch):
-        """Once the Scheduled event ages out of the window every pre-bind
-        Warning has aged out ahead of it, so there is nothing to demote."""
-        events = [
-            self._event('FailedMount',
-                        'Warning',
-                        'Unable to attach or mount volumes',
-                        last_observed=1000),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason(
-            'ctx', 'ns',
-            'p') == ('FailedMount', 'Unable to attach or mount volumes')
-
-    def test_undated_warning_is_never_treated_as_stale(self, monkeypatch):
-        """Only a Warning that can be shown to be older than the Normal loses.
-        An event the API server left undated cannot be, so it keeps winning."""
-        events = [
-            self._event('Pulling',
-                        'Normal',
-                        'Pulling image "foo:bar"',
-                        last_observed=2000),
-            self._event('FailedMount', 'Warning',
-                        'Unable to attach or mount volumes'),
-        ]
-        self._patch_events(monkeypatch, events)
-        assert instance._get_pod_pending_reason(
-            'ctx', 'ns',
-            'p') == ('FailedMount', 'Unable to attach or mount volumes')
+            'ctx', 'ns', 'p') == self._expected(self._WARNING)
 
     def test_allow_listed_normal_returned_when_no_warning(self, monkeypatch):
         events = [self._event('Pulling', 'Normal', 'Pulling image "foo:bar"')]
@@ -3633,17 +3546,6 @@ class TestStallExemptionHelpers:
     def test_non_exempt_reasons(self, reason):
         assert not instance._reason_is_exempt_from_stall(reason)
 
-    def test_pod_initialization_is_not_exempt(self):
-        """'PodInitializing' with no init container running or being created
-        means the init phase is done and the kubelet has not moved on. There is
-        no legitimately-slow work behind it, so it must not be exempt -- it was
-        previously labelled 'init container running' and swept up by the
-        prefix match, which left that hang unbounded."""
-        assert not instance._reason_is_exempt_from_stall(
-            instance._POD_INITIALIZATION_REASON)
-        assert not instance._POD_INITIALIZATION_REASON.startswith(
-            instance._INIT_CONTAINER_REASON_PREFIX)
-
     def test_synthetic_reasons_stay_in_sync_with_the_exemption(self):
         """The exemption matches on the literals _inspect_pod_status builds, so
         both sides must come from the same constants."""
@@ -3651,6 +3553,11 @@ class TestStallExemptionHelpers:
                 in instance._STALL_EXEMPT_PENDING_REASONS)
         assert instance._PENDING_REASON_NORMAL_EVENT_ALLOWLIST.issubset(
             instance._STALL_EXEMPT_PENDING_REASONS)
+        # 'pod initialization' must stay clear of the init-container prefix:
+        # it was previously labelled 'init container running', which the
+        # prefix match swept up and left that hang unbounded.
+        assert not instance._POD_INITIALIZATION_REASON.startswith(
+            instance._INIT_CONTAINER_REASON_PREFIX)
 
     def test_mount_failures_keep_their_own_window(self):
         assert (instance._stall_timeout_seconds('FailedMount') ==
@@ -3884,58 +3791,49 @@ class TestWaitForPodsToRunStallEscalation:
         assert 'reports no reason why' in msg
         assert 'pod-0' in msg
 
-    @pytest.mark.parametrize('stale_warning',
-                             ['FailedScheduling', 'FailedMount'])
-    def test_a_resolved_warning_does_not_fail_a_healthy_pull(
-            self, monkeypatch, stale_warning):
-        """The regression this deadline is most exposed to: kubernetes keeps
-        events for ~1h, so a pod that waited on the autoscaler, or whose mount
-        the kubelet retried successfully, still carries that Warning while it
-        pulls its image. A stale Warning never changes, so counting it would
-        fail a launch that was making progress the whole time. Driven through
-        the real _get_pod_pending_reason: 200 iterations at 301s is ~16
-        simulated hours of pulling.
+    @pytest.mark.parametrize('warning_reason,warning_at,escalates', [
+        pytest.param('FailedScheduling', 1000, False, id='stale-scheduling'),
+        pytest.param('FailedMount', 1000, False, id='stale-mount'),
+        pytest.param('FailedCreatePodSandBox', 3000, True, id='live-sandbox'),
+    ])
+    def test_the_pull_and_the_warning_decide_the_launch_together(
+            self, monkeypatch, warning_reason, warning_at, escalates):
+        """The same two events, in both orders, driven through the *real*
+        _get_pod_pending_reason rather than a stub -- so the tiering and the
+        deadline are covered as one.
+
+        Kubernetes keeps events for ~1h, so a pod that waited on the autoscaler
+        or whose mount the kubelet retried successfully still carries that
+        Warning while it pulls. A stale Warning never changes, so counting it
+        would fail a launch that was making progress the whole time; 200
+        iterations at 301s is ~16 simulated hours of pulling. A Warning newer
+        than the pull, on the other hand, is the pod's live condition and must
+        still fail the launch.
         """
         events = [
-            TestGetPodPendingReasonTieredEventFilter._event(
-                'Pulling',
-                'Normal',
-                'Pulling image "foo:bar"',
-                last_observed=2000),
-            TestGetPodPendingReasonTieredEventFilter._event(
-                stale_warning,
-                'Warning',
-                'resolved a while ago',
-                last_observed=1000),
+            _make_pod_event('Pulling',
+                            'Normal',
+                            'Pulling image "foo:bar"',
+                            last_observed=2000),
+            _make_pod_event(warning_reason,
+                            'Warning',
+                            self._EVENT_MSG,
+                            last_observed=warning_at),
         ]
-        self._run_wait(monkeypatch,
-                       pod=self._make_pending_pod(),
-                       pod_events=events,
-                       healthy_after=200)
 
-    def test_a_live_warning_still_escalates_over_an_older_pull(
-            self, monkeypatch):
-        """The other side of the same tiering: a Warning that is newer than the
-        pull is the pod's live condition and must still fail the launch."""
-        events = [
-            TestGetPodPendingReasonTieredEventFilter._event(
-                'FailedCreatePodSandBox',
-                'Warning',
-                self._EVENT_MSG,
-                last_observed=2000),
-            TestGetPodPendingReasonTieredEventFilter._event(
-                'Pulling',
-                'Normal',
-                'Pulling image "foo:bar"',
-                last_observed=1000),
-        ]
-        with pytest.raises(config_lib.KubernetesError) as exc_info:
+        def run():
             self._run_wait(monkeypatch,
                            pod=self._make_pending_pod(),
-                           pod_events=events)
-        msg = str(exc_info.value)
-        assert 'FailedCreatePodSandBox' in msg
-        assert self._EVENT_MSG in msg
+                           pod_events=events,
+                           healthy_after=None if escalates else 200)
+
+        if not escalates:
+            run()
+            return
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            run()
+        assert warning_reason in str(exc_info.value)
+        assert self._EVENT_MSG in str(exc_info.value)
 
     def test_timer_resets_when_reason_changes(self, monkeypatch):
         """Two different non-exempt reasons in sequence: the deadline is
@@ -4000,20 +3898,17 @@ class TestWaitForPodsToRunMissingPodDiagnosis:
         assert 'sky logs --provision cn' in msg
 
     def test_absence_of_a_reason_is_explained(self, monkeypatch):
-        """Name the pod and say a cause could not be derived, rather than only
-        implying it ran and died."""
+        """Name the pod and say a cause could not be *derived*, rather than
+        implying it ran and died -- and without asserting one the code never
+        established. _get_pod_missing_reason returns None in three situations
+        and only one of them is 'the pod had no events': it also returns None
+        when the events were all seen on an earlier pass, and when they name
+        no cause it recognises (the common case -- Scheduled/Pulled/Created/
+        Killing)."""
         msg = self._run(monkeypatch, missing_reason=None)
         assert "['pod-0']" in msg
         assert 'no cause could be derived from their events' in msg
         assert 'may have been deleted' in msg
-
-    def test_no_reason_does_not_claim_there_were_no_events(self, monkeypatch):
-        """_get_pod_missing_reason returns None in three situations, and only
-        one of them is 'the pod had no events': it also returns None when the
-        events were all seen on an earlier pass, and when they name no cause it
-        recognises (the common case -- Scheduled/Pulled/Created/Killing). The
-        message must not assert a cause the code never established."""
-        msg = self._run(monkeypatch, missing_reason=None)
         assert 'no events were found' not in msg
         assert 'was likely deleted' not in msg
 
@@ -4332,70 +4227,54 @@ class TestInspectPodStatusInitContainerReason:
 
         return apply
 
-    def test_pod_initializing_no_running_init_container(self, monkeypatch):
-        """PodInitializing with every init container already terminated
-        successfully is not 'an init container is running' -- the init phase is
-        over and the kubelet has not moved on to the main containers. It gets
-        its own reason, which (unlike the init-container ones) is not exempt
-        from the no-progress deadline."""
-        monkeypatch.setattr(instance, '_get_pod_pending_reason',
-                            lambda *a, **kw: None)
-
-        pending_init = self._pod_initializing_with([
+    @pytest.mark.parametrize('make_init_statuses,expected_reason,exempt', [
+        pytest.param(lambda: [
             _make_init_status_with_name(name='init-copy-home',
                                         terminated_exit_code=0),
-        ])
-
-        def running(pod):
-            pod.status.phase = 'Running'
-            pod.status.container_statuses = [
-                self._make_running_container_status()
-            ]
-
-        results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        assert results[0] == [(False, instance._POD_INITIALIZATION_REASON)]
-        assert not instance._reason_is_exempt_from_stall(results[0][0][1])
-
-    @pytest.mark.parametrize('waiting_reason',
-                             ['ContainerCreating', 'PodInitializing'])
-    def test_init_container_being_created_is_reported_as_starting(
-            self, monkeypatch, waiting_reason):
-        """An init container the kubelet is still creating is most often
-        pulling its own image -- legitimately slow, and distinct from both the
-        running case and the nothing-is-happening case."""
-        monkeypatch.setattr(instance, '_get_pod_pending_reason',
-                            lambda *a, **kw: None)
-
-        pending_init = self._pod_initializing_with([
+        ],
+                     'pod initialization',
+                     False,
+                     id='init-done-kubelet-has-not-moved-on'),
+        pytest.param(lambda: [
             _make_init_status_with_name(name='init-setup-ssh',
                                         terminated_exit_code=0),
             _make_init_status_with_name(name='init-copy-home',
-                                        waiting_reason=waiting_reason),
-        ])
-
-        def running(pod):
-            pod.status.phase = 'Running'
-            pod.status.container_statuses = [
-                self._make_running_container_status()
-            ]
-
-        results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        reason = results[0][0][1]
-        assert reason == "init container 'init-copy-home' starting (2/2)"
-        assert instance._reason_is_exempt_from_stall(reason)
-
-    def test_running_init_container_outranks_one_being_created(
-            self, monkeypatch):
-        """With a sidecar running and a later init container being created,
-        the running one is what the pod is waiting on."""
-        monkeypatch.setattr(instance, '_get_pod_pending_reason',
-                            lambda *a, **kw: None)
-
-        pending_init = self._pod_initializing_with([
+                                        waiting_reason='ContainerCreating'),
+        ],
+                     "init container 'init-copy-home' starting (2/2)",
+                     True,
+                     id='being-created'),
+        pytest.param(lambda: [
+            _make_init_status_with_name(name='init-setup-ssh',
+                                        terminated_exit_code=0),
+            _make_init_status_with_name(name='init-copy-home',
+                                        waiting_reason='PodInitializing'),
+        ],
+                     "init container 'init-copy-home' starting (2/2)",
+                     True,
+                     id='being-created-reported-as-podinitializing'),
+        pytest.param(lambda: [
             _make_init_status_with_name(name='init-copy-home',
                                         waiting_reason='ContainerCreating'),
             _make_init_status_with_name(name='init-sidecar', running=True),
-        ])
+        ],
+                     "init container 'init-sidecar' running (2/2)",
+                     True,
+                     id='running-outranks-being-created'),
+    ])
+    def test_init_phase_states_are_distinguished(self, monkeypatch,
+                                                 make_init_statuses,
+                                                 expected_reason, exempt):
+        """_check_init_containers reports three different things, and the
+        no-progress deadline turns on telling them apart: an init container
+        running (arbitrary user work), one the kubelet is still creating (most
+        often pulling an image of its own), and neither -- the init phase is
+        over and the kubelet has not moved on to the main containers. Only the
+        last is bounded; it was previously labelled 'init container running'
+        too, and the prefix-based exemption swept it up.
+        """
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
 
         def running(pod):
             pod.status.phase = 'Running'
@@ -4403,9 +4282,11 @@ class TestInspectPodStatusInitContainerReason:
                 self._make_running_container_status()
             ]
 
-        results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        assert results[0] == [(False,
-                               "init container 'init-sidecar' running (2/2)")]
+        results, _ = self._run_wait(
+            monkeypatch,
+            [self._pod_initializing_with(make_init_statuses()), running])
+        assert results[0] == [(False, expected_reason)]
+        assert instance._reason_is_exempt_from_stall(expected_reason) is exempt
 
     def test_pod_initializing_multiple_init_containers(self, monkeypatch):
         """With multiple init containers, report the currently running one."""

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3373,6 +3373,307 @@ class TestWaitForPodsToRunMountFailureEscalation:
         assert 'kubectl describe pod' in hint
 
 
+class TestStallExemptionHelpers:
+    """The pure predicates behind the no-progress deadline."""
+
+    @pytest.mark.parametrize('reason', [
+        'Pulling',
+        'Provisioning',
+        'WaitForFirstConsumer',
+        'container creation',
+        "init container 'setup' running (1/2)",
+        'init container running',
+    ])
+    def test_exempt_reasons(self, reason):
+        assert instance._reason_is_exempt_from_stall(reason)
+
+    @pytest.mark.parametrize('reason', [
+        None,
+        'FailedMount',
+        'FailedAttachVolume',
+        'FailedCreatePodSandBox',
+        'CrashLoopBackOff',
+        'OOMKilled',
+    ])
+    def test_non_exempt_reasons(self, reason):
+        assert not instance._reason_is_exempt_from_stall(reason)
+
+    def test_synthetic_reasons_stay_in_sync_with_the_exemption(self):
+        """The exemption matches on the literals _inspect_pod_status builds, so
+        both sides must come from the same constants."""
+        assert (instance._CONTAINER_CREATION_REASON
+                in instance._STALL_EXEMPT_PENDING_REASONS)
+        assert instance._PENDING_REASON_NORMAL_EVENT_ALLOWLIST.issubset(
+            instance._STALL_EXEMPT_PENDING_REASONS)
+
+    def test_mount_failures_keep_their_own_window(self):
+        assert (instance._stall_timeout_seconds('FailedMount') ==
+                instance._MOUNT_FAILURE_TIMEOUT_SECONDS)
+        assert (instance._stall_timeout_seconds('FailedCreatePodSandBox') ==
+                instance._POD_RUN_STALL_TIMEOUT_SECONDS)
+        assert (instance._stall_timeout_seconds(None) ==
+                instance._POD_RUN_STALL_TIMEOUT_SECONDS)
+
+
+class TestWaitForPodsToRunStallEscalation:
+    """A pod that keeps reporting the same non-exempt condition must escalate
+    to a KubernetesError once the no-progress deadline elapses, instead of
+    spinning in _wait_for_pods_to_run forever. Reasons that can legitimately
+    persist unchanged for a long time (image pull, volume provisioning, a
+    running init container, plain container creation) must never escalate,
+    however long they last.
+    """
+
+    _EVENT_MSG = 'failed to create pod network sandbox: plugin not initialized'
+
+    @staticmethod
+    def _make_pending_pod(*, name='pod-0', initializing=False):
+        """A scheduled pod whose container is still waiting."""
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.deletion_timestamp = None
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: 'cn-on-cloud',
+        }
+        pod.status.phase = 'Pending'
+        cs = mock.MagicMock()
+        cs.state.waiting = mock.MagicMock(
+            reason='PodInitializing' if initializing else 'ContainerCreating',
+            message=None)
+        cs.state.terminated = None
+        cs.state.running = None
+        cs.last_state.terminated = None
+        pod.status.container_statuses = [cs]
+        if initializing:
+            init_status = mock.MagicMock()
+            init_status.name = 'setup'
+            init_status.state.terminated = None
+            init_status.state.running = mock.MagicMock()
+            init_status.state.waiting = None
+            pod.status.init_container_statuses = [init_status]
+        return pod
+
+    @staticmethod
+    def _make_running_pod(*, name='pod-0', all_containers_running=True):
+        """A Running pod. With all_containers_running=False one container has
+        exited cleanly (e.g. a sidecar), which is the case that produces a
+        pending reason of None: not running, and nothing to report.
+        """
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.deletion_timestamp = None
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: 'cn-on-cloud',
+        }
+        pod.status.phase = 'Running'
+        cs = mock.MagicMock()
+        cs.state.waiting = None
+        cs.state.running = (mock.MagicMock()
+                            if all_containers_running else None)
+        cs.state.terminated = (None if all_containers_running else
+                               mock.MagicMock(exit_code=0, reason='Completed'))
+        cs.last_state.terminated = None
+        pod.status.container_statuses = [cs]
+        return pod
+
+    def _run_wait(self,
+                  monkeypatch,
+                  *,
+                  pod,
+                  pending_reasons=(None,),
+                  clock_step=301.0,
+                  healthy_after=None,
+                  max_iterations=500):
+        """Drive _wait_for_pods_to_run against a single pod, with a scripted
+        event-derived pending reason per iteration (the last entry repeats).
+        The fake clock advances by `clock_step` at each end-of-iteration sleep.
+        If `healthy_after` is set, that iteration (0-based) lists an
+        all-Running pod so the loop exits cleanly.
+
+        The loop is expected to either exit or raise within `max_iterations`;
+        past that the harness fails the test rather than hanging, so a
+        regression that makes the wait unbounded again shows up as a failure
+        and not as a stuck CI job.
+        """
+        healthy_pod = self._make_running_pod()
+        iteration = {'n': -1}
+
+        core_api = mock.MagicMock()
+
+        def _list_pods(*args, **kwargs):
+            iteration['n'] += 1
+            if iteration['n'] > max_iterations:
+                raise AssertionError(
+                    f'_wait_for_pods_to_run did not terminate within '
+                    f'{max_iterations} iterations '
+                    f'({max_iterations * clock_step / 3600:.1f} simulated '
+                    'hours)')
+            if healthy_after is not None and iteration['n'] >= healthy_after:
+                return mock.MagicMock(items=[healthy_pod])
+            return mock.MagicMock(items=[pod])
+
+        core_api.list_namespaced_pod.side_effect = _list_pods
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        def _pending_reason(context, namespace, pod_name):
+            del context, namespace, pod_name  # unused
+            idx = min(max(iteration['n'], 0), len(pending_reasons) - 1)
+            reason = pending_reasons[idx]
+            if reason is None:
+                return None
+            return reason, self._EVENT_MSG
+
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            _pending_reason)
+
+        clock = {'t': 1000.0}
+        monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
+
+        def _sleep(seconds):
+            del seconds  # unused
+            clock['t'] += clock_step
+
+        monkeypatch.setattr(instance.time, 'sleep', _sleep)
+        monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                            lambda fn, items, n: [fn(p) for p in items])
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+
+        instance._wait_for_pods_to_run(namespace='ns',
+                                       context='ctx',
+                                       cluster_name='cn',
+                                       new_pods=[pod])
+
+    def test_sustained_warning_reason_raises(self, monkeypatch):
+        """A kubelet Warning that leaves the container in ContainerCreating
+        (here: pod sandbox creation failing) must escalate, carrying both the
+        reason and the event message."""
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(monkeypatch,
+                           pod=self._make_pending_pod(),
+                           pending_reasons=['FailedCreatePodSandBox'])
+        msg = str(exc_info.value)
+        assert 'FailedCreatePodSandBox' in msg
+        assert self._EVENT_MSG in msg
+        assert 'pod-0' in msg
+
+    @pytest.mark.parametrize(
+        'reason', ['Pulling', 'Provisioning', 'WaitForFirstConsumer'])
+    def test_legitimately_slow_reasons_never_raise(self, monkeypatch, reason):
+        """A large image pull or a slow volume provision holds the same reason
+        for its whole duration and must not be failed. 200 iterations at 301s
+        each is ~16 hours of it."""
+        self._run_wait(monkeypatch,
+                       pod=self._make_pending_pod(),
+                       pending_reasons=[reason],
+                       healthy_after=200)
+
+    def test_container_creation_never_raises(self, monkeypatch):
+        """'container creation' is the no-event fallback, and is also what a
+        pod reports once its 'Pulling' event has aged out of the event window
+        — so it must not be failed either."""
+        self._run_wait(monkeypatch,
+                       pod=self._make_pending_pod(),
+                       pending_reasons=[None],
+                       healthy_after=200)
+
+    def test_running_init_container_never_raises(self, monkeypatch):
+        """An init container may run arbitrarily long user work."""
+        self._run_wait(monkeypatch,
+                       pod=self._make_pending_pod(initializing=True),
+                       pending_reasons=[None],
+                       healthy_after=200)
+
+    def test_no_reason_at_all_raises(self, monkeypatch):
+        """A pod that is neither running nor able to say why is the pure
+        'infinite Launching spinner' case: no pending reason means no spinner
+        detail and no error, forever."""
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(
+                monkeypatch,
+                pod=self._make_running_pod(all_containers_running=False),
+                pending_reasons=[None])
+        msg = str(exc_info.value)
+        assert 'reports no reason why' in msg
+        assert 'pod-0' in msg
+
+    def test_timer_resets_when_reason_changes(self, monkeypatch):
+        """Two different non-exempt reasons in sequence: the deadline is
+        measured from the most recent onset, so neither window is long enough
+        to raise even though the total elapsed time exceeds the deadline."""
+        self._run_wait(monkeypatch,
+                       pod=self._make_pending_pod(),
+                       pending_reasons=[
+                           'FailedCreatePodSandBox', 'FailedCreatePodSandBox',
+                           'FailedCreatePodContainer'
+                       ],
+                       healthy_after=3)
+
+    def test_stall_error_picks_up_the_failure_hint(self):
+        """A stall whose reason names a known cause must still trip
+        KUBERNETES_FAILURE_HINTS, since the hint match is a substring test on
+        the message."""
+        message = ('Pod pod-0 has been stuck on the same condition for over '
+                   '10 minutes: OOMKilled: killed')
+        hint = kubernetes_utils.match_kubernetes_failure_hint(message)
+        assert hint is not None
+        assert 'ran out of memory' in hint
+
+
+class TestWaitForPodsToRunMissingPodDiagnosis:
+    """When pods vanish while waiting for them to run, the raised error must
+    carry whatever the events said, not just the generic sentence.
+    """
+
+    def _run(self, monkeypatch, *, missing_reason):
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = 'pod-0'
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: 'cn-on-cloud',
+        }
+
+        core_api = mock.MagicMock()
+        # The pod is never returned by the list call -- it is missing.
+        core_api.list_namespaced_pod.return_value = mock.MagicMock(items=[])
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+        monkeypatch.setattr(instance, '_get_pod_missing_reason',
+                            lambda *a, **kw: missing_reason)
+        monkeypatch.setattr(instance.time, 'sleep', lambda seconds: None)
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            instance._wait_for_pods_to_run(namespace='ns',
+                                           context='ctx',
+                                           cluster_name='cn',
+                                           new_pods=[pod])
+        return str(exc_info.value)
+
+    def test_reason_is_surfaced(self, monkeypatch):
+        msg = self._run(monkeypatch,
+                        missing_reason='pod was evicted by taint manager')
+        assert 'pod-0: pod was evicted by taint manager' in msg
+        assert 'sky logs --provision cn' in msg
+
+    def test_absence_of_events_is_explained(self, monkeypatch):
+        """The common case for a pod the API server rejected outright: no
+        events at all. Name the pod and say so, rather than only implying it
+        ran and died."""
+        msg = self._run(monkeypatch, missing_reason=None)
+        assert "['pod-0']" in msg
+        assert 'no events were found' in msg
+        assert 'rejected by the API server' in msg
+
+
 class TestCheckInitContainersEnrichedRaise:
     """Tests the enriched raise message in _check_init_containers when an
     init container is in CrashLoopBackOff."""

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3135,6 +3135,28 @@ class TestGetPodPendingReasonTieredEventFilter:
         result = instance._get_pod_pending_reason('ctx', 'ns', 'p')
         assert result == ('FailedScheduling', '')
 
+    @pytest.mark.parametrize('warning_at,expect_warning', [
+        pytest.param(3000, True, id='live-warning-answers'),
+        pytest.param(1000, False, id='warning-overtaken-by-the-normal'),
+        pytest.param(None, False, id='no-warning-at-all'),
+    ])
+    def test_warnings_only_withholds_the_normal_tier(self, monkeypatch,
+                                                     warning_at,
+                                                     expect_warning):
+        """warnings_only answers the narrower question its caller is asking --
+        is the pod actively failing? -- so an allow-listed Normal yields None
+        rather than the reason the caller already has. The tiering still runs
+        in full: a Warning the Normal has overtaken must not be resurrected
+        just because the Normal is being withheld.
+        """
+        events = [self._event(*self._NORMAL, last_observed=2000)]
+        if warning_at is not None:
+            events.append(self._event(*self._WARNING, last_observed=warning_at))
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns', 'p', warnings_only=True) == (self._expected(
+                self._WARNING) if expect_warning else None)
+
     def test_events_fetch_failure_returns_none(self, monkeypatch):
 
         def raise_for_events(*a, **kw):
@@ -3580,14 +3602,17 @@ class TestWaitForPodsToRunStallEscalation:
     _EVENT_MSG = 'failed to create pod network sandbox: plugin not initialized'
 
     @staticmethod
-    def _make_pending_pod(*, name='pod-0', initializing=False, init_done=False):
+    def _make_pending_pod(*, name='pod-0', init=None):
         """A scheduled pod whose container is still waiting.
 
-        With initializing=True the pod reports PodInitializing: by default an
-        init container is running, and with init_done=True they have all
-        terminated successfully while the kubelet has not moved on.
+        `init` selects the init phase the pod reports, mirroring the three
+        states _check_init_containers distinguishes: 'running' (an init
+        container is doing its own work), 'starting' (the kubelet has not
+        started it yet) and 'done' (they have all terminated successfully while
+        the kubelet has not moved on). None reports plain ContainerCreating.
         """
         from sky.provision import constants as prov_constants
+        assert init in (None, 'running', 'starting', 'done'), init
         pod = mock.MagicMock()
         pod.metadata.name = name
         pod.metadata.deletion_timestamp = None
@@ -3597,23 +3622,26 @@ class TestWaitForPodsToRunStallEscalation:
         pod.status.phase = 'Pending'
         cs = mock.MagicMock()
         cs.state.waiting = mock.MagicMock(
-            reason='PodInitializing' if initializing else 'ContainerCreating',
+            reason='PodInitializing' if init else 'ContainerCreating',
             message=None)
         cs.state.terminated = None
         cs.state.running = None
         cs.last_state.terminated = None
         pod.status.container_statuses = [cs]
-        if initializing:
+        if init:
             init_status = mock.MagicMock()
             init_status.name = 'setup'
             init_status.state.waiting = None
-            if init_done:
+            init_status.state.running = None
+            init_status.state.terminated = None
+            if init == 'starting':
+                init_status.state.waiting = mock.MagicMock(
+                    reason='ContainerCreating', message=None)
+            elif init == 'running':
+                init_status.state.running = mock.MagicMock()
+            else:
                 init_status.state.terminated = mock.MagicMock(exit_code=0,
                                                               message=None)
-                init_status.state.running = None
-            else:
-                init_status.state.terminated = None
-                init_status.state.running = mock.MagicMock()
             pod.status.init_container_statuses = [init_status]
         return pod
 
@@ -3691,11 +3719,20 @@ class TestWaitForPodsToRunStallEscalation:
                                 lambda *a, **kw: pod_events)
         else:
 
-            def _pending_reason(context, namespace, pod_name):
+            def _pending_reason(context,
+                                namespace,
+                                pod_name,
+                                warnings_only=False):
                 del context, namespace, pod_name  # unused
                 idx = min(max(iteration['n'], 0), len(pending_reasons) - 1)
                 reason = pending_reasons[idx]
                 if reason is None:
+                    return None
+                if (warnings_only and reason
+                        in instance._PENDING_REASON_NORMAL_EVENT_ALLOWLIST):
+                    # Stand in for the real tiering: a caller asking only
+                    # whether the pod is actively failing gets nothing back
+                    # from an allow-listed Normal event.
                     return None
                 return reason, self._EVENT_MSG
 
@@ -3755,10 +3792,13 @@ class TestWaitForPodsToRunStallEscalation:
                        pending_reasons=[None],
                        healthy_after=200)
 
-    def test_running_init_container_never_raises(self, monkeypatch):
-        """An init container may run arbitrarily long user work."""
+    @pytest.mark.parametrize('init', ['running', 'starting'])
+    def test_init_container_in_flight_never_raises(self, monkeypatch, init):
+        """An init container may run arbitrarily long user work, and one the
+        kubelet has not started yet is most often pulling an image of its
+        own."""
         self._run_wait(monkeypatch,
-                       pod=self._make_pending_pod(initializing=True),
+                       pod=self._make_pending_pod(init=init),
                        pending_reasons=[None],
                        healthy_after=200)
 
@@ -3771,12 +3811,51 @@ class TestWaitForPodsToRunStallEscalation:
         """
         with pytest.raises(config_lib.KubernetesError) as exc_info:
             self._run_wait(monkeypatch,
-                           pod=self._make_pending_pod(initializing=True,
-                                                      init_done=True),
+                           pod=self._make_pending_pod(init='done'),
                            pending_reasons=[None])
         msg = str(exc_info.value)
         assert instance._POD_INITIALIZATION_REASON in msg
         assert 'pod-0' in msg
+
+    @pytest.mark.parametrize('warning_at,escalates', [
+        pytest.param(3000, True, id='live-warning-bounds-the-wait'),
+        pytest.param(1000, False, id='pre-bind-warning-leaves-it-exempt'),
+    ])
+    def test_a_live_warning_bounds_an_init_container_that_cannot_start(
+            self, monkeypatch, warning_at, escalates):
+        """An init container the kubelet cannot start looks exactly like one it
+        is slowly starting -- both are 'starting', which is exempt -- and the
+        difference is only in the events. Driven through the *real*
+        _get_pod_pending_reason: a live Warning must take over the reason and
+        bring the deadline with it, while one the pod has already moved past
+        must leave the exemption in place for the whole (~16 simulated hour)
+        wait.
+        """
+        events = [
+            _make_pod_event('FailedCreatePodSandBox',
+                            'Warning',
+                            self._EVENT_MSG,
+                            last_observed=warning_at),
+            _make_pod_event('Scheduled',
+                            'Normal',
+                            'Successfully assigned ns/pod-0 to node-1',
+                            last_observed=2000),
+        ]
+
+        def run():
+            self._run_wait(monkeypatch,
+                           pod=self._make_pending_pod(init='starting'),
+                           pod_events=events,
+                           healthy_after=None if escalates else 200)
+
+        if not escalates:
+            run()
+            return
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            run()
+        msg = str(exc_info.value)
+        assert 'FailedCreatePodSandBox' in msg
+        assert self._EVENT_MSG in msg
 
     def test_no_reason_at_all_raises(self, monkeypatch):
         """A pod that is neither running nor able to say why is the pure
@@ -4287,6 +4366,96 @@ class TestInspectPodStatusInitContainerReason:
             [self._pod_initializing_with(make_init_statuses()), running])
         assert results[0] == [(False, expected_reason)]
         assert instance._reason_is_exempt_from_stall(expected_reason) is exempt
+
+    @pytest.mark.parametrize('init_state,events,expected_reason', [
+        pytest.param('starting', [
+            ('FailedCreatePodSandBox', 'Warning', 'plugin not initialized',
+             3000),
+        ],
+                     'FailedCreatePodSandBox',
+                     id='live-warning-replaces-the-assumption'),
+        pytest.param('starting', [
+            ('FailedScheduling', 'Warning', 'insufficient cpu', 1000),
+        ],
+                     "init container 'init-copy-home' starting (1/1)",
+                     id='pre-bind-warning-does-not'),
+        pytest.param('starting', [
+            ('Pulling', 'Normal', 'Pulling image "foo:bar"', 3000),
+        ],
+                     "init container 'init-copy-home' starting (1/1)",
+                     id='allow-listed-normal-is-not-consulted'),
+        pytest.param('running', [
+            ('FailedCreatePodSandBox', 'Warning', 'plugin not initialized',
+             3000),
+        ],
+                     "init container 'init-copy-home' running (1/1)",
+                     id='a-running-init-container-outranks-a-live-warning'),
+    ])
+    def test_a_live_warning_replaces_the_starting_assumption(
+            self, monkeypatch, init_state, events, expected_reason):
+        """'starting' says only that the kubelet has not started the container
+        yet; that this is legitimately slow work -- and so stall-exempt -- is an
+        assumption, and the same state is what a pod shows when the kubelet
+        cannot start it at all. So a live Warning replaces it, since it is both
+        truer and bounded by the no-progress deadline.
+
+        Only the assumption gives way: a Warning the pod has already moved past
+        does not displace it, an allow-listed Normal is not consulted (exempt
+        either way, and the init label names the container being waited on), and
+        an init container the kubelet reports as *running* is not an assumption
+        at all.
+        """
+        pod_events = [
+            _make_pod_event(reason, event_type, message, last_observed=at)
+            for reason, event_type, message, at in events
+        ] + [
+            _make_pod_event('Scheduled',
+                            'Normal',
+                            'Successfully assigned ns/p to node-1',
+                            last_observed=2000)
+        ]
+        monkeypatch.setattr(instance, '_get_pod_events',
+                            lambda *a, **kw: pod_events)
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        init_status = _make_init_status_with_name(
+            name='init-copy-home',
+            running=init_state == 'running',
+            waiting_reason=('ContainerCreating'
+                            if init_state == 'starting' else None))
+        results, _ = self._run_wait(
+            monkeypatch, [self._pod_initializing_with([init_status]), running])
+        assert results[0] == [(False, expected_reason)]
+
+    def test_a_running_init_container_does_not_read_the_events(
+            self, monkeypatch):
+        """The events lookup is skipped outright, not just outranked: a pod
+        whose init container is running needs no event to explain it, and each
+        poll of every pod would otherwise cost an extra API call."""
+        calls = []
+
+        def _events(*args, **kwargs):
+            calls.append(args)
+            return []
+
+        monkeypatch.setattr(instance, '_get_pod_events', _events)
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        init_status = _make_init_status_with_name(name='init-copy-home',
+                                                  running=True)
+        self._run_wait(monkeypatch,
+                       [self._pod_initializing_with([init_status]), running])
+        assert not calls
 
     def test_pod_initializing_multiple_init_containers(self, monkeypatch):
         """With multiple init containers, report the currently running one."""

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3075,6 +3075,79 @@ class TestGetPodPendingReasonTieredEventFilter:
             'ctx', 'ns',
             'p') == ('FailedMount', 'Unable to attach or mount volumes')
 
+    def test_warning_from_before_the_bind_is_dropped(self, monkeypatch):
+        """The autoscaler case with nothing to overtake it: the pod carries a
+        FailedScheduling for the event TTL and no allow-listed Normal follows
+        (image already cached, a slow volume attach that emits nothing yet).
+        Everything this function observes happens after the bind, so a Warning
+        older than the Scheduled event cannot describe the pod now."""
+        events = [
+            self._event('Scheduled',
+                        'Normal',
+                        'Successfully assigned ns/p to node-1',
+                        last_observed=2000),
+            self._event('FailedScheduling',
+                        'Warning',
+                        '0/3 nodes are available: insufficient cpu.',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason('ctx', 'ns', 'p') is None
+
+    def test_warning_after_the_bind_is_kept(self, monkeypatch):
+        """The kubelet's own warnings all postdate the bind and must survive
+        the same check."""
+        events = [
+            self._event('FailedCreatePodSandBox',
+                        'Warning',
+                        'plugin not initialized',
+                        last_observed=3000),
+            self._event('Scheduled',
+                        'Normal',
+                        'Successfully assigned ns/p to node-1',
+                        last_observed=2000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns',
+            'p') == ('FailedCreatePodSandBox', 'plugin not initialized')
+
+    def test_a_pre_bind_warning_does_not_hide_a_live_one(self, monkeypatch):
+        """Dropping the stale Warning must fall through to the next Warning,
+        not abandon the tier."""
+        events = [
+            self._event('FailedMount',
+                        'Warning',
+                        'Unable to attach or mount volumes',
+                        last_observed=3000),
+            self._event('Scheduled',
+                        'Normal',
+                        'Successfully assigned ns/p to node-1',
+                        last_observed=2000),
+            self._event('FailedScheduling',
+                        'Warning',
+                        'insufficient cpu',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns',
+            'p') == ('FailedMount', 'Unable to attach or mount volumes')
+
+    def test_no_scheduled_event_leaves_warnings_alone(self, monkeypatch):
+        """Once the Scheduled event ages out of the window every pre-bind
+        Warning has aged out ahead of it, so there is nothing to demote."""
+        events = [
+            self._event('FailedMount',
+                        'Warning',
+                        'Unable to attach or mount volumes',
+                        last_observed=1000),
+        ]
+        self._patch_events(monkeypatch, events)
+        assert instance._get_pod_pending_reason(
+            'ctx', 'ns',
+            'p') == ('FailedMount', 'Unable to attach or mount volumes')
+
     def test_undated_warning_is_never_treated_as_stale(self, monkeypatch):
         """Only a Warning that can be shown to be older than the Normal loses.
         An event the API server left undated cannot be, so it keeps winning."""
@@ -3543,7 +3616,7 @@ class TestStallExemptionHelpers:
         'WaitForFirstConsumer',
         'container creation',
         "init container 'setup' running (1/2)",
-        'init container running',
+        "init container 'setup' starting (1/2)",
     ])
     def test_exempt_reasons(self, reason):
         assert instance._reason_is_exempt_from_stall(reason)
@@ -3555,9 +3628,21 @@ class TestStallExemptionHelpers:
         'FailedCreatePodSandBox',
         'CrashLoopBackOff',
         'OOMKilled',
+        'pod initialization',
     ])
     def test_non_exempt_reasons(self, reason):
         assert not instance._reason_is_exempt_from_stall(reason)
+
+    def test_pod_initialization_is_not_exempt(self):
+        """'PodInitializing' with no init container running or being created
+        means the init phase is done and the kubelet has not moved on. There is
+        no legitimately-slow work behind it, so it must not be exempt -- it was
+        previously labelled 'init container running' and swept up by the
+        prefix match, which left that hang unbounded."""
+        assert not instance._reason_is_exempt_from_stall(
+            instance._POD_INITIALIZATION_REASON)
+        assert not instance._POD_INITIALIZATION_REASON.startswith(
+            instance._INIT_CONTAINER_REASON_PREFIX)
 
     def test_synthetic_reasons_stay_in_sync_with_the_exemption(self):
         """The exemption matches on the literals _inspect_pod_status builds, so
@@ -3588,8 +3673,13 @@ class TestWaitForPodsToRunStallEscalation:
     _EVENT_MSG = 'failed to create pod network sandbox: plugin not initialized'
 
     @staticmethod
-    def _make_pending_pod(*, name='pod-0', initializing=False):
-        """A scheduled pod whose container is still waiting."""
+    def _make_pending_pod(*, name='pod-0', initializing=False, init_done=False):
+        """A scheduled pod whose container is still waiting.
+
+        With initializing=True the pod reports PodInitializing: by default an
+        init container is running, and with init_done=True they have all
+        terminated successfully while the kubelet has not moved on.
+        """
         from sky.provision import constants as prov_constants
         pod = mock.MagicMock()
         pod.metadata.name = name
@@ -3609,9 +3699,14 @@ class TestWaitForPodsToRunStallEscalation:
         if initializing:
             init_status = mock.MagicMock()
             init_status.name = 'setup'
-            init_status.state.terminated = None
-            init_status.state.running = mock.MagicMock()
             init_status.state.waiting = None
+            if init_done:
+                init_status.state.terminated = mock.MagicMock(exit_code=0,
+                                                              message=None)
+                init_status.state.running = None
+            else:
+                init_status.state.terminated = None
+                init_status.state.running = mock.MagicMock()
             pod.status.init_container_statuses = [init_status]
         return pod
 
@@ -3760,6 +3855,22 @@ class TestWaitForPodsToRunStallEscalation:
                        pending_reasons=[None],
                        healthy_after=200)
 
+    def test_stuck_after_init_containers_finished_raises(self, monkeypatch):
+        """PodInitializing with every init container already terminated
+        successfully: the init phase is over and the kubelet never started the
+        main containers. Nothing is legitimately slow here, so this must be
+        bounded -- it was previously labelled 'init container running', which
+        the prefix-based exemption swept up, leaving the launch hung forever.
+        """
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(monkeypatch,
+                           pod=self._make_pending_pod(initializing=True,
+                                                      init_done=True),
+                           pending_reasons=[None])
+        msg = str(exc_info.value)
+        assert instance._POD_INITIALIZATION_REASON in msg
+        assert 'pod-0' in msg
+
     def test_no_reason_at_all_raises(self, monkeypatch):
         """A pod that is neither running nor able to say why is the pure
         'infinite Launching spinner' case: no pending reason means no spinner
@@ -3888,14 +3999,23 @@ class TestWaitForPodsToRunMissingPodDiagnosis:
         assert 'pod-0: pod was evicted by taint manager' in msg
         assert 'sky logs --provision cn' in msg
 
-    def test_absence_of_events_is_explained(self, monkeypatch):
-        """The common case for a pod the API server rejected outright: no
-        events at all. Name the pod and say so, rather than only implying it
-        ran and died."""
+    def test_absence_of_a_reason_is_explained(self, monkeypatch):
+        """Name the pod and say a cause could not be derived, rather than only
+        implying it ran and died."""
         msg = self._run(monkeypatch, missing_reason=None)
         assert "['pod-0']" in msg
-        assert 'no events were found' in msg
-        assert 'rejected by the API server' in msg
+        assert 'no cause could be derived from their events' in msg
+        assert 'may have been deleted' in msg
+
+    def test_no_reason_does_not_claim_there_were_no_events(self, monkeypatch):
+        """_get_pod_missing_reason returns None in three situations, and only
+        one of them is 'the pod had no events': it also returns None when the
+        events were all seen on an earlier pass, and when they name no cause it
+        recognises (the common case -- Scheduled/Pulled/Created/Killing). The
+        message must not assert a cause the code never established."""
+        msg = self._run(monkeypatch, missing_reason=None)
+        assert 'no events were found' not in msg
+        assert 'was likely deleted' not in msg
 
 
 class TestCheckInitContainersEnrichedRaise:
@@ -4195,13 +4315,11 @@ class TestInspectPodStatusInitContainerReason:
         assert '(1/1)' in init_logs[0]
         assert 'Pulling' not in init_logs[0]
 
-    def test_pod_initializing_no_running_init_container(self, monkeypatch):
-        """When PodInitializing but no init container is in running state,
-        fall back to generic message."""
-        monkeypatch.setattr(instance, '_get_pod_pending_reason',
-                            lambda *a, **kw: None)
+    @staticmethod
+    def _pod_initializing_with(init_statuses):
+        """A Pending pod whose main container reports PodInitializing."""
 
-        def pending_init(pod):
+        def apply(pod):
             pod.status.phase = 'Pending'
             cs = mock.MagicMock()
             cs.state = mock.MagicMock()
@@ -4210,10 +4328,23 @@ class TestInspectPodStatusInitContainerReason:
             cs.state.terminated = None
             cs.last_state.terminated = None
             pod.status.container_statuses = [cs]
-            pod.status.init_container_statuses = [
-                _make_init_status_with_name(name='init-copy-home',
-                                            terminated_exit_code=0),
-            ]
+            pod.status.init_container_statuses = init_statuses
+
+        return apply
+
+    def test_pod_initializing_no_running_init_container(self, monkeypatch):
+        """PodInitializing with every init container already terminated
+        successfully is not 'an init container is running' -- the init phase is
+        over and the kubelet has not moved on to the main containers. It gets
+        its own reason, which (unlike the init-container ones) is not exempt
+        from the no-progress deadline."""
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
+
+        pending_init = self._pod_initializing_with([
+            _make_init_status_with_name(name='init-copy-home',
+                                        terminated_exit_code=0),
+        ])
 
         def running(pod):
             pod.status.phase = 'Running'
@@ -4222,7 +4353,59 @@ class TestInspectPodStatusInitContainerReason:
             ]
 
         results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        assert results[0] == [(False, 'init container running')]
+        assert results[0] == [(False, instance._POD_INITIALIZATION_REASON)]
+        assert not instance._reason_is_exempt_from_stall(results[0][0][1])
+
+    @pytest.mark.parametrize('waiting_reason',
+                             ['ContainerCreating', 'PodInitializing'])
+    def test_init_container_being_created_is_reported_as_starting(
+            self, monkeypatch, waiting_reason):
+        """An init container the kubelet is still creating is most often
+        pulling its own image -- legitimately slow, and distinct from both the
+        running case and the nothing-is-happening case."""
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
+
+        pending_init = self._pod_initializing_with([
+            _make_init_status_with_name(name='init-setup-ssh',
+                                        terminated_exit_code=0),
+            _make_init_status_with_name(name='init-copy-home',
+                                        waiting_reason=waiting_reason),
+        ])
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, _ = self._run_wait(monkeypatch, [pending_init, running])
+        reason = results[0][0][1]
+        assert reason == "init container 'init-copy-home' starting (2/2)"
+        assert instance._reason_is_exempt_from_stall(reason)
+
+    def test_running_init_container_outranks_one_being_created(
+            self, monkeypatch):
+        """With a sidecar running and a later init container being created,
+        the running one is what the pod is waiting on."""
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
+
+        pending_init = self._pod_initializing_with([
+            _make_init_status_with_name(name='init-copy-home',
+                                        waiting_reason='ContainerCreating'),
+            _make_init_status_with_name(name='init-sidecar', running=True),
+        ])
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, _ = self._run_wait(monkeypatch, [pending_init, running])
+        assert results[0] == [(False,
+                               "init container 'init-sidecar' running (2/2)")]
 
     def test_pod_initializing_multiple_init_containers(self, monkeypatch):
         """With multiple init containers, report the currently running one."""


### PR DESCRIPTION
`_wait_for_pods_to_run` is a bare `while True` with no deadline. Every pod that reaches it is already bound to a node (`_wait_for_pods_to_schedule` only returns once all pods are scheduled), so what remains is kubelet-side work — but only two of its failure modes escalate today: a sustained mount failure, and a persistent API-server transport error. Anything else that leaves a container stuck, or leaves the pod not-running with nothing to report, spins here forever behind a `Launching` spinner and never errors.

Concretely, these all hang a launch indefinitely today:

- a pod sandbox that cannot be created (`FailedCreatePodSandBox`, e.g. a CNI failure, or a `RuntimeClass` whose handler does not exist on the node)
- a container crash-looping while the pod's phase is already `Running` — `_inspect_pod_status` raises on `CrashLoopBackOff` only while the phase is `Pending`
- a pod that is not running and reports no reason at all, e.g. a container that exited cleanly, which never satisfies the all-containers-running exit condition

## Changes

**Generalize the existing mount-failure deadline into a no-progress deadline.** A pod that keeps reporting the same pending reason for 10 minutes now fails provisioning instead of spinning. The deadline is measured from the most recent onset of a single reason, so a reason that changes counts as progress and resets the clock.

**Nothing that works today starts failing.** Reasons that can legitimately persist unchanged for a very long time are exempt:

| Exempt reason | Why |
|---|---|
| `Pulling` | a large image pull holds this for its whole duration |
| `Provisioning` | an external CSI provisioner creating a volume |
| `WaitForFirstConsumer` | late-binding storage class |
| `container creation` | the no-event fallback — and also what a pod reports once its `Pulling` event has aged out of the event window |
| `init container ... running` | may be doing arbitrary user work |
| `init container ... starting` | the kubelet is creating it — most often pulling an image of its own |

Mount failures keep their own window and their existing message, so the `FailedMount` / `FailedAttachVolume` remediation hint still matches.

**Stop a resolved Warning event from outranking a newer Normal.** The deadline reads "the reason did not change" as "the pod made no progress", which only holds if the reason stops being reported once the pod moves past it. `_get_pod_pending_reason` returned the newest Warning unconditionally, and Kubernetes keeps events for the event TTL (~1h) — so a pod that waited on an autoscaler still carried its `FailedScheduling` long after being bound, and a mount the kubelet retried successfully still carried its `FailedMount`, both outranking the live `Pulling` for the whole pull. Merely a mislabeled spinner before this PR; a spurious launch failure after it. Two independent checks now demote a Warning:

1. one last observed **before the pod was bound** is dropped outright — everything `_wait_for_pods_to_run` sees happens after the bind, so a pre-bind `FailedScheduling` cannot describe the pod, whether or not any Normal follows it. The bind is read from the pod's own `Scheduled` event, so once that ages out of the event window every pre-bind Warning has aged out ahead of it and the check correctly no-ops;
2. one observed **less recently than the allow-listed Normal** has been overtaken by it — e.g. a mount the kubelet retried successfully, whose `FailedMount` predates the pull now under way.

Both compare last-observed time (`series.last_observed_time` → `last_timestamp` → `event_time` → `creation_timestamp`) rather than creation time: Kubernetes folds a repeated event back into the original object, so creation time says when a condition *started* and only last-observed says whether it is *still happening*. A live Warning being re-emitted survives both checks, ordering within a tier is unchanged, and an undated event is never treated as stale.

**Give the init phase's two states two labels.** `init container running` was reported both when an init container was genuinely running and when none was, and the stall exemption matches on the `init container ` prefix — so a pod stuck in `PodInitializing` with every init container already terminated successfully stayed exempt and hung the launch forever, mislabeled. `_check_init_containers` now also reports an init container the kubelet is still *creating* (which may be pulling a large image of its own, and stays exempt) as `starting`, which leaves the genuinely stuck case its own non-exempt `pod initialization` reason. Native sidecars stay in `running` and remain exempt.

**Let a live Warning bound an init container that cannot start.** `init container ... starting` says only that the kubelet has not started the container yet; that this is legitimately slow work — an image pull of its own — is an assumption, and it is the assumption, not the state, that earns the exemption. The same state is what a pod shows when the kubelet cannot get as far as starting the container at all (a sandbox it cannot create, a volume it cannot mount), which is reported only through events — and the synthetic init reason wins over every event-based reason, so those events were never consulted. That left the sandbox failure this PR exists to bound still hanging the launch indefinitely, reached by a different route.

So when the init reason is an assumption, a live Warning replaces it: truer, and unlike the init label it comes with the no-progress deadline. Three things deliberately do not displace it — a Warning the pod has already moved past (reusing the same staleness checks above, or this reintroduces the spurious failure they fixed), an allow-listed Normal (exempt either way, and the init label additionally names which container is being waited on), and an init container the kubelet reports as *running*, which is not an assumption and skips the events lookup entirely. Mechanically this is a `warnings_only` flag on `_get_pod_pending_reason` that withholds the tier-3 Normal; the tiering still runs in full, so a Warning a newer Normal has overtaken is not resurrected just because the Normal is being withheld.

**Surface the missing-pod diagnosis.** `_get_pod_missing_reason` already analyses the pod's events, but its result only reached the debug log — the raised error read identically whether the pod was evicted, deleted by another controller, or rejected by the API server before it ever started. Include the reason in the error, and name the missing pods when there is no reason to be had — saying only that no cause could be *derived*, since `_get_pod_missing_reason` also returns None when the events were all seen on an earlier pass and when they name none of the causes it recognises.

## Tested

- `pytest tests/unit_tests/kubernetes/` passes.
- New tests cover both escalations and, more importantly, the exemptions: each legitimately-slow reason is driven for 200 polls (~16 simulated hours) and must not raise.
- The test harness now fails if the wait does not terminate within 500 iterations, so a regression that makes the loop unbounded again surfaces as a test failure rather than a hung CI job. Both new escalation tests were confirmed to fail that way against the pre-change function.
- Two of those cases drive `_wait_for_pods_to_run` through the *real* `_get_pod_pending_reason` rather than a stub, so the event tiering is covered end to end: a stale `FailedScheduling` / `FailedMount` alongside a fresh `Pulling` must survive ~16 simulated hours, and a `FailedCreatePodSandBox` newer than the pull must still escalate. Both fail against the pre-fix tiering with the exact spurious error (`Pod pod-0 has failed to attach or mount volumes for over 10 minutes: FailedMount: resolved a while ago`).
- The `Scheduled`-boundary check is covered both ways (pre-bind Warning dropped, post-bind Warning kept, a stale Warning not hiding a live one behind it, and no `Scheduled` event leaving Warnings alone), as is the init-phase split — the stuck-after-init case escalates end to end, having previously tripped the 500-iteration guard at ~42 simulated hours.
- The init-container escalation is covered end to end through the real `_get_pod_pending_reason` (it too previously ran past the 500-iteration guard, at 41.8 simulated hours), alongside the three cases that must *not* displace the init label, a `warnings_only` unit table over live / overtaken / no-Warning, and an assertion that a *running* init container never fetches the events at all.

The escalation was verified with a simulated clock rather than on a real cluster. To reproduce the main path by hand on kind — pointing the `nvidia` RuntimeClass at a handler containerd does not have makes pod sandbox creation fail while the pod stays in `ContainerCreating`:

```bash
kubectl patch runtimeclass nvidia --type=merge -p '{"handler":"does-not-exist"}'
sky launch --gpus <gpu>:1 -c stuck -- 'true'
```

Before this change that launch shows `Launching` forever — the kubelet re-emits `FailedCreatePodSandBox` and nothing ever surfaces. After it, provisioning fails after 10 minutes with the reason and the kubelet's message.



