### PR TITLE
[LLM] slime example: pin swebench/swesmith deps; declare inter_connection in Job Group YAMLs

### DIFF
--- a/llm/slime/coding-agent-2engine.yaml
+++ b/llm/slime/coding-agent-2engine.yaml
@@ -17,6 +17,9 @@ name: coding-agent-rl-2eng
 execution: parallel
 primary_tasks: [trainer]
 termination_delay: 60s
+# In-group networking is required: the trainer discovers/health-gates the
+# engines by hostname, and engines dial the trainer back for weight sync.
+inter_connection: true
 ---
 name: sglang
 resources:

--- a/llm/slime/coding-agent-3engine.yaml
+++ b/llm/slime/coding-agent-3engine.yaml
@@ -19,6 +19,9 @@ name: coding-agent-rl-3eng
 execution: parallel
 primary_tasks: [trainer]
 termination_delay: 60s
+# In-group networking is required: the trainer discovers/health-gates the
+# engines by hostname, and engines dial the trainer back for weight sync.
+inter_connection: true
 ---
 name: sglang
 resources:

--- a/llm/slime/coding-agent.yaml
+++ b/llm/slime/coding-agent.yaml
@@ -19,6 +19,9 @@ name: coding-agent-rl
 execution: parallel
 primary_tasks: [trainer]
 termination_delay: 60s
+# In-group networking is required: the trainer discovers/health-gates the
+# engines by hostname, and engines dial the trainer back for weight sync.
+inter_connection: true
 ---
 name: sglang
 resources:

--- a/llm/slime/scripts/trainer-setup.sh
+++ b/llm/slime/scripts/trainer-setup.sh
@@ -25,7 +25,7 @@ pip install -q mini-swe-agent==2.4.5 litellm pillow datasets
 # imports at load time -> dataset generation crashes. swesmith is pinned to a
 # known-good commit for the same reason (git HEAD can break the same way).
 pip install -q swebench==4.1.0
-pip install -q "swesmith @ git+https://github.com/SWE-bench/SWE-smith.git@9b74ac08118a" || pip install -q swesmith
+pip install -q "swesmith @ git+https://github.com/SWE-bench/SWE-smith.git@9b74ac08118a85c39c356802f7961893af73e07f"
 
 [ -d /root/${MODEL_DIR} ] || hf download ${MODEL_HF_REPO} --local-dir /root/${MODEL_DIR}
 if [ ! -d /root/${MODEL_DIR}_torch_dist ]; then

--- a/llm/slime/scripts/trainer-setup.sh
+++ b/llm/slime/scripts/trainer-setup.sh
@@ -21,8 +21,11 @@ pip install --force-reinstall --no-deps /wheels/skypilot_sandbox_sdk-*.whl
 pip install -q mini-swe-agent==2.4.5 litellm pillow datasets
 # Host-side grading: SWE-smith's test command + log parser run on the TRAINER
 # (not in the sandbox image), so swesmith/swebench are installed here.
-pip install -q swebench
-pip install -q "swesmith @ git+https://github.com/SWE-bench/SWE-smith.git" || pip install -q swesmith
+# Pinned: swebench 5.0.0 removed harness.constants.DOCKER_USER, which swesmith
+# imports at load time -> dataset generation crashes. swesmith is pinned to a
+# known-good commit for the same reason (git HEAD can break the same way).
+pip install -q swebench==4.1.0
+pip install -q "swesmith @ git+https://github.com/SWE-bench/SWE-smith.git@9b74ac08118a" || pip install -q swesmith
 
 [ -d /root/${MODEL_DIR} ] || hf download ${MODEL_HF_REPO} --local-dir /root/${MODEL_DIR}
 if [ ! -d /root/${MODEL_DIR}_torch_dist ]; then


### PR DESCRIPTION
## Summary

- **Pin `swebench==4.1.0` and `swesmith` to a known-good commit** in the slime example's trainer setup. `swebench 5.0.0` (released 2026-08-17) removed `harness.constants.DOCKER_USER`, which `swesmith` imports at load time — so the example's unpinned `pip install swebench` now crashes every fresh launch during dataset generation:
  ```
  ImportError: cannot import name 'DOCKER_USER' from 'swebench.harness.constants'
  ```
  The swesmith git-HEAD install is pinned for the same reason (same failure class, one release away). Same reproducibility rationale as the image pin in #10249.
- **Declare `inter_connection: true`** in all three Job Group YAMLs. The example's members require in-group networking — the trainer discovers and health-gates engines by hostname, and engines dial the trainer back for the weight-sync rendezvous — so the requirement is now stated explicitly rather than relying on the field's default.

## Test plan

- Repro: launching the example unmodified today fails in trainer setup with the `ImportError` above (swebench 5.0.0 gets installed).
- With the pins: setup completes and the run proceeds past dataset generation + engine health gate (verified on a Kubernetes H100 cluster with `coding-agent-3engine.yaml`, trainer H100:4 + 3×H100:1).
- `inter_connection: true` parses and admits on a current API server; all members co-scheduled on one cluster as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)