### PR TITLE
[Jobs] Don't overwrite a job's terminal state when cleanup fails

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -3211,6 +3211,45 @@ class ControllerManager:
                     f'Failed to download logs for job {job_id}, '
                     f'task {task_id}: {common_utils.format_exception(e)}')
 
+    async def _record_final_job_status(self, job_id: int,
+                                       cleanup_failure: Optional[str]) -> None:
+        """Make sure the job ends in an accurate terminal state.
+
+        Called at the very end of the job loop, after cleanup and (for
+        cancelled jobs) the CANCELLING -> CANCELLED transition.
+
+        - If the job never reached a terminal state, the controller is
+          genuinely responsible, so fail it with FAILED_CONTROLLER. A
+          cleanup failure, if any, is the failure reason.
+        - If the job already reached a legitimate terminal state
+          (SUCCEEDED / CANCELLED / FAILED / ...), a failed best-effort
+          cleanup must not rewrite that outcome (#10456, #9189): keep the
+          status and record the cleanup failure separately.
+        """
+        job_status = await managed_job_state.get_status_async(job_id)
+        assert job_status is not None
+        if not job_status.is_terminal():
+            # The job can be non-terminal if the controller exited
+            # abnormally, e.g. failed to launch cluster after reaching
+            # the MAX_RETRY, or if cleanup was interrupted before the job
+            # recorded a terminal state.
+            logger.info(f'Previous job status: {job_status.value}')
+            if cleanup_failure is not None:
+                failure_reason = cleanup_failure
+            else:
+                failure_reason = ('Unexpected error occurred. For details, '
+                                  f'run: sky jobs logs --controller {job_id}')
+            await managed_job_state.set_failed_async(
+                job_id,
+                task_id=None,
+                failure_type=managed_job_state.ManagedJobStatus.
+                FAILED_CONTROLLER,
+                failure_reason=failure_reason,
+                override_terminal=cleanup_failure is not None)
+        elif cleanup_failure is not None:
+            await managed_job_state.set_cleanup_failed_async(
+                job_id, cleanup_failure)
+
     # Use context.contextual to enable per-job output redirection and env var
     # isolation.
     @context.contextual_async
@@ -3372,6 +3411,7 @@ class ControllerManager:
                          f'{common_utils.format_exception(e)}')
             raise
         finally:
+            cleanup_failure: Optional[str] = None
             try:
                 await self._cleanup(job_id,
                                     pool=pool,
@@ -3380,17 +3420,15 @@ class ControllerManager:
                 logger.info(f'Cluster of managed job {job_id} has been cleaned '
                             'up.')
             except Exception as e:  # pylint: disable=broad-except
-                failure_reason = (
+                # Do not fail the job here: if the job already reached a
+                # terminal state (or is CANCELLING and about to become
+                # CANCELLED below), stamping FAILED_CONTROLLER would
+                # overwrite the outcome the user cares about (#10456).
+                cleanup_failure = (
                     'Failed to clean up, resources may have leaked: '
                     f'{common_utils.format_exception(e)}. Please check '
                     'whether the job\'s cluster and storage still exist.')
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=failure_reason,
-                    override_terminal=True)
+                logger.error(cleanup_failure)
 
             if cancelling:
                 # Since it's set with cancelling
@@ -3401,23 +3439,7 @@ class ControllerManager:
                         job_id=job_id, task_id=task_id,
                         task=dag.tasks[task_id]))
 
