### PR TITLE
[Kubernetes] Let the k8s images be rebuilt on a different base

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,6 +1,8 @@
 # Ubuntu 22.04 to match the GPU image's base (nvidia/cuda:*-ubuntu22.04 is
-# layered on top of ubuntu:22.04).
-FROM ubuntu:22.04
+# layered on top of ubuntu:22.04). Overridable so the same recipe can be
+# rebuilt on another base (e.g. ubuntu:24.04 for a newer glibc).
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE}
 
 # Detect architecture using ARG with default value
 ARG TARGETARCH
@@ -31,7 +33,19 @@ RUN mkdir -p /var/run/sshd && \
     ssh-keygen -A
 
 # Setup new user named sky and add to sudoers.
-RUN useradd -m -s /bin/bash sky && \
+# sky must own uid/gid 1000: kubernetes-ray.yml.j2 pins runAsUser/runAsGroup/
+# fsGroup to 1000. Ubuntu 24.04+ base images ship a placeholder user holding it,
+# so evict whoever owns 1000 first -- keyed on the id rather than the name,
+# which varies across bases. userdel frees the account before it cleans up the
+# home dir and mail spool, so its exit status is not load-bearing here; the
+# explicit -u/-g is the real guard, failing the build instead of silently
+# landing sky on 1001.
+RUN existing_user=$(getent passwd 1000 | cut -d: -f1) && \
+    if [ -n "$existing_user" ]; then userdel -r "$existing_user" || true; fi && \
+    existing_group=$(getent group 1000 | cut -d: -f1) && \
+    if [ -n "$existing_group" ]; then groupdel "$existing_group" || true; fi && \
+    groupadd -g 1000 sky && \
+    useradd -m -s /bin/bash -u 1000 -g 1000 sky && \
     echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Switch to sky user

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -1,5 +1,8 @@
 # We use the cuda runtime image instead of devel image to reduce size (1.3GB vs 3.6GB)
-FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
+# Overridable so the same recipe can be rebuilt on another base (e.g.
+# nvidia/cuda:*-runtime-ubuntu24.04 for a newer glibc).
+ARG BASE_IMAGE=nvidia/cuda:12.1.1-runtime-ubuntu22.04
+FROM ${BASE_IMAGE}
 
 # Detect architecture using ARG with default value
 ARG TARGETARCH
@@ -35,7 +38,19 @@ RUN mkdir -p /var/run/sshd && \
     ssh-keygen -A
 
 # Setup new user named sky and add to sudoers.
-RUN useradd -m -s /bin/bash sky && \
+# sky must own uid/gid 1000: kubernetes-ray.yml.j2 pins runAsUser/runAsGroup/
+# fsGroup to 1000. Ubuntu 24.04+ base images ship a placeholder user holding it,
+# so evict whoever owns 1000 first -- keyed on the id rather than the name,
+# which varies across bases. userdel frees the account before it cleans up the
+# home dir and mail spool, so its exit status is not load-bearing here; the
+# explicit -u/-g is the real guard, failing the build instead of silently
+# landing sky on 1001.
+RUN existing_user=$(getent passwd 1000 | cut -d: -f1) && \
+    if [ -n "$existing_user" ]; then userdel -r "$existing_user" || true; fi && \
+    existing_group=$(getent group 1000 | cut -d: -f1) && \
+    if [ -n "$existing_group" ]; then groupdel "$existing_group" || true; fi && \
+    groupadd -g 1000 sky && \
+    useradd -m -s /bin/bash -u 1000 -g 1000 sky && \
     echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Switch to sky user

--- a/sky/catalog/images/skypilot-k8s-image.sh
+++ b/sky/catalog/images/skypilot-k8s-image.sh
@@ -6,18 +6,24 @@
 # first may solve some segmentation faults issue with QEMU when building the
 # image across architectures.
 #
-# Usage: ./skypilot-k8s-image.sh [-p] [-g] [-l] [-r region]
+# Usage: ./skypilot-k8s-image.sh [-p] [-g] [-l] [-r region] [-b base_image] [-s suffix]
 # -p: Push the image to the registry
 # -g: Builds the GPU image in Dockerfile_k8s_gpu. GPU image is built only for amd64
 # -l: Use latest tag instead of the date tag. Date tag is of the form YYYYMMDDHHMM
 # -r: Specify the region to be us, europe or asia
+# -b: Build on a different base image (Dockerfile BASE_IMAGE arg), e.g.
+#     ubuntu:24.04 or nvidia/cuda:12.8.1-runtime-ubuntu24.04
+# -s: Append a suffix to the version tag, e.g. -s ubuntu2404 -> <date>-ubuntu2404.
+#     Use with -b so a variant build does not collide with the default one.
 region=us
 push=false
 gpu=false
 latest=false
+base_image=""
+suffix=""
 
 # Parse command line arguments
-OPTSTRING=":pglr:"
+OPTSTRING=":pglr:b:s:"
 while getopts ${OPTSTRING} opt; do
   case ${opt} in
     p)
@@ -32,12 +38,20 @@ while getopts ${OPTSTRING} opt; do
     r)
       region=${OPTARG}
       ;;
+    b)
+      base_image=${OPTARG}
+      ;;
+    s)
+      suffix=${OPTARG}
+      ;;
     ?)
       echo "Usage: ./build_image.sh [-p] [-g] [-l] [-r region]"
       echo "-p: Push the image to the registry"
       echo "-g: Build the GPU image"
       echo "-l: Use latest tag instead of the date tag"
       echo "-r: Specify the region to be us, europe or asia"
