### PR TITLE
[Dashboard] Surface Slurm query failures on the Infra page instead of loading silently

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -37,7 +37,9 @@ import {
   getContextJobs,
   getContextClusters,
   getSlurmInfrastructure,
+  getSlurmClusterNames,
 } from '@/data/connectors/infra';
+import { ErrorDisplay } from '@/components/elements/ErrorDisplay';
 import { CLOUDS_LIST } from '@/data/connectors/constants';
 import {
   runSkyCheck,
@@ -348,6 +350,7 @@ export function InfrastructureSection({
   actionButton = null, // Optional action button for the header
   contextWorkspaceMap = {}, // Mapping of contexts to workspaces
   contextErrors = {}, // Mapping of contexts to error messages
+  sectionError = null, // Section-wide fetch failure, shown as a banner
   gpuMetricsRefreshTrigger = 0, // Counter for forcing iframe refresh
   loadedContexts = new Set(), // Set of contexts that have had their GPU data loaded
   isInitialLoad = true, // Controls panel-level loading spinner (not cell spinners)
@@ -481,6 +484,10 @@ export function InfrastructureSection({
             <h3 className="text-lg font-semibold">{title}</h3>
             {actionButton}
           </div>
+          <ErrorDisplay
+            error={sectionError}
+            title={`Failed to query ${title}`}
+          />
           <p className="text-sm text-gray-500">
             No {title} found or {title} is not configured.
           </p>
@@ -542,6 +549,13 @@ export function InfrastructureSection({
               )}
             </div>
           </div>
+          {/* A section-wide fetch failure (e.g. an unreachable Slurm login
+              node) — surface the actual error instead of silently rendering
+              empty cells under the listed rows. */}
+          <ErrorDisplay
+            error={sectionError}
+            title={`Failed to query ${title}`}
+          />
           <GpuTypeSummaryStrip gpus={gpus} />
           {/* Desktop: unified full-width table. No inner vertical scroll —
               per-type sub-rows make row count = contexts x GPU types, so a
@@ -2506,6 +2520,9 @@ export function GPUs() {
   // Slurm loading state (separate from Kubernetes/SSH for parallel loading)
   const [slurmLoading, setSlurmLoading] = useState(true);
   const [slurmDataLoaded, setSlurmDataLoaded] = useState(false);
+  // The actual failure behind an empty Slurm section (e.g. the SSH error of
+  // an unreachable login node), surfaced as a banner in the section.
+  const [slurmError, setSlurmError] = useState(null);
 
   const [sshAndKubeJobsDataLoading, setSshAndKubeJobsDataLoading] =
     useState(true);
@@ -2610,6 +2627,7 @@ export function GPUs() {
         setAllSlurmGPUs([]);
         setPerClusterSlurmGPUs([]);
         setPerNodeSlurmGPUs([]);
+        setSlurmError(null);
         setSshAndKubeJobsData({});
         setSshAndKubeJobsDataLoading(false);
 
@@ -2841,12 +2859,32 @@ export function GPUs() {
   // Fetch Slurm data separately for parallel loading with Kubernetes/SSH
   const fetchSlurmData = async () => {
     try {
+      // The cluster-name query answers from ~/.slurm/config without
+      // contacting any login node, so it returns quickly even when a cluster
+      // is unreachable. Render the cluster rows from it right away instead of
+      // holding the whole section on a spinner behind the GPU/node queries,
+      // which go over SSH and can hang for minutes on connect timeouts.
+      dashboardCache
+        .get(getSlurmClusterNames)
+        .then((names) => {
+          if (Array.isArray(names) && names.length > 0) {
+            // Keep whatever the full fetch set if it won the race.
+            setConfiguredSlurmClusters((prev) =>
+              prev.length > 0 ? prev : names
+            );
+            setSlurmDataLoaded(true);
+          }
+        })
+        .catch(() => {
+          // The full fetch below reports errors.
+        });
       const slurmData = await dashboardCache.get(getSlurmInfrastructure);
       if (slurmData) {
         setConfiguredSlurmClusters(slurmData.slurmClusterNames || []);
         setAllSlurmGPUs(slurmData.allSlurmGPUs || []);
         setPerClusterSlurmGPUs(slurmData.perClusterSlurmGPUs || []);
         setPerNodeSlurmGPUs(slurmData.perNodeSlurmGPUs || []);
+        setSlurmError(slurmData.slurmError || null);
       }
       setSlurmDataLoaded(true);
       setSlurmLoading(false);
@@ -2856,6 +2894,7 @@ export function GPUs() {
       setAllSlurmGPUs([]);
       setPerClusterSlurmGPUs([]);
       setPerNodeSlurmGPUs([]);
+      setSlurmError(error.message || String(error));
       setSlurmDataLoaded(true);
       setSlurmLoading(false);
     }
@@ -3702,6 +3741,7 @@ export function GPUs() {
         isSSH={false}
         isSlurm={true}
         contextWorkspaceMap={{}}
+        sectionError={slurmError}
         isInitialLoad={isInitialLoad}
         statusByKey={extraStatusByKey}
       />

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -488,9 +488,13 @@ export function InfrastructureSection({
             error={sectionError}
             title={`Failed to query ${title}`}
           />
-          <p className="text-sm text-gray-500">
-            No {title} found or {title} is not configured.
-          </p>
+          {/* The banner already explains why nothing is listed, so don't
+              guess "not configured" under it. */}
+          {!sectionError && (
+            <p className="text-sm text-gray-500">
+              No {title} found or {title} is not configured.
+            </p>
+          )}
         </div>
       </div>
     );
@@ -3101,6 +3105,9 @@ export function GPUs() {
     dashboardCache.invalidate(getCloudInfrastructure, [false]); // Keep for backwards compatibility
     dashboardCache.invalidate(getSSHNodePools);
     dashboardCache.invalidate(getSlurmInfrastructure);
+    // The fast row-render path reads the config-backed name list through the
+    // cache too; without this, Refresh keeps serving stale cluster names.
+    dashboardCache.invalidate(getSlurmClusterNames);
 
     // Increment GPU metrics refresh trigger to force iframe reload
     setGpuMetricsRefreshTrigger((prev) => prev + 1);

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -350,7 +350,10 @@ export function InfrastructureSection({
   actionButton = null, // Optional action button for the header
   contextWorkspaceMap = {}, // Mapping of contexts to workspaces
   contextErrors = {}, // Mapping of contexts to error messages
-  sectionError = null, // Section-wide fetch failure, shown as a banner
+  // Section-wide fetch failure. Only shown as a banner in the empty state,
+  // where there is no row to carry the per-row error icon; when rows exist
+  // the failure is attached to them via contextErrors instead.
+  sectionError = null,
   gpuMetricsRefreshTrigger = 0, // Counter for forcing iframe refresh
   loadedContexts = new Set(), // Set of contexts that have had their GPU data loaded
   isInitialLoad = true, // Controls panel-level loading spinner (not cell spinners)
@@ -553,13 +556,6 @@ export function InfrastructureSection({
               )}
             </div>
           </div>
-          {/* A section-wide fetch failure (e.g. an unreachable Slurm login
-              node) — surface the actual error instead of silently rendering
-              empty cells under the listed rows. */}
-          <ErrorDisplay
-            error={sectionError}
-            title={`Failed to query ${title}`}
-          />
           <GpuTypeSummaryStrip gpus={gpus} />
           {/* Desktop: unified full-width table. No inner vertical scroll —
               per-type sub-rows make row count = contexts x GPU types, so a
@@ -843,18 +839,27 @@ export function InfrastructureSection({
                                 layout; the name cell is its home in the
                                 unified table. */}
                             <AllowedNodesRowBadge id={rowId} kind={rowKind} />
-                            {contextErrors[context] && !statusByKey && (
-                              // Hidden when a plugin is contributing status data
-                              // via the infra.row.namePrefix slot — the plugin's
-                              // status dot + per-context detail page cover this
-                              // information already.
-                              <NonCapitalizedTooltip
-                                content={`Context unreachable: ${contextErrors[context]}`}
-                                className="text-sm text-muted-foreground"
-                              >
-                                <AlertTriangleIcon className="w-4 h-4 text-yellow-500 flex-shrink-0" />
-                              </NonCapitalizedTooltip>
-                            )}
+                            {contextErrors[context] &&
+                              (isSlurm || !statusByKey) && (
+                                // Hidden when a plugin is contributing status
+                                // data via the infra.row.namePrefix slot — the
+                                // plugin's status dot + per-context detail page
+                                // cover this information already. Slurm rows
+                                // are exempt: their errors come from the
+                                // inventory queries, which can fail while a
+                                // plugin still reports the cluster's
+                                // connection healthy, so the status dot does
+                                // not cover them.
+                                <NonCapitalizedTooltip
+                                  content={`${
+                                    contextNoun.charAt(0).toUpperCase() +
+                                    contextNoun.slice(1)
+                                  } unreachable: ${contextErrors[context]}`}
+                                  className="text-sm text-muted-foreground"
+                                >
+                                  <AlertTriangleIcon className="w-4 h-4 text-yellow-500 flex-shrink-0" />
+                                </NonCapitalizedTooltip>
+                              )}
                           </div>
                           {workspaces.length > 0 && (
                             <div className="text-sm text-gray-500 mt-1.5">
@@ -3345,6 +3350,17 @@ export function GPUs() {
     return [...clusterSet].sort();
   }, [configuredSlurmClusters, perClusterSlurmGPUs, perNodeSlurmGPUs]);
 
+  // Attach the Slurm fetch failure to every listed cluster — the same
+  // warning-icon treatment unreachable Kubernetes contexts get. The inventory
+  // queries cover all clusters in one call, so one failure applies to each
+  // row.
+  const slurmContextErrors = React.useMemo(() => {
+    if (!slurmError) return {};
+    return Object.fromEntries(
+      slurmClusters.map((cluster) => [cluster, slurmError])
+    );
+  }, [slurmError, slurmClusters]);
+
   // Group perClusterSlurmGPUs by cluster
   const groupedPerClusterSlurmGPUs = React.useMemo(() => {
     if (!perClusterSlurmGPUs) return {};
@@ -3748,6 +3764,7 @@ export function GPUs() {
         isSSH={false}
         isSlurm={true}
         contextWorkspaceMap={{}}
+        contextErrors={slurmContextErrors}
         sectionError={slurmError}
         isInitialLoad={isInitialLoad}
         statusByKey={extraStatusByKey}

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -237,25 +237,43 @@ describe('InfrastructureSection unreachable Slurm cluster', () => {
 // A failed section-wide query (e.g. the SSH error of an unreachable Slurm
 // login node) arrives as `sectionError` and renders as a banner, so the page
 // says what went wrong instead of silently showing empty cells.
-describe('InfrastructureSection section-wide error banner', () => {
+describe('InfrastructureSection Slurm error reporting', () => {
   const sshError =
     'ssh: connect to host 10.0.0.5 port 22: Connection timed out';
+  const rowErrorIcon = (container) =>
+    container.querySelector('table tbody td svg.text-yellow-500');
 
-  it('shows the failure text above the listed cluster rows', () => {
+  it('marks the cluster row with the same warning icon k8s contexts get', () => {
     const { container } = renderSection({
       isSlurm: true,
       contexts: ['offline-cluster'],
       gpus: [],
+      contextErrors: { 'offline-cluster': sshError },
       sectionError: sshError,
     });
-    expect(container.textContent).toContain('Failed to query Slurm');
-    expect(container.textContent).toContain(sshError);
-    // The configured cluster still renders as a row under the banner.
+    // The failure rides on the row (icon + tooltip), not a banner.
+    expect(rowErrorIcon(container)).not.toBeNull();
+    expect(container.textContent).not.toContain('Failed to query Slurm');
     expect(tableRows(container)).toHaveLength(1);
     expect(normalize(tableRows(container)[0])).toContain('offline-cluster');
   });
 
-  it('shows the banner instead of the "not configured" guess when empty', () => {
+  it('keeps the icon when a plugin supplies row status data', () => {
+    // For Kubernetes rows a plugin's status dot suppresses the icon (it
+    // carries the same reachability information). Slurm errors come from the
+    // inventory queries, which can fail while the plugin still reports the
+    // cluster's connection healthy — so the icon must survive.
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['offline-cluster'],
+      gpus: [],
+      contextErrors: { 'offline-cluster': sshError },
+      statusByKey: new Map([['slurm:offline-cluster', { status: 'ready' }]]),
+    });
+    expect(rowErrorIcon(container)).not.toBeNull();
+  });
+
+  it('falls back to the banner when there is no row to carry the icon', () => {
     const { container } = renderSection({
       isSlurm: true,
       contexts: [],
@@ -269,14 +287,16 @@ describe('InfrastructureSection section-wide error banner', () => {
     expect(container.textContent).not.toContain('not configured');
   });
 
-  it('renders no banner when there is no error', () => {
+  it('renders neither icon nor banner when there is no error', () => {
     const { container } = renderSection({
       isSlurm: true,
       contexts: ['healthy-cluster'],
       gpus: [],
+      contextErrors: {},
       sectionError: null,
     });
     expect(container.textContent).not.toContain('Failed to query');
+    expect(rowErrorIcon(container)).toBeNull();
   });
 });
 

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -234,6 +234,52 @@ describe('InfrastructureSection unreachable Slurm cluster', () => {
   });
 });
 
+// A failed section-wide query (e.g. the SSH error of an unreachable Slurm
+// login node) arrives as `sectionError` and renders as a banner, so the page
+// says what went wrong instead of silently showing empty cells.
+describe('InfrastructureSection section-wide error banner', () => {
+  const sshError =
+    'ssh: connect to host 10.0.0.5 port 22: Connection timed out';
+
+  it('shows the failure text above the listed cluster rows', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['offline-cluster'],
+      gpus: [],
+      sectionError: sshError,
+    });
+    expect(container.textContent).toContain('Failed to query Slurm');
+    expect(container.textContent).toContain(sshError);
+    // The configured cluster still renders as a row under the banner.
+    expect(tableRows(container)).toHaveLength(1);
+    expect(normalize(tableRows(container)[0])).toContain('offline-cluster');
+  });
+
+  it('shows the banner instead of the "not configured" guess when empty', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: [],
+      gpus: [],
+      sectionError: sshError,
+    });
+    expect(container.textContent).toContain('Failed to query Slurm');
+    expect(container.textContent).toContain(sshError);
+    // The banner already explains why nothing is listed; guessing "not
+    // configured" next to it would contradict it.
+    expect(container.textContent).not.toContain('not configured');
+  });
+
+  it('renders no banner when there is no error', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['healthy-cluster'],
+      gpus: [],
+      sectionError: null,
+    });
+    expect(container.textContent).not.toContain('Failed to query');
+  });
+});
+
 // Mirrors slurm_catalog.list_accelerators_realtime, which feeds the
 // "Requestable: N / node" tooltip. If the backend rule changes, this is the
 // copy that has to move with it.

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -1089,6 +1089,29 @@ export async function getDetailedGpuInfo(filter) {
   }
 }
 
+// Pull the failure message raised server-side out of a failed /api/get
+// response. The body is {detail: {error: '<json>'}} where the JSON carries the
+// message of the exception the request died with — e.g. the SSH error of an
+// unreachable Slurm login node. Falls back to the given message when the body
+// doesn't have that shape.
+async function extractRequestError(fetchedData, fallback) {
+  try {
+    const data = await fetchedData.json();
+    if (data.detail && data.detail.error) {
+      const error = JSON.parse(data.detail.error);
+      if (error.message) {
+        return error.message;
+      }
+    }
+  } catch (parseError) {
+    console.error('Error parsing failed request response:', parseError);
+  }
+  return fallback;
+}
+
+// The two SSH-bound Slurm queries return {data, error} instead of throwing:
+// the section still renders the configured clusters when a login node is
+// unreachable, with `error` carrying the actual failure to show for them.
 async function getSlurmClusterGPUs() {
   try {
     const response = await apiClient.post(`/slurm_gpu_availability`, {});
@@ -1102,32 +1125,20 @@ async function getSlurmClusterGPUs() {
       throw new Error(msg);
     }
     const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
-    if (fetchedData.status === 500) {
-      try {
-        const data = await fetchedData.json();
-        if (data.detail && data.detail.error) {
-          try {
-            const error = JSON.parse(data.detail.error);
-            console.error('Error fetching Slurm cluster GPUs:', error.message);
-          } catch (jsonError) {
-            console.error('Error parsing JSON for Slurm error:', jsonError);
-          }
-        }
-      } catch (parseError) {
-        console.error('Error parsing JSON for Slurm 500 response:', parseError);
-      }
-      return [];
-    }
     if (!fetchedData.ok) {
-      const msg = `Failed to get slurm cluster GPUs result with status ${fetchedData.status}`;
-      throw new Error(msg);
+      const msg = await extractRequestError(
+        fetchedData,
+        `Failed to get slurm cluster GPUs result with status ${fetchedData.status}`
+      );
+      console.error('Error fetching Slurm cluster GPUs:', msg);
+      return { data: [], error: msg };
     }
     const data = await fetchedData.json();
     const clusterGPUs = data.return_value ? JSON.parse(data.return_value) : [];
-    return clusterGPUs;
+    return { data: clusterGPUs, error: null };
   } catch (error) {
     console.error('Error fetching Slurm cluster GPUs:', error);
-    return [];
+    return { data: [], error: error.message || String(error) };
   }
 }
 
@@ -1144,38 +1155,20 @@ async function getSlurmPerNodeGPUs() {
       throw new Error(msg);
     }
     const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
-    if (fetchedData.status === 500) {
-      try {
-        const data = await fetchedData.json();
-        if (data.detail && data.detail.error) {
-          try {
-            const error = JSON.parse(data.detail.error);
-            console.error('Error fetching Slurm per node GPUs:', error.message);
-          } catch (jsonError) {
-            console.error(
-              'Error parsing JSON for Slurm node error:',
-              jsonError
-            );
-          }
-        }
-      } catch (parseError) {
-        console.error(
-          'Error parsing JSON for Slurm node 500 response:',
-          parseError
-        );
-      }
-      return [];
-    }
     if (!fetchedData.ok) {
-      const msg = `Failed to get slurm node info result with status ${fetchedData.status}`;
-      throw new Error(msg);
+      const msg = await extractRequestError(
+        fetchedData,
+        `Failed to get slurm node info result with status ${fetchedData.status}`
+      );
+      console.error('Error fetching Slurm per node GPUs:', msg);
+      return { data: [], error: msg };
     }
     const data = await fetchedData.json();
     const nodeInfo = data.return_value ? JSON.parse(data.return_value) : [];
-    return nodeInfo;
+    return { data: nodeInfo, error: null };
   } catch (error) {
     console.error('Error fetching Slurm per node GPUs:', error);
-    return [];
+    return { data: [], error: error.message || String(error) };
   }
 }
 
@@ -1183,7 +1176,10 @@ async function getSlurmPerNodeGPUs() {
 // contacting any login node. Independent of the GPU and node queries, so it is
 // fetched alongside them rather than before them: a cluster that is
 // unreachable still comes back here after those two report nothing for it.
-async function getSlurmClusterNames() {
+// Exported so the Infra page can render the cluster rows from it immediately,
+// without waiting on the SSH-bound queries (which can hang on connect
+// timeouts when a login node is unreachable).
+export async function getSlurmClusterNames() {
   try {
     const response = await apiClient.post(`/slurm_cluster_names`, {});
     if (!response.ok) {
@@ -1217,11 +1213,11 @@ async function getSlurmServiceGPUs() {
   try {
     // Fetch the configured cluster names, cluster GPUs and node GPUs in
     // parallel — none of the three depends on another.
-    const [clusterNames, clusterGPUsRaw, nodeGPUsRaw] = await Promise.all([
-      getSlurmClusterNames(),
-      getSlurmClusterGPUs(),
-      getSlurmPerNodeGPUs(),
-    ]);
+    const [clusterNames, clusterGPUsResult, nodeGPUsResult] = await Promise.all(
+      [getSlurmClusterNames(), getSlurmClusterGPUs(), getSlurmPerNodeGPUs()]
+    );
+    const clusterGPUsRaw = clusterGPUsResult.data;
+    const nodeGPUsRaw = nodeGPUsResult.data;
 
     const allSlurmGPUs = {};
     const perClusterSlurmGPUs = {}; // Similar to perContextGPUs for Kubernetes
@@ -1295,6 +1291,10 @@ async function getSlurmServiceGPUs() {
           (a.node_name || '').localeCompare(b.node_name || '') ||
           (a.gpu_name || '').localeCompare(b.gpu_name || '')
       ),
+      // The first failure among the GPU and node queries. Both go over SSH to
+      // the same login nodes, so when a cluster is unreachable they fail with
+      // the same root cause — reporting one of them is enough.
+      slurmError: clusterGPUsResult.error || nodeGPUsResult.error || null,
     };
   } catch (error) {
     console.error('Error fetching Slurm GPUs:', error);
@@ -1303,6 +1303,7 @@ async function getSlurmServiceGPUs() {
       allSlurmGPUs: [],
       perClusterSlurmGPUs: [],
       perNodeSlurmGPUs: [],
+      slurmError: error.message || String(error),
     };
   }
 }

--- a/sky/dashboard/src/data/connectors/infra.test.jsx
+++ b/sky/dashboard/src/data/connectors/infra.test.jsx
@@ -97,5 +97,58 @@ describe('getSlurmInfrastructure configured clusters', () => {
     const data = await getSlurmInfrastructure();
 
     expect(data.slurmClusterNames).toEqual([]);
+    expect(data.slurmError).toBeNull();
+  });
+
+  // The failure of the SSH-bound queries must reach the page as the actual
+  // server-side message (e.g. the login node's SSH error), not vanish into an
+  // empty section — that is what the Infra page renders in its error banner.
+  it('surfaces the server error message when the SSH-bound queries fail', async () => {
+    const failure = (message) => ({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        detail: { error: JSON.stringify({ message }) },
+      }),
+    });
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return result(['prod']);
+      if (path.includes('req-gpus'))
+        return failure('ssh: connect to host 10.0.0.1 port 22: timed out');
+      return failure('ssh: connect to host 10.0.0.1 port 22: timed out');
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    expect(data.slurmClusterNames).toEqual(['prod']);
+    expect(data.perClusterSlurmGPUs).toEqual([]);
+    expect(data.perNodeSlurmGPUs).toEqual([]);
+    expect(data.slurmError).toEqual(
+      'ssh: connect to host 10.0.0.1 port 22: timed out'
+    );
+  });
+
+  it('reports no error when all queries succeed', async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return result(['prod']);
+      return result([]);
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    expect(data.slurmError).toBeNull();
+  });
+
+  it('falls back to a status message when a failed response has no detail', async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return result(['prod']);
+      return { ok: false, status: 503, json: async () => ({}) };
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    expect(data.slurmError).toEqual(
+      'Failed to get slurm cluster GPUs result with status 503'
+    );
   });
 });


### PR DESCRIPTION
## Summary

When a Slurm login node is unreachable, the Infra page's Slurm section previously sat on a loading spinner until the SSH-bound queries (`/slurm_gpu_availability`, `/slurm_node_info`) timed out server-side (minutes), then rendered the configured clusters with empty cells and no indication anything went wrong.

- **Propagate the actual error**: `getSlurmClusterGPUs` / `getSlurmPerNodeGPUs` now extract the server-side failure message from the failed `/api/get` response (`detail.error`) and return it through `getSlurmInfrastructure` as a new `slurmError` field, instead of swallowing it into `console.error` + empty arrays.
- **Show it the same way unreachable Kubernetes contexts are shown**: each Slurm cluster row gets the warning icon next to its name, with the tooltip carrying the actual error (`Cluster unreachable: ...`). A banner is used only in the empty state, where there is no row to carry the icon. Slurm rows keep the icon even when a plugin supplies row status data, since the inventory queries can fail while a plugin still reports the cluster's connection healthy.
- **Stop blocking on the slow queries**: cluster rows now render immediately from `/slurm_cluster_names` (answered from `~/.slurm/config` without contacting a login node), with skeleton cells while the SSH-bound queries are in flight, instead of holding the whole section behind them.
- Fix a cache-invalidation gap: manual Refresh now also invalidates the cluster-name query cache.

## Test plan

- `npx jest src/data/connectors/infra.test.jsx src/components/infra.test.jsx` — 22/22 passing, including: connector-level (error message extracted from a failed response, `slurmError` null on success, status-code fallback when the body has no detail) and component-level (row warning icon with rows present, icon survives plugin row-status data, empty-state banner fallback, neither icon nor banner without an error).
- `npx next lint` clean on changed files; `npm run build` succeeds.
- Manually verified against an API server whose Slurm login node SSH times out: the cluster row appears immediately with the warning icon once the queries fail, and the tooltip shows the underlying SSH connect-timeout message — instead of a minutes-long spinner followed by a silently empty section.

Note: when the server skips an unreachable cluster while aggregating (`Skipping Slurm cluster ... while collecting node info`) it returns 200 with an empty list, which this PR cannot surface — propagating per-cluster skip reasons in the response payload is left as a follow-up server-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJQBYeyCzxi1BuJPoG2NcY