### PR TITLE
[Azure] Update A10 GRID driver for vGPU 18

### DIFF
--- a/sky/catalog/images/provisioners/cuda-azure-grid.sh
+++ b/sky/catalog/images/provisioners/cuda-azure-grid.sh
@@ -4,12 +4,15 @@ sudo apt update
 sudo apt install -y build-essential
 
 echo "Installing GRID driver..."
-GRID_DRIVER_URL="https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"
-GRID_DRIVER_FILE="NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"
+GRID_DRIVER_VERSION="570.237"
+GRID_DRIVER_URL="https://download.microsoft.com/download/5e213ec5-834f-4b0a-87f7-772751353b06/NVIDIA-Linux-x86_64-${GRID_DRIVER_VERSION}-grid-azure.run"
+GRID_DRIVER_FILE="NVIDIA-Linux-x86_64-${GRID_DRIVER_VERSION}-grid-azure.run"
+GRID_DRIVER_SHA256="1a529dd4d173ba3b36f3c284bb54fce5dd39c9e757856980b8ae0b7798e7764b"
 
-wget -nv $GRID_DRIVER_URL -O $GRID_DRIVER_FILE
-sudo chmod +x $GRID_DRIVER_FILE
-sudo sh $GRID_DRIVER_FILE --silent --disable-nouveau
+wget -nv "$GRID_DRIVER_URL" -O "$GRID_DRIVER_FILE"
+echo "$GRID_DRIVER_SHA256  $GRID_DRIVER_FILE" | sha256sum --check --strict
+sudo chmod +x "$GRID_DRIVER_FILE"
+sudo sh "$GRID_DRIVER_FILE" --silent --disable-nouveau
 
 echo "Set vGPU Licensing Daemon config..."
 sudo cp /etc/nvidia/gridd.conf.template /etc/nvidia/gridd.conf
@@ -29,5 +32,5 @@ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-12.2/lib64' >> ~/.
 source ~/.bashrc
 
 # Verify installations
-rm -f NVIDIA-Linux-x86_64-535.161.08-grid-azure.run cuda_12.2.0_535.54.03_linux.run
+rm -f "$GRID_DRIVER_FILE" "$CUDA_TOOLKIT_FILE"
 nvidia-smi

--- a/sky/catalog/images/provisioners/cuda-azure-grid.sh
+++ b/sky/catalog/images/provisioners/cuda-azure-grid.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 sudo apt update
 sudo apt install -y build-essential
 

--- a/sky/catalog/images/provisioners/user-toolkit.sh
+++ b/sky/catalog/images/provisioners/user-toolkit.sh
@@ -7,6 +7,6 @@ pip install numpy
 pip install pandas
 
 if [ "$AZURE_GRID_DRIVER" = 1 ]; then
-    # Need PyTorch X.X.X+cu121 version to be compatible with older NVIDIA driver (535.161.08 or lower)
+    # Keep the PyTorch runtime aligned with this image's CUDA 12.2 toolkit.
     pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 fi


### PR DESCRIPTION
Fixes #10468.

Azure's current NVadsA10_v5 support table specifies vGPU 18.8 / GRID
`570.237`, while the A10 image provisioner still installs `535.161.08` (now
listed for NVv3). On current A10 hosts that stale guest branch can fail with
Xid 78, leaving both `nvidia-smi` and Docker without a GPU.

This updates the image builder to Microsoft's current R570 payload, verifies
its independently checked SHA-256 before execution, and keeps the existing
CUDA 12.2 / PyTorch cu121 user environment. A new community image version must
be published after merge for existing SkyPilot releases to consume the fix.

Tested:

- [x] `bash -n` on both changed provisioner scripts
- [x] `shellcheck` on both changed scripts (only pre-existing `.bashrc` source/expansion notices)
- [x] independently downloaded and verified the GRID `570.237` SHA-256
- [x] baked from SkyPilot community image `26.03.19`; verified GRID version, full A10, DKMS, `nvidia-gridd`, CUDA 12.2 `nvcc`, PyTorch GPU access, and Docker GPU access after reboot
- [ ] All smoke tests: requires publishing the rebuilt Azure community image

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->