+      echo "-b: Build on a different base image (BASE_IMAGE build arg)"
+      echo "-s: Append a suffix to the version tag"
       exit 1
       ;;
   esac
@@ -48,6 +62,8 @@ echo "Push: $push"
 echo "GPU: $gpu"
 echo "Latest: $latest"
 echo "Region: $region"
+echo "Base image: ${base_image:-<Dockerfile default>}"
+echo "Tag suffix: ${suffix:-<none>}"
 
 TAG=$region-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot
 
@@ -56,6 +72,15 @@ if [[ $latest == "true" ]]; then
   VERSION_TAG=latest
 else
   VERSION_TAG=$(date +%Y%m%d%H%M)
+fi
+
+if [[ -n $suffix ]]; then
+  VERSION_TAG=${VERSION_TAG}-${suffix}
+fi
+
+BUILD_ARGS=()
+if [[ -n $base_image ]]; then
+  BUILD_ARGS+=(--build-arg "BASE_IMAGE=$base_image")
 fi
 
 # Add -gpu to the tag if the GPU image is being built
@@ -87,15 +112,15 @@ fi
 if [[ $push == "true" ]]; then
   # Build for both architectures
   echo "Building and pushing image for amd64 and arm64: $TAG"
-  docker buildx build --push --platform linux/amd64,linux/arm64 -t $TAG -f $DOCKERFILE ./sky
+  docker buildx build --push "${BUILD_ARGS[@]}" --platform linux/amd64,linux/arm64 -t $TAG -f $DOCKERFILE ./sky
 else
   # Load the right image depending on the architecture of the host machine (Apple Silicon or Intel)
   if [[ $(uname -m) == "arm64" ]]; then
     echo "Loading image for arm64 (Apple Silicon etc.): $TAG"
-    docker buildx build --load --platform linux/arm64 -t $TAG -f $DOCKERFILE ./sky
+    docker buildx build --load "${BUILD_ARGS[@]}" --platform linux/arm64 -t $TAG -f $DOCKERFILE ./sky
   elif [[ $(uname -m) == "x86_64" ]]; then
     echo "Building for amd64 (Intel CPUs): $TAG"
-    docker buildx build --load --platform linux/amd64 -t $TAG -f $DOCKERFILE ./sky
+    docker buildx build --load "${BUILD_ARGS[@]}" --platform linux/amd64 -t $TAG -f $DOCKERFILE ./sky
   else
     echo "Unsupported architecture: $(uname -m)"
     exit 1


### PR DESCRIPTION
## Summary

- `Dockerfile_k8s` / `Dockerfile_k8s_gpu` take a `BASE_IMAGE` build arg (defaulting to the current base), so the same recipe can be rebuilt on a different distro — e.g. an Ubuntu 24.04 rebuild for a newer glibc — without patching the Dockerfiles.
- `skypilot-k8s-image.sh` grows `-b <base image>` (passes the build arg) and `-s <suffix>` (appends to the version tag), so a variant build lands on its own tag instead of colliding with the default one.
- `sky` is now pinned to uid/gid 1000. `kubernetes-ray.yml.j2` sets `runAsUser` / `runAsGroup` / `fsGroup` to 1000, but Ubuntu 24.04 and later ship a placeholder user holding uid 1000, so `useradd sky` there silently lands on 1001 and every pod that mounts a volume loses write access to its own home. The eviction is keyed on the id rather than the name (the placeholder's name varies across bases), and `-u`/`-g` are passed explicitly so a failed eviction fails the build instead of drifting.

On the current 22.04 bases the uid block is a no-op: there is no uid/gid 1000 to evict, and `groupadd -g 1000` / `useradd -u 1000 -g 1000` land on exactly the ids that were being auto-assigned before.

## Test plan

Manual, on a Linux builder (no GPU needed — the checks assert that the libraries and tools are present, they don't exercise a device):

```bash
# 1. Default base (22.04) — behavior must be unchanged
docker buildx build --load -t sky-cpu-2204 -f Dockerfile_k8s ./sky
docker run --rm sky-cpu-2204 sh -c 'id -u sky; id -g sky; ldd --version | head -1'
#   -> 1000 / 1000 / glibc 2.35

# 2. Same recipe on a newer base
docker buildx build --load --build-arg BASE_IMAGE=ubuntu:24.04 \
  -t sky-cpu-2404 -f Dockerfile_k8s ./sky
docker run --rm sky-cpu-2404 sh -c 'id -u sky; id -g sky; getent passwd 1000; ldd --version | head -1'
#   -> 1000 / 1000 / sky owns uid 1000 (not `ubuntu`) / glibc 2.39

# 3. GPU image, both bases
docker buildx build --load -t sky-gpu-2204 -f Dockerfile_k8s_gpu ./sky
docker buildx build --load --build-arg BASE_IMAGE=nvidia/cuda:12.8.1-runtime-ubuntu24.04 \
  -t sky-gpu-2404 -f Dockerfile_k8s_gpu ./sky
docker run --rm sky-gpu-2404 sh -c 'ibv_devinfo -l >/dev/null; ldconfig -p | grep -c libibverbs'

# 4. Build script options
./sky/catalog/images/skypilot-k8s-image.sh -g -b nvidia/cuda:12.8.1-runtime-ubuntu24.04 -s ubuntu2404
#   -> tag ...skypilot-gpu:<date>-ubuntu2404, BASE_IMAGE forwarded
```

Reverting the uid block and rebuilding on 24.04 makes check 2 report uid 1001 with `ubuntu` owning 1000, which is the regression this guards against.

No unit tests: the change is confined to the image recipes and their build script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->