### PR TITLE
[Jobs] Preserve any_of semantics when adding Kubernetes annotations

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -144,13 +144,14 @@ def _add_k8s_annotations(task: 'sky.Task', job_id: int) -> None:
             }
         }
     }
+    resource_type = type(task.resources)
     new_resources_list: List['sky.Resources'] = [
         original_resource.copy(_cluster_config_overrides=annotations_override)
         for original_resource in task.resources
     ]
 
     # Set the new resources back to the task
-    task.set_resources(new_resources_list)
+    task.set_resources(resource_type(new_resources_list))
 
 
 def _task_uses_kubernetes(task: 'sky.Task') -> bool:

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1819,12 +1819,27 @@ class TestAddK8sAnnotations:
 
     @staticmethod
     def _pod_config(resource_or_task):
-        # Task.resources is a set before _add_k8s_annotations and a list
-        # after it, so index through a list either way.
+        # Index through a list regardless of collection type.
         resource = resource_or_task
         if isinstance(resource_or_task, task_lib.Task):
             resource = list(resource_or_task.resources)[0]
         return resource.cluster_config_overrides['kubernetes']['pod_config']
+
+    @pytest.mark.parametrize('resource_type,config_key', [(set, 'any_of'),
+                                                          (list, 'ordered')])
+    def test_resource_collection_type_preserved(self, resource_type,
+                                                config_key):
+        """Adding annotations must not change any_of/ordered semantics."""
+        task = task_lib.Task(name='test-task', run='echo hi')
+        resources = [sky.Resources(cpus=1), sky.Resources(cpus=2)]
+        task.set_resources(resource_type(resources))
+
+        controller_module._add_k8s_annotations(task, job_id=1)
+
+        assert isinstance(task.resources, resource_type)
+        assert config_key in task.get_resource_config()
+        if resource_type is list:
+            assert [resource.cpus for resource in task.resources] == ['1', '2']
 
     def test_lists_without_patch_merge_key_not_duplicated(self):
         """Lists appended by the merge must not be doubled."""


### PR DESCRIPTION
## Description

Fixes #10489.

Managed-job controller's `_add_k8s_annotations()` rebuilt every resource collection as a list. SkyPilot represents `any_of` resources as a set and `ordered` resources as a list, so this changed `any_of` into `ordered` immediately before launch. Optimizer then selected first launchable resource in set-iteration order instead of comparing all candidates by cost.

Preserve original resource collection type when copying resources with Kubernetes annotations:

- `set` remains `any_of`;
- `list` remains `ordered`, with order preserved.

Adds regression coverage for both collection types and their serialized config keys.

Tested:

- [x] New and existing annotation tests:
  ```bash
  pytest -o addopts='' -n 0 -q --tb=short \
    tests/unit_tests/test_sky/jobs/test_controller.py::TestAddK8sAnnotations
  ```
  Result: `7 passed`
- [x] Full managed-job controller unit test module:
  ```bash
  pytest -o addopts='' -n 0 -q --tb=short \
    tests/unit_tests/test_sky/jobs/test_controller.py
  ```
  Result: `72 passed`
- [ ] Code formatting: CI
- [ ] All smoke tests
- [ ] Backward compatibility suite

No cloud credentials or provisioning required.

---

*This code was generated using GPT-5.6 in Pi Coding Agent.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->