### PR TITLE
[Core]: Allow setting arbitrary `rclone` args in `MOUNT_CACHED` config

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -455,10 +455,10 @@ FAQ
 
   AWS SSO credentials are only supported when accessing S3 from EC2 or EKS clusters with ``mode: MOUNT_CACHED``.
   ``mode: MOUNT`` is not supported when using AWS SSO credentials.
-  
-  On EKS clusters, you must set up IAM roles (via Pod Identity or IRSA) to 
-  allow SkyPilot pods to access S3 buckets without static AWS credentials. 
-  See :ref:`aws-eks-iam-roles` for setup instructions. 
+
+  On EKS clusters, you must set up IAM roles (via Pod Identity or IRSA) to
+  allow SkyPilot pods to access S3 buckets without static AWS credentials.
+  See :ref:`aws-eks-iam-roles` for setup instructions.
 
   When accessing S3 buckets outside of EC2 or EKS, static AWS credentials
   (e.g., ``~/.aws/credentials``) are required.
@@ -617,12 +617,8 @@ Storage YAML reference
                 Delay before uploading dirty files to remote.
             - read_only: bool; default: false
                 Whether the mount is read-only.
-            - upload_concurrency: int; e.g. 8
-                Chunks uploaded concurrently per transfer for multipart
-                uploads. Only applies to backends with multipart-upload
-                tuning (S3-family, Azure); ignored on GCS.
-            - chunk_size: str; e.g. "64M"
-                Chunk size for multipart uploads. Same backend support as
-                upload_concurrency.
+            - rclone_flags: list of str; e.g. ["--no-modtime"]
+                Extra `rclone mount` flags forwarded verbatim, as shell
+                tokens. Override flags set by config options from above.
             Size values accept suffixes: K, M, G, T, P (e.g. "64M", "10G").
             Duration values accept suffixes: ns, us, ms, s, m, h (e.g. "5s", "1h").

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -617,5 +617,12 @@ Storage YAML reference
                 Delay before uploading dirty files to remote.
             - read_only: bool; default: false
                 Whether the mount is read-only.
