### PR TITLE
[API] Sweep the clients dir off the event loop, and GC legacy task YAMLs

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -25,7 +25,8 @@ import threading
 import time
 import traceback
 import typing
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Type
+from typing import (Any, Dict, Iterator, List, Literal, Optional, Set, Tuple,
+                    Type)
 import uuid
 import zipfile
 import zlib
@@ -768,10 +769,19 @@ async def cleanup_unreferenced_file_mounts():
                          f'{common_utils.format_exception(e)}')
 
 
+def _scandir_or_skip(dir_path: str) -> Iterator[os.DirEntry]:
+    """Yield dir entries; yields nothing if the dir is gone or unreadable."""
+    try:
+        with os.scandir(dir_path) as entries:
+            yield from entries
+    except OSError:
+        return
+
+
 def _prune_expired_files(dir_path: str, suffix: str, cutoff: float) -> int:
     """Remove files under dir_path matching suffix and older than cutoff."""
     removed = 0
-    for entry in os.scandir(dir_path):
+    for entry in _scandir_or_skip(dir_path):
         try:
             if (entry.name.endswith(suffix) and
                     entry.is_file(follow_symlinks=False) and
@@ -807,12 +817,12 @@ def _prune_clients_tmp(cutoff: float) -> int:
 
     removed = 0
     for root_dir, (sweep_dirs, sweep_yamls) in roots.items():
-        if not os.path.isdir(root_dir):
-            continue
-        for user_entry in os.scandir(root_dir):
+        # Skip rather than raise: a dir can vanish under us (peer replicas
+        # sweep the same tree), and one bad dir must not abort the pass.
+        for user_entry in _scandir_or_skip(root_dir):
             if not user_entry.is_dir():
                 continue
-            for entry in os.scandir(user_entry.path):
+            for entry in _scandir_or_skip(user_entry.path):
                 try:
                     if entry.is_dir(follow_symlinks=False):
                         if sweep_dirs and entry.stat().st_mtime < cutoff:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -770,12 +770,12 @@ async def cleanup_unreferenced_file_mounts():
 
 
 def _scandir_or_skip(dir_path: str) -> Iterator[os.DirEntry]:
-    """Yield dir entries; yields nothing if the dir is gone or unreadable."""
+    """Yield dir entries; yields nothing if dir_path is not a readable dir."""
     try:
         with os.scandir(dir_path) as entries:
             yield from entries
-    except OSError:
-        return
+    except OSError as e:
+        logger.debug(f'Skipping {dir_path}: {e}')
 
 
 def _prune_expired_files(dir_path: str, suffix: str, cutoff: float) -> int:
@@ -817,11 +817,11 @@ def _prune_clients_tmp(cutoff: float) -> int:
 
     removed = 0
     for root_dir, (sweep_dirs, sweep_yamls) in roots.items():
-        # Skip rather than raise: a dir can vanish under us (peer replicas
-        # sweep the same tree), and one bad dir must not abort the pass.
+        # Every filesystem touch below is guarded: a dir can vanish under us
+        # (peer replicas sweep the same tree) or go stale on a shared FS, and
+        # one bad entry must not abort the pass. Non-dir entries need no
+        # is_dir() check — scandir rejects them and _scandir_or_skip absorbs it.
         for user_entry in _scandir_or_skip(root_dir):
-            if not user_entry.is_dir():
-                continue
             for entry in _scandir_or_skip(user_entry.path):
                 try:
                     if entry.is_dir(follow_symlinks=False):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -786,24 +786,13 @@ def _prune_expired_files(dir_path: str, suffix: str, cutoff: float) -> int:
 def _prune_clients_tmp(cutoff: float) -> int:
     """Remove client tmp artifacts older than cutoff; returns count removed.
 
-    Two kinds of transient state pile up under the per-user client dirs:
-
-    - Download staging dirs: logs synced from the cluster for the client to
-      download, then no longer needed. Only swept for backends that keep them
-      in a dedicated tree (``download_tmp_base_dir()``); the ones sharing the
-      persistent log dir need no separate cleanup.
-    - Task YAMLs: the submitted task (``tasks/<task_id>.yaml``) and its
-      translated form (``<task_id>_translated.yaml``) used to be persisted per
-      submission to ease debugging. Task YAMLs are processed in memory now, so
-      whatever is still on disk was left behind by an older server version and
-      can be reclaimed.
+    Swept per user dir: download staging dirs (only for backends with a
+    dedicated ``download_tmp_base_dir()``) and legacy task YAMLs, no longer
+    written now that task YAMLs are processed in memory.
     """
-    # Both sweeps walk clients/<user_hash>/, and for backends whose download
-    # staging tree *is* the clients dir the two roots coincide, so they are
-    # keyed by root to walk each tree only once. The tree can be on a shared
-    # filesystem with hundreds of user dirs, where a redundant walk is far
-    # from free.
-    # Value: (sweep expired dirs, sweep expired legacy task YAMLs).
+    # Keyed by root so backends whose download staging tree *is* the clients
+    # dir walk it once, not twice.
+    # root -> (sweep expired dirs, sweep expired legacy task YAMLs)
     roots: Dict[str, Tuple[bool, bool]] = {}
 
     def add_root(path: str, sweep_dirs: bool, sweep_yamls: bool) -> None:
@@ -830,8 +819,7 @@ def _prune_clients_tmp(cutoff: float) -> int:
                             shutil.rmtree(entry.path, ignore_errors=True)
                             removed += 1
                         elif sweep_yamls and entry.name == 'tasks':
-                            # The legacy submitted-task dir; it holds nothing
-                            # but per-submission YAMLs.
+                            # Legacy dir, holds per-submission YAMLs only.
                             removed += _prune_expired_files(
                                 entry.path, '.yaml', cutoff)
                     elif sweep_yamls:
@@ -848,10 +836,8 @@ def _prune_clients_tmp(cutoff: float) -> int:
 async def cleanup_clients_tmp():
     """Hourly GC of expired tmp artifacts under the API server clients dir.
 
-    Everything older than the blob GC grace period (1 hour by default) is
-    removed. The walk runs in a worker thread: the clients dir can be on a
-    shared filesystem where a full pass takes minutes, and this event loop
-    also serves the metrics server and the other background daemons.
+    The walk runs in a worker thread: it takes minutes on a shared filesystem,
+    and this loop also serves the metrics server and the sibling daemons.
     """
     while True:
         await asyncio.sleep(3600)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -798,6 +798,7 @@ async def cleanup_clients_tmp():
                 elif entry.name.endswith('_translated.yaml'):
                     # Deprecated: task YAMLs are no longer persisted, so any
                     # file left here is unreferenced regardless of its age.
+                    # TODO(aylei): remove in next major release
                     try:
                         os.remove(entry.path)
                     except OSError:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -768,36 +768,82 @@ async def cleanup_unreferenced_file_mounts():
                          f'{common_utils.format_exception(e)}')
 
 
