### PR TITLE
[Core] Expose `MOUNT_CACHED` configuration for `rclone` upload concurrency flags

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -617,5 +617,12 @@ Storage YAML reference
                 Delay before uploading dirty files to remote.
             - read_only: bool; default: false
                 Whether the mount is read-only.
+            - upload_concurrency: int; e.g. 8
+                Chunks uploaded concurrently per transfer for multipart
+                uploads. Only applies to backends with multipart-upload
+                tuning (S3-family, Azure); ignored on GCS.
+            - chunk_size: str; e.g. "64M"
+                Chunk size for multipart uploads. Same backend support as
+                upload_concurrency.
             Size values accept suffixes: K, M, G, T, P (e.g. "64M", "10G").
             Duration values accept suffixes: ns, us, ms, s, m, h (e.g. "5s", "1h").

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -621,6 +621,7 @@ def validate(
     omit_priority_class = _omit(43)
     omit_max_hourly_cost = _omit(44)
     omit_mount_config = _omit(48)
+    omit_mount_cached_upload_tuning = _omit(58)
 
     for task in dag.tasks:
         if omit_user_specified_yaml:
@@ -650,6 +651,14 @@ def validate(
                 storage.mount_config = None
             logger.debug('`mount_config` is ignored because the server '
                          'does not support it yet.')
+        if omit_mount_cached_upload_tuning:
+            for storage in task.storage_mounts.values():
+                config = storage.mount_cached_config
+                if config is not None:
+                    config.upload_concurrency = None
+                    config.chunk_size = None
+            logger.debug('`upload_concurrency`/`chunk_size` are ignored '
+                         'because the server does not support them yet.')
         if omit_priority_class:
             for resource in task.resources:
                 if resource.priority_class:

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '57';
+export const CLIENT_API_VERSION = '58';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -748,6 +748,23 @@ class Rclone:
         VASTDATA = 'VASTDATA'
         OCI = 'OCI'
 
+        @property
+        def backend_flag_prefix(self) -> str:
+            """rclone backend name used as the prefix for backend-specific
+            flags (e.g. "s3" -> --s3-region, --s3-chunk-size).
+            """
+            return {
+                Rclone.RcloneStores.S3: 's3',
+                Rclone.RcloneStores.GCS: 'gcs',
+                Rclone.RcloneStores.IBM: 's3',
+                Rclone.RcloneStores.R2: 's3',
+                Rclone.RcloneStores.AZURE: 'azureblob',
+                Rclone.RcloneStores.NEBIUS: 's3',
+                Rclone.RcloneStores.COREWEAVE: 's3',
+                Rclone.RcloneStores.VASTDATA: 's3',
+                Rclone.RcloneStores.OCI: 's3',
+            }[self]
+
         def get_profile_name(self, bucket_name: str) -> str:
             """Gets the Rclone profile name for a given bucket.
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -696,11 +696,12 @@ def get_cos_mount_cmd(rclone_config: str,
 
 
 def get_mount_cached_cmd(
-        rclone_config: str,
-        rclone_profile_name: str,
-        bucket_name: str,
-        mount_path: str,
-        mount_cached_config: Optional['storage.MountCachedConfig'] = None
+    rclone_config: str,
+    rclone_profile_name: str,
+    bucket_name: str,
+    mount_path: str,
+    mount_cached_config: Optional['storage.MountCachedConfig'] = None,
+    backend_flag_prefix: Optional[str] = None,
 ) -> str:
     """Returns a command to mount a bucket using rclone with vfs cache."""
     # stores bucket profile in rclone config file at the remote nodes.
@@ -763,7 +764,7 @@ def get_mount_cached_cmd(
         # Recommended by rclone documentation for buckets like s3.
         '--vfs-fast-fingerprint '
         # Other customizable rclone flags. Refer to `MountCachedConfig`.
-        f'{mount_cached_config.to_rclone_flags()} '
+        f'{mount_cached_config.to_rclone_flags(backend_flag_prefix)} '
         # This command produces children processes, which need to be
         # detached from the current process's terminal. The command doesn't
         # produce any output, so we aren't dropping any logs.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -424,6 +424,13 @@ def merge_mount_cached_config(
     return MountCachedConfig(**base)
 
 
+# rclone backends whose uploads are not chunked, so they define no
+# --<backend>-upload-concurrency / --<backend>-chunk-size flags. The
+# upload_concurrency/chunk_size settings have no effect there and must not be
+# emitted (an undefined backend flag is a hard error).
+_BACKENDS_WITHOUT_UPLOAD_TUNING = frozenset({'gcs'})
+
+
 @dataclasses.dataclass
 class MountCachedConfig:
     """Per-bucket configuration for MOUNT_CACHED mode (rclone flags).
@@ -459,9 +466,22 @@ class MountCachedConfig:
     # Mount as read-only.
     # rclone flag: --read-only
     read_only: Optional[bool] = None
+    # Number of chunks uploaded concurrently per transfer for multipart uploads.
+    # rclone flag: --<backend>-upload-concurrency
+    upload_concurrency: Optional[int] = None
+    # Chunk size for multipart uploads (e.g. "64M").
+    # rclone flag: --<backend>-chunk-size
+    chunk_size: Optional[str] = None
 
-    def to_rclone_flags(self) -> str:
-        """Convert non-None fields to rclone CLI flag string."""
+    def to_rclone_flags(self, backend_flag_prefix: Optional[str] = None) -> str:
+        """Convert non-None fields to rclone CLI flag string.
+
+        Args:
+            backend_flag_prefix: rclone backend name used as the prefix for
+                backend-specific flags (e.g. "s3"), or None if no backend
+                context is available. Multipart-upload tuning flags are only
+                emitted for backends that actually define them.
+        """
         flags = []
         if self.transfers is not None:
             flags.append(f'--transfers {self.transfers}')
@@ -493,6 +513,19 @@ class MountCachedConfig:
         flags.append(f'--vfs-write-back {self.vfs_write_back or "1s"}')
         if self.read_only:
             flags.append('--read-only')
+        # Backend-specific multipart-upload tuning (e.g. --s3-*, --azureblob-*).
+        if self.upload_concurrency is not None or self.chunk_size is not None:
+            if backend_flag_prefix in _BACKENDS_WITHOUT_UPLOAD_TUNING:
+                logger.warning(f'upload_concurrency/chunk_size are set but the '
+                               f'{backend_flag_prefix} backend has no rclone '
+                               'multipart-upload tuning flags; ignoring them.')
+            elif backend_flag_prefix is not None:
+                if self.upload_concurrency is not None:
+                    flags.append(f'--{backend_flag_prefix}-upload-concurrency '
+                                 f'{self.upload_concurrency}')
+                if self.chunk_size is not None:
+                    flags.append(f'--{backend_flag_prefix}-chunk-size '
+                                 f'{self.chunk_size.upper()}')
         return ' '.join(flags)
 
     def to_yaml_config(self) -> Dict[str, Any]:
@@ -2978,7 +3011,7 @@ class GcsStore(AbstractStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.GCS.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -3886,7 +3919,7 @@ class AzureBlobStore(AbstractStore):
             storage_account_key=self.storage_account_key)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.container_name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.AZURE.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -4970,7 +5003,7 @@ class S3Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.S3.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5039,7 +5072,7 @@ class R2Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.R2.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5094,7 +5127,7 @@ class NebiusStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.NEBIUS.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5190,7 +5223,8 @@ class CoreWeaveStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config,
+            data_utils.Rclone.RcloneStores.COREWEAVE.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5265,7 +5299,7 @@ class VastDataStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.VASTDATA.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5377,7 +5411,7 @@ class OciS3CompatibleStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.OCI.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 57  # Slurm inline host path volume mounts
+API_VERSION = 58  # mount_cached upload_concurrency / chunk_size
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -813,6 +813,17 @@ def get_storage_schema():
                             'read_only': {
                                 'type': 'boolean',
                             },
+                            # Multipart-upload tuning; applies to S3-family and
+                            # Azure backends. Ignored on GCS, whose rclone
+                            # backend has no equivalent flags.
+                            'upload_concurrency': {
+                                'type': 'integer',
+                                'minimum': 1,
+                            },
+                            'chunk_size': {
+                                'type': 'string',
+                                'pattern': rclone_memory_pattern,
+                            },
                         },
                     },
                     'mount': {

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+from unittest import mock
 
 import pytest
 
@@ -176,6 +177,38 @@ class TestMountCachedConfig:
     def test_read_only_false_not_emitted(self):
         config = storage_lib.MountCachedConfig(read_only=False)
         assert '--read-only' not in config.to_rclone_flags()
+
+    def test_upload_tuning_flags_use_backend_prefix(self):
+        config = storage_lib.MountCachedConfig(upload_concurrency=8,
+                                               chunk_size='64m')
+        s3_flags = config.to_rclone_flags(backend_flag_prefix='s3')
+        assert '--s3-upload-concurrency 8' in s3_flags
+        assert '--s3-chunk-size 64M' in s3_flags
+        azure_flags = config.to_rclone_flags(backend_flag_prefix='azureblob')
+        assert '--azureblob-upload-concurrency 8' in azure_flags
+        assert '--azureblob-chunk-size 64M' in azure_flags
+
+    def test_upload_tuning_flags_skipped_without_backend(self):
+        # No backend context (None) -> can't emit backend-prefixed flags.
+        config = storage_lib.MountCachedConfig(upload_concurrency=8,
+                                               chunk_size='64M')
+        flags = config.to_rclone_flags(backend_flag_prefix=None)
+        assert 'upload-concurrency' not in flags
+        assert 'chunk-size' not in flags
+
+    def test_upload_tuning_flags_warn_on_unsupported_backend(self):
+        # GCS is a real backend but defines no multipart-upload tuning flags,
+        # so setting them warns and emits nothing.
+        config = storage_lib.MountCachedConfig(upload_concurrency=8)
+        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
+            flags = config.to_rclone_flags(backend_flag_prefix='gcs')
+        mock_warn.assert_called_once()
+        assert 'upload-concurrency' not in flags
+        # No warning when the fields are unset.
+        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
+            storage_lib.MountCachedConfig().to_rclone_flags(
+                backend_flag_prefix='gcs')
+        mock_warn.assert_not_called()
 
     def test_round_trip_yaml(self):
         config = storage_lib.MountCachedConfig(transfers=8, read_only=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR exposes two `rclone` flags that affect upload (multi-part) concurrency: `--<backend>-upload-concurrency` and `--<backend>-upload-chunk-size`. 

Note that for some reason passing these to `gcs` backend is not supported by `rgclone`, so it is gracefully skipped (but a warning is emitted to let the user know `gcs` is not supported). 

Resolves #10493 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
