### PR TITLE
[Slurm] Retry transiently missing jobs during status refresh

### DIFF
--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -21,6 +21,7 @@ from sky.provision.slurm import utils as slurm_utils
 from sky.skylet import constants as skylet_constants
 from sky.utils import command_runner
 from sky.utils import common_utils
+from sky.utils import context_utils
 from sky.utils import env_options
 from sky.utils import rich_utils
 from sky.utils import status_lib
@@ -38,6 +39,12 @@ def _sbatch_log_path(base_dir: str, job_id: str) -> str:
 
 
 POLL_INTERVAL_SECONDS = 2
+# A Slurm status query opens one SSH command per state, so keep this lower than
+# the Kubernetes equivalent.  The retry is only used when the entire first
+# query returns no jobs, where a false negative would otherwise delete the
+# cluster record.
+_MAX_QUERY_INSTANCES_RETRIES = 2
+_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS = 0.5
 # Default KillWait is 30 seconds, so we add some buffer time here.
 _JOB_TERMINATION_TIMEOUT_SECONDS = 60
 # How long to give the batch script's TERM trap to run cleanup and exit
@@ -826,7 +833,7 @@ def query_instances(
     retry_if_missing: bool = False,
 ) -> Dict[str, Tuple[Optional[status_lib.ClusterStatus], Optional[str]]]:
     """See sky/provision/__init__.py"""
-    del cluster_name, retry_if_missing  # Unused for Slurm
+    del cluster_name  # Unused for Slurm
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
 
     ssh_config_dict = provider_config['ssh']
@@ -866,40 +873,59 @@ def query_instances(
         'node_fail': None,
     }
 
-    statuses: Dict[str, Tuple[Optional[status_lib.ClusterStatus],
-                              Optional[str]]] = {}
-    for state, sky_status in status_map.items():
-        jobs = client.query_jobs(
-            cluster_name_on_cloud,
-            [state],
-        )
+    attempts = 0
+    while True:
+        statuses: Dict[str, Tuple[Optional[status_lib.ClusterStatus],
+                                  Optional[str]]] = {}
+        found_any_job = False
+        for state, sky_status in status_map.items():
+            jobs = client.query_jobs(
+                cluster_name_on_cloud,
+                [state],
+            )
+            found_any_job = found_any_job or bool(jobs)
 
-        for job_id in jobs:
-            if state in ('pending', 'failed', 'node_fail', 'cancelled',
-                         'completed'):
-                reason = client.get_job_reason(job_id)
-                if non_terminated_only and sky_status is None:
-                    # TODO(kevin): For better UX, we should also find out
-                    # which node(s) exactly that failed if it's a node_fail
-                    # state.
-                    logger.debug(f'Job {job_id} is terminated, but '
-                                 'query_instances is called with '
-                                 f'non_terminated_only=True. State: {state}, '
-                                 f'Reason: {reason}')
-                    continue
-                statuses[job_id] = (sky_status, reason)
-            else:
-                nodes, _ = client.get_job_nodes(job_id)
-                for node in nodes:
-                    instance_id = slurm_utils.instance_id(job_id, node)
-                    statuses[instance_id] = (sky_status, None)
+            for job_id in jobs:
+                if state in ('pending', 'failed', 'node_fail', 'cancelled',
+                             'completed'):
+                    reason = client.get_job_reason(job_id)
+                    if non_terminated_only and sky_status is None:
+                        # TODO(kevin): For better UX, we should also find out
+                        # which node(s) exactly that failed if it's a node_fail
+                        # state.
+                        logger.debug(f'Job {job_id} is terminated, but '
+                                     'query_instances is called with '
+                                     f'non_terminated_only=True. State: '
+                                     f'{state}, Reason: {reason}')
+                        continue
+                    statuses[job_id] = (sky_status, reason)
+                else:
+                    nodes, _ = client.get_job_nodes(job_id)
+                    for node in nodes:
+                        instance_id = slurm_utils.instance_id(job_id, node)
+                        statuses[instance_id] = (sky_status, None)
 
-        # TODO(kevin): Query sacct too to get more historical job info.
-        # squeue only includes completed jobs that finished in the last
-        # MinJobAge seconds (default 300s). Or could be earlier if it
-        # reaches MaxJobCount first (default 10_000).
+            # TODO(kevin): Query sacct too to get more historical job info.
+            # squeue only includes completed jobs that finished in the last
+            # MinJobAge seconds (default 300s). Or could be earlier if it
+            # reaches MaxJobCount first (default 10_000).
 
-    return statuses
+        if (found_any_job or not retry_if_missing or
+                attempts >= _MAX_QUERY_INSTANCES_RETRIES):
+            return statuses
+
+        # A server shutdown can cancel the status-refresh request between the
+        # remote command finishing and this function returning.  Do not let an
+        # interrupted refresh commit an empty result and delete live cluster
+        # metadata.
+        context_utils.raise_if_canceled()
+        attempts += 1
+        logger.debug(
+            f'No Slurm jobs found for {cluster_name_on_cloud}; retrying '
+            f'{attempts}/{_MAX_QUERY_INSTANCES_RETRIES} after '
+            f'{_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS} seconds.')
+        time.sleep(_QUERY_INSTANCES_RETRY_INTERVAL_SECONDS)
+        context_utils.raise_if_canceled()
 
 
 def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1,10 +1,12 @@
 """Unit tests for sky.provision.slurm.instance."""
