### PR TITLE
[Dashboard] Show why a volume is not ready

### DIFF
--- a/sky/dashboard/src/components/elements/TruncatedDetails.jsx
+++ b/sky/dashboard/src/components/elements/TruncatedDetails.jsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { TableRow, TableCell } from '@/components/ui/table';
+
+const TOGGLE_SELECTOR = '[data-button-type="show-more-less"]';
+
+// A table that collapses the expanded row on an outside click must not count
+// the toggle itself as outside: its mousedown would collapse the row, and the
+// click that follows would re-expand it, so "show less" would never close.
+export function isDetailsToggle(target) {
+  return Boolean(target?.closest?.(TOGGLE_SELECTOR));
+}
+
+export function ExpandedDetailsRow({ text, colSpan, innerRef }) {
+  return (
+    <TableRow className="expanded-details">
+      <TableCell colSpan={colSpan}>
+        <div
+          className="p-4 bg-gray-50 rounded-md border border-gray-200"
+          ref={innerRef}
+        >
+          <div className="flex justify-between items-start">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-gray-900">Full Details</p>
+              <p
+                className="mt-1 text-sm text-gray-700"
+                style={{ whiteSpace: 'pre-wrap' }}
+              >
+                {text}
+              </p>
+            </div>
+          </div>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function TruncatedDetails({
+  text,
+  rowId,
+  expandedRowId,
+  setExpandedRowId,
+}) {
+  const safeText = text || '';
+  const isTruncated = safeText.length > 50;
+  const isExpanded = expandedRowId === rowId;
+  // Always show truncated text in the table cell
+  const displayText = isTruncated ? `${safeText.substring(0, 50)}` : safeText;
+  const buttonRef = useRef(null);
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setExpandedRowId(isExpanded ? null : rowId);
+  };
+
+  return (
+    <div className="truncated-details relative max-w-full flex items-center">
+      <span className="truncate">{displayText}</span>
+      {isTruncated && (
+        <button
+          ref={buttonRef}
+          type="button"
+          onClick={handleClick}
+          className="text-blue-600 hover:text-blue-800 font-medium ml-1 flex-shrink-0"
+          // isDetailsToggle finds the button by this attribute.
+          data-button-type="show-more-less"
+        >
+          {isExpanded ? '... show less' : '... show more'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -69,6 +69,11 @@ import { StatusBadge, getStatusStyle } from '@/components/elements/StatusBadge';
 import { PrimaryBadge } from '@/components/elements/PrimaryBadge';
 import { BatchBadge } from '@/components/elements/BatchBadge';
 import { UserDisplay } from '@/components/elements/UserDisplay';
+import {
+  TruncatedDetails,
+  ExpandedDetailsRow,
+  isDetailsToggle,
+} from '@/components/elements/TruncatedDetails';
 import { useMobile } from '@/hooks/useMobile';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
@@ -2726,7 +2731,8 @@ export function ClusterJobs({
       if (
         expandedRowId &&
         expandedRowRef.current &&
-        !expandedRowRef.current.contains(event.target)
+        !expandedRowRef.current.contains(event.target) &&
+        !isDetailsToggle(event.target)
       ) {
         setExpandedRowId(null);
       }
@@ -2979,63 +2985,6 @@ export function ClusterJobs({
           onPageSizeChange={handlePageSizeChange}
           pageSizeOptions={CLUSTER_JOBS_PAGE_SIZE_OPTIONS}
         />
-      )}
-    </div>
-  );
-}
-
-function ExpandedDetailsRow({ text, colSpan, innerRef }) {
-  return (
-    <TableRow className="expanded-details">
-      <TableCell colSpan={colSpan}>
-        <div
-          className="p-4 bg-gray-50 rounded-md border border-gray-200"
-          ref={innerRef}
-        >
-          <div className="flex justify-between items-start">
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-900">Full Details</p>
-              <p
-                className="mt-1 text-sm text-gray-700"
-                style={{ whiteSpace: 'pre-wrap' }}
-              >
-                {text}
-              </p>
-            </div>
-          </div>
-        </div>
-      </TableCell>
-    </TableRow>
-  );
-}
-
-function TruncatedDetails({ text, rowId, expandedRowId, setExpandedRowId }) {
-  const safeText = text || '';
-  const isTruncated = safeText.length > 50;
-  const isExpanded = expandedRowId === rowId;
-  // Always show truncated text in the table cell
-  const displayText = isTruncated ? `${safeText.substring(0, 50)}` : safeText;
-  const buttonRef = useRef(null);
-
-  const handleClick = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setExpandedRowId(isExpanded ? null : rowId);
-  };
-
-  return (
-    <div className="truncated-details relative max-w-full flex items-center">
-      <span className="truncate">{displayText}</span>
-      {isTruncated && (
-        <button
-          ref={buttonRef}
-          type="button"
-          onClick={handleClick}
-          className="text-blue-600 hover:text-blue-800 font-medium ml-1 flex-shrink-0"
-          data-button-type="show-more-less"
-        >
-          {isExpanded ? '... show less' : '... show more'}
-        </button>
       )}
     </div>
   );

--- a/sky/dashboard/src/components/jobs.test.jsx
+++ b/sky/dashboard/src/components/jobs.test.jsx
@@ -1,0 +1,84 @@
+// The cluster jobs table truncates a long job name and expands it into a row
+// of its own. That expansion also collapses when the user clicks away, and the
+// two must not fight: the toggle's own press would otherwise collapse and
+// re-expand in one go, leaving "show less" looking dead.
+// The row's action menu reads the route; nothing here navigates.
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: () => ({ query: {}, push: jest.fn(), asPath: '/clusters/g40' }),
+}));
+jest.mock('@/lib/cache', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), invalidate: jest.fn(), setPreloader: jest.fn() },
+}));
+jest.mock('@/plugins/PluginSlot', () => ({
+  __esModule: true,
+  PluginSlot: () => null,
+}));
+jest.mock('@/plugins/PluginProvider', () => ({
+  __esModule: true,
+  usePluginComponents: () => [],
+  useTableColumns: () => [],
+}));
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ClusterJobs } from '@/components/jobs';
+
+const LONG_NAME =
+  'train-llama-70b-on-the-whole-of-common-crawl-with-a-very-long-name';
+
+const job = (id, name) => ({
+  id,
+  job: name,
+  user: 'alice',
+  user_hash: 'hash-alice',
+  submitted_at: 1700000000,
+  job_duration: 60,
+  status: 'RUNNING',
+  resources: '1x A100',
+});
+
+const renderClusterJobs = (jobs) =>
+  render(
+    <ClusterJobs
+      clusterName="g40"
+      clusterJobData={jobs}
+      loading={false}
+      refreshClusterJobsOnly={() => {}}
+    />
+  );
+
+// A real pointer press fires mousedown before click, and the collapse-on-
+// outside-click handler listens on mousedown.
+const press = (element) => {
+  fireEvent.mouseDown(element);
+  fireEvent.click(element);
+};
+
+describe('ClusterJobs long job names', () => {
+  it('expands and collapses from the same toggle', () => {
+    renderClusterJobs([job(1, LONG_NAME)]);
+
+    expect(screen.queryByText('Full Details')).toBeNull();
+    press(screen.getByText('... show more'));
+    expect(screen.getByText('Full Details')).toBeTruthy();
+
+    press(screen.getByText('... show less'));
+    expect(screen.queryByText('Full Details')).toBeNull();
+  });
+
+  it('collapses on a click elsewhere', () => {
+    const { container } = renderClusterJobs([job(1, LONG_NAME)]);
+    press(screen.getByText('... show more'));
+
+    fireEvent.mouseDown(container.querySelector('table'));
+
+    expect(screen.queryByText('Full Details')).toBeNull();
+  });
+
+  it('leaves a short job name alone', () => {
+    renderClusterJobs([job(1, 'quick')]);
+
+    expect(screen.queryByText('... show more')).toBeNull();
+  });
+});

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -45,6 +45,11 @@ import { useRouter } from 'next/router';
 import { TimestampWithTooltip, LastUpdatedTimestamp } from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import {
+  TruncatedDetails,
+  ExpandedDetailsRow,
+  isDetailsToggle,
+} from '@/components/elements/TruncatedDetails';
+import {
   FilterDropdown,
   Filters,
   filterData,
@@ -481,7 +486,7 @@ export function Volumes() {
   );
 }
 