-async def cleanup_download_tmp():
-    """Delete expired download tmp directories.
+def _prune_clients_tmp(cutoff: float) -> int:
+    """Remove client tmp artifacts older than cutoff; returns count removed.
 
-    Downloaded logs are transient — synced from the cluster for the client
-    to download, then no longer needed.  Clean up anything older than the
-    blob GC grace period (1 hour by default).
+    Two kinds of transient state pile up under the per-user client dirs:
+
+    - Download staging dirs: logs synced from the cluster for the client to
+      download, then no longer needed. Only swept for backends that keep them
+      in a dedicated tree (``download_tmp_base_dir()``); the ones sharing the
+      persistent log dir need no separate cleanup.
+    - ``*_translated.yaml`` files: the translated client task used to be
+      persisted next to the client dir to ease debugging. Task YAMLs are
+      translated in memory now, so any file still on disk was left behind by
+      an older server version and can be reclaimed.
+    """
+    # Both sweeps walk clients/<user_hash>/, and for backends whose download
+    # staging tree *is* the clients dir the two roots coincide, so they are
+    # keyed by root to walk each tree only once. The tree can be on a shared
+    # filesystem with hundreds of user dirs, where a redundant walk is far
+    # from free.
+    # Value: (sweep expired dirs, sweep expired translated task YAMLs).
+    roots: Dict[str, Tuple[bool, bool]] = {}
+
+    def add_root(path: str, sweep_dirs: bool, sweep_yamls: bool) -> None:
+        root_dir = os.path.realpath(os.path.expanduser(path))
+        prev_dirs, prev_yamls = roots.get(root_dir, (False, False))
+        roots[root_dir] = (prev_dirs or sweep_dirs, prev_yamls or sweep_yamls)
+
+    add_root(str(common.API_SERVER_CLIENT_DIR), False, True)
+    download_tmp_base = bs.get_blob_storage().download_tmp_base_dir()
+    if download_tmp_base is not None:
+        add_root(download_tmp_base, True, False)
+
+    removed = 0
+    for root_dir, (sweep_dirs, sweep_yamls) in roots.items():
+        if not os.path.isdir(root_dir):
+            continue
+        for user_entry in os.scandir(root_dir):
+            if not user_entry.is_dir():
+                continue
+            for entry in os.scandir(user_entry.path):
+                try:
+                    if sweep_dirs and entry.is_dir(follow_symlinks=False):
+                        if entry.stat().st_mtime < cutoff:
+                            shutil.rmtree(entry.path, ignore_errors=True)
+                            removed += 1
+                    elif (sweep_yamls and
+                          entry.name.endswith('_translated.yaml') and
+                          entry.is_file(follow_symlinks=False) and
+                          entry.stat().st_mtime < cutoff):
+                        os.remove(entry.path)
+                        removed += 1
+                except OSError:
+                    pass
+    return removed
+
+
+async def cleanup_clients_tmp():
+    """Hourly GC of expired tmp artifacts under the API server clients dir.
+
+    Everything older than the blob GC grace period (1 hour by default) is
+    removed. The walk runs in a worker thread: the clients dir can be on a
+    shared filesystem where a full pass takes minutes, and this event loop
+    also serves the metrics server and the other background daemons.
     """
     while True:
         await asyncio.sleep(3600)
         try:
-            tmp_dir = bs.get_blob_storage().download_tmp_base_dir()
-            if tmp_dir is None:
-                # Backend shares the persistent log dir; no separate
-                # cleanup needed.
-                continue
-            if not os.path.exists(tmp_dir):
-                continue
             cutoff = time.time() - bs.GC_GRACE_SECONDS
-            for user_entry in os.scandir(tmp_dir):
-                if not user_entry.is_dir():
-                    continue
-                for entry in os.scandir(user_entry.path):
-                    if entry.is_dir():
-                        try:
-                            if entry.stat().st_mtime < cutoff:
-                                shutil.rmtree(entry.path, ignore_errors=True)
-                        except OSError:
-                            pass
+            removed = await anyio.to_thread.run_sync(_prune_clients_tmp,
+                                                     cutoff,
+                                                     abandon_on_cancel=True)
+            if removed:
+                logger.info(f'Cleaned up {removed} expired client tmp '
+                            'artifact(s)')
         except Exception as e:  # pylint: disable=broad-except
-            logger.error('Error in cleanup_download_tmp: '
+            logger.error('Error in cleanup_clients_tmp: '
                          f'{common_utils.format_exception(e)}')
 
 
@@ -4073,7 +4119,7 @@ if __name__ == '__main__':
         # be a singleton task.
         global_tasks.append(
             background.create_task(cleanup_unreferenced_file_mounts()))
-        global_tasks.append(background.create_task(cleanup_download_tmp()))
+        global_tasks.append(background.create_task(cleanup_clients_tmp()))
         global_tasks.append(background.create_task(cleanup_sky_logs()))
         threading.Thread(target=background.run_forever, daemon=True).start()
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -768,6 +768,21 @@ async def cleanup_unreferenced_file_mounts():
                          f'{common_utils.format_exception(e)}')
 
 
+def _prune_expired_files(dir_path: str, suffix: str, cutoff: float) -> int:
+    """Remove files under dir_path matching suffix and older than cutoff."""
+    removed = 0
+    for entry in os.scandir(dir_path):
+        try:
+            if (entry.name.endswith(suffix) and
+                    entry.is_file(follow_symlinks=False) and
+                    entry.stat().st_mtime < cutoff):
+                os.remove(entry.path)
+                removed += 1
+        except OSError:
+            pass
+    return removed
+
+
 def _prune_clients_tmp(cutoff: float) -> int:
     """Remove client tmp artifacts older than cutoff; returns count removed.
 