-            # We should check job status after 'set_cancelled', otherwise
-            # the job status is not terminal.
-            job_status = await managed_job_state.get_status_async(job_id)
-            assert job_status is not None
-            # The job can be non-terminal if the controller exited
-            # abnormally, e.g. failed to launch cluster after reaching
-            # the MAX_RETRY.
-            if not job_status.is_terminal():
-                logger.info(f'Previous job status: {job_status.value}')
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=(
-                        'Unexpected error occurred. For details, '
-                        f'run: sky jobs logs --controller {job_id}'))
+            await self._record_final_job_status(job_id, cleanup_failure)
 
             await scheduler.job_done_async(job_id)
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3529,6 +3529,45 @@ async def set_failed_async(
     logger.info(failure_reason)
 
 
+async def set_cleanup_failed_async(job_id: int, cleanup_failure: str):
+    """Record a cleanup failure without changing the job's status.
+
+    Used when the job has already reached a legitimate terminal state
+    (SUCCEEDED / CANCELLED / FAILED / ...) and only the best-effort cleanup
+    afterwards failed. The terminal status is the outcome the user cares
+    about, so it is kept as-is; the cleanup failure (and its
+    resources-may-have-leaked warning) is surfaced through the job's
+    failure_reason and the event log instead of overwriting the status
+    with FAILED_CONTROLLER.
+    """
+    status = await get_status_async(job_id)
+    assert status is not None, job_id
+    await add_job_event_async(job_id, None, status,
+                              f'Cleanup failed: {cleanup_failure}')
+
+    async def _op(session):
+        # Get existing failure_reason with row lock to prevent race
+        # conditions.
+        result = await session.execute(
+            sqlalchemy.select(spot_table.c.failure_reason).where(
+                spot_table.c.spot_job_id == job_id).with_for_update())
+        existing_reason_row = result.fetchone()
+        new_reason = cleanup_failure
+        if existing_reason_row and existing_reason_row[0]:
+            # Keep the original failure first: it describes the job's
+            # actual outcome; the cleanup failure is secondary.
+            new_reason = (f'{existing_reason_row[0]}. In addition: '
+                          f'{cleanup_failure}')
+        await session.execute(
+            sqlalchemy.update(spot_table).where(
+                spot_table.c.spot_job_id == job_id).values(
+                    {spot_table.c.failure_reason: new_reason}))
+        await session.commit()
+
+    await _retry_session(_op)
+    logger.warning(cleanup_failure)
+
+
 async def update_links_async(job_id: int, task_id: int,
                              links: Dict[str, str]) -> None:
     """Update the links for a managed job task.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3546,22 +3546,33 @@ async def set_cleanup_failed_async(job_id: int, cleanup_failure: str):
                               f'Cleanup failed: {cleanup_failure}')
 
     async def _op(session):
-        # Get existing failure_reason with row lock to prevent race
-        # conditions.
+        # Compose the new reason per task row (with a row lock to prevent
+        # race conditions): a task that already recorded a failure keeps
+        # its own reason first — it describes the job's actual outcome;
+        # the cleanup failure is secondary. Rows without a reason are left
+        # NULL so get_failure_reason() keeps surfacing the real failure.
+        # Only when no task has a reason at all (e.g. a SUCCEEDED or
+        # CANCELLED job) is the cleanup failure written to every row.
         result = await session.execute(
-            sqlalchemy.select(spot_table.c.failure_reason).where(
-                spot_table.c.spot_job_id == job_id).with_for_update())
-        existing_reason_row = result.fetchone()
-        new_reason = cleanup_failure
-        if existing_reason_row and existing_reason_row[0]:
-            # Keep the original failure first: it describes the job's
-            # actual outcome; the cleanup failure is secondary.
-            new_reason = (f'{existing_reason_row[0]}. In addition: '
-                          f'{cleanup_failure}')
-        await session.execute(
-            sqlalchemy.update(spot_table).where(
-                spot_table.c.spot_job_id == job_id).values(
-                    {spot_table.c.failure_reason: new_reason}))
+            sqlalchemy.select(
+                spot_table.c.task_id, spot_table.c.failure_reason).where(
+                    spot_table.c.spot_job_id == job_id).with_for_update())
+        rows = result.fetchall()
+        any_existing = any(reason for _, reason in rows)
+        for row_task_id, existing_reason in rows:
+            if existing_reason:
+                new_reason = (f'{existing_reason}. In addition: '
+                              f'{cleanup_failure}')
+            elif not any_existing:
+                new_reason = cleanup_failure
+            else:
+                continue
+            await session.execute(
+                sqlalchemy.update(spot_table).where(
+                    sqlalchemy.and_(
+                        spot_table.c.spot_job_id == job_id,
+                        spot_table.c.task_id == row_task_id)).values(
+                            {spot_table.c.failure_reason: new_reason}))
         await session.commit()
 
     await _retry_session(_op)

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2299,3 +2299,77 @@ class TestJobGroupPhase2FailurePropagation:
                 await JobController._run_job_group(controller)
 
         controller._cleanup_job_group_clusters.assert_not_awaited()
+
+
+class TestRecordFinalJobStatus:
+    """Tests for ControllerManager._record_final_job_status.
+
+    A failed best-effort cleanup must not rewrite a job's legitimate
+    terminal state (SUCCEEDED / CANCELLED / FAILED / ...) with
+    FAILED_CONTROLLER (#10456, #9189). FAILED_CONTROLLER is reserved for
+    jobs that never reached a terminal state.
+    """
+
+    _CLEANUP_FAILURE = 'Failed to clean up, resources may have leaked: boom'
+
+    def _make_manager(self):
+        manager = MagicMock(spec=ControllerManager)
+        manager._record_final_job_status = (
+            ControllerManager._record_final_job_status.__get__(
+                manager, ControllerManager))
+        return manager
+
+    async def _run(self, status, cleanup_failure):
+        manager = self._make_manager()
+        with patch('sky.jobs.controller.managed_job_state') as state:
+            # Keep the real enum/statuses on the mocked module.
+            state.ManagedJobStatus = managed_job_state.ManagedJobStatus
+            state.get_status_async = AsyncMock(return_value=status)
+            state.set_failed_async = AsyncMock()
+            state.set_cleanup_failed_async = AsyncMock()
+            await manager._record_final_job_status(1, cleanup_failure)
+        return state
+
+    @pytest.mark.asyncio
+    async def test_terminal_job_keeps_status_on_cleanup_failure(self):
+        """CANCELLED + failed cleanup: no FAILED_CONTROLLER overwrite."""
+        state = await self._run(managed_job_state.ManagedJobStatus.CANCELLED,
+                                self._CLEANUP_FAILURE)
+        state.set_failed_async.assert_not_awaited()
+        state.set_cleanup_failed_async.assert_awaited_once_with(
+            1, self._CLEANUP_FAILURE)
+
+    @pytest.mark.asyncio
+    async def test_terminal_job_no_cleanup_failure_is_noop(self):
+        state = await self._run(managed_job_state.ManagedJobStatus.SUCCEEDED,
+                                None)
+        state.set_failed_async.assert_not_awaited()
+        state.set_cleanup_failed_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_terminal_job_fails_with_cleanup_reason(self):
+        """A job that never reached a terminal state is genuinely the
+        controller's responsibility: FAILED_CONTROLLER with the cleanup
+        failure as the reason."""
+        state = await self._run(managed_job_state.ManagedJobStatus.RUNNING,
+                                self._CLEANUP_FAILURE)
+        state.set_cleanup_failed_async.assert_not_awaited()
+        state.set_failed_async.assert_awaited_once_with(
+            1,
+            task_id=None,
+            failure_type=managed_job_state.ManagedJobStatus.FAILED_CONTROLLER,
+            failure_reason=self._CLEANUP_FAILURE,
+            override_terminal=True)
+
+    @pytest.mark.asyncio
+    async def test_non_terminal_job_fails_with_generic_reason(self):
+        state = await self._run(managed_job_state.ManagedJobStatus.RECOVERING,
+                                None)
+        state.set_cleanup_failed_async.assert_not_awaited()
+        state.set_failed_async.assert_awaited_once_with(
+            1,
+            task_id=None,
+            failure_type=managed_job_state.ManagedJobStatus.FAILED_CONTROLLER,
+            failure_reason=('Unexpected error occurred. For details, '
+                            'run: sky jobs logs --controller 1'),
+            override_terminal=False)

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -1487,3 +1487,95 @@ class TestGetLatestRecoveryAndPendingReasons:
                                                                           [1])
         assert recovery == {}
         assert pending == {1: 'Job is in backoff'}
+
+
+class TestSetCleanupFailed:
+    """set_cleanup_failed_async records a cleanup failure without touching a
+    job's terminal status (#10456, #9189)."""
+
+    _CLEANUP_FAILURE = ('Failed to clean up, resources may have leaked: '
+                        'boom. Please check whether the job\'s cluster and '
+                        'storage still exist.')
+
+    async def _seed_running_job(self) -> int:
+        """Create a job and drive it to RUNNING."""
+
+        async def mock_callback(status: str):
+            del status
+
+        job_id = state.set_job_info_without_job_id(name='cleanup-test-job',
+                                                   workspace='ws1',
+                                                   entrypoint='ep',
+                                                   pool=None,
+                                                   pool_hash=None,
+                                                   user_hash='user1')
+        state.set_pending(job_id,
+                          task_id=0,
+                          task_name='task0',
+                          resources_str='{}',
+                          metadata='{}')
+        state.scheduler_set_waiting([job_id], '/tmp/dag.yaml', '/tmp/user.yaml',
+                                    '/tmp/env', None, 100)
+        await state.set_starting_async(job_id, 0, 'run_xyz', time.time(), '{}',
+                                       {}, mock_callback)
+        await state.set_started_async(job_id, 0, time.time(), mock_callback)
+        return job_id
+
+    @pytest.mark.asyncio
+    async def test_succeeded_job_keeps_status(self, _mock_managed_jobs_db_conn):
+        """A SUCCEEDED job stays SUCCEEDED; the failure is still recorded."""
+
+        async def mock_callback(status: str):
+            del status
+
+        job_id = await self._seed_running_job()
+        await state.set_succeeded_async(job_id, 0, time.time(), mock_callback)
+
+        await state.set_cleanup_failed_async(job_id, self._CLEANUP_FAILURE)
+
+        assert state.get_status(job_id) == state.ManagedJobStatus.SUCCEEDED
+        assert state.get_failure_reason(job_id) == self._CLEANUP_FAILURE
+        events = state.get_job_events(job_id)
+        assert any('Cleanup failed' in e['reason'] for e in events)
+
+    @pytest.mark.asyncio
+    async def test_failed_job_appends_reason(self, _mock_managed_jobs_db_conn):
+        """A FAILED job keeps its status and its original failure_reason
+        first; the cleanup failure is appended."""
+
+        async def mock_callback(status: str):
+            del status
+
+        job_id = await self._seed_running_job()
+        await state.set_failed_async(job_id, 0, state.ManagedJobStatus.FAILED,
+                                     'User program exited with code 1',
+                                     mock_callback)
+
+        await state.set_cleanup_failed_async(job_id, self._CLEANUP_FAILURE)
+
+        assert state.get_status(job_id) == state.ManagedJobStatus.FAILED
+        assert state.get_failure_reason(job_id) == (
+            'User program exited with code 1. In addition: '
+            f'{self._CLEANUP_FAILURE}')
+
+    @pytest.mark.asyncio
+    async def test_cancelled_job_keeps_status(self, _mock_managed_jobs_db_conn):
+        """Regression for #10456: a cancelled job whose cleanup failed must
+        end CANCELLED, not FAILED_CONTROLLER.
+
+        Mirrors the controller's finally-block ordering: the CANCELLING ->
+        CANCELLED transition runs first, then the cleanup failure is
+        recorded without overriding the terminal state.
+        """
+
+        async def mock_callback(status: str):
+            del status
+
+        job_id = await self._seed_running_job()
+        await state.set_cancelling_async(job_id, mock_callback)
+        await state.set_cancelled_async(job_id, mock_callback)
+
+        await state.set_cleanup_failed_async(job_id, self._CLEANUP_FAILURE)
+
+        assert state.get_status(job_id) == state.ManagedJobStatus.CANCELLED
+        assert state.get_failure_reason(job_id) == self._CLEANUP_FAILURE

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import filelock
 import pytest
+import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -1579,3 +1580,59 @@ class TestSetCleanupFailed:
 
         assert state.get_status(job_id) == state.ManagedJobStatus.CANCELLED
         assert state.get_failure_reason(job_id) == self._CLEANUP_FAILURE
+
+    @pytest.mark.asyncio
+    async def test_pipeline_keeps_failed_task_reason(
+            self, _mock_managed_jobs_db_conn):
+        """A multi-task job's real failure reason must survive the cleanup
+        note: it is appended per row, and rows without a reason stay NULL
+        so get_failure_reason() keeps surfacing the actual failure."""
+
+        async def mock_callback(status: str):
+            del status
+
+        job_id = state.set_job_info_without_job_id(name='pipeline-job',
+                                                   workspace='ws1',
+                                                   entrypoint='ep',
+                                                   pool=None,
+                                                   pool_hash=None,
+                                                   user_hash='user1')
+        for task_id in (0, 1):
+            state.set_pending(job_id,
+                              task_id=task_id,
+                              task_name=f'task{task_id}',
+                              resources_str='{}',
+                              metadata='{}')
+        state.scheduler_set_waiting([job_id], '/tmp/dag.yaml', '/tmp/user.yaml',
+                                    '/tmp/env', None, 100)
+        # Task 0 succeeds, task 1 fails with a meaningful reason.
+        await state.set_starting_async(job_id, 0, 'run_p0', time.time(), '{}',
+                                       {}, mock_callback)
+        await state.set_started_async(job_id, 0, time.time(), mock_callback)
+        await state.set_succeeded_async(job_id, 0, time.time(), mock_callback)
+        await state.set_starting_async(job_id, 1, 'run_p1', time.time(), '{}',
+                                       {}, mock_callback)
+        await state.set_started_async(job_id, 1, time.time(), mock_callback)
+        await state.set_failed_async(job_id, 1, state.ManagedJobStatus.FAILED,
+                                     'User program exited with code 1',
+                                     mock_callback)
+
+        await state.set_cleanup_failed_async(job_id, self._CLEANUP_FAILURE)
+
+        # The surfaced reason keeps the real failure first.
+        assert state.get_failure_reason(job_id) == (
+            'User program exited with code 1. In addition: '
+            f'{self._CLEANUP_FAILURE}')
+        # The succeeded task's row stays NULL: writing the cleanup note
+        # there would shadow the real failure in get_failure_reason(),
+        # which returns the first non-NULL reason ordered by task_id.
+        engine = _mock_managed_jobs_db_conn
+        with engine.connect() as conn:
+            rows = dict(
+                conn.execute(
+                    sqlalchemy.select(state.spot_table.c.task_id,
+                                      state.spot_table.c.failure_reason).
+                    where(state.spot_table.c.spot_job_id == job_id)).fetchall())
+        assert rows[0] is None
+        assert rows[1] == ('User program exited with code 1. In addition: '
+                           f'{self._CLEANUP_FAILURE}')


### PR DESCRIPTION
Fixes #10456. Also resolves the scenario in #9189 (same code path, auto-closed as stale).

## Problem

When a managed job's best-effort cleanup fails, the job loop's `finally:` block in `sky/jobs/controller.py` unconditionally stamps `FAILED_CONTROLLER` with `override_terminal=True`. That rewrites the outcome the user actually cares about:

- **Cancelled jobs** (#10456): the cleanup failure is stamped *before* the `CANCELLING → CANCELLED` transition. `set_cancelled_async()` only transitions rows still in `CANCELLING`, so it silently no-ops and the job that the user explicitly cancelled is reported as `FAILED_CONTROLLER`. Reproduces on every job in a batch cancelled while its cluster is already unreachable (e.g. head pod OOM-killed on Kubernetes).
- **Succeeded jobs** (#9189): the job already recorded `SUCCEEDED`, then a log-download / termination hiccup in `_cleanup()` overwrites it via `override_terminal=True`.

In both cases the jobs controller was healthy — a best-effort cleanup step failed — yet anything treating `FAILED_CONTROLLER` as "the controller malfunctioned" (dashboards, alerting, retry automation) gets a false signal, and the record that the job succeeded / was cancelled is lost.

## Fix

Restructure the `finally:` block so the cleanup failure is *captured* instead of immediately stamped, the `CANCELLING → CANCELLED` transition runs first, and then a new `ControllerManager._record_final_job_status()` resolves the final state:

- **Job never reached a terminal state** → `FAILED_CONTROLLER`, exactly as before ("the controller failed" is genuinely accurate). The cleanup failure, when that is what happened, is the failure reason, with the same `override_terminal=True` semantics as the old code.
- **Job already reached a legitimate terminal state** (`SUCCEEDED` / `CANCELLED` / `FAILED` / ...) → keep it. A new `managed_job_state.set_cleanup_failed_async()` records the cleanup failure without touching status or `end_at`: it is appended to `failure_reason` (after the original reason, which describes the job's actual outcome) and written to the job event log, so the resources-may-have-leaked warning is not lost either.

This is exactly the split the issue proposes: reserve `FAILED_CONTROLLER` (and `override_terminal=True`) for the case where the job had not reached a terminal state.

## Tests

New unit tests, all running without cloud credentials:

- `TestRecordFinalJobStatus` (`tests/unit_tests/test_sky/jobs/test_controller.py`): the four quadrants of terminal/non-terminal × cleanup-failed/clean — terminal states are never overwritten; non-terminal jobs still get `FAILED_CONTROLLER` with the same reasons and `override_terminal` semantics as before.
- `TestSetCleanupFailed` (`tests/unit_tests/test_sky/jobs/test_jobs_state.py`, real temp SQLite DB): a `SUCCEEDED` job keeps its status with the failure recorded in `failure_reason` and the event log; a `FAILED` job keeps its original reason first with the cleanup failure appended; and the #10456 regression — a job driven through `CANCELLING → CANCELLED` with a subsequent cleanup failure ends `CANCELLED`, not `FAILED_CONTROLLER`.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/unit_tests/test_sky/jobs/` — 506 passed (7 new)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->