### PR TITLE
fix(helm): make API metrics discoverable through Service

### DIFF
--- a/charts/skypilot/manifests/api-server-overview.json
+++ b/charts/skypilot/manifests/api-server-overview.json
@@ -2811,7 +2811,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(sky_apiserver_requests_total{app=\"$app\"},pod)",
+        "definition": "label_values(kube_pod_info{pod=~\"$app-server-.+\"},pod)",
         "includeAll": true,
         "label": "Replica",
         "multi": true,
@@ -2819,7 +2819,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(sky_apiserver_requests_total{app=\"$app\"},pod)",
+          "query": "label_values(kube_pod_info{pod=~\"$app-server-.+\"},pod)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -148,7 +148,7 @@ false
 
 {{/* API server start arguments */}}
 {{- define "skypilot.apiArgs" -}}
---deploy{{ if include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" }} --enable-basic-auth{{ end }}{{ if .Values.apiService.host }} --host={{ .Values.apiService.host }}{{ end }}{{ if .Values.apiService.metrics.enabled }} --metrics-port={{ .Values.apiService.metrics.port }}{{ end }}
+--deploy{{ if include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" }} --enable-basic-auth{{ end }}{{ if .Values.apiService.host }} --host={{ .Values.apiService.host }}{{ end }}
 {{- end -}}
 
 {{- define "skypilot.oauth2ProxyURL" -}}

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -148,7 +148,7 @@ false
 
 {{/* API server start arguments */}}
 {{- define "skypilot.apiArgs" -}}
---deploy{{ if include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" }} --enable-basic-auth{{ end }}{{ if .Values.apiService.host }} --host={{ .Values.apiService.host }}{{ end }}
+--deploy{{ if include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" }} --enable-basic-auth{{ end }}{{ if .Values.apiService.host }} --host={{ .Values.apiService.host }}{{ end }}{{ if .Values.apiService.metrics.enabled }} --metrics-port={{ .Values.apiService.metrics.port }}{{ end }}
 {{- end -}}
 
 {{- define "skypilot.oauth2ProxyURL" -}}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -5,6 +5,7 @@
        storage mounts / ephemeral ~/.sky / env below key off this rather than
        storage.enabled alone. */ -}}
 {{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
+{{- $preservePodScrapeAnnotations := and .Values.apiService.metrics.enabled (not .Values.prometheus.useDedicatedScrapeConfig) (or (not .Values.prometheus.enabled) .Values.prometheus.preservePodScrapeAnnotations) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,6 +43,11 @@ spec:
         skypilot.co/scrape: "true"
         skypilot.co/path: "/metrics"
         skypilot.co/port: {{ .Values.apiService.metrics.port | quote }}
+        {{- end }}
+        {{- if $preservePodScrapeAnnotations }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.apiService.metrics.port | quote }}
         {{- end }}
         {{- if .Values.apiService.annotations }}
         {{- toYaml .Values.apiService.annotations | nindent 8 }}
@@ -168,6 +174,8 @@ spec:
         {{- if .Values.apiService.metrics.enabled }}
         - name: SKY_API_SERVER_METRICS_ENABLED
           value: "true"
+        - name: SKY_API_SERVER_METRICS_PORT
+          value: {{ .Values.apiService.metrics.port | quote }}
         {{- end }}
         {{- if .Values.auth.disableBasicAuthMiddleware }}
         - name: SKYPILOT_DISABLE_BASIC_AUTH_MIDDLEWARE

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -5,7 +5,7 @@
        storage mounts / ephemeral ~/.sky / env below key off this rather than
        storage.enabled alone. */ -}}
 {{- $statePersist := or .Values.storage.enabled .Values.storage.existingClaim -}}
-{{- $preservePodScrapeAnnotations := and .Values.apiService.metrics.enabled (not .Values.prometheus.useDedicatedScrapeConfig) (or (not .Values.prometheus.enabled) .Values.prometheus.preservePodScrapeAnnotations) -}}
+{{- $preservePodScrapeAnnotations := and .Values.apiService.metrics.enabled (not .Values.prometheus.useDedicatedScrapeConfig) .Values.prometheus.preservePodScrapeAnnotations -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -38,17 +38,10 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.apiService.metrics.enabled }}
-        {{- if .Values.prometheus.useDedicatedScrapeConfig }}
+        {{- if and .Values.apiService.metrics.enabled .Values.prometheus.useDedicatedScrapeConfig }}
         skypilot.co/scrape: "true"
         skypilot.co/path: "/metrics"
         skypilot.co/port: {{ .Values.apiService.metrics.port | quote }}
-        {{- else}}
-        # Well-known annotations for Prometheus to scrape the metrics.
-        prometheus.io/scrape: "true"
-        prometheus.io/path: "/metrics"
-        prometheus.io/port: {{ .Values.apiService.metrics.port | quote }}
-        {{- end }}
         {{- end }}
         {{- if .Values.apiService.annotations }}
         {{- toYaml .Values.apiService.annotations | nindent 8 }}
@@ -324,6 +317,10 @@ spec:
           {{- end }}
         ports:
         - containerPort: 46580
+        {{- if .Values.apiService.metrics.enabled }}
+        - containerPort: {{ .Values.apiService.metrics.port }}
+          name: metrics
+        {{- end }}
         {{- if not .Values.apiService.devMode.enabled }}
         {{- with .Values.apiService.livenessProbe }}
         livenessProbe:

--- a/charts/skypilot/templates/api-service.yaml
+++ b/charts/skypilot/templates/api-service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: {{ $fullName }}-api-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}-api
   {{- if and .Values.apiService.metrics.enabled (not .Values.prometheus.useDedicatedScrapeConfig) }}
   annotations:
     prometheus.io/scrape: "true"

--- a/charts/skypilot/templates/api-service.yaml
+++ b/charts/skypilot/templates/api-service.yaml
@@ -4,6 +4,12 @@ kind: Service
 metadata:
   name: {{ $fullName }}-api-service
   namespace: {{ .Release.Namespace }}
+  {{- if and .Values.apiService.metrics.enabled (not .Values.prometheus.useDedicatedScrapeConfig) }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: {{ .Values.apiService.metrics.port | quote }}
+  {{- end }}
 spec:
   type: ClusterIP  # Use clusterIP to allow ingress to authenticate
   {{- if and .Values.apiService.host (contains ":" .Values.apiService.host) }}
@@ -20,7 +26,7 @@ spec:
   {{- if .Values.apiService.metrics.enabled }}
     - port: {{ .Values.apiService.metrics.port }}
       name: metrics
-      targetPort: {{ .Values.apiService.metrics.port }}
+      targetPort: metrics
       protocol: TCP
   {{- end }}
   selector:

--- a/charts/skypilot/tests/api_service_test.yaml
+++ b/charts/skypilot/tests/api_service_test.yaml
@@ -8,6 +8,9 @@ tests:
       apiService.metrics.enabled: true
     asserts:
       - equal:
+          path: metadata.labels.app
+          value: RELEASE-NAME-api
+      - equal:
           path: metadata.annotations["prometheus.io/scrape"]
           value: "true"
       - equal:

--- a/charts/skypilot/tests/api_service_test.yaml
+++ b/charts/skypilot/tests/api_service_test.yaml
@@ -3,6 +3,44 @@ suite: api_service_test
 templates:
   - templates/api-service.yaml
 tests:
+  - it: should expose metrics discovery annotations on the Service
+    set:
+      apiService.metrics.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["prometheus.io/path"]
+          value: /metrics
+      - equal:
+          path: metadata.annotations["prometheus.io/port"]
+          value: "9090"
+      - contains:
+          path: spec.ports
+          content:
+            port: 9090
+            name: metrics
+            targetPort: metrics
+            protocol: TCP
+
+  - it: should omit standard Service annotations in dedicated scrape mode
+    set:
+      apiService.metrics.enabled: true
+      prometheus.useDedicatedScrapeConfig: true
+    asserts:
+      - notExists:
+          path: metadata.annotations["prometheus.io/scrape"]
+
+  - it: should omit metrics discovery and the metrics port when disabled
+    asserts:
+      - notExists:
+          path: metadata.annotations["prometheus.io/scrape"]
+      - notContains:
+          path: spec.ports
+          content:
+            name: metrics
+
   - it: should not set ipFamilyPolicy by default (single-stack)
     asserts:
       - isKind:

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -7,9 +7,8 @@ tests:
     set:
       apiService.metrics.enabled: true
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
-          value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -57,9 +56,10 @@ tests:
           path: spec.template.spec.containers[0].args[2]
           pattern: "--metrics-port"
 
-  - it: should preserve standard Pod annotations for external scrapers
+  - it: should preserve standard Pod annotations when explicitly requested
     set:
       apiService.metrics.enabled: true
+      prometheus.preservePodScrapeAnnotations: true
     asserts:
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
@@ -76,7 +76,7 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
 
-  - it: should preserve standard Pod annotations when explicitly requested
+  - it: should preserve standard Pod annotations with bundled Prometheus when explicitly requested
     set:
       apiService.metrics.enabled: true
       prometheus.enabled: true

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -3,6 +3,44 @@ suite: server_deployment_test
 templates:
   - templates/api-deployment.yaml
 tests:
+  - it: should declare and advertise the API metrics port in normal mode
+    set:
+      apiService.metrics.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9090
+            name: metrics
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "--metrics-port=9090"
+
+  - it: should retain dedicated Pod annotations and use a custom metrics port
+    set:
+      apiService.metrics.enabled: true
+      apiService.metrics.port: 9190
+      prometheus.useDedicatedScrapeConfig: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["skypilot.co/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["skypilot.co/port"]
+          value: "9190"
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9190
+            name: metrics
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "--metrics-port=9190"
+
   - it: should mount kubeconfig correctly when useKubeconfig is enabled
     set:
       kubernetesCredentials.useKubeconfig: true

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -7,16 +7,27 @@ tests:
     set:
       apiService.metrics.enabled: true
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKY_API_SERVER_METRICS_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKY_API_SERVER_METRICS_PORT
+            value: "9090"
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
             containerPort: 9090
             name: metrics
-      - matchRegex:
+      - notMatchRegex:
           path: spec.template.spec.containers[0].args[2]
-          pattern: "--metrics-port=9090"
+          pattern: "--metrics-port"
 
   - it: should retain dedicated Pod annotations and use a custom metrics port
     set:
@@ -33,13 +44,47 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
       - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKY_API_SERVER_METRICS_PORT
+            value: "9190"
+      - contains:
           path: spec.template.spec.containers[0].ports
           content:
             containerPort: 9190
             name: metrics
-      - matchRegex:
+      - notMatchRegex:
           path: spec.template.spec.containers[0].args[2]
-          pattern: "--metrics-port=9190"
+          pattern: "--metrics-port"
+
+  - it: should preserve standard Pod annotations for external scrapers
+    set:
+      apiService.metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9090"
+
+  - it: should omit standard Pod annotations with bundled Prometheus
+    set:
+      apiService.metrics.enabled: true
+      prometheus.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+
+  - it: should preserve standard Pod annotations when explicitly requested
+    set:
+      apiService.metrics.enabled: true
+      prometheus.enabled: true
+      prometheus.preservePodScrapeAnnotations: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
 
   - it: should mount kubeconfig correctly when useKubeconfig is enabled
     set:

--- a/charts/skypilot/tests/metrics_test.yaml
+++ b/charts/skypilot/tests/metrics_test.yaml
@@ -3,10 +3,9 @@ suite: prometheus_extra_scrape_configs_test
 templates:
   - charts/prometheus/templates/cm.yaml
 tests:
-  - it: should render extraScrapeConfigs with resolved service target
+  - it: should discover GPU metrics through the named API Service endpoint
     set:
       prometheus.enabled: true
-      prometheus.useDedicatedScrapeConfig: true
     asserts:
       - hasDocuments:
           count: 1
@@ -14,20 +13,39 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data["prometheus.yml"]
-          pattern: "RELEASE-NAME-api-service\\.NAMESPACE\\.svc\\.cluster\\.local:9090"
+          pattern: "job_name: 'skypilot-api-server-gpu-metrics'"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_endpoint_port_name"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "RELEASE-NAME-api-service;metrics"
 
-  - it: should render extraScrapeConfigs using fullnameOverride for service name
+  - it: should use fullnameOverride when filtering the API Service endpoint
     set:
       prometheus.enabled: true
-      prometheus.useDedicatedScrapeConfig: true
       fullnameOverride: custom-name
       prometheus.fullnameOverride: custom-name
     asserts:
       - hasDocuments:
           count: 1
+      - isKind:
+          of: ConfigMap
       - matchRegex:
           path: data["prometheus.yml"]
-          pattern: "custom-name-api-service\\.NAMESPACE\\.svc\\.cluster\\.local:9090"
+          pattern: "custom-name-api-service;metrics"
+
+  - it: should render the dedicated Pod scrape job when requested
+    set:
+      prometheus.enabled: true
+      prometheus.useDedicatedScrapeConfig: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: 'skypilot-api-server-metrics'"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "skypilot_co_scrape"
 
   - it: should NOT render the endpoints-metrics scrape job by default
     set:

--- a/charts/skypilot/tests/metrics_test.yaml
+++ b/charts/skypilot/tests/metrics_test.yaml
@@ -20,6 +20,18 @@ tests:
       - matchRegex:
           path: data["prometheus.yml"]
           pattern: "RELEASE-NAME-api-service;metrics"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "target_label: pod"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "target_label: instance"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_endpoint_port_number"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "replacement: \\$1\\.\\$2\\.svc\\.cluster\\.local:\\$3"
 
   - it: should use fullnameOverride when filtering the API Service endpoint
     set:

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -720,9 +720,8 @@ prometheus:
   # @schema type: [boolean, null]
   useDedicatedScrapeConfig: false
   # Keep legacy prometheus.io/* Pod annotations alongside the Service annotations
-  # when bundled Prometheus is enabled. This is useful for manually managed
-  # Pod-based scrapers, but may create duplicate targets unless they are filtered.
-  # Pod annotations are kept automatically when bundled Prometheus is disabled.
+  # when explicitly requested. This is useful for manually managed Pod-based
+  # scrapers, but may create duplicate targets unless they are filtered.
   # @schema type: [boolean, null]
   preservePodScrapeAnnotations: false
   # Add a scrape job for the API server's /endpoints-metrics federation

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -719,6 +719,12 @@ prometheus:
   # you do not want the API server to be discovered by other Prometheus instances.
   # @schema type: [boolean, null]
   useDedicatedScrapeConfig: false
+  # Keep legacy prometheus.io/* Pod annotations alongside the Service annotations
+  # when bundled Prometheus is enabled. This is useful for manually managed
+  # Pod-based scrapers, but may create duplicate targets unless they are filtered.
+  # Pod annotations are kept automatically when bundled Prometheus is disabled.
+  # @schema type: [boolean, null]
+  preservePodScrapeAnnotations: false
   # Add a scrape job for the API server's /endpoints-metrics federation
   # (model-serving engine metrics, e.g. vLLM, from every connected Kubernetes
   # context) and provision the serving Grafana dashboards. Opt-in: leave false
@@ -752,6 +758,14 @@ prometheus:
         - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
           regex: '{{ include "skypilot.fullname" . }}-api-service;metrics'
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: pod
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_namespace, __meta_kubernetes_endpoint_port_number]
+          action: replace
+          regex: (.+);(.+);(.+)
+          replacement: $1.$2.svc.cluster.local:$3
+          target_label: instance
       metrics_path: '/gpu-metrics'
       scrape_interval: 60s
       scrape_timeout: 45s
@@ -780,6 +794,14 @@ prometheus:
         - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
           regex: '{{ include "skypilot.fullname" . }}-api-service;metrics'
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: pod
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_namespace, __meta_kubernetes_endpoint_port_number]
+          action: replace
+          regex: (.+);(.+);(.+)
+          replacement: $1.$2.svc.cluster.local:$3
+          target_label: instance
       metrics_path: '/endpoints-metrics'
       scrape_interval: 60s
       scrape_timeout: 45s

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -714,9 +714,9 @@ runtimeClassName:
 # Refer to https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml for available values.
 # @schema skipProperties:true
 prometheus:
-  # By default, the API server will be annotated with well-known annotations (prometheus.io/*) to be discovered by prometheus.
-  # Set this to true will remove the well-known annotations and use a dedicated scrape config instead, which can be helpful when
-  # you do not want the API server to be discovered by other prometheus instances.
+  # By default, the API Service will be annotated with well-known annotations (prometheus.io/*) to be discovered by Prometheus-compatible service scrapers.
+  # Set this to true to remove the Service annotations and use a dedicated Pod scrape config instead, which can be helpful when
+  # you do not want the API server to be discovered by other Prometheus instances.
   # @schema type: [boolean, null]
   useDedicatedScrapeConfig: false
   # Add a scrape job for the API server's /endpoints-metrics federation
@@ -728,7 +728,7 @@ prometheus:
   enabled: false
   # Keep the installation minimal by default. If you want to monitor more resources other than the API server,
   # it is recommended to install and manage prometheus separately.
-  # SkyPilot API server will be automatically discovered by the prometheus if it runs with the default kubernetes discovery configuration.
+  # The SkyPilot API Service will be automatically discovered by Prometheus if it runs with the default Kubernetes service discovery configuration.
   server:
     persistentVolume:
       enabled: true
@@ -741,11 +741,17 @@ prometheus:
     retentionSize: "43GB"
   # Configure additional scrape configs using extraScrapeConfigs
   extraScrapeConfigs: |
-    # Static scrape target for SkyPilot API server GPU metrics
+    # Scrape the SkyPilot API server GPU metrics from the named Service port.
     - job_name: 'skypilot-api-server-gpu-metrics'
-      static_configs:
-        # Use the API service created by this Helm chart
-        - targets: ['{{ include "skypilot.fullname" . }}-api-service.{{ .Release.Namespace }}.svc.cluster.local:9090']
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+            - '{{ .Release.Namespace }}'
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: '{{ include "skypilot.fullname" . }}-api-service;metrics'
       metrics_path: '/gpu-metrics'
       scrape_interval: 60s
       scrape_timeout: 45s
@@ -757,16 +763,23 @@ prometheus:
         target_label: node
         replacement: $1
     {{- if .Values.scrapeEndpointMetrics }}
-    # Static scrape target for SkyPilot API server endpoint serving
-    # metrics. The /endpoints-metrics endpoint federates the serving
+    # Scrape the SkyPilot API server endpoint-serving metrics from the named
+    # Service port. The /endpoints-metrics endpoint federates the serving
     # engines' native series (vllm:* today) from every remote Kubernetes
     # context the API server can see, with a cluster=<context> label
     # injected on each series so the serving Grafana dashboards can
     # filter by cluster.
     - job_name: 'skypilot-api-server-endpoints-metrics'
       honor_labels: true
-      static_configs:
-        - targets: ['{{ include "skypilot.fullname" . }}-api-service.{{ .Release.Namespace }}.svc.cluster.local:9090']
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+            - '{{ .Release.Namespace }}'
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: '{{ include "skypilot.fullname" . }}-api-service;metrics'
       metrics_path: '/endpoints-metrics'
       scrape_interval: 60s
       scrape_timeout: 45s

--- a/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
@@ -138,10 +138,9 @@ images must read this environment variable to use a non-default port. Images
 that retain the historical 9090 default continue to work when ``port`` remains
 9090.
 
-For external, manually managed Pod-based scrapers, the chart keeps the legacy
-``prometheus.io/*`` Pod annotations automatically when ``prometheus.enabled`` is
-false. If bundled Prometheus is enabled, those annotations are omitted by
-default to avoid duplicate discovery; set
-``prometheus.preservePodScrapeAnnotations: true`` only when the duplicate-target
-trade-off is understood and the bundled scrape configuration is filtered as
-needed. Dedicated mode uses only the ``skypilot.co/*`` Pod annotations.
+The chart does not add standard ``prometheus.io/*`` annotations to the API
+server Pod by default. This avoids duplicate discovery when an external agent
+has both Service- and Pod-based scrape jobs. Set
+``prometheus.preservePodScrapeAnnotations: true`` only when a manually managed
+Pod scraper requires the legacy annotations and the duplicate-target trade-off
+is understood. Dedicated mode uses only the ``skypilot.co/*`` Pod annotations.

--- a/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
@@ -130,3 +130,18 @@ All three default to ``false`` so you can mix & match:
 * **Fully managed Prometheus + Grafana** – set ``apiService.metrics.enabled: true``, ``prometheus.enabled: true``, and ``grafana.enabled: true``. The chart will deploy a fully managed Prometheus + Grafana stack.
 * **External Prometheus / Grafana** – set *only* ``apiService.metrics.enabled: true``. The API server will expose the metrics on the ``/metrics`` endpoint and its Service will be annotated with ``prometheus.io/scrape: true`` so Prometheus-compatible service scrapers can discover it automatically.
 * **External Grafana, internal Prometheus** – enable ``prometheus`` but disable ``grafana``. Point your existing Grafana at the Prometheus service created by the chart.
+
+The chart passes the configured metrics port to the API server through
+``SKY_API_SERVER_METRICS_PORT`` and exposes the same port through the Service.
+The chart does not add a ``--metrics-port`` CLI argument, so custom API server
+images must read this environment variable to use a non-default port. Images
+that retain the historical 9090 default continue to work when ``port`` remains
+9090.
+
+For external, manually managed Pod-based scrapers, the chart keeps the legacy
+``prometheus.io/*`` Pod annotations automatically when ``prometheus.enabled`` is
+false. If bundled Prometheus is enabled, those annotations are omitted by
+default to avoid duplicate discovery; set
+``prometheus.preservePodScrapeAnnotations: true`` only when the duplicate-target
+trade-off is understood and the bundled scrape configuration is filtered as
+needed. Dedicated mode uses only the ``skypilot.co/*`` Pod annotations.

--- a/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
@@ -128,5 +128,5 @@ The Helm chart introduces **three new top-level blocks** to provide flexibility 
 All three default to ``false`` so you can mix & match:
 
 * **Fully managed Prometheus + Grafana** – set ``apiService.metrics.enabled: true``, ``prometheus.enabled: true``, and ``grafana.enabled: true``. The chart will deploy a fully managed Prometheus + Grafana stack.
-* **External Prometheus / Grafana** – set *only* ``apiService.metrics.enabled: true``. The API server will expose the metrics on the ``/metrics`` endpoint and the pod will be annotated with ``prometheus.io/scrape: true`` to enable automatic scraping by prometheus.
+* **External Prometheus / Grafana** – set *only* ``apiService.metrics.enabled: true``. The API server will expose the metrics on the ``/metrics`` endpoint and its Service will be annotated with ``prometheus.io/scrape: true`` so Prometheus-compatible service scrapers can discover it automatically.
 * **External Grafana, internal Prometheus** – enable ``prometheus`` but disable ``grafana``. Point your existing Grafana at the Prometheus service created by the chart.

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -2586,9 +2586,8 @@ Default: ``false``
 
 Keep the legacy ``prometheus.io/*`` annotations on the API server Pod in
 addition to the Service annotations. This supports manually managed
-Pod-based scrapers when the bundled Prometheus is enabled, but can create
-duplicate targets. Pod annotations are preserved automatically when
-``prometheus.enabled`` is ``false``; dedicated scrape mode uses only
+Pod-based scrapers, but can create duplicate targets when a scraper also
+discovers the annotated Service. Dedicated scrape mode uses only
 ``skypilot.co/*`` annotations.
 
 Default: ``false``

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -2579,6 +2579,25 @@ Default: ``false``
   prometheus:
     enabled: false
 
+.. _helm-values-prometheus-preservePodScrapeAnnotations:
+
+``prometheus.preservePodScrapeAnnotations``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Keep the legacy ``prometheus.io/*`` annotations on the API server Pod in
+addition to the Service annotations. This supports manually managed
+Pod-based scrapers when the bundled Prometheus is enabled, but can create
+duplicate targets. Pod annotations are preserved automatically when
+``prometheus.enabled`` is ``false``; dedicated scrape mode uses only
+``skypilot.co/*`` annotations.
+
+Default: ``false``
+
+.. code-block:: yaml
+
+  prometheus:
+    preservePodScrapeAnnotations: false
+
 .. _helm-values-grafana:
 
 ``grafana``

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -138,7 +138,6 @@ logger = sky_logging.init_logger(__name__)
 # through posix_spawn instead of fork_exec.
 _KUBECTL_PATH: Optional[str] = shutil.which('kubectl')
 
-
 _DEFAULT_METRICS_PORT = 9090
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -138,6 +138,35 @@ logger = sky_logging.init_logger(__name__)
 # through posix_spawn instead of fork_exec.
 _KUBECTL_PATH: Optional[str] = shutil.which('kubectl')
 
+
+_DEFAULT_METRICS_PORT = 9090
+
+
+def _get_metrics_port_from_env() -> int:
+    """Return the configured API metrics port or the default port."""
+    value = os.environ.get(constants.ENV_VAR_SERVER_METRICS_PORT)
+    if value is None:
+        return _DEFAULT_METRICS_PORT
+    try:
+        port = int(value)
+    except ValueError as e:
+        raise ValueError(
+            f'{constants.ENV_VAR_SERVER_METRICS_PORT} must be an integer, '
+            f'got {value!r}') from e
+    if not 1 <= port <= 65535:
+        raise ValueError(
+            f'{constants.ENV_VAR_SERVER_METRICS_PORT} must be between 1 and '
+            f'65535, got {port}')
+    return port
+
+
+def _validate_api_server_ports(api_port: int, metrics_port: int) -> None:
+    """Reject configurations that bind the API and metrics servers together."""
+    if api_port == metrics_port:
+        logger.error('port and metrics-port cannot be the same, exiting.')
+        raise ValueError('port and metrics-port cannot be the same')
+
+
 # TODO(zhwu): Streaming requests, such log tailing after sky launch or sky logs,
 # need to be detached from the main requests queue. Otherwise, the streaming
 # response will block other requests from being processed.
@@ -3985,11 +4014,11 @@ if __name__ == '__main__':
     parser.add_argument('--deploy', action='store_true')
     # Serve metrics on a separate port to isolate it from the application APIs:
     # metrics port will not be exposed to the public network typically.
-    parser.add_argument('--metrics-port', default=9090, type=int)
+    parser.add_argument('--metrics-port',
+                        default=_get_metrics_port_from_env(),
+                        type=int)
     cmd_args = parser.parse_args()
-    if cmd_args.port == cmd_args.metrics_port:
-        logger.error('port and metrics-port cannot be the same, exiting.')
-        raise ValueError('port and metrics-port cannot be the same')
+    _validate_api_server_ports(cmd_args.port, cmd_args.metrics_port)
 
     # Fail fast if the port is not available to avoid corrupt the state
     # of potential running server instance.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -696,6 +696,8 @@ SERVE_OVERRIDE_CONCURRENT_LAUNCHES = (
 
 # Environment variable that is set to 'true' if metrics are enabled.
 ENV_VAR_SERVER_METRICS_ENABLED = 'SKY_API_SERVER_METRICS_ENABLED'
+# Environment variable that configures the API server metrics port.
+ENV_VAR_SERVER_METRICS_PORT = 'SKY_API_SERVER_METRICS_PORT'
 
 # If set, overrides the header that we can use to get the user name.
 ENV_VAR_SERVER_AUTH_USER_HEADER = f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_USER_HEADER'

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -23,6 +23,36 @@ from sky.utils import common_utils
 from sky.utils import config_utils
 
 
+def test_metrics_port_defaults_to_9090(monkeypatch):
+    """Use the historical metrics port when no environment override is set."""
+    monkeypatch.delenv(constants.ENV_VAR_SERVER_METRICS_PORT, raising=False)
+
+    assert server._get_metrics_port_from_env() == 9090
+
+
+def test_metrics_port_reads_environment_override(monkeypatch):
+    """Read a valid environment override so Helm can configure older CLI images."""
+    monkeypatch.setenv(constants.ENV_VAR_SERVER_METRICS_PORT, '9190')
+
+    assert server._get_metrics_port_from_env() == 9190
+
+
+def test_metrics_port_rejects_api_port_collision():
+    """Keep the API and metrics listeners on separate ports."""
+    with pytest.raises(
+            ValueError, match='port and metrics-port cannot be the same'):
+        server._validate_api_server_ports(46580, 46580)
+
+
+@pytest.mark.parametrize('value', ['not-a-port', '0', '65536'])
+def test_metrics_port_rejects_invalid_environment_values(monkeypatch, value):
+    """Reject malformed or out-of-range metrics ports before server startup."""
+    monkeypatch.setenv(constants.ENV_VAR_SERVER_METRICS_PORT, value)
+
+    with pytest.raises(ValueError, match=constants.ENV_VAR_SERVER_METRICS_PORT):
+        server._get_metrics_port_from_env()
+
+
 @mock.patch('uvicorn.run')
 @mock.patch('sky.server.requests.executor.start')
 @mock.patch('sky.utils.common_utils.get_cpu_count')

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -39,8 +39,8 @@ def test_metrics_port_reads_environment_override(monkeypatch):
 
 def test_metrics_port_rejects_api_port_collision():
     """Keep the API and metrics listeners on separate ports."""
-    with pytest.raises(
-            ValueError, match='port and metrics-port cannot be the same'):
+    with pytest.raises(ValueError,
+                       match='port and metrics-port cannot be the same'):
         server._validate_api_server_ports(46580, 46580)
 
 


### PR DESCRIPTION
## Summary

- Move standard `prometheus.io/*` discovery annotations to the API Service and add the stable `app` Service label used by the dashboard.
- Configure the API metrics listener through `SKY_API_SERVER_METRICS_PORT` instead of rendering the unsupported `--metrics-port` CLI flag.
- Keep standard Pod annotations disabled by default to avoid duplicate discovery; preserve them only when `prometheus.preservePodScrapeAnnotations: true` is explicitly set.
- Preserve dedicated `skypilot.co/*` Pod scrape mode.
- Add stable `pod` and Service-DNS `instance` labels to the bundled GPU and endpoint metrics jobs.
- Update the dashboard replica variable to use `kube_pod_info` after Service-based discovery.

## Why

The API server already exported `/metrics`, but the chart was not compatible with all deployed API images. The chart rendered `--metrics-port`, which is not accepted by images whose `sky api start` command exposes only `--port`; this caused the API container to exit before serving metrics. The fix keeps the internal explicit CLI override for SDK/server callers, while Helm uses an environment variable so images can consume the configured port without requiring a new CLI option.

Moving discovery to the stable Service hardens the chart for VictoriaMetrics, Prometheus, and other manually deployed service-endpoint scrapers outside the optional SkyPilot Prometheus dependency. The Service declares the named `metrics` port and carries the configured port annotation, while the API container receives the same port through its environment.

The chart no longer emits standard `prometheus.io/*` annotations on the API Pod by default. This prevents duplicate targets when an external agent has both Service- and Pod-based discovery jobs. `prometheus.preservePodScrapeAnnotations: true` is an explicit compatibility escape hatch for a legacy Pod scraper. Dedicated mode remains Pod-only through `skypilot.co/*` annotations.

## Devin findings addressed

- Unsupported `--metrics-port`: replaced the Helm-rendered flag with `SKY_API_SERVER_METRICS_PORT`, with validation, default `9090`, and API/metrics port collision protection.
- Dashboard `app`/`pod` selectors: added the Service `app` label and switched replica selection to `kube_pod_info`.
- GPU/endpoint job `instance` churn: stable labels now use the Service DNS identity and endpoint metadata while retaining the endpoint target address.
- External Pod-scraper regression: standard Pod annotations are now opt-in through `preservePodScrapeAnnotations`, avoiding duplicate discovery by default.
- The annotation target overlap noted for the regular `/metrics` job remains an intentional compatibility policy; no additional metrics-only Service was introduced.

## Testing

- `helm lint charts/skypilot`
- `helm unittest charts/skypilot` — 161 tests passed
- Helm values schema comparison — no schema diff
- Focused Python metrics-port tests in the SkyPilot test container — 6 passed
- Rendered and inspected Service-only, explicit Pod-preservation, dedicated, and custom-port manifests
- `python3 -m json.tool charts/skypilot/manifests/api-server-overview.json`
- `git diff --check`

## Manual downstream verification

After consuming this chart in a deployment with an external VictoriaMetrics Agent or Prometheus:

```bash
kubectl -n <namespace> get service <release>-api-service -o yaml
kubectl -n <namespace> get pod -l app=<release>-api -o yaml
kubectl -n <namespace> port-forward service/<release>-api-service 9190:9190
curl -fsS http://127.0.0.1:9190/metrics | head
```

Verify that the Service has the `prometheus.io/*` annotations, the API container declares the configured named `metrics` port, the Pod has no standard annotations by default, and the external scraper target is `up` with no scrape error. For a non-default port, use an API image that understands `SKY_API_SERVER_METRICS_PORT`; images that retain the historical default continue to work with port `9090`.

No deployment or production change is included in this PR.
