### PR TITLE
[Core] Force sslmode=disable in the DB pooler hostport rewrite

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -711,10 +711,16 @@ ENV_VAR_DB_CONNECTION_URI = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_CONNECTION_URI')
 # case the state DB is reached directly via ENV_VAR_DB_CONNECTION_URI.
 #
 # ENV_VAR_DB_POOL_CONNECTION_URI: a full replacement connection URI for the
-# pooled engines (escape hatch, e.g. an entirely separate pooler endpoint).
+# pooled engines, used verbatim (escape hatch, e.g. an entirely separate
+# pooler endpoint or a TLS-terminating/remote pooler).
 # ENV_VAR_DB_POOL_HOSTPORT: a `host:port` that replaces just the host:port of
-# ENV_VAR_DB_CONNECTION_URI, preserving user/password/dbname/query — so no DB
-# credentials need re-plumbing when the pooler runs as a local sidecar.
+# ENV_VAR_DB_CONNECTION_URI, preserving user/password/dbname and non-ssl query
+# params — so no DB credentials need re-plumbing when the pooler runs as a
+# local loopback sidecar. Because such a sidecar (e.g. PgBouncer on
+# 127.0.0.1) typically does not terminate client TLS, the rewrite drops any
+# ssl* libpq query params from the direct URI and forces `sslmode=disable`
+# toward the pooler; a pooler that requires client TLS must be configured via
+# ENV_VAR_DB_POOL_CONNECTION_URI instead.
 ENV_VAR_DB_POOL_CONNECTION_URI = (
     f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_CONNECTION_URI')
 ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -545,14 +545,36 @@ def _rewrite_hostport(uri: str, hostport: str) -> str:
     percent-encoded password is not re-encoded. Non-PostgreSQL URIs are
     returned unchanged (only PostgreSQL URIs have a rewritable host:port
     netloc).
+
+    ``ENV_VAR_DB_POOL_HOSTPORT`` targets a plaintext loopback sidecar (e.g.
+    PgBouncer on 127.0.0.1) that typically does not terminate client TLS, so
+    every ``ssl*`` libpq query param carried by the direct URI (``sslmode``,
+    ``sslcert``, ``sslkey``, ``sslrootcert``, ``sslcrl``, ...) is dropped and
+    ``sslmode=disable`` is set explicitly — otherwise a direct URI with e.g.
+    ``?sslmode=require`` would demand TLS from the pooler and every pooled
+    connect would fail with "server does not support SSL, but SSL was
+    required". Setting ``disable`` explicitly (rather than merely stripping
+    the params) matters because URI params take precedence over libpq
+    environment variables such as ``PGSSLMODE``, making the pooled DSN
+    deterministic regardless of process environment. All non-ssl query params
+    are preserved. A TLS-terminating or remote pooler must be configured via
+    ``ENV_VAR_DB_POOL_CONNECTION_URI`` instead, which is used verbatim.
     """
     parts = urllib.parse.urlsplit(uri)
     if not parts.scheme.startswith('postgres'):
         return uri
     at = parts.netloc.rfind('@')
     userinfo = parts.netloc[:at + 1] if at != -1 else ''
-    return urllib.parse.urlunsplit((parts.scheme, userinfo + hostport,
-                                    parts.path, parts.query, parts.fragment))
+    # The pooler is a plaintext loopback sidecar: drop every ssl* libpq param
+    # and force sslmode=disable (see docstring).
+    query_params = [(key, value)
+                    for key, value in urllib.parse.parse_qsl(
+                        parts.query, keep_blank_values=True)
+                    if not key.lower().startswith('ssl')]
+    query_params.append(('sslmode', 'disable'))
+    query = urllib.parse.urlencode(query_params)
+    return urllib.parse.urlunsplit(
+        (parts.scheme, userinfo + hostport, parts.path, query, parts.fragment))
 
 
 def _resolve_conn_string(direct: bool) -> Optional[str]:
@@ -564,9 +586,11 @@ def _resolve_conn_string(direct: bool) -> Optional[str]:
     When ``direct`` is True, always returns the unpooled
     ``ENV_VAR_DB_CONNECTION_URI`` so session-scoped advisory locks keep a
     direct, session-pinned connection. When False, routes through a pooler if
-    one is configured (``ENV_VAR_DB_POOL_CONNECTION_URI`` wins, else a
-    host:port rewrite via ``ENV_VAR_DB_POOL_HOSTPORT``); otherwise returns the
-    direct URI unchanged, so deployments without a pooler are unaffected.
+    one is configured (``ENV_VAR_DB_POOL_CONNECTION_URI`` wins and is used
+    verbatim, else a host:port rewrite via ``ENV_VAR_DB_POOL_HOSTPORT`` that
+    also forces ``sslmode=disable`` for the plaintext loopback sidecar — see
+    ``_rewrite_hostport``); otherwise returns the direct URI unchanged, so
+    deployments without a pooler are unaffected.
     """
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
         return None

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -489,7 +489,7 @@ class TestGetEngine:
             db_utils.get_engine(db_name='ignored')
 
             assert mock_create.call_args[0][0] == (
-                'postgresql://user:pass@127.0.0.1:6432/db')
+                'postgresql://user:pass@127.0.0.1:6432/db?sslmode=disable')
 
     def test_direct_bypasses_pooler(self, monkeypatch):
         """direct=True keeps the raw URI even when a pooler is configured."""
