### PR TITLE
[API] Validate the role a service account may be granted

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -397,11 +397,15 @@ class PermissionService:
             self.invalidate_user_permission_cache(user_id)
 
     def get_user_roles(self, user_id: str) -> List[str]:
-        """Get all roles for a user.
+        """Get the roles directly assigned to a user.
 
-        This method returns all roles that the user has, including inherited
-        roles. For example, if a user has role 'admin' and 'admin' inherits
-        from 'user', this method will return ['admin', 'user'].
+        Roles do not inherit from one another: the only grouping policies
+        this module ever writes are `(user_id, role)`, never `(role, role)`,
+        and `get_roles_for_user` does not expand transitively anyway (that
+        would be `get_implicit_roles_for_user`). Every user therefore has
+        exactly zero or one role in practice, since `update_role` replaces
+        rather than adds. Callers deciding *authorization* should not treat a
+        second role as additive — see `sky.users.server._caller_is_admin`.
 
         Args:
             user: The user ID to get roles for.

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -338,11 +338,13 @@ class PermissionService:
         if policy_updated:
             enforcer.save_policy()
 
-    def add_user_if_not_exists(self, user_id: str) -> None:
-        """Add user role relationship."""
+    def add_user_if_not_exists(self,
+                               user_id: str,
+                               role: Optional[str] = None) -> None:
+        """Add user role relationship. `role` overrides the default role."""
         self._lazy_initialize()
         with _policy_lock():
-            self._add_user_if_not_exists_no_lock(user_id)
+            self._add_user_if_not_exists_no_lock(user_id, role)
 
     def _add_user_if_not_exists_no_lock(self,
                                         user_id: str,
@@ -939,13 +941,13 @@ def _policy_lock() -> Generator[None, None, None]:
 permission_service = PermissionService()
 
 
-def seed_new_user_role(user_id: str) -> None:
+def seed_new_user_role(user_id: str, role: Optional[str] = None) -> None:
     """Reload config, then set up policies for a newly-created user.
 
-    Assigns the default role and grants any private-workspace access that
-    the config's `allowed_users` lists owe this user (see
-    `resync_workspace_policies_for_new_user` for why this can only happen
-    once the user record exists).
+    Assigns `role` (the default role when omitted) and grants any
+    private-workspace access that the config's `allowed_users` lists owe this
+    user (see `resync_workspace_policies_for_new_user` for why this can only
+    happen once the user record exists).
 
     Refreshes the in-memory config first so a runtime change to
     `rbac.default_role` or `workspaces` is honored without a server restart:
@@ -957,7 +959,7 @@ def seed_new_user_role(user_id: str) -> None:
     via `asyncio.to_thread` so it does not block the event loop.
     """
     skypilot_config.safe_reload_config()
-    permission_service.add_user_if_not_exists(user_id)
+    permission_service.add_user_if_not_exists(user_id, role)
     try:
         permission_service.resync_workspace_policies_for_new_user(user_id)
     except Exception as e:  # pylint: disable=broad-except

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -395,8 +395,29 @@ class RoleName(str, enum.Enum):
     VIEWER = 'viewer'
 
 
+# Roles from most to least privileged. Consulted wherever a decision has to be
+# made about a principal holding more than one role: take the least privileged,
+# never whichever came first -- `get_user_roles` does not order its result
+# deterministically, so the first entry is a coin flip.
+_ROLE_PRECEDENCE = (RoleName.ADMIN.value, RoleName.USER.value,
+                    RoleName.VIEWER.value)
+
+
 def get_supported_roles() -> List[str]:
     return [role_name.value for role_name in RoleName]
+
+
+def least_privileged_role(roles: List[str]) -> str:
+    """The least privileged of `roles`, ignoring names we do not know.
+
+    An unrecognized name must never win: it has no policy attached, which the
+    blocklist reads as allow-everything. With nothing recognizable left, falls
+    back to the most restricted role.
+    """
+    known = [role for role in roles if role in _ROLE_PRECEDENCE]
+    if not known:
+        return _ROLE_PRECEDENCE[-1]
+    return max(known, key=_ROLE_PRECEDENCE.index)
 
 
 def get_default_role() -> str:

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -50,11 +50,11 @@ router = fastapi.APIRouter()
 def _is_admin(roles: List[str]) -> bool:
     """Whether a role list means admin, i.e. `admin` is the only role.
 
-    Holding a second, more restricted role alongside `admin` is not reachable
-    through any normal path (`update_role` replaces rather than adds), and a
-    leftover one must not be trusted by an authorization gate: the blocklist
-    in `check_endpoint_permission` matches on *any* of the caller's roles, so
-    such a caller is still denied the admin-only endpoints.
+    Deliberately stricter than the `admin in roles` reads elsewhere, which
+    answer "does the viewer allowlist apply" rather than gating a grant. A
+    leftover role beside `admin` is unreachable (`update_role` replaces), and
+    `check_endpoint_permission` matches the blocklist against *any* of the
+    caller's roles, so it would still deny such a caller the admin endpoints.
     """
     return roles == [rbac.RoleName.ADMIN.value]
 

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -83,6 +83,28 @@ def _check_role_grantable(role: str, caller_user_id: str) -> None:
             status_code=403, detail='Only admins can grant the admin role.')
 
 