+            - upload_concurrency: int; e.g. 8
+                Chunks uploaded concurrently per transfer for multipart
+                uploads. Only applies to backends with multipart-upload
+                tuning (S3-family, Azure); ignored on GCS.
+            - chunk_size: str; e.g. "64M"
+                Chunk size for multipart uploads. Same backend support as
+                upload_concurrency.
             Size values accept suffixes: K, M, G, T, P (e.g. "64M", "10G").
             Duration values accept suffixes: ns, us, ms, s, m, h (e.g. "5s", "1h").

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -621,6 +621,7 @@ def validate(
     omit_priority_class = _omit(43)
     omit_max_hourly_cost = _omit(44)
     omit_mount_config = _omit(48)
+    omit_mount_cached_upload_tuning = _omit(58)
 
     for task in dag.tasks:
         if omit_user_specified_yaml:
@@ -650,6 +651,14 @@ def validate(
                 storage.mount_config = None
             logger.debug('`mount_config` is ignored because the server '
                          'does not support it yet.')
+        if omit_mount_cached_upload_tuning:
+            for storage in task.storage_mounts.values():
+                config = storage.mount_cached_config
+                if config is not None:
+                    config.upload_concurrency = None
+                    config.chunk_size = None
+            logger.debug('`upload_concurrency`/`chunk_size` are ignored '
+                         'because the server does not support them yet.')
         if omit_priority_class:
             for resource in task.resources:
                 if resource.priority_class:

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -621,7 +621,7 @@ def validate(
     omit_priority_class = _omit(43)
     omit_max_hourly_cost = _omit(44)
     omit_mount_config = _omit(48)
-    omit_mount_cached_upload_tuning = _omit(58)
+    omit_mount_cached_rclone_flags = _omit(58)
 
     for task in dag.tasks:
         if omit_user_specified_yaml:
@@ -651,14 +651,13 @@ def validate(
                 storage.mount_config = None
             logger.debug('`mount_config` is ignored because the server '
                          'does not support it yet.')
-        if omit_mount_cached_upload_tuning:
+        if omit_mount_cached_rclone_flags:
             for storage in task.storage_mounts.values():
                 config = storage.mount_cached_config
                 if config is not None:
-                    config.upload_concurrency = None
-                    config.chunk_size = None
-            logger.debug('`upload_concurrency`/`chunk_size` are ignored '
-                         'because the server does not support them yet.')
+                    config.rclone_flags = None
+            logger.debug('`rclone_flags` is ignored because the server does '
+                         'not support it yet.')
         if omit_priority_class:
             for resource in task.resources:
                 if resource.priority_class:

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '57';
+export const CLIENT_API_VERSION = '58';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -748,23 +748,6 @@ class Rclone:
         VASTDATA = 'VASTDATA'
         OCI = 'OCI'
 
-        @property
-        def backend_flag_prefix(self) -> str:
-            """rclone backend name used as the prefix for backend-specific
-            flags (e.g. "s3" -> --s3-region, --s3-chunk-size).
-            """
-            return {
-                Rclone.RcloneStores.S3: 's3',
-                Rclone.RcloneStores.GCS: 'gcs',
-                Rclone.RcloneStores.IBM: 's3',
-                Rclone.RcloneStores.R2: 's3',
-                Rclone.RcloneStores.AZURE: 'azureblob',
-                Rclone.RcloneStores.NEBIUS: 's3',
-                Rclone.RcloneStores.COREWEAVE: 's3',
-                Rclone.RcloneStores.VASTDATA: 's3',
-                Rclone.RcloneStores.OCI: 's3',
-            }[self]
-
         def get_profile_name(self, bucket_name: str) -> str:
             """Gets the Rclone profile name for a given bucket.
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -748,6 +748,23 @@ class Rclone:
         VASTDATA = 'VASTDATA'
         OCI = 'OCI'
 
+        @property
+        def backend_flag_prefix(self) -> str:
+            """rclone backend name used as the prefix for backend-specific
+            flags (e.g. "s3" -> --s3-region, --s3-chunk-size).
+            """
+            return {
+                Rclone.RcloneStores.S3: 's3',
+                Rclone.RcloneStores.GCS: 'gcs',
+                Rclone.RcloneStores.IBM: 's3',
+                Rclone.RcloneStores.R2: 's3',
+                Rclone.RcloneStores.AZURE: 'azureblob',
+                Rclone.RcloneStores.NEBIUS: 's3',
+                Rclone.RcloneStores.COREWEAVE: 's3',
+                Rclone.RcloneStores.VASTDATA: 's3',
+                Rclone.RcloneStores.OCI: 's3',
+            }[self]
+
         def get_profile_name(self, bucket_name: str) -> str:
             """Gets the Rclone profile name for a given bucket.
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -696,11 +696,12 @@ def get_cos_mount_cmd(rclone_config: str,
 
 
 def get_mount_cached_cmd(
-        rclone_config: str,
-        rclone_profile_name: str,
-        bucket_name: str,
-        mount_path: str,
-        mount_cached_config: Optional['storage.MountCachedConfig'] = None
+    rclone_config: str,
+    rclone_profile_name: str,
+    bucket_name: str,
+    mount_path: str,
+    mount_cached_config: Optional['storage.MountCachedConfig'] = None,
+    backend_flag_prefix: Optional[str] = None,
 ) -> str:
     """Returns a command to mount a bucket using rclone with vfs cache."""
     # stores bucket profile in rclone config file at the remote nodes.
@@ -763,7 +764,7 @@ def get_mount_cached_cmd(
         # Recommended by rclone documentation for buckets like s3.
         '--vfs-fast-fingerprint '
         # Other customizable rclone flags. Refer to `MountCachedConfig`.
-        f'{mount_cached_config.to_rclone_flags()} '
+        f'{mount_cached_config.to_rclone_flags(backend_flag_prefix)} '
         # This command produces children processes, which need to be
         # detached from the current process's terminal. The command doesn't
         # produce any output, so we aren't dropping any logs.

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -701,7 +701,6 @@ def get_mount_cached_cmd(
     bucket_name: str,
     mount_path: str,
     mount_cached_config: Optional['storage.MountCachedConfig'] = None,
-    backend_flag_prefix: Optional[str] = None,
 ) -> str:
     """Returns a command to mount a bucket using rclone with vfs cache."""
     # stores bucket profile in rclone config file at the remote nodes.
@@ -764,7 +763,7 @@ def get_mount_cached_cmd(
         # Recommended by rclone documentation for buckets like s3.
         '--vfs-fast-fingerprint '
         # Other customizable rclone flags. Refer to `MountCachedConfig`.
-        f'{mount_cached_config.to_rclone_flags(backend_flag_prefix)} '
+        f'{mount_cached_config.to_rclone_flags()} '
         # This command produces children processes, which need to be
         # detached from the current process's terminal. The command doesn't
         # produce any output, so we aren't dropping any logs.
@@ -803,33 +802,13 @@ def get_rclone_version_check_cmd() -> str:
     return f'rclone --version | grep -q {RCLONE_VERSION}'
 
 
-def _get_mount_binary(mount_cmd: str) -> str:
-    """Returns mounting binary in string given as the mount command.
-
-    Args:
-        mount_cmd: Command used to mount a cloud storage.
-
-    Returns:
-        str: Name of the binary used to mount a cloud storage.
-    """
-    if 'goofys' in mount_cmd:
-        return 'goofys'
-    elif 'gcsfuse' in mount_cmd:
-        return 'gcsfuse'
-    elif 'blobfuse2' in mount_cmd:
-        return 'blobfuse2'
-    elif 'hf-mount' in mount_cmd:
-        return 'hf-mount'
-    else:
-        assert 'rclone' in mount_cmd
-        return 'rclone'
-
-
 def get_mounting_script(
     mount_path: str,
     mount_cmd: str,
     install_cmd: str,
     version_check_cmd: Optional[str] = None,
+    *,
+    mount_binary: str,
 ) -> str:
     """Generates the mounting script.
 
@@ -844,11 +823,14 @@ def get_mounting_script(
         mount_cmd: Command to mount the bucket. Should be single line.
         version_check_cmd: Command to check the version of already installed
           mounting util.
+        mount_binary: The mounting binary (e.g. "rclone", "goofys"). Passed
+          explicitly by each caller rather than inferred from ``mount_cmd``,
+          which is unreliable once the command can carry arbitrary
+          user-provided tokens (e.g. rclone_flags).
 
     Returns:
         str: Mounting script as a str.
     """
-    mount_binary = _get_mount_binary(mount_cmd)
     installed_check = f'[ -x "$(command -v {mount_binary})" ]'
     if version_check_cmd is not None:
         installed_check += f' && {version_check_cmd}'
@@ -975,6 +957,8 @@ def get_mounting_command(
     install_cmd: str,
     mount_cmd: str,
     version_check_cmd: Optional[str] = None,
+    *,
+    mount_binary: str,
 ) -> str:
     """Generates the mounting command for a given bucket.
 
@@ -989,12 +973,17 @@ def get_mounting_command(
         mount_cmd: Command to mount the bucket. Should be single line.
         version_check_cmd: Command to check the version of already installed
           mounting util.
+        mount_binary: The mounting binary (e.g. "rclone"); forwarded to
+          get_mounting_script. Passed explicitly by each caller.
 
     Returns:
         str: Mounting command with the mounting script as a heredoc.
     """
-    script = get_mounting_script(mount_path, mount_cmd, install_cmd,
-                                 version_check_cmd)
+    script = get_mounting_script(mount_path,
+                                 mount_cmd,
+                                 install_cmd,
+                                 version_check_cmd,
+                                 mount_binary=mount_binary)
 
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -424,13 +424,6 @@ def merge_mount_cached_config(
     return MountCachedConfig(**base)
 
 
-# rclone backends whose uploads are not chunked, so they define no
-# --<backend>-upload-concurrency / --<backend>-chunk-size flags. The
-# upload_concurrency/chunk_size settings have no effect there and must not be
-# emitted (an undefined backend flag is a hard error).
-_BACKENDS_WITHOUT_UPLOAD_TUNING = frozenset({'gcs'})
-
-
 @dataclasses.dataclass
 class MountCachedConfig:
     """Per-bucket configuration for MOUNT_CACHED mode (rclone flags).
@@ -466,22 +459,13 @@ class MountCachedConfig:
     # Mount as read-only.
     # rclone flag: --read-only
     read_only: Optional[bool] = None
-    # Number of chunks uploaded concurrently per transfer for multipart uploads.
-    # rclone flag: --<backend>-upload-concurrency
-    upload_concurrency: Optional[int] = None
-    # Chunk size for multipart uploads (e.g. "64M").
-    # rclone flag: --<backend>-chunk-size
-    chunk_size: Optional[str] = None
+    # Extra flags forwarded verbatim to `rclone mount`, as shell tokens
+    # (e.g. ["--vfs-read-chunk-size-limit", "2G", "--no-modtime"]).
+    # They override the flags generated from the other fields.
+    rclone_flags: Optional[List[str]] = None
 
-    def to_rclone_flags(self, backend_flag_prefix: Optional[str] = None) -> str:
-        """Convert non-None fields to rclone CLI flag string.
-
-        Args:
-            backend_flag_prefix: rclone backend name used as the prefix for
-                backend-specific flags (e.g. "s3"), or None if no backend
-                context is available. Multipart-upload tuning flags are only
-                emitted for backends that actually define them.
-        """
+    def to_rclone_flags(self) -> str:
+        """Convert non-None fields to rclone CLI flag string."""
         flags = []
         if self.transfers is not None:
             flags.append(f'--transfers {self.transfers}')
@@ -513,19 +497,10 @@ class MountCachedConfig:
         flags.append(f'--vfs-write-back {self.vfs_write_back or "1s"}')
         if self.read_only:
             flags.append('--read-only')
-        # Backend-specific multipart-upload tuning (e.g. --s3-*, --azureblob-*).
-        if self.upload_concurrency is not None or self.chunk_size is not None:
-            if backend_flag_prefix in _BACKENDS_WITHOUT_UPLOAD_TUNING:
-                logger.warning(f'upload_concurrency/chunk_size are set but the '
-                               f'{backend_flag_prefix} backend has no rclone '
-                               'multipart-upload tuning flags; ignoring them.')
-            elif backend_flag_prefix is not None:
-                if self.upload_concurrency is not None:
-                    flags.append(f'--{backend_flag_prefix}-upload-concurrency '
-                                 f'{self.upload_concurrency}')
-                if self.chunk_size is not None:
-                    flags.append(f'--{backend_flag_prefix}-chunk-size '
-                                 f'{self.chunk_size.upper()}')
+        # User-provided escape-hatch flags, appended last so they take
+        # precedence. Quote each token to guard against shell injection.
+        if self.rclone_flags:
+            flags.extend(shlex.quote(flag) for flag in self.rclone_flags)
         return ' '.join(flags)
 
     def to_yaml_config(self) -> Dict[str, Any]:
@@ -2275,8 +2250,13 @@ class S3CompatibleStore(AbstractStore):
                                                   mount_path,
                                                   self._bucket_sub_path,
                                                   read_only=read_only)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd)
+        # The command picks the binary at runtime by arch (goofys on x86,
+        # rclone on ARM); goofys is the x86 default and matches the
+        # install/version check performed by get_s3_mount_install_cmd.
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   mount_binary='goofys')
 
     def mount_cached_command(self,
                              mount_path: str,
@@ -2289,8 +2269,10 @@ class S3CompatibleStore(AbstractStore):
         install_cmd = mounting_utils.get_rclone_install_cmd()
         mount_cmd = self.config.mount_cached_cmd_factory(
             self.bucket.name, mount_path, self._bucket_sub_path, config)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   mount_binary='rclone')
 
     def batch_aws_rsync(self,
                         source_path_list: List[Path],
@@ -2998,8 +2980,11 @@ class GcsStore(AbstractStore):
                                                      read_only=read_only)
         version_check_cmd = (
             f'gcsfuse --version | grep -q {mounting_utils.GCSFUSE_VERSION}')
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd, version_check_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   version_check_cmd,
+                                                   mount_binary='gcsfuse')
 
     def mount_cached_command(self,
                              mount_path: str,
@@ -3011,9 +2996,11 @@ class GcsStore(AbstractStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.GCS.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on GS bucket
@@ -3904,8 +3891,10 @@ class AzureBlobStore(AbstractStore):
                                                     self.storage_account_key,
                                                     self._bucket_sub_path,
                                                     read_only=read_only)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   mount_binary='blobfuse2')
 
     def mount_cached_command(self,
                              mount_path: str,
@@ -3919,9 +3908,11 @@ class AzureBlobStore(AbstractStore):
             storage_account_key=self.storage_account_key)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.container_name, mount_path,
-            config, data_utils.Rclone.RcloneStores.AZURE.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
     def _create_az_bucket(self, container_name: str) -> StorageHandle:
         """Creates AZ Container.
@@ -4415,8 +4406,10 @@ class IBMCosStore(AbstractStore):
                 self._bucket_sub_path,  # type: ignore
                 read_only=read_only,
             ))
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   mount_binary='rclone')
 
     def _create_cos_bucket(self,
                            bucket_name: str,
@@ -4839,8 +4832,11 @@ class OciStore(AbstractStore):
             read_only=read_only)
         version_check_cmd = mounting_utils.get_rclone_version_check_cmd()
 
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd, version_check_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   version_check_cmd,
+                                                   mount_binary='rclone')
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on OCI bucket
@@ -5003,9 +4999,11 @@ class S3Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.S3.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
 
 @register_s3_compatible_store
@@ -5072,9 +5070,11 @@ class R2Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.R2.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
 
 @register_s3_compatible_store
@@ -5127,9 +5127,11 @@ class NebiusStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.NEBIUS.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
 
 @register_s3_compatible_store
@@ -5223,10 +5225,11 @@ class CoreWeaveStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config,
-            data_utils.Rclone.RcloneStores.COREWEAVE.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
     def _create_bucket(self, bucket_name: str) -> StorageHandle:
         """Create bucket using S3 API with timing handling for CoreWeave."""
@@ -5299,9 +5302,11 @@ class VastDataStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.VASTDATA.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
 
 class OciS3CompatibleStore(S3CompatibleStore):
@@ -5411,9 +5416,11 @@ class OciS3CompatibleStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config, data_utils.Rclone.RcloneStores.OCI.backend_flag_prefix)
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cached_cmd)
+            config)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cached_cmd,
+                                                   mount_binary='rclone')
 
 
 class HuggingFaceStore(AbstractStore):