@@ -558,8 +558,9 @@ class TestGetEngine:
             db_utils.get_engine(db_name='ignored')  # pooled
             db_utils.get_engine(db_name='ignored', direct=True)  # direct
 
-        assert pools['postgresql://user:pass@127.0.0.1:6432/db'] == (
-            sqlalchemy.pool.QueuePool)
+        assert pools[
+            'postgresql://user:pass@127.0.0.1:6432/db?sslmode=disable'] == (
+                sqlalchemy.pool.QueuePool)
         assert pools['postgresql://user:pass@10.0.0.5:5432/db'] == (
             sqlalchemy.NullPool)
 
@@ -589,22 +590,48 @@ class TestConnStringResolution:
         monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
         monkeypatch.delenv('SKYPILOT_DB_POOL_CONNECTION_URI', raising=False)
 
-    def test_rewrite_preserves_userinfo_dbname_query(self):
+    def test_rewrite_preserves_userinfo_and_dbname(self):
         out = db_utils._rewrite_hostport(
-            'postgresql://u:p%40ss@10.0.0.5:5432/staging-db?sslmode=require',
-            '127.0.0.1:6432')
+            'postgresql://u:p%40ss@10.0.0.5:5432/staging-db', '127.0.0.1:6432')
         assert out == (
-            'postgresql://u:p%40ss@127.0.0.1:6432/staging-db?sslmode=require')
+            'postgresql://u:p%40ss@127.0.0.1:6432/staging-db?sslmode=disable')
 
     def test_rewrite_no_userinfo(self):
         out = db_utils._rewrite_hostport('postgresql://10.0.0.5:5432/db',
                                          '127.0.0.1:6432')
-        assert out == 'postgresql://127.0.0.1:6432/db'
+        assert out == 'postgresql://127.0.0.1:6432/db?sslmode=disable'
 
     def test_rewrite_no_explicit_port(self):
         out = db_utils._rewrite_hostport('postgresql://u:p@host/db',
                                          '127.0.0.1:6432')
-        assert out == 'postgresql://u:p@127.0.0.1:6432/db'
+        assert out == 'postgresql://u:p@127.0.0.1:6432/db?sslmode=disable'
+
+    def test_rewrite_drops_ssl_params_and_forces_disable(self):
+        """ssl* params from the direct URI must not reach the plaintext
+        pooler; sslmode=disable is set explicitly and the other params are
+        kept."""
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db'
+            '?sslmode=require&sslrootcert=/x.pem&connect_timeout=10',
+            '127.0.0.1:6432')
+        assert out == ('postgresql://u:p@127.0.0.1:6432/db'
+                       '?connect_timeout=10&sslmode=disable')
+
+    def test_rewrite_no_query_gains_sslmode_disable(self):
+        """Even without ssl params in the direct URI, the pooled DSN must
+        say sslmode=disable explicitly: URI params take precedence over
+        libpq env (e.g. PGSSLMODE), so this makes the pooled connection
+        deterministic regardless of process environment."""
+        out = db_utils._rewrite_hostport('postgresql://u:p@10.0.0.5:5432/db',
+                                         '127.0.0.1:6432')
+        assert out == 'postgresql://u:p@127.0.0.1:6432/db?sslmode=disable'
+
+    def test_rewrite_keeps_non_ssl_params(self):
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db'
+            '?application_name=sky&sslmode=verify-full', '127.0.0.1:6432')
+        assert out == ('postgresql://u:p@127.0.0.1:6432/db'
+                       '?application_name=sky&sslmode=disable')
 
     def test_rewrite_non_postgres_is_noop(self):
         uri = 'sqlite:////var/lib/sky/state.db'
@@ -628,11 +655,22 @@ class TestConnStringResolution:
         monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
                            'postgresql://u:p@h:5432/db')
         monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
-        assert db_utils._resolve_conn_string(
-            direct=False) == 'postgresql://u:p@127.0.0.1:6432/db'
+        assert db_utils._resolve_conn_string(direct=False) == (
+            'postgresql://u:p@127.0.0.1:6432/db?sslmode=disable')
         # direct always bypasses the pooler.
         assert db_utils._resolve_conn_string(
             direct=True) == 'postgresql://u:p@h:5432/db'