+def _clamped_default_role(caller_user_id: str) -> str:
+    """The default role to seed a service account with, capped at the caller's.
+
+    `rbac.default_role` falls back to `admin`, so an operator who leaves it
+    unset while demoting individual people to `user` would otherwise hand a
+    non-admin an admin-scoped token just by omitting `role` -- the same
+    escalation `_check_role_grantable` blocks on the explicit path. A service
+    account must not out-rank the identity that created it.
+
+    Assumes the config was reloaded by the caller.
+    """
+    default_role = rbac.get_default_role()
+    if default_role != rbac.RoleName.ADMIN.value:
+        return default_role
+    caller_roles = permission.permission_service.get_user_roles(caller_user_id)
+    if _is_admin(caller_roles):
+        return default_role
+    # Fall back to the least privilege we can name if the caller somehow holds
+    # no role: an unrecognized or absent role matches no blocklist policy.
+    return caller_roles[0] if caller_roles else rbac.RoleName.USER.value
+
+
 def get_user_type(user: models.User) -> str:
     """Get user type for a user for backward compatibility.
 
@@ -881,9 +903,17 @@ def create_service_account_token(
             status_code=400,
             detail='Expiration days must be positive or 0 for never expire')
 
-    # Validate the optional role up front so we fail before creating anything.
-    if token_body.role is not None:
-        _check_role_grantable(token_body.role, auth_user.id)
+    # Resolve the account's role up front, so we fail before creating anything
+    # and can seed the right role in one write. Refresh the config first for
+    # the same reason `seed_new_user_role` does: this handler runs in the main
+    # API-server process, which has no per-request config reload, so a runtime
+    # `rbac.default_role` change would otherwise be missed.
+    skypilot_config.safe_reload_config()
+    seed_role = token_body.role
+    if seed_role is not None:
+        _check_role_grantable(seed_role, auth_user.id)
+    else:
+        seed_role = _clamped_default_role(auth_user.id)
 
     try:
         # Generate a unique service account user ID
@@ -903,17 +933,9 @@ def create_service_account_token(
                 f'already exists ({service_account_user_id}). '
                 'Please use a different name.')
 
-        # Add the service account to the permission system with the default
-        # role. This handler runs in the main API-server process (no per-request
-        # config reload), so seed via the helper that refreshes config first —
-        # an admin's runtime `rbac.default_role` change then applies without a
-        # server restart.
-        permission.seed_new_user_role(service_account_user_id)
-        # If a role was requested, apply it now so the token is created with the
-        # intended role atomically (no separate update-role round trip).
-        if token_body.role is not None:
-            permission.permission_service.update_role(service_account_user_id,
-                                                      token_body.role)
+        # Seed the resolved role directly, so the account is never briefly
+        # more privileged than it ends up.
+        permission.seed_new_user_role(service_account_user_id, role=seed_role)
 
         # Handle expiration: 0 means "never expire"
         expires_in_days = token_body.expires_in_days

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -47,6 +47,42 @@ _INTERNAL_USER_IDS = (
 router = fastapi.APIRouter()
 
 
+def _is_admin(roles: List[str]) -> bool:
+    """Whether a role list means admin, i.e. `admin` is the only role.
+
+    Holding a second, more restricted role alongside `admin` is not reachable
+    through any normal path (`update_role` replaces rather than adds), and a
+    leftover one must not be trusted by an authorization gate: the blocklist
+    in `check_endpoint_permission` matches on *any* of the caller's roles, so
+    such a caller is still denied the admin-only endpoints.
+    """
+    return roles == [rbac.RoleName.ADMIN.value]
+
+
+def _caller_is_admin(user_id: str) -> bool:
+    """`_is_admin` for a caller whose roles have not been fetched yet."""
+    return _is_admin(permission.permission_service.get_user_roles(user_id))
+
+
+def _check_role_grantable(role: str, caller_user_id: str) -> None:
+    """Reject a role the caller may not grant, before anything is written.
+
+    An unrecognized role name must be rejected rather than passed through:
+    it has no Casbin policy at all, and the blocklist reads "no matching
+    policy" as allow, so such a role grants *more* than `user`, not less.
+    """
+    supported_roles = rbac.get_supported_roles()
+    if role not in supported_roles:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid role {role!r}. Supported roles: '
+            f'{", ".join(supported_roles)}.')
+    if (role == rbac.RoleName.ADMIN.value and
+            not _caller_is_admin(caller_user_id)):
+        raise fastapi.HTTPException(
+            status_code=403, detail='Only admins can grant the admin role.')
+
+
 def get_user_type(user: models.User) -> str:
     """Get user type for a user for backward compatibility.
 
