### PR TITLE
fix(aws): make MOUNT_CACHED to S3 work under IRSA (#10408)

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1195,6 +1195,10 @@ class AWS(clouds.Cloud):
             AWSIdentityType.IAM_ROLE,
             AWSIdentityType.CONTAINER_ROLE,
             AWSIdentityType.LOGIN,
+            # Web-identity federation (EKS IRSA) reports as `assume-role`, and
+            # like the other role types it hands out temporary credentials that
+            # must not be embedded in an rclone profile.
+            AWSIdentityType.ASSUME_ROLE,
         }
         return identity_type in non_static_types
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -824,6 +824,12 @@ class Rclone:
                         secret_access_key = {secret_access_key}
                         acl = private
                         """)
+                    if aws_credentials.token:
+                        # Any temporary credential that still reaches this
+                        # branch (e.g. credential_process, or env vars
+                        # sourced from STS) is rejected on the first request
+                        # without its session token.
+                        config += (f'session_token = {aws_credentials.token}\n')
             elif self is Rclone.RcloneStores.GCS:
                 config = textwrap.dedent(f"""\
                     [{rclone_profile_name}]


### PR DESCRIPTION
Fixes #10408.

## Problem

On an API server using EKS IRSA, `MOUNT_CACHED` against S3 cannot authenticate. Two independent defects compound, as diagnosed in the issue:

**1. `ASSUME_ROLE` is missing from `non_static_types`** (`sky/clouds/aws.py`)

`aws configure list` reports web-identity federation as `assume-role-with-web-identity`, which `_current_identity_type()` matches to `AWSIdentityType.ASSUME_ROLE` through the `assume-role` substring. Because `non_static_types` omits it, `should_use_env_auth_for_s3()` returns `False` and the rclone profile takes the static-credential branch instead of `env_auth = true`. Every other role-based type already in that set is temporary-credential based, so `ASSUME_ROLE` belongs with them.

**2. The static branch drops `session_token`** (`sky/data/data_utils.py`)

That branch writes `access_key_id` and `secret_access_key` only. For a temporary credential this is not "expires in an hour" — rclone gets an `ASIA*` key with no session token and the first request is rejected outright.

Fixing (1) alone routes IRSA away from that branch, but (2) stays reachable for any other temporary credential that lands there (`credential_process`, or env vars sourced from STS), so both are fixed.

## Behaviour

`should_use_env_auth_for_s3()` across every `AWSIdentityType`, running the real function extracted from both revisions:

| identity type | before | after |
|---|---|---|
| `sso` | True | True |
| `env` | False | False |
| `iam-role` | True | True |
| `container-role` | True | True |
| `custom-process` | False | False |
| **`assume-role`** | **False** | **True** |
| `login` | True | True |
| `shared-credentials-file` | False | False |

Exactly one type changes, which is the one the issue reports.

The rclone S3 branch, rendered from the real code with a stubbed credential provider:

| frozen credentials | before | after |
|---|---|---|
| carry a session token | `session_token` absent | `session_token` present |
| no session token (static) | absent | absent |

So profiles for genuinely static credentials are byte-for-byte unchanged; the line is emitted only when the credential actually carries a token.

## Notes

`_current_identity_type()` is untouched — `assume-role-with-web-identity` already maps to `ASSUME_ROLE` correctly, the classification downstream of it was the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->