### PR TITLE
[Jobs] Bound the job-status retry window by retries as well as elapsed time

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -42,6 +42,9 @@ Below is the configuration syntax and some example values. See detailed explanat
   :ref:`jobs <config-yaml-jobs>`:
     :ref:`bucket <config-yaml-jobs-bucket>`: s3://my-bucket/
     :ref:`force_disable_cloud_bucket <config-yaml-jobs-force-disable-cloud-bucket>`: false
+    :ref:`status_check <config-yaml-jobs-status-check>`:
+      min_elapsed_seconds: 60
+      min_retries: 5
     controller:
       :ref:`resources <config-yaml-jobs-controller-resources>`:  # same spec as 'resources' in a task YAML
         infra: gcp/us-central1
@@ -462,6 +465,35 @@ Example:
 
   jobs:
     force_disable_cloud_bucket: true
+
+.. _config-yaml-jobs-status-check:
+
+``jobs.status_check``
+~~~~~~~~~~~~~~~~~~~~~
+
+Tune how long the managed jobs controller tolerates consecutive failures of its job-status check before treating the job as unhealthy and recovering it (which cancels the job and relaunches it).
+
+A status check can fail for reasons that say nothing about whether the job is alive -- for example a transport error on the way to the cluster, or a provider API error while refreshing cluster status. The controller retries such failures, and recovers the job only once **both** of these budgets are exhausted:
+
+- ``min_elapsed_seconds``: seconds elapsed since the first failure in the run.
+- ``min_retries``: retries made since the first failure in the run.
+
+Requiring both matters, because either alone is unreliable. A single status-check round can itself take longer than the time budget, since the cluster-status refresh performed before recovery does its own retried probes of the cluster; an elapsed-time-only budget can therefore be spent within the round that opened it, and the job is recovered without ever being retried. Conversely, a burst of failures that each return immediately can exhaust a retry-count-only budget within a couple of seconds, before a transient condition has had a chance to clear.
+
+Raise either value if the controller reaches its clusters over a link that is known to be slow or intermittent, and you would rather wait than have a long-running job relaunched.
+
+A successful status check ends the run and resets both budgets.
+
+Defaults: ``min_elapsed_seconds: 60``, ``min_retries: 5``.
+
+Example:
+
+.. code-block:: yaml
+
+  jobs:
+    status_check:
+      min_elapsed_seconds: 600
+      min_retries: 10
 
 .. _config-yaml-jobs-controller:
 .. _config-yaml-jobs-controller-consolidation-mode:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1013,8 +1013,7 @@ class JobController:
             callback_func = managed_job_utils.event_callback_func(
                 job_id=self._job_id, task_id=task_id, task=task)
 
-        transient_job_check_error_start_time = None
-        job_check_backoff = None
+        status_check_window = managed_job_utils.TransientStatusCheckWindow()
         # External-link labels already surfaced for this task, so we stop
         # polling the worker's metadata once every pattern has matched.
         live_link_labels: Set[str] = set()
@@ -1097,13 +1096,9 @@ class JobController:
                     f'status. Reason: {transient_job_check_error_reason}.\n'
                     'Check cluster status to determine if the job is '
                     'preempted or failed.')
-                if transient_job_check_error_start_time is None:
-                    transient_job_check_error_start_time = time.time()
-                    job_check_backoff = common_utils.Backoff(
-                        initial_backoff=1, max_backoff_factor=5)
+                status_check_window.record_failure()
             else:
-                transient_job_check_error_start_time = None
-                job_check_backoff = None
+                status_check_window.reset()
 
             # Handle success
             if job_status == job_lib.JobStatus.SUCCEEDED:
@@ -1200,26 +1195,16 @@ class JobController:
                 # the false alarm this handler exists to prevent, and recovery
                 # could not relaunch anyway while the provider API is
                 # unreachable. Only when both get_job_status and this refresh
-                # keep failing for JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS is
+                # keep failing until the window's budgets are exhausted is
                 # the error re-raised, escalating to emergency recovery.
                 status_logger.reset()
