### PR TITLE
[Jobs] Guard job queue against NULL last_recovered_at/job_duration

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2841,11 +2841,24 @@ def get_managed_job_queue(
             if end_at is None:
                 end_at = time.time()
 
-            job_submitted_at = job['last_recovered_at'] - job['job_duration']
+            # Defensively coalesce SQL NULLs to the schema defaults
+            # (last_recovered_at=-1, job_duration=0). Such rows should not
+            # normally exist, but have been observed in the wild, and a
+            # single bad row would otherwise raise a TypeError here and
+            # break the entire job queue listing. With the defaults, the
+            # row degrades to the "never started" rendering below.
+            last_recovered_at = job['last_recovered_at']
+            if last_recovered_at is None:
+                last_recovered_at = -1
+            raw_job_duration = job['job_duration']
+            if raw_job_duration is None:
+                raw_job_duration = 0
+
+            job_submitted_at = last_recovered_at - raw_job_duration
             if job['status'] == managed_job_state.ManagedJobStatus.RECOVERING:
                 # When job is recovering, the duration is exact
                 # job['job_duration']
-                job_duration = job['job_duration']
+                job_duration = raw_job_duration
             elif job_submitted_at > 0:
                 job_duration = end_at - job_submitted_at
             else:

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -346,6 +346,51 @@ class TestGetManagedJobQueue:
         expected_duration = (current_time - 50) - (current_time - 200 - 50)
         assert job['job_duration'] == expected_duration
 
+    def test_job_duration_with_null_fields_does_not_break_listing(
+            self, monkeypatch):
+        """A row with SQL NULL last_recovered_at/job_duration must not raise.
+
+        Such rows should not normally exist (the schema has defaults), but
+        have been observed in the wild. One bad row must not take down the
+        entire jobs listing with a TypeError; it should degrade to the
+        "never started" sentinel (job_duration == 0).
+        """
+        jobs = [
+            # Healthy job, to make sure the whole listing survives.
+            self._make_test_job(1),
+            # Poisoned row: NULL in both columns.
+            self._make_test_job(2, last_recovered_at=None, job_duration=None),
+        ]
+        self._patch_managed_job_state(monkeypatch, jobs)
+        self._patch_global_user_state(monkeypatch)
+
+        result = jobs_utils.get_managed_job_queue()
+
+        assert len(result['jobs']) == 2
+        job = result['jobs'][1]
+        assert job['job_id'] == 2
+        # NULLs coalesce to the schema defaults (last_recovered_at=-1,
+        # job_duration=0), i.e. the job renders as never started.
+        assert job['job_duration'] == 0
+
+    def test_job_duration_with_null_fields_for_recovering_job(
+            self, monkeypatch):
+        """A RECOVERING row with NULL job_duration degrades to 0, not None."""
+        jobs = [
+            self._make_test_job(
+                1,
+                status=managed_job_state.ManagedJobStatus.RECOVERING,
+                last_recovered_at=None,
+                job_duration=None)
+        ]
+        self._patch_managed_job_state(monkeypatch, jobs)
+        self._patch_global_user_state(monkeypatch)
+
+        result = jobs_utils.get_managed_job_queue()
+
+        job = result['jobs'][0]
+        assert job['job_duration'] == 0
+
     def test_finished_job_falls_back_to_cached_infra(self, monkeypatch):
         """A finished job with no live handle shows last-cached infra/resources.
 


### PR DESCRIPTION
## Summary

- A single job row with SQL `NULL` in `last_recovered_at` / `job_duration` raises a `TypeError` in `get_managed_job_queue` (`job_submitted_at = job['last_recovered_at'] - job['job_duration']`), which breaks the **entire** managed jobs listing (`sky jobs queue`, dashboard) — one poisoned row takes down the whole queue.
- The schema has server defaults for these columns (`last_recovered_at=-1`, `job_duration=0`) so such rows should not normally exist, but they have been observed in the wild. Since one bad row breaking every listing is a poor failure mode, defensively coalesce `NULL` to the schema defaults before the arithmetic, so the row degrades to the normal "never started" rendering (duration 0) instead of raising.
- No schema changes; behavior for well-formed rows is unchanged.

## Test plan

- Added unit tests in `tests/unit_tests/test_sky/jobs/test_utils.py`:
  - a listing containing a row with `None` in both fields succeeds and renders that row with `job_duration == 0` (never-started sentinel), alongside a healthy row;
  - a `RECOVERING` row with `None` fields degrades to `job_duration == 0` instead of `None`.
- Verified the first test reproduces the exact failure without the fix: `TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'`.
- `pytest tests/unit_tests/test_sky/jobs/test_utils.py`: 105 passed, 0 failed.

-Claude
