### PR TITLE
[Test] Wait for a created volume to be mountable before launching against it

### DIFF
--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -939,6 +939,12 @@ class TestBackwardCompatibility:
                 # Use volume in current version
                 f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
                 f'sky volumes ls | grep "{volume_name}"',
+                # `apply` above only started provisioning; the launch below
+                # mounts the volume and is refused with VolumeNotReadyError
+                # until the claim binds. Waited for on the current side, the
+                # one that does the mounting.
+                f'{self.ACTIVATE_CURRENT} && '
+                f'{smoke_tests_utils.get_cmd_wait_until_volume_is_ready(volume_name)}',
                 # Launch new task with volume
                 f'{self.ACTIVATE_CURRENT} && sky launch -y -c {cluster_name} --infra k8s {task_yaml_path}',
                 f'{self.ACTIVATE_CURRENT} && sky logs {cluster_name} 1 --status',

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -251,6 +251,59 @@ def get_cmd_wait_until_volume_is_not_found(volume_name: str,
                                                   timeout=timeout)
 
 
+_WAIT_UNTIL_VOLUME_IS_READY = (
+    # A while loop to wait until a volume is mountable, or timeout.
+    # `sky volumes apply` only *starts* provisioning: on a storage class with
+    # `volumeBindingMode: Immediate` the PersistentVolume is created
+    # asynchronously, so the claim stays Pending -- and the volume NOT_READY --
+    # after the command returns. Mounting it before then is refused with
+    # VolumeNotReadyError, so a test that creates a volume must wait for it,
+    # exactly as a user would.
+    # Deliberately not `--refresh`: that re-probes the backing resource and so
+    # would end the wait the moment the claim binds, but it refreshes the whole
+    # volume table -- a file lock and a database round-trip per volume -- and
+    # would contend with the volume operations of every other test sharing the
+    # API server. Read the row the refresh daemon maintains instead, which
+    # costs the server nothing and bounds the wait by its 60s interval.
+    'start_time=$SECONDS; '
+    'while true; do '
+    'vols=$(sky volumes ls); '
+    # Read the status out of the volume's own row -- matched on the whole first
+    # field, so a longer name containing this one is not mistaken for it -- at
+    # the character offset the header gives for the STATUS column. The table is
+    # space-padded and left-aligned, and columns before STATUS hold spaces of
+    # their own ("alice (SA)", "3 secs"), so splitting the row on whitespace
+    # would not line up. Taking the column rather than searching the row also
+    # keeps NOT_READY, or a stray word in MESSAGE, from passing for READY.
+    'status=$(echo "$vols" | awk -v n="{volume_name}" '
+    '\'$1 == "NAME" {{c = index($0, "STATUS")}} '
+    '$1 == n && c {{split(substr($0, c), f, " "); print f[1]; exit}}\'); '
+    # IN_USE is READY plus a mount; both are mountable.
+    'if [ "$status" = READY ] || [ "$status" = IN_USE ]; then '
+    '  echo "Volume {volume_name} is ready."; break; '
+    'fi; '
+    'if (( $SECONDS - $start_time > {timeout} )); then '
+    '  echo "$vols"; '
+    '  echo "Timeout after {timeout} seconds waiting for volume '
+    '{volume_name} to be ready"; exit 1; '
+    'fi; '
+    'echo "Waiting for volume {volume_name}: ${{status:-not found}}"; '
+    'sleep 5; '
+    'done')
+
+
+def get_cmd_wait_until_volume_is_ready(volume_name: str, timeout: int = 300):
+    """Blocks until a volume is mountable.
+
+    The default timeout leaves room for a cloud storage class to provision its
+    first volume plus the up-to-60s lag of the status refresh daemon this reads
+    from, and is still short enough that a genuinely broken volume fails the
+    step well inside the test timeout.
+    """
+    return _WAIT_UNTIL_VOLUME_IS_READY.format(volume_name=volume_name,
+                                              timeout=timeout)
+
+
 _WAIT_UNTIL_JOB_STATUS_CONTAINS_MATCHING_JOB_ID = (
     # A while loop to wait until the job status
     # contains certain status, with timeout.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1606,12 +1606,21 @@ def test_volumes_on_kubernetes():
             f'sky volumes apply -y -n existing0 --type k8s-pvc --size 2GB --use-existing',
             f'sky volumes apply -y -n vol-existing1 --type k8s-pvc --size 2GB --use-existing',
             f'vols=$(sky volumes ls) && echo "$vols" && echo "$vols" | grep "pvc0" && echo "$vols" | grep "existing0" && echo "$vols" | grep "vol-existing1"',
+            # `apply` only starts provisioning; launching before the claims
+            # bind is refused with VolumeNotReadyError.
+            smoke_tests_utils.get_cmd_wait_until_volume_is_ready('pvc0'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_ready('existing0'),
+            smoke_tests_utils.get_cmd_wait_until_volume_is_ready(
+                'vol-existing1'),
             f'sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume.yaml',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
             f'vols=$(sky volumes ls) && echo "$vols" && echo "$vols" | grep "{name}"',
             # Test volume mounting warning on relaunch with new volume
             # Create a new volume pvc1
             f'sky volumes apply -y -n pvc1 --type k8s-pvc --size 2GB',
+            # pvc1 is mounted by the last launch below, so it has to bind
+            # first; readiness does not make the relaunch mount it.
+            smoke_tests_utils.get_cmd_wait_until_volume_is_ready('pvc1'),
             # Launch with the new volume - should show warning that pvc1 and /mnt/data4 won't be mounted
             f's=$(sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume_with_new.yaml 2>&1 | tee /dev/stderr) && echo "$s" | grep -i "WARNING: New ephemeral volume(s) with path /mnt/data4 and new volume(s) pvc1 specified in task but not mounted"',
             f'sky logs {name} 2 --status',  # Ensure the second job succeeded.
@@ -1690,6 +1699,10 @@ def test_enable_docker_on_kubernetes(yaml_file, volumes_needed, sidecar,
     for vol in volumes_needed:
         setup_cmds.append(
             f'sky volumes apply -y -n {vol} --type k8s-pvc --size 2GB')
+        # `apply` only starts provisioning; the launch below mounts the volume
+        # and is refused with VolumeNotReadyError until the claim binds.
+        setup_cmds.append(
+            smoke_tests_utils.get_cmd_wait_until_volume_is_ready(vol))
 
     # kubectl exec into the sidecar to verify cache mount exists.
     # For _dv cases the mount is a PVC; for default cases it is an emptyDir.
@@ -1747,6 +1760,10 @@ def test_volume_env_mount_kubernetes():
             'volume_env_mount_kubernetes',
             [
                 f'sky volumes apply -y -n {full_pvc_name} --type k8s-pvc --size 2GB',
+                # `apply` only starts provisioning; launching before the claim
+                # binds is refused with VolumeNotReadyError.
+                smoke_tests_utils.get_cmd_wait_until_volume_is_ready(
+                    full_pvc_name),
                 f's=$(sky jobs launch -y --infra kubernetes {f.name} --env USERNAME=user); echo "$s"; echo "$s" | grep "Job finished (status: SUCCEEDED)"',
             ],
             smoke_tests_utils.chain_teardown(


### PR DESCRIPTION
## Summary

- `sky volumes apply` only *starts* provisioning. On a storage class with `volumeBindingMode: Immediate` the PersistentVolume is created asynchronously, so the claim is still Pending — and the volume recorded `NOT_READY` — when the command returns. Since #10402 that status is enforced: `VolumeMount.resolve` refuses the launch with `VolumeNotReadyError`. #10443 tried to absorb the gap and was reverted in #10451, so the window is open again.
- Smoke tests that create a volume and immediately mount it therefore race. Add `get_cmd_wait_until_volume_is_ready` and gate those launches on it, so a test waits for the volume exactly as a user would.

Observed on a shared remote API server — the volume bound about three seconds after the create returned, and the launch had already been refused:

```
Created volume user-<name>-pvc on cloud Kubernetes      18:19:56
VolumeNotReadyError: ... PVC is pending: the PersistentVolume
is still being provisioned                              18:19:59
```

## What is and is not gated

Every smoke test that creates a volume and then mounts it:

| test | volumes |
|---|---|
| `test_volume_env_mount_kubernetes` | the `user-*-pvc` it mounts (the failure above) |
| `test_volumes_on_kubernetes` | `pvc0`, `existing0`, `vol-existing1`, `pvc1` |
| `test_enable_docker_on_kubernetes` | each entry of `volumes_needed` |
| `TestBackwardCompatibility` volume test | created on base, mounted on current |

Left alone, deliberately:

- the four `*_not_ready` tests — the whole point is a volume that never becomes ready, so a gate would defeat the assertion;
- `test_hostpath_volume_on_kubernetes` — hostpath has no claim to bind and `get_all_volumes_errors` reports it healthy unconditionally;
- `test_recipe_volume_apply` and the other backward-compat volume steps — they only create and `sky volumes ls | grep`, never mount.

## Notes on the implementation

**Reading the status.** The gate takes the `STATUS` value at the character offset its header gives, rather than splitting the row on whitespace: the table is space-padded and the columns before `STATUS` hold spaces of their own (`alice (SA)`, `3 secs`). Taking the column also keeps `NOT_READY`, or a stray word in the `MESSAGE` column, from being read as `READY`.

**No `--refresh`.** It would end the wait the moment the claim binds, but it refreshes the whole volume table — a file lock and a database round-trip per volume, the contention #10452 describes — on every poll, against a server the rest of the suite is sharing. Reading the row the refresh daemon already maintains costs the server nothing and bounds the wait by its 60s interval, comfortably inside the per-step timeout.

## Test plan

The gate is bash parsing a rendered table, so it was pinned offline against output generated with the CLI's own prettytable settings (`border=False`, left-aligned, `right_padding_width=2`) before being put in front of CI:

| case | expected | guards against |
|---|---|---|
| `NOT_READY` row | keeps waiting | the status being read as READY |
| `NOT_READY` whose `MESSAGE` contains the bare word `READY` | keeps waiting | matching anywhere in the row |
| decoy row `pvc01` (`READY`) while waiting on `pvc0` | keeps waiting | prefix match on the name |
| `READY` in a second table section (hostpath) below the PVC one | keeps waiting | cross-section leakage |
| volume absent from the listing | keeps waiting, reports `not found` | silently passing |
| `READY` / `IN_USE` | passes | — |
| `NOT_READY` flipping to `READY` across polls | passes | — |

All eight pass. `yapf`/`isort`/`mypy` clean via pre-commit.

On CI (`-k` is a plain substring resolved by the pipeline generator, so one line per selector):

```
/smoke-test --kubernetes -k volume
/smoke-test --kubernetes -k auto_mount
/smoke-test --kubernetes -k test_enable_docker
/quicktest-core --kubernetes
```

`-k volume` covers both changed tests in `test_cluster_job.py` and, in the same run, the untouched guards — `test_volume_not_ready_on_kubernetes`, `test_managed_job_volume_not_ready`, `test_hostpath_volume_on_kubernetes`, `test_recipe_volume_apply` — which must keep passing, confirming no gate leaked into a test that wants `NOT_READY`. `-k auto_mount` covers the other two not-ready guards. `test_volume_mount_*` are `@pytest.mark.gcp` and are not scheduled on a Kubernetes lane.

`test_volume_compatibility` lives in `test_backward_compat.py`, which the generator routes to the quick-tests-core pipeline, so it needs `/quicktest-core` rather than `/smoke-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