+
+    def test_resolve_direct_keeps_ssl_params_untouched(self, monkeypatch):
+        """direct=True returns the base URI verbatim, ssl params included,
+        even when a pooler hostport is configured."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv(
+            'SKYPILOT_DB_CONNECTION_URI',
+            'postgresql://u:p@h:5432/db?sslmode=require&sslrootcert=/x.pem')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        assert db_utils._resolve_conn_string(direct=True) == (
+            'postgresql://u:p@h:5432/db?sslmode=require&sslrootcert=/x.pem')
 
     def test_resolve_full_override_wins(self, monkeypatch):
         monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
@@ -643,3 +681,16 @@ class TestConnStringResolution:
                            'postgresql://u:p@pooler:6432/db')
         assert db_utils._resolve_conn_string(
             direct=False) == 'postgresql://u:p@pooler:6432/db'
+
+    def test_resolve_full_override_is_verbatim_including_ssl(self, monkeypatch):
+        """ENV_VAR_DB_POOL_CONNECTION_URI is the explicit escape hatch (e.g.
+        a TLS-terminating or remote pooler): it is used verbatim, including
+        any ssl params it carries."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        monkeypatch.setenv(
+            'SKYPILOT_DB_POOL_CONNECTION_URI',
+            'postgresql://u:p@pooler:6432/db?sslmode=verify-full')
+        assert db_utils._resolve_conn_string(direct=False) == (
+            'postgresql://u:p@pooler:6432/db?sslmode=verify-full')


### PR DESCRIPTION
## Problem

When the state DB is routed through a transaction pooler via `SKYPILOT_DB_POOL_HOSTPORT` (introduced in #10301), every pooled connection fails if the direct DB URI carries libpq SSL params:

```
server does not support SSL, but SSL was required
```

This is fatal at API server startup: `sky/skypilot_config.py` loads config from the DB through a pooled engine at import time, so the server cannot come up at all.

## Root cause

`_rewrite_hostport` in `sky/utils/db/db_utils.py` replaces only the `host:port` of `SKYPILOT_DB_CONNECTION_URI` and preserves the URI query verbatim. If the direct URI has e.g. `?sslmode=require` (common when the actual database requires TLS), the rewritten DSN demands TLS from the pooler too. But `SKYPILOT_DB_POOL_HOSTPORT` is documented as a local loopback sidecar (typically PgBouncer, which does not terminate client TLS), so the TLS negotiation is refused and the connect fails.

## Fix

In the hostport rewrite path only:
- Drop every query param whose key starts with `ssl` (`sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `sslcrl`, `sslpassword`, ...).
- Set `sslmode=disable` explicitly. Explicit `disable` (rather than just stripping the params) matters because URI params take precedence over libpq environment variables such as `PGSSLMODE`, so the pooled DSN is deterministic regardless of the pod/process environment.
- All non-ssl query params are preserved; userinfo is preserved verbatim (no password re-encoding), as before.
- Docstrings for `_rewrite_hostport` / `_resolve_conn_string` and the env var comment block in `sky/skylet/constants.py` updated: hostport mode is loopback-sidecar mode and forces plaintext to the pooler.

**`SKYPILOT_DB_POOL_CONNECTION_URI` is intentionally untouched** — it remains the verbatim, explicit escape hatch for a TLS-terminating or remote pooler (its ssl params, if any, are passed through unchanged).

**Async engines are covered by the same fix**: `_resolve_conn_string` produces the one resolved DSN that feeds both `sqlalchemy.create_engine` (sync) and `_make_asyncpg_creator` (async, where asyncpg parses the libpq DSN natively) — no second change is needed.

## Tests

Added to `tests/unit_tests/test_sky/utils/test_db_utils.py`:
- Rewrite with `?sslmode=require&sslrootcert=/x.pem&connect_timeout=10` → `sslmode=disable`, no `sslrootcert`, `connect_timeout` intact.
- Rewrite with no query → gains `sslmode=disable` (deterministic vs. `PGSSLMODE`).
- Rewrite with `?application_name=sky&sslmode=verify-full` → keeps `application_name`, ssl param replaced with `disable`.
- `SKYPILOT_DB_POOL_CONNECTION_URI` override returned verbatim including its ssl params.
- `direct=True` returns the base URI untouched, ssl params included.
- Updated existing exact-string assertions for the rewrite (now expecting `?sslmode=disable`).

## Tested

- `python -m pytest tests/unit_tests/test_sky/utils/test_db_utils.py` (all tests in the touched module pass).

Manual verification plan: set `SKYPILOT_DB_CONNECTION_URI=postgresql://user:pass@db-host:5432/db?sslmode=require` and `SKYPILOT_DB_POOL_HOSTPORT=127.0.0.1:6432` with a plain (non-TLS) PgBouncer sidecar on 6432. Before this change the API server fails at startup with "server does not support SSL, but SSL was required"; after it, the server starts and pooled queries succeed, while direct (advisory-lock/migration) connections still use TLS to the real database.

-Claude
