### PR TITLE
[Core] Redact credential-shaped env var values in debug dumps

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -3470,11 +3470,13 @@ def _build_client_info() -> Dict[str, Any]:
         'python_version': platform.python_version(),
         'platform': platform.platform(),
         'user_hash': common_utils.get_user_hash(),
-        'environment': {
+        # Names are kept (which vars are set is diagnostic signal), but
+        # credential-shaped values are redacted.
+        'environment': debug_dump_helpers.redact_env_vars({
             k: v
             for k, v in sorted(os.environ.items())
             if k.startswith(('SKYPILOT_', 'SKY_'))
-        },
+        }),
         'user_config': user_config,
         'merged_config': merged_config,
     }

--- a/sky/utils/debug_dump_helpers.py
+++ b/sky/utils/debug_dump_helpers.py
@@ -7,6 +7,7 @@ Extracted to avoid a circular import:
 """
 import copy
 import datetime
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from sky import global_user_state
@@ -14,12 +15,89 @@ from sky import task as task_lib
 from sky.utils import config_utils
 from sky.utils import yaml_utils
 
+REDACTED_VALUE = '<redacted>'
+
 # Sensitive config paths to redact in debug dumps, following the same
 # pattern as provision/common.py:ProvisionConfig.get_redacted_config().
 _SENSITIVE_CONFIG_KEYS: List[Tuple[str, ...]] = [
     ('api_server', 'endpoint'),
     ('api_server', 'service_account_token'),
 ]
+
+# Config paths holding connection URIs: keep the value's shape (host and db
+# name are diagnostic signal) but mask any password component.
+_URI_CONFIG_KEYS: List[Tuple[str, ...]] = [
+    ('db',),
+]
+
+# Env var names whose values are always redacted in debug dumps, even though
+# the name does not match _SENSITIVE_ENV_VAR_NAME_RE (e.g. URI- or
+# AUTH-suffixed names).
+_SENSITIVE_ENV_VAR_NAMES = frozenset({
+    'SKYPILOT_DB_CONNECTION_URI',
+    'SKYPILOT_INITIAL_BASIC_AUTH',
+    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
+    'SKYPILOT_DOCKER_PASSWORD',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_ACCESS_KEY_ID',
+    'AZURE_CLIENT_SECRET',
+})
+
+# Any env var whose NAME matches this pattern has its value redacted in debug
+# dumps. Deliberately broad: a false positive (redacting a non-secret value
+# whose name merely contains e.g. 'KEY') only costs a little diagnostic
+# signal, while a false negative leaks a credential into a shareable dump.
+_SENSITIVE_ENV_VAR_NAME_RE = re.compile(
+    r'TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL|PASSWD', re.IGNORECASE)
+
+# Password component of URI-shaped values, userinfo style:
+# scheme://user:password@host
+_URI_USERINFO_PASSWORD_RE = re.compile(r'(://[^/@:\s]*):[^/@\s]*@')
+# Password passed as a query/connection parameter: ...password=... (also
+# matches libpq-style 'password=...' keyword/value connection strings).
+_URI_QUERY_PASSWORD_RE = re.compile(r'((?:password|passwd|pwd)=)[^&\s]+',
+                                    re.IGNORECASE)
+
+
+def is_sensitive_env_var(name: str) -> bool:
+    """Whether an env var's value must be redacted in debug dumps."""
+    return (name in _SENSITIVE_ENV_VAR_NAMES or
+            _SENSITIVE_ENV_VAR_NAME_RE.search(name) is not None)
+
+
+def mask_uri_password(value: str) -> str:
+    """Mask the password component of a URI-shaped value.
+
+    Handles both userinfo passwords (scheme://user:password@host) and
+    password query/connection parameters (...?password=...). Values with no
+    password component are returned unchanged.
+    """
+    value = _URI_USERINFO_PASSWORD_RE.sub(rf'\1:{REDACTED_VALUE}@', value)
+    value = _URI_QUERY_PASSWORD_RE.sub(rf'\g<1>{REDACTED_VALUE}', value)
+    return value
+
+
+def redact_env_vars(env_vars: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of env_vars safe to include in a debug dump.
+
+    Names are kept (which vars are set is diagnostic signal). Values of
+    credential-shaped names are replaced with '<redacted>', and any other
+    string value that looks like a URI carrying a password has the password
+    component masked. Used by both the client (sdk.py) and the server
+    (debug_utils.py) for every environment section in a debug dump.
+    """
+    redacted: Dict[str, Any] = {}
+    for name, value in env_vars.items():
+        if is_sensitive_env_var(name):
+            # Keep falsy values (e.g. set-but-empty vars) as-is: there is
+            # nothing to leak, and the emptiness itself is diagnostic signal.
+            redacted[name] = REDACTED_VALUE if value else value
+        elif isinstance(value, str):
+            redacted[name] = mask_uri_password(value)
+        else:
+            redacted[name] = value
+    return redacted
 
 
 def redact_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -32,7 +110,11 @@ def redact_config(config: Dict[str, Any]) -> Dict[str, Any]:
     for field_path in _SENSITIVE_CONFIG_KEYS:
         val = config_copy.get_nested(field_path, default_value=None)
         if val is not None:
-            config_copy.set_nested(field_path, '<redacted>')
+            config_copy.set_nested(field_path, REDACTED_VALUE)
+    for field_path in _URI_CONFIG_KEYS:
+        val = config_copy.get_nested(field_path, default_value=None)
+        if isinstance(val, str):
+            config_copy.set_nested(field_path, mask_uri_password(val))
     return dict(**config_copy)
 
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -185,19 +185,6 @@ def _log_timed_out_stragglers(orphans: List[Dict[str, Any]]) -> None:
 # Persistent location for debug dumps
 DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
 
-# Env var names whose values should be redacted (show bool presence only).
-# Used for both server_info environment and request body sanitization.
-_SENSITIVE_ENV_VARS = {
-    'SKYPILOT_DB_CONNECTION_URI',
-    'SKYPILOT_INITIAL_BASIC_AUTH',
-    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
-    'SKYPILOT_DOCKER_PASSWORD',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_SESSION_TOKEN',
-    'AWS_ACCESS_KEY_ID',
-    'AZURE_CLIENT_SECRET',
-}
-
 # Maps request name → field names containing task/dag YAML to redact.
 # Empty tuple means include body verbatim (no YAML fields).
 # Requests not in this dict have their body excluded entirely.
@@ -958,12 +945,14 @@ def _dump_server_info(dump_dir: str,
                 'traceback': _full_traceback()
             })
 
-    # Add all SKYPILOT_*/SKY_* environment variables, redacting sensitive ones
-    env = {}
-    for k, v in sorted(os.environ.items()):
-        if k.startswith(('SKYPILOT_', 'SKY_')):
-            env[k] = bool(v) if k in _SENSITIVE_ENV_VARS else v
-    server_info['environment'] = env
+    # Add all SKYPILOT_*/SKY_* environment variables. Names are kept (which
+    # vars are set is diagnostic signal), but credential-shaped values are
+    # redacted -- see debug_dump_helpers.redact_env_vars.
+    server_info['environment'] = debug_dump_helpers.redact_env_vars({
+        k: v
+        for k, v in sorted(os.environ.items())
+        if k.startswith(('SKYPILOT_', 'SKY_'))
+    })
 
     # Add cloud status (keyed by workspace name, each mapping cloud names
     # to a list of capability strings — already JSON-serializable).
@@ -1028,9 +1017,12 @@ def _sanitize_request_body(request) -> Optional[Dict[str, Any]]:
     # Redact sensitive env var values
     env_vars = data.get('env_vars')
     if isinstance(env_vars, dict):
-        for k in env_vars:
-            if k in _SENSITIVE_ENV_VARS:
-                env_vars[k] = '<redacted>'
+        data['env_vars'] = debug_dump_helpers.redact_env_vars(env_vars)
+    # Redact sensitive fields in any client-supplied config overrides
+    override_config = data.get('override_skypilot_config')
+    if isinstance(override_config, dict) and override_config:
+        data['override_skypilot_config'] = (
+            debug_dump_helpers.redact_config(override_config))
     # Redact task/dag YAML fields
     for field in task_fields:
         if field in data and isinstance(data[field], str):

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2297,15 +2297,89 @@ class TestManifestPathTraversal:
 
 
 # ---------------------------------------------------------------------------
-# Tests for _SENSITIVE_ENV_VARS redaction
+# Tests for sensitive env var redaction
 # ---------------------------------------------------------------------------
 class TestSensitiveEnvVarRedaction:
     """Tests for sensitive environment variable redaction."""
 
-    def test_sensitive_env_vars_redacted(self):
-        """Sensitive env vars should have their values replaced with bool."""
-        assert 'SKYPILOT_DB_CONNECTION_URI' in debug_utils._SENSITIVE_ENV_VARS
-        assert 'SKYPILOT_INITIAL_BASIC_AUTH' in debug_utils._SENSITIVE_ENV_VARS
+    @pytest.mark.parametrize('name', [
+        'SKYPILOT_SOME_TOKEN',
+        'SKYPILOT_MY_SECRET',
+        'SKY_API_KEY',
+        'SKYPILOT_ADMIN_PASSWORD',
+        'SKYPILOT_CLOUD_CREDENTIALS',
+        'SKY_DB_PASSWD',
+        'skypilot_lowercase_token',
+        'SKYPILOT_ACCESS_KEY_ID',
+    ])
+    def test_credential_shaped_names_are_sensitive(self, name):
+        """Names containing TOKEN/SECRET/KEY/... match case-insensitively."""
+        assert debug_dump_helpers.is_sensitive_env_var(name)
+
+    @pytest.mark.parametrize('name', [
+        'SKYPILOT_DEBUG',
+        'SKY_NORMAL_VAR',
+        'SKYPILOT_CONFIG',
+        'SKYPILOT_USER_ID',
+    ])
+    def test_ordinary_names_are_not_sensitive(self, name):
+        assert not debug_dump_helpers.is_sensitive_env_var(name)
+
+    def test_exact_sensitive_names_still_covered(self):
+        """URI/AUTH-suffixed names that miss the pattern stay redacted."""
+        assert debug_dump_helpers.is_sensitive_env_var(
+            'SKYPILOT_DB_CONNECTION_URI')
+        assert debug_dump_helpers.is_sensitive_env_var(
+            'SKYPILOT_INITIAL_BASIC_AUTH')
+
+    def test_redact_env_vars(self):
+        env = {
+            'SKYPILOT_SOME_TOKEN': 'tok-value',
+            'SKY_API_KEY': 'key-value',
+            'SKYPILOT_DEBUG': '1',
+            'SKY_NORMAL_VAR': 'visible',
+        }
+        redacted = debug_dump_helpers.redact_env_vars(env)
+        # Names are all kept; credential-shaped values are replaced.
+        assert set(redacted) == set(env)
+        assert redacted['SKYPILOT_SOME_TOKEN'] == '<redacted>'
+        assert redacted['SKY_API_KEY'] == '<redacted>'
+        # Ordinary vars untouched.
+        assert redacted['SKYPILOT_DEBUG'] == '1'
+        assert redacted['SKY_NORMAL_VAR'] == 'visible'
+        # Input not mutated.
+        assert env['SKYPILOT_SOME_TOKEN'] == 'tok-value'
+
+    def test_redact_env_vars_keeps_empty_values(self):
+        """Set-but-empty sensitive vars stay empty (nothing to leak)."""
+        redacted = debug_dump_helpers.redact_env_vars(
+            {'SKYPILOT_SOME_TOKEN': ''})
+        assert redacted['SKYPILOT_SOME_TOKEN'] == ''
+
+    def test_redact_env_vars_masks_uri_password(self):
+        """A URI-valued var with an ordinary name gets its password masked."""
+        env = {'SKYPILOT_METRICS_URI': 'postgresql://user:hunter2@host:5432/db'}
+        redacted = debug_dump_helpers.redact_env_vars(env)
+        assert redacted['SKYPILOT_METRICS_URI'] == (
+            'postgresql://user:<redacted>@host:5432/db')
+        assert 'hunter2' not in redacted['SKYPILOT_METRICS_URI']
+
+    @pytest.mark.parametrize(
+        'value,expected',
+        [
+            ('postgresql://user:pw@host/db',
+             'postgresql://user:<redacted>@host/db'),
+            ('postgresql://host/db?user=u&password=pw&sslmode=require',
+             'postgresql://host/db?user=u&password=<redacted>&sslmode=require'),
+            ('host=h dbname=d password=pw',
+             'host=h dbname=d password=<redacted>'),
+            # No password component: unchanged.
+            ('postgresql://user@host/db', 'postgresql://user@host/db'),
+            ('https://example.com/path', 'https://example.com/path'),
+            ('plain value', 'plain value'),
+        ])
+    def test_mask_uri_password(self, value, expected):
+        assert debug_dump_helpers.mask_uri_password(value) == expected
 
     @mock.patch('sky.utils.debug_utils.sky_check.check', return_value={})
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
@@ -2317,6 +2391,9 @@ class TestSensitiveEnvVarRedaction:
         env_patch = {
             'SKYPILOT_DEBUG': '1',
             'SKYPILOT_DB_CONNECTION_URI': 'postgresql://secret@host/db',
+            'SKYPILOT_SOME_TOKEN': 'tok-value',
+            'SKY_API_KEY': 'key-value',
+            'SKYPILOT_METRICS_URI': 'postgresql://user:hunter2@host/db',
             'SKY_NORMAL_VAR': 'visible',
         }
         with mock.patch.dict(os.environ, env_patch, clear=False):
@@ -2326,10 +2403,20 @@ class TestSensitiveEnvVarRedaction:
             info = json.load(f)
 
         env = info['environment']
+        # Ordinary vars untouched.
         assert env['SKYPILOT_DEBUG'] == '1'
         assert env['SKY_NORMAL_VAR'] == 'visible'
-        # Sensitive var should be redacted to bool
-        assert env['SKYPILOT_DB_CONNECTION_URI'] is True
+        # Exact-name and credential-shaped names are redacted (names kept).
+        assert env['SKYPILOT_DB_CONNECTION_URI'] == '<redacted>'
+        assert env['SKYPILOT_SOME_TOKEN'] == '<redacted>'
+        assert env['SKY_API_KEY'] == '<redacted>'
+        # URI-valued ordinary var: password masked, rest kept.
+        assert env['SKYPILOT_METRICS_URI'] == (
+            'postgresql://user:<redacted>@host/db')
+        raw = json.dumps(info)
+        assert 'tok-value' not in raw
+        assert 'key-value' not in raw
+        assert 'hunter2' not in raw
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
                 return_value=None)
@@ -2874,6 +2961,18 @@ class TestRedactConfig:
         debug_dump_helpers.redact_config(config)
         assert config['api_server']['service_account_token'] == 'sky_secret'
 
+    def test_db_uri_password_masked(self):
+        """The db connection string keeps its shape, password masked."""
+        config = {'db': 'postgresql://skyuser:hunter2@dbhost:5432/skypilot'}
+        result = debug_dump_helpers.redact_config(config)
+        assert result['db'] == (
+            'postgresql://skyuser:<redacted>@dbhost:5432/skypilot')
+
+    def test_db_uri_without_password_unchanged(self):
+        config = {'db': 'postgresql://dbhost:5432/skypilot'}
+        result = debug_dump_helpers.redact_config(config)
+        assert result['db'] == 'postgresql://dbhost:5432/skypilot'
+
 
 # ---------------------------------------------------------------------------
 # Tests for _REQUEST_BODY_ALLOWLIST coverage
@@ -2981,6 +3080,51 @@ class TestSanitizeRequestBody:
         assert result['env_vars']['NORMAL_VAR'] == 'visible'
         assert result['env_vars']['AWS_SECRET_ACCESS_KEY'] == '<redacted>'
         assert result['env_vars']['SKYPILOT_DB_CONNECTION_URI'] == '<redacted>'
+
+    def test_credential_shaped_env_vars_redacted(self):
+        """Env vars with credential-shaped names are redacted by pattern."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'env_vars': {
+                        'SKYPILOT_SOME_TOKEN': 'tok-value',
+                        'MY_API_KEY': 'key-value',
+                        'SKYPILOT_DEBUG': '1',
+                    }
+                }
+
+        request = _make_request(name='sky.stop', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        assert result['env_vars']['SKYPILOT_SOME_TOKEN'] == '<redacted>'
+        assert result['env_vars']['MY_API_KEY'] == '<redacted>'
+        assert result['env_vars']['SKYPILOT_DEBUG'] == '1'
+
+    def test_override_config_redacted(self):
+        """Client-supplied config overrides get the config redaction."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'override_skypilot_config': {
+                        'api_server': {
+                            'service_account_token': 'sky_secret123',
+                        },
+                        'db': 'postgresql://user:hunter2@host/db',
+                    },
+                }
+
+        request = _make_request(name='sky.stop', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        override = result['override_skypilot_config']
+        assert override['api_server']['service_account_token'] == '<redacted>'
+        assert override['db'] == 'postgresql://user:<redacted>@host/db'
 
     def test_task_yaml_field_redacted(self):
         """Task YAML fields should have secrets redacted."""


### PR DESCRIPTION
## Summary

Debug dumps are designed to be shared (attached to GitHub issues, sent to support), but the environment sections captured `SKYPILOT_*`/`SKY_*` env vars with only an exact-name redaction list. Any credential-bearing env var not on that list — e.g. anything ending in `_TOKEN` or `_KEY` set on the API server — was written into the dump in plaintext.

- **Pattern-based env value redaction.** Any captured env var whose *name* matches `TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL|PASSWD` (case-insensitive) now has its value replaced with `<redacted>`. Var names are kept, so dumps still show *which* vars are set (diagnostic signal). The former exact-name list is retained for names the pattern misses (e.g. `SKYPILOT_DB_CONNECTION_URI`, `SKYPILOT_INITIAL_BASIC_AUTH`).
- **Applied at every env serialization site in the dump path:**
  - `server_info.json` environment section (`debug_utils._dump_server_info`)
  - request body `env_vars` (`debug_utils._sanitize_request_body`)
  - client-side `client_info` environment section (`sdk._build_client_info`) — this one previously had **no** redaction at all
- **URI password masking.** Non-redacted env values that look like a URI carrying a password (`scheme://user:password@host`, `?password=...`, or libpq-style `password=...`) get just the password component masked, keeping host/db name visible. The same masking is applied to the `db` connection string in dumped configs (previously included verbatim).
- **Config overrides in request bodies** (`override_skypilot_config`) now go through the same config redaction used for the server/user config sections.

**Trade-off:** the name pattern deliberately over-matches. A false positive (redacting a non-secret value whose name merely contains e.g. `KEY`) costs a little diagnostic signal; a false negative leaks a live credential into a shareable artifact. We accept the former to prevent the latter.

Behavior change: exact-name-listed vars were previously serialized as a boolean (`true`); they now show `<redacted>` like all other redacted vars. Set-but-empty vars keep their empty value (nothing to leak, and emptiness is itself signal).

## Tested

- Unit tests in `tests/unit_tests/test_sky/utils/test_debug_utils.py`, extended with:
  - credential-shaped names (`*_TOKEN`, `*_KEY`, `*_PASSWORD`, lowercase, etc.) are redacted; ordinary `SKYPILOT_*` vars pass through untouched
  - URI-valued vars get only the password component masked (userinfo, query-param, and keyword forms)
  - set-but-empty sensitive vars stay empty
  - `_dump_server_info` end-to-end: redacted names present, secret values absent from the serialized JSON
  - request-body `env_vars` pattern redaction and `override_skypilot_config` redaction
  - `db` config connection-string password masking
- `pytest tests/unit_tests/test_sky/utils/test_debug_utils.py`: 240 tests, 232 passed; the 8 failures are pre-existing on master in this dev environment (kube-context tests that pick up the local kubeconfig) and unrelated to this change.
- `format.sh` (yapf/isort/pylint clean on touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude