### PR TITLE
[EFA] Skip warm nodes running a different accelerator when sizing EFA

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1594,6 +1594,44 @@ class Kubernetes(clouds.Cloud):
             return None
 
     @classmethod
+    def _node_runs_accelerator(cls, node: Any, label_key: str,
+                               acc_type: str) -> Optional[bool]:
+        """Whether ``node`` runs ``acc_type``. None when it cannot be told.
+
+        Deliberately asks the question the same way
+        ``get_accelerator_label_key_values`` already does when it decides a node
+        can host the request, so this agrees with scheduling by construction:
+        offer the label's RAW value and its formatter-normalized form to
+        ``accelerator_name_matches``.
+
+        A plain string compare is wrong here, because label VALUES are
+        formatter-specific and normalization is not identity:
+          - Karpenter/SkyPilot: 'h100'                 -> 'H100'
+          - GKE:                'nvidia-tesla-a100'    -> 'A100'
+          - GFD:                'NVIDIA-H100-80GB-HBM3'-> 'H100-80GB'
+        The GFD case is why: asking for 'H100' on a p5.48xlarge would fail an
+        equality test against 'H100-80GB', and that node -- the richest EFA SKU
+        on AWS, 32 interfaces -- would be skipped. `accelerator_name_matches`
+        handles that prefix relationship (and guards against matching across
+        different memory sizes).
+        """
+        raw = node.metadata.labels.get(label_key)
+        if not raw:
+            # Absent or empty: unknown, not "different". Callers must not skip.
+            return None
+        viable = [raw.lower()]
+        for formatter in kubernetes_utils.LABEL_FORMATTER_REGISTRY:
+            if formatter.match_label_key(label_key):
+                try:
+                    viable.append(
+                        formatter.get_accelerator_from_label_value(raw).lower())
+                except Exception:  # pylint: disable=broad-except
+                    # A formatter that cannot parse this value tells us nothing.
+                    return None
+                break
+        return kubernetes_utils.accelerator_name_matches(acc_type, viable)
+
+    @classmethod
     def _detect_network_type(
         cls,
         context: str,
@@ -1677,6 +1715,29 @@ class Kubernetes(clouds.Cloud):
                                         allocatable[k8s_resource_key]) <
                                     acc_count):
                                 continue
+                            # The checks above only prove the node carries the
+                            # accelerator label KEY -- not that it runs the
+                            # accelerator that was actually requested. On a
+                            # heterogeneous cluster every GPU node carries the
+                            # key, so without this guard an L4:8 request matches
+                            # a warm p5 (h100, 32 EFA) node and derives
+                            # floor(8/8*32) = 32 EFA interfaces. The pod then
+                            # requests 32 on a node that has none and stays
+                            # Pending forever (or is rejected 422).
+                            #
+                            # Skip only on a POSITIVE mismatch: if we cannot
+                            # determine the node's accelerator we keep today's
+                            # behaviour, because wrongly skipping is not free
+                            # either -- it falls through to the catalog, which
+                            # is safe but sized from the lowest variant of the
+                            # accelerator and so can under-request on a larger
+                            # SKU. acc_type is legitimately None for callers
+                            # that ask for network_tier without an accelerator.
+                            if acc_type is not None:
+                                runs_it = cls._node_runs_accelerator(
+                                    node, k8s_acc_label_key, acc_type)
+                                if runs_it is False:
+                                    continue
                             # Calculate EFA count proportionally
                             if AWS_EFA_RESOURCE_KEY in node.status.allocatable:
                                 node_gpu_count = int(

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -857,8 +857,8 @@ class GFDLabelFormatter(GPULabelFormatter):
                                                  '').replace('RTX-', 'RTX')
 
 
-def _accelerator_name_matches(requested_acc: str,
-                              viable_names: List[str]) -> bool:
+def accelerator_name_matches(requested_acc: str,
+                             viable_names: List[str]) -> bool:
     """Check if requested accelerator matches any viable name.
 
     For backward compatibility with GPU name changes (e.g., when canonical names
@@ -1383,9 +1383,9 @@ class GKEAutoscaler(Autoscaler):
                 continue
             node_accelerator_count = accelerator['acceleratorCount']
             viable_names = [node_accelerator_type.lower(), raw_value.lower()]
-            # Use _accelerator_name_matches for backward compatibility
+            # Use accelerator_name_matches for backward compatibility
             # with GPU name changes (e.g., 'H200' vs 'H200-SXM-80GB').
-            if (_accelerator_name_matches(requested_gpu_type, viable_names) and
+            if (accelerator_name_matches(requested_gpu_type, viable_names) and
                     int(node_accelerator_count) >= requested_gpu_count):
                 return True
         return False
@@ -2792,12 +2792,12 @@ def get_accelerator_label_key_values(
                 for label, value in label_list:
                     if label_formatter.match_label_key(label):
                         # Match either canonicalized name or raw name.
-                        # Use _accelerator_name_matches for backward compatibility
+                        # Use accelerator_name_matches for backward compatibility
                         # with GPU name changes (e.g., H200-SXM-80GB -> H200).
                         accelerator = (label_formatter.
                                        get_accelerator_from_label_value(value))
                         viable = [value.lower(), accelerator.lower()]
-                        if not _accelerator_name_matches(acc_type, viable):
+                        if not accelerator_name_matches(acc_type, viable):
                             continue
                         if is_tpu_on_gke(acc_type):
                             assert isinstance(label_formatter,

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -2,7 +2,7 @@
 
 Tests verify correct GPU detection from Kubernetes labels.
 """
-from sky.provision.kubernetes.utils import _accelerator_name_matches
+from sky.provision.kubernetes.utils import accelerator_name_matches
 from sky.provision.kubernetes.utils import GFDLabelFormatter
 from sky.provision.kubernetes.utils import is_neuron_accelerator
 from sky.provision.kubernetes.utils import KarpenterLabelFormatter
@@ -306,10 +306,10 @@ class TestAcceleratorNameMatches:
 
     def test_exact_match(self):
         """Test exact accelerator name matching."""
-        assert _accelerator_name_matches('H200', ['h200'])
-        assert _accelerator_name_matches('H100', ['h100'])
-        assert _accelerator_name_matches('A100-80GB', ['a100-80gb'])
-        assert not _accelerator_name_matches('H200', ['h100'])
+        assert accelerator_name_matches('H200', ['h200'])
+        assert accelerator_name_matches('H100', ['h100'])
+        assert accelerator_name_matches('A100-80GB', ['a100-80gb'])
+        assert not accelerator_name_matches('H200', ['h100'])
 
     def test_backward_compat_canonical_to_fallback(self):
         """Test matching canonical name against fallback name.
@@ -319,11 +319,11 @@ class TestAcceleratorNameMatches:
         launched_resources has 'H200-SXM-80GB', viable list has ['h200'].
         """
         # Old acc_type (H200-SXM-80GB) should match new canonical (h200)
-        assert _accelerator_name_matches('H200-SXM-80GB', ['h200'])
-        assert _accelerator_name_matches('H200-SXM-80GB',
-                                         ['nvidia-h200-sxm-80gb', 'h200'])
-        assert _accelerator_name_matches('H100-PCIE-80GB', ['h100'])
-        assert _accelerator_name_matches('L40S-48GB', ['l40s'])
+        assert accelerator_name_matches('H200-SXM-80GB', ['h200'])
+        assert accelerator_name_matches('H200-SXM-80GB',
+                                        ['nvidia-h200-sxm-80gb', 'h200'])
+        assert accelerator_name_matches('H100-PCIE-80GB', ['h100'])
+        assert accelerator_name_matches('L40S-48GB', ['l40s'])
 
     def test_forward_compat_fallback_to_canonical(self):
         """Test matching fallback name against canonical name.
@@ -332,36 +332,36 @@ class TestAcceleratorNameMatches:
         fallback 'H200-SXM-80GB' from get_accelerator_from_label_value.
         """
         # New acc_type (H200) should match old fallback (h200-sxm-80gb)
