### PR TITLE
[Core] Preserve query param bytes in DB pooler hostport rewrite

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -557,8 +557,14 @@ def _rewrite_hostport(uri: str, hostport: str) -> str:
     the params) matters because URI params take precedence over libpq
     environment variables such as ``PGSSLMODE``, making the pooled DSN
     deterministic regardless of process environment. All non-ssl query params
-    are preserved. A TLS-terminating or remote pooler must be configured via
-    ``ENV_VAR_DB_POOL_CONNECTION_URI`` instead, which is used verbatim.
+    are preserved byte-for-byte: the raw ``key=value`` pairs are filtered
+    without a decode/re-encode round trip, because that round trip is not
+    byte-preserving — ``urlencode`` writes spaces as ``+``, which libpq does
+    not interpret as a space in URI query values, and ``parse_qsl`` decodes a
+    literal ``+`` into a space — so a surviving value such as
+    ``options=-c%20search_path%3Dfoo`` would be mangled. A TLS-terminating or
+    remote pooler must be configured via ``ENV_VAR_DB_POOL_CONNECTION_URI``
+    instead, which is used verbatim.
     """
     parts = urllib.parse.urlsplit(uri)
     if not parts.scheme.startswith('postgres'):
@@ -566,13 +572,20 @@ def _rewrite_hostport(uri: str, hostport: str) -> str:
     at = parts.netloc.rfind('@')
     userinfo = parts.netloc[:at + 1] if at != -1 else ''
     # The pooler is a plaintext loopback sidecar: drop every ssl* libpq param
-    # and force sslmode=disable (see docstring).
-    query_params = [(key, value)
-                    for key, value in urllib.parse.parse_qsl(
-                        parts.query, keep_blank_values=True)
-                    if not key.lower().startswith('ssl')]
-    query_params.append(('sslmode', 'disable'))
-    query = urllib.parse.urlencode(query_params)
+    # and force sslmode=disable (see docstring). Surviving pairs are kept
+    # byte-for-byte; only the key is percent-decoded, and only for the ssl*
+    # prefix match (libpq percent-decodes keywords, so e.g. ``%73slmode`` is
+    # ``sslmode`` to libpq).
+    pairs = []
+    for pair in parts.query.split('&'):
+        if not pair:
+            continue
+        raw_key = pair.split('=', 1)[0]
+        if urllib.parse.unquote(raw_key).lower().startswith('ssl'):
+            continue
+        pairs.append(pair)
+    pairs.append('sslmode=disable')
+    query = '&'.join(pairs)
     return urllib.parse.urlunsplit(
         (parts.scheme, userinfo + hostport, parts.path, query, parts.fragment))
 

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -633,6 +633,43 @@ class TestConnStringResolution:
         assert out == ('postgresql://u:p@127.0.0.1:6432/db'
                        '?application_name=sky&sslmode=disable')
 
+    def test_rewrite_preserves_percent_encoded_values(self):
+        """Surviving params must keep their exact bytes. A parse_qsl +
+        urlencode round trip would rewrite ``options=-c%20search_path%3Dfoo``
+        as ``options=-c+search_path%3Dfoo``, and libpq does not interpret
+        ``+`` as a space in URI query values, so the value would be
+        mangled."""
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db'
+            '?options=-c%20search_path%3Dfoo&sslmode=require', '127.0.0.1:6432')
+        assert out == ('postgresql://u:p@127.0.0.1:6432/db'
+                       '?options=-c%20search_path%3Dfoo&sslmode=disable')
+
+    def test_rewrite_preserves_literal_plus(self):
+        """A literal ``+`` in a value must survive as ``+``: parse_qsl
+        decodes it into a space on the way in, so a round trip would not
+        return the original bytes."""
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db?application_name=a+b',
+            '127.0.0.1:6432')
+        assert out == ('postgresql://u:p@127.0.0.1:6432/db'
+                       '?application_name=a+b&sslmode=disable')
+
+    def test_rewrite_keeps_bare_key_pair(self):
+        """A bare ``key`` pair (no ``=``) survives byte-for-byte."""
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db?keepalives', '127.0.0.1:6432')
+        assert out == ('postgresql://u:p@127.0.0.1:6432/db'
+                       '?keepalives&sslmode=disable')
+
+    def test_rewrite_drops_percent_encoded_ssl_key(self):
+        """libpq percent-decodes URI keywords, so a percent-encoded ssl*
+        key (e.g. ``%73slmode``) must be dropped like its plain form."""
+        out = db_utils._rewrite_hostport(
+            'postgresql://u:p@10.0.0.5:5432/db?%73slmode=require',
+            '127.0.0.1:6432')
+        assert out == 'postgresql://u:p@127.0.0.1:6432/db?sslmode=disable'
+
     def test_rewrite_non_postgres_is_noop(self):
         uri = 'sqlite:////var/lib/sky/state.db'
         assert db_utils._rewrite_hostport(uri, '127.0.0.1:6432') == uri


### PR DESCRIPTION
Follow-up to #10463.

## Summary

- The `ssl*` query-param filtering in `_rewrite_hostport` used `urllib.parse.parse_qsl(...)` + `urllib.parse.urlencode(...)`, which is not a byte-preserving round trip: `urlencode` encodes spaces as `+`, and libpq does **not** interpret `+` as a space in URI query values; `parse_qsl` also decodes a literal `+` into a space on the way in. Harmless when the URI carries no query params (the common case), but any real param surviving the ssl* filter — e.g. `options=-c%20search_path%3Dfoo` — would be mangled into an invalid value (`options=-c+search_path%3Dfoo`).
- Rework the filtering to operate on the raw `key=value` pairs: split the query on `&`, drop pairs whose key (percent-decoded and lowercased, since libpq percent-decodes URI keywords) starts with `ssl`, keep every other pair byte-for-byte, then append `sslmode=disable`. A bare `key` pair (no `=`) also survives byte-identical.
- Add regression tests: percent-encoded values survive byte-identical, a literal `+` survives as `+`, bare keys survive, percent-encoded `ssl*` keys are still dropped, and the existing behavior (ssl* dropped, `sslmode=disable` appended, no-query case) is unchanged.

## Test plan

- `pytest tests/unit_tests/test_sky/utils/test_db_utils.py` — 45 passed (4 new regression tests plus all pre-existing tests).
- Manual check: `_rewrite_hostport('postgresql://u:p@10.0.0.5:5432/db?options=-c%20search_path%3Dfoo&sslmode=require', '127.0.0.1:6432')` now returns `postgresql://u:p@127.0.0.1:6432/db?options=-c%20search_path%3Dfoo&sslmode=disable` (previously the `options` value was rewritten to `-c+search_path%3Dfoo`).
- `bash format.sh --files sky/utils/db/db_utils.py tests/unit_tests/test_sky/utils/test_db_utils.py` — clean (pylint 10.00/10, mypy no issues in changed files).

-Claude