### PR TITLE
[Helm] Optional scrape job for sidecar containers

### DIFF
--- a/charts/skypilot/tests/metrics_test.yaml
+++ b/charts/skypilot/tests/metrics_test.yaml
@@ -49,6 +49,48 @@ tests:
           path: data["prometheus.yml"]
           pattern: "/endpoints-metrics"
 
+  - it: should NOT render the pgbouncer scrape job by default
+    set:
+      prometheus.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "skypilot-pgbouncer-metrics"
+
+  - it: should render the pgbouncer scrape job when scrapePgBouncer is enabled
+    set:
+      prometheus.enabled: true
+      prometheus.scrapePgBouncer: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: 'skypilot-pgbouncer-metrics'"
+      # The annotation meta-label spelling is load-bearing: a typo yields a job
+      # that silently matches no pods.
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_pod_annotation_skypilot_co_pgbouncer_scrape"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_pod_annotation_skypilot_co_pgbouncer_port"
+
+  # The job must survive the minimal/full scrape-config split: extraScrapeConfigs
+  # is appended to prometheus.yml either way, unlike serverFiles.
+  - it: should render the pgbouncer scrape job alongside a custom prometheus.yml
+    set:
+      prometheus.enabled: true
+      prometheus.scrapePgBouncer: true
+      prometheus.serverFiles:
+        prometheus.yml:
+          scrape_configs:
+            - job_name: prometheus
+              static_configs:
+                - targets: [localhost:9090]
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: 'skypilot-pgbouncer-metrics'"
+
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 suite: grafana_ingress_annotations_test

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -725,6 +725,20 @@ prometheus:
   # unless you run model-serving workloads.
   # @schema type: [boolean, null]
   scrapeEndpointMetrics: false
+  # Add a scrape job for a PgBouncer exporter running as an API server sidecar
+  # (apiService.sidecarContainers), which turns the PgBouncer console into
+  # Prometheus metrics — most usefully the number of clients queued for a
+  # server connection and how long the oldest has waited, the signals that
+  # precede pool starvation.
+  #
+  # The exporter shares the API server's pod IP, and a pod can advertise only
+  # one port per annotation set, so it cannot reuse skypilot.co/scrape (which
+  # points at the API server's own metrics port). It advertises its own pair
+  # instead — skypilot.co/pgbouncer-scrape: "true" and
+  # skypilot.co/pgbouncer-port: "<port>" on the API server pod — and this job
+  # keys on that pair. Opt-in: leave false unless you run such a sidecar.
+  # @schema type: [boolean, null]
+  scrapePgBouncer: false
   enabled: false
   # Keep the installation minimal by default. If you want to monitor more resources other than the API server,
   # it is recommended to install and manage prometheus separately.
@@ -770,6 +784,44 @@ prometheus:
       metrics_path: '/endpoints-metrics'
       scrape_interval: 60s
       scrape_timeout: 45s
+    {{- end }}
+    {{- if .Values.scrapePgBouncer }}
+    # PgBouncer exporter sidecar, discovered through the API server pod's
+    # skypilot.co/pgbouncer-* annotations (see prometheus.scrapePgBouncer).
+    # Kubernetes SD spells an annotation as
+    # __meta_kubernetes_pod_annotation_<key>, with every character outside
+    # [a-zA-Z0-9_] replaced by '_'.
+    - job_name: 'skypilot-pgbouncer-metrics'
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - '{{ .Release.Namespace }}'
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_skypilot_co_pgbouncer_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_skypilot_co_pgbouncer_port, __meta_kubernetes_pod_ip]
+          action: replace
+          regex: (\d+);((([0-9]+?)(\.|$)){4})
+          replacement: $2:$1
+          target_label: __address__
+        - source_labels: [__meta_kubernetes_pod_phase]
+          regex: Pending|Succeeded|Failed|Completed
+          action: drop
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: pod
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          target_label: node
     {{- end }}
     {{ if .Values.useDedicatedScrapeConfig }}
     - job_name: 'skypilot-api-server-metrics'


### PR DESCRIPTION
A PgBouncer exporter can run next to the API server via `apiService.sidecarContainers`, turning the PgBouncer console into Prometheus metrics — most usefully the count of clients queued for a server connection and the age of the oldest wait, which rise well before clients start timing out.

Nothing scrapes it today. The exporter shares the API server's pod IP, and a pod can advertise only one port per annotation set, so it cannot reuse `skypilot.co/scrape` (that pair points at the API server's own metrics port) and none of the chart's existing jobs match anything else. The result is silent: the sidecar runs, the annotations are there, and no series exist.

This adds `prometheus.scrapePgBouncer` (default false), which appends a scrape job keyed on a second annotation pair the sidecar advertises on the API server pod — `skypilot.co/pgbouncer-scrape: "true"` and `skypilot.co/pgbouncer-port: "<port>"`. Kubernetes SD exposes each annotation as `__meta_kubernetes_pod_annotation_<key>` with every character outside `[a-zA-Z0-9_]` replaced by `_`, so the job keys on `__meta_kubernetes_pod_annotation_skypilot_co_pgbouncer_{scrape,port}`.

It lives in `extraScrapeConfigs` rather than `serverFiles` because that is the only channel present under both scrape-config layouts: a deployment that supplies its own `serverFiles["prometheus.yml"]` replaces the `scrape_configs` list outright (Helm replaces lists, it does not merge), while `extraScrapeConfigs` is appended to `prometheus.yml` either way. The job's label set mirrors `skypilot-api-server-metrics`, so the series carry the same namespace / pod / node / pod-label dimensions.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Specifically:

- `helm unittest charts/skypilot -f 'tests/metrics_test.yaml'` — 8 passed. Three are new: the job is absent by default, present when `scrapePgBouncer` is set (with both meta-label spellings pinned, since a typo there yields a job that silently matches no pods), and still present when the deployment supplies its own `prometheus.yml` via `serverFiles`.
- Rendered the chart with `prometheus.enabled=true --set prometheus.scrapePgBouncer=true` and confirmed the job lands in `prometheus.yml` alongside the chart's default scrape jobs; the resulting scrape configs pass `promtool check config` (Prometheus 3.4.1, the version this chart deploys).
- Checked the relabel arithmetic the way Prometheus applies it (regex anchored as `^(?:...)$` over the `;`-joined source labels): `"9127;10.42.0.7"` → `10.42.0.7:9127`. The job sets no `metrics_path`, which matches the exporter's `/metrics` default.

No smoke tests: this is chart values only, with no Python code path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->