-                if transient_job_check_error_start_time is None:
-                    transient_job_check_error_start_time = time.time()
-                    job_check_backoff = common_utils.Backoff(
-                        initial_backoff=1, max_backoff_factor=5)
-                elapsed = time.time() - transient_job_check_error_start_time
-                timeout = (
-                    managed_job_utils.JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS)
-                if elapsed >= timeout:
-                    logger.error(
-                        'Failed to refresh cluster status after retrying for '
-                        f'{elapsed:.1f} seconds: '
-                        f'{common_utils.format_exception(e)}')
+                status_check_window.record_failure()
+                if status_check_window.exhausted:
+                    logger.error('Failed to refresh cluster status after '
+                                 f'{status_check_window.summary()}: '
+                                 f'{common_utils.format_exception(e)}')
                     raise
-                assert job_check_backoff is not None, (
-                    transient_job_check_error_start_time, job_check_backoff)
-                backoff_time = min(job_check_backoff.current_backoff(),
-                                   timeout - elapsed)
+                backoff_time = status_check_window.next_backoff()
                 logger.info(
                     'Failed to refresh cluster status, likely due to a '
                     'transient provider API error. Retrying to avoid a false '
@@ -1457,33 +1442,23 @@ class JobController:
                     # job status. Try to recover the job (will not restart the
                     # cluster, if the cluster is healthy).
                     if transient_job_check_error_reason is not None:
-                        assert (transient_job_check_error_start_time
-                                is not None), (
-                                    transient_job_check_error_start_time,
-                                    transient_job_check_error_reason)
-                        assert job_check_backoff is not None, (
-                            job_check_backoff, transient_job_check_error_reason)
-                        elapsed = time.time(
-                        ) - transient_job_check_error_start_time
-                        timeout = (managed_job_utils.
-                                   JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS)
-                        if elapsed < timeout:
-                            remaining_timeout = timeout - elapsed
-                            backoff_time = min(
-                                job_check_backoff.current_backoff(),
-                                remaining_timeout)
+                        assert status_check_window.active, (
+                            transient_job_check_error_reason)
+                        if not status_check_window.exhausted:
+                            backoff_time = status_check_window.next_backoff()
                             logger.info(
                                 'Failed to fetch the job status while the '
-                                'cluster is healthy. Retrying to avoid false'
-                                'alarm for job failure. Retrying in '
+                                'cluster is healthy. Retrying to avoid a '
+                                'false alarm for job failure. Retrying in '
                                 f'{backoff_time:.1f} seconds...')
                             await asyncio.sleep(backoff_time)
                             continue
                         else:
                             logger.info(
-                                'Failed to fetch the job status after retrying '
-                                f'for {elapsed:.1f} seconds. Try to recover '
-                                'the job by restarting the job/cluster.')
+                                'Failed to fetch the job status after '
+                                f'{status_check_window.summary()}. Try to '
+                                'recover the job by restarting the '
+                                'job/cluster.')
                     else:
                         logger.info(
                             'Failed to fetch the job status due to '
@@ -1675,11 +1650,10 @@ class JobController:
             # status-fetch-failure window belongs to the previous cluster and
             # must not carry over. If it did, the first status-fetch failure
             # after recovery would measure `elapsed` from before the recovery,
-            # exceed JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS immediately, and
-            # trigger another recovery with no retries. One transient
-            # control-plane error would then become an unbounded recovery loop.
-            transient_job_check_error_start_time = None
-            job_check_backoff = None
+            # exceed the window's budgets immediately, and trigger another
+            # recovery with no retries. One transient control-plane error
+            # would then become an unbounded recovery loop.
+            status_check_window.reset()
 
             # Reset force flag after first recovery
             force_transit_to_recovering = False

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -104,7 +104,13 @@ _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5
 _PROVISION_LOG_POLL_GAP_SECONDS = 1
 
 _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
-JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
+
+# Defaults for the transient status-check window; see
+# TransientStatusCheckWindow for why both a time and a retry budget are
+# needed. Both are overridable under `jobs.status_check` in
+# ~/.sky/config.yaml.
+JOB_STATUS_FETCH_MIN_ELAPSED_SECONDS = 60
+JOB_STATUS_FETCH_MIN_RETRIES = 5
 
 # Pattern matching the "From controller <UUID>" line that the controller
 # emits at job-claim time (see sky/jobs/controller.py: run_job). Used by
@@ -518,6 +524,106 @@ class JobStatusLogger:
         """
         self.flush()
         self._message = None
+
+
+class TransientStatusCheckWindow:
+    """Tracks a run of consecutive transient job-status-check failures.
+
+    The controller polls its job's status every
+    JOB_STATUS_CHECK_GAP_SECONDS. A check can fail for reasons that say
+    nothing about whether the job is alive: a transport error on the way to
+    the cluster, or a provider API error while refreshing cluster status. To
+    avoid tearing down a healthy job on such a blip, the controller retries
+    before escalating to recovery -- which cancels the job and relaunches it.
+
+    A run is only treated as the job being unhealthy once *both* budgets are
+    exhausted: at least ``min_elapsed_seconds`` have passed since the first
+    failure in the run, *and* at least ``min_retries`` retries have been
+    made. Requiring both is deliberate, because either alone is unreliable:
+
+    - Elapsed time alone: a single status-check round can itself take far
+      longer than the time budget, because the cluster-status refresh that
+      runs before recovery does its own retried probes of the cluster. The
+      budget can therefore be fully consumed within the round that opened
+      the window, and the job is torn down without ever being retried --
+      the retry exists on paper only.
+    - Retry count alone: a burst of failures that each return immediately
+      (a connection error, say) can exhaust a retry count in a couple of
+      seconds, long before a transient condition has had a chance to clear.
+
+    A successful status check ends the run; see ``reset()``.
+    """
+
+    def __init__(self,
+                 min_elapsed_seconds: Optional[float] = None,
+                 min_retries: Optional[int] = None) -> None:
+        if min_elapsed_seconds is None:
+            min_elapsed_seconds = skypilot_config.get_nested(
+                ('jobs', 'status_check', 'min_elapsed_seconds'),
+                JOB_STATUS_FETCH_MIN_ELAPSED_SECONDS)
+        if min_retries is None:
+            min_retries = skypilot_config.get_nested(
+                ('jobs', 'status_check', 'min_retries'),
+                JOB_STATUS_FETCH_MIN_RETRIES)
+        self._min_elapsed_seconds = min_elapsed_seconds
+        self._min_retries = min_retries
+        self._start_time: Optional[float] = None
+        self._retries = 0
+        self._backoff: Optional[common_utils.Backoff] = None
+
+    def record_failure(self) -> None:
+        """Opens the run if it is not already open."""
+        if self._start_time is None:
+            self._start_time = time.time()
+            self._backoff = common_utils.Backoff(initial_backoff=1,
+                                                 max_backoff_factor=5)
+
+    def reset(self) -> None:
+        """Ends the run, e.g. after a successful check or after a recovery."""
+        self._start_time = None
+        self._retries = 0
+        self._backoff = None
+
+    @property
+    def active(self) -> bool:
+        return self._start_time is not None
+
+    @property
+    def elapsed(self) -> float:
+        """Seconds since the first failure in the current run."""
+        if self._start_time is None:
+            return 0.0
+        return time.time() - self._start_time
+
+    @property
+    def retries(self) -> int:
+        """Retries made in the current run."""
+        return self._retries
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether both budgets are spent, i.e. the job looks unhealthy."""
+        return (self.elapsed >= self._min_elapsed_seconds and
+                self._retries >= self._min_retries)
+
+    def next_backoff(self) -> float:
+        """Records a retry and returns how long to wait before making it."""
+        assert self._backoff is not None, (
+            'record_failure() must be called before next_backoff()')
+        self._retries += 1
+        backoff_time = self._backoff.current_backoff()
+        remaining = self._min_elapsed_seconds - self.elapsed
+        if remaining > 0:
+            # Do not sleep past the time budget: the retry budget may already
+            # be satisfied, in which case the run should be re-evaluated as
+            # soon as the time budget expires.
+            return min(backoff_time, remaining)
+        return backoff_time
+
+    def summary(self) -> str:
+        """Human-readable description of what has been spent so far."""
+        return (f'{self.elapsed:.1f} seconds and {self._retries} '
+                f'{"retry" if self._retries == 1 else "retries"}')
 
 
 async def get_job_status(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1857,6 +1857,27 @@ def get_config_schema():
             'properties': props,
         }
 
+    # Budgets bounding how long the managed-job controller tolerates
+    # consecutive failures of its job-status check before treating the job as
+    # unhealthy and recovering it. Recovery is only triggered once *both*
+    # budgets are exhausted; see
+    # sky.jobs.utils.TransientStatusCheckWindow.
+    jobs_status_check_schema = {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'min_elapsed_seconds': {
+                'type': 'number',
+                'minimum': 0,
+            },
+            'min_retries': {
+                'type': 'integer',
+                'minimum': 0,
+            },
+        },
+    }
+
     cloud_configs = {
         'aws': {
             'type': 'object',
@@ -2866,8 +2887,10 @@ def get_config_schema():
             'db': {
                 'type': 'string',
             },
-            'jobs': _get_controller_schema(
-                extra_properties=_extra_jobs_properties,),
+            'jobs': _get_controller_schema(extra_properties={
+                'status_check': jobs_status_check_schema,
+                **_extra_jobs_properties,
+            },),
             'serve': _get_controller_schema(),
             'allowed_clouds': allowed_clouds,
             'admin_policy': admin_policy_schema,

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -1464,3 +1464,114 @@ class TestCleanupExpiredApiAccessTokens:
     def test_no_expired_tokens_is_noop(self, mock_get_expired):
         mock_get_expired.return_value = []
         assert utils.cleanup_expired_api_access_tokens() == 0
+
+
+def _make_window(min_elapsed_seconds=60, min_retries=3):
+    return utils.TransientStatusCheckWindow(
+        min_elapsed_seconds=min_elapsed_seconds, min_retries=min_retries)
+
+
+class TestTransientStatusCheckWindow:
+    """A run of failed status checks ends only when *both* budgets are spent.
+
+    Either budget alone is unreliable. A single status-check round can outlast
+    the time budget by itself, because the cluster-status refresh that runs
+    before recovery performs its own retried probes -- so a time-only budget
+    can be spent before even one retry happens, and the job is recovered
+    having never been retried. Conversely, a burst of checks that each fail
+    immediately can exhaust a retry-only budget within seconds, long before a
+    transient condition has had a chance to clear.
+    """
+
+    def test_fresh_window_is_not_exhausted(self):
+        window = _make_window()
+        assert not window.active
+        assert not window.exhausted
+        assert window.retries == 0
+        assert window.elapsed == 0.0
+
+    def test_time_alone_does_not_exhaust_the_window(self):
+        clock = {'t': 1000.0}
+        with mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = _make_window(min_elapsed_seconds=60, min_retries=3)
+            window.record_failure()
+            # One round that takes far longer than the whole time budget.
+            clock['t'] += 10_000
+            assert window.elapsed >= 60
+            assert window.retries == 0
+            assert not window.exhausted, (
+                'a slow round must not spend the window before any retry')
+
+    def test_retries_alone_do_not_exhaust_the_window(self):
+        clock = {'t': 1000.0}
+        with mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = _make_window(min_elapsed_seconds=60, min_retries=3)
+            window.record_failure()
+            # Failures that each return immediately: the clock barely moves.
+            for _ in range(5):
+                window.next_backoff()
+            assert window.retries >= 3
+            assert window.elapsed < 60
+            assert not window.exhausted, (
+                'a burst of fast failures must not spend the window early')
+
+    def test_both_budgets_spent_exhausts_the_window(self):
+        clock = {'t': 1000.0}
+        with mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = _make_window(min_elapsed_seconds=60, min_retries=3)
+            window.record_failure()
+            for _ in range(3):
+                window.next_backoff()
+            clock['t'] += 61
+            assert window.exhausted
+
+    def test_reset_clears_both_budgets(self):
+        clock = {'t': 1000.0}
+        with mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = _make_window(min_elapsed_seconds=60, min_retries=1)
+            window.record_failure()
+            window.next_backoff()
+            clock['t'] += 61
+            assert window.exhausted
+            window.reset()
+            assert not window.active
+            assert window.retries == 0
+            assert window.elapsed == 0.0
+            assert not window.exhausted
+
+    def test_backoff_never_overshoots_the_time_budget(self):
+        clock = {'t': 1000.0}
+        with mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = _make_window(min_elapsed_seconds=60, min_retries=100)
+            window.record_failure()
+            clock['t'] += 59.5
+            # Only 0.5s of the time budget is left, so the sleep is clamped to
+            # it: the window must be re-evaluated as soon as the budget
+            # expires rather than sleeping past it.
+            assert window.next_backoff() == pytest.approx(0.5)
+            clock['t'] += 10
+            # Past the time budget the retry budget is what remains, so the
+            # plain backoff applies instead of a clamp to a negative value.
+            assert window.next_backoff() > 0
+
+    def test_budgets_are_read_from_config(self):
+        overrides = {
+            ('jobs', 'status_check', 'min_elapsed_seconds'): 600,
+            ('jobs', 'status_check', 'min_retries'): 10,
+        }
+        clock = {'t': 1000.0}
+        with mock.patch.object(
+                utils.skypilot_config,
+                'get_nested',
+                side_effect=lambda keys, default_value, **kwargs: overrides.get(
+                    tuple(keys), default_value)), \
+             mock.patch.object(time, 'time', side_effect=lambda: clock['t']):
+            window = utils.TransientStatusCheckWindow()
+            window.record_failure()
+            for _ in range(9):
+                window.next_backoff()
+            clock['t'] += 601
+            assert not window.exhausted, (
+                'the configured retry budget was not honored')
+            window.next_backoff()
+            assert window.exhausted

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -1659,15 +1659,16 @@ class TestDunderMainDispatchesToImportedModule:
 
 
 class TestTransientJobStatusRecoveryWindow:
-    """Tests for the transient job-status-check retry window across recovery.
+    """Tests for the transient job-status-check retry window.
 
     When the controller cannot fetch a task's job status but the cluster is
-    healthy, it retries for up to JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS before
-    recovering, to avoid a false alarm from a transient control-plane error.
-    That window (`transient_job_check_error_start_time`) must be reset after a
-    recovery; otherwise the first status-fetch failure after a recovery is
-    measured from before the recovery, exceeds the timeout immediately, and
-    triggers another recovery with no retries -- turning one transient error
+    healthy, it retries before recovering, to avoid a false alarm from a
+    transient control-plane error. The window is only spent once *both* its
+    budgets are exhausted (see
+    ``managed_job_utils.TransientStatusCheckWindow``), and it must be reset
+    after a recovery -- otherwise the first status-fetch failure after a
+    recovery is measured from before the recovery, is immediately past the
+    time budget, and triggers another recovery, turning one transient error
     into an unbounded recovery loop.
     """
 
@@ -1690,7 +1691,11 @@ class TestTransientJobStatusRecoveryWindow:
         ``test_status_logger_flushed_when_body_raises``).
         """
         monkeypatch.setattr(managed_job_utils,
-                            'JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS', 60)
+                            'JOB_STATUS_FETCH_MIN_ELAPSED_SECONDS', 60)
+        # This test is about the reset, not the retry budget: drop the retry
+        # budget so the time budget alone decides when the window is spent.
+        monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_FETCH_MIN_RETRIES',
+                            0)
         monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_CHECK_GAP_SECONDS',
                             0)
 