@@ -777,17 +792,18 @@ def _prune_clients_tmp(cutoff: float) -> int:
       download, then no longer needed. Only swept for backends that keep them
       in a dedicated tree (``download_tmp_base_dir()``); the ones sharing the
       persistent log dir need no separate cleanup.
-    - ``*_translated.yaml`` files: the translated client task used to be
-      persisted next to the client dir to ease debugging. Task YAMLs are
-      translated in memory now, so any file still on disk was left behind by
-      an older server version and can be reclaimed.
+    - Task YAMLs: the submitted task (``tasks/<task_id>.yaml``) and its
+      translated form (``<task_id>_translated.yaml``) used to be persisted per
+      submission to ease debugging. Task YAMLs are processed in memory now, so
+      whatever is still on disk was left behind by an older server version and
+      can be reclaimed.
     """
     # Both sweeps walk clients/<user_hash>/, and for backends whose download
     # staging tree *is* the clients dir the two roots coincide, so they are
     # keyed by root to walk each tree only once. The tree can be on a shared
     # filesystem with hundreds of user dirs, where a redundant walk is far
     # from free.
-    # Value: (sweep expired dirs, sweep expired translated task YAMLs).
+    # Value: (sweep expired dirs, sweep expired legacy task YAMLs).
     roots: Dict[str, Tuple[bool, bool]] = {}
 
     def add_root(path: str, sweep_dirs: bool, sweep_yamls: bool) -> None:
@@ -809,16 +825,21 @@ def _prune_clients_tmp(cutoff: float) -> int:
                 continue
             for entry in os.scandir(user_entry.path):
                 try:
-                    if sweep_dirs and entry.is_dir(follow_symlinks=False):
-                        if entry.stat().st_mtime < cutoff:
+                    if entry.is_dir(follow_symlinks=False):
+                        if sweep_dirs and entry.stat().st_mtime < cutoff:
                             shutil.rmtree(entry.path, ignore_errors=True)
                             removed += 1
-                    elif (sweep_yamls and
-                          entry.name.endswith('_translated.yaml') and
-                          entry.is_file(follow_symlinks=False) and
-                          entry.stat().st_mtime < cutoff):
-                        os.remove(entry.path)
-                        removed += 1
+                        elif sweep_yamls and entry.name == 'tasks':
+                            # The legacy submitted-task dir; it holds nothing
+                            # but per-submission YAMLs.
+                            removed += _prune_expired_files(
+                                entry.path, '.yaml', cutoff)
+                    elif sweep_yamls:
+                        if (entry.name.endswith('_translated.yaml') and
+                                entry.is_file(follow_symlinks=False) and
+                                entry.stat().st_mtime < cutoff):
+                            os.remove(entry.path)
+                            removed += 1
                 except OSError:
                     pass
     return removed

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -25,8 +25,7 @@ import threading
 import time
 import traceback
 import typing
-from typing import (Any, Dict, Iterator, List, Literal, Optional, Set, Tuple,
-                    Type)
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Type
 import uuid
 import zipfile
 import zlib
@@ -769,96 +768,46 @@ async def cleanup_unreferenced_file_mounts():
                          f'{common_utils.format_exception(e)}')
 
 
-def _scandir_or_skip(dir_path: str) -> Iterator[os.DirEntry]:
-    """Yield dir entries; yields nothing if dir_path is not a readable dir."""
-    try:
-        with os.scandir(dir_path) as entries:
-            yield from entries
-    except OSError as e:
-        logger.debug(f'Skipping {dir_path}: {e}')
-
-
-def _prune_expired_files(dir_path: str, suffix: str, cutoff: float) -> int:
-    """Remove files under dir_path matching suffix and older than cutoff."""
-    removed = 0
-    for entry in _scandir_or_skip(dir_path):
-        try:
-            if (entry.name.endswith(suffix) and
-                    entry.is_file(follow_symlinks=False) and
-                    entry.stat().st_mtime < cutoff):
-                os.remove(entry.path)
-                removed += 1
-        except OSError:
-            pass
-    return removed
-
-
-def _prune_clients_tmp(cutoff: float) -> int:
-    """Remove client tmp artifacts older than cutoff; returns count removed.
-
-    Swept per user dir: download staging dirs (only for backends with a
-    dedicated ``download_tmp_base_dir()``) and legacy task YAMLs, no longer
-    written now that task YAMLs are processed in memory.
-    """
-    # Keyed by root so backends whose download staging tree *is* the clients
-    # dir walk it once, not twice.
-    # root -> (sweep expired dirs, sweep expired legacy task YAMLs)
-    roots: Dict[str, Tuple[bool, bool]] = {}
-
-    def add_root(path: str, sweep_dirs: bool, sweep_yamls: bool) -> None:
-        root_dir = os.path.realpath(os.path.expanduser(path))
-        prev_dirs, prev_yamls = roots.get(root_dir, (False, False))
-        roots[root_dir] = (prev_dirs or sweep_dirs, prev_yamls or sweep_yamls)
-
-    add_root(str(common.API_SERVER_CLIENT_DIR), False, True)
-    download_tmp_base = bs.get_blob_storage().download_tmp_base_dir()
-    if download_tmp_base is not None:
-        add_root(download_tmp_base, True, False)
-
-    removed = 0
-    for root_dir, (sweep_dirs, sweep_yamls) in roots.items():
-        # Every filesystem touch below is guarded: a dir can vanish under us
-        # (peer replicas sweep the same tree) or go stale on a shared FS, and
-        # one bad entry must not abort the pass. Non-dir entries need no
-        # is_dir() check — scandir rejects them and _scandir_or_skip absorbs it.
-        for user_entry in _scandir_or_skip(root_dir):
-            for entry in _scandir_or_skip(user_entry.path):
-                try:
-                    if entry.is_dir(follow_symlinks=False):
-                        if sweep_dirs and entry.stat().st_mtime < cutoff:
-                            shutil.rmtree(entry.path, ignore_errors=True)
-                            removed += 1
-                        elif sweep_yamls and entry.name == 'tasks':
-                            # Legacy dir, holds per-submission YAMLs only.
-                            removed += _prune_expired_files(
-                                entry.path, '.yaml', cutoff)
-                    elif sweep_yamls:
-                        if (entry.name.endswith('_translated.yaml') and
-                                entry.is_file(follow_symlinks=False) and
-                                entry.stat().st_mtime < cutoff):
-                            os.remove(entry.path)
-                            removed += 1
-                except OSError:
-                    pass
-    return removed
-
-
 async def cleanup_clients_tmp():
-    """Hourly GC of expired tmp artifacts under the API server clients dir.
+    """Delete expired client tmp directories and deprecated task YAMLs.
 
-    The walk runs in a worker thread: it takes minutes on a shared filesystem,
-    and this loop also serves the metrics server and the sibling daemons.
+    Downloaded logs are transient — synced from the cluster for the client
+    to download, then no longer needed.  Clean up anything older than the
+    blob GC grace period (1 hour by default).
     """