@@ -370,7 +406,7 @@ def user_update(request: fastapi.Request,
             current_user.id)
         if not current_user_roles:
             raise fastapi.HTTPException(status_code=403, detail='Invalid user')
-        if current_user_roles[0] != rbac.RoleName.ADMIN.value:
+        if not _is_admin(current_user_roles):
             if need_update_role:
                 raise fastapi.HTTPException(
                     status_code=403, detail='Only admin can update user role')
@@ -446,7 +482,7 @@ def user_batch_update(request: fastapi.Request,
             current_user.id)
         if not current_user_roles:
             raise fastapi.HTTPException(status_code=403, detail='Invalid user')
-        if current_user_roles[0] != rbac.RoleName.ADMIN.value:
+        if not _is_admin(current_user_roles):
             raise fastapi.HTTPException(
                 status_code=403, detail='Only admin can update user roles')
 
@@ -847,21 +883,7 @@ def create_service_account_token(
 
     # Validate the optional role up front so we fail before creating anything.
     if token_body.role is not None:
-        if token_body.role not in rbac.get_supported_roles():
-            raise fastapi.HTTPException(
-                status_code=400,
-                detail=f'Invalid role {token_body.role!r}. Supported roles: '
-                f'{", ".join(rbac.get_supported_roles())}.')
-        # Only admins may create an admin-role service account; otherwise a
-        # non-admin could escalate by minting an admin-scoped token.
-        if token_body.role == rbac.RoleName.ADMIN.value:
-            caller_roles = permission.permission_service.get_user_roles(
-                auth_user.id)
-            if not caller_roles or caller_roles[0] != rbac.RoleName.ADMIN.value:
-                raise fastapi.HTTPException(
-                    status_code=403,
-                    detail='Only admins can create a service account with the '
-                    'admin role.')
+        _check_role_grantable(token_body.role, auth_user.id)
 
     try:
         # Generate a unique service account user ID
@@ -1034,13 +1056,10 @@ def update_service_account_role(
             'Only admins can update roles for service accounts owned by other '
             'users.')
 
-    # Only admin can grant the admin role (mirrors user_update guard).
-    if role_body.role == rbac.RoleName.ADMIN.value:
-        caller_roles = permission.permission_service.get_user_roles(
-            auth_user.id)
-        if rbac.RoleName.ADMIN.value not in caller_roles:
-            raise fastapi.HTTPException(
-                status_code=403, detail='Only admin can grant the admin role.')
+    # Owning a service account does not entitle the caller to raise its role
+    # above their own. Kept outside the try below so the 400/403 is not
+    # swallowed into a 500 by the broad handler.
+    _check_role_grantable(role_body.role, auth_user.id)
 
     try:
         # Update service account role

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -100,9 +100,12 @@ def _clamped_default_role(caller_user_id: str) -> str:
     caller_roles = permission.permission_service.get_user_roles(caller_user_id)
     if _is_admin(caller_roles):
         return default_role
-    # Fall back to the least privilege we can name if the caller somehow holds
-    # no role: an unrecognized or absent role matches no blocklist policy.
-    return caller_roles[0] if caller_roles else rbac.RoleName.USER.value
+    if not caller_roles:
+        logger.warning(f'User {caller_user_id} holds no role; seeding their '
+                       f'service account with the most restricted role.')
+    # A caller can hold more than one role, and the order they come back in is
+    # not stable, so cap at the least privileged rather than the first.
+    return rbac.least_privileged_role(caller_roles)
 
 
 def get_user_type(user: models.User) -> str:

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -1583,16 +1583,22 @@ class TestSeedNewUserRole:
         calls = []
         monkeypatch.setattr(permission.skypilot_config, 'safe_reload_config',
                             lambda: calls.append('reload'))
-        monkeypatch.setattr(permission.permission_service,
-                            'add_user_if_not_exists',
-                            lambda user_id: calls.append(f'add:{user_id}'))
+        monkeypatch.setattr(
+            permission.permission_service,
+            'add_user_if_not_exists',
+            lambda user_id, role=None: calls.append(f'add:{user_id}:{role}'))
         monkeypatch.setattr(permission.permission_service,
                             'resync_workspace_policies_for_new_user',
                             lambda user_id: calls.append(f'resync:{user_id}'))
 
         permission.seed_new_user_role('u1')
 
-        assert calls == ['reload', 'add:u1', 'resync:u1']
+        assert calls == ['reload', 'add:u1:None', 'resync:u1']
+
+        # An explicit role overrides the default and is forwarded as-is.
+        calls.clear()
+        permission.seed_new_user_role('u2', role='viewer')
+        assert calls == ['reload', 'add:u2:viewer', 'resync:u2']
 
     def test_resync_failure_does_not_fail_seed(self, monkeypatch):
         # A transient re-sync failure (lock timeout, DB error) must not fail
@@ -1602,9 +1608,10 @@ class TestSeedNewUserRole:
         calls = []
         monkeypatch.setattr(permission.skypilot_config, 'safe_reload_config',
                             lambda: calls.append('reload'))
-        monkeypatch.setattr(permission.permission_service,
-                            'add_user_if_not_exists',
-                            lambda user_id: calls.append(f'add:{user_id}'))
+        monkeypatch.setattr(
+            permission.permission_service,
+            'add_user_if_not_exists',
+            lambda user_id, role=None: calls.append(f'add:{user_id}:{role}'))
 
         def _boom(user_id):
             raise RuntimeError('lock timeout')
@@ -1614,7 +1621,7 @@ class TestSeedNewUserRole:
 
         permission.seed_new_user_role('u1')  # Must not raise.
 
-        assert calls == ['reload', 'add:u1']
+        assert calls == ['reload', 'add:u1:None']
 
 
 @pytest.mark.usefixtures("cleanup_env_vars")

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -197,9 +197,19 @@ class TestDefaultRoleClamp:
             _fake_request(user_id='caller'), body)
         return mock_perm.seed_new_user_role.call_args.kwargs['role']
 
