### PR TITLE
[Jobs] Add max_duration support for managed jobs

### DIFF
--- a/agent/skills/skypilot/references/yaml-spec.md
+++ b/agent/skills/skypilot/references/yaml-spec.md
@@ -187,6 +187,25 @@ num_nodes: 4
 ```
 
 
+### ``max_duration``
+
+Maximum duration a managed job is allowed to run (optional). When set, the
+managed-jobs controller terminates the job once it has been running longer
+than this limit, bounding runtime for cost control and reliability.
+
+This field is **only supported for managed jobs** (`sky jobs launch`). It is
+ignored by `sky launch` and `sky exec`.
+
+The value is a duration string with an optional unit suffix: `s` (seconds),
+`m` (minutes), `h` (hours), `d` (days), `w` (weeks). A plain number is
+treated as seconds.
+
+```yaml
+max_duration: 10h
+
+```
+
+
 ### ``resources``
 
 Per-node resource requirements (optional).

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -193,6 +193,27 @@ A task can set this to a smaller value than the size of a cluster.
   num_nodes: 4
 
 
+.. _yaml-spec-max-duration:
+
+``max_duration``
+~~~~~~~~~~~~~~~~
+
+Maximum duration a managed job is allowed to run (optional). When set, the
+managed-jobs controller terminates the job once it has been running longer
+than this limit, bounding runtime for cost control and reliability.
+
+This field is **only supported for managed jobs** (``sky jobs launch``). It is
+ignored by ``sky launch`` and ``sky exec``.
+
+The value is a duration string with an optional unit suffix: ``s`` (seconds),
+``m`` (minutes), ``h`` (hours), ``d`` (days), ``w`` (weeks). A plain number is
+treated as seconds.
+
+.. code-block:: yaml
+
+  max_duration: 10h
+
+
 .. _yaml-spec-resources:
 
 ``resources``

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -937,6 +937,23 @@ def _get_recipe_yaml(entrypoint: str) -> Optional[str]:
     return None
 
 
+def _warn_if_max_duration_unsupported(
+        task_or_dag: Union['task_lib.Task', 'dag_lib.Dag']) -> None:
+    """Warn if max_duration is set on a non-managed (sky launch/sky exec) task.
+
+    max_duration is only enforced by the managed-jobs controller
+    (sky jobs launch). On a regular cluster launch or exec it is silently
+    ignored, so warn the user that it will have no effect.
+    """
+    tasks = ([task_or_dag]
+             if isinstance(task_or_dag, task_lib.Task) else task_or_dag.tasks)
+    if any(getattr(t, 'max_duration', None) is not None for t in tasks):
+        logger.warning(
+            f'{colorama.Fore.YELLOW}max_duration is only supported for '
+            'managed jobs (sky jobs launch), and will be ignored by '
+            'sky launch / sky exec.{colorama.Style.RESET_ALL}')
+
+
 # TODO(zhwu): All CLI command handlers should be wrapped with
 # @annotations.client_api so that is_on_api_server is False during
 # YAML parsing and schema validation. For now, we wrap this common
@@ -1437,6 +1454,8 @@ def launch(
             _DAG_NOT_SUPPORTED_MESSAGE.format(command='sky launch'))
     task = task_or_dag
 
+    _warn_if_max_duration_unsupported(task)
+
     backend: backends.Backend
     if backend_name == backends.LocalDockerBackend.NAME:
         backend = backends.LocalDockerBackend()
@@ -1702,6 +1721,8 @@ def exec(
         raise click.UsageError('YAML specifies a DAG, while `sky exec` '
                                'supports a single task only.')
     task = task_or_dag
+
+    _warn_if_max_duration_unsupported(task)
 
     click.secho('Submitting job to cluster: ', fg='cyan', nl=False)
     click.secho(cluster)

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '57';
+export const CLIENT_API_VERSION = '58';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -88,6 +88,16 @@ def launch(
     if name is not None:
         dag.name = name
 
+    # max_duration requires a server that understands the field. A newer
+    # client sending max_duration to an older server would otherwise get an
+    # opaque schema rejection instead of a clear message.
+    if (any(getattr(t, 'max_duration', None) is not None for t in dag.tasks) and
+        (remote_api_version is None or
+         remote_api_version < server_constants.MIN_MAX_DURATION_API_VERSION)):
+        raise click.UsageError(
+            'max_duration is not supported by your API server. '
+            'Please upgrade to a newer API server to use max_duration.')
+
     with admin_policy_utils.apply_and_use_config_in_current_request(
             dag,
             request_name=request_names.AdminPolicyRequestName.JOBS_LAUNCH,

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -53,6 +53,7 @@ from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
 from sky.utils import log_links
+from sky.utils import resources_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
 from sky.utils.plugin_extensions import ExternalClusterFailure
@@ -79,6 +80,36 @@ _background_tasks_lock: asyncio.Lock = asyncio.Lock()
 # bounds SSH round-trips on non-gRPC clusters (one job-queue read per attempt).
 _LIVE_LINK_POLL_EVERY = 4  # ~1 attempt per 4 status polls (~60s)
 _LIVE_LINK_MAX_ATTEMPTS = 30  # give up live updates after ~30 attempts
+
+
+def _should_timeout(start_time: float, max_duration: Optional[str]) -> bool:
+    """Return True if the job has exceeded its max_duration.
+
+    Args:
+        start_time: The wall-clock time (epoch seconds) the job started.
+        max_duration: Optional duration string (e.g. "10h", "30m"). None means
+            no time limit.
+
+    Returns:
+        True if the job has been running longer than max_duration.
+    """
+    if max_duration is None:
+        return False
+    max_seconds = resources_utils.parse_time_seconds(max_duration)
+    return time.time() - start_time > max_seconds
+
+
+def _get_task_start_time(job_id: int, task_id: int) -> Optional[float]:
+    """Return the wall-clock start time (epoch seconds) of a managed job task.
+
+    Reads ``start_at`` from the managed-job state table. Returns None if the
+    task has not started yet (e.g. still PENDING) or the row is unavailable.
+    """
+    tasks = managed_job_state.get_managed_job_tasks(job_id)
+    for task in tasks:
+        if task.get('task_id') == task_id:
+            return task.get('start_at')
+    return None
 
 
 async def create_background_task(coro: typing.Coroutine) -> None:
@@ -173,6 +204,7 @@ def _build_task_specs(
     base_specs: Dict[str, Any] = {
         'max_restarts_on_errors': executor.max_restarts_on_errors,
         'recover_on_exit_codes': executor.recover_on_exit_codes,
+        'max_duration': executor.dag.tasks[executor.task_id].max_duration,
     }
     strategy_specs = executor.task_specs()
     overlap = set(base_specs) & set(strategy_specs)
@@ -1104,6 +1136,29 @@ class JobController:
             else:
                 transient_job_check_error_start_time = None
                 job_check_backoff = None
+
+            # Enforce max_duration: if the task has been running longer than
+            # its configured max_duration, terminate it. This is checked only
+            # while the job is still running (non-terminal), so a job that
+            # finishes on its own is never affected.
+            if (task.max_duration is not None and job_status is not None and
+                    not job_status.is_terminal()):
+                start_time = await asyncio.to_thread(_get_task_start_time,
+                                                     self._job_id, task_id)
+                if start_time is not None and _should_timeout(
+                        start_time, task.max_duration):
+                    logger.info(f'Task {task_id} exceeded max_duration '
+                                f'({task.max_duration}). Terminating the job.')
+                    failure_reason = (
+                        f'Job exceeded max_duration of {task.max_duration}. '
+                        'The job was terminated by the controller.')
+                    await managed_job_state.set_failed_async(
+                        self._job_id,
+                        task_id,
+                        failure_type=managed_job_state.ManagedJobStatus.FAILED,
+                        failure_reason=failure_reason,
+                        callback_func=callback_func)
+                    return False
 
             # Handle success
             if job_status == job_lib.JobStatus.SUCCEEDED:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1089,7 +1089,8 @@ class JobController:
                             start_time, task.max_duration):
                         logger.info(
                             f'Task {task_id} exceeded max_duration '
-                            f'({task.max_duration}). Terminating the job.')
+                            f'({task.max_duration}). Terminating the job.'
+                            )
                         failure_reason = (
                             f'Job exceeded max_duration of {task.max_duration}. '
                             'The job was terminated by the controller.')

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -204,7 +204,11 @@ def _build_task_specs(
     base_specs: Dict[str, Any] = {
         'max_restarts_on_errors': executor.max_restarts_on_errors,
         'recover_on_exit_codes': executor.recover_on_exit_codes,
-        'max_duration': executor.dag.tasks[executor.task_id].max_duration,
+        # The executor's DAG always contains exactly one task (the task being
+        # executed), regardless of its job-wide task_id. Indexing by task_id
+        # would raise IndexError for task_id >= 1 in multi-stage jobs and job
+        # groups, so always access the single task at index 0.
+        'max_duration': executor.dag.tasks[0].max_duration,
     }
     strategy_specs = executor.task_specs()
     overlap = set(base_specs) & set(strategy_specs)
@@ -1064,6 +1068,40 @@ class JobController:
             # value never leaks into the on_before_recovery hook.
             exit_codes: Optional[List[int]] = None
 
+            # Enforce max_duration unconditionally each iteration, before any
+            # status-based branching. The deadline is derived from the
+            # persisted start_at, not the live status, so it must also fire
+            # while the job is recovering, relaunching, or when the status
+            # probe is failing -- a job stuck flapping in RECOVERING or hidden
+            # behind a network/status-fetch outage would otherwise exceed its
+            # max_duration indefinitely. Guard against already-terminal tasks
+            # (e.g. SUCCEEDED) via the persisted state so a finished job is
+            # never force-failed.
+            if task.max_duration is not None:
+                persisted_status = (
+                    await managed_job_state.get_job_status_with_task_id_async(
+                        job_id=self._job_id, task_id=task_id))
+                if (persisted_status is None or
+                        not persisted_status.is_terminal()):
+                    start_time = await asyncio.to_thread(
+                        _get_task_start_time, self._job_id, task_id)
+                    if start_time is not None and _should_timeout(
+                            start_time, task.max_duration):
+                        logger.info(
+                            f'Task {task_id} exceeded max_duration '
+                            f'({task.max_duration}). Terminating the job.')
+                        failure_reason = (
+                            f'Job exceeded max_duration of {task.max_duration}. '
+                            'The job was terminated by the controller.')
+                        await managed_job_state.set_failed_async(
+                            self._job_id,
+                            task_id,
+                            failure_type=managed_job_state.ManagedJobStatus.
+                            FAILED,
+                            failure_reason=failure_reason,
+                            callback_func=callback_func)
+                        return False
+
             if not force_transit_to_recovering:
                 await asyncio.sleep(
                     managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS)
@@ -1136,29 +1174,6 @@ class JobController:
             else:
                 transient_job_check_error_start_time = None
                 job_check_backoff = None
-
-            # Enforce max_duration: if the task has been running longer than
-            # its configured max_duration, terminate it. This is checked only
-            # while the job is still running (non-terminal), so a job that
-            # finishes on its own is never affected.
-            if (task.max_duration is not None and job_status is not None and
-                    not job_status.is_terminal()):
-                start_time = await asyncio.to_thread(_get_task_start_time,
-                                                     self._job_id, task_id)
-                if start_time is not None and _should_timeout(
-                        start_time, task.max_duration):
-                    logger.info(f'Task {task_id} exceeded max_duration '
-                                f'({task.max_duration}). Terminating the job.')
-                    failure_reason = (
-                        f'Job exceeded max_duration of {task.max_duration}. '
-                        'The job was terminated by the controller.')
-                    await managed_job_state.set_failed_async(
-                        self._job_id,
-                        task_id,
-                        failure_type=managed_job_state.ManagedJobStatus.FAILED,
-                        failure_reason=failure_reason,
-                        callback_func=callback_func)
-                    return False
 
             # Handle success
             if job_status == job_lib.JobStatus.SUCCEEDED:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1091,9 +1091,9 @@ class JobController:
                             f'Task {task_id} exceeded max_duration '
                             f'({task.max_duration}). Terminating the job.')
                         failure_reason = (
-                            f'Job exceeded max_duration of {task.max_duration}. '
-                            'The job was terminated by the controller.'
-                            )
+                            f'Job exceeded max_duration of '
+                            f'{task.max_duration}. '
+                            'The job was terminated by the controller.')
                         await managed_job_state.set_failed_async(
                             self._job_id,
                             task_id,

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1089,11 +1089,11 @@ class JobController:
                             start_time, task.max_duration):
                         logger.info(
                             f'Task {task_id} exceeded max_duration '
-                            f'({task.max_duration}). Terminating the job.'
-                            )
+                            f'({task.max_duration}). Terminating the job.')
                         failure_reason = (
                             f'Job exceeded max_duration of {task.max_duration}. '
-                            'The job was terminated by the controller.')
+                            'The job was terminated by the controller.'
+                            )
                         await managed_job_state.set_failed_async(
                             self._job_id,
                             task_id,

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 57  # Slurm inline host path volume mounts
+API_VERSION = 58  # max_duration field on Task
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):
@@ -80,6 +80,12 @@ MIN_JOBS_SUBMITTED_AT_FILTER_API_VERSION = 54
 # clients don't know the value and would crash parsing it, so the server
 # downgrades WAITING to RUNNING on the wire for clients below this version.
 MIN_WAITING_STATUS_API_VERSION = 55
+
+# Minimum server API version that supports the `max_duration` field on managed
+# job tasks. A newer client sending max_duration to an older server would
+# otherwise get an opaque schema rejection, so the client raises a clear error
+# when the remote peer is below this version.
+MIN_MAX_DURATION_API_VERSION = 58
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/task.py
+++ b/sky/task.py
@@ -23,6 +23,7 @@ from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import git
 from sky.utils import registry
+from sky.utils import resources_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
 from sky.utils import volume as volume_lib
@@ -334,6 +335,7 @@ class Task:
         resources: Optional[Union['resources_lib.Resources',
                                   List['resources_lib.Resources'],
                                   Set['resources_lib.Resources']]] = None,
+        max_duration: Optional[str] = None,
         # Advanced:
         docker_image: Optional[str] = None,
         event_callback: Optional[str] = None,
@@ -444,6 +446,7 @@ class Task:
         if secrets is not None:
             self._secrets = {k: SecretStr(v) for k, v in secrets.items()}
         self._volumes = volumes or {}
+        self._max_duration = max_duration
         self._managed_secret_refs: List[ManagedSecretRef] = []
         self._api_server_access = api_server_access
 
@@ -530,6 +533,7 @@ class Task:
         """
         self.validate_name()
         self.validate_run()
+        self.validate_max_duration()
         if not skip_workdir:
             self.expand_and_validate_workdir()
         if not skip_file_mounts:
@@ -580,6 +584,17 @@ class Task:
                             f'File mount source {source!r} does not exist '
                             'locally. To fix: check if it exists, and correct '
                             'the path.')
+
+    def validate_max_duration(self):
+        """Validates the max_duration field format."""
+        if self.max_duration is None:
+            return
+        try:
+            resources_utils.parse_time_seconds(self.max_duration)
+        except ValueError as e:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Invalid max_duration {self.max_duration!r}. '
+                                 f'{e}') from None
 
     def _validate_mount_path(self, path: str, location: str):
         self._validate_path(path, location)
@@ -814,6 +829,7 @@ class Task:
             envs=config.pop('envs', None),
             secrets=inline_secrets or None,
             volumes=config.pop('volumes', None),
+            max_duration=config.pop('max_duration', None),
             event_callback=config.pop('event_callback', None),
             api_server_access=config.pop('api_server_access', True),
             _file_mounts_mapping=config.pop('file_mounts_mapping', None),
@@ -1205,6 +1221,10 @@ class Task:
     @property
     def volumes(self) -> Dict[str, Union[str, Dict[str, Any]]]:
         return self._volumes
+
+    @property
+    def max_duration(self) -> Optional[str]:
+        return self._max_duration
 
     def set_volumes(self, volumes: Dict[str, Union[str, Dict[str,
                                                              Any]]]) -> None:
@@ -2023,6 +2043,7 @@ class Task:
             add_if_not_none('service', self.service.to_yaml_config())
 
         add_if_not_none('num_nodes', self.num_nodes)
+        add_if_not_none('max_duration', self.max_duration)
 
         if self.inputs is not None:
             add_if_not_none('inputs',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1191,6 +1191,9 @@ def get_task_schema():
             'num_nodes': {
                 'type': 'integer',
             },
+            'max_duration': {
+                'type': 'string',
+            },
             # resources config is validated separately using RESOURCES_SCHEMA
             'resources': {
                 'type': 'object',

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -562,13 +562,6 @@ def test_managed_job_max_duration(generic_cloud: str):
                 # failure reason). Filter by name via grep since
                 # `sky jobs queue` has no -n/--name option.
                 f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
-                f'sky jobs queue --all -v | grep "{name}"
-                # Verify the job was terminated (FAILED) and the failure
-                # reason mentions max_duration. Use --all (the job is
-                # finished) and -v (to show the DETAILS column with the
-                # failure reason). Filter by name via grep since
-                # `sky jobs queue` has no -n/--name option.
-                f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
                 f'sky jobs queue --all -v | grep "{name}" | grep "max_duration"',
             ],
             timeout=smoke_tests_utils.get_timeout(generic_cloud),

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -533,7 +533,6 @@ def test_debug_dump_nonexistent_resources(generic_cloud: str):
     )
     smoke_tests_utils.run_one_test(test)
 
-
 def test_managed_job_max_duration(generic_cloud: str):
     """Test that a managed job is terminated after max_duration."""
     name = smoke_tests_utils.get_cluster_name()
@@ -553,11 +552,26 @@ def test_managed_job_max_duration(generic_cloud: str):
             'managed_job_max_duration',
             [
                 f'sky jobs launch -y -n {name} {job_yaml_file.name}',
-                # Wait for the job to be terminated by max_duration
+                # Wait for the job to be terminated by max_duration. The
+                # controller polls job status every ~30s, so give it enough
+                # time to detect the timeout (1m limit + polling gap).
                 f'sleep 90',
-                f'sky jobs queue -n {name} | grep "FAILED"',
-                f'sky jobs logs -n {name} | grep "max_duration"',
+                # Verify the job was terminated (FAILED) and the failure
+                # reason mentions max_duration. Use --all (the job is
+                # finished) and -v (to show the DETAILS column with the
+                # failure reason). Filter by name via grep since
+                # `sky jobs queue` has no -n/--name option.
+                f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
+                f'sky jobs queue --all -v | grep "{name}"
+                # Verify the job was terminated (FAILED) and the failure
+                # reason mentions max_duration. Use --all (the job is
+                # finished) and -v (to show the DETAILS column with the
+                # failure reason). Filter by name via grep since
+                # `sky jobs queue` has no -n/--name option.
+                f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
+                f'sky jobs queue --all -v | grep "{name}" | grep "max_duration"',
             ],
             timeout=smoke_tests_utils.get_timeout(generic_cloud),
             teardown=f'sky jobs cancel -y -n {name}')
         smoke_tests_utils.run_one_test(test)
+        

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -533,6 +533,7 @@ def test_debug_dump_nonexistent_resources(generic_cloud: str):
     )
     smoke_tests_utils.run_one_test(test)
 
+
 def test_managed_job_max_duration(generic_cloud: str):
     """Test that a managed job is terminated after max_duration."""
     name = smoke_tests_utils.get_cluster_name()
@@ -570,4 +571,3 @@ def test_managed_job_max_duration(generic_cloud: str):
             timeout=smoke_tests_utils.get_timeout(generic_cloud),
             teardown=f'sky jobs cancel -y -n {name}')
         smoke_tests_utils.run_one_test(test)
-        

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -555,13 +555,15 @@ def test_managed_job_max_duration(generic_cloud: str):
                 # Wait for the job to be terminated by max_duration. The
                 # controller polls job status every ~30s, so give it enough
                 # time to detect the timeout (1m limit + polling gap).
-                f'sleep 90',
-                # Verify the job was terminated (FAILED) and the failure
-                # reason mentions max_duration. Use --all (the job is
-                # finished) and -v (to show the DETAILS column with the
-                # failure reason). Filter by name via grep since
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=name,
+                    job_status=[sky.ManagedJobStatus.FAILED],
+                    timeout=smoke_tests_utils.get_timeout(generic_cloud)),
+                # Verify the failure reason mentions max_duration. Use --all
+                # (the job is finished) and -v (to show the DETAILS column
+                # with the failure reason). Filter by name via grep since
                 # `sky jobs queue` has no -n/--name option.
-                f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
                 f'sky jobs queue --all -v | grep "{name}" | grep "max_duration"',
             ],
             timeout=smoke_tests_utils.get_timeout(generic_cloud),

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -539,7 +539,7 @@ def test_managed_job_max_duration(generic_cloud: str):
     job_yaml = textwrap.dedent(f"""
     name: {name}-job
     resources:
-        cpus: 2
+        cpus: 1
         infra: {generic_cloud}
     max_duration: 1m
     run: |
@@ -551,7 +551,7 @@ def test_managed_job_max_duration(generic_cloud: str):
         test = smoke_tests_utils.Test(
             'managed_job_max_duration',
             [
-                f'sky jobs launch -y -n {name} {job_yaml_file.name}',
+                f'sky jobs launch -y -d -n {name} {job_yaml_file.name}',
                 # Wait for the job to be terminated by max_duration. The
                 # controller polls job status every ~30s, so give it enough
                 # time to detect the timeout (1m limit + polling gap).
@@ -564,6 +564,7 @@ def test_managed_job_max_duration(generic_cloud: str):
                 # (the job is finished) and -v (to show the DETAILS column
                 # with the failure reason). Filter by name via grep since
                 # `sky jobs queue` has no -n/--name option.
+                f'sky jobs queue --all -v | grep "{name}" | grep "FAILED"',
                 f'sky jobs queue --all -v | grep "{name}" | grep "max_duration"',
             ],
             timeout=smoke_tests_utils.get_timeout(generic_cloud),

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -532,3 +532,32 @@ def test_debug_dump_nonexistent_resources(generic_cloud: str):
         timeout=2 * 60,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+def test_managed_job_max_duration(generic_cloud: str):
+    """Test that a managed job is terminated after max_duration."""
+    name = smoke_tests_utils.get_cluster_name()
+    job_yaml = textwrap.dedent(f"""
+    name: {name}-job
+    resources:
+        cpus: 2
+        infra: {generic_cloud}
+    max_duration: 1m
+    run: |
+        sleep 3600
+    """)
+    with tempfile.NamedTemporaryFile(delete=True) as job_yaml_file:
+        job_yaml_file.write(job_yaml.encode('utf-8'))
+        job_yaml_file.flush()
+        test = smoke_tests_utils.Test(
+            'managed_job_max_duration',
+            [
+                f'sky jobs launch -y -n {name} {job_yaml_file.name}',
+                # Wait for the job to be terminated by max_duration
+                f'sleep 90',
+                f'sky jobs queue -n {name} | grep "FAILED"',
+                f'sky jobs logs -n {name} | grep "max_duration"',
+            ],
+            timeout=smoke_tests_utils.get_timeout(generic_cloud),
+            teardown=f'sky jobs cancel -y -n {name}')
+        smoke_tests_utils.run_one_test(test)

--- a/tests/unit_tests/test_jobs_max_duration.py
+++ b/tests/unit_tests/test_jobs_max_duration.py
@@ -2,6 +2,8 @@
 import time
 import unittest.mock as mock
 
+from sky import task as task_lib
+from sky.jobs.controller import _build_task_specs
 from sky.jobs.controller import _get_task_start_time
 from sky.jobs.controller import _should_timeout
 
@@ -38,22 +40,79 @@ def test_days_parsing():
     assert _should_timeout(time.time() - 86401, '1d') is True
     assert _should_timeout(time.time() - 86399, '1d') is False
 
+
 def test_get_task_start_time_returns_start_at():
-    tasks = [{'task_id': 0, 'start_at': 123.0}, {'task_id': 1, 'start_at': 456.0}]
-    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
-                    return_value=tasks):
+    tasks = [{
+        'task_id': 0,
+        'start_at': 123.0
+    }, {
+        'task_id': 1,
+        'start_at': 456.0
+    }]
+    with mock.patch(
+            'sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+            return_value=tasks):
         assert _get_task_start_time(1, 1) == 456.0
 
 
 def test_get_task_start_time_returns_none_for_unknown_task():
     tasks = [{'task_id': 0, 'start_at': 123.0}]
-    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
-                    return_value=tasks):
+    with mock.patch(
+            'sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+            return_value=tasks):
         assert _get_task_start_time(1, 99) is None
 
 
 def test_get_task_start_time_returns_none_when_not_started():
     tasks = [{'task_id': 0, 'start_at': None}]
-    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
-                    return_value=tasks):
+    with mock.patch(
+            'sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+            return_value=tasks):
         assert _get_task_start_time(1, 0) is None
+
+
+def _make_mock_executor(task_id: int, max_duration: str):
+    """Build a mock StrategyExecutor with a single-task DAG.
+
+    Mirrors the real StrategyExecutor: ``dag`` always contains exactly one
+    task (the task being executed), while ``task_id`` is the job-wide task
+    index (0, 1, 2, ... for multi-stage jobs / job groups).
+    """
+    task = task_lib.Task(name=f'task-{task_id}', max_duration=max_duration)
+    executor = mock.Mock()
+    executor.dag = mock.Mock()
+    executor.dag.tasks = [task]
+    executor.task_id = task_id
+    executor.max_restarts_on_errors = 0
+    executor.recover_on_exit_codes = []
+    executor.task_specs.return_value = {}
+    return executor
+
+
+def test_build_task_specs_works_for_first_task():
+    """_build_task_specs must work for task_id == 0."""
+    executor = _make_mock_executor(task_id=0, max_duration='10h')
+    specs = _build_task_specs(executor)
+    assert specs['max_duration'] == '10h'
+
+
+def test_build_task_specs_works_for_later_tasks():
+    """Regression test: _build_task_specs must not crash for task_id >= 1.
+
+    The executor's DAG always contains exactly one task, so indexing it by
+    the job-wide task_id (executor.dag.tasks[task_id]) would raise
+    IndexError for task_id >= 1 in multi-stage jobs and job groups. The
+    correct lookup is executor.dag.tasks[0].
+    """
+    for task_id in (1, 2, 5):
+        executor = _make_mock_executor(task_id=task_id, max_duration='30m')
+        # Must not raise IndexError.
+        specs = _build_task_specs(executor)
+        assert specs['max_duration'] == '30m'
+
+
+def test_build_task_specs_no_max_duration():
+    """_build_task_specs must handle a task with no max_duration."""
+    executor = _make_mock_executor(task_id=1, max_duration=None)
+    specs = _build_task_specs(executor)
+    assert specs['max_duration'] is None

--- a/tests/unit_tests/test_jobs_max_duration.py
+++ b/tests/unit_tests/test_jobs_max_duration.py
@@ -1,0 +1,59 @@
+"""Unit tests for the managed-job max_duration timeout helper."""
+import time
+import unittest.mock as mock
+
+from sky.jobs.controller import _get_task_start_time
+from sky.jobs.controller import _should_timeout
+
+
+def test_no_max_duration_never_times_out():
+    # A job that started long ago with no max_duration must never time out.
+    assert _should_timeout(time.time() - 100000, None) is False
+
+
+def test_within_duration_no_timeout():
+    # A job that started 5 seconds ago with a 10h limit is within the limit.
+    assert _should_timeout(time.time() - 5, '10h') is False
+
+
+def test_exceeded_duration_times_out():
+    # A job that started 36001 seconds ago with a 10h limit has exceeded it.
+    assert _should_timeout(time.time() - 36001, '10h') is True
+
+
+def test_minutes_parsing():
+    # 1m = 60s; a job running 61s has exceeded it.
+    assert _should_timeout(time.time() - 61, '1m') is True
+    assert _should_timeout(time.time() - 59, '1m') is False
+
+
+def test_seconds_parsing():
+    # 90s = 90s; a job running 91s has exceeded it.
+    assert _should_timeout(time.time() - 91, '90s') is True
+    assert _should_timeout(time.time() - 89, '90s') is False
+
+
+def test_days_parsing():
+    # 1d = 86400s; a job running 86401s has exceeded it.
+    assert _should_timeout(time.time() - 86401, '1d') is True
+    assert _should_timeout(time.time() - 86399, '1d') is False
+
+def test_get_task_start_time_returns_start_at():
+    tasks = [{'task_id': 0, 'start_at': 123.0}, {'task_id': 1, 'start_at': 456.0}]
+    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+                    return_value=tasks):
+        assert _get_task_start_time(1, 1) == 456.0
+
+
+def test_get_task_start_time_returns_none_for_unknown_task():
+    tasks = [{'task_id': 0, 'start_at': 123.0}]
+    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+                    return_value=tasks):
+        assert _get_task_start_time(1, 99) is None
+
+
+def test_get_task_start_time_returns_none_when_not_started():
+    tasks = [{'task_id': 0, 'start_at': None}]
+    with mock.patch('sky.jobs.controller.managed_job_state.get_managed_job_tasks',
+                    return_value=tasks):
+        assert _get_task_start_time(1, 0) is None


### PR DESCRIPTION
Fixes skypilot-org/skypilot#10370

# Summary

Add support for a `max_duration` field in managed job YAMLs. When set, the SkyPilot jobs controller automatically terminates a managed job once it has been running longer than the configured limit (e.g. `max_duration`: 10h). This gives users a simple, declarative way to bound job runtime for cost control and reliability, a job that hangs or runs too long is killed automatically instead of running indefinitely.

## Example:

```
resources:
  cpus: 1