+
+    def _do_cleanup():
+        tmp_dir = bs.get_blob_storage().download_tmp_base_dir()
+        if tmp_dir is None:
+            # Backend shares the persistent log dir; no separate
+            # cleanup needed.
+            return
+        if not os.path.exists(tmp_dir):
+            return
+        cutoff = time.time() - bs.GC_GRACE_SECONDS
+        for user_entry in os.scandir(tmp_dir):
+            if not user_entry.is_dir():
+                continue
+            for entry in os.scandir(user_entry.path):
+                if entry.is_dir():
+                    try:
+                        if entry.stat().st_mtime < cutoff:
+                            shutil.rmtree(entry.path, ignore_errors=True)
+                    except OSError:
+                        pass
+                elif entry.name.endswith('_translated.yaml'):
+                    # Deprecated: task YAMLs are no longer persisted, so any
+                    # file left here is unreferenced regardless of its age.
+                    try:
+                        os.remove(entry.path)
+                    except OSError:
+                        pass
+
     while True:
         await asyncio.sleep(3600)
         try:
-            cutoff = time.time() - bs.GC_GRACE_SECONDS
-            removed = await anyio.to_thread.run_sync(_prune_clients_tmp,
-                                                     cutoff,
-                                                     abandon_on_cancel=True)
-            if removed:
-                logger.info(f'Cleaned up {removed} expired client tmp '
-                            'artifact(s)')
+            # Offloaded to a worker thread: the event loop must not block.
+            await anyio.to_thread.run_sync(_do_cleanup, abandon_on_cancel=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.error('Error in cleanup_clients_tmp: '
                          f'{common_utils.format_exception(e)}')

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1188,6 +1188,27 @@ def test_prune_clients_tmp_removes_expired_translated_yamls(
     assert logs_dir.exists()
 
 
+def test_prune_clients_tmp_removes_expired_legacy_task_yamls(
+        tmp_path, monkeypatch):
+    """Expired tasks/<task_id>.yaml files go; fresh ones and non-YAMLs stay."""
+    clients_dir = tmp_path / 'clients'
+    _set_clients_dir(monkeypatch, clients_dir)
+    _set_download_tmp_base(monkeypatch, None)
+    now = 1_000_000.0
+    tasks_dir = clients_dir / 'user1' / 'tasks'
+    old = _touch_file(tasks_dir / 'abc.yaml', now - 10_000)
+    fresh = _touch_file(tasks_dir / 'def.yaml', now - 100)
+    other = _touch_file(tasks_dir / 'notes.txt', now - 10_000)
+
+    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert not old.exists()
+    assert fresh.exists()
+    assert other.exists()
+    assert tasks_dir.exists()
+
+
 def test_prune_clients_tmp_sweeps_download_dirs(tmp_path, monkeypatch):
     """A dedicated download tmp tree has its expired user entries removed."""
     clients_dir = tmp_path / 'clients'
@@ -1209,7 +1230,7 @@ def test_prune_clients_tmp_sweeps_download_dirs(tmp_path, monkeypatch):
 
 
 def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
-    """Dirs and translated YAMLs are both swept when the two roots coincide."""
+    """Dirs and legacy task YAMLs are both swept when the roots coincide."""
     clients_dir = tmp_path / 'clients'
     _set_clients_dir(monkeypatch, clients_dir)
     _set_download_tmp_base(monkeypatch, str(clients_dir))
@@ -1220,14 +1241,21 @@ def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
                            now - 10_000)
     fresh_yaml = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
                              now - 100)