-    @pytest.mark.parametrize('caller_roles,expected',
-                             [(['user'], 'user'), (['viewer'], 'viewer'),
-                              ([], 'user'), (['user', 'admin'], 'user')])
+    # The multi-role cases are the point: `get_user_roles` does not order its
+    # result deterministically, so both orderings must land on `user`, and an
+    # unrecognized name must not be mistaken for a low-privilege one.
+    @pytest.mark.parametrize('caller_roles,expected', [
+        (['user'], 'user'),
+        (['viewer'], 'viewer'),
+        ([], 'viewer'),
+        (['user', 'admin'], 'user'),
+        (['admin', 'user'], 'user'),
+        (['viewer', 'admin'], 'viewer'),
+        (['admin', 'bogus'], 'admin'),
+        (['bogus'], 'viewer'),
+    ])
     @mock.patch('sky.users.rbac.get_default_role', return_value='admin')
     @mock.patch('sky.users.server.global_user_state')
     @mock.patch('sky.users.server.token_service')

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -128,8 +128,7 @@ class TestCreateServiceAccountTokenRole:
         result = users_server.create_service_account_token(
             _fake_request(user_id='regular-user'), body)
         assert result['token'] == 'sky_x'
-        assert mock_perm.permission_service.update_role.call_args[0][
-            1] == 'user'
+        assert mock_perm.seed_new_user_role.call_args.kwargs['role'] == 'user'
 
     @mock.patch('sky.users.server.global_user_state')
     @mock.patch('sky.users.server.token_service')
