### PR TITLE
fix(server): allow disabling the loopback auth exemption (#10409)

### DIFF
--- a/sky/server/auth/loopback.py
+++ b/sky/server/auth/loopback.py
@@ -5,6 +5,7 @@ import ipaddress
 import fastapi
 
 from sky import sky_logging
+from sky import skypilot_config
 
 logger = sky_logging.init_logger(__name__)
 
@@ -24,7 +25,19 @@ def _is_loopback_ip(ip_str: str) -> bool:
 
 
 def is_loopback_request(request: fastapi.Request) -> bool:
-    """Determine if a request is coming from localhost."""
+    """Determine if a request is coming from localhost.
+
+    Callers use this to exempt local traffic from authentication, so the
+    exemption can be turned off with `api_server.trust_loopback: false`.
+    That matters on Kubernetes: `kubectl port-forward` delivers a remote
+    client's traffic to the pod from 127.0.0.1 with no proxy headers, which
+    is indistinguishable here from traffic that never left the host. A
+    deployment that authenticates every caller (e.g. behind oauth2-proxy)
+    can opt out so port-forwarded requests are authenticated like any other.
+    """
+    if not skypilot_config.get_nested(('api_server', 'trust_loopback'), True):
+        return False
+
     if request.client is None:
         return False
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2355,6 +2355,9 @@ def get_config_schema():
                 'type': 'integer',
                 'minimum': 0,
             },
+            'trust_loopback': {
+                'type': 'boolean',
+            },
         }
     }
 

--- a/tests/unit_tests/test_sky/server/auth/test_loopback.py
+++ b/tests/unit_tests/test_sky/server/auth/test_loopback.py
@@ -118,3 +118,36 @@ class TestLoopbackDetection:
         request.headers = Headers({})
 
         assert not is_loopback_request(request)
+
+    def test_is_loopback_request_honors_trust_loopback_false(self):
+        """api_server.trust_loopback: false drops the exemption."""
+        request = mock.Mock(spec=fastapi.Request)
+        request.client = mock.Mock()
+        request.client.host = '127.0.0.1'
+        request.headers = Headers({})
+
+        # Default (unset) keeps the exemption.
+        assert is_loopback_request(request)
+
+        # A kubectl port-forwarded request looks exactly like the one above,
+        # so an operator that authenticates every caller can opt out.
+        with mock.patch('sky.skypilot_config.get_nested',
+                        return_value=False) as get_nested:
+            assert not is_loopback_request(request)
+        get_nested.assert_called_once_with(('api_server', 'trust_loopback'),
+                                           True)
+
+    def test_is_loopback_request_trust_loopback_true(self):
+        """api_server.trust_loopback: true is the current behavior."""
+        request = mock.Mock(spec=fastapi.Request)
+        request.client = mock.Mock()
+        request.client.host = '127.0.0.1'
+        request.headers = Headers({})
+
+        with mock.patch('sky.skypilot_config.get_nested', return_value=True):
+            assert is_loopback_request(request)
+
+        # Opting in does not weaken the proxy-header check.
+        request.headers = Headers({'X-Forwarded-For': '203.0.113.1'})
+        with mock.patch('sky.skypilot_config.get_nested', return_value=True):
+            assert not is_loopback_request(request)


### PR DESCRIPTION
Fixes #10409.

## Problem

`BasicAuthMiddleware` and the oauth2-proxy middleware both skip authentication entirely for a request that looks like loopback:

```python
if loopback.is_loopback_request(request):
    return await call_next(request)
```

On a Kubernetes-hosted API server, `kubectl port-forward` delivers a **remote** client's traffic to the pod from `127.0.0.1` with no proxy headers. `is_loopback_request()` therefore returns `True`, and the request skips auth. The existing proxy-header check shows the intent is "genuinely local traffic" — on Kubernetes that assumption does not hold, and there is currently no way for an operator to say so.

As the reporter notes, this also degrades admin policies: the policy sees `user_type is None`, indistinguishable from any other unauthenticated caller, so a policy that stamps ownership from authenticated identity silently mislabels this traffic instead of refusing it.

## Change

Add `api_server.trust_loopback` (boolean). The gate lives inside `is_loopback_request()`, so both auth middlewares that call it are covered by the one check:

```python
if not skypilot_config.get_nested(('api_server', 'trust_loopback'), True):
    return False
```

**The default is `True`, so behavior is unchanged unless an operator opts out.** Deployments that authenticate every caller (e.g. behind oauth2-proxy) can set:

```yaml
api_server:
  trust_loopback: false
```

Helm users reach this through `apiService.config`.

I put the check inside `is_loopback_request()` rather than adding a separate `is_trusted_loopback_request()` wrapper for two reasons: both production call sites are auth exemptions, so there is no caller that wants the ungated meaning; and existing tests (e.g. `tests/unit_tests/test_sky/server/test_metrics.py`) patch `sky.server.auth.loopback.is_loopback_request` directly — renaming the call sites would silently turn those patches into no-ops. Happy to switch to a wrapper if you'd prefer the split.

## Testing

`sky` is not installable on this machine, so I exercised `sky/server/auth/loopback.py` as the real module inside a minimal package tree, with `sky.sky_logging` and `sky.skypilot_config` stubbed (the stub reproduces `get_nested`'s documented contract: walk the key tuple, return `default_value` when a key is missing or an intermediate value is not a dict). The file under test is the actual source, unmodified.

Running the repo's own `tests/unit_tests/test_sky/server/auth/test_loopback.py`, before vs. after:

| | result |
|---|---|
| upstream `main`, unpatched | **1 failed**, 16 passed |
| this branch | **17 passed** |

The single baseline failure is the new `test_is_loopback_request_honors_trust_loopback_false` — i.e. the new test reproduces the reported gap and the change closes it. All 16 pre-existing tests pass unchanged in both runs.

Simulating the reported scenario directly (client host `127.0.0.1`, no proxy headers — what the pod sees for a port-forward):

| config | auth exemption granted |
|---|---|
| no config at all (default) | `True` |
| `api_server.trust_loopback: true` | `True` |
| `api_server.trust_loopback: false` | `False` |
| unrelated `api_server` keys only | `True` |

Opting in does not weaken the existing proxy-header rejection (covered by the second new test).

Formatting: `yapf==0.32.0` with the repo's `pyproject.toml` style reports no changes for all three files. (Local `isort` flags the import blocks in `loopback.py` and `test_loopback.py`, but it flags the unmodified upstream files identically, so I left them alone rather than churn unrelated lines.)

## Notes

This branch is based on an older `master` because my token lacks the `workflow` scope and rebasing onto current `master` would pull a `.github/` change into the push. The diff is 3 files and does not touch any workflow file; let me know if you'd like it rebased and I can coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->