+    # A tasks dir too young for the dir sweep still gets its expired YAMLs
+    # pruned individually.
+    old_task_yaml = _touch_file(clients_dir / 'user1' / 'tasks' / 'abc.yaml',
+                                now - 10_000)
+    os.utime(old_task_yaml.parent, (now - 100, now - 100))
 
     removed = server._prune_clients_tmp(cutoff=now - 5_000)
 
-    assert removed == 2
+    assert removed == 3
     assert not old_dir.exists()
     assert fresh_dir.exists()
     assert not old_yaml.exists()
     assert fresh_yaml.exists()
+    assert not old_task_yaml.exists()
+    assert old_task_yaml.parent.exists()
 
 
 def test_prune_clients_tmp_missing_dirs_is_noop(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1150,6 +1150,92 @@ def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
     assert server._prune_sky_logs(cutoff=1_000_000.0) == 0
 
 
+# --- Tests for _prune_clients_tmp (API server clients dir GC) ---
+
+
+def _set_clients_dir(monkeypatch, path: pathlib.Path) -> None:
+    monkeypatch.setattr(server.common, 'API_SERVER_CLIENT_DIR', path)
+
+
+def _set_download_tmp_base(monkeypatch, base) -> None:
+    storage = mock.Mock()
+    storage.download_tmp_base_dir.return_value = base
+    monkeypatch.setattr(server.bs, 'get_blob_storage', lambda: storage)
+
+
+def test_prune_clients_tmp_removes_expired_translated_yamls(
+        tmp_path, monkeypatch):
+    """Expired *_translated.yaml files go; other files and dirs stay."""
+    clients_dir = tmp_path / 'clients'
+    _set_clients_dir(monkeypatch, clients_dir)
+    # Backend shares the persistent log dir: nothing to sweep besides the
+    # leftover translated task YAMLs.
+    _set_download_tmp_base(monkeypatch, None)
+    now = 1_000_000.0
+    old = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
+                      now - 10_000)
+    fresh = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
+                        now - 100)
+    other = _touch_file(clients_dir / 'user2' / 'config.yaml', now - 10_000)
+    logs_dir = _touch_dir(clients_dir / 'user2' / 'sky_logs', now - 10_000)
+
+    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert not old.exists()
+    assert fresh.exists()
+    assert other.exists()
+    assert logs_dir.exists()
+
+
+def test_prune_clients_tmp_sweeps_download_dirs(tmp_path, monkeypatch):
+    """A dedicated download tmp tree has its expired user entries removed."""
+    clients_dir = tmp_path / 'clients'
+    download_dir = tmp_path / 'downloads'
+    _set_clients_dir(monkeypatch, clients_dir)
+    _set_download_tmp_base(monkeypatch, str(download_dir))
+    now = 1_000_000.0
+    old = _touch_dir(download_dir / 'user1' / 'sky_logs', now - 10_000)
+    fresh = _touch_dir(download_dir / 'user1' / 'sky_logs_fresh', now - 100)
+    old_yaml = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
+                           now - 10_000)
+
+    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+
+    assert removed == 2
+    assert not old.exists()
+    assert fresh.exists()
+    assert not old_yaml.exists()
+
+
+def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
+    """Dirs and translated YAMLs are both swept when the two roots coincide."""
+    clients_dir = tmp_path / 'clients'
+    _set_clients_dir(monkeypatch, clients_dir)
+    _set_download_tmp_base(monkeypatch, str(clients_dir))
+    now = 1_000_000.0
+    old_dir = _touch_dir(clients_dir / 'user1' / 'sky_logs', now - 10_000)
+    fresh_dir = _touch_dir(clients_dir / 'user1' / 'file_mounts', now - 100)
+    old_yaml = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
+                           now - 10_000)
+    fresh_yaml = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
+                             now - 100)
+
+    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+
+    assert removed == 2
+    assert not old_dir.exists()
+    assert fresh_dir.exists()
+    assert not old_yaml.exists()
+    assert fresh_yaml.exists()
+
+
+def test_prune_clients_tmp_missing_dirs_is_noop(tmp_path, monkeypatch):
+    _set_clients_dir(monkeypatch, tmp_path / 'does-not-exist')
+    _set_download_tmp_base(monkeypatch, str(tmp_path / 'neither-does-this'))
+    assert server._prune_clients_tmp(cutoff=1_000_000.0) == 0
+
+
 class _FakeTask:
     """Minimal stand-in for a Request row (only the fields get_expanded uses)."""
 

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1178,6 +1178,8 @@ def test_prune_clients_tmp_removes_expired_translated_yamls(
                         now - 100)
     other = _touch_file(clients_dir / 'user2' / 'config.yaml', now - 10_000)
     logs_dir = _touch_dir(clients_dir / 'user2' / 'sky_logs', now - 10_000)