@@ -1765,6 +1770,99 @@ class TestTransientJobStatusRecoveryWindow:
         assert recover_calls == 1, (
             'expected exactly one recovery; a second recovery means the '
             'transient retry window was not reset after the first recovery')
+
+    @pytest.mark.asyncio
+    async def test_slow_check_still_gets_its_retries(self, monkeypatch):
+        """A check that outlasts the time budget is still retried.
+
+        The cluster-status refresh that runs before recovery performs its own
+        retried probes of the cluster, so one round can take far longer than
+        the time budget. With a time-only budget the whole window is spent
+        inside the round that opened it: the loop reaches its retry decision
+        already past the deadline and recovers a job it never retried once.
+        The retry budget must hold the loop in place until it has actually
+        retried ``JOB_STATUS_FETCH_MIN_RETRIES`` times.
+        """
+        monkeypatch.setattr(managed_job_utils,
+                            'JOB_STATUS_FETCH_MIN_ELAPSED_SECONDS', 60)
+        monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_FETCH_MIN_RETRIES',
+                            2)
+        monkeypatch.setattr(managed_job_utils, 'JOB_STATUS_CHECK_GAP_SECONDS',
+                            0)
+
+        # The clock only advances inside the cluster-status refresh, i.e.
+        # after the window has opened and before its retry decision -- which
+        # is where the real time goes. Every round jumps well past the time
+        # budget, so the time budget alone would recover at the first check.
+        clock = {'t': 1000.0}
+        checks = 0
+        checks_before_recovery = None
+
+        async def fake_get_job_status(*args, **kwargs):
+            nonlocal checks
+            if checks >= 4:
+                raise TestTransientJobStatusRecoveryWindow._StopLoop()
+            checks += 1
+            return None, 'Job status check timed out after 30s.'
+
+        async def fake_recover(*args, **kwargs):
+            nonlocal checks_before_recovery
+            if checks_before_recovery is None:
+                checks_before_recovery = checks
+            return clock['t']
+
+        handle = MagicMock()
+        handle.launched_resources.need_cleanup_after_preemption_or_failure.\
+            return_value = False
+
+        def fake_refresh(*args, **kwargs):
+            clock['t'] += 1000.0
+            return status_lib.ClusterStatus.UP, handle
+
+        mock_self = MagicMock()
+        mock_self._job_id = 1
+        mock_self._pool = None
+
+        executor = MagicMock()
+        executor.recover = AsyncMock(side_effect=fake_recover)
+
+        state = controller_module.managed_job_state
+        with patch.object(controller_module.time, 'time',
+                          side_effect=lambda: clock['t']), \
+             patch.object(managed_job_utils, 'get_job_status',
+                          side_effect=fake_get_job_status), \
+             patch.object(controller_module.backend_utils,
+                          'refresh_cluster_status_handle',
+                          side_effect=fake_refresh), \
+             patch.object(controller_module.backend_utils,
+                          'async_check_network_connection',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(controller_module.managed_job_runtime,
+                          'is_registered', return_value=False), \
+             patch.object(state, 'set_recovering_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(state, 'set_recovered_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(state, 'set_started_async',
+                          new=AsyncMock(return_value=None)), \
+             patch.object(controller_module.asyncio, 'sleep',
+                          new=AsyncMock(return_value=None)):
+            with pytest.raises(TestTransientJobStatusRecoveryWindow._StopLoop):
+                await controller_module.JobController._monitor_one_task_impl(
+                    mock_self,
+                    task_id=0,
+                    task=MagicMock(name='task'),
+                    cluster_name='cluster',
+                    executor=executor,
+                    status_logger=managed_job_utils.JobStatusLogger(),
+                    callback_func=MagicMock(),
+                    force_transit_to_recovering=False)
+
+        # Checks 1 and 2 must each be retried; only the third may recover. A
+        # time-only budget recovers at check 1, having never retried.
+        assert checks_before_recovery == 3, (
+            'expected recovery only after the retry budget was spent, but '
+            f'recovered after {checks_before_recovery} status check(s)')
 
     @pytest.mark.asyncio
     async def test_status_logger_flushed_when_body_raises(self, monkeypatch):


### PR DESCRIPTION
Part of skypilot-org/skypilot#10157.

The controller retries a failed job-status check before recovering a job, so that a transient control-plane error does not tear down a healthy job. That window was bounded by elapsed time alone, which does not guarantee any retry actually happens: the cluster-status refresh that runs before recovery performs its own retried probes of the cluster, so a single round can outlast the entire budget. The loop then reaches its retry decision already past the deadline and recovers a job it never retried once — the `Retrying to avoid a false alarm` path is skipped entirely, and the elapsed time it logs is the duration of that refresh rather than time spent retrying.

This bounds the window by two budgets, and gives up only once **both** are exhausted:

* `min_elapsed_seconds` — seconds since the first failure in the run (default 60, unchanged).
* `min_retries` — retries made since the first failure in the run (default 5, new).

Requiring both also covers the converse case: a burst of checks that each fail immediately can exhaust a retry count within a couple of seconds, long before a transient condition has had a chance to clear.

Both budgets are configurable under `jobs.status_check` and documented, so a deployment whose controller reaches its clusters over a slow or intermittent link can widen the tolerance without patching source:

```yaml
jobs:
  status_check:
    min_elapsed_seconds: 600
    min_retries: 10
```

The window state moves into `managed_job_utils.TransientStatusCheckWindow`, shared by the two call sites that consulted it (the job-status check, and the cluster-status refresh handler that deliberately reuses the same window) and directly unit-testable.

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
  - New `tests/unit_tests/test_jobs_utils.py::TestTransientStatusCheckWindow`: neither budget alone ends the run, both together do, `reset()` clears both, the backoff never overshoots the time budget, and the budgets are read from config.
  - New `test_controller.py::TestTransientJobStatusRecoveryWindow::test_slow_check_still_gets_its_retries`: a cluster-status refresh that jumps the clock past the time budget must still be retried. Confirmed it fails without the retry budget, reporting `recovered after 1 status check`.
  - `test_window_reset_after_recovery` updated for the new constants, with the retry budget set to 0 so that test stays focused on the post-recovery reset.
  - `pytest tests/unit_tests/test_sky/jobs/test_controller.py tests/unit_tests/test_jobs_utils.py` — 141 passed.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)