@@ -150,17 +149,18 @@ class TestCreateServiceAccountTokenRole:
         result = users_server.create_service_account_token(
             _fake_request(), body)
         assert result['token'] == 'sky_x'
-        mock_perm.permission_service.update_role.assert_called_once()
-        assert mock_perm.permission_service.update_role.call_args[0][
-            1] == 'admin'
+        mock_perm.seed_new_user_role.assert_called_once()
+        assert mock_perm.seed_new_user_role.call_args.kwargs['role'] == 'admin'
 
+    @mock.patch('sky.users.rbac.get_default_role', return_value='user')
     @mock.patch('sky.users.server.global_user_state')
     @mock.patch('sky.users.server.token_service')
     @mock.patch('sky.users.server.permission')
-    def test_no_role_keeps_default_seed(self, mock_perm, mock_token_service,
-                                        mock_gus):
-        """Without a role, only the default seed runs (no update_role)."""
+    def test_no_role_uses_default(self, mock_perm, mock_token_service, mock_gus,
+                                  _mock_default):
+        """Without a role, the account is seeded with the configured default."""
         mock_gus.add_or_update_user.return_value = True
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
         mock_token_service.token_service.create_token.return_value = {
             'token_id': 'tid',
             'token_hash': 'h',
@@ -170,8 +170,56 @@ class TestCreateServiceAccountTokenRole:
         body = payloads.ServiceAccountTokenCreateBody(token_name='sa_default',
                                                       expires_in_days=0)
         users_server.create_service_account_token(_fake_request(), body)
-        mock_perm.seed_new_user_role.assert_called_once()
-        mock_perm.permission_service.update_role.assert_not_called()
+        assert mock_perm.seed_new_user_role.call_args.kwargs['role'] == 'user'
+
+
+class TestDefaultRoleClamp:
+    """`rbac.default_role` falls back to admin; an SA can't out-rank its creator.
+
+    Reachable whenever an operator leaves `rbac.default_role` unset and demotes
+    individual people -- omitting `role` would otherwise hand a non-admin an
+    admin-scoped token.
+    """
+
+    @staticmethod
+    def _create_as(mock_perm, mock_token_service, mock_gus, caller_roles):
+        mock_gus.add_or_update_user.return_value = True
+        mock_perm.permission_service.get_user_roles.return_value = caller_roles
+        mock_token_service.token_service.create_token.return_value = {
+            'token_id': 'tid',
+            'token_hash': 'h',
+            'token': 'sky_x',
+            'expires_at': None,
+        }
+        body = payloads.ServiceAccountTokenCreateBody(token_name='sa_clamp',
+                                                      expires_in_days=0)
+        users_server.create_service_account_token(
+            _fake_request(user_id='caller'), body)
+        return mock_perm.seed_new_user_role.call_args.kwargs['role']
+
+    @pytest.mark.parametrize('caller_roles,expected',
+                             [(['user'], 'user'), (['viewer'], 'viewer'),
+                              ([], 'user'), (['user', 'admin'], 'user')])
+    @mock.patch('sky.users.rbac.get_default_role', return_value='admin')
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.token_service')
+    @mock.patch('sky.users.server.permission')
+    def test_non_admin_creator_clamps_admin_default(self, mock_perm,
+                                                    mock_token_service,
+                                                    mock_gus, _mock_default,
+                                                    caller_roles, expected):
+        assert self._create_as(mock_perm, mock_token_service, mock_gus,
+                               caller_roles) == expected
+
+    @mock.patch('sky.users.rbac.get_default_role', return_value='admin')
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.token_service')
+    @mock.patch('sky.users.server.permission')
+    def test_admin_creator_keeps_admin_default(self, mock_perm,
+                                               mock_token_service, mock_gus,
+                                               _mock_default):
+        assert self._create_as(mock_perm, mock_token_service, mock_gus,
+                               ['admin']) == 'admin'
 
 
 def _update_role_body(role):

--- a/tests/unit_tests/test_sky/users/test_service_account_tokens.py
+++ b/tests/unit_tests/test_sky/users/test_service_account_tokens.py
@@ -172,3 +172,88 @@ class TestCreateServiceAccountTokenRole:
         users_server.create_service_account_token(_fake_request(), body)
         mock_perm.seed_new_user_role.assert_called_once()
         mock_perm.permission_service.update_role.assert_not_called()
+
+
+def _update_role_body(role):
+    return payloads.ServiceAccountTokenUpdateRoleBody(token_id='tid', role=role)
+
+
+def _token_info(creator='regular-user'):
+    return {
+        'creator_user_hash': creator,
+        'service_account_user_id': 'sa-1234',
+    }
+
+
+class TestUpdateServiceAccountRole:
+    """Owning a service account does not entitle raising its role."""
+
+    # 'Admin' and '' are the same escalation as 'bogus': an unrecognized role
+    # has no Casbin policy, and the blocklist reads that as allow-everything.
+    @pytest.mark.parametrize('role', ['bogus', 'Admin', ''])
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.permission')
+    def test_unsupported_role_rejected(self, mock_perm, mock_gus, role):
+        mock_gus.get_service_account_token.return_value = _token_info()
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
+        with pytest.raises(fastapi.HTTPException) as exc:
+            users_server.update_service_account_role(
+                _fake_request(user_id='regular-user'), _update_role_body(role))
+        assert exc.value.status_code == 400
+        assert 'Invalid role' in exc.value.detail
+        mock_perm.permission_service.update_role.assert_not_called()
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.permission')
+    def test_non_admin_cannot_grant_admin(self, mock_perm, mock_gus):
+        mock_gus.get_service_account_token.return_value = _token_info()
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
+        with pytest.raises(fastapi.HTTPException) as exc:
+            users_server.update_service_account_role(
+                _fake_request(user_id='regular-user'),
+                _update_role_body('admin'))
+        assert exc.value.status_code == 403
+        assert 'Only admins' in exc.value.detail
+        mock_perm.permission_service.update_role.assert_not_called()
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.permission')
+    def test_residual_admin_role_does_not_grant(self, mock_perm, mock_gus):
+        """A leftover `admin` next to a restricted role is not admin.
+
+        `check_endpoint_permission` still applies the `user` blocklist to such
+        a caller, so treating them as admin here would be an escalation.
+        """
+        mock_gus.get_service_account_token.return_value = _token_info()
+        mock_perm.permission_service.get_user_roles.return_value = [
+            'user', 'admin'
+        ]
+        with pytest.raises(fastapi.HTTPException) as exc:
+            users_server.update_service_account_role(
+                _fake_request(user_id='regular-user'),
+                _update_role_body('admin'))
+        assert exc.value.status_code == 403
+        mock_perm.permission_service.update_role.assert_not_called()
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.permission')
+    def test_non_admin_can_grant_non_admin(self, mock_perm, mock_gus):
+        mock_gus.get_service_account_token.return_value = _token_info()
+        mock_perm.permission_service.get_user_roles.return_value = ['user']
+        result = users_server.update_service_account_role(
+            _fake_request(user_id='regular-user'), _update_role_body('viewer'))
+        assert result['new_role'] == 'viewer'
+        assert mock_perm.permission_service.update_role.call_args[0] == (
+            'sa-1234', 'viewer')
+
+    @mock.patch('sky.users.server.global_user_state')
+    @mock.patch('sky.users.server.permission')
+    def test_admin_can_grant_admin(self, mock_perm, mock_gus):
+        mock_gus.get_service_account_token.return_value = _token_info(
+            creator='admin-user')
+        mock_perm.permission_service.get_user_roles.return_value = ['admin']
+        result = users_server.update_service_account_role(
+            _fake_request(), _update_role_body('admin'))
+        assert result['new_role'] == 'admin'
+        assert mock_perm.permission_service.update_role.call_args[0] == (
+            'sa-1234', 'admin')


### PR DESCRIPTION
## Problem

Follow-up to #9932, which closed the `role == 'admin'` case on
`POST /users/service-account-tokens/update-role` but left the endpoint passing
`role` straight through to `update_role()` without validating it. **The same
escalation still works under a different string.**

Endpoint permissions are a Casbin **blocklist** — `sky/users/model.conf` uses
`e = some(where (p.eft == allow))`, and the only `p` rules are the deny entries
attached to the `user` role. A principal whose role matches no policy is
therefore blocked on *nothing*. An unrecognized role is an escalation, not a
downgrade:

```
enforce('alice',   '/users/create', 'POST')  -> True   (g, alice, user)     blocked
enforce('mallory', '/users/create', 'POST')  -> False  (g, mallory, pwned)  allowed
```

So a plain `user`-role caller could still:

1. create a service account (allowed for any authenticated user),
2. `update-role` it to `pwned` — not `'admin'`, so the #9932 guard never fires,
3. use that token against `/users/create` — which has **no** in-handler admin
   check, relying entirely on the blocklist — to mint a real admin user.

Reproduced end to end on a local server with auth enforced and
`rbac.default_role: user`; see the test plan.

`'Admin'` and `''` are the same bug.

## Fix

**`sky/users/server.py`**

- `_check_role_grantable(role, caller_user_id)` — rejects any role outside
  `rbac.get_supported_roles()` (400) before the admin gate (403). The create
  path already did exactly this, so both endpoints now share one gate instead
  of two copies that drifted.
- `_is_admin(roles)` / `_caller_is_admin(user_id)` — one definition of "the
  caller is an admin": `admin` is the caller's only role. A leftover second
  role must not be trusted by an authorization gate, because
  `check_endpoint_permission` matches the blocklist against *any* of the
  caller's roles and would still deny such a caller the admin-only endpoints.
  Treating them as admin here would re-open the same class of hole.
- `user_update` and `user_batch_update` move onto `_is_admin` as well, so all
  four caller checks agree. The remaining `roles[0]` reads are the *target*
  user's role in the demotion checks, which is a different question and is
  left alone.

**`sky/users/permission.py`** — `get_user_roles`'s docstring claimed it returns
inherited roles (`admin` inherits `user`). It does not: the only grouping
policies written anywhere are `(user_id, role)`, never `(role, role)`, and
`get_roles_for_user` is not transitive. Corrected, since that claim is what
makes `'admin' in roles` look correct.

### Not done deliberately

#9932's description also proposed adding the endpoint to
`_DEFAULT_USER_BLOCKLIST` as defense in depth (it is not in the merged diff).
That would break a supported operation: a non-admin managing the role of a
service account **they own** — which the ownership check and the create path
both permit. Covered by case A6 below.

## Test plan

### Unit

```bash
pytest tests/unit_tests/test_sky/users/test_service_account_tokens.py
# 18 passed
```

7 new cases. Revert-check — with `update_service_account_role` restored to the
state merged in #9932, 5 of them fail:

```
FAILED TestUpdateServiceAccountRole::test_unsupported_role_rejected[bogus]
FAILED TestUpdateServiceAccountRole::test_unsupported_role_rejected[Admin]
FAILED TestUpdateServiceAccountRole::test_unsupported_role_rejected[]
FAILED TestUpdateServiceAccountRole::test_non_admin_cannot_grant_admin
FAILED TestUpdateServiceAccountRole::test_residual_admin_role_does_not_grant
```

### Manual, against a local API server with auth enforced

`rbac.default_role: user`; two accounts, one `admin` and one `user`.
Preconditions confirmed the `user` blocklist is live (`GET /users/export` →
403 for the non-admin, 200 for the admin). 21/21 assertions pass:

| # | scenario | result |
| --- | --- | --- |
| A1 | non-admin creates SA, no role → seeded default | 200 `roles:["user"]` |
| A2 | non-admin sets own SA role `pwned` | 400 Invalid role |
| A3 | non-admin sets own SA role `Admin` | 400 Invalid role |
| A4 | non-admin sets own SA role `""` | 400 Invalid role |
| A5 | non-admin sets own SA role `admin` | 403 Only admins |
| A6 | non-admin sets own SA role `viewer` | 200 — self-service still works |
| A7 | admin sets that SA role `admin` | 200 |
| B1 | non-admin creates SA with role `bogus` | 400 Invalid role |
| B2 | non-admin creates SA with role `admin` | 403 Only admins |
| B3 | non-admin creates SA with role `viewer` | 200 |
| B4 | admin creates SA with role `admin` | 200 |
| C1 | non-admin changes own role to admin | 403 Only admin can update user role |
| C2 | non-admin sets another user's password | 403 Only admin can update password for other users |
| C3 | non-admin sets own password | 200 |
| C4 | admin changes a user's role | 200 |
| C5 | non-admin `POST /users/batch_update` | 403 (blocklist) |
| C6 | admin `POST /users/batch_update` | 200 |

### Manual, escalation chain with the fix reverted

Guard restored to the merged state, server restarted, chain run, then the fix
restored and the chain re-run:

| step | as merged (#9932) | with this PR |
| --- | --- | --- |
| non-admin creates SA | 200 | 200 |
| `update-role` → `pwned` | **200 `new_role: pwned`** | **400 Invalid role** |
| SA token → `GET /users/export` | **200** | 403 |
| SA token → `POST /users/create` `role=admin` | **200** | 403 |

On the merged code the created user was real — a new user row with the Casbin
grant `(<id>, 'admin')`, and the service account carrying `(<sa>, 'pwned')`, a
role no policy matches. Full escalation from `user` to `admin`. Both removed
afterwards.

---

## Second door: the default-seeded role (added in 0ff3e74)

Blocking an explicit `role='admin'` was not enough. Omitting `role` seeds via
`seed_new_user_role` → `rbac.get_default_role()`, whose **fallback is `admin`**.
An operator who leaves `rbac.default_role` unset while demoting individual
people to `user` hands any of them an admin-scoped token for the asking.

Reproduced on the same harness with `rbac.default_role` unset, as a `user`:

| step | before 0ff3e74 | after |
| --- | --- | --- |
| explicit `role=admin` | 403 | 403 |
| **no role at all** | **seeded `["admin"]`** | seeded `["user"]` |
| that token → `GET /users/export` | **200** | 403 |
| that token → `POST /users/create` `role=admin` | **200** | 403 |
| admin creator, no role | `["admin"]` | `["admin"]` (unchanged) |

The fix resolves the role once, before anything is created, and caps the
default at the caller's own role — a service account must not out-rank the
identity that created it. `seed_new_user_role` takes an optional role so the
resolved value lands in a single policy write; the two other callers (first
login, OAuth) pass nothing and keep seeding the default, which is the intended
behavior for a human user. This also removes the seed-then-update pair on the
explicit-role path, so an account is never briefly more privileged than it ends
up.

Covered by `TestDefaultRoleClamp` (caller roles `user` / `viewer` / none /
`['user','admin']`, plus the admin-creator case) and a forwarding assertion in
`test_permission.py`. `tests/unit_tests/test_sky/users/`: 234 passed.

The manual suite grew a `D` section for this and now runs against **both**
`rbac.default_role` settings, since the clamp is a no-op when the default is
already non-admin — one config proves nothing:

| # | scenario | `default_role: user` | `default_role` unset |
| --- | --- | --- | --- |
| D1 | non-admin, no role -> seeded role | `user` | `user` (clamped from `admin`) |
| D2 | that token -> `GET /users/export` | 403 | 403 |
| D3 | that token -> `POST /users/create` `role=admin` | 403 | 403 |
| D4 | **admin** creator, no role -> seeded role | `user` | `admin` (unclamped) |

25 assertions pass on each. Revert-check, with `_clamped_default_role` replaced
by a bare `rbac.get_default_role()`: 25 pass under `default_role: user` (the
clamp is inert there), while `default_role` unset turns **A1, D1, D2 and D3**
red — seeded `admin`, `/users/export` 200, and `/users/create` 200 creating a
real admin user.

`rbac.default_role`'s own fallback is left alone — flipping it to `user` would
change behavior for every deployment that never configured RBAC, and belongs in
its own change.