+    # A stray file where a user dir is expected must be left alone.
+    stray = _touch_file(clients_dir / 'stray_translated.yaml', now - 10_000)
 
     removed = server._prune_clients_tmp(cutoff=now - 5_000)
 
@@ -1186,6 +1188,7 @@ def test_prune_clients_tmp_removes_expired_translated_yamls(
     assert fresh.exists()
     assert other.exists()
     assert logs_dir.exists()
+    assert stray.exists()
 
 
 def test_prune_clients_tmp_removes_expired_legacy_task_yamls(

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1168,8 +1168,7 @@ def test_prune_clients_tmp_removes_expired_translated_yamls(
     """Expired *_translated.yaml files go; other files and dirs stay."""
     clients_dir = tmp_path / 'clients'
     _set_clients_dir(monkeypatch, clients_dir)
-    # Backend shares the persistent log dir: nothing to sweep besides the
-    # leftover translated task YAMLs.
+    # Backend shares the persistent log dir: no download tree to sweep.
     _set_download_tmp_base(monkeypatch, None)
     now = 1_000_000.0
     old = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
@@ -1241,8 +1240,7 @@ def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
                            now - 10_000)
     fresh_yaml = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
                              now - 100)
-    # A tasks dir too young for the dir sweep still gets its expired YAMLs
-    # pruned individually.
+    # A tasks dir too young for the dir sweep still loses its expired YAMLs.
     old_task_yaml = _touch_file(clients_dir / 'user1' / 'tasks' / 'abc.yaml',
                                 now - 10_000)
     os.utime(old_task_yaml.parent, (now - 100, now - 100))

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import errno
 import json
 import os
 import pathlib
@@ -1254,6 +1255,33 @@ def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
     assert fresh_yaml.exists()
     assert not old_task_yaml.exists()
     assert old_task_yaml.parent.exists()
+
+
+def test_prune_clients_tmp_unreadable_user_dir_does_not_abort(
+        tmp_path, monkeypatch):
+    """An unreadable user dir is skipped, the rest of the pass still runs."""
+    clients_dir = tmp_path / 'clients'
+    _set_clients_dir(monkeypatch, clients_dir)
+    _set_download_tmp_base(monkeypatch, None)
+    now = 1_000_000.0
+    unreadable = clients_dir / 'user1'
+    unreadable.mkdir(parents=True)
+    old = _touch_file(clients_dir / 'user2' / 'abc_translated.yaml',
+                      now - 10_000)
+
+    real_scandir = os.scandir
+
+    def fake_scandir(path):
+        if str(path) == str(unreadable):
+            raise PermissionError(errno.EACCES, 'permission denied')
+        return real_scandir(path)
+
+    monkeypatch.setattr(server.os, 'scandir', fake_scandir)
+
+    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert not old.exists()
 
 
 def test_prune_clients_tmp_missing_dirs_is_noop(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -2,7 +2,6 @@
 
 import argparse
 import asyncio
-import errno
 import json
 import os
 import pathlib
@@ -1151,11 +1150,7 @@ def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
     assert server._prune_sky_logs(cutoff=1_000_000.0) == 0
 
 
-# --- Tests for _prune_clients_tmp (API server clients dir GC) ---
-
-
-def _set_clients_dir(monkeypatch, path: pathlib.Path) -> None:
-    monkeypatch.setattr(server.common, 'API_SERVER_CLIENT_DIR', path)
+# --- Tests for cleanup_clients_tmp (client tmp dir GC) ---
 
 
 def _set_download_tmp_base(monkeypatch, base) -> None:
@@ -1164,133 +1159,67 @@ def _set_download_tmp_base(monkeypatch, base) -> None:
     monkeypatch.setattr(server.bs, 'get_blob_storage', lambda: storage)
 
 
-def test_prune_clients_tmp_removes_expired_translated_yamls(
-        tmp_path, monkeypatch):
-    """Expired *_translated.yaml files go; other files and dirs stay."""
-    clients_dir = tmp_path / 'clients'
-    _set_clients_dir(monkeypatch, clients_dir)
-    # Backend shares the persistent log dir: no download tree to sweep.
-    _set_download_tmp_base(monkeypatch, None)
-    now = 1_000_000.0
-    old = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
-                      now - 10_000)
-    fresh = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
-                        now - 100)
-    other = _touch_file(clients_dir / 'user2' / 'config.yaml', now - 10_000)
-    logs_dir = _touch_dir(clients_dir / 'user2' / 'sky_logs', now - 10_000)
-    # A stray file where a user dir is expected must be left alone.
-    stray = _touch_file(clients_dir / 'stray_translated.yaml', now - 10_000)
+async def _run_one_cleanup_pass(monkeypatch, daemon) -> None:
+    """Run a single pass of an hourly cleanup daemon, then stop it."""
+    sleeps = []
 