-function VolumesTable({
+export function VolumesTable({
   refreshInterval,
   setLoading,
   refreshDataRef,
@@ -507,6 +512,26 @@ function VolumesTable({
       10
     )
   );
+  // Held at table level so at most one row is expanded at a time.
+  const [expandedRowId, setExpandedRowId] = useState(null);
+  const expandedRowRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        expandedRowId &&
+        expandedRowRef.current &&
+        !expandedRowRef.current.contains(event.target) &&
+        !isDetailsToggle(event.target)
+      ) {
+        setExpandedRowId(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [expandedRowId]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -654,6 +679,14 @@ function VolumesTable({
 
   const pluginColumns = useTableColumns('volumes');
 
+  // Volumes are usable most of the time, so a column of dashes would be noise.
+  // Judge over the whole dataset, not the current page or filter, so the column
+  // does not come and go while paging.
+  const anyVolumeHasDetails = useMemo(
+    () => data.some((volume) => volume.error_message),
+    [data]
+  );
+
   const sortableHeader = (label, sortKey) => (
     <TableHead
       className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
@@ -740,6 +773,33 @@ function VolumesTable({
         </TableCell>
       ),
     },
+    // What the status means: a CSI provisioner's own words on why the volume is
+    // not ready, which until now only a tooltip on the badge revealed. Last
+    // before the actions, as in the jobs table: the text is wide, and it reads
+    // as an aside rather than a property of the volume.
+    ...(anyVolumeHasDetails
+      ? [
+          {
+            id: 'details',
+            order: 999,
+            renderHeader: () => <TableHead>Details</TableHead>,
+            renderCell: (volume) => (
+              <TableCell>
+                {volume.error_message ? (
+                  <TruncatedDetails
+                    text={volume.error_message}
+                    rowId={volume.name}
+                    expandedRowId={expandedRowId}
+                    setExpandedRowId={setExpandedRowId}
+                  />
+                ) : (
+                  '-'
+                )}
+              </TableCell>
+            ),
+          },
+        ]
+      : []),
     {
       id: 'actions',
       order: 1000,
@@ -846,13 +906,24 @@ function VolumesTable({
                 </TableRow>
               ) : paginatedData.length > 0 && !isForceEmpty() ? (
                 paginatedData.map((volume) => (
-                  <TableRow key={volume.name}>
-                    {visibleColumns.map((col) =>
-                      React.cloneElement(col.renderCell(volume), {
-                        key: col.id,
-                      })
+                  <React.Fragment key={volume.name}>
+                    <TableRow>
+                      {visibleColumns.map((col) =>
+                        React.cloneElement(col.renderCell(volume), {
+                          key: col.id,
+                        })
+                      )}
+                    </TableRow>
+                    {/* A volume can become ready while its reason is
+                        expanded, taking the column with it. */}
+                    {expandedRowId === volume.name && volume.error_message && (
+                      <ExpandedDetailsRow
+                        text={volume.error_message}
+                        colSpan={totalColSpan}
+                        innerRef={expandedRowRef}
+                      />
                     )}
-                  </TableRow>
+                  </React.Fragment>
                 ))
               ) : (
                 <EmptyTableState

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -1,0 +1,173 @@
+// The volumes table reaches for its data through the shared cache rather than
+// taking it as a prop, so the cache is where a fixed set of volumes goes in.
+jest.mock('@/lib/cache', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), invalidate: jest.fn(), setPreloader: jest.fn() },
+}));
+jest.mock('@/plugins/PluginSlot', () => ({
+  __esModule: true,
+  PluginSlot: () => null,
+}));
+jest.mock('@/plugins/PluginProvider', () => ({
+  __esModule: true,
+  usePluginComponents: () => [],
+  useTableColumns: () => [],
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import dashboardCache from '@/lib/cache';
+import { VolumesTable } from '@/components/volumes';
+
+// A CSI provisioner's refusal, long enough that the cell must truncate it.
+const CSI_ERROR =
+  'PVC is pending. ProvisioningFailed: error generating accessibility ' +
+  'requirements: failed to get selected CSINode node-1: ' +
+  'csinode.storage.k8s.io "node-1" not found';
+
+const volume = (name, errorMessage = null) => ({
+  name,
+  status: errorMessage ? 'NOT_READY' : 'READY',
+  error_message: errorMessage,
+  type: 'k8s-pvc',
+  infra: 'Kubernetes/ctx',
+  size: 1,
+  user_name: 'alice',
+});
+
+const renderTable = async (volumes, { refreshInterval = 100000 } = {}) => {
+  dashboardCache.get.mockResolvedValue(volumes);
+  const result = render(
+    <VolumesTable
+      refreshInterval={refreshInterval}
+      setLoading={() => {}}
+      refreshDataRef={{ current: null }}
+      onDeleteVolume={() => {}}
+      preloadingComplete={true}
+    />
+  );
+  await waitFor(() => expect(screen.getByText(volumes[0].name)).toBeTruthy());
+  return result;
+};
+
+const headers = (container) =>
+  Array.from(container.querySelectorAll('table thead th')).map(
+    (th) => th.textContent
+  );
+
+describe('VolumesTable details column', () => {
+  it('is absent while every volume is usable', async () => {
+    const { container } = await renderTable([volume('ok1'), volume('ok2')]);
+
+    expect(headers(container)).not.toContain('Details');
+  });
+
+  it('appears once any volume carries a reason, just before the actions', async () => {
+    const { container } = await renderTable([
+      volume('ok1'),
+      volume('broken', CSI_ERROR),
+    ]);
+
+    const columns = headers(container);
+    expect(columns).toContain('Details');
+    expect(columns.indexOf('Details')).toBe(columns.length - 2);
+    expect(columns[columns.length - 1]).toBe('Actions');
+  });
+
+  // A real pointer press fires mousedown before click, and the outside-click
+  // handler listens on mousedown -- so a test that only clicks would miss the
+  // toggle collapsing and re-expanding in one press.
+  const press = (element) => {
+    fireEvent.mouseDown(element);
+    fireEvent.click(element);
+  };
+
+  it('truncates the reason and reveals the whole of it on demand', async () => {
+    await renderTable([volume('broken', CSI_ERROR)]);
+
+    // The point of the column: the text the tooltip used to hide is readable.
+    expect(screen.queryByText(CSI_ERROR)).toBeNull();
+    press(screen.getByText('... show more'));
+    expect(screen.getByText(CSI_ERROR)).toBeTruthy();
+
+    press(screen.getByText('... show less'));
+    expect(screen.queryByText(CSI_ERROR)).toBeNull();
+  });
+
+  it('collapses on a click anywhere else', async () => {
+    const { container } = await renderTable([volume('broken', CSI_ERROR)]);
+    press(screen.getByText('... show more'));
+
+    fireEvent.mouseDown(container.querySelector('table'));
+
+    expect(screen.queryByText(CSI_ERROR)).toBeNull();
+  });
+
+  it('expands one volume at a time', async () => {
+    const other = `${CSI_ERROR} on another volume`;
+    await renderTable([volume('broken1', CSI_ERROR), volume('broken2', other)]);
+
+    const [first, second] = screen.getAllByText('... show more');
+    press(first);
+    press(second);
+
+    expect(screen.getByText(other)).toBeTruthy();
+    expect(screen.queryByText(CSI_ERROR)).toBeNull();
+  });
+
+  it('leaves a short reason whole, with nothing to expand', async () => {
+    await renderTable([volume('broken', 'Storage class not found')]);
+
+    expect(screen.getByText('Storage class not found')).toBeTruthy();
+    expect(screen.queryByText('... show more')).toBeNull();
+  });
+
+  it('keeps the reason expanded across a refresh', async () => {
+    // The table refreshes every few seconds; collapsing under the user
+    // mid-read would make a long reason unreadable.
+    await renderTable([volume('broken', CSI_ERROR)], { refreshInterval: 20 });
+    fireEvent.click(screen.getByText('... show more'));
+
+    await waitFor(() =>
+      expect(dashboardCache.get.mock.calls.length).toBeGreaterThan(1)
+    );
+    expect(screen.getByText(CSI_ERROR)).toBeTruthy();
+  });
+
+  it('drops the expanded reason once the volume becomes usable', async () => {
+    const { container } = await renderTable([volume('broken', CSI_ERROR)], {
+      refreshInterval: 20,
+    });
+    fireEvent.click(screen.getByText('... show more'));
+    dashboardCache.get.mockResolvedValue([volume('broken')]);
+
+    // The column goes with the last reason, so the panel must not outlive it.
+    await waitFor(() => expect(headers(container)).not.toContain('Details'));
+    expect(screen.queryByText('Full Details')).toBeNull();
+  });
+
+  it('does not carry an expanded reason onto another page', async () => {
+    const volumes = Array.from({ length: 11 }, (_, i) =>
+      volume(`vol${i}`, i === 0 ? CSI_ERROR : null)
+    );
+    await renderTable(volumes);
+    fireEvent.click(screen.getByText('... show more'));
+
+    fireEvent.click(screen.getByText('1 – 10 of 11').nextSibling.children[1]);
+
+    expect(screen.getByText('vol10')).toBeTruthy();
+    expect(screen.queryByText('Full Details')).toBeNull();
+  });
+
+  it('shows nothing for the usable volumes alongside a broken one', async () => {
+    const { container } = await renderTable([
+      volume('ok1'),
+      volume('broken', CSI_ERROR),
+    ]);
+
+    const detailsIndex = headers(container).indexOf('Details');
+    const cellsInColumn = Array.from(
+      container.querySelectorAll('table tbody tr')
+    ).map((row) => row.querySelectorAll('td')[detailsIndex]?.textContent);
+    expect(cellsInColumn).toContain('-');
+  });
+});

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -39,6 +39,11 @@ export async function getVolumes() {
           usedby_clusters: volume.usedby_clusters,
           last_use: volume.last_use || null,
           error_message: volume.error_message || null,
+          // Whether the error above is one the volume can recover from. Servers
+          // older than this field report nothing, which reads as undefined --
+          // distinct from a definite false, so callers can tell "will not bind"
+          // from "cannot tell".
+          error_may_resolve: volume.error_may_resolve,
           creation_yaml: volume.creation_yaml || null,
         };
       }) || [];

--- a/sky/dashboard/src/pages/volumes/[volume].js
+++ b/sky/dashboard/src/pages/volumes/[volume].js
@@ -358,7 +358,7 @@ function VolumeDetailCard({ volumeData }) {
               {volumeData.error_message && (
                 <div className="col-span-2">
                   <div className="text-gray-600 font-medium text-base">
-                    Status details
+                    Status Details
                   </div>
                   <div
                     className="text-base mt-1"

--- a/sky/dashboard/src/pages/volumes/[volume].js
+++ b/sky/dashboard/src/pages/volumes/[volume].js
@@ -353,6 +353,22 @@ function VolumeDetailCard({ volumeData }) {
                 </div>
               </div>
 
+              {/* Why the status is what it is, in the provisioner's own words.
+                  Spans both columns: a CSI error runs long. */}
+              {volumeData.error_message && (
+                <div className="col-span-2">
+                  <div className="text-gray-600 font-medium text-base">
+                    Status details
+                  </div>
+                  <div
+                    className="text-base mt-1"
+                    style={{ whiteSpace: 'pre-wrap' }}
+                  >
+                    {volumeData.error_message}
+                  </div>
+                </div>
+              )}
+
               {/* Used By - spans both columns */}
               <div className="col-span-2">
                 <div className="text-gray-600 font-medium text-base">

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -291,5 +291,9 @@ class VolumeRecord(ResponseBaseModel):
     # Error message for volume in ERROR state (e.g., PVC pending due to
     # access mode mismatch)
     error_message: Optional[str] = None
+    # Whether the error above is one the volume can still recover from, such as
+    # a network filesystem that takes minutes to provision. False for a volume
+    # that will never bind, and for a volume with no error at all.
+    error_may_resolve: bool = False
     # YAML configuration used to create the volume
     creation_yaml: Optional[str] = None

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -18,6 +18,7 @@ from sky.utils import registry
 from sky.utils import rich_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
+from sky.utils import volume as volume_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -231,6 +232,7 @@ def volume_list(
                 'usedby_fetch_failed': bool,
                 'is_ephemeral': bool,
                 'error_message': Optional[str],
+                'error_may_resolve': bool,
             }
         ]
     """
@@ -250,6 +252,7 @@ def volume_list(
                 continue
 
             status = volume.get('status')
+            error_message = volume.get('error_message')
             record: Dict[str, Any] = {
                 'name': volume_name,
                 'launched_at': volume.get('launched_at'),
@@ -263,7 +266,13 @@ def volume_list(
                 'usedby_clusters': volume.get('usedby_clusters', []),
                 'usedby_fetch_failed': False,
                 'is_ephemeral': volume.get('is_ephemeral', False),
-                'error_message': volume.get('error_message'),
+                'error_message': error_message,
+                # NOT_READY covers both a volume still being provisioned and
+                # one that will never bind. Only the recorded reason tells them
+                # apart, so decide it here rather than leave every caller to
+                # match on the message.
+                'error_may_resolve':
+                    volume_utils.volume_error_may_resolve(error_message),
                 'creation_yaml': volume.get('creation_yaml'),
                 'type': config.type,
                 'cloud': config.cloud,

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -11,6 +11,7 @@ from sky import provision
 from sky.schemas.api import responses
 from sky.server import plugin_hooks
 from sky.utils import status_lib
+from sky.utils import volume as volume_utils
 from sky.volumes.server import core
 
 
@@ -2189,3 +2190,61 @@ class TestVolumeRefreshScopedToNames:
         assert sorted(c.args[0] for c in mock_update.call_args_list) == [
             'vol-a', 'vol-b'
         ]
+
+
+class TestVolumeListReportsWhetherTheErrorMayResolve:
+    """NOT_READY covers a volume still being provisioned and one that will
+    never bind. Callers deciding whether to refuse a launch -- or whether to
+    let an admin auto-mount the volume -- need them told apart, and the reason
+    is only distinguishable by its text, so the listing decides it centrally.
+    """
+
+    def _list_one(self, monkeypatch, error_message):
+        volume = {
+            'name': 'vol',
+            'launched_at': 1,
+            'user_hash': 'u',
+            'workspace': 'default',
+            'status': status_lib.VolumeStatus.NOT_READY,
+            'error_message': error_message,
+            'usedby_pods': [],
+            'usedby_clusters': [],
+            'handle': mock.MagicMock(type='k8s-pvc',
+                                     cloud='kubernetes',
+                                     region='ctx',
+                                     zone=None,
+                                     size='1',
+                                     config={},
+                                     name_on_cloud='vol-abc',
+                                     spec=models.VolumeConfig),
+        }
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=[volume]))
+        monkeypatch.setattr(global_user_state, 'get_all_users',
+                            mock.MagicMock(return_value=[]))
+        return core.volume_list()[0]
+
+    def test_a_volume_still_being_provisioned_may_resolve(self, monkeypatch):
+        record = self._list_one(
+            monkeypatch, f'{volume_utils.PVC_PROVISIONING_MESSAGE} To debug, '
+            f'run: kubectl describe pvc vol-abc')
+
+        assert record['error_may_resolve'] is True
+
+    def test_a_volume_that_will_never_bind_does_not(self, monkeypatch):
+        record = self._list_one(
+            monkeypatch, 'PVC is pending. ProvisioningFailed: rpc error: '
+            'code = InvalidArgument desc = tier "not-a-real-tier" is invalid')
+
+        assert record['error_may_resolve'] is False
+
+    def test_no_error_does_not(self, monkeypatch):
+        assert self._list_one(monkeypatch, None)['error_may_resolve'] is False
+
+    def test_the_field_survives_the_response_model(self, monkeypatch):
+        """The listing returns a pydantic model, which drops keys it does not
+        declare -- so a field added to the dict alone never reaches a client."""
+        record = self._list_one(monkeypatch,
+                                volume_utils.PVC_PROVISIONING_MESSAGE)
+
+        assert 'error_may_resolve' in record.model_dump()


### PR DESCRIPTION
## Summary

When a volume is `NOT_READY`, the reason is a CSI provisioner's own words on what went wrong — an invalid storage tier, a missing CSINode, an access mode no PersistentVolume supports. Until now that sentence was only reachable by hovering the status badge, so the one piece of text that explains the failure went unread.

- **Volumes table grows a `Details` column**, reusing the truncate-and-expand pattern the jobs table already has (`TruncatedDetails` + `ExpandedDetailsRow`). Those two components move to `elements/TruncatedDetails.jsx` instead of being copied a third time; the jobs table now imports them.
- **The column appears only when some volume has a reason to show**, so the common all-healthy listing does not grow a column of dashes. The decision is made over the whole dataset, not the current page, so the column does not come and go while paging.
- **The volume detail page** shows the reason in full, spanning both columns, next to the status it explains.
- **Fixes the toggle.** The collapse-on-outside-click handler listens on `mousedown`, and the toggle button is not inside the expanded row — so pressing "show less" collapsed the row and the click that followed re-expanded it, and the button looked dead. The cluster jobs table had the same defect; both now skip the toggle when deciding whether a press landed outside.
- **The listing reports a new `error_may_resolve` field.** `NOT_READY` covers both a volume still being provisioned (launches wait for it and succeed) and one that will never bind (launches are refused), and only the recorded reason distinguishes them. Deciding it once on the server keeps every caller from matching on the message text. Additive and optional, so an older client is unaffected.

## Test plan

Unit tests, all in CI:

- `sky/dashboard/src/components/volumes.test.jsx` — 10 cases: the column is absent while every volume is usable; appears just before the actions once one carries a reason; a long reason truncates and expands; a short one has nothing to expand; "show less" collapses; a click elsewhere collapses; one row expands at a time; the expansion survives a refresh; the panel and the column both go when the volume becomes usable; healthy rows show `-`.
- `sky/dashboard/src/components/jobs.test.jsx` — 3 cases on the cluster jobs table: expand and collapse from the same toggle, collapse on a click elsewhere, leave a short job name alone.
- `tests/unit_tests/test_sky/volumes/test_core.py` — 4 cases on `error_may_resolve`: true for a volume still being provisioned, false for one that will never bind, false with no error, and one that pins the field against the response model dropping it.

```bash
npm --prefix sky/dashboard test -- src/components/volumes.test.jsx src/components/jobs.test.jsx
pytest tests/unit_tests/test_sky/volumes/
```

Reverting each fix was checked to make the matching test fail: dropping the `volume.error_message` guard on the expanded row fails only "drops the expanded reason once the volume becomes usable"; dropping the toggle guard fails only the two "expand and collapse from the same toggle" cases; removing the schema field fails all four Python cases.

Manual, against a local API server with real volumes (five of them `NOT_READY`, including a GKE Filestore instance rejected for an invalid tier and a PVC whose CSINode had gone):

1. `npm --prefix sky/dashboard run build && sky api stop && sky api start`, open `/dashboard/volumes`.
2. The `Details` column sits between `Used By` and `Actions`. A broken volume's cell shows the first 50 characters and a `... show more` link; expanding it prints the whole CSI error, including the `kubectl describe pvc ...` hint. `... show less` closes it, and so does a click anywhere else. Expanding a second row closes the first.
3. Click a broken volume's name — the detail page shows the same text under **Status details**.
4. With every volume healthy (clear `error_message` in the volume table), the column is gone and the other ten columns are unchanged.
5. `curl` the listing and confirm `error_may_resolve` is `true` for a volume whose reason is the provisioning message and `false` for one rejected by the provisioner.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->