max_duration: 2h
run: |
  python train.py
```

# Description of Changes

* Task spec: `max_duration` is parsed from the YAML, validated at submission time (rejecting malformed values like `max_duration: banana` with a clear error rather than failing confusingly later), and round-trips through serialization like other task fields.
* Controller: the jobs controller's monitoring loop evaluates each task's elapsed time (from the persisted `start_at`) against its `max_duration` on every iteration, independent of the task's live status — so a task stuck in `RECOVERING` or hitting transient status-fetch errors is still subject to the deadline, not just one that's cleanly `RUNNING`. Applies correctly to every task in a pipeline or job group, not just the first. On timeout, the job is marked `FAILED` with an explicit reason ("Job exceeded `max_duration` of . The job was terminated by the controller.") and its cluster is torn down.
* CLI warning: sky launch / sky exec warn (rather than silently ignore) if max_duration is set, since the field is only enforced for managed jobs (sky jobs launch).
* Client/server version gating: `sky jobs launch`checks the connected API server's version before submitting a job with `max_duration` set, and fails fast with a clear error if the server predates support for the field, avoiding an opaque schema-validation rejection on older, not-yet-upgraded servers. Bumps `API_VERSION` per the project's backward-compatibility guidelines.
* Docs: added `max_duration` to the task YAML reference (docs/source/reference/yaml-spec.rst), including supported duration units and the managed-jobs-only scope.
* Backward compatible: jobs without `max_duration` set are unaffected.

# Tested

## What the tests verify:

* Unit tests cover the core timeout logic in isolation: a job with no `max_duration` never times out, a job within its limit does not time out, a job past its limit does time out, duration strings (`1m`, `90s`, `1d`) parse correctly, and the job start-time lookup returns the correct value (including edge cases like unknown/not-started tasks).
* The smoke test verifies the feature end-to-end on a real cluster: a managed job with `max_duration` set is launched, runs past its limit, and is terminated by the controller with the expected failure reason.

## Tests run:

* `bash format.sh` — yapf, isort, mypy, pylint all pass (mypy: no issues in 587 source files; pylint: 10.00/10)
* `pytest tests/unit_tests/test_jobs_max_duration.py` — 9 passed

  <img src="https://github.com/user-attachments/assets/32216be2-4919-4cc2-9d45-d16712689ce4 " alt="image" width="1247" data-linear-height="57" />
* Smoke test `test_managed_job_max_duration`, run locally against a Kubernetes cluster:

  <img src="https://github.com/user-attachments/assets/4d248250-173b-49ff-bd04-ef18ba8fd195 " alt="image" width="1165" data-linear-height="666" />
* Manually verified end-to-end on a local Kubernetes (minikube) cluster: launched a managed job with `max_duration: 1m` and a 10-minute sleep, confirmed it was terminated by the controller around the 1-minute mark with the correct failure reason, and confirmed the underlying pod was actually cleaned up (not just marked failed).

  <img src="https://github.com/user-attachments/assets/84149630-cd7b-4005-bd6b-4c3e085948cf " alt="image" width="1611" data-linear-height="172" />

## Why this doesn't break existing jobs:

* `max_duration` is a new optional field (`Optional[str] = None`). Existing YAMLs without it are unaffected, and the controller's timeout check is guarded by `if task.max_duration is not None`, so jobs without it never hit the new logic.
* The timeout check itself returns `False` when `max_duration` is `None`, so existing managed jobs run exactly as before.
* The timeout marks the job `FAILED` through the same state-transition path used elsewhere, which only applies if the job hasn't already reached a terminal state, this avoids conflicting with cancellation or other terminal transitions happening concurrently.

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)