-        assert _accelerator_name_matches('H200', ['h200-sxm-80gb'])
-        assert _accelerator_name_matches(
+        assert accelerator_name_matches('H200', ['h200-sxm-80gb'])
+        assert accelerator_name_matches(
             'H200', ['nvidia-h200-sxm-80gb', 'h200-sxm-80gb'])
-        assert _accelerator_name_matches('H100', ['h100-pcie-80gb'])
-        assert _accelerator_name_matches('L40S', ['l40s-48gb'])
+        assert accelerator_name_matches('H100', ['h100-pcie-80gb'])
+        assert accelerator_name_matches('L40S', ['l40s-48gb'])
 
     def test_no_false_positive_prefix(self):
         """Test that partial prefixes don't match incorrectly."""
         # H2 should not match H200 (no dash separator)
-        assert not _accelerator_name_matches('H2', ['h200'])
-        assert not _accelerator_name_matches('H20', ['h200'])
+        assert not accelerator_name_matches('H2', ['h200'])
+        assert not accelerator_name_matches('H20', ['h200'])
         # L4 should not match L40 (different GPU)
-        assert not _accelerator_name_matches('L4', ['l40'])
-        assert not _accelerator_name_matches('L40', ['l4'])
+        assert not accelerator_name_matches('L4', ['l40'])
+        assert not accelerator_name_matches('L40', ['l4'])
         # A10 should not match A100
-        assert not _accelerator_name_matches('A10', ['a100'])
+        assert not accelerator_name_matches('A10', ['a100'])
 
     def test_case_insensitive(self):
         """Test case-insensitive matching."""
-        assert _accelerator_name_matches('H200', ['H200'])
-        assert _accelerator_name_matches('h200', ['H200'])
-        assert _accelerator_name_matches('H200-SXM-80GB', ['h200'])
-        assert _accelerator_name_matches('h200-sxm-80gb', ['H200'])
+        assert accelerator_name_matches('H200', ['H200'])
+        assert accelerator_name_matches('h200', ['H200'])
+        assert accelerator_name_matches('H200-SXM-80GB', ['h200'])
+        assert accelerator_name_matches('h200-sxm-80gb', ['H200'])
 
     def test_multiple_viable_names(self):
         """Test matching against multiple viable names."""
         viable = ['nvidia-h200-sxm-80gb', 'h200']
-        assert _accelerator_name_matches('H200', viable)
-        assert _accelerator_name_matches('H200-SXM-80GB', viable)
-        assert not _accelerator_name_matches('H100', viable)
+        assert accelerator_name_matches('H200', viable)
+        assert accelerator_name_matches('H200-SXM-80GB', viable)
+        assert not accelerator_name_matches('H100', viable)
 
     def test_h100_80gb_backward_compat(self):
         """Test H100 ↔ H100-80GB backward compatibility.
@@ -376,21 +376,21 @@ class TestAcceleratorNameMatches:
         - New SkyPilot: label 'H100-SXM-80GB' → canonical 'H100-80GB'
         - Cluster launched with old SkyPilot has 'H100' in launched_resources
         - After upgrade, viable_names = ['h100-80gb', 'nvidia-h100-sxm-80gb']
-        - _accelerator_name_matches('H100', viable_names) should return True
+        - accelerator_name_matches('H100', viable_names) should return True
         """
         # Old stored 'H100' should match new canonical 'H100-80GB'
-        assert _accelerator_name_matches('H100', ['h100-80gb'])
-        assert _accelerator_name_matches('H100',
-                                         ['h100-80gb', 'nvidia-h100-sxm-80gb'])
+        assert accelerator_name_matches('H100', ['h100-80gb'])
+        assert accelerator_name_matches('H100',
+                                        ['h100-80gb', 'nvidia-h100-sxm-80gb'])
 
         # New stored 'H100-80GB' should match old canonical 'H100'
-        assert _accelerator_name_matches('H100-80GB', ['h100'])
-        assert _accelerator_name_matches('H100-80GB',
-                                         ['h100', 'nvidia-h100-sxm-80gb'])
+        assert accelerator_name_matches('H100-80GB', ['h100'])
+        assert accelerator_name_matches('H100-80GB',
+                                        ['h100', 'nvidia-h100-sxm-80gb'])
 
         # GH200 variants (GH200-480GB is a possible variant)
-        assert _accelerator_name_matches('GH200', ['gh200-480gb'])
-        assert _accelerator_name_matches('GH200-480GB', ['gh200'])
+        assert accelerator_name_matches('GH200', ['gh200-480gb'])
+        assert accelerator_name_matches('GH200-480GB', ['gh200'])
 
     def test_memory_variant_no_oom_match(self):
         """A request must not match a node with less device memory.
@@ -400,33 +400,33 @@ class TestAcceleratorNameMatches:
         direction and same-hardware renames keep matching.
         """
         # OOM direction: 80GB request must not match a 40GB node.
-        assert not _accelerator_name_matches('A100-80GB', ['a100'])
-        assert not _accelerator_name_matches('A100-80GB',
-                                             ['nvidia-a100-sxm4-40gb', 'a100'])
-        assert not _accelerator_name_matches('V100-32GB', ['v100'])
+        assert not accelerator_name_matches('A100-80GB', ['a100'])
+        assert not accelerator_name_matches('A100-80GB',
+                                            ['nvidia-a100-sxm4-40gb', 'a100'])
+        assert not accelerator_name_matches('V100-32GB', ['v100'])
 
         # Same, but with names that are NOT canonicalized. On a Kubernetes-only
         # cluster a user-typed 'A100-80G' (missing the 'B') is not normalized to
         # 'A100-80GB', so the guard must parse the memory suffix to still reject
         # the 40GB node. This is the exact shape that reached production.
-        assert not _accelerator_name_matches('A100-80G', ['a100'])
-        assert not _accelerator_name_matches('A100-80G',
-                                             ['nvidia-a100-sxm4-40gb', 'a100'])
-        assert not _accelerator_name_matches('V100-32G', ['v100'])
+        assert not accelerator_name_matches('A100-80G', ['a100'])
+        assert not accelerator_name_matches('A100-80G',
+                                            ['nvidia-a100-sxm4-40gb', 'a100'])
+        assert not accelerator_name_matches('V100-32G', ['v100'])
 
         # Backward-compat direction: a smaller-memory request may still land
         # on a larger-memory node (pre-existing benign behavior).
-        assert _accelerator_name_matches('A100', ['a100-80gb'])
-        assert _accelerator_name_matches('V100', ['v100-32gb'])
+        assert accelerator_name_matches('A100', ['a100-80gb'])
+        assert accelerator_name_matches('V100', ['v100-32gb'])
 
         # Same-hardware renames (equal memory) must still match.
-        assert _accelerator_name_matches('H100', ['h100-80gb'])
-        assert _accelerator_name_matches('H100-80GB', ['h100'])
+        assert accelerator_name_matches('H100', ['h100-80gb'])
+        assert accelerator_name_matches('H100-80GB', ['h100'])
 
         # H100-MEGA is the same H100 80GB silicon (A3 Mega instance), so
         # cross-matching with H100 is harmless and preserved.
-        assert _accelerator_name_matches('H100', ['h100-mega'])
-        assert _accelerator_name_matches('H100-MEGA', ['h100'])
+        assert accelerator_name_matches('H100', ['h100-mega'])
+        assert accelerator_name_matches('H100-MEGA', ['h100'])
 
     def test_no_cross_variant_matching(self):
         """Test that different GPU variants don't incorrectly match.
@@ -438,10 +438,10 @@ class TestAcceleratorNameMatches:
         2. Not matching would break backward compat for valid cases
         """
         # These will match due to prefix logic - this is expected behavior
-        assert _accelerator_name_matches('H100', ['h100-mega'])
+        assert accelerator_name_matches('H100', ['h100-mega'])
         # But ensure unrelated GPUs don't match
-        assert not _accelerator_name_matches('H200', ['h100-mega'])
-        assert not _accelerator_name_matches('A100', ['h100-mega'])
+        assert not accelerator_name_matches('H200', ['h100-mega'])
+        assert not accelerator_name_matches('A100', ['h100-mega'])
 
 
 class TestKarpenterNeuronLabelFormatter:

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes_efa_warm_scan.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes_efa_warm_scan.py
@@ -1,0 +1,182 @@
+"""Warm-node EFA scan must respect the requested accelerator type.
+
+`Kubernetes._detect_network_type` derives the `vpc.amazonaws.com/efa` count for a
+`network_tier: best` request. It has two paths: scan a running node and use its
+own EFA allocatable (warm), or size from the instance-type catalog (cold).
+
+The warm scan used to accept any node that merely carried the accelerator label
+KEY, without comparing its VALUE to the requested accelerator. On a
+heterogeneous cluster every GPU node carries the key, so an `L4:8` request
+matched a warm `p5.48xlarge` (label `h100`, 8 GPUs, 32 EFA) and derived
+`floor(8/8*32) = 32`. The pod then requested 32 EFA interfaces on a node type
+that has none and stayed Pending. Upstream bug from #8557.
+
+These tests pin all three behaviours, because fixing only the first one is easy
+to over-correct into skipping every warm node -- which still "works" (the cold
+catalog path is safe) and would therefore ship green.
+"""
+from unittest import mock
+
+import pytest
+
+from sky.clouds import kubernetes as ck
+from sky.utils import resources_utils
+
+_GPU_LABEL = 'karpenter.k8s.aws/instance-gpu-name'
+_GPU_RESOURCE = 'nvidia.com/gpu'
+_EFA_RESOURCE = 'vpc.amazonaws.com/efa'
+
+
+def _node(gpu_name, gpu_count, efa_count):
+    """A warm AWS GPU node carrying Karpenter's gpu-name label."""
+    node = mock.MagicMock()
+    node.metadata.labels = {
+        _GPU_LABEL: gpu_name,
+        # Any AWS node carries these; this is what sets saw_aws_efa_node.
+        'k8s.io/cloud-provider-aws': 'true',
+    }
+    allocatable = {_GPU_RESOURCE: str(gpu_count)}
+    if efa_count is not None:
+        allocatable[_EFA_RESOURCE] = str(efa_count)
+    node.status.allocatable = allocatable
+    return node
+
+
+def _detect(nodes, acc_type, acc_count, autoscaler=None):
+    with mock.patch.object(ck.kubernetes_utils,
+                           'get_kubernetes_nodes',
+                           return_value=nodes), \
+         mock.patch.object(ck.skypilot_config,
+                           'get_effective_region_config',
+                           return_value=autoscaler):
+        return ck.Kubernetes._detect_network_type(
+            'ctx',
+            resources_utils.NetworkTier.BEST,
+            _GPU_LABEL,
+            _GPU_RESOURCE,
+            acc_count=acc_count,
+            acc_type=acc_type)
+
+
+def test_warm_node_of_a_different_accelerator_is_not_used():
+    """L4:8 must not inherit a warm h100 node's 32 EFA interfaces.
+
+    This is the regression: 32 on an L4 node is unschedulable.
+    """
+    _, meta = _detect([_node('h100', 8, 32)], acc_type='L4', acc_count=8)
+    assert meta != {
+        'efa_count': 32
+    }, ('warm h100 node leaked its EFA count into an L4 request')
+    assert meta is None or meta.get('efa_count') != 32
+
+
+def test_warm_node_of_the_matching_accelerator_is_still_used():
+    """The guard must not skip EVERYTHING -- catches an over-correction.
+
+    A naive raw-string compare (label 'h100' != acc_type 'H100') would skip this
+    node too, silently falling through to the catalog. That still schedules, so
+    it would pass a test that only checked the mismatch case.
+    """
+    _, meta = _detect([_node('h100', 8, 32)], acc_type='H100', acc_count=8)
+    assert meta == {
+        'efa_count': 32
+    }, (f'matching warm node should supply its own EFA count, got {meta}')
+
+
+def test_no_accelerator_requested_keeps_previous_behaviour():
+    """acc_type=None is a legitimate caller; the guard must be a no-op there."""
+    _, meta = _detect([_node('h100', 8, 32)], acc_type=None, acc_count=8)
+    assert meta == {'efa_count': 32}
+
+
+def test_mismatched_warm_node_falls_through_to_the_catalog():
+    """With an autoscaler configured, the type-aware cold path takes over.
+
+    That is the whole point of skipping the mismatched node: the catalog knows
+    L4's real per-accelerator EFA ratio, the warm p5 node does not.
+    """
+    with mock.patch.object(ck.Kubernetes,
+                           '_derive_efa_count_from_catalog',
+                           return_value=1) as derived:
+        net, meta = _detect([_node('h100', 8, 32)],
+                            acc_type='L4',
+                            acc_count=8,
+                            autoscaler='karpenter')
+    derived.assert_called_once_with('L4', 8)
+    assert meta == {'efa_count': 1}
+    assert net == ck.KubernetesHighPerformanceNetworkType.AWS_EFA
+
+
+def test_matching_accelerator_among_several_warm_nodes():
+    """A mismatched node earlier in the list must not shadow a matching one."""
+    nodes = [_node('h100', 8, 32), _node('l4', 8, 1)]
+    _, meta = _detect(nodes, acc_type='L4', acc_count=8)
+    assert meta == {
+        'efa_count': 1
+    }, (f'should have used the l4 node, not the h100 one; got {meta}')
+
+
+@pytest.mark.parametrize('label_value,requested', [
+    ('h100', 'H100'),
+    ('H100', 'h100'),
+    ('l4', 'L4'),
+])
+def test_label_value_case_does_not_matter(label_value, requested):
+    """Karpenter/SkyPilot label values are lowercase; acc_type is canonical."""
+    _, meta = _detect([_node(label_value, 8, 32)],
+                      acc_type=requested,
+                      acc_count=8)
+    assert meta == {'efa_count': 32}
+
+
+def test_node_with_an_empty_accelerator_label_is_still_used():
+    """Skip only on a POSITIVE mismatch -- "cannot tell" must not skip.
+
+    An empty label value is legitimate on heterogeneous clusters, and elsewhere
+    in the codebase it means "unknown" rather than "different". Uses the REAL
+    helper (no mock): an earlier version of this test mocked
+    _node_accelerator_name to return None and so asserted behaviour the code did
+    not actually have -- the None branch was unreachable because the helper
+    returned the raw value for unrecognised labels.
+    """
+    node = _node('', 8, 32)
+    # The pre-existing key check requires the key to be PRESENT, which it is.
+    _, meta = _detect([node], acc_type='L4', acc_count=8)
+    assert meta == {
+        'efa_count': 32
+    }, (f'an undeterminable accelerator must not cause a skip; got {meta}')
+
+
+def test_gfd_labelled_p5_still_matches_a_plain_h100_request():
+    """The regression a plain string compare would have introduced.
+
+    GPU-Feature-Discovery (NVIDIA GPU Operator, common on EKS) labels a p5 node
+    `nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3`, which normalizes to
+    'H100-80GB'. The catalog's canonical name -- what a user types and what
+    Resources canonicalizes to -- is 'H100'. An equality test would skip
+    p5.48xlarge, the richest EFA SKU on AWS (32 interfaces), and silently lose
+    the warm path on every GFD-labelled cluster.
+    """
+    gfd_key = 'nvidia.com/gpu.product'
+    node = mock.MagicMock()
+    node.metadata.labels = {
+        gfd_key: 'NVIDIA-H100-80GB-HBM3',
+        'k8s.io/cloud-provider-aws': 'true',
+    }
+    node.status.allocatable = {_GPU_RESOURCE: '8', _EFA_RESOURCE: '32'}
+    with mock.patch.object(ck.kubernetes_utils,
+                           'get_kubernetes_nodes',
+                           return_value=[node]), \
+         mock.patch.object(ck.skypilot_config,
+                           'get_effective_region_config',
+                           return_value=None):
+        _, meta = ck.Kubernetes._detect_network_type(
+            'ctx',
+            resources_utils.NetworkTier.BEST,
+            gfd_key,
+            _GPU_RESOURCE,
+            acc_count=8,
+            acc_type='H100')
+    assert meta == {
+        'efa_count': 32
+    }, (f'GFD-labelled p5 must satisfy an H100 request; got {meta}')


### PR DESCRIPTION
Fixes #10491.

## Problem

`Kubernetes._detect_network_type` could use a warm node with the wrong GPU type to size EFA.

The warm-node check only verified that the node had an accelerator label and enough GPUs; it did not verify that the label value matched `acc_type`.

For example, an `L4:8` request could match a warm `p5.48xlarge` (`h100`, 8 GPUs, 32 EFA) and request 32 `vpc.amazonaws.com/efa`.

Because the pod is still pinned to L4 nodes via required node affinity, this makes the pod unschedulable until `provision_timeout`.

Introduced by b4d5204e9 (#8557).

## Fix

Use `acc_type` when scanning warm nodes and skip nodes with a known accelerator mismatch.

Matching uses `accelerator_name_matches` rather than raw string equality so equivalent labels such as `H100` and `NVIDIA-H100-80GB-HBM3` are handled consistently with the existing scheduling logic.

If the node's accelerator cannot be determined, or `acc_type` is `None`, existing behavior is unchanged.

Mismatched warm nodes fall through to the existing accelerator-aware catalog path.

Also promotes `_accelerator_name_matches` to `accelerator_name_matches` so it can be reused from `sky/clouds/kubernetes.py`.

## Tests

Added coverage for:

- mismatched and matching warm nodes
- multiple warm nodes
- GFD-formatted H100 labels
- case-insensitive labels
- `acc_type=None`
- unknown accelerator labels
- catalog fallback after a mismatch

42 tests passed across the affected test files.

`yapf`, `isort`, and `pylint` are clean.