### PR TITLE
[API] Reload the policy under the lock before mutating it

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -401,11 +401,14 @@ class PermissionService:
             removed_roles = enforcer.remove_filtered_grouping_policy(0, user_id)
             # Private-workspace membership is a `p` row (user, workspace, '*').
             # Role names also sit at field 0 of `p` rows (the blocklist rules),
-            # but a user id is an 8-char hash or an `sa-` prefixed id, so it can
-            # never collide with one.
-            removed_grants = enforcer.remove_filtered_policy(0, user_id)
+            # so match the '*' action as well instead of field 0 alone: no user
+            # id is a role name today, but taking out a role's whole blocklist
+            # would leave that role unrestricted rather than merely wrong. ''
+            # matches any value, in the model and in the sqlalchemy adapter.
+            removed_grants = enforcer.remove_filtered_policy(
+                0, user_id, '', '*')
             if not removed_roles and not removed_grants:
-                logger.debug(f'User {user_id} has no policies')
+                # Nothing to persist, and nothing to invalidate.
                 return
             enforcer.save_policy()
             self.invalidate_user_permission_cache(user_id)
@@ -416,7 +419,6 @@ class PermissionService:
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
             if enforcer.get_roles_for_user(user_id) == [new_role]:
-                logger.debug(f'User {user_id} already has role {new_role}')
                 return
             # Replace, don't add: a user is only ever meant to hold one role,
             # and a leftover `admin` would survive a demotion -- silently

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -369,15 +369,25 @@ class PermissionService:
         return False
 
     def delete_user(self, user_id: str) -> None:
-        """Remove every role held by a user."""
+        """Remove every policy naming a user: their role and workspace grants.
+
+        User ids are derived from the username, so a delete followed by a
+        recreate reuses the id -- anything left behind is silently inherited by
+        the next holder. Both row types are keyed by user id at field 0, and a
+        filtered removal also clears duplicates, which a loop over the
+        deduplicated role list cannot reach.
+        """
         with _policy_lock():
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
-            # Filtered removal takes every grouping row for this user in one
-            # call, duplicates included. Dropping only the first would leave a
-            # live grant for whoever next occupies this user id.
-            if not enforcer.remove_filtered_grouping_policy(0, user_id):
-                logger.debug(f'User {user_id} has no roles')
+            removed_roles = enforcer.remove_filtered_grouping_policy(0, user_id)
+            # Private-workspace membership is a `p` row (user, workspace, '*').
+            # Role names also sit at field 0 of `p` rows (the blocklist rules),
+            # but a user id is an 8-char hash or an `sa-` prefixed id, so it can
+            # never collide with one.
+            removed_grants = enforcer.remove_filtered_policy(0, user_id)
+            if not removed_roles and not removed_grants:
+                logger.debug(f'User {user_id} has no policies')
                 return
             enforcer.save_policy()
             self.invalidate_user_permission_cache(user_id)

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -209,7 +209,10 @@ class PermissionService:
                      f'{len(self._read_only_endpoints)}')
 
     def _maybe_initialize_basic_auth_user(self) -> None:
-        """Initialize basic auth user if it is enabled."""
+        """Initialize basic auth user if it is enabled.
+
+        Caller holds `_policy_lock()`.
+        """
         basic_auth = os.environ.get(constants.SKYPILOT_INITIAL_BASIC_AUTH)
         if not basic_auth:
             return
@@ -229,13 +232,28 @@ class PermissionService:
                             password=password,
                             user_type=models.UserType.BASIC.value))
             enforcer = self._ensure_enforcer()
+            # Same reason as `_maybe_initialize_policies`: `save_policy()`
+            # rewrites the whole table from this model, which predates the
+            # lock unless refreshed.
+            self._load_policy_no_lock()
             enforcer.add_grouping_policy(user_hash, rbac.RoleName.ADMIN.value)
             enforcer.save_policy()
             logger.info(f'Basic auth user {username} initialized')
 
     def _maybe_initialize_policies(self) -> None:
-        """Initialize policies if they don't already exist."""
+        """Initialize policies if they don't already exist.
+
+        Caller holds `_policy_lock()`.
+        """
         logger.debug(f'Initializing policies in process: {os.getpid()}')