-    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) > 1:
+            raise asyncio.CancelledError()
 
-    assert removed == 1
-    assert not old.exists()
+    monkeypatch.setattr(server.asyncio, 'sleep', fake_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await daemon()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_clients_tmp_removes_expired_dirs(tmp_path, monkeypatch):
+    """Expired per-user entries go; fresh ones stay."""
+    tmp_base = tmp_path / 'clients'
+    _set_download_tmp_base(monkeypatch, str(tmp_base))
+    now = time.time()
+    logs = _touch_dir(tmp_base / 'user1' / 'sky_logs', now - 10_000)
+    # Legacy task YAMLs live in a dir, so they go with the dir sweep.
+    tasks = _touch_dir(tmp_base / 'user1' / 'tasks', now - 10_000)
+    fresh = _touch_dir(tmp_base / 'user1' / 'file_mounts', now - 10)
+
+    await _run_one_cleanup_pass(monkeypatch, server.cleanup_clients_tmp)
+
+    assert not logs.exists()
+    assert not tasks.exists()
     assert fresh.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_clients_tmp_removes_translated_yamls_of_any_age(
+        tmp_path, monkeypatch):
+    """*_translated.yaml is deprecated, so age does not matter."""
+    tmp_base = tmp_path / 'clients'
+    _set_download_tmp_base(monkeypatch, str(tmp_base))
+    now = time.time()
+    old = _touch_file(tmp_base / 'user1' / 'abc_translated.yaml', now - 10_000)
+    fresh = _touch_file(tmp_base / 'user1' / 'def_translated.yaml', now)
+    other = _touch_file(tmp_base / 'user1' / 'config.yaml', now - 10_000)
+
+    await _run_one_cleanup_pass(monkeypatch, server.cleanup_clients_tmp)
+
+    assert not old.exists()
+    assert not fresh.exists()
     assert other.exists()
-    assert logs_dir.exists()
-    assert stray.exists()
 
 
-def test_prune_clients_tmp_removes_expired_legacy_task_yamls(
+@pytest.mark.asyncio
+async def test_cleanup_clients_tmp_noop_without_download_tmp_base(
         tmp_path, monkeypatch):
-    """Expired tasks/<task_id>.yaml files go; fresh ones and non-YAMLs stay."""
-    clients_dir = tmp_path / 'clients'
-    _set_clients_dir(monkeypatch, clients_dir)
+    """Backends sharing the persistent log dir need no cleanup."""
     _set_download_tmp_base(monkeypatch, None)
-    now = 1_000_000.0
-    tasks_dir = clients_dir / 'user1' / 'tasks'
-    old = _touch_file(tasks_dir / 'abc.yaml', now - 10_000)
-    fresh = _touch_file(tasks_dir / 'def.yaml', now - 100)
-    other = _touch_file(tasks_dir / 'notes.txt', now - 10_000)
+    kept = _touch_file(tmp_path / 'user1' / 'abc_translated.yaml',
+                       time.time() - 10_000)
 
-    removed = server._prune_clients_tmp(cutoff=now - 5_000)
+    await _run_one_cleanup_pass(monkeypatch, server.cleanup_clients_tmp)
 
-    assert removed == 1
-    assert not old.exists()
-    assert fresh.exists()
-    assert other.exists()
-    assert tasks_dir.exists()
-
-
-def test_prune_clients_tmp_sweeps_download_dirs(tmp_path, monkeypatch):
-    """A dedicated download tmp tree has its expired user entries removed."""
-    clients_dir = tmp_path / 'clients'
-    download_dir = tmp_path / 'downloads'
-    _set_clients_dir(monkeypatch, clients_dir)
-    _set_download_tmp_base(monkeypatch, str(download_dir))
-    now = 1_000_000.0
-    old = _touch_dir(download_dir / 'user1' / 'sky_logs', now - 10_000)
-    fresh = _touch_dir(download_dir / 'user1' / 'sky_logs_fresh', now - 100)
-    old_yaml = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
-                           now - 10_000)
-
-    removed = server._prune_clients_tmp(cutoff=now - 5_000)
-
-    assert removed == 2
-    assert not old.exists()
-    assert fresh.exists()
-    assert not old_yaml.exists()
-
-
-def test_prune_clients_tmp_download_base_is_clients_dir(tmp_path, monkeypatch):
-    """Dirs and legacy task YAMLs are both swept when the roots coincide."""
-    clients_dir = tmp_path / 'clients'
-    _set_clients_dir(monkeypatch, clients_dir)
-    _set_download_tmp_base(monkeypatch, str(clients_dir))
-    now = 1_000_000.0
-    old_dir = _touch_dir(clients_dir / 'user1' / 'sky_logs', now - 10_000)
-    fresh_dir = _touch_dir(clients_dir / 'user1' / 'file_mounts', now - 100)
-    old_yaml = _touch_file(clients_dir / 'user1' / 'abc_translated.yaml',
-                           now - 10_000)
-    fresh_yaml = _touch_file(clients_dir / 'user1' / 'def_translated.yaml',
-                             now - 100)
-    # A tasks dir too young for the dir sweep still loses its expired YAMLs.
-    old_task_yaml = _touch_file(clients_dir / 'user1' / 'tasks' / 'abc.yaml',
-                                now - 10_000)
-    os.utime(old_task_yaml.parent, (now - 100, now - 100))
-
-    removed = server._prune_clients_tmp(cutoff=now - 5_000)
-
-    assert removed == 3
-    assert not old_dir.exists()
-    assert fresh_dir.exists()
-    assert not old_yaml.exists()
-    assert fresh_yaml.exists()
-    assert not old_task_yaml.exists()
-    assert old_task_yaml.parent.exists()
-
-
-def test_prune_clients_tmp_unreadable_user_dir_does_not_abort(
-        tmp_path, monkeypatch):
-    """An unreadable user dir is skipped, the rest of the pass still runs."""
-    clients_dir = tmp_path / 'clients'
-    _set_clients_dir(monkeypatch, clients_dir)
-    _set_download_tmp_base(monkeypatch, None)
-    now = 1_000_000.0
-    unreadable = clients_dir / 'user1'
-    unreadable.mkdir(parents=True)
-    old = _touch_file(clients_dir / 'user2' / 'abc_translated.yaml',
-                      now - 10_000)
-
-    real_scandir = os.scandir
-
-    def fake_scandir(path):
-        if str(path) == str(unreadable):
-            raise PermissionError(errno.EACCES, 'permission denied')
-        return real_scandir(path)
-
-    monkeypatch.setattr(server.os, 'scandir', fake_scandir)
-
-    removed = server._prune_clients_tmp(cutoff=now - 5_000)
-
-    assert removed == 1
-    assert not old.exists()
-
-
-def test_prune_clients_tmp_missing_dirs_is_noop(tmp_path, monkeypatch):
-    _set_clients_dir(monkeypatch, tmp_path / 'does-not-exist')
-    _set_download_tmp_base(monkeypatch, str(tmp_path / 'neither-does-this'))
-    assert server._prune_clients_tmp(cutoff=1_000_000.0) == 0
+    assert kept.exists()
 
 
 class _FakeTask:


### PR DESCRIPTION
`cleanup_download_tmp` walked the API server clients dir synchronously on the background event loop, which also hosts the metrics server and the sibling GC / retention daemons. When that dir is on a shared filesystem with hundreds of user dirs, one pass takes tens of minutes — for that whole window `/metrics` cannot even accept a connection and the other daemons do not tick (observed in production: `py-spy` caught the background loop thread inside the per-user `scandir` in back-to-back dumps, 30+ min into a single pass).

The sweep itself is unchanged; two things happen around it:

- Run it in a worker thread (`anyio.to_thread.run_sync`, `abandon_on_cancel` so a long pass cannot delay shutdown), and rename it to `cleanup_clients_tmp` since it no longer collects only download tmp.
- Unlink `*_translated.yaml`. Since #10435 the translated client task is never persisted, so every such file on disk is garbage whatever its mtime — no age check needed, which also saves a stat per file on a tree that can hold hundreds of thousands of them. Being plain files, the dir-only sweep never collected them, so they piled up monotonically. `tasks/<task_id>.yaml`, dropped by the same PR, needs no special case: `tasks/` is a directory, so the existing dir sweep already collects it.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

- `pytest tests/unit_tests/test_sky/server/test_server.py` → 48 passed, including 3 new cases that drive one pass of the daemon (so they cover the worker-thread path too): expired per-user dirs collected including `tasks/`, fresh dirs kept, `*_translated.yaml` collected at any age, and no-op when the backend reports no download tmp base.
- Ran the daemon on a background uvloop against a clients dir with 20k expired files, with a 10 ms latency probe standing in for the metrics server: **max loop lag 4 ms** while the sweep was still mid-crawl. The pre-fix inline shape wedges the same loop for **1811 ms** on the same fixture.
