### PR TITLE
Fix serve autoscaler version churn

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -17,6 +17,7 @@ import uvicorn
 
 from sky import serve
 from sky import sky_logging
+from sky.serve import constants as serve_constants
 from sky.serve import autoscalers
 from sky.serve import replica_managers
 from sky.serve import serve_state
@@ -54,6 +55,15 @@ class SkyServeController:
                                                     version=version))
         self._autoscaler: autoscalers.Autoscaler = (
             autoscalers.Autoscaler.from_spec(service_name, service_spec))
+
+        # Restore autoscaler version to avoid scale churn on controller restart.
+        # This matches the logic in the live update path (/controller/update).
+        if version > serve_constants.INITIAL_VERSION:
+            self._autoscaler.update_version(
+                version,
+                service_spec,
+                update_mode=serve_utils.DEFAULT_UPDATE_MODE,
+            )
         self._host = host
         self._port = port
         self._app = fastapi.FastAPI(lifespan=self.lifespan)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -17,8 +17,8 @@ import uvicorn
 
 from sky import serve
 from sky import sky_logging
-from sky.serve import constants as serve_constants
 from sky.serve import autoscalers
+from sky.serve import constants as serve_constants
 from sky.serve import replica_managers
 from sky.serve import serve_state
 from sky.serve import serve_utils


### PR DESCRIPTION
Fixes #8562

### summary
When the SkyServe controller restarts (or is rescheduled in K8s), the autoscaler is recreated from scratch via `Autoscaler.from_spec()`, which defaults `latest_version` to `INITIAL_VERSION` (1). 

If the service was already running at a higher version (e.g., version 3), this mismatch causes the autoscaler to aggressively scale up new replicas for version 1 and immediately scale them back down, creating a continuous "scale churn" loop.

This PR restores the recovered `version` on the autoscaler instance inside `SkyServeController.__init__()` to match the behavior of the live `/controller/update` path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->