+
+        # The model was loaded by the enforcer's constructor, before the lock
+        # was acquired -- and waiting for it can take seconds. Anything another
+        # replica wrote in that window is missing here, and this method both
+        # ends in a full-table `save_policy()` and deletes whatever it
+        # considers redundant, so it would erase those writes rather than
+        # merely miss them.
+        self._load_policy_no_lock()
 
         policy_updated = False
 

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -344,6 +344,12 @@ class PermissionService:
         """Add user role relationship. `role` overrides the default role."""
         self._lazy_initialize()
         with _policy_lock():
+            # Refresh before deciding: the callee reads this process's
+            # in-memory model, which may predate another worker's write, and
+            # would then add a *second* role for a user who already has one.
+            # Deliberately here rather than in the callee, which
+            # `_maybe_initialize_policies` calls once per user in a loop.
+            self._load_policy_no_lock()
             self._add_user_if_not_exists_no_lock(user_id, role)
 
     def _add_user_if_not_exists_no_lock(self,
@@ -363,35 +369,32 @@ class PermissionService:
         return False
 
     def delete_user(self, user_id: str) -> None:
-        """Delete user role relationship."""
+        """Remove every role held by a user."""
         with _policy_lock():
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
-            current_roles = enforcer.get_roles_for_user(user_id)
-            if not current_roles:
+            # Filtered removal takes every grouping row for this user in one
+            # call, duplicates included. Dropping only the first would leave a
+            # live grant for whoever next occupies this user id.
+            if not enforcer.remove_filtered_grouping_policy(0, user_id):
                 logger.debug(f'User {user_id} has no roles')
                 return
-            enforcer.remove_grouping_policy(user_id, current_roles[0])
             enforcer.save_policy()
             self.invalidate_user_permission_cache(user_id)
 
     def update_role(self, user_id: str, new_role: str) -> None:
-        """Update user role relationship."""
+        """Replace every role held by a user with `new_role`."""
         with _policy_lock():
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
-            current_roles = enforcer.get_roles_for_user(user_id)
-            if not current_roles:
-                logger.debug(f'User {user_id} has no roles')
-            else:
-                # TODO(hailong): how to handle multiple roles?
-                current_role = current_roles[0]
-                if current_role == new_role:
-                    logger.debug(f'User {user_id} already has role {new_role}')
-                    return
-                enforcer.remove_grouping_policy(user_id, current_role)
-
-            # Update user role
+            if enforcer.get_roles_for_user(user_id) == [new_role]:
+                logger.debug(f'User {user_id} already has role {new_role}')
+                return
+            # Replace, don't add: a user is only ever meant to hold one role,
+            # and a leftover `admin` would survive a demotion -- silently
+            # restoring what the demotion took away, since the blocklist check
+            # lets admin win over the other role.
+            enforcer.remove_filtered_grouping_policy(0, user_id)
             enforcer.add_grouping_policy(user_id, new_role)
             enforcer.save_policy()
             # Always invalidate: even a first role assignment can grant
@@ -912,6 +915,12 @@ class PermissionService:
     def remove_workspace_policy(self, workspace_name: str) -> None:
         """Remove workspace policy."""
         with _policy_lock():
+            # Reload from the DB inside the lock before mutating: save_policy()
+            # rewrites the whole table from this process's in-memory model, so
+            # without this a stale worker deleting a workspace also erases
+            # every policy another worker wrote since this one last loaded.
+            # Same reason as `add_workspace_policy` / `update_workspace_policy`.
+            self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
             enforcer.remove_filtered_policy(1, workspace_name)
             enforcer.save_policy()

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2191,6 +2191,21 @@ class TestStalePolicyWrites:
         # grant the config no longer lists is *meant* to go.)
         assert _grouping_rows(worker_a, 'early') == ['admin']
 
+    @mock.patch('sky.global_user_state.add_or_update_user')
+    @mock.patch('sky.global_user_state.get_user', return_value=None)
+    def test_basic_auth_initialization_keeps_other_writes(
+            self, _get_user, _add_user, monkeypatch, two_workers):
+        """The basic-auth seed also ends in a whole-table rewrite."""
+        monkeypatch.setenv(constants.SKYPILOT_INITIAL_BASIC_AUTH,
+                           'admin:password123')
+        worker_a, worker_b = two_workers
+        worker_b.enforcer.load_policy()
+        worker_a.update_role('early', 'viewer')
+
+        worker_b._maybe_initialize_basic_auth_user()
+
+        assert _grouping_rows(worker_a, 'early') == ['viewer']
+
     def test_remove_workspace_policy_keeps_other_writes(self, two_workers):
         worker_a, worker_b = two_workers
         worker_a.add_workspace_policy('ws_victim', ['bob'])
@@ -2256,3 +2271,20 @@ class TestRoleReplacement:
         assert ['leaver', 'team_private', '*'] not in remaining
         # Only that user's grant goes; the workspace's other members stay.
         assert ['stayer', 'team_private', '*'] in remaining
+
+    def test_delete_user_keeps_a_blocklist_of_the_same_name(self, two_workers):
+        """A user id equal to a role name must not take the role's rules.
+
+        Nothing produces such an id today, but the failure is fail-open: a role
+        with no blocklist rows is permitted everywhere.
+        """
+        worker_a, _ = two_workers
+        worker_a.enforcer.add_policy('user', '/workspaces/update', 'POST')
+        worker_a.enforcer.add_policy('user', 'team_private', '*')
+
+        worker_a.delete_user('user')
+
+        worker_a.enforcer.load_policy()
+        remaining = worker_a.enforcer.get_policy()
+        assert ['user', '/workspaces/update', 'POST'] in remaining
+        assert ['user', 'team_private', '*'] not in remaining

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2154,6 +2154,43 @@ class TestStalePolicyWrites:
         # default on top, leaving ['admin', 'viewer'] -- which reads as admin.
         assert _grouping_rows(worker_a, 'victim') == ['viewer']
 
+    @mock.patch('sky.global_user_state.add_or_update_user')
+    @mock.patch('sky.global_user_state.get_all_users', return_value=[])
+    @mock.patch('sky.users.rbac.get_workspace_policy_permissions',
+                return_value={})
+    @mock.patch('sky.users.rbac.get_role_permissions',
+                return_value={'user': {
+                    'permissions': {
+                        'blocklist': []
+                    }
+                }})
+    @mock.patch.object(permission.PermissionService,
+                       '_get_plugin_rbac_rules',
+                       return_value={})
+    def test_startup_initialization_keeps_other_writes(self, _rules, _perms,
+                                                       _ws, _users, _add,
+                                                       two_workers):
+        """Startup rewrites the whole table, so it must refresh first.
+
+        The enforcer loads in its constructor, before `_policy_lock()` is
+        acquired -- and waiting for that lock can take seconds. A replica that
+        booted earlier can write in the window, and this path both saves the
+        whole table and deletes what it thinks is redundant.
+        """
+        worker_a, worker_b = two_workers
+        # B is mid-boot: model loaded, still waiting for the lock.
+        worker_b.enforcer.load_policy()
+        worker_a.update_role('early', 'admin')
+
+        worker_b._maybe_initialize_policies()
+
+        # Role assignments are not derived from config, so this method has no
+        # basis for dropping one -- it only does so by rewriting the table from
+        # a model that never saw it. (Workspace `p` rows are a different
+        # matter: reconciling those against config is this method's job, so a
+        # grant the config no longer lists is *meant* to go.)
+        assert _grouping_rows(worker_a, 'early') == ['admin']
+
     def test_remove_workspace_policy_keeps_other_writes(self, two_workers):
         worker_a, worker_b = two_workers
         worker_a.add_workspace_policy('ws_victim', ['bob'])

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -5,7 +5,9 @@ import threading
 import time
 from unittest import mock
 
+import casbin
 import pytest
+import sqlalchemy
 import sqlalchemy_adapter
 
 from sky import models
@@ -279,7 +281,9 @@ class TestPermissionService:
 
         mock_enforcer = mock.Mock()
         mock_enforcer.get_roles_for_user.return_value = ['user']  # Current role
-        mock_enforcer.remove_grouping_policy.return_value = True
+        mock_enforcer.remove_filtered_grouping_policy.return_value = [[
+            'user1', 'user'
+        ]]
         mock_enforcer.add_grouping_policy.return_value = True
 
         service = permission.PermissionService()
@@ -288,9 +292,9 @@ class TestPermissionService:
 
         service.update_role('user1', 'admin')
 
-        # Verify old role was removed and new role was added
-        mock_enforcer.remove_grouping_policy.assert_called_once_with(
-            'user1', 'user')
+        # Every existing role is dropped, then the new one added.
+        mock_enforcer.remove_filtered_grouping_policy.assert_called_once_with(
+            0, 'user1')
         mock_enforcer.add_grouping_policy.assert_called_once_with(
             'user1', 'admin')
         mock_enforcer.save_policy.assert_called_once()
@@ -732,8 +736,9 @@ class TestPermissionService:
         """Test deleting a user who has a role."""
         mock_enforcer = mock.Mock()
         # User has a role
-        mock_enforcer.get_roles_for_user.return_value = ['user']
-        mock_enforcer.remove_grouping_policy.return_value = True
+        mock_enforcer.remove_filtered_grouping_policy.return_value = [[
+            'user1', 'user'
+        ]]
 
         with mock.patch.object(permission.PermissionService,
                                '__init__',
@@ -743,9 +748,8 @@ class TestPermissionService:
 
             service.delete_user('user1')
 
-            mock_enforcer.get_roles_for_user.assert_called_once_with('user1')
-            mock_enforcer.remove_grouping_policy.assert_called_once_with(
-                'user1', 'user')
+            mock_enforcer.remove_filtered_grouping_policy.assert_called_once_with(
+                0, 'user1')
             mock_enforcer.save_policy.assert_called_once()
             # Verify cache invalidation
             mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_called_once(
@@ -758,8 +762,8 @@ class TestPermissionService:
     def test_delete_user_without_role(self, mock_kv_cache):
         """Test deleting a user who has no roles."""
         mock_enforcer = mock.Mock()
-        # User has no roles
-        mock_enforcer.get_roles_for_user.return_value = []
+        # User has no roles: nothing matched the filter.
+        mock_enforcer.remove_filtered_grouping_policy.return_value = []
 
         with mock.patch.object(permission.PermissionService,
                                '__init__',
@@ -769,8 +773,8 @@ class TestPermissionService:
 
             service.delete_user('user2')
 
-            mock_enforcer.get_roles_for_user.assert_called_once_with('user2')
-            mock_enforcer.remove_grouping_policy.assert_not_called()
+            mock_enforcer.remove_filtered_grouping_policy.assert_called_once_with(
+                0, 'user2')
             mock_enforcer.save_policy.assert_not_called()
             # No cache invalidation for user without role (early return)
             mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called(
@@ -2093,3 +2097,105 @@ class TestWorkspaceReadOnlyAccess:
         assert ('u2', 'ws', '*') in calls
         # No materialized read-only wildcard is ever written.
         assert all(c[2] == '*' for c in calls)
+
+
+@pytest.fixture
+def two_workers(tmp_path):
+    """Two PermissionServices over one database, as two API-server workers.
+
+    Each uvicorn worker holds its own in-memory casbin model, so a write by one
+    is invisible to the other until it reloads. Two enforcers over one SQLite
+    file reproduce that exactly, without needing two processes.
+    """
+    engine = sqlalchemy.create_engine(f'sqlite:///{tmp_path}/policy.db')
+    model_path = os.path.join(os.path.dirname(permission.__file__),
+                              'model.conf')
+
+    def _worker():
+        service = permission.PermissionService()
+        adapter = sqlalchemy_adapter.Adapter(
+            engine, db_class=sqlalchemy_adapter.CasbinRule)
+        service.enforcer = casbin.SyncedEnforcer(model_path, adapter)
+        return service
+
+    with mock.patch('sky.users.permission._policy_lock'), \
+         mock.patch.object(permission.PermissionService,
+                           'invalidate_user_permission_cache'), \
+         mock.patch.object(permission.PermissionService,
+                           'invalidate_workspace_permission_cache'):
+        yield _worker(), _worker()
+
+
+def _grouping_rows(service, user_id):
+    """The user's grouping rows as persisted, read through a fresh model."""
+    service.enforcer.load_policy()
+    return sorted(service.enforcer.get_roles_for_user(user_id))
+
+
+class TestStalePolicyWrites:
+    """A worker must reload inside the lock before it mutates the policy.
+
+    Every one of these fails if the corresponding `_load_policy_no_lock()` is
+    removed, because worker B's in-memory model is deliberately older than
+    worker A's write.
+    """
+
+    def test_add_user_if_not_exists_does_not_duplicate_role(self, two_workers):
+        worker_a, worker_b = two_workers
+        # B snapshots the empty policy, then A assigns a role behind its back.
+        worker_b.enforcer.load_policy()
+        worker_a.update_role('victim', 'viewer')
+
+        worker_b.add_user_if_not_exists('victim')
+
+        # Without the reload, B believes victim is role-less and adds the
+        # default on top, leaving ['admin', 'viewer'] -- which reads as admin.
+        assert _grouping_rows(worker_a, 'victim') == ['viewer']
+
+    def test_remove_workspace_policy_keeps_other_writes(self, two_workers):
+        worker_a, worker_b = two_workers
+        worker_a.add_workspace_policy('ws_victim', ['bob'])
+        worker_b.enforcer.load_policy()
+        # A demotes alice and grants her a workspace, after B's snapshot.
+        worker_a.update_role('alice', 'viewer')
+        worker_a.add_workspace_policy('ws_keep', ['alice'])
+
+        worker_b.remove_workspace_policy('ws_victim')
+
+        # save_policy() rewrites the whole table from the caller's model, so
+        # without the reload this also erases everything A just wrote.
+        worker_a.enforcer.load_policy()
+        remaining = worker_a.enforcer.get_policy()
+        assert ['alice', 'ws_keep', '*'] in remaining
+        assert ['bob', 'ws_victim', '*'] not in remaining
+        assert _grouping_rows(worker_a, 'alice') == ['viewer']
+
+
+class TestRoleReplacement:
+    """A user is only ever meant to hold one role."""
+
+    def test_update_role_replaces_every_role(self, two_workers):
+        worker_a, _ = two_workers
+        worker_a.enforcer.add_grouping_policy('multi', 'admin')
+        worker_a.enforcer.add_grouping_policy('multi', 'user')
+
+        worker_a.update_role('multi', 'viewer')
+
+        # A leftover 'admin' would silently undo the demotion.
+        assert _grouping_rows(worker_a, 'multi') == ['viewer']
+
+    def test_update_role_to_the_only_held_role_is_a_noop(self, two_workers):
+        worker_a, _ = two_workers
+        worker_a.update_role('solo', 'user')
+        worker_a.update_role('solo', 'user')
+        assert _grouping_rows(worker_a, 'solo') == ['user']
+
+    def test_delete_user_removes_every_role(self, two_workers):
+        worker_a, _ = two_workers
+        worker_a.enforcer.add_grouping_policy('multi', 'admin')
+        worker_a.enforcer.add_grouping_policy('multi', 'user')
+
+        worker_a.delete_user('multi')
+
+        # An orphan grant would be inherited by whoever next takes this id.
+        assert _grouping_rows(worker_a, 'multi') == []

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -735,10 +735,11 @@ class TestPermissionService:
     def test_delete_user_with_role(self, mock_kv_cache):
         """Test deleting a user who has a role."""
         mock_enforcer = mock.Mock()
-        # User has a role
+        # User has a role, no workspace grants
         mock_enforcer.remove_filtered_grouping_policy.return_value = [[
             'user1', 'user'
         ]]
+        mock_enforcer.remove_filtered_policy.return_value = []
 
         with mock.patch.object(permission.PermissionService,
                                '__init__',
@@ -762,8 +763,9 @@ class TestPermissionService:
     def test_delete_user_without_role(self, mock_kv_cache):
         """Test deleting a user who has no roles."""
         mock_enforcer = mock.Mock()
-        # User has no roles: nothing matched the filter.
+        # User has neither roles nor workspace grants: nothing matched.
         mock_enforcer.remove_filtered_grouping_policy.return_value = []
+        mock_enforcer.remove_filtered_policy.return_value = []
 
         with mock.patch.object(permission.PermissionService,
                                '__init__',
@@ -2199,3 +2201,21 @@ class TestRoleReplacement:
 
         # An orphan grant would be inherited by whoever next takes this id.
         assert _grouping_rows(worker_a, 'multi') == []
+
+    def test_delete_user_removes_workspace_grants(self, two_workers):
+        """Deleting a user must revoke their private-workspace membership.
+
+        User ids are derived from the username, so recreating a deleted user
+        reuses the id and would silently inherit whatever was left behind.
+        """
+        worker_a, _ = two_workers
+        worker_a.update_role('leaver', 'user')
+        worker_a.add_workspace_policy('team_private', ['leaver', 'stayer'])
+
+        worker_a.delete_user('leaver')
+
+        worker_a.enforcer.load_policy()
+        remaining = worker_a.enforcer.get_policy()
+        assert ['leaver', 'team_private', '*'] not in remaining
+        # Only that user's grant goes; the workspace's other members stay.
+        assert ['stayer', 'team_private', '*'] in remaining


### PR DESCRIPTION
## Problem

The API server runs `uvicorn` with `workers=cpu_count`, and workspace
create/delete run in executor processes on top of that. Every process holds its
own in-memory casbin model.

Every read and write path in `PermissionService` reloads from the database
first — `update_role`, `delete_user`, `get_user_roles`, `get_users_for_role`,
`add_workspace_policy`, `update_workspace_policy`,
`resync_workspace_policies_for_new_user` — except two.

### `remove_workspace_policy` erases other processes' writes

`sqlalchemy_adapter.Adapter.save_policy` is a blind full-table rewrite:

```python
def save_policy(self, model):
    with self._session_scope() as session:
        session.query(self._db_class).delete()   # every casbin_rule row
        for sec in ["p", "g"]: ...               # rewritten from THIS process
```

`remove_workspace_policy` takes the lock but does not reload before calling it,
so a stale process deleting one workspace also erases whatever another process
wrote since this one last loaded. Reproduced with two processes over one
isolated database — process A demotes `alice` admin→viewer and grants her a
workspace, process B then deletes an *unrelated* workspace:

```
rows 23 -> 21
  LOST:  g, alice, viewer          <- the demotion
         p, alice, ws_from_A, *    <- an unrelated grant
         p, bob, ws_victim, *      <- the only intended deletion
  ADDED: g, alice, admin           <- alice's old admin role, resurrected
```

Reachable from `sky workspace delete` (`sky/workspaces/core.py:642`) and the
bulk workspace-config update's delete branch (`core.py:760`). The stale window
is "since this process last loaded policy", which can be hours.

`add_workspace_policy` and `update_workspace_policy` already reload, one with a
comment saying it is precisely to avoid clobbering.

### `add_user_if_not_exists` can add a second role

It decides "does this user already have a role?" from the process-local model.
The distributed lock serializes the write, but the decision came from a snapshot
taken before the lock was ever acquired:

```
[B] snapshot: roles for victim = []
[A] update_role(victim, viewer)      -> ['viewer']
[B] in-memory roles still []         -> add_user_if_not_exists(victim)

id  ptype  v0      v1
19  g      victim  viewer
20  g      victim  admin       <- second grouping policy
```

Not inert — `check_endpoint_permission` lets admin win over viewer when both are
held, so the leftover row restores what the demotion removed:

```
check_endpoint_permission(victim, /down, POST) -> blocked=False   (viewer-only: True)
```

This one needs a user id the `users` table considers new while casbin already
has a role for it, so routine login does not produce it — but the
delete-and-rewrite above does, and a `_delete_user` that fails between the two
tables does too.

## Fix

One `_load_policy_no_lock()` inside the existing lock in each, matching the five
siblings.

The reload goes in the **public** `add_user_if_not_exists`, not in
`_add_user_if_not_exists_no_lock`: `_maybe_initialize_policies` calls the helper
once per user in a loop at startup, and a reload there would be one full policy
load per user. Measured, a load is ~1 ms at 84 policy rows and ~400 ms at 20k
(roughly 20 µs/row, where `g` grows with users and `p` with users × private
workspaces) — so per-user at startup would be untenable, while once per new
identity and once per `sky workspace delete` is free.

### `delete_user` also revokes workspace grants

Clearing only the role rows left the user's private-workspace membership behind,
and user ids are derived from the username (`md5(username)[:8]`) — so deleting
`alice` and recreating `alice` reuses the id and silently inherits the old
grant:

```
before delete: [('g', <id>, 'user', None), ('p', <id>, 'team_private', '*')]
after  delete: [('p', <id>, 'team_private', '*')]
_writable_workspace_names(<id>, {'team_private'}) -> {'team_private'}
```

Nothing else cleaned those up: `_delete_user` only calls
`global_user_state.delete_user` and `permission_service.delete_user`, and
`_writable_workspace_names` matches `p` rows by user id directly. Role names do
share field 0 with user ids on `p` rows (blocklist entries are
`p, user, /path, METHOD`), but a user id is an 8-char hash or an `sa-` prefixed
id and cannot collide with one.

### Startup rewrites the table from a pre-lock snapshot too

The enforcer loads its model in the `casbin.SyncedEnforcer` constructor, and
only then is `_policy_lock()` acquired — a wait bounded at 20s.
`_maybe_initialize_policies` and `_maybe_initialize_basic_auth_user` run inside
that lock and end in `save_policy()`, and the former also derives
`redundant_policies` from the same stale snapshot and *deletes* them.

Only reachable during full initialization, which runs once per server process,
so a single node has nobody to race. HA does: `_detect_lock_type` returns
`postgres` when the dialect is PostgreSQL, so the lock genuinely serializes
replicas — and every replica runs this on boot, so one acquiring the lock a
moment later can wipe the first one's writes. (With SQLite the lock is a
per-host filelock, which is enough there: SQLite is single-node, and the
processes that matter — uvicorn workers, executors — are all on that host.)

Both now reload as their first act inside the lock, self-contained rather than
relying on the caller.

### `update_role` / `delete_user` now clear every grouping row

Previously they dropped `current_roles[0]`. A database already in the multi-role
state was therefore unrepairable through the API: `get_roles_for_user`'s
ordering is not stable across processes (two fresh processes reading the same
database returned `['admin','user']` and `['user','admin']`), so which row
survived was a coin flip — and once `viewer` happened to sort first,
`update_role`'s `current_role == new_role` early return made the demotion a
complete no-op while the user kept `admin`.

`remove_filtered_grouping_policy(0, user_id)` also clears byte-identical
duplicate rows, which a loop over the deduplicated role list cannot reach, and
matches the `remove_filtered_policy(1, workspace_name)` idiom already in the
file.

## Test plan

```bash
pytest tests/unit_tests/test_sky/users/
# 245 passed
```

Seven new tests in `TestStalePolicyWrites` / `TestRoleReplacement` drive two real
casbin enforcers over one temporary SQLite file — the same in-memory divergence
two worker processes have, without needing two processes.

Revert-checked one fix at a time; each maps to exactly one failing test, with no
overlap:

| reverted | fails |
| --- | --- |
| `add_user_if_not_exists` reload | `test_add_user_if_not_exists_does_not_duplicate_role` |
| `remove_workspace_policy` reload | `test_remove_workspace_policy_keeps_other_writes` |
| `update_role` dropping only the first role | `test_update_role_replaces_every_role` |
| `delete_user` dropping only the first role | `test_delete_user_removes_every_role` |
| `delete_user` not removing workspace grants | `test_delete_user_removes_workspace_grants` |
| the startup reload | `test_startup_initialization_keeps_other_writes` |

Three existing mock-based tests were updated to the filtered-removal call.

Also exercised end to end against a local multi-worker server (`--deploy`, 10
processes) with its own runtime dir, driving the real API and asserting on the
persisted `casbin_rule` table. On `master` a demotion followed by an unrelated
`sky workspace delete` reverted the role to `admin`, `update_role` left
`admin|user|viewer`, and `delete_user` left an orphan; all clean with this
change. The end-to-end probe depends on process staleness and so is not
deterministic on a loaded machine — the two-process reproductions above are the
reliable evidence.

## Not in scope

`check_endpoint_permission` still never reloads, and still reads "no roles" as
"no restrictions" (an unknown or absent role matches no blocklist policy, so it
is permitted everywhere). That is the enforcement side of the same problem and
needs a decision on what a role-less authenticated principal should mean, plus
something cheaper than a full reload on the request path. Separate change.
