### PR TITLE
[Test] Make volume smoke tests behave against a shared remote API server

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1850,6 +1850,13 @@ def test_hostpath_volume_on_kubernetes():
 
 # ---------- Auto-mount refuses a volume that is not ready ----------
 @pytest.mark.kubernetes
+# The unprovisionable-StorageClass fixture needs the agent's kubectl to have
+# cluster-admin on the same cluster the API server schedules onto. A remote
+# server's agent is a plain client with no kubeconfig, and routing the fixture
+# through the cloud-cmd helper does not work either: the helper pod's kubectl
+# runs as skypilot-service-account, whose ClusterRole has no storage.k8s.io
+# verbs, so a cluster-scoped StorageClass write is Forbidden.
+@pytest.mark.no_remote_server
 def test_auto_mount_not_ready_on_kubernetes():
     """A volume whose storage cannot be provisioned must stop the launch.
 
@@ -1958,6 +1965,9 @@ def test_auto_mount_not_ready_on_kubernetes():
 
 # ---------- A volume declared on the task must be ready ----------
 @pytest.mark.kubernetes
+# See test_auto_mount_not_ready_on_kubernetes: the StorageClass fixture
+# needs cluster-admin kubectl co-located with the API server.
+@pytest.mark.no_remote_server
 def test_volume_not_ready_on_kubernetes():
     """The reference behaviour the auto-mount check is modelled on.
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1750,7 +1750,13 @@ def test_volume_env_mount_kubernetes():
                 f's=$(sky jobs launch -y --infra kubernetes {f.name} --env USERNAME=user); echo "$s"; echo "$s" | grep "Job finished (status: SUCCEEDED)"',
             ],
             smoke_tests_utils.chain_teardown(
-                'sky jobs cancel -a -y || true',
+                # Cancel by name, never -a: on a shared remote API server all
+                # concurrently running smoke tests submit jobs as the same
+                # service-account user, so `-a` cancels *their* in-flight jobs
+                # too (observed in enterprise CI: one such teardown killed an
+                # unrelated job-group test's job and another lane's kueue
+                # blocker mid-run).
+                f'sky jobs cancel -y -n {name}-job || true',
                 # The managed job's worker cluster is torn down in the
                 # controller's `finally` block, and the controller only sets
                 # schedule_state=DONE after that cleanup completes — so DONE

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -4142,6 +4142,10 @@ def test_managed_jobs_emergency_recovery(generic_cloud: str):
 # ---------- Managed job with a volume that is not ready ----------
 @pytest.mark.managed_jobs
 @pytest.mark.kubernetes
+# See test_auto_mount_not_ready_on_kubernetes in test_cluster_job.py: the
+# StorageClass fixture needs cluster-admin kubectl co-located with the API
+# server.
+@pytest.mark.no_remote_server
 def test_managed_job_volume_not_ready():
     """Submitting a managed job against a not-ready volume is refused outright.
 
@@ -4215,6 +4219,10 @@ def test_managed_job_volume_not_ready():
 # ---------- Managed job with a not-ready auto-mount volume ----------
 @pytest.mark.managed_jobs
 @pytest.mark.kubernetes
+# See test_auto_mount_not_ready_on_kubernetes in test_cluster_job.py: the
+# StorageClass fixture needs cluster-admin kubectl co-located with the API
+# server.
+@pytest.mark.no_remote_server
 def test_managed_job_auto_mount_not_ready():
     """The auto-mount path is separate from a volume declared on the task, so
     it needs its own check that a managed job stops instead of retrying.


### PR DESCRIPTION
## Summary

Two fixes that make the volume smoke tests behave against a shared remote API server:

- Mark the four not-ready volume tests (`test_volume_not_ready_on_kubernetes`, `test_auto_mount_not_ready_on_kubernetes`, `test_managed_job_volume_not_ready`, `test_managed_job_auto_mount_not_ready`) `@pytest.mark.no_remote_server`.
- `test_volume_env_mount_kubernetes`: tear down with `sky jobs cancel -n <job>` instead of `-a`.

## 1. The four not-ready tests cannot run against a remote server

These tests build their fixture by `kubectl apply`-ing a StorageClass with a nonexistent provisioner, and pin the volume to the agent's own kubectl context (`AGENT_K8S_INFRA = '--infra k8s/$(kubectl config current-context)'`). That assumes the agent has cluster-admin kubectl co-located with the cluster the API server schedules onto.

Against a remote API server the agent is a plain client with no kubeconfig, so `kubectl` falls back to `localhost:8080` and all four die on their **first step** with `connection refused` — no product code runs. Observed on an enterprise CI lane that runs the suite against a shared remote server via `--env-file`: all four have failed every run there since they were added in #10402, while passing on the local-server lane on the identical commit.

**Why not route the fixture through the cloud-cmd helper?** Considered `run_cloud_cmd_on_cluster` + the landed-context pinning helpers, the standard answer when the agent lacks cloud credentials. It cannot carry this fixture: the helper pod's kubectl runs with in-cluster `skypilot-service-account` credentials (per `resolve_k8s_context_cmd`'s docstring), and that ClusterRole (`sky/templates/kubernetes-ray.yml.j2`) has **no `storage.k8s.io` verbs** — a cluster-scoped StorageClass write is `Forbidden`. Every existing helper usage in the suite is a namespaced read. Extending the product SA's RBAC to serve a test fixture would widen every deployment's ClusterRole for no product reason.

No coverage is lost: the refusal behavior under test is server-side and identical on the local-server lanes, where these tests keep running (and pass).

## 2. `cancel -a` in a teardown is a shotgun on a shared server

On a shared remote server, every concurrently running smoke test submits jobs as the same service-account user, and `test_volume_env_mount_kubernetes`'s teardown ran `sky jobs cancel -a -y` — on pass and fail alike.

Traced in enterprise CI (server request log): one `--all` cancel from this teardown killed an unrelated job-group test's job **28 seconds after submission** in the same lane, and a kueue pause test's 600s blocker job mid-`STARTING` in a second lane running against the same server — both then failed with symptoms that looked like spontaneous job cancellations.

The job is launched from a YAML that names it `{name}-job`, and the teardown's DONE-wait loop already filters on exactly that name, so cancel by that name.

(The other `--all` usages are fine: `test_api_server.py` exercises `--all` semantics as the test subject under its own per-test users, and `test_api_server_benchmark.py` is gated behind `@pytest.mark.benchmark`.)

## Tested

- `python -m py_compile` on both files.
- Marker attaches and fires — collect-only with `--remote-server --kubernetes` shows all four collected with `skip`:

```
test_auto_mount_not_ready_on_kubernetes ... ['no_remote_server', 'kubernetes', 'skip', ...]
test_volume_not_ready_on_kubernetes     ... ['no_remote_server', 'kubernetes', 'skip', ...]
test_managed_job_volume_not_ready       ... ['no_remote_server', 'kubernetes', 'managed_jobs', 'skip', ...]
test_managed_job_auto_mount_not_ready   ... ['no_remote_server', 'kubernetes', 'managed_jobs', 'skip', ...]
```

- Without `--remote-server`, the same collection carries no `skip` from this marker (local lanes unaffected).
- Teardown change: cancel target `{name}-job` matches the YAML's `name:` field and the name the existing DONE-wait loop filters on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XG5rYLRkstgZFqzuATBwB5