@@ -5996,8 +6003,11 @@ class HuggingFaceStore(AbstractStore):
             revision=self._revision,
             extra_args=hf_mount_args)
         version_check_cmd = mounting_utils.get_hf_mount_version_check_cmd()
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd, version_check_cmd)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   version_check_cmd,
+                                                   mount_binary='hf-mount')
 
     def mount_cached_command(self,
                              mount_path: str,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -424,6 +424,13 @@ def merge_mount_cached_config(
     return MountCachedConfig(**base)
 
 
+# rclone backends whose uploads are not chunked, so they define no
+# --<backend>-upload-concurrency / --<backend>-chunk-size flags. The
+# upload_concurrency/chunk_size settings have no effect there and must not be
+# emitted (an undefined backend flag is a hard error).
+_BACKENDS_WITHOUT_UPLOAD_TUNING = frozenset({'gcs'})
+
+
 @dataclasses.dataclass
 class MountCachedConfig:
     """Per-bucket configuration for MOUNT_CACHED mode (rclone flags).
@@ -459,9 +466,22 @@ class MountCachedConfig:
     # Mount as read-only.
     # rclone flag: --read-only
     read_only: Optional[bool] = None
+    # Number of chunks uploaded concurrently per transfer for multipart uploads.
+    # rclone flag: --<backend>-upload-concurrency
+    upload_concurrency: Optional[int] = None
+    # Chunk size for multipart uploads (e.g. "64M").
+    # rclone flag: --<backend>-chunk-size
+    chunk_size: Optional[str] = None
 
-    def to_rclone_flags(self) -> str:
-        """Convert non-None fields to rclone CLI flag string."""
+    def to_rclone_flags(self, backend_flag_prefix: Optional[str] = None) -> str:
+        """Convert non-None fields to rclone CLI flag string.
+
+        Args:
+            backend_flag_prefix: rclone backend name used as the prefix for
+                backend-specific flags (e.g. "s3"), or None if no backend
+                context is available. Multipart-upload tuning flags are only
+                emitted for backends that actually define them.
+        """
         flags = []
         if self.transfers is not None:
             flags.append(f'--transfers {self.transfers}')
@@ -493,6 +513,19 @@ class MountCachedConfig:
         flags.append(f'--vfs-write-back {self.vfs_write_back or "1s"}')
         if self.read_only:
             flags.append('--read-only')
+        # Backend-specific multipart-upload tuning (e.g. --s3-*, --azureblob-*).
+        if self.upload_concurrency is not None or self.chunk_size is not None:
+            if backend_flag_prefix in _BACKENDS_WITHOUT_UPLOAD_TUNING:
+                logger.warning(f'upload_concurrency/chunk_size are set but the '
+                               f'{backend_flag_prefix} backend has no rclone '
+                               'multipart-upload tuning flags; ignoring them.')
+            elif backend_flag_prefix is not None:
+                if self.upload_concurrency is not None:
+                    flags.append(f'--{backend_flag_prefix}-upload-concurrency '
+                                 f'{self.upload_concurrency}')
+                if self.chunk_size is not None:
+                    flags.append(f'--{backend_flag_prefix}-chunk-size '
+                                 f'{self.chunk_size.upper()}')
         return ' '.join(flags)
 
     def to_yaml_config(self) -> Dict[str, Any]:
@@ -2978,7 +3011,7 @@ class GcsStore(AbstractStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.GCS.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -3886,7 +3919,7 @@ class AzureBlobStore(AbstractStore):
             storage_account_key=self.storage_account_key)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.container_name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.AZURE.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -4970,7 +5003,7 @@ class S3Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.S3.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5039,7 +5072,7 @@ class R2Store(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.R2.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5094,7 +5127,7 @@ class NebiusStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.NEBIUS.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5190,7 +5223,8 @@ class CoreWeaveStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config,
+            data_utils.Rclone.RcloneStores.COREWEAVE.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5265,7 +5299,7 @@ class VastDataStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.VASTDATA.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 
@@ -5377,7 +5411,7 @@ class OciS3CompatibleStore(S3CompatibleStore):
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
-            config)
+            config, data_utils.Rclone.RcloneStores.OCI.backend_flag_prefix)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 58  # mount_cached upload_concurrency / chunk_size
+API_VERSION = 58  # mount_cached rclone_flags
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 57  # Slurm inline host path volume mounts
+API_VERSION = 58  # mount_cached upload_concurrency / chunk_size
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -813,6 +813,17 @@ def get_storage_schema():
                             'read_only': {
                                 'type': 'boolean',
                             },
+                            # Multipart-upload tuning; applies to S3-family and
+                            # Azure backends. Ignored on GCS, whose rclone
+                            # backend has no equivalent flags.
+                            'upload_concurrency': {
+                                'type': 'integer',
+                                'minimum': 1,
+                            },
+                            'chunk_size': {
+                                'type': 'string',
+                                'pattern': rclone_memory_pattern,
+                            },
                         },
                     },
                     'mount': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -813,16 +813,13 @@ def get_storage_schema():
                             'read_only': {
                                 'type': 'boolean',
                             },
-                            # Multipart-upload tuning; applies to S3-family and
-                            # Azure backends. Ignored on GCS, whose rclone
-                            # backend has no equivalent flags.
-                            'upload_concurrency': {
-                                'type': 'integer',
-                                'minimum': 1,
-                            },
-                            'chunk_size': {
-                                'type': 'string',
-                                'pattern': rclone_memory_pattern,
+                            # extra `rclone mount` flags as shell tokens,
+                            # forwarded verbatim.
+                            'rclone_flags': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
                             },
                         },
                     },

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,5 @@
 import tempfile
 import time
-from unittest import mock
 
 import pytest
 
@@ -178,37 +177,32 @@ class TestMountCachedConfig:
         config = storage_lib.MountCachedConfig(read_only=False)
         assert '--read-only' not in config.to_rclone_flags()
 
-    def test_upload_tuning_flags_use_backend_prefix(self):
-        config = storage_lib.MountCachedConfig(upload_concurrency=8,
-                                               chunk_size='64m')
-        s3_flags = config.to_rclone_flags(backend_flag_prefix='s3')
-        assert '--s3-upload-concurrency 8' in s3_flags
-        assert '--s3-chunk-size 64M' in s3_flags
-        azure_flags = config.to_rclone_flags(backend_flag_prefix='azureblob')
-        assert '--azureblob-upload-concurrency 8' in azure_flags
-        assert '--azureblob-chunk-size 64M' in azure_flags
+    def test_rclone_flags_appended_and_quoted(self):
+        config = storage_lib.MountCachedConfig(
+            transfers=8, rclone_flags=['--no-modtime', '--exclude', '*.tmp'])
+        flags = config.to_rclone_flags()
+        # Appended last, after the generated flags.
+        assert flags.endswith("--no-modtime --exclude '*.tmp'")
+        # A token with shell metacharacters is quoted.
+        assert "'*.tmp'" in flags
 
-    def test_upload_tuning_flags_skipped_without_backend(self):
-        # No backend context (None) -> can't emit backend-prefixed flags.
-        config = storage_lib.MountCachedConfig(upload_concurrency=8,
-                                               chunk_size='64M')
-        flags = config.to_rclone_flags(backend_flag_prefix=None)
-        assert 'upload-concurrency' not in flags
-        assert 'chunk-size' not in flags
+    def test_rclone_flags_none_emits_nothing_extra(self):
+        base = storage_lib.MountCachedConfig(transfers=8).to_rclone_flags()
+        with_empty = storage_lib.MountCachedConfig(
+            transfers=8, rclone_flags=[]).to_rclone_flags()
+        assert base == with_empty
 
-    def test_upload_tuning_flags_warn_on_unsupported_backend(self):
-        # GCS is a real backend but defines no multipart-upload tuning flags,
-        # so setting them warns and emits nothing.
-        config = storage_lib.MountCachedConfig(upload_concurrency=8)
-        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
-            flags = config.to_rclone_flags(backend_flag_prefix='gcs')
-        mock_warn.assert_called_once()
-        assert 'upload-concurrency' not in flags
-        # No warning when the fields are unset.
-        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
-            storage_lib.MountCachedConfig().to_rclone_flags(
-                backend_flag_prefix='gcs')
-        mock_warn.assert_not_called()
+    def test_mount_binary_is_explicit_not_inferred(self):
+        # The binary is passed explicitly, so a mount command carrying another
+        # binary's name in an arbitrary flag (e.g. rclone_flags with "goofys")
+        # does not select the wrong binary.
+        mount_cmd = 'rclone mount foo --exclude goofys-cache/'
+        script = mounting_utils.get_mounting_script(mount_path='/mnt/x',
+                                                    mount_cmd=mount_cmd,
+                                                    install_cmd='true',
+                                                    mount_binary='rclone')
+        assert 'MOUNT_BINARY=rclone' in script
+        assert 'MOUNT_BINARY=goofys' not in script
 
     def test_round_trip_yaml(self):
         config = storage_lib.MountCachedConfig(transfers=8, read_only=True)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+from unittest import mock
 
 import pytest
 
@@ -176,6 +177,38 @@ class TestMountCachedConfig:
     def test_read_only_false_not_emitted(self):
         config = storage_lib.MountCachedConfig(read_only=False)
         assert '--read-only' not in config.to_rclone_flags()
+
+    def test_upload_tuning_flags_use_backend_prefix(self):
+        config = storage_lib.MountCachedConfig(upload_concurrency=8,
+                                               chunk_size='64m')
+        s3_flags = config.to_rclone_flags(backend_flag_prefix='s3')
+        assert '--s3-upload-concurrency 8' in s3_flags
+        assert '--s3-chunk-size 64M' in s3_flags
+        azure_flags = config.to_rclone_flags(backend_flag_prefix='azureblob')
+        assert '--azureblob-upload-concurrency 8' in azure_flags
+        assert '--azureblob-chunk-size 64M' in azure_flags
+
+    def test_upload_tuning_flags_skipped_without_backend(self):
+        # No backend context (None) -> can't emit backend-prefixed flags.
+        config = storage_lib.MountCachedConfig(upload_concurrency=8,
+                                               chunk_size='64M')
+        flags = config.to_rclone_flags(backend_flag_prefix=None)
+        assert 'upload-concurrency' not in flags
+        assert 'chunk-size' not in flags
+
+    def test_upload_tuning_flags_warn_on_unsupported_backend(self):
+        # GCS is a real backend but defines no multipart-upload tuning flags,
+        # so setting them warns and emits nothing.
+        config = storage_lib.MountCachedConfig(upload_concurrency=8)
+        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
+            flags = config.to_rclone_flags(backend_flag_prefix='gcs')
+        mock_warn.assert_called_once()
+        assert 'upload-concurrency' not in flags
+        # No warning when the fields are unset.
+        with mock.patch.object(storage_lib.logger, 'warning') as mock_warn:
+            storage_lib.MountCachedConfig().to_rclone_flags(
+                backend_flag_prefix='gcs')
+        mock_warn.assert_not_called()
 
     def test_round_trip_yaml(self):
         config = storage_lib.MountCachedConfig(transfers=8, read_only=True)

--- a/tests/unit_tests/test_mounting_utils_arm64.py
+++ b/tests/unit_tests/test_mounting_utils_arm64.py
@@ -161,20 +161,6 @@ class TestMountingUtilsArm64(unittest.TestCase):
         self.assertIn(f':s3:{self.bucket_name}{expected_sub_path}', cmd)
         self.assertIn(f'{self.bucket_name}{expected_sub_path}', cmd)
 
-    def test_mount_binary_detection_rclone(self):
-        """Test mount binary detection for rclone commands."""
-        # Test with rclone command
-        rclone_cmd = 'rclone mount :s3:bucket /mnt/test --daemon'
-        binary = mounting_utils._get_mount_binary(rclone_cmd)
-        self.assertEqual(binary, 'rclone')
-
-    def test_mount_binary_detection_goofys(self):
-        """Test mount binary detection for goofys commands."""
-        # Test with goofys command
-        goofys_cmd = 'goofys -o allow_other bucket /mnt/test'
-        binary = mounting_utils._get_mount_binary(goofys_cmd)
-        self.assertEqual(binary, 'goofys')
-
     def test_fusermount3_soft_link_in_rclone_commands(self):
         """Test that rclone commands include fusermount3 soft link setup."""
         # Test S3 mount command
@@ -206,12 +192,14 @@ class TestMountingUtilsArm64(unittest.TestCase):
         self.assertIn(mounting_utils.RCLONE_VERSION, rclone_install)
 
     def test_mount_script_generation_with_rclone(self):
-        """Test mount script generation includes proper rclone binary detection."""
+        """Test mount script generation for the explicit rclone binary."""
         mount_cmd = 'rclone mount :s3:bucket /mnt/test --daemon'
         install_cmd = 'echo "install rclone"'
 
-        script = mounting_utils.get_mounting_script(self.mount_path, mount_cmd,
-                                                    install_cmd)
+        script = mounting_utils.get_mounting_script(self.mount_path,
+                                                    mount_cmd,
+                                                    install_cmd,
+                                                    mount_binary='rclone')
 
         # Should set MOUNT_BINARY to rclone
         self.assertIn('MOUNT_BINARY=rclone', script)
@@ -219,12 +207,14 @@ class TestMountingUtilsArm64(unittest.TestCase):
         self.assertIn('[ -x "$(command -v rclone)" ]', script)
 
     def test_mount_script_generation_with_goofys(self):
-        """Test mount script generation includes proper goofys binary detection."""
+        """Test mount script generation for the explicit goofys binary."""
         mount_cmd = 'goofys -o allow_other bucket /mnt/test'
         install_cmd = 'echo "install goofys"'
 
-        script = mounting_utils.get_mounting_script(self.mount_path, mount_cmd,
-                                                    install_cmd)
+        script = mounting_utils.get_mounting_script(self.mount_path,
+                                                    mount_cmd,
+                                                    install_cmd,
+                                                    mount_binary='goofys')
 
         # Should set MOUNT_BINARY to goofys
         self.assertIn('MOUNT_BINARY=goofys', script)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a new `rclone_flags` config option that can be used to pass arbitrary flags to `rclone` when using `MOUNT_CACHED` bucket mounts. 

Resolves #10495. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->