+import asyncio
 from unittest import mock
 
 import pytest
 
 from sky import exceptions
 from sky.provision.slurm import instance
+from sky.utils import status_lib
 
 _CLUSTER = 'test-cluster'
 _PROVIDER_CONFIG = {
@@ -193,3 +195,101 @@ class TestWaitForJobStates:
             255, 'squeue', 'ssh dropped', None)
         assert not instance._wait_for_job_states(
             client, 'job', instance._EXITING_JOB_STATES, timeout=0)
+
+
+class TestQueryInstances:
+    """Test query_instances() missing-job safeguards."""
+
+    def test_retries_missing_job(self, mock_client, monkeypatch):
+        running_queries = 0
+
+        def query_jobs(job_name, state_filters):
+            nonlocal running_queries
+            assert job_name == _CLUSTER
+            if state_filters == ['running']:
+                running_queries += 1
+                if running_queries == 2:
+                    return ['386700']
+            return []
+
+        mock_client.query_jobs.side_effect = query_jobs
+        mock_client.get_job_nodes.return_value = (['node-a'], None)
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=True)
+
+        assert result == {
+            'job386700-node-a': (status_lib.ClusterStatus.UP, None)
+        }
+        assert running_queries == 2
+        sleep.assert_called_once_with(
+            instance._QUERY_INSTANCES_RETRY_INTERVAL_SECONDS)
+
+    def test_does_not_retry_by_default(self, mock_client, monkeypatch):
+        mock_client.query_jobs.return_value = []
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=False)
+
+        assert not result
+        assert mock_client.query_jobs.call_count == 7
+        sleep.assert_not_called()
+
+    def test_retry_exhaustion_returns_empty(self, mock_client, monkeypatch):
+        mock_client.query_jobs.return_value = []
+        monkeypatch.setattr(instance.time, 'sleep', mock.MagicMock())
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          retry_if_missing=True)
+
+        assert not result
+        expected_rounds = 1 + instance._MAX_QUERY_INSTANCES_RETRIES
+        assert mock_client.query_jobs.call_count == 7 * expected_rounds
+
+    def test_does_not_retry_filtered_terminated_job(self, mock_client,
+                                                    monkeypatch):
+
+        def query_jobs(job_name, state_filters):
+            assert job_name == _CLUSTER
+            return ['386700'] if state_filters == ['completed'] else []
+
+        mock_client.query_jobs.side_effect = query_jobs
+        mock_client.get_job_reason.return_value = 'Completed'
+        sleep = mock.MagicMock()
+        monkeypatch.setattr(instance.time, 'sleep', sleep)
+
+        result = instance.query_instances(_CLUSTER,
+                                          _CLUSTER,
+                                          provider_config=_PROVIDER_CONFIG,
+                                          non_terminated_only=True,
+                                          retry_if_missing=True)
+
+        assert not result
+        assert mock_client.query_jobs.call_count == 7
+        mock_client.get_job_reason.assert_called_once_with('386700')
+        sleep.assert_not_called()
+
+    def test_retry_observes_request_cancellation(self, mock_client,
+                                                 monkeypatch):
+        mock_client.query_jobs.return_value = []
+        monkeypatch.setattr(instance.context_utils, 'raise_if_canceled',
+                            mock.MagicMock(side_effect=asyncio.CancelledError))
+
+        with pytest.raises(asyncio.CancelledError):
+            instance.query_instances(_CLUSTER,
+                                     _CLUSTER,
+                                     provider_config=_PROVIDER_CONFIG,
+                                     retry_if_missing=True)
+
+        # Only the initial full status query ran; no empty result was returned.
+        assert mock_client.query_jobs.call_count == 7


### PR DESCRIPTION
Fixes #10457

## Summary
- Honor `retry_if_missing` in the Slurm provisioner's `query_instances()`.
- Retry a completely empty Slurm status result before treating an allocation as terminated.
- Check request cancellation before and after the retry delay so API server shutdown cannot commit an interrupted empty refresh.
- Include regression test updates.

## Root cause
The Slurm implementation accepted `retry_if_missing` but explicitly discarded it (`del cluster_name, retry_if_missing`). A single transient empty result from the series of `squeue` calls was therefore returned as authoritative. The status refresh path interpreted that as all nodes being terminated and removed the cluster record even when the Slurm allocation was still running.

## Test plan
- `bash format.sh --files sky/provision/slurm/instance.py tests/unit_tests/test_sky/provision/slurm/test_instance.py`
- `PYTHONPATH=. python -m pytest -q tests/unit_tests/test_sky/provision/slurm/test_instance.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->