### PR TITLE
[API] Deny a principal whose role the policy system does not recognize

### DIFF
--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -32,6 +32,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky.server.requests import executor
 from sky.users import permission
+from sky.utils import common_utils
 from sky.utils import context_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -53,6 +54,22 @@ async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     """
     return await asyncio.wait_for(context_utils.to_thread_with_executor(
         executor.get_auth_thread_executor(), func, *args),
+                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+
+
+async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
+    """Like `call_with_deadline`, on the request executor instead.
+
+    For auth-path work that is *not* a short lookup. The auth executor is 32
+    threads for exactly that, and its docstring is explicit that anything whose
+    exhaustion must not lock users out belongs on the request executor (128).
+    The deadline releases the caller, never the thread -- `wait_for` cannot
+    cancel a thread parked on a lock -- so work that can hold a thread for
+    `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS` would otherwise let a burst of first
+    logins exhaust authentication for every other request on this worker.
+    """
+    return await asyncio.wait_for(context_utils.to_thread_with_executor(
+        executor.get_request_thread_executor(), func, *args),
                                   timeout=AUTH_DB_TIMEOUT_SECONDS)
 
 
@@ -81,17 +98,22 @@ async def ensure_role_for_authenticated_user(
     """
     if newly_added:
         try:
-            await call_with_deadline(permission.seed_new_user_role, user_id)
-        except asyncio.TimeoutError:
-            logger.error(f'Seeding a role for new user {user_id} timed out; '
-                         f'queueing it off the request')
-            permission.permission_service.queue_role_repair(user_id)
-            return db_timeout_response()
+            await _call_on_request_pool(permission.seed_new_user_role, user_id)
         except exceptions.ConcurrentWorkerExhaustedError as e:
             logger.error(f'Concurrent worker exhausted seeding a role for '
                          f'{user_id}: {e}')
             permission.permission_service.queue_role_repair(user_id)
             return worker_exhausted_response()
+        except Exception as e:  # pylint: disable=broad-except
+            # Everything, not just the timeout: an exception raised in a
+            # middleware surfaces as a bare 500, which clients do not retry
+            # (see this module's docstring). A first request that cannot get a
+            # role is exactly what should be retried.
+            logger.error(f'Seeding a role for new user {user_id} failed; '
+                         f'queueing it off the request: '
+                         f'{common_utils.format_exception(e)}')
+            permission.permission_service.queue_role_repair(user_id)
+            return db_timeout_response()
         return None
     if not permission.permission_service.probably_has_role(user_id):
         permission.permission_service.queue_role_repair(user_id)

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -104,16 +104,29 @@ async def ensure_role_for_authenticated_user(
                          f'{user_id}: {e}')
             permission.permission_service.queue_role_repair(user_id)
             return worker_exhausted_response()
+        except asyncio.TimeoutError:
+            # Separated from the clause below for the log, not the answer: the
+            # deadline elapsed but the seed is still running in its thread and
+            # usually lands, whereas the cases below have already failed. The
+            # caller gets the same 503 either way -- from a client's side both
+            # are "not ready yet, come back".
+            logger.error(f'Seeding a role for new user {user_id} did not '
+                         f'finish within {AUTH_DB_TIMEOUT_SECONDS}s; queueing '
+                         f'it off the request')
+            permission.permission_service.queue_role_repair(user_id)
+            return role_seed_unavailable_response()
         except Exception as e:  # pylint: disable=broad-except
-            # Everything, not just the timeout: an exception raised in a
-            # middleware surfaces as a bare 500, which clients do not retry
-            # (see this module's docstring). A first request that cannot get a
-            # role is exactly what should be retried.
+            # Everything else, because an exception raised in a middleware
+            # surfaces as a bare 500, which clients do not retry (see this
+            # module's docstring). Note a contended policy lock arrives here
+            # rather than above: `_policy_lock` converts its own timeout into a
+            # RuntimeError. That is the common case for this branch, and what
+            # the response's wording is written for.
             logger.error(f'Seeding a role for new user {user_id} failed; '
                          f'queueing it off the request: '
                          f'{common_utils.format_exception(e)}')
             permission.permission_service.queue_role_repair(user_id)
-            return db_timeout_response()
+            return role_seed_unavailable_response()
         return None
     if not permission.permission_service.probably_has_role(user_id):
         permission.permission_service.queue_role_repair(user_id)
@@ -138,8 +151,29 @@ def db_timeout_response() -> fastapi.responses.JSONResponse:
         })
 
 
+def role_seed_unavailable_response() -> fastapi.responses.JSONResponse:
+    """503 for a new user whose role could not be assigned in time.
+
+    Not `db_timeout_response`: that one names a slow database, and the reason
+    this path gives up is usually contention on the policy lock, which is a
+    healthy database doing exactly what it should. Same 503 so the client
+    retries with backoff, and by then the queued repair has normally landed.
+    """
+    return fastapi.responses.JSONResponse(
+        status_code=503,
+        headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
+        content={
+            'detail': ('Could not finish setting up your account in time '
+                       '(the server is busy assigning roles). It is being '
+                       'completed in the background -- please try again.')
+        })
+
+
 def worker_exhausted_response() -> fastapi.responses.JSONResponse:
-    """503 for an auth lookup rejected by a saturated auth executor.
+    """503 for auth-path work rejected by a saturated thread executor.
+
+    Either pool: the auth executor for lookups, or the request executor for a
+    new user's role seed, which is deliberately not on the auth pool.
 
     Mirrors ``handle_concurrent_worker_exhausted_error`` in
     ``sky/server/server.py`` — that app-level handler cannot see

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -24,12 +24,17 @@ which clients do not retry.
 """
 import asyncio
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import fastapi
 
+from sky import exceptions
+from sky import sky_logging
 from sky.server.requests import executor
+from sky.users import permission
 from sky.utils import context_utils
+
+logger = sky_logging.init_logger(__name__)
 
 # Total client-side deadline on each auth DB lookup. Healthy lookups are
 # small indexed queries; this only trips when the DB layer is in real
@@ -49,6 +54,48 @@ async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     return await asyncio.wait_for(context_utils.to_thread_with_executor(
         executor.get_auth_thread_executor(), func, *args),
                                   timeout=AUTH_DB_TIMEOUT_SECONDS)
+
+
+async def ensure_role_for_authenticated_user(
+        user_id: str,
+        newly_added: bool) -> Optional[fastapi.responses.JSONResponse]:
+    """Give an authenticated principal a role. A response to send, or None.
+
+    Both auth front-ends (the auth-proxy middleware and the oauth2-proxy one)
+    need the same two branches, so they live here rather than twice:
+
+    A **brand-new** user's seed is awaited: the RBAC gate denies a principal
+    with no role, so their first request has to find one. Bounded, because the
+    seed takes the distributed policy lock (up to
+    `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS`) and an unbounded await hangs the login
+    for that long -- and on the bounded auth executor, so a burst of signups
+    cannot drain the default thread pool every other `to_thread` caller shares.
+    On a timeout the account is queued for repair and the caller gets a
+    retryable 503: proceeding would hand the gate a role-less principal and 403
+    their first request, and dropping the seed would leave the account broken
+    until something else noticed.
+
+    A **returning** user whose seed never completed is only queued. The repair
+    wants the same contended lock that stranded them, nothing about answering
+    this request depends on it, and the gate denies them until it lands.
+    """
+    if newly_added:
+        try:
+            await call_with_deadline(permission.seed_new_user_role, user_id)
+        except asyncio.TimeoutError:
+            logger.error(f'Seeding a role for new user {user_id} timed out; '
+                         f'queueing it off the request')
+            permission.permission_service.queue_role_repair(user_id)
+            return db_timeout_response()
+        except exceptions.ConcurrentWorkerExhaustedError as e:
+            logger.error(f'Concurrent worker exhausted seeding a role for '
+                         f'{user_id}: {e}')
+            permission.permission_service.queue_role_repair(user_id)
+            return worker_exhausted_response()
+        return None
+    if not permission.permission_service.probably_has_role(user_id):
+        permission.permission_service.queue_role_repair(user_id)
+    return None
 
 
 def db_timeout_response() -> fastapi.responses.JSONResponse:

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -160,23 +160,22 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                                 'setup.'
                         })
                 newly_added = global_user_state.add_or_update_user(auth_user)
-                # `needs_role_seed` also retries a seed that never completed:
-                # it only ever ran under `newly_added`, so a policy-lock
-                # timeout on someone's first request left them with a `users`
-                # row and no role, and nothing to try again. It answers from
-                # memory for anyone who already has one.
-                if newly_added or permission.permission_service.needs_role_seed(
-                        auth_user.id):
-                    # Offload the blocking config reload + role seed to a
-                    # worker thread so this async middleware doesn't block the
-                    # event loop. The reload lets a runtime `rbac.default_role`
-                    # change take effect for this new user without a restart.
-                    if not newly_added:
-                        logger.warning(
-                            f'User {auth_user.id} has no role; re-seeding with '
-                            f'the default role. Their first seed did not '
-                            f'complete.')
+                # Offload the blocking config reload + role seed to a
+                # worker thread so this async middleware doesn't block the
+                # event loop. The reload lets a runtime `rbac.default_role`
+                # change take effect for this new user without a restart.
+                if newly_added:
                     await asyncio.to_thread(permission.seed_new_user_role,
+                                            auth_user.id)
+                elif not permission.permission_service.probably_has_role(
+                        auth_user.id):
+                    # A seed only ever ran under `newly_added`, so a
+                    # policy-lock timeout on someone's first request left them
+                    # with a `users` row and no role, and nothing to try again.
+                    # The guard reads only in-memory state; confirming and
+                    # repairing it can reload the policy, so that goes to a
+                    # thread as well.
+                    await asyncio.to_thread(permission.reseed_role_if_missing,
                                             auth_user.id)
                 request.state.auth_user = auth_user
                 return await call_next(request)

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -160,11 +160,22 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                                 'setup.'
                         })
                 newly_added = global_user_state.add_or_update_user(auth_user)
-                if newly_added:
+                # `needs_role_seed` also retries a seed that never completed:
+                # it only ever ran under `newly_added`, so a policy-lock
+                # timeout on someone's first request left them with a `users`
+                # row and no role, and nothing to try again. It answers from
+                # memory for anyone who already has one.
+                if newly_added or permission.permission_service.needs_role_seed(
+                        auth_user.id):
                     # Offload the blocking config reload + role seed to a
                     # worker thread so this async middleware doesn't block the
                     # event loop. The reload lets a runtime `rbac.default_role`
                     # change take effect for this new user without a restart.
+                    if not newly_added:
+                        logger.warning(
+                            f'User {auth_user.id} has no role; re-seeding with '
+                            f'the default role. Their first seed did not '
+                            f'complete.')
                     await asyncio.to_thread(permission.seed_new_user_role,
                                             auth_user.id)
                 request.state.auth_user = auth_user

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -12,6 +12,7 @@ import aiohttp
 import fastapi
 import starlette.middleware.base
 
+from sky import exceptions
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
@@ -159,7 +160,20 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                                 'return user info, check your oauth2-proxy'
                                 'setup.'
                         })
-                newly_added = global_user_state.add_or_update_user(auth_user)
+                # Bounded and off the loop, matching the same call in
+                # `server.py`'s auth-proxy middleware. It is a database upsert:
+                # run inline, a slow database stalls this worker's event loop
+                # for every request, not just this login.
+                try:
+                    newly_added = await db_lookup.call_with_deadline(
+                        global_user_state.add_or_update_user, auth_user)
+                except asyncio.TimeoutError:
+                    logger.error('oauth2-proxy user upsert timed out')
+                    return db_lookup.db_timeout_response()
+                except exceptions.ConcurrentWorkerExhaustedError as e:
+                    logger.error(f'Concurrent worker exhausted during '
+                                 f'oauth2-proxy user upsert: {e}')
+                    return db_lookup.worker_exhausted_response()
                 failed = await db_lookup.ensure_role_for_authenticated_user(
                     auth_user.id, newly_added)
                 if failed is not None:

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -17,8 +17,8 @@ from sky import models
 from sky import sky_logging
 from sky.server import constants as server_constants
 from sky.server import middleware_utils
+from sky.server.auth import db_lookup
 from sky.server.auth import loopback
-from sky.users import permission
 from sky.utils import common_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -160,23 +160,10 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                                 'setup.'
                         })
                 newly_added = global_user_state.add_or_update_user(auth_user)
-                # Offload the blocking config reload + role seed to a
-                # worker thread so this async middleware doesn't block the
-                # event loop. The reload lets a runtime `rbac.default_role`
-                # change take effect for this new user without a restart.
-                if newly_added:
-                    await asyncio.to_thread(permission.seed_new_user_role,
-                                            auth_user.id)
-                elif not permission.permission_service.probably_has_role(
-                        auth_user.id):
-                    # A seed only ever ran under `newly_added`, so a
-                    # policy-lock timeout on someone's first request left them
-                    # with a `users` row and no role, and nothing to try again.
-                    # The guard reads only in-memory state; confirming and
-                    # repairing it can reload the policy, so that goes to a
-                    # thread as well.
-                    await asyncio.to_thread(permission.reseed_role_if_missing,
-                                            auth_user.id)
+                failed = await db_lookup.ensure_role_for_authenticated_user(
+                    auth_user.id, newly_added)
+                if failed is not None:
+                    return failed
                 request.state.auth_user = auth_user
                 return await call_next(request)
             elif auth_response.status == http.HTTPStatus.UNAUTHORIZED:

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -50,9 +50,8 @@ def request_owner_scope(request: fastapi.Request) -> Optional[str]:
     auth_user = getattr(request.state, 'auth_user', None)
     if auth_user is None:
         return None
-    # In-memory Casbin lookup (no DB roundtrip), matching `_is_viewer`.
-    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
-    roles = enforcer.get_roles_for_user(auth_user.id)
+    # In-memory lookup (no DB roundtrip), matching `_is_viewer`.
+    roles = permission.permission_service.roles_in_memory(auth_user.id)
     if rbac.RoleName.ADMIN.value in roles:
         return None
     return auth_user.id
@@ -91,8 +90,7 @@ def _is_viewer(request: fastapi.Request) -> bool:
         return False
     # Trust the in-memory grouping policy; same source the middleware
     # already consulted to gate this request to here.
-    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
-    roles = enforcer.get_roles_for_user(auth_user.id)
+    roles = permission.permission_service.roles_in_memory(auth_user.id)
     # Admin wins over viewer when both roles are present.
     return (rbac.RoleName.VIEWER.value in roles and
             rbac.RoleName.ADMIN.value not in roles)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -680,12 +680,22 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 logger.error(f'Concurrent worker exhausted during auth proxy '
                              f'user upsert: {e}')
                 return db_lookup.worker_exhausted_response()
-            if newly_added:
+            # `needs_role_seed` also covers a user whose original seed failed:
+            # it only ever ran under `newly_added`, so a policy-lock timeout on
+            # someone's first request left them with a `users` row, no role,
+            # and nothing to retry it. It answers from memory for anyone who
+            # already has a role, so this costs a dict lookup per request.
+            if newly_added or permission.permission_service.needs_role_seed(
+                    auth_user.id):
                 # Offload the blocking config reload + role seed to a worker
                 # thread so this async middleware doesn't block the event loop.
                 # The reload lets a runtime `rbac.default_role` change take
                 # effect for this new user without a restart (the main
                 # API-server process does not reload config per request).
+                if not newly_added:
+                    logger.warning(
+                        f'User {auth_user.id} has no role; re-seeding with the '
+                        f'default role. Their first seed did not complete.')
                 await asyncio.to_thread(permission.seed_new_user_role,
                                         auth_user.id)
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -680,23 +680,23 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 logger.error(f'Concurrent worker exhausted during auth proxy '
                              f'user upsert: {e}')
                 return db_lookup.worker_exhausted_response()
-            # `needs_role_seed` also covers a user whose original seed failed:
-            # it only ever ran under `newly_added`, so a policy-lock timeout on
-            # someone's first request left them with a `users` row, no role,
-            # and nothing to retry it. It answers from memory for anyone who
-            # already has a role, so this costs a dict lookup per request.
-            if newly_added or permission.permission_service.needs_role_seed(
-                    auth_user.id):
-                # Offload the blocking config reload + role seed to a worker
-                # thread so this async middleware doesn't block the event loop.
-                # The reload lets a runtime `rbac.default_role` change take
-                # effect for this new user without a restart (the main
-                # API-server process does not reload config per request).
-                if not newly_added:
-                    logger.warning(
-                        f'User {auth_user.id} has no role; re-seeding with the '
-                        f'default role. Their first seed did not complete.')
+            # Offload the blocking config reload + role seed to a worker
+            # thread so this async middleware doesn't block the event loop.
+            # The reload lets a runtime `rbac.default_role` change take
+            # effect for this new user without a restart (the main
+            # API-server process does not reload config per request).
+            if newly_added:
                 await asyncio.to_thread(permission.seed_new_user_role,
+                                        auth_user.id)
+            elif not permission.permission_service.probably_has_role(
+                    auth_user.id):
+                # A seed only ever ran under `newly_added`, so a policy-lock
+                # timeout on someone's first request left them with a `users`
+                # row, no role, and nothing to retry it -- and a role-less
+                # principal matches no blocklist rule. The guard above reads
+                # only what is already in memory; confirming it and repairing
+                # it can reload the policy, so that part goes to a thread too.
+                await asyncio.to_thread(permission.reseed_role_if_missing,
                                         auth_user.id)
 
         # Store user info in request.state for access by GET endpoints

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -680,24 +680,12 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 logger.error(f'Concurrent worker exhausted during auth proxy '
                              f'user upsert: {e}')
                 return db_lookup.worker_exhausted_response()
-            # Offload the blocking config reload + role seed to a worker
-            # thread so this async middleware doesn't block the event loop.
-            # The reload lets a runtime `rbac.default_role` change take
-            # effect for this new user without a restart (the main
-            # API-server process does not reload config per request).
-            if newly_added:
-                await asyncio.to_thread(permission.seed_new_user_role,
-                                        auth_user.id)
-            elif not permission.permission_service.probably_has_role(
-                    auth_user.id):
-                # A seed only ever ran under `newly_added`, so a policy-lock
-                # timeout on someone's first request left them with a `users`
-                # row, no role, and nothing to retry it -- and a role-less
-                # principal matches no blocklist rule. The guard above reads
-                # only what is already in memory; confirming it and repairing
-                # it can reload the policy, so that part goes to a thread too.
-                await asyncio.to_thread(permission.reseed_role_if_missing,
-                                        auth_user.id)
+            # Same deadline as the upsert above; see the helper for why a new
+            # user's seed is awaited while a returning one's repair is queued.
+            failed = await db_lookup.ensure_role_for_authenticated_user(
+                auth_user.id, newly_added)
+            if failed is not None:
+                return failed
 
         # Store user info in request.state for access by GET endpoints
         if auth_user is not None:

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -48,6 +48,31 @@ POLICY_UPDATE_LOCK_POLL_INTERVAL_SECONDS = 0.1
 # for a hard memory bound in a long-lived server process.
 _READ_ONLY_ENDPOINT_CACHE_MAX = 4096
 
+# How long a worker remembers "this principal has no role I recognize" before
+# paying for another policy load. Bounds the cost of the permanent case (a
+# genuinely role-less principal) without letting the transient one (a role
+# assigned on another worker moments ago) stay wrong for long.
+_NO_ROLE_PROBE_TTL_SECONDS = 30
+# Upper bound on that memo, cleared wholesale on overflow like
+# `_read_only_endpoint_cache`. Keys are authenticated user ids, so the space is
+# bounded by real principals rather than by traffic.
+_NO_ROLE_PROBE_CACHE_MAX = 4096
+
+# Materialized once: the role set is a static enum, and this is consulted on
+# every request.
+_SUPPORTED_ROLES = frozenset(rbac.get_supported_roles())
+
+
+def _recognized_roles(roles: List[str]) -> List[str]:
+    """The subset of `roles` the policy system actually knows about.
+
+    An unrecognized name is not a weaker role, it is no role: nothing in the
+    blocklist mentions it, so `enforce` permits it everywhere. Databases
+    predating the update-role validation can still hold one.
+    """
+    return [role for role in roles if role in _SUPPORTED_ROLES]
+
+
 _enforcer_instance: Optional['PermissionService'] = None
 
 # KV cache constants for workspace permission checks.
@@ -73,6 +98,9 @@ class PermissionService:
         # every request in the main event loop. Cleared whenever the allowlist
         # is rebuilt (`_build_viewer_allowlist_no_lock`).
         self._read_only_endpoint_cache: Dict[Tuple[str, str], bool] = {}
+        # user_id -> when this worker last reloaded on their behalf. See
+        # `_probe_unknown_principal`.
+        self._no_role_probe_cache: Dict[str, float] = {}
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -514,6 +542,44 @@ class PermissionService:
         return (workspaces_utils.get_read_only_workspace_names() &
                 workspace_names)
 
+    def _probe_unknown_principal(self, user_id: str) -> List[str]:
+        """Reload once for a principal with no role here, and re-read it.
+
+        Either this worker's model predates whoever created them, or they have
+        no role at all. Only the database can tell the two apart, so pay for
+        one load -- but at most once per TTL per user, because the other case
+        is permanent: without the cache a role-less principal would trigger a
+        full policy load on every request it makes.
+        """
+        now = time.time()
+        if now - self._no_role_probe_cache.get(
+                user_id, 0.0) < _NO_ROLE_PROBE_TTL_SECONDS:
+            return self._ensure_enforcer().get_roles_for_user(user_id)
+        if len(self._no_role_probe_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
+            self._no_role_probe_cache.clear()
+        self._no_role_probe_cache[user_id] = now
+        self._load_policy_no_lock()
+        return self._ensure_enforcer().get_roles_for_user(user_id)
+
+    def needs_role_seed(self, user_id: str) -> bool:
+        """Whether this principal looks like it never got a role.
+
+        For the login path, which already seeds new users: `seed_new_user_role`
+        is only called when the `users` row was newly inserted, so a seed that
+        failed (the policy lock has a bounded wait) is never retried and the
+        user stays role-less -- and therefore unrestricted -- until the next
+        restart re-seeds them.
+
+        Shares `_probe_unknown_principal`'s cache, so a worker whose model is
+        merely stale does not take the distributed policy lock on every one of
+        that user's requests, which is the contention that strands them in the
+        first place.
+        """
+        enforcer = self._ensure_enforcer()
+        if _recognized_roles(enforcer.get_roles_for_user(user_id)):
+            return False
+        return not _recognized_roles(self._probe_unknown_principal(user_id))
+
     def check_endpoint_permission(self, user_id: str, path: str,
                                   method: str) -> bool:
         """Check permission.
@@ -527,6 +593,11 @@ class PermissionService:
         Viewer role uses an in-memory allowlist:
         True (block) unless the (path, method) matches an entry in
         `self._viewer_allowlist`.
+
+        A principal holding no role this model recognizes is confined to the
+        `user` blocklist. Under blocklist semantics an unknown or absent role
+        matches no policy at all, which `enforce` reads as permitted
+        everywhere -- so the unconfigured case must not be the permissive one.
         """
         # We intentionally don't load the policy here, as it is a hot path, and
         # we don't support updating the policy.
@@ -540,6 +611,16 @@ class PermissionService:
         # _load_policy_no_lock and would put a query on the request hot
         # path.
         roles = enforcer.get_roles_for_user(user_id)
+        if not _recognized_roles(roles):
+            # Reload before confining them: a role assigned moments ago on
+            # another worker has not reached this model, and refusing a new
+            # admin every admin endpoint until something else happens to
+            # reload is its own outage.
+            roles = self._probe_unknown_principal(user_id)
+            if not _recognized_roles(roles):
+                # Casbin's `g` is reflexive, so passing the role name as the
+                # subject evaluates that role's rules directly.
+                return enforcer.enforce(rbac.RoleName.USER.value, path, method)
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -101,6 +101,9 @@ class PermissionService:
         # user_id -> when this worker last reloaded on their behalf. See
         # `_probe_unknown_principal`.
         self._no_role_probe_cache: Dict[str, float] = {}
+        # user_id -> when this worker last tried to seed a missing role. See
+        # `needs_role_seed`.
+        self._seed_attempt_cache: Dict[str, float] = {}
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -561,24 +564,66 @@ class PermissionService:
         self._load_policy_no_lock()
         return self._ensure_enforcer().get_roles_for_user(user_id)
 
+    def _confinement_role(self) -> str:
+        """The role an unidentified principal is evaluated against.
+
+        The deployment's own default, so one that defaults to `viewer` does not
+        hand an unidentified principal more access than it gives everyone else
+        -- but never `admin`, which is what `rbac.default_role` falls back to
+        when it was never configured.
+        """
+        default_role = rbac.get_default_role()
+        if default_role == rbac.RoleName.ADMIN.value:
+            return rbac.RoleName.USER.value
+        return default_role
+
+    def probably_has_role(self, user_id: str) -> bool:
+        """Cheap, non-blocking: answers from whatever is already in memory.
+
+        Never initializes the enforcer and never touches the database, so it is
+        safe to call from the event loop. A worker that has not built an
+        enforcer yet answers False, and the caller is expected to do the real
+        work off the loop.
+        """
+        enforcer = self.enforcer
+        if enforcer is None:
+            return False
+        return bool(enforcer.get_roles_for_user(user_id))
+
     def needs_role_seed(self, user_id: str) -> bool:
-        """Whether this principal looks like it never got a role.
+        """Whether this principal has no role row at all, so one is owed.
 
-        For the login path, which already seeds new users: `seed_new_user_role`
-        is only called when the `users` row was newly inserted, so a seed that
-        failed (the policy lock has a bounded wait) is never retried and the
-        user stays role-less -- and therefore unrestricted -- until the next
-        restart re-seeds them.
+        For the login paths, which seed only when the `users` row was newly
+        inserted: a seed that failed (the policy lock has a bounded wait) is
+        otherwise never retried, and the user stays role-less -- and therefore
+        unrestricted -- until a restart re-seeds them.
 
-        Shares `_probe_unknown_principal`'s cache, so a worker whose model is
-        merely stale does not take the distributed policy lock on every one of
-        that user's requests, which is the contention that strands them in the
-        first place.
+        Deliberately False for a principal holding an *unrecognized* role.
+        Seeding only ever adds a role when there is none, so answering True
+        there would take the distributed lock on every request and repair
+        nothing; `check_endpoint_permission` confines such a principal instead.
+        Replacing a role nobody recognizes is an administrative act, not
+        something a login should do behind the operator's back.
+
+        Blocking (may reload the policy). Call from a worker thread.
         """
         enforcer = self._ensure_enforcer()
-        if _recognized_roles(enforcer.get_roles_for_user(user_id)):
+        if enforcer.get_roles_for_user(user_id):
             return False
-        return not _recognized_roles(self._probe_unknown_principal(user_id))
+        if self._probe_unknown_principal(user_id):
+            # Only this worker was behind; the role exists.
+            return False
+        # Rate-limit the attempt itself, not just the probe: if the seed keeps
+        # failing because the policy lock is contended, retrying on every
+        # request would feed the contention that caused it.
+        now = time.time()
+        if now - self._seed_attempt_cache.get(user_id,
+                                              0.0) < _NO_ROLE_PROBE_TTL_SECONDS:
+            return False
+        if len(self._seed_attempt_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
+            self._seed_attempt_cache.clear()
+        self._seed_attempt_cache[user_id] = now
+        return True
 
     def check_endpoint_permission(self, user_id: str, path: str,
                                   method: str) -> bool:
@@ -618,9 +663,12 @@ class PermissionService:
             # reload is its own outage.
             roles = self._probe_unknown_principal(user_id)
             if not _recognized_roles(roles):
+                confine_to = self._confinement_role()
+                if confine_to == rbac.RoleName.VIEWER.value:
+                    return not self._is_viewer_allowed(path, method)
                 # Casbin's `g` is reflexive, so passing the role name as the
                 # subject evaluates that role's rules directly.
-                return enforcer.enforce(rbac.RoleName.USER.value, path, method)
+                return enforcer.enforce(confine_to, path, method)
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and
@@ -1020,6 +1068,28 @@ def _policy_lock() -> Generator[None, None, None]:
 
 # Singleton instance of PermissionService for other modules to use.
 permission_service = PermissionService()
+
+
+def reseed_role_if_missing(user_id: str) -> None:
+    """Add a role to a principal whose original seed never completed.
+
+    Blocking (policy reload plus, at most once per user per TTL, the policy
+    lock) -- call it from a worker thread.
+
+    Failures are swallowed on purpose. The only reason this runs at all is that
+    a contended policy lock stranded the user once already; letting a second
+    timeout surface would turn their request into a 500, and the next request
+    retries anyway.
+    """
+    try:
+        if not permission_service.needs_role_seed(user_id):
+            return
+        logger.warning(f'User {user_id} has no role; seeding one now. Their '
+                       f'original seed did not complete.')
+        seed_new_user_role(user_id)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to re-seed a role for {user_id}; will retry on '
+                       f'a later request: {common_utils.format_exception(e)}')
 
 
 def seed_new_user_role(user_id: str, role: Optional[str] = None) -> None:

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -196,8 +196,10 @@ class PermissionService:
         self._repair_in_flight: Set[str] = set()
         self._repair_worker: Optional[threading.Thread] = None
         self._repair_lock = threading.Lock()
-        # Rate limit for the in-flight cap warning; see `_schedule_role_repair`.
-        self._cap_log_cache: Dict[str, float] = {}
+        # When the in-flight cap warning was last emitted. A timestamp, not one
+        # of the TTL caches: the condition is global, so there is nothing to key
+        # by and no cache to bound. Read and written under `_repair_lock`.
+        self._cap_warned_at: float = 0.0
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -749,11 +751,10 @@ class PermissionService:
             if len(self._repair_in_flight) >= _REPAIR_MAX_IN_FLIGHT:
                 # Rate-limited like the denial log, and for the same reason:
                 # this is the line that tells an operator repairs are being
-                # dropped, so a burst must not be able to repeat it per
-                # request. One key, not one per principal -- the condition is
-                # about the queue, not about who arrived last.
-                if _take_ttl_permit(self._cap_log_cache, 'cap',
-                                    _DENIED_LOG_TTL_SECONDS, 2):
+                # dropped, so a burst must not repeat it per request.
+                now = time.time()
+                if now - self._cap_warned_at >= _DENIED_LOG_TTL_SECONDS:
+                    self._cap_warned_at = now
                     logger.warning(
                         f'Not queueing a role repair for {user_id}: '
                         f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something '

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -766,8 +766,16 @@ class PermissionService:
             if not self.claim_role_seed_attempt(user_id):
                 return
             self._repair_in_flight.add(user_id)
-            if self._repair_worker is None:
-                self._start_repair_worker()
+            try:
+                if self._repair_worker is None:
+                    self._start_repair_worker()
+            except Exception:
+                # Rolled back, or a failed thread start strands this principal
+                # for the life of the process: the entry below is what dedups
+                # later attempts, and only the drain worker removes it -- and
+                # there is no worker.
+                self._repair_in_flight.discard(user_id)
+                raise
         self._repair_queue.put(user_id)
 
     def _start_repair_worker(self) -> None:
@@ -840,11 +848,6 @@ class PermissionService:
         return user_id in self._role_seen
 
     def remember_role_seen(self, user_id: str) -> None:
-        """Record that this worker has seen a role for them. See
-        `probably_has_role`."""
-        self._remember_role_seen(user_id)
-
-    def _remember_role_seen(self, user_id: str) -> None:
         """Record that this principal holds a role, for `probably_has_role`."""
         if len(self._role_seen) >= _NO_ROLE_PROBE_CACHE_MAX:
             # Half, not all: clearing sends every principal back through a
@@ -873,11 +876,11 @@ class PermissionService:
             return False
         enforcer = self._ensure_enforcer()
         if enforcer.get_roles_for_user(user_id):
-            self._remember_role_seen(user_id)
+            self.remember_role_seen(user_id)
             return False
         if self._probe_unknown_principal(user_id):
             # Only this worker was behind; the role exists.
-            self._remember_role_seen(user_id)
+            self.remember_role_seen(user_id)
             return False
         return True
 
@@ -974,7 +977,11 @@ class PermissionService:
                     # Only for an empty role: seeding fills a gap, and a name
                     # nobody recognizes is not one -- queueing it would spin,
                     # and spend a slot the genuinely role-less need.
-                    self._schedule_role_repair(user_id)
+                    #
+                    # Through the guarded entry point: this runs inside the RBAC
+                    # middleware, where an exception is a bare 500 rather than a
+                    # denial.
+                    self.queue_role_repair(user_id)
                 self._log_denied_principal(user_id, path, method)
                 return True
         # Recognized, by either route: remember it for the loop-side guard.
@@ -983,7 +990,7 @@ class PermissionService:
         # one had run -- and the login paths that consult it queued a pointless
         # repair for each of them after every restart, which could fire the
         # in-flight cap warning on ordinary warm-up.
-        self._remember_role_seen(user_id)
+        self.remember_role_seen(user_id)
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -1,4 +1,5 @@
 """Permission service for SkyPilot API Server."""
+import concurrent.futures as futures
 import contextlib
 import hashlib
 import logging
@@ -62,21 +63,54 @@ _NO_ROLE_PROBE_CACHE_MAX = 4096
 # that the operator sees the condition is ongoing.
 _DENIED_LOG_TTL_SECONDS = 300
 
+# Share of a worker's wall time it may spend reloading the policy for
+# principals it does not recognize. The per-principal memo does not bound this
+# (it expires, and one contended provisioning strands many principals at once),
+# and each reload holds the enforcer's write lock. Expressed as a duty cycle so
+# it self-tunes to policy size: after a reload takes D, the next waits
+# D * (1/duty - 1).
+_PROBE_DUTY_CYCLE = 0.1
+
+# Cap on repairs queued but not yet run. The per-principal claim bounds the
+# rate; this bounds a burst, so one SCIM push that strands hundreds cannot grow
+# an unbounded queue behind a single worker thread.
+_REPAIR_MAX_IN_FLIGHT = 64
+
 # Materialized once: the role set is a static enum, and this is consulted on
 # every request.
 _SUPPORTED_ROLES = frozenset(rbac.get_supported_roles())
 
 
+def _claim_within_ttl(cache: Dict[str, float], key: str, ttl: float,
+                      cap: int) -> bool:
+    """Was `key` last stamped longer ago than `ttl`? If so, stamp it now.
+
+    The shape behind every per-principal rate limit here. Over the cap it drops
+    what has expired -- deliberately not the whole cache: these entries all
+    expire, so clearing them wholesale would let one eviction send every
+    principal back through the work the limit exists to space out.
+    """
+    now = time.time()
+    if now - cache.get(key, 0.0) < ttl:
+        return False
+    if len(cache) >= cap:
+        for expired in [k for k, at in cache.items() if now - at >= ttl]:
+            del cache[expired]
+        if len(cache) >= cap:
+            # Everything is live and we are still over: drop the oldest half,
+            # which costs those principals one extra pass, not all of them.
+            for old, _ in sorted(cache.items(),
+                                 key=lambda kv: kv[1])[:cap // 2]:
+                del cache[old]
+    cache[key] = now
+    return True
+
+
 def _system_user_roles() -> Dict[str, str]:
     """The server's own identities and the role each of them has.
 
-    Not a default the policy may override: `sky.users.server` refuses to delete
-    these users or change their role, so the role is a property of the identity
-    rather than an administrative choice. `_maybe_initialize_policies` writes
-    the matching rows at boot for anything that reads casbin directly, but the
-    answer here does not depend on that write having landed -- if it failed,
-    reading the policy would leave the server unable to authorize its own
-    internal calls.
+    Fixed, not a default: `sky.users.server` refuses to delete these users or
+    change their role, so the policy can only agree or be wrong about them.
     """
     return {
         common.SERVER_ID: rbac.RoleName.ADMIN.value,
@@ -95,18 +129,13 @@ def _recognized_roles(roles: List[str]) -> List[str]:
     return [role for role in roles if role in _SUPPORTED_ROLES]
 
 
-def _resolve_roles(user_id: str, roles: List[str]) -> List[str]:
-    """`roles`, with the server's own identities resolved to their own role.
+def _system_role(user_id: str) -> Optional[str]:
+    """The role this identity has by definition, or None if it is not one.
 
-    Every decision that reads a principal's roles goes through this, so the
-    endpoint gate, the workspace checks and the request filters cannot disagree
-    about the same principal -- which they did while only the gate knew about
-    system identities.
+    Checked before the policy, so the server can authorize its own calls
+    whatever the policy holds -- and without a reload.
     """
-    if _recognized_roles(roles):
-        return roles
-    system_role = _system_user_roles().get(user_id)
-    return [system_role] if system_role is not None else roles
+    return _system_user_roles().get(user_id)
 
 
 _enforcer_instance: Optional['PermissionService'] = None
@@ -146,6 +175,15 @@ class PermissionService:
         # Principals this worker has already seen hold a role. Read on the
         # event loop by `probably_has_role`, which must not touch the enforcer.
         self._role_seen: Set[str] = set()
+        # When this worker may next reload on an unrecognized principal's
+        # behalf, and the lock guarding it. See `_probe_unknown_principal`.
+        self._probe_cooldown_until: float = 0.0
+        self._probe_lock = threading.Lock()
+        # Repairs queued on `_repair_executor`, and the executor itself --
+        # created on first use so importing this module (the CLI does) never
+        # starts a thread. See `_schedule_role_repair`.
+        self._repair_in_flight: Set[str] = set()
+        self._repair_executor: Optional[futures.ThreadPoolExecutor] = None
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -403,6 +441,10 @@ class PermissionService:
         users_with_roles = {tuple(g)[0] for g in enforcer.get_grouping_policy()}
         all_users = global_user_state.get_all_users()
         for existing_user in all_users:
+            if existing_user.id in _system_user_roles():
+                # Their explicit role is seeded below. Letting the default land
+                # first would win, because the seed only fills a gap.
+                continue
             if str(existing_user.id) not in users_with_roles:
                 logger.debug(f'Adding role for user: {existing_user.name}'
                              f'({existing_user.id})')
@@ -515,20 +557,27 @@ class PermissionService:
         Returns:
             A list of role names that the user has.
         """
+        system_role = _system_role(user_id)
+        if system_role is not None:
+            # Skips the reload as well, which the server's own identities would
+            # otherwise pay on every internal call.
+            return [system_role]
         self._load_policy_no_lock()
         enforcer = self._ensure_enforcer()
-        return _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
+        return enforcer.get_roles_for_user(user_id)
 
     def roles_in_memory(self, user_id: str) -> List[str]:
         """This process's current view of a principal's roles, no reload.
 
         For decisions on the request path, which cannot afford the database
-        roundtrip `get_user_roles` makes. Same resolution otherwise, so a
-        caller that reads this cannot reach a different conclusion about a
+        roundtrip `get_user_roles` makes. Resolves identities the same way, so
+        a caller that reads this cannot reach a different conclusion about a
         principal than one that reads `get_user_roles`.
         """
-        enforcer = self._ensure_enforcer()
-        return _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
+        system_role = _system_role(user_id)
+        if system_role is not None:
+            return [system_role]
+        return self._ensure_enforcer().get_roles_for_user(user_id)
 
     def get_users_for_role(self, role: str) -> List[str]:
         """Get all users for a role."""
@@ -628,21 +677,76 @@ class PermissionService:
     def _probe_unknown_principal(self, user_id: str) -> List[str]:
         """Reload once for a principal with no role here, and re-read it.
 
-        Either this worker's model predates whoever created them, or they have
-        no role at all. Only the database can tell the two apart, so pay for
-        one load -- but at most once per TTL per user, because the other case
-        is permanent: without the cache a role-less principal would trigger a
-        full policy load on every request it makes.
+        Only the database distinguishes "assigned elsewhere" from "never
+        seeded", so pay for one load -- bounded per principal by TTL and per
+        worker by `_PROBE_DUTY_CYCLE`. A failed reload answers "no roles" (the
+        caller denies): raising would leave the middleware with a bare 500.
         """
-        now = time.time()
-        if now - self._no_role_probe_cache.get(
-                user_id, 0.0) < _NO_ROLE_PROBE_TTL_SECONDS:
-            return self._ensure_enforcer().get_roles_for_user(user_id)
-        if len(self._no_role_probe_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
-            self._no_role_probe_cache.clear()
-        self._no_role_probe_cache[user_id] = now
-        self._load_policy_no_lock()
-        return self._ensure_enforcer().get_roles_for_user(user_id)
+        roles = lambda: self._ensure_enforcer().get_roles_for_user(user_id)
+        if not _claim_within_ttl(self._no_role_probe_cache, user_id,
+                                 _NO_ROLE_PROBE_TTL_SECONDS,
+                                 _NO_ROLE_PROBE_CACHE_MAX):
+            return roles()
+        with self._probe_lock:
+            if time.time() < self._probe_cooldown_until:
+                # Another principal's probe is paying for the whole worker
+                # right now. Theirs refreshes the model this one reads.
+                return roles()
+            self._probe_cooldown_until = float('inf')
+        started = time.time()
+        try:
+            self._load_policy_no_lock()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Policy reload for unrecognized principal '
+                           f'{user_id} failed; treating them as role-less: '
+                           f'{common_utils.format_exception(e)}')
+            return []
+        finally:
+            elapsed = time.time() - started
+            with self._probe_lock:
+                self._probe_cooldown_until = time.time() + elapsed * (
+                    1.0 / _PROBE_DUTY_CYCLE - 1.0)
+        return roles()
+
+    def _schedule_role_repair(self, user_id: str) -> None:
+        """Queue a seed for a principal the policy holds no role for.
+
+        Off the request because the caller runs inside the auth executor's 5s
+        deadline while the policy lock waits up to 20s: seeding inline would
+        answer 503 under the very contention that strands principals. This
+        request stays denied; the next one finds a role.
+        """
+        if not self.claim_role_seed_attempt(user_id):
+            return
+        with self._lock:
+            if len(self._repair_in_flight) >= _REPAIR_MAX_IN_FLIGHT:
+                logger.warning(
+                    f'Not queueing a role repair for {user_id}: '
+                    f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something is '
+                    f'stranding principals faster than they can be repaired.')
+                return
+            if self._repair_executor is None:
+                self._repair_executor = futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix='role-repair')
+            self._repair_in_flight.add(user_id)
+            executor = self._repair_executor
+        executor.submit(self._run_role_repair, user_id)
+
+    def _run_role_repair(self, user_id: str) -> None:
+        """Body of a queued repair. Never raises: nothing awaits it."""
+        try:
+            if not self.role_seed_missing(user_id):
+                return
+            logger.warning(f'User {user_id} has no role; seeding one now. '
+                           f'Their original seed did not complete.')
+            seed_new_user_role(user_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Queued role repair for {user_id} failed; a later '
+                           f'request retries: '
+                           f'{common_utils.format_exception(e)}')
+        finally:
+            with self._lock:
+                self._repair_in_flight.discard(user_id)
 
     def _log_denied_principal(self, user_id: str, path: str,
                               method: str) -> None:
@@ -653,13 +757,10 @@ class PermissionService:
         point of denying rather than confining is that this is loud, so it must
         actually reach the operator without drowning the log.
         """
-        now = time.time()
-        if now - self._denied_log_cache.get(user_id,
-                                            0.0) < _DENIED_LOG_TTL_SECONDS:
+        if not _claim_within_ttl(self._denied_log_cache, user_id,
+                                 _DENIED_LOG_TTL_SECONDS,
+                                 _NO_ROLE_PROBE_CACHE_MAX):
             return
-        if len(self._denied_log_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
-            self._denied_log_cache.clear()
-        self._denied_log_cache[user_id] = now
         logger.warning(
             f'Denying {method} {path} for user {user_id}: the policy holds no '
             f'role for them, so nothing grants access. Their role seed did not '
@@ -668,17 +769,10 @@ class PermissionService:
     def probably_has_role(self, user_id: str) -> bool:
         """Cheap, non-blocking: has this worker ever seen a role for them?
 
-        A plain set lookup, deliberately not `enforcer.get_roles_for_user`:
-        that takes the enforcer's read lock, and a concurrent `load_policy()`
-        holds the write lock for the length of a full reload (hundreds of ms on
-        a large policy). This is called on the event loop, where that would
-        stall every request on the worker -- the reason the RBAC middleware
-        offloads its own check.
-
-        False therefore means "not known to have one", not "has none": the
-        caller is expected to confirm off the loop. Only the transition matters
-        for cost, since a principal who has a role is answered from memory from
-        their second request onward.
+        A set lookup, deliberately not `enforcer.get_roles_for_user`: this runs
+        on the event loop, and that takes a lock a concurrent `load_policy()`
+        holds for the length of a full reload. False means "not known to have
+        one", not "has none" -- confirm off the loop.
         """
         return user_id in self._role_seen
 
@@ -688,26 +782,23 @@ class PermissionService:
             self._role_seen.clear()
         self._role_seen.add(user_id)
 
-    def needs_role_seed(self, user_id: str) -> bool:
-        """Whether this principal has no role row at all, so one is owed.
+    def role_seed_missing(self, user_id: str) -> bool:
+        """Whether the policy holds no role for this principal, so one is owed.
 
-        For the login paths, which seed only when the `users` row was newly
-        inserted: a seed that failed (the policy lock has a bounded wait) is
-        otherwise never retried, and the user stays role-less -- and therefore
-        unrestricted -- until a restart re-seeds them.
+        A query, not a claim -- ask `claim_role_seed_attempt` for permission to
+        act on the answer. False for a principal holding an *unrecognized*
+        role: seeding only ever fills a gap, so acting there would take the
+        distributed lock and repair nothing, and replacing a role nobody
+        recognizes is an administrative act rather than something a login does
+        behind the operator's back. `check_endpoint_permission` denies them.
 
-        Deliberately False for a principal holding an *unrecognized* role.
-        Seeding only ever adds a role when there is none, so answering True
-        there would take the distributed lock on every request and repair
-        nothing; `check_endpoint_permission` denies such a principal instead.
-        Replacing a role nobody recognizes is an administrative act, not
-        something a login should do behind the operator's back.
-
-        Also feeds `probably_has_role`'s memo, so the loop-side guard can stay
-        a set lookup.
+        Also feeds `probably_has_role`'s memo, so the loop-side guard can stay a
+        set lookup.
 
         Blocking (may reload the policy). Call from a worker thread.
         """
+        if _system_role(user_id) is not None:
+            return False
         enforcer = self._ensure_enforcer()
         if enforcer.get_roles_for_user(user_id):
             self._remember_role_seen(user_id)
@@ -716,17 +807,35 @@ class PermissionService:
             # Only this worker was behind; the role exists.
             self._remember_role_seen(user_id)
             return False
-        # Rate-limit the attempt itself, not just the probe: if the seed keeps
-        # failing because the policy lock is contended, retrying on every
-        # request would feed the contention that caused it.
-        now = time.time()
-        if now - self._seed_attempt_cache.get(user_id,
-                                              0.0) < _NO_ROLE_PROBE_TTL_SECONDS:
-            return False
-        if len(self._seed_attempt_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
-            self._seed_attempt_cache.clear()
-        self._seed_attempt_cache[user_id] = now
         return True
+
+    def claim_role_seed_attempt(self, user_id: str) -> bool:
+        """Take this worker's per-principal permission to attempt a seed.
+
+        True at most once per TTL per principal, and it *consumes* that
+        permission -- so a caller that asks twice for one request gets False the
+        second time and silently skips the repair. Rate-limiting the attempt
+        rather than only the probe matters because a seed that keeps failing on
+        a contended policy lock would otherwise retry on every request and feed
+        the contention that caused it.
+
+        Cheap and non-blocking: in-memory only.
+        """
+        return _claim_within_ttl(self._seed_attempt_cache, user_id,
+                                 _NO_ROLE_PROBE_TTL_SECONDS,
+                                 _NO_ROLE_PROBE_CACHE_MAX)
+
+    def needs_role_seed(self, user_id: str) -> bool:
+        """`role_seed_missing` and a claim, for the login paths.
+
+        Kept as one call because that is what the provisioning paths want: ask
+        once, and act if the answer is yes. Claim semantics, so two calls in one
+        request do not both answer True -- see `claim_role_seed_attempt`.
+
+        Blocking (may reload the policy). Call from a worker thread.
+        """
+        return self.role_seed_missing(user_id) and self.claim_role_seed_attempt(
+            user_id)
 
     def check_endpoint_permission(self, user_id: str, path: str,
                                   method: str) -> bool:
@@ -755,19 +864,30 @@ class PermissionService:
         # as long as it is eventually consistent.
         # self._load_policy_no_lock()
         enforcer = self._ensure_enforcer()
+        system_role = _system_role(user_id)
+        if system_role is not None:
+            # Judged by the role the identity carries, so the server can
+            # authorize its own calls whatever the policy holds. Evaluated
+            # against the *role* rather than the id: casbin's `g` is reflexive,
+            # and this way an operator's blocklist for that role still applies.
+            if system_role == rbac.RoleName.VIEWER.value:
+                return not self._is_viewer_allowed(path, method)
+            return enforcer.enforce(system_role, path, method)
         # Read roles from in-memory enforcer state. Do NOT use
         # self.get_user_roles(...) here — that does a DB roundtrip via
         # _load_policy_no_lock and would put a query on the request hot
         # path.
-        roles = _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
+        roles = enforcer.get_roles_for_user(user_id)
         if not _recognized_roles(roles):
             # Reload before denying them: a role assigned moments ago on
             # another worker has not reached this model, and refusing a new
             # admin every admin endpoint until something else happens to
             # reload is its own outage.
-            roles = _resolve_roles(user_id,
-                                   self._probe_unknown_principal(user_id))
+            roles = self._probe_unknown_principal(user_id)
             if not _recognized_roles(roles):
+                # Off-request, so the write never lands inside the auth
+                # deadline: this request stays denied, the next one is not.
+                self._schedule_role_repair(user_id)
                 self._log_denied_principal(user_id, path, method)
                 return True
         # Admin wins over viewer when a user holds both — viewer's

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -724,20 +724,27 @@ class PermissionService:
         request stays denied; the next one finds a role.
         """
         with self._repair_lock:
+            # Already queued before the cap: otherwise a principal that is
+            # waiting its turn gets logged as one that was turned away.
+            if user_id in self._repair_in_flight:
+                return
             if len(self._repair_in_flight) >= _REPAIR_MAX_IN_FLIGHT:
                 logger.warning(
                     f'Not queueing a role repair for {user_id}: '
                     f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something is '
                     f'stranding principals faster than they can be repaired.')
                 return
-            if user_id in self._repair_in_flight:
-                return
             # Claimed last: a claim spent while the queue was full would make
             # this principal wait out a TTL for a repair that never ran.
             if not self.claim_role_seed_attempt(user_id):
                 return
             self._repair_in_flight.add(user_id)
-            if self._repair_worker is None:
+            # Restarted if it died: only a BaseException can end the drain loop,
+            # but leaving a dead worker attached would queue every later repair
+            # into a thread that will never read them, and the only symptom
+            # would be the cap warning above, forever.
+            if self._repair_worker is None or not self._repair_worker.is_alive(
+            ):
                 self._repair_worker = threading.Thread(
                     target=self._drain_role_repairs,
                     name='role-repair',
@@ -759,6 +766,11 @@ class PermissionService:
             try:
                 self._run_role_repair(user_id)
             finally:
+                # The queue owns the in-flight bookkeeping, not the repair
+                # itself: a caller that stubs the repair body would otherwise
+                # leave the principal marked as queued forever.
+                with self._repair_lock:
+                    self._repair_in_flight.discard(user_id)
                 self._repair_queue.task_done()
 
     def _run_role_repair(self, user_id: str) -> None:
@@ -773,9 +785,6 @@ class PermissionService:
             logger.warning(f'Queued role repair for {user_id} failed; a later '
                            f'request retries: '
                            f'{common_utils.format_exception(e)}')
-        finally:
-            with self._repair_lock:
-                self._repair_in_flight.discard(user_id)
 
     def _log_denied_principal(self, user_id: str, path: str,
                               method: str) -> None:

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -1,9 +1,9 @@
 """Permission service for SkyPilot API Server."""
-import concurrent.futures as futures
 import contextlib
 import hashlib
 import logging
 import os
+import queue
 import threading
 import time
 from typing import Dict, Generator, List, Optional, Set, Tuple
@@ -94,14 +94,19 @@ def _claim_within_ttl(cache: Dict[str, float], key: str, ttl: float,
     if now - cache.get(key, 0.0) < ttl:
         return False
     if len(cache) >= cap:
-        for expired in [k for k, at in cache.items() if now - at >= ttl]:
-            del cache[expired]
+        # Snapshot with list() and remove with pop(): several auth-executor
+        # threads reach this at once, and iterating a dict another thread is
+        # writing raises, as does deleting a key it already removed. Losing
+        # that race should change which entries go, not fail the request.
+        for cached, at in list(cache.items()):
+            if now - at >= ttl:
+                cache.pop(cached, None)
         if len(cache) >= cap:
             # Everything is live and we are still over: drop the oldest half,
             # which costs those principals one extra pass, not all of them.
-            for old, _ in sorted(cache.items(),
-                                 key=lambda kv: kv[1])[:cap // 2]:
-                del cache[old]
+            oldest = sorted(list(cache.items()), key=lambda kv: kv[1])
+            for cached, _ in oldest[:cap // 2]:
+                cache.pop(cached, None)
     cache[key] = now
     return True
 
@@ -179,11 +184,13 @@ class PermissionService:
         # behalf, and the lock guarding it. See `_probe_unknown_principal`.
         self._probe_cooldown_until: float = 0.0
         self._probe_lock = threading.Lock()
-        # Repairs queued on `_repair_executor`, and the executor itself --
-        # created on first use so importing this module (the CLI does) never
+        # Queued repairs, the worker draining them, and the lock over both --
+        # started on first use so importing this module (the CLI does) never
         # starts a thread. See `_schedule_role_repair`.
+        self._repair_queue: 'queue.Queue[str]' = queue.Queue()
         self._repair_in_flight: Set[str] = set()
-        self._repair_executor: Optional[futures.ThreadPoolExecutor] = None
+        self._repair_worker: Optional[threading.Thread] = None
+        self._repair_lock = threading.Lock()
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -716,21 +723,43 @@ class PermissionService:
         answer 503 under the very contention that strands principals. This
         request stays denied; the next one finds a role.
         """
-        if not self.claim_role_seed_attempt(user_id):
-            return
-        with self._lock:
+        with self._repair_lock:
             if len(self._repair_in_flight) >= _REPAIR_MAX_IN_FLIGHT:
                 logger.warning(
                     f'Not queueing a role repair for {user_id}: '
                     f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something is '
                     f'stranding principals faster than they can be repaired.')
                 return
-            if self._repair_executor is None:
-                self._repair_executor = futures.ThreadPoolExecutor(
-                    max_workers=1, thread_name_prefix='role-repair')
+            if user_id in self._repair_in_flight:
+                return
+            # Claimed last: a claim spent while the queue was full would make
+            # this principal wait out a TTL for a repair that never ran.
+            if not self.claim_role_seed_attempt(user_id):
+                return
             self._repair_in_flight.add(user_id)
-            executor = self._repair_executor
-        executor.submit(self._run_role_repair, user_id)
+            if self._repair_worker is None:
+                self._repair_worker = threading.Thread(
+                    target=self._drain_role_repairs,
+                    name='role-repair',
+                    daemon=True)
+                self._repair_worker.start()
+        self._repair_queue.put(user_id)
+
+    def _drain_role_repairs(self) -> None:
+        """Run queued repairs one at a time, forever.
+
+        One worker on purpose: each repair takes the distributed policy lock,
+        and the contention that strands principals is what running them in
+        parallel would feed. A daemon thread, so a repair waiting on that lock
+        cannot delay interpreter exit -- the lock is released either way when
+        the process dies.
+        """
+        while True:
+            user_id = self._repair_queue.get()
+            try:
+                self._run_role_repair(user_id)
+            finally:
+                self._repair_queue.task_done()
 
     def _run_role_repair(self, user_id: str) -> None:
         """Body of a queued repair. Never raises: nothing awaits it."""
@@ -745,7 +774,7 @@ class PermissionService:
                            f'request retries: '
                            f'{common_utils.format_exception(e)}')
         finally:
-            with self._lock:
+            with self._repair_lock:
                 self._repair_in_flight.discard(user_id)
 
     def _log_denied_principal(self, user_id: str, path: str,
@@ -779,7 +808,11 @@ class PermissionService:
     def _remember_role_seen(self, user_id: str) -> None:
         """Record that this principal holds a role, for `probably_has_role`."""
         if len(self._role_seen) >= _NO_ROLE_PROBE_CACHE_MAX:
-            self._role_seen.clear()
+            # Half, not all: clearing sends every principal back through a
+            # confirmation off the loop at the same moment. No timestamps in a
+            # set, so which half is arbitrary.
+            for stale in list(self._role_seen)[:_NO_ROLE_PROBE_CACHE_MAX // 2]:
+                self._role_seen.discard(stale)
         self._role_seen.add(user_id)
 
     def role_seed_missing(self, user_id: str) -> bool:
@@ -885,9 +918,13 @@ class PermissionService:
             # reload is its own outage.
             roles = self._probe_unknown_principal(user_id)
             if not _recognized_roles(roles):
-                # Off-request, so the write never lands inside the auth
-                # deadline: this request stays denied, the next one is not.
-                self._schedule_role_repair(user_id)
+                if not roles:
+                    # Off-request, so the write never lands inside the auth
+                    # deadline: this request stays denied, the next one is not.
+                    # Only for an empty role: seeding fills a gap, and a name
+                    # nobody recognizes is not one -- queueing it would spin,
+                    # and spend a slot the genuinely role-less need.
+                    self._schedule_role_repair(user_id)
                 self._log_denied_principal(user_id, path, method)
                 return True
         # Admin wins over viewer when a user holds both — viewer's

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -57,10 +57,30 @@ _NO_ROLE_PROBE_TTL_SECONDS = 30
 # `_read_only_endpoint_cache`. Keys are authenticated user ids, so the space is
 # bounded by real principals rather than by traffic.
 _NO_ROLE_PROBE_CACHE_MAX = 4096
+# How often a worker repeats the denial warning for the same principal. Long
+# enough that a client retrying in a loop cannot flood the log, short enough
+# that the operator sees the condition is ongoing.
+_DENIED_LOG_TTL_SECONDS = 300
 
 # Materialized once: the role set is a static enum, and this is consulted on
 # every request.
 _SUPPORTED_ROLES = frozenset(rbac.get_supported_roles())
+
+
+def _system_user_roles() -> Dict[str, str]:
+    """The server's own identities and the role each is seeded with.
+
+    Their role rows are written once, by `_maybe_initialize_policies` at boot,
+    under the policy lock. A denial for a principal with no recognized role
+    must not apply to them: if that one seed failed, denying would take the
+    server's internal calls (including the HA replica-to-replica authorize)
+    from degraded to dead.
+    """
+    return {
+        common.SERVER_ID: rbac.RoleName.ADMIN.value,
+        constants.SKYPILOT_SYSTEM_USER_ID: rbac.RoleName.ADMIN.value,
+        constants.SKYPILOT_SYSTEM_VIEWER_USER_ID: rbac.RoleName.VIEWER.value,
+    }
 
 
 def _recognized_roles(roles: List[str]) -> List[str]:
@@ -104,6 +124,12 @@ class PermissionService:
         # user_id -> when this worker last tried to seed a missing role. See
         # `needs_role_seed`.
         self._seed_attempt_cache: Dict[str, float] = {}
+        # user_id -> when this worker last logged a denial for them. See
+        # `_log_denied_principal`.
+        self._denied_log_cache: Dict[str, float] = {}
+        # Principals this worker has already seen hold a role. Read on the
+        # event loop by `probably_has_role`, which must not touch the enforcer.
+        self._role_seen: Set[str] = set()
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -349,13 +375,7 @@ class PermissionService:
                 user_added = self._add_user_if_not_exists_no_lock(
                     existing_user.id)
                 policy_updated = policy_updated or user_added
-        system_users = [
-            (common.SERVER_ID, rbac.RoleName.ADMIN.value),
-            (constants.SKYPILOT_SYSTEM_USER_ID, rbac.RoleName.ADMIN.value),
-            (constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
-             rbac.RoleName.VIEWER.value),
-        ]
-        for system_user_id, system_user_role in system_users:
+        for system_user_id, system_user_role in _system_user_roles().items():
             global_user_state.add_or_update_user(
                 models.User(id=system_user_id,
                             name=system_user_id,
@@ -564,31 +584,49 @@ class PermissionService:
         self._load_policy_no_lock()
         return self._ensure_enforcer().get_roles_for_user(user_id)
 
-    def _confinement_role(self) -> str:
-        """The role an unidentified principal is evaluated against.
+    def _log_denied_principal(self, user_id: str, path: str,
+                              method: str) -> None:
+        """Report a denial for a principal with no recognized role.
 
-        The deployment's own default, so one that defaults to `viewer` does not
-        hand an unidentified principal more access than it gives everyone else
-        -- but never `admin`, which is what `rbac.default_role` falls back to
-        when it was never configured.
+        Rate-limited per principal per worker: the state is persistent, so an
+        unrated log would repeat for every request such a principal makes. The
+        point of denying rather than confining is that this is loud, so it must
+        actually reach the operator without drowning the log.
         """
-        default_role = rbac.get_default_role()
-        if default_role == rbac.RoleName.ADMIN.value:
-            return rbac.RoleName.USER.value
-        return default_role
+        now = time.time()
+        if now - self._denied_log_cache.get(user_id,
+                                            0.0) < _DENIED_LOG_TTL_SECONDS:
+            return
+        if len(self._denied_log_cache) >= _NO_ROLE_PROBE_CACHE_MAX:
+            self._denied_log_cache.clear()
+        self._denied_log_cache[user_id] = now
+        logger.warning(
+            f'Denying {method} {path} for user {user_id}: the policy holds no '
+            f'role for them, so nothing grants access. Their role seed did not '
+            f'complete; assign a role to restore access.')
 
     def probably_has_role(self, user_id: str) -> bool:
-        """Cheap, non-blocking: answers from whatever is already in memory.
+        """Cheap, non-blocking: has this worker ever seen a role for them?
 
-        Never initializes the enforcer and never touches the database, so it is
-        safe to call from the event loop. A worker that has not built an
-        enforcer yet answers False, and the caller is expected to do the real
-        work off the loop.
+        A plain set lookup, deliberately not `enforcer.get_roles_for_user`:
+        that takes the enforcer's read lock, and a concurrent `load_policy()`
+        holds the write lock for the length of a full reload (hundreds of ms on
+        a large policy). This is called on the event loop, where that would
+        stall every request on the worker -- the reason the RBAC middleware
+        offloads its own check.
+
+        False therefore means "not known to have one", not "has none": the
+        caller is expected to confirm off the loop. Only the transition matters
+        for cost, since a principal who has a role is answered from memory from
+        their second request onward.
         """
-        enforcer = self.enforcer
-        if enforcer is None:
-            return False
-        return bool(enforcer.get_roles_for_user(user_id))
+        return user_id in self._role_seen
+
+    def _remember_role_seen(self, user_id: str) -> None:
+        """Record that this principal holds a role, for `probably_has_role`."""
+        if len(self._role_seen) >= _NO_ROLE_PROBE_CACHE_MAX:
+            self._role_seen.clear()
+        self._role_seen.add(user_id)
 
     def needs_role_seed(self, user_id: str) -> bool:
         """Whether this principal has no role row at all, so one is owed.
@@ -601,17 +639,22 @@ class PermissionService:
         Deliberately False for a principal holding an *unrecognized* role.
         Seeding only ever adds a role when there is none, so answering True
         there would take the distributed lock on every request and repair
-        nothing; `check_endpoint_permission` confines such a principal instead.
+        nothing; `check_endpoint_permission` denies such a principal instead.
         Replacing a role nobody recognizes is an administrative act, not
         something a login should do behind the operator's back.
+
+        Also feeds `probably_has_role`'s memo, so the loop-side guard can stay
+        a set lookup.
 
         Blocking (may reload the policy). Call from a worker thread.
         """
         enforcer = self._ensure_enforcer()
         if enforcer.get_roles_for_user(user_id):
+            self._remember_role_seen(user_id)
             return False
         if self._probe_unknown_principal(user_id):
             # Only this worker was behind; the role exists.
+            self._remember_role_seen(user_id)
             return False
         # Rate-limit the attempt itself, not just the probe: if the seed keeps
         # failing because the policy lock is contended, retrying on every
@@ -639,10 +682,11 @@ class PermissionService:
         True (block) unless the (path, method) matches an entry in
         `self._viewer_allowlist`.
 
-        A principal holding no role this model recognizes is confined to the
-        `user` blocklist. Under blocklist semantics an unknown or absent role
-        matches no policy at all, which `enforce` reads as permitted
-        everywhere -- so the unconfigured case must not be the permissive one.
+        A principal holding no role this model recognizes is denied, the way
+        every mainstream authorization system treats an unbound principal.
+        Under blocklist semantics an unknown or absent role matches no policy
+        at all, which `enforce` reads as permitted everywhere -- so the
+        unconfigured case must not be the permissive one.
         """
         # We intentionally don't load the policy here, as it is a hot path, and
         # we don't support updating the policy.
@@ -657,18 +701,20 @@ class PermissionService:
         # path.
         roles = enforcer.get_roles_for_user(user_id)
         if not _recognized_roles(roles):
-            # Reload before confining them: a role assigned moments ago on
+            # Reload before denying them: a role assigned moments ago on
             # another worker has not reached this model, and refusing a new
             # admin every admin endpoint until something else happens to
             # reload is its own outage.
             roles = self._probe_unknown_principal(user_id)
             if not _recognized_roles(roles):
-                confine_to = self._confinement_role()
-                if confine_to == rbac.RoleName.VIEWER.value:
-                    return not self._is_viewer_allowed(path, method)
-                # Casbin's `g` is reflexive, so passing the role name as the
-                # subject evaluates that role's rules directly.
-                return enforcer.enforce(confine_to, path, method)
+                system_role = _system_user_roles().get(user_id)
+                if system_role is None:
+                    self._log_denied_principal(user_id, path, method)
+                    return True
+                # Judge them by the role their boot-time seed would have
+                # given them. `admin` then falls through to `enforce`, whose
+                # blocklist for admin is empty, i.e. allowed.
+                roles = [system_role]
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -724,6 +724,17 @@ class PermissionService:
         request stays denied; the next one finds a role.
         """
         with self._repair_lock:
+            # Replaced first, because whether the worker died is orthogonal to
+            # whether this principal gets queued. Every return below leaves the
+            # queue holding repairs nobody reads, and a full in-flight set --
+            # which is what a dead worker produces -- sends every caller into
+            # one of those returns. A restart placed after them never runs, and
+            # the cap warning below stays the only symptom, forever. Only a
+            # BaseException can get the drain loop into this state.
+            if (self._repair_worker is not None and
+                    not self._repair_worker.is_alive()):
+                logger.warning('The role repair worker died; replacing it.')
+                self._start_repair_worker()
             # Already queued before the cap: otherwise a principal that is
             # waiting its turn gets logged as one that was turned away.
             if user_id in self._repair_in_flight:
@@ -739,18 +750,16 @@ class PermissionService:
             if not self.claim_role_seed_attempt(user_id):
                 return
             self._repair_in_flight.add(user_id)
-            # Restarted if it died: only a BaseException can end the drain loop,
-            # but leaving a dead worker attached would queue every later repair
-            # into a thread that will never read them, and the only symptom
-            # would be the cap warning above, forever.
-            if self._repair_worker is None or not self._repair_worker.is_alive(
-            ):
-                self._repair_worker = threading.Thread(
-                    target=self._drain_role_repairs,
-                    name='role-repair',
-                    daemon=True)
-                self._repair_worker.start()
+            if self._repair_worker is None:
+                self._start_repair_worker()
         self._repair_queue.put(user_id)
+
+    def _start_repair_worker(self) -> None:
+        """Attach a drain thread. The caller holds `_repair_lock`."""
+        self._repair_worker = threading.Thread(target=self._drain_role_repairs,
+                                               name='role-repair',
+                                               daemon=True)
+        self._repair_worker.start()
 
     def _drain_role_repairs(self) -> None:
         """Run queued repairs one at a time, forever.

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -178,7 +178,6 @@ class PermissionService:
         # `_probe_unknown_principal`.
         self._no_role_probe_cache: Dict[str, float] = {}
         # user_id -> when this worker last tried to seed a missing role. See
-        # `needs_role_seed`.
         self._seed_attempt_cache: Dict[str, float] = {}
         # user_id -> when this worker last logged a denial for them. See
         # `_log_denied_principal`.
@@ -197,6 +196,8 @@ class PermissionService:
         self._repair_in_flight: Set[str] = set()
         self._repair_worker: Optional[threading.Thread] = None
         self._repair_lock = threading.Lock()
+        # Rate limit for the in-flight cap warning; see `_schedule_role_repair`.
+        self._cap_log_cache: Dict[str, float] = {}
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -746,10 +747,18 @@ class PermissionService:
             if user_id in self._repair_in_flight:
                 return
             if len(self._repair_in_flight) >= _REPAIR_MAX_IN_FLIGHT:
-                logger.warning(
-                    f'Not queueing a role repair for {user_id}: '
-                    f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something is '
-                    f'stranding principals faster than they can be repaired.')
+                # Rate-limited like the denial log, and for the same reason:
+                # this is the line that tells an operator repairs are being
+                # dropped, so a burst must not be able to repeat it per
+                # request. One key, not one per principal -- the condition is
+                # about the queue, not about who arrived last.
+                if _take_ttl_permit(self._cap_log_cache, 'cap',
+                                    _DENIED_LOG_TTL_SECONDS, 2):
+                    logger.warning(
+                        f'Not queueing a role repair for {user_id}: '
+                        f'{_REPAIR_MAX_IN_FLIGHT} already pending. Something '
+                        f'is stranding principals faster than they can be '
+                        f'repaired.')
                 return
             # Claimed last: a claim spent while the queue was full would make
             # this principal wait out a TTL for a repair that never ran.
@@ -829,6 +838,11 @@ class PermissionService:
         """
         return user_id in self._role_seen
 
+    def remember_role_seen(self, user_id: str) -> None:
+        """Record that this worker has seen a role for them. See
+        `probably_has_role`."""
+        self._remember_role_seen(user_id)
+
     def _remember_role_seen(self, user_id: str) -> None:
         """Record that this principal holds a role, for `probably_has_role`."""
         if len(self._role_seen) >= _NO_ROLE_PROBE_CACHE_MAX:
@@ -882,17 +896,28 @@ class PermissionService:
                                 _NO_ROLE_PROBE_TTL_SECONDS,
                                 _NO_ROLE_PROBE_CACHE_MAX)
 
-    def needs_role_seed(self, user_id: str) -> bool:
-        """`role_seed_missing` and a claim, for the login paths.
+    def queue_role_repair(self, user_id: str) -> None:
+        """Hand a role-less principal to the off-request repair queue.
 
-        Kept as one call because that is what the provisioning paths want: ask
-        once, and act if the answer is yes. Claim semantics, so two calls in one
-        request do not both answer True -- see `claim_role_seed_attempt`.
+        Cheap and non-blocking -- an in-memory claim and a queue put -- so an
+        async caller may do this inline. That is the point: the seed takes the
+        distributed policy lock, which waits up to
+        `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS`, and the contention that strands
+        principals is exactly when a login would be waiting for it. This
+        request is unaffected either way; the next one finds a role.
 
-        Blocking (may reload the policy). Call from a worker thread.
+        Never raises, so callers on the login and provisioning paths need no
+        guard of their own: queueing cannot fail for lock reasons, but starting
+        the drain thread can (`RuntimeError` when the process is out of
+        threads), and a repair nobody is waiting for must not turn a login into
+        a 500. The next caller retries.
         """
-        return self.role_seed_missing(user_id) and self.claim_role_seed_attempt(
-            user_id)
+        try:
+            self._schedule_role_repair(user_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Could not queue a role repair for {user_id}; a '
+                           f'later request retries: '
+                           f'{common_utils.format_exception(e)}')
 
     def check_endpoint_permission(self, user_id: str, path: str,
                                   method: str) -> bool:
@@ -951,6 +976,13 @@ class PermissionService:
                     self._schedule_role_repair(user_id)
                 self._log_denied_principal(user_id, path, method)
                 return True
+        # Recognized, by either route: remember it for the loop-side guard.
+        # Without this the memo was only ever written by a repair, so
+        # `probably_has_role` answered False for every healthy principal until
+        # one had run -- and the login paths that consult it queued a pointless
+        # repair for each of them after every restart, which could fire the
+        # in-flight cap warning on ordinary warm-up.
+        self._remember_role_seen(user_id)
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and
@@ -1361,28 +1393,6 @@ def _policy_lock() -> Generator[None, None, None]:
 permission_service = PermissionService()
 
 
-def reseed_role_if_missing(user_id: str) -> None:
-    """Add a role to a principal whose original seed never completed.
-
-    Blocking (policy reload plus, at most once per user per TTL, the policy
-    lock) -- call it from a worker thread.
-
-    Failures are swallowed on purpose. The only reason this runs at all is that
-    a contended policy lock stranded the user once already; letting a second
-    timeout surface would turn their request into a 500, and the next request
-    retries anyway.
-    """
-    try:
-        if not permission_service.needs_role_seed(user_id):
-            return
-        logger.warning(f'User {user_id} has no role; seeding one now. Their '
-                       f'original seed did not complete.')
-        seed_new_user_role(user_id)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to re-seed a role for {user_id}; will retry on '
-                       f'a later request: {common_utils.format_exception(e)}')
-
-
 def seed_new_user_role(user_id: str, role: Optional[str] = None) -> None:
     """Reload config, then set up policies for a newly-created user.
 
@@ -1402,6 +1412,9 @@ def seed_new_user_role(user_id: str, role: Optional[str] = None) -> None:
     """
     skypilot_config.safe_reload_config()
     permission_service.add_user_if_not_exists(user_id, role)
+    # This worker just gave them a role; the loop-side guard should not have to
+    # learn that from a repair.
+    permission_service.remember_role_seen(user_id)
     try:
         permission_service.resync_workspace_policies_for_new_user(user_id)
     except Exception as e:  # pylint: disable=broad-except

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -81,12 +81,18 @@ _REPAIR_MAX_IN_FLIGHT = 64
 _SUPPORTED_ROLES = frozenset(rbac.get_supported_roles())
 
 
-def _claim_within_ttl(cache: Dict[str, float], key: str, ttl: float,
-                      cap: int) -> bool:
-    """Was `key` last stamped longer ago than `ttl`? If so, stamp it now.
+def _take_ttl_permit(cache: Dict[str, float], key: str, ttl: float,
+                     cap: int) -> bool:
+    """Take `key`'s permit for the work behind it, if the last one has expired.
 
-    The shape behind every per-principal rate limit here. Over the cap it drops
-    what has expired -- deliberately not the whole cache: these entries all
+    One permit per key per `ttl`, consumed by taking it: a caller that asks
+    twice for one request gets False the second time. The shape behind every
+    per-principal rate limit here -- a probe's policy reload, a seed attempt, a
+    denial log line.
+
+    Over the cap it drops what has expired, and if that is not enough the oldest
+    half of what remains -- so a live permit can be revoked early under
+    sustained pressure. Deliberately not the whole cache: these entries all
     expire, so clearing them wholesale would let one eviction send every
     principal back through the work the limit exists to space out.
     """
@@ -690,9 +696,9 @@ class PermissionService:
         caller denies): raising would leave the middleware with a bare 500.
         """
         roles = lambda: self._ensure_enforcer().get_roles_for_user(user_id)
-        if not _claim_within_ttl(self._no_role_probe_cache, user_id,
-                                 _NO_ROLE_PROBE_TTL_SECONDS,
-                                 _NO_ROLE_PROBE_CACHE_MAX):
+        if not _take_ttl_permit(self._no_role_probe_cache, user_id,
+                                _NO_ROLE_PROBE_TTL_SECONDS,
+                                _NO_ROLE_PROBE_CACHE_MAX):
             return roles()
         with self._probe_lock:
             if time.time() < self._probe_cooldown_until:
@@ -804,9 +810,9 @@ class PermissionService:
         point of denying rather than confining is that this is loud, so it must
         actually reach the operator without drowning the log.
         """
-        if not _claim_within_ttl(self._denied_log_cache, user_id,
-                                 _DENIED_LOG_TTL_SECONDS,
-                                 _NO_ROLE_PROBE_CACHE_MAX):
+        if not _take_ttl_permit(self._denied_log_cache, user_id,
+                                _DENIED_LOG_TTL_SECONDS,
+                                _NO_ROLE_PROBE_CACHE_MAX):
             return
         logger.warning(
             f'Denying {method} {path} for user {user_id}: the policy holds no '
@@ -872,9 +878,9 @@ class PermissionService:
 
         Cheap and non-blocking: in-memory only.
         """
-        return _claim_within_ttl(self._seed_attempt_cache, user_id,
-                                 _NO_ROLE_PROBE_TTL_SECONDS,
-                                 _NO_ROLE_PROBE_CACHE_MAX)
+        return _take_ttl_permit(self._seed_attempt_cache, user_id,
+                                _NO_ROLE_PROBE_TTL_SECONDS,
+                                _NO_ROLE_PROBE_CACHE_MAX)
 
     def needs_role_seed(self, user_id: str) -> bool:
         """`role_seed_missing` and a claim, for the login paths.

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -68,13 +68,15 @@ _SUPPORTED_ROLES = frozenset(rbac.get_supported_roles())
 
 
 def _system_user_roles() -> Dict[str, str]:
-    """The server's own identities and the role each is seeded with.
+    """The server's own identities and the role each of them has.
 
-    Their role rows are written once, by `_maybe_initialize_policies` at boot,
-    under the policy lock. A denial for a principal with no recognized role
-    must not apply to them: if that one seed failed, denying would take the
-    server's internal calls (including the HA replica-to-replica authorize)
-    from degraded to dead.
+    Not a default the policy may override: `sky.users.server` refuses to delete
+    these users or change their role, so the role is a property of the identity
+    rather than an administrative choice. `_maybe_initialize_policies` writes
+    the matching rows at boot for anything that reads casbin directly, but the
+    answer here does not depend on that write having landed -- if it failed,
+    reading the policy would leave the server unable to authorize its own
+    internal calls.
     """
     return {
         common.SERVER_ID: rbac.RoleName.ADMIN.value,
@@ -91,6 +93,20 @@ def _recognized_roles(roles: List[str]) -> List[str]:
     predating the update-role validation can still hold one.
     """
     return [role for role in roles if role in _SUPPORTED_ROLES]
+
+
+def _resolve_roles(user_id: str, roles: List[str]) -> List[str]:
+    """`roles`, with the server's own identities resolved to their own role.
+
+    Every decision that reads a principal's roles goes through this, so the
+    endpoint gate, the workspace checks and the request filters cannot disagree
+    about the same principal -- which they did while only the gate knew about
+    system identities.
+    """
+    if _recognized_roles(roles):
+        return roles
+    system_role = _system_user_roles().get(user_id)
+    return [system_role] if system_role is not None else roles
 
 
 _enforcer_instance: Optional['PermissionService'] = None
@@ -501,7 +517,18 @@ class PermissionService:
         """
         self._load_policy_no_lock()
         enforcer = self._ensure_enforcer()
-        return enforcer.get_roles_for_user(user_id)
+        return _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
+
+    def roles_in_memory(self, user_id: str) -> List[str]:
+        """This process's current view of a principal's roles, no reload.
+
+        For decisions on the request path, which cannot afford the database
+        roundtrip `get_user_roles` makes. Same resolution otherwise, so a
+        caller that reads this cannot reach a different conclusion about a
+        principal than one that reads `get_user_roles`.
+        """
+        enforcer = self._ensure_enforcer()
+        return _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
 
     def get_users_for_role(self, role: str) -> List[str]:
         """Get all users for a role."""
@@ -732,27 +759,25 @@ class PermissionService:
         # self.get_user_roles(...) here — that does a DB roundtrip via
         # _load_policy_no_lock and would put a query on the request hot
         # path.
-        roles = enforcer.get_roles_for_user(user_id)
+        roles = _resolve_roles(user_id, enforcer.get_roles_for_user(user_id))
         if not _recognized_roles(roles):
             # Reload before denying them: a role assigned moments ago on
             # another worker has not reached this model, and refusing a new
             # admin every admin endpoint until something else happens to
             # reload is its own outage.
-            roles = self._probe_unknown_principal(user_id)
+            roles = _resolve_roles(user_id,
+                                   self._probe_unknown_principal(user_id))
             if not _recognized_roles(roles):
-                system_role = _system_user_roles().get(user_id)
-                if system_role is None:
-                    self._log_denied_principal(user_id, path, method)
-                    return True
-                # Judge them by the role their boot-time seed would have
-                # given them. `admin` then falls through to `enforce`, whose
-                # blocklist for admin is empty, i.e. allowed.
-                roles = [system_role]
+                self._log_denied_principal(user_id, path, method)
+                return True
         # Admin wins over viewer when a user holds both — viewer's
         # default-deny semantics shouldn't restrict an admin.
         if (rbac.RoleName.VIEWER.value in roles and
                 rbac.RoleName.ADMIN.value not in roles):
             return not self._is_viewer_allowed(path, method)
+        # `enforce` resolves the id through casbin's `g`, so a system identity
+        # whose row never landed matches nothing -- which under blocklist
+        # semantics is "allowed", the same answer its admin role gives.
         return enforcer.enforce(user_id, path, method)
 
     def _is_viewer_allowed(self, path: str, method: str) -> bool:

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -429,8 +429,11 @@ def get_default_role() -> str:
     as a role name nothing recognizes, and a principal holding an unrecognized
     role is denied everywhere.
     """
-    return skypilot_config.get_nested(
-        ('rbac', 'default_role'), default_value=RoleName.ADMIN.value).lower()
+    configured = skypilot_config.get_nested(('rbac', 'default_role'),
+                                            default_value=None)
+    # `or` rather than get_nested's default: an explicit `default_role:` with no
+    # value parses as None, and this runs on the login path.
+    return (configured or RoleName.ADMIN.value).lower()
 
 
 def get_viewer_allowlist(

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -421,8 +421,16 @@ def least_privileged_role(roles: List[str]) -> str:
 
 
 def get_default_role() -> str:
-    return skypilot_config.get_nested(('rbac', 'default_role'),
-                                      default_value=RoleName.ADMIN.value)
+    """The role a newly provisioned user is seeded with.
+
+    Lowercased: the schema validates `default_role` with
+    `case_insensitive_enum`, which validates without normalizing, so
+    `default_role: Viewer` is a legal config. Returned as-is it would be seeded
+    as a role name nothing recognizes, and a principal holding an unrecognized
+    role is denied everywhere.
+    """
+    return skypilot_config.get_nested(
+        ('rbac', 'default_role'), default_value=RoleName.ADMIN.value).lower()
 
 
 def get_viewer_allowlist(

--- a/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
+++ b/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
@@ -10,6 +10,8 @@ import fastapi
 import pytest
 from starlette.datastructures import Headers
 
+from sky import models
+from sky.server.auth import db_lookup
 from sky.server.auth.oauth2_proxy import OAuth2ProxyMiddleware
 
 

--- a/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
+++ b/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
@@ -530,3 +530,82 @@ class TestOriginalOAuth2ProxyMiddlewareLoopback:
 
             # Should NOT bypass due to proxy headers - proceed to normal OAuth2 flow
             assert response.status_code == http.HTTPStatus.TEMPORARY_REDIRECT.value
+
+
+class _AcceptedSession:
+    """An aiohttp-shaped stub whose auth call answers 202 ACCEPTED."""
+
+    def request(self, **_kwargs):
+        response = mock.Mock()
+        response.status = http.HTTPStatus.ACCEPTED
+
+        class _Ctx:
+
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        return _Ctx()
+
+
+def _authenticated_request():
+    request = mock.Mock()
+    request.url = mock.Mock()
+    request.url.hostname = 'localhost'
+    request.url.path = '/status'
+    request.cookies = {}
+    request.state = mock.Mock()
+    return request
+
+
+class TestOAuth2ProxyUserUpsert:
+    """The user upsert is a database write; it must not run on the event loop.
+
+    `server.py`'s auth-proxy middleware has always bounded the same call. This
+    one ran it inline, so a slow database stalled every request on the worker,
+    not only the login that triggered it. Reaches `_authenticate` through the
+    wrapper's `.middleware`, since `websocket_aware` replaces the exported
+    class.
+    """
+
+    def _middleware(self):
+        return OAuth2ProxyMiddleware(app=mock.Mock()).middleware
+
+    @pytest.mark.asyncio
+    async def test_the_upsert_is_bounded(self):
+        middleware = self._middleware()
+        call_next = mock.AsyncMock(return_value='ok')
+        user = models.User(id='u-1', name='tester')
+        with mock.patch.object(middleware, 'get_auth_user',
+                               return_value=user), \
+                mock.patch('sky.users.permission.permission_service'), \
+                mock.patch.object(db_lookup,
+                                  'call_with_deadline',
+                                  new=mock.AsyncMock(
+                                      return_value=False)) as bounded, \
+                mock.patch.object(db_lookup,
+                                  'ensure_role_for_authenticated_user',
+                                  new=mock.AsyncMock(return_value=None)):
+            await middleware._authenticate(_authenticated_request(), call_next,
+                                           _AcceptedSession())
+        bounded.assert_awaited_once()
+        assert bounded.await_args[0][0].__name__ == 'add_or_update_user'
+
+    @pytest.mark.asyncio
+    async def test_a_slow_upsert_answers_503_without_authenticating(self):
+        middleware = self._middleware()
+        call_next = mock.AsyncMock(return_value='ok')
+        user = models.User(id='u-1', name='tester')
+        with mock.patch.object(middleware, 'get_auth_user',
+                               return_value=user), \
+                mock.patch('sky.users.permission.permission_service'), \
+                mock.patch.object(db_lookup,
+                                  'call_with_deadline',
+                                  side_effect=asyncio.TimeoutError):
+            response = await middleware._authenticate(_authenticated_request(),
+                                                      call_next,
+                                                      _AcceptedSession())
+        assert response.status_code == 503
+        call_next.assert_not_called()

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -473,4 +473,8 @@ class TestEnsureRoleForAuthenticatedUser:
             response = await db_lookup.ensure_role_for_authenticated_user(
                 'u-broken', True)
         assert response is not None and response.status_code == 503
+        # And it says why it gave up. `db_timeout_response`'s text blames a slow
+        # database, which is wrong for the reason this path usually fails:
+        # contention on the policy lock, a healthy database doing its job.
+        assert b'assigning roles' in response.body
         perm.queue_role_repair.assert_called_once_with('u-broken')

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -240,12 +240,11 @@ class TestAuthProxyDeadline:
 
 
 async def _seed_times_out(func, *args):
-    """Time out the seed only. The user upsert above it uses the same helper,
-    so failing every call would answer 503 before the seed is ever reached --
-    which is how this test first passed for the wrong reason."""
-    if getattr(func, '__name__', '') == 'seed_new_user_role':
-        raise asyncio.TimeoutError()
-    return True
+    """Time out the seed. Kept separate from `call_with_deadline`, which the
+    user upsert still uses: failing every call answered 503 before the seed was
+    ever reached, which is how this test first passed for the wrong reason."""
+    del func, args
+    raise asyncio.TimeoutError()
 
 
 class TestAuthProxyRoleRepair:
@@ -353,7 +352,7 @@ class TestAuthProxyRoleRepair:
                 mock.patch('sky.users.permission.permission_service'
                           ) as perm_service, \
                 mock.patch.object(db_lookup,
-                                  'call_with_deadline',
+                                  '_call_on_request_pool',
                                   side_effect=_seed_times_out):
             response = await middleware.dispatch(mock_request,
                                                  call_next_sentinel)
@@ -387,7 +386,7 @@ class TestEnsureRoleForAuthenticatedUser:
     @pytest.mark.asyncio
     async def test_a_new_user_is_seeded_before_the_request_proceeds(self):
         with mock.patch.object(db_lookup,
-                               'call_with_deadline',
+                               '_call_on_request_pool',
                                new=mock.AsyncMock()) as bounded, \
              mock.patch('sky.users.permission.permission_service') as perm:
             assert await db_lookup.ensure_role_for_authenticated_user(
@@ -400,7 +399,7 @@ class TestEnsureRoleForAuthenticatedUser:
     async def test_a_seed_that_times_out_answers_503_and_queues(self):
         """Never proceed without a role, and never strand them either."""
         with mock.patch.object(db_lookup,
-                               'call_with_deadline',
+                               '_call_on_request_pool',
                                side_effect=asyncio.TimeoutError), \
              mock.patch('sky.users.permission.permission_service') as perm:
             response = await db_lookup.ensure_role_for_authenticated_user(
@@ -412,7 +411,7 @@ class TestEnsureRoleForAuthenticatedUser:
     async def test_a_saturated_executor_answers_503_and_queues(self):
         with mock.patch.object(
                 db_lookup,
-                'call_with_deadline',
+                '_call_on_request_pool',
                 side_effect=exceptions.ConcurrentWorkerExhaustedError('busy')
         ), mock.patch('sky.users.permission.permission_service') as perm:
             response = await db_lookup.ensure_role_for_authenticated_user(
@@ -425,7 +424,7 @@ class TestEnsureRoleForAuthenticatedUser:
         """Queued, not awaited: the repair wants the lock that stranded them."""
         with mock.patch('sky.users.permission.permission_service') as perm, \
              mock.patch.object(db_lookup,
-                               'call_with_deadline',
+                               '_call_on_request_pool',
                                new=mock.AsyncMock()) as bounded:
             perm.probably_has_role.return_value = False
             assert await db_lookup.ensure_role_for_authenticated_user(
@@ -440,3 +439,38 @@ class TestEnsureRoleForAuthenticatedUser:
             assert await db_lookup.ensure_role_for_authenticated_user(
                 'u-fine', False) is None
         perm.queue_role_repair.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_seed_stays_off_the_auth_pool(self):
+        """32 auth threads, and a seed can hold one for the policy lock's 20s.
+
+        `wait_for` releases the caller, never the thread, so a burst of first
+        logins under lock contention would exhaust the pool every request
+        authenticates through -- which the auth executor's own docstring says
+        belongs on the request executor instead.
+        """
+        with mock.patch('sky.users.permission.permission_service'), \
+             mock.patch('sky.users.permission.seed_new_user_role'), \
+             mock.patch.object(db_lookup.executor,
+                               'get_auth_thread_executor') as auth_pool, \
+             mock.patch.object(db_lookup.executor,
+                               'get_request_thread_executor') as request_pool:
+            await db_lookup.ensure_role_for_authenticated_user('u-new', True)
+        auth_pool.assert_not_called()
+        request_pool.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_any_seed_failure_answers_503_rather_than_500(self):
+        """A middleware exception is a bare 500, and clients do not retry those.
+
+        Only the timeout was converted before, so a DB error inside the seed
+        escaped as a 500 on a brand-new user's first request.
+        """
+        with mock.patch.object(db_lookup,
+                               '_call_on_request_pool',
+                               side_effect=RuntimeError('db is unhappy')), \
+             mock.patch('sky.users.permission.permission_service') as perm:
+            response = await db_lookup.ensure_role_for_authenticated_user(
+                'u-broken', True)
+        assert response is not None and response.status_code == 503
+        perm.queue_role_repair.assert_called_once_with('u-broken')

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -30,6 +30,7 @@ import unittest.mock as mock
 import fastapi
 import pytest
 
+from sky import exceptions
 from sky import models
 from sky.server import server
 from sky.server.auth import db_lookup
@@ -238,6 +239,15 @@ class TestAuthProxyDeadline:
         assert not call_next_sentinel.reached
 
 
+async def _seed_times_out(func, *args):
+    """Time out the seed only. The user upsert above it uses the same helper,
+    so failing every call would answer 503 before the seed is ever reached --
+    which is how this test first passed for the wrong reason."""
+    if getattr(func, '__name__', '') == 'seed_new_user_role':
+        raise asyncio.TimeoutError()
+    return True
+
+
 class TestAuthProxyRoleRepair:
     """The login path repairs a role that was never seeded.
 
@@ -255,8 +265,30 @@ class TestAuthProxyRoleRepair:
             return server.AuthProxyMiddleware(app=mock.Mock())
 
     @pytest.mark.asyncio
-    async def test_repairs_a_returning_user_with_no_known_role(
+    async def test_a_returning_user_with_no_known_role_is_queued(
             self, mock_request, call_next_sentinel):
+        """Queued, not awaited: the repair wants the lock that stranded them."""
+        middleware = self._middleware()
+        with mock.patch.object(
+                server, '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           return_value=False), \
+                mock.patch('sky.users.permission.permission_service'
+                          ) as perm_service:
+            perm_service.probably_has_role.return_value = False
+            await middleware.dispatch(mock_request, call_next_sentinel)
+        perm_service.queue_role_repair.assert_called_once_with('u-1')
+
+    @pytest.mark.asyncio
+    async def test_the_repair_never_blocks_the_login(self, mock_request,
+                                                     call_next_sentinel):
+        """A login must not wait on the policy lock. Nothing here may await.
+
+        The whole point of queueing: the seed takes a lock held for up to
+        POLICY_UPDATE_LOCK_TIMEOUT_SECONDS, and a login that waits for it hangs
+        for that long under exactly the contention that caused the strand.
+        """
         middleware = self._middleware()
         with mock.patch.object(
                 server, '_extract_user_from_header',
@@ -265,16 +297,16 @@ class TestAuthProxyRoleRepair:
                            return_value=False), \
                 mock.patch('sky.users.permission.permission_service'
                           ) as perm_service, \
-                mock.patch('sky.users.permission.reseed_role_if_missing'
-                          ) as reseed:
+                mock.patch('asyncio.to_thread') as to_thread:
             perm_service.probably_has_role.return_value = False
             await middleware.dispatch(mock_request, call_next_sentinel)
-        reseed.assert_called_once_with('u-1')
+        to_thread.assert_not_called()
+        perm_service.queue_role_repair.assert_called_once_with('u-1')
 
     @pytest.mark.asyncio
     async def test_no_repair_when_a_role_is_known(self, mock_request,
                                                   call_next_sentinel):
-        """The guard is what keeps this off the policy lock on every request."""
+        """The guard is what keeps this off the queue on every request."""
         middleware = self._middleware()
         with mock.patch.object(
                 server, '_extract_user_from_header',
@@ -282,16 +314,14 @@ class TestAuthProxyRoleRepair:
                 mock.patch('sky.global_user_state.add_or_update_user',
                            return_value=False), \
                 mock.patch('sky.users.permission.permission_service'
-                          ) as perm_service, \
-                mock.patch('sky.users.permission.reseed_role_if_missing'
-                          ) as reseed:
+                          ) as perm_service:
             perm_service.probably_has_role.return_value = True
             await middleware.dispatch(mock_request, call_next_sentinel)
-        reseed.assert_not_called()
+        perm_service.queue_role_repair.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_a_new_user_is_seeded_not_repaired(self, mock_request,
-                                                     call_next_sentinel):
+    async def test_a_new_user_is_seeded_not_queued(self, mock_request,
+                                                   call_next_sentinel):
         middleware = self._middleware()
         with mock.patch.object(
                 server, '_extract_user_from_header',
@@ -299,11 +329,36 @@ class TestAuthProxyRoleRepair:
                 mock.patch('sky.global_user_state.add_or_update_user',
                            return_value=True), \
                 mock.patch('sky.users.permission.seed_new_user_role') as seed, \
-                mock.patch('sky.users.permission.reseed_role_if_missing'
-                          ) as reseed:
+                mock.patch('sky.users.permission.permission_service'
+                          ) as perm_service:
             await middleware.dispatch(mock_request, call_next_sentinel)
         seed.assert_called_once_with('u-1')
-        reseed.assert_not_called()
+        perm_service.queue_role_repair.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_seed_that_times_out_answers_503_and_queues(
+            self, mock_request, call_next_sentinel):
+        """Never proceed without a role, and never strand them either.
+
+        Proceeding would hand the RBAC gate a role-less principal and 403 the
+        brand-new user's first request; dropping the seed would leave the
+        account broken until something else noticed.
+        """
+        middleware = self._middleware()
+        with mock.patch.object(
+                server, '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           return_value=True), \
+                mock.patch('sky.users.permission.permission_service'
+                          ) as perm_service, \
+                mock.patch.object(db_lookup,
+                                  'call_with_deadline',
+                                  side_effect=_seed_times_out):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+        assert response.status_code == 503
+        perm_service.queue_role_repair.assert_called_once_with('u-1')
 
 
 @pytest.mark.asyncio
@@ -318,3 +373,70 @@ async def test_call_with_deadline_returns_fast_results(monkeypatch):
 async def test_call_with_deadline_raises_timeout():
     with pytest.raises(asyncio.TimeoutError):
         await db_lookup.call_with_deadline(_slow(None))
+
+
+class TestEnsureRoleForAuthenticatedUser:
+    """The decision both auth front-ends share.
+
+    Tested here rather than through either middleware: the oauth2-proxy class is
+    wrapped by `middleware_utils.websocket_aware`, so its real methods are not
+    reachable from the exported name and its copy of this branch had no
+    coverage at all while it was duplicated.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_new_user_is_seeded_before_the_request_proceeds(self):
+        with mock.patch.object(db_lookup,
+                               'call_with_deadline',
+                               new=mock.AsyncMock()) as bounded, \
+             mock.patch('sky.users.permission.permission_service') as perm:
+            assert await db_lookup.ensure_role_for_authenticated_user(
+                'u-new', True) is None
+        assert bounded.await_count == 1
+        assert bounded.await_args[0][1] == 'u-new'
+        perm.queue_role_repair.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_seed_that_times_out_answers_503_and_queues(self):
+        """Never proceed without a role, and never strand them either."""
+        with mock.patch.object(db_lookup,
+                               'call_with_deadline',
+                               side_effect=asyncio.TimeoutError), \
+             mock.patch('sky.users.permission.permission_service') as perm:
+            response = await db_lookup.ensure_role_for_authenticated_user(
+                'u-slow', True)
+        assert response is not None and response.status_code == 503
+        perm.queue_role_repair.assert_called_once_with('u-slow')
+
+    @pytest.mark.asyncio
+    async def test_a_saturated_executor_answers_503_and_queues(self):
+        with mock.patch.object(
+                db_lookup,
+                'call_with_deadline',
+                side_effect=exceptions.ConcurrentWorkerExhaustedError('busy')
+        ), mock.patch('sky.users.permission.permission_service') as perm:
+            response = await db_lookup.ensure_role_for_authenticated_user(
+                'u-busy', True)
+        assert response is not None and response.status_code == 503
+        perm.queue_role_repair.assert_called_once_with('u-busy')
+
+    @pytest.mark.asyncio
+    async def test_a_returning_user_with_no_known_role_is_only_queued(self):
+        """Queued, not awaited: the repair wants the lock that stranded them."""
+        with mock.patch('sky.users.permission.permission_service') as perm, \
+             mock.patch.object(db_lookup,
+                               'call_with_deadline',
+                               new=mock.AsyncMock()) as bounded:
+            perm.probably_has_role.return_value = False
+            assert await db_lookup.ensure_role_for_authenticated_user(
+                'u-old', False) is None
+        perm.queue_role_repair.assert_called_once_with('u-old')
+        bounded.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_returning_user_with_a_role_does_nothing(self):
+        with mock.patch('sky.users.permission.permission_service') as perm:
+            perm.probably_has_role.return_value = True
+            assert await db_lookup.ensure_role_for_authenticated_user(
+                'u-fine', False) is None
+        perm.queue_role_repair.assert_not_called()

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -238,6 +238,74 @@ class TestAuthProxyDeadline:
         assert not call_next_sentinel.reached
 
 
+class TestAuthProxyRoleRepair:
+    """The login path repairs a role that was never seeded.
+
+    The endpoint gate queues a repair too, but only after refusing the request.
+    Doing it here means a returning user whose seed failed is fixed before they
+    are ever denied.
+    """
+
+    def _middleware(self):
+        proxy_config = mock.Mock()
+        proxy_config.enabled = True
+        with mock.patch.object(server.server_config,
+                               'load_external_proxy_config',
+                               return_value=proxy_config):
+            return server.AuthProxyMiddleware(app=mock.Mock())
+
+    @pytest.mark.asyncio
+    async def test_repairs_a_returning_user_with_no_known_role(
+            self, mock_request, call_next_sentinel):
+        middleware = self._middleware()
+        with mock.patch.object(
+                server, '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           return_value=False), \
+                mock.patch('sky.users.permission.permission_service'
+                          ) as perm_service, \
+                mock.patch('sky.users.permission.reseed_role_if_missing'
+                          ) as reseed:
+            perm_service.probably_has_role.return_value = False
+            await middleware.dispatch(mock_request, call_next_sentinel)
+        reseed.assert_called_once_with('u-1')
+
+    @pytest.mark.asyncio
+    async def test_no_repair_when_a_role_is_known(self, mock_request,
+                                                  call_next_sentinel):
+        """The guard is what keeps this off the policy lock on every request."""
+        middleware = self._middleware()
+        with mock.patch.object(
+                server, '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           return_value=False), \
+                mock.patch('sky.users.permission.permission_service'
+                          ) as perm_service, \
+                mock.patch('sky.users.permission.reseed_role_if_missing'
+                          ) as reseed:
+            perm_service.probably_has_role.return_value = True
+            await middleware.dispatch(mock_request, call_next_sentinel)
+        reseed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_new_user_is_seeded_not_repaired(self, mock_request,
+                                                     call_next_sentinel):
+        middleware = self._middleware()
+        with mock.patch.object(
+                server, '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           return_value=True), \
+                mock.patch('sky.users.permission.seed_new_user_role') as seed, \
+                mock.patch('sky.users.permission.reseed_role_if_missing'
+                          ) as reseed:
+            await middleware.dispatch(mock_request, call_next_sentinel)
+        seed.assert_called_once_with('u-1')
+        reseed.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_call_with_deadline_returns_fast_results(monkeypatch):
     """The healthy path is unperturbed: fast lookups return their value."""

--- a/tests/unit_tests/test_sky/server/test_role_filter.py
+++ b/tests/unit_tests/test_sky/server/test_role_filter.py
@@ -36,9 +36,7 @@ def _anonymous_request():
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_status_body_for_viewer(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     body = payloads.StatusBody(
         refresh=common_lib.StatusRefreshMode.FORCE,
@@ -52,9 +50,7 @@ def test_force_viewer_status_body_for_viewer(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_status_body_for_user_unchanged(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.USER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.USER.value]
 
     body = payloads.StatusBody(
         refresh=common_lib.StatusRefreshMode.FORCE,
@@ -80,9 +76,7 @@ def test_force_viewer_status_body_anonymous_unchanged():
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_jobs_queue_body(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     body = payloads.JobsQueueBody(refresh=True)
     out = role_filter.force_viewer_jobs_queue_body(_viewer_request(), body)
@@ -91,9 +85,7 @@ def test_force_viewer_jobs_queue_body(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_jobs_queue_v2_body(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     body = payloads.JobsQueueV2Body(refresh=True)
     out = role_filter.force_viewer_jobs_queue_v2_body(_viewer_request(), body)
@@ -102,9 +94,7 @@ def test_force_viewer_jobs_queue_v2_body(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_jobs_logs_body(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     body = payloads.JobsLogsBody(refresh=True)
     out = role_filter.force_viewer_jobs_logs_body(_viewer_request(), body)
@@ -113,9 +103,7 @@ def test_force_viewer_jobs_logs_body(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_jobs_download_logs_body(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     body = payloads.JobsDownloadLogsBody(name='job', job_id=1, refresh=True)
     out = role_filter.force_viewer_jobs_download_logs_body(
@@ -125,9 +113,7 @@ def test_force_viewer_jobs_download_logs_body(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_volume_refresh(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.VIEWER.value]
 
     out = role_filter.force_viewer_volume_refresh(_viewer_request(),
                                                   refresh=True)
@@ -136,9 +122,7 @@ def test_force_viewer_volume_refresh(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_viewer_volume_refresh_user_unchanged(mock_svc):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = [rbac.RoleName.USER.value]
-    mock_svc._ensure_enforcer.return_value = enforcer
+    mock_svc.roles_in_memory.return_value = [rbac.RoleName.USER.value]
 
     out = role_filter.force_viewer_volume_refresh(_user_request(), refresh=True)
     # Non-viewer is unaffected.
@@ -153,29 +137,33 @@ def _admin_request():
     return request
 
 
-def _enforcer_returning(mock_svc, roles):
-    enforcer = mock.Mock()
-    enforcer.get_roles_for_user.return_value = roles
-    mock_svc._ensure_enforcer.return_value = enforcer
+def _roles_returning(mock_svc, roles):
+    """Stub the resolved roles, which is what these filters ask for.
+
+    Not the enforcer: `roles_in_memory` also resolves the server's own
+    identities, so stubbing one layer down would let these tests pass while the
+    filters disagreed with every other reader about such a principal.
+    """
+    mock_svc.roles_in_memory.return_value = roles
 
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_request_owner_scope_user_scopes_to_self(mock_svc):
-    _enforcer_returning(mock_svc, [rbac.RoleName.USER.value])
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
     assert role_filter.request_owner_scope(_user_request()) == 'user-alice'
 
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_request_owner_scope_viewer_scopes_to_self(mock_svc):
-    _enforcer_returning(mock_svc, [rbac.RoleName.VIEWER.value])
+    _roles_returning(mock_svc, [rbac.RoleName.VIEWER.value])
     # A viewer is still a non-admin: reads are scoped to their own requests.
     assert role_filter.request_owner_scope(_viewer_request()) == 'viewer-bob'
 
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_request_owner_scope_admin_unscoped(mock_svc):
-    _enforcer_returning(mock_svc,
-                        [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
+    _roles_returning(mock_svc,
+                     [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
     # Admin sees every user's requests.
     assert role_filter.request_owner_scope(_admin_request()) is None
 
@@ -187,7 +175,7 @@ def test_request_owner_scope_no_auth_unscoped():
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_caller_scope_cancel_body_user_forced(mock_svc):
-    _enforcer_returning(mock_svc, [rbac.RoleName.USER.value])
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
     # A non-admin cannot cancel on behalf of another user, even by asking.
     body = payloads.RequestCancelBody(request_ids=['abc'],
                                       user_id='someone-else')
@@ -197,8 +185,8 @@ def test_force_caller_scope_cancel_body_user_forced(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_caller_scope_cancel_body_admin_preserved(mock_svc):
-    _enforcer_returning(mock_svc,
-                        [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
+    _roles_returning(mock_svc,
+                     [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
     # Admin keeps the client-supplied scope, incl. user_id=None (all users).
     body = payloads.RequestCancelBody(request_ids=None, user_id=None)
     out = role_filter.force_caller_scope_cancel_body(_admin_request(), body)
@@ -207,7 +195,7 @@ def test_force_caller_scope_cancel_body_admin_preserved(mock_svc):
 
 @mock.patch.object(role_filter.permission, 'permission_service')
 def test_force_caller_scope_cancel_body_viewer_forbidden(mock_svc):
-    _enforcer_returning(mock_svc, [rbac.RoleName.VIEWER.value])
+    _roles_returning(mock_svc, [rbac.RoleName.VIEWER.value])
     body = payloads.RequestCancelBody(request_ids=['abc'])
     with pytest.raises(fastapi.HTTPException) as exc:
         role_filter.force_caller_scope_cancel_body(_viewer_request(), body)

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2696,6 +2696,46 @@ class TestScheduledRoleRepair:
         assert len(
             [c for c in warn.call_args_list if 'Not queueing' in c[0][0]]) == 1
 
+    def test_a_failed_thread_start_leaves_nothing_stranded(self, policy_db):
+        """The in-flight entry is what dedups later attempts, so it must not
+        outlive a failed queueing.
+
+        Only the drain worker removes it -- and if the worker could not start,
+        there is no worker. The principal would be unrepairable for the life of
+        the process, which is worse than the exception that got them there.
+        """
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker,
+                               '_start_repair_worker',
+                               side_effect=RuntimeError('out of threads')):
+            worker.queue_role_repair('ghost')
+
+        assert 'ghost' not in worker._repair_in_flight
+        # And a later attempt is not merely accepted but actually run. Asserting
+        # only the empty set, or joining the queue, proves neither: `join()`
+        # returns at once on a queue nothing was ever put on.
+        worker._seed_attempt_cache.clear()
+        with mock.patch.object(worker, '_run_role_repair') as run:
+            worker.queue_role_repair('ghost')
+            worker._repair_queue.join()
+        run.assert_called_once_with('ghost')
+
+    def test_the_gate_survives_a_queueing_failure(self, policy_db):
+        """The gate runs inside the RBAC middleware, where an exception is a
+        bare 500 rather than a denial.
+
+        Reverting it to the unguarded private method leaves the denial path
+        raising instead of answering.
+        """
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker,
+                               '_start_repair_worker',
+                               side_effect=RuntimeError('out of threads')):
+            assert worker.check_endpoint_permission('ghost', '/users/export',
+                                                    'GET') is True
+
     def test_queueing_never_raises(self, policy_db):
         """A repair nobody waits for must not turn a login into a 500.
 

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2552,12 +2552,17 @@ class TestScheduledRoleRepair:
             'policy lock makes a repair wait')
 
     def test_queueing_is_claimed_once_per_ttl(self, policy_db):
+        """Draining between attempts, so the in-flight dedup cannot stand in.
+
+        With the queue emptied each time, only the per-principal claim stops the
+        next attempt -- which is what this pins.
+        """
         worker = policy_db()
         worker.enforcer.load_policy()
         with mock.patch.object(worker, '_run_role_repair') as run:
             for _ in range(5):
                 worker._schedule_role_repair('ghost')
-            worker._repair_queue.join()
+                worker._repair_queue.join()
         assert run.call_count == 1
 
     def test_a_burst_is_bounded(self, policy_db):
@@ -2591,6 +2596,37 @@ class TestScheduledRoleRepair:
         assert worker.claim_role_seed_attempt('ghost'), (
             'the claim was consumed by a queueing attempt that did nothing')
 
+    def test_an_unrecognized_role_is_not_queued(self, policy_db):
+        """A seed fills a gap, and a name nobody recognizes is not one.
+
+        Queueing it would spin in the worker and spend a slot the genuinely
+        role-less need.
+        """
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('weird', 'pwned')
+        worker.enforcer.load_policy()
+
+        assert worker.check_endpoint_permission('weird', '/users/export', 'GET')
+
+        assert worker._repair_in_flight == set()
+        assert worker._repair_queue.empty()
+        assert worker._repair_worker is None
+
+    def test_a_dead_worker_is_replaced(self, policy_db):
+        """Otherwise every later repair queues into a thread nobody reads."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker, '_run_role_repair'):
+            worker._schedule_role_repair('ghost1')
+            worker._repair_queue.join()
+        dead = worker._repair_worker
+        assert dead is not None
+        with mock.patch.object(dead, 'is_alive', return_value=False), \
+             mock.patch.object(worker, '_run_role_repair'):
+            worker._schedule_role_repair('ghost2')
+            worker._repair_queue.join()
+        assert worker._repair_worker is not dead
+
     def test_no_thread_until_one_is_needed(self):
         """The CLI imports this module; it must not start a thread."""
         assert permission.PermissionService()._repair_worker is None
@@ -2614,7 +2650,20 @@ class TestScheduledRoleRepair:
                                'seed_new_user_role',
                                side_effect=RuntimeError('lock timeout')):
             worker._run_role_repair('ghost')  # must not raise
-        assert 'ghost' not in worker._repair_in_flight
+
+    def test_a_drained_repair_leaves_no_claim_on_the_queue(self, policy_db):
+        """The drain loop clears in-flight, so a later attempt can queue again.
+
+        Keeping that in the repair body meant a stubbed body left the principal
+        marked as queued forever -- which silently turned the claim's rate limit
+        into dedup, and hid a missing rate limit from its own test.
+        """
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker, '_run_role_repair'):
+            worker._schedule_role_repair('ghost')
+            worker._repair_queue.join()
+        assert worker._repair_in_flight == set()
 
 
 class TestProbeThrottle:
@@ -2693,6 +2742,23 @@ class TestBoundedClaimCache:
         # All live and over the cap: half go, the rest keep their rate limit.
         assert 2 <= len(cache) <= 4
         assert not permission._claim_within_ttl(cache, 'new', ttl=60.0, cap=4)
+
+    def test_a_seen_role_set_drops_half_when_full(self):
+        """Same argument as the TTL caches: clearing it stampedes every one.
+
+        Every principal whose entry vanished pays another confirmation off the
+        loop, and after a clear that is all of them at once.
+        """
+        service = permission.PermissionService()
+        cap = permission._NO_ROLE_PROBE_CACHE_MAX
+        for i in range(cap):
+            service._remember_role_seen(f'u{i}')
+
+        service._remember_role_seen('one-more')
+
+        assert len(service._role_seen) > cap // 4, (
+            f'{len(service._role_seen)} left: the set was cleared, not halved')
+        assert 'one-more' in service._role_seen
 
     def test_the_claim_is_consumed(self):
         cache: dict = {}

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -5,7 +5,9 @@ import threading
 import time
 from unittest import mock
 
+import casbin
 import pytest
+import sqlalchemy
 import sqlalchemy_adapter
 
 from sky import models
@@ -2093,3 +2095,109 @@ class TestWorkspaceReadOnlyAccess:
         assert ('u2', 'ws', '*') in calls
         # No materialized read-only wildcard is ever written.
         assert all(c[2] == '*' for c in calls)
+
+
+@pytest.fixture
+def policy_db(tmp_path):
+    """A real sqlite-backed enforcer, so blocklist semantics are the real ones.
+
+    Yields a factory: each call returns an independent PermissionService over
+    the same database, which is what two API-server worker processes are.
+    """
+    engine = sqlalchemy.create_engine(f'sqlite:///{tmp_path}/policy.db')
+    model_path = os.path.join(os.path.dirname(permission.__file__),
+                              'model.conf')
+
+    def _worker():
+        service = permission.PermissionService()
+        adapter = sqlalchemy_adapter.Adapter(
+            engine, db_class=sqlalchemy_adapter.CasbinRule)
+        service.enforcer = casbin.SyncedEnforcer(model_path, adapter)
+        return service
+
+    seed = _worker()
+    # The `user` role's blocklist, as `_maybe_initialize_policies` would write.
+    seed.enforcer.add_policy('user', '/users/export', 'GET')
+    seed.enforcer.add_policy('user', '/users/create', 'POST')
+    with mock.patch('sky.users.permission._policy_lock'):
+        yield _worker
+
+
+class TestRolelessPrincipalIsConfined:
+    """A principal with no role this model recognizes must not be unrestricted.
+
+    Blocklist semantics make the unconfigured case the permissive one: nothing
+    mentions an unknown or absent role, so `enforce` permits it everywhere.
+    """
+
+    @pytest.mark.parametrize('roles', [[], ['pwned'], ['Admin'], ['']])
+    def test_unrecognized_or_absent_role_gets_the_user_blocklist(
+            self, policy_db, roles):
+        worker = policy_db()
+        for role in roles:
+            worker.enforcer.add_grouping_policy('subject', role)
+        worker.enforcer.load_policy()
+
+        assert worker.check_endpoint_permission('subject', '/users/export',
+                                                'GET')
+        # Confined to `user`, not denied outright: ordinary endpoints still work.
+        assert not worker.check_endpoint_permission('subject', '/status',
+                                                    'POST')
+
+    def test_recognized_roles_are_unaffected(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('an_admin', 'admin')
+        worker.enforcer.add_grouping_policy('a_user', 'user')
+        worker.enforcer.load_policy()
+
+        assert not worker.check_endpoint_permission('an_admin', '/users/export',
+                                                    'GET')
+        assert worker.check_endpoint_permission('a_user', '/users/export',
+                                                'GET')
+
+    def test_a_role_assigned_elsewhere_is_picked_up(self, policy_db):
+        """Otherwise a brand-new admin is refused until something else reloads."""
+        worker, writer = policy_db(), policy_db()
+        worker.enforcer.load_policy()  # stale from here on
+        writer.enforcer.add_grouping_policy('fresh_admin', 'admin')
+        writer.enforcer.save_policy()
+
+        assert not worker.check_endpoint_permission('fresh_admin',
+                                                    '/users/export', 'GET')
+
+    def test_reload_is_not_repeated_per_request(self, policy_db):
+        """A genuinely role-less principal must not reload on every request."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        loads = []
+        original = worker._load_policy_no_lock
+        worker._load_policy_no_lock = lambda: (loads.append(1), original())[1]
+
+        for _ in range(5):
+            worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+
+        assert len(loads) == 1, f'reloaded {len(loads)} times, expected 1'
+
+
+class TestNeedsRoleSeed:
+    """Retry a seed that never completed, without hammering the policy lock."""
+
+    def test_true_for_a_roleless_principal(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        assert worker.needs_role_seed('stranded')
+
+    def test_false_for_a_principal_with_a_role(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('known', 'user')
+        worker.enforcer.load_policy()
+        assert not worker.needs_role_seed('known')
+
+    def test_false_when_only_this_worker_is_stale(self, policy_db):
+        """A stale worker must not take the policy lock for every request."""
+        worker, writer = policy_db(), policy_db()
+        worker.enforcer.load_policy()
+        writer.enforcer.add_grouping_policy('elsewhere', 'user')
+        writer.enforcer.save_policy()
+
+        assert not worker.needs_role_seed('elsewhere')

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2127,7 +2127,7 @@ def policy_db(tmp_path):
         yield _worker
 
 
-class TestRolelessPrincipalIsConfined:
+class TestRolelessPrincipalIsDenied:
     """A principal with no role this model recognizes must not be unrestricted.
 
     Blocklist semantics make the unconfigured case the permissive one: nothing
@@ -2135,8 +2135,7 @@ class TestRolelessPrincipalIsConfined:
     """
 
     @pytest.mark.parametrize('roles', [[], ['pwned'], ['Admin'], ['']])
-    def test_unrecognized_or_absent_role_gets_the_user_blocklist(
-            self, policy_db, roles):
+    def test_unrecognized_or_absent_role_is_denied(self, policy_db, roles):
         worker = policy_db()
         for role in roles:
             worker.enforcer.add_grouping_policy('subject', role)
@@ -2144,9 +2143,8 @@ class TestRolelessPrincipalIsConfined:
 
         assert worker.check_endpoint_permission('subject', '/users/export',
                                                 'GET')
-        # Confined to `user`, not denied outright: ordinary endpoints still work.
-        assert not worker.check_endpoint_permission('subject', '/status',
-                                                    'POST')
+        # Denied outright, not confined: nothing grants this principal access.
+        assert worker.check_endpoint_permission('subject', '/status', 'POST')
 
     def test_recognized_roles_are_unaffected(self, policy_db):
         worker = policy_db()
@@ -2237,32 +2235,80 @@ class TestNeedsRoleSeed:
         assert not service.probably_has_role('anyone')
         assert service.enforcer is None
 
+    def test_probably_has_role_never_touches_the_enforcer(self, policy_db):
+        """It runs on the event loop, where the enforcer's read lock can block.
 
-class TestConfinementRole:
-    """An unidentified principal is held to the deployment's own default."""
+        `load_policy()` holds the write lock for a whole reload, so consulting
+        the enforcer here would stall every request on this worker.
+        """
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('known', 'user')
+        worker.enforcer.load_policy()
+        worker.enforcer = mock.Mock(wraps=worker.enforcer)
 
-    @mock.patch('sky.users.rbac.get_default_role', return_value='viewer')
-    def test_viewer_default_confines_via_the_allowlist(self, _default,
-                                                       policy_db):
-        # `/users` is on the viewer allowlist, `/dashboard/x` is not... but the
-        # allowlist is what decides, not the blocklist.
+        assert not worker.probably_has_role('known')
+        worker.enforcer.get_roles_for_user.assert_not_called()
+
+    def test_a_seen_role_is_remembered_for_the_loop_side_guard(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('known', 'user')
+        worker.enforcer.load_policy()
+
+        assert not worker.probably_has_role('known')
+        assert not worker.needs_role_seed('known')
+        assert worker.probably_has_role('known')
+
+
+class TestDenialScope:
+    """Who the denial must not catch, and how loudly it reports.
+
+    The server's own identities get their role rows from one write, at boot,
+    under the policy lock. If that write failed, denying them would take
+    internal calls (the HA replica-to-replica authorize included) from degraded
+    to dead, so they are judged by the role that seed would have given them.
+    """
+
+    def test_system_identities_keep_their_seeded_role(self, policy_db):
         worker = policy_db()
         worker.enforcer.load_policy()
 
-        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
-        assert not worker.check_endpoint_permission('ghost', '/users', 'GET')
-        # Outside the viewer allowlist: blocked, where the `user` blocklist
-        # would have allowed it.
-        assert worker.check_endpoint_permission('ghost', '/jobs/launch', 'POST')
+        for admin_id in (common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID):
+            assert not worker.check_endpoint_permission(admin_id,
+                                                        '/users/export', 'GET')
+        # And the read-only one is still held to the viewer allowlist.
+        viewer_id = constants.SKYPILOT_SYSTEM_VIEWER_USER_ID
+        assert not worker.check_endpoint_permission(viewer_id, '/users', 'GET')
+        assert worker.check_endpoint_permission(viewer_id, '/users/create',
+                                                'POST')
 
-    @mock.patch('sky.users.rbac.get_default_role', return_value='admin')
-    def test_unconfigured_default_never_confines_to_admin(
-            self, _default, policy_db):
-        """`rbac.default_role` falls back to admin; confinement must not."""
+    def test_the_denial_is_logged_once_per_principal(self, policy_db):
+        """Persistent state, so an unrated log would repeat on every request."""
         worker = policy_db()
         worker.enforcer.load_policy()
 
-        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+        with mock.patch.object(permission.logger, 'warning') as warn:
+            for _ in range(5):
+                worker.check_endpoint_permission('ghost', '/users/export',
+                                                 'GET')
+        assert warn.call_count == 1
+        assert 'ghost' in warn.call_args[0][0]
+
+
+class TestDefaultRoleCasing:
+    """`default_role` is validated case-insensitively but stored verbatim.
+
+    So `default_role: Viewer` is a legal config whose literal string would be
+    seeded as a role name, and an unrecognized role is now denied everywhere --
+    turning one operator's capitalization into a deployment-wide lockout.
+    """
+
+    @pytest.mark.parametrize('configured,expected', [('Viewer', 'viewer'),
+                                                     ('ADMIN', 'admin'),
+                                                     ('user', 'user')])
+    def test_get_default_role_is_normalized(self, configured, expected):
+        with mock.patch('sky.users.rbac.skypilot_config.get_nested',
+                        return_value=configured):
+            assert rbac.get_default_role() == expected
 
 
 class TestReseedRoleIfMissing:

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2545,9 +2545,11 @@ class TestScheduledRoleRepair:
         submitted = []
         with mock.patch.object(worker, '_run_role_repair', submitted.append):
             worker._schedule_role_repair('ghost')
-            assert worker._repair_executor is not None
-            worker._repair_executor.shutdown(wait=True)
+            worker._repair_queue.join()
         assert submitted == ['ghost']
+        assert worker._repair_worker.daemon, (
+            'a non-daemon worker delays interpreter exit by however long the '
+            'policy lock makes a repair wait')
 
     def test_queueing_is_claimed_once_per_ttl(self, policy_db):
         worker = policy_db()
@@ -2555,33 +2557,53 @@ class TestScheduledRoleRepair:
         with mock.patch.object(worker, '_run_role_repair') as run:
             for _ in range(5):
                 worker._schedule_role_repair('ghost')
-            assert worker._repair_executor is not None
-            worker._repair_executor.shutdown(wait=True)
+            worker._repair_queue.join()
         assert run.call_count == 1
 
     def test_a_burst_is_bounded(self, policy_db):
         """The per-principal claim bounds the rate; this bounds the burst."""
         worker = policy_db()
         worker.enforcer.load_policy()
-        with mock.patch.object(worker, '_run_role_repair'):
-            for i in range(permission._REPAIR_MAX_IN_FLIGHT + 10):
-                worker._schedule_role_repair(f'ghost{i}')
-            in_flight = len(worker._repair_in_flight)
-            assert worker._repair_executor is not None
-            worker._repair_executor.shutdown(wait=True)
+        release = threading.Event()
+        # Hold the worker on the first repair so the queue cannot drain while
+        # the burst is being measured.
+        with mock.patch.object(worker, '_run_role_repair',
+                               lambda _: release.wait(10)):
+            try:
+                for i in range(permission._REPAIR_MAX_IN_FLIGHT + 10):
+                    worker._schedule_role_repair(f'ghost{i}')
+                in_flight = len(worker._repair_in_flight)
+            finally:
+                release.set()
+                worker._repair_queue.join()
         assert in_flight <= permission._REPAIR_MAX_IN_FLIGHT
 
-    def test_no_thread_until_one_is_needed(self):
-        """The CLI imports this module; it must not start a thread pool."""
-        assert permission.PermissionService()._repair_executor is None
-
-    def test_the_repair_seeds_and_the_next_check_passes(self, policy_db):
+    def test_a_claim_is_not_spent_when_the_queue_is_full(self, policy_db):
+        """Otherwise that principal waits out a TTL for a repair never run."""
         worker = policy_db()
         worker.enforcer.load_policy()
-        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+        worker._repair_in_flight = {
+            f'other{i}' for i in range(permission._REPAIR_MAX_IN_FLIGHT)
+        }
+
+        worker._schedule_role_repair('ghost')
+
+        assert worker.claim_role_seed_attempt('ghost'), (
+            'the claim was consumed by a queueing attempt that did nothing')
+
+    def test_no_thread_until_one_is_needed(self):
+        """The CLI imports this module; it must not start a thread."""
+        assert permission.PermissionService()._repair_worker is None
+
+    def test_a_denial_reaches_the_seed(self, policy_db):
+        """Gate -> queue -> worker -> seed, in one process."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
 
         with mock.patch.object(permission, 'seed_new_user_role') as seed:
-            worker._run_role_repair('ghost')
+            assert worker.check_endpoint_permission('ghost', '/users/export',
+                                                    'GET')
+            worker._repair_queue.join()
         seed.assert_called_once_with('ghost')
 
     def test_a_failed_repair_is_swallowed(self, policy_db):

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2627,6 +2627,23 @@ class TestScheduledRoleRepair:
             worker._repair_queue.join()
         assert worker._repair_worker is not dead
 
+    def test_a_queued_principal_is_not_logged_as_turned_away(self, policy_db):
+        """A full queue must not report the principals already in it as dropped.
+
+        Reading that warning is how an operator learns repairs are being lost,
+        so it has to mean that.
+        """
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        worker._repair_in_flight = {'ghost'} | {
+            f'other{i}' for i in range(permission._REPAIR_MAX_IN_FLIGHT)
+        }
+
+        with mock.patch.object(permission.logger, 'warning') as warn:
+            worker._schedule_role_repair('ghost')
+
+        assert not [c for c in warn.call_args_list if 'Not queueing' in c[0][0]]
+
     def test_no_thread_until_one_is_needed(self):
         """The CLI imports this module; it must not start a thread."""
         assert permission.PermissionService()._repair_worker is None

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2763,7 +2763,7 @@ class TestBoundedClaimCache:
 
     def test_an_expired_entry_is_dropped_before_a_live_one(self):
         cache = {'old': time.time() - 10.0, 'fresh': time.time()}
-        assert permission._claim_within_ttl(cache, 'new', ttl=5.0, cap=2)
+        assert permission._take_ttl_permit(cache, 'new', ttl=5.0, cap=2)
         assert 'old' not in cache
         assert 'fresh' in cache, 'a live entry was dropped'
         assert 'new' in cache
@@ -2772,10 +2772,10 @@ class TestBoundedClaimCache:
         """`fresh` keeping its stamp is what stops the herd."""
         now = time.time()
         cache = {f'u{i}': now for i in range(4)}
-        permission._claim_within_ttl(cache, 'new', ttl=60.0, cap=4)
+        permission._take_ttl_permit(cache, 'new', ttl=60.0, cap=4)
         # All live and over the cap: half go, the rest keep their rate limit.
         assert 2 <= len(cache) <= 4
-        assert not permission._claim_within_ttl(cache, 'new', ttl=60.0, cap=4)
+        assert not permission._take_ttl_permit(cache, 'new', ttl=60.0, cap=4)
 
     def test_a_seen_role_set_drops_half_when_full(self):
         """Same argument as the TTL caches: clearing it stampedes every one.
@@ -2796,8 +2796,8 @@ class TestBoundedClaimCache:
 
     def test_the_claim_is_consumed(self):
         cache: dict = {}
-        assert permission._claim_within_ttl(cache, 'u', ttl=60.0, cap=8)
-        assert not permission._claim_within_ttl(cache, 'u', ttl=60.0, cap=8)
+        assert permission._take_ttl_permit(cache, 'u', ttl=60.0, cap=8)
+        assert not permission._take_ttl_permit(cache, 'u', ttl=60.0, cap=8)
 
 
 class TestDefaultRoleCasing:

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2374,19 +2374,19 @@ class TestRolelessPrincipalIsDenied:
         assert len(loads) == 1, f'reloaded {len(loads)} times, expected 1'
 
 
-class TestNeedsRoleSeed:
-    """Retry a seed that never completed, without hammering the policy lock."""
+class TestRoleSeedMissing:
+    """Is a seed owed? Asked by the drain worker before it takes the lock."""
 
     def test_true_for_a_roleless_principal(self, policy_db):
         worker = policy_db()
         worker.enforcer.load_policy()
-        assert worker.needs_role_seed('stranded')
+        assert worker.role_seed_missing('stranded')
 
     def test_false_for_a_principal_with_a_role(self, policy_db):
         worker = policy_db()
         worker.enforcer.add_grouping_policy('known', 'user')
         worker.enforcer.load_policy()
-        assert not worker.needs_role_seed('known')
+        assert not worker.role_seed_missing('known')
 
     def test_false_when_only_this_worker_is_stale(self, policy_db):
         """A stale worker must not take the policy lock for every request."""
@@ -2395,7 +2395,7 @@ class TestNeedsRoleSeed:
         writer.enforcer.add_grouping_policy('elsewhere', 'user')
         writer.enforcer.save_policy()
 
-        assert not worker.needs_role_seed('elsewhere')
+        assert not worker.role_seed_missing('elsewhere')
 
     def test_false_for_an_unrecognized_role(self, policy_db):
         """Seeding cannot repair this, so asking for it is a pure lock storm.
@@ -2409,17 +2409,20 @@ class TestNeedsRoleSeed:
         worker.enforcer.add_grouping_policy('weird', 'pwned')
         worker.enforcer.load_policy()
 
-        assert not worker.needs_role_seed('weird')
+        assert not worker.role_seed_missing('weird')
 
     def test_attempts_are_rate_limited(self, policy_db):
-        """A seed that keeps failing must not be retried on every request."""
+        """A seed that keeps failing must not be retried on every request.
+
+        The query itself is idempotent -- it answers from the policy, so it
+        keeps saying yes. The backoff is the claim beside it.
+        """
         worker = policy_db()
         worker.enforcer.load_policy()
-        # First ask says yes; the seed is assumed to have failed, so the role is
-        # still missing -- but the next asks must back off.
-        assert worker.needs_role_seed('stranded')
-        assert not worker.needs_role_seed('stranded')
-        assert not worker.needs_role_seed('stranded')
+        assert worker.role_seed_missing('stranded')
+        assert worker.claim_role_seed_attempt('stranded')
+        assert not worker.claim_role_seed_attempt('stranded')
+        assert not worker.claim_role_seed_attempt('stranded')
 
     def test_probably_has_role_never_initializes(self):
         """Safe on the event loop: no enforcer, no database, no answer but False."""
@@ -2448,7 +2451,7 @@ class TestNeedsRoleSeed:
         worker.enforcer.load_policy()
 
         assert not worker.probably_has_role('known')
-        assert not worker.needs_role_seed('known')
+        assert not worker.role_seed_missing('known')
         assert worker.probably_has_role('known')
 
 
@@ -2661,6 +2664,50 @@ class TestScheduledRoleRepair:
 
         assert not [c for c in warn.call_args_list if 'Not queueing' in c[0][0]]
 
+    def test_a_healthy_principal_warms_the_loop_side_guard(self, policy_db):
+        """Otherwise the guard is cold for everyone until a repair has run.
+
+        The login paths queue a repair when it answers False, so a memo written
+        only by repairs made every login after a restart queue a pointless one
+        -- enough of them to fire the in-flight cap warning on warm-up.
+        """
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('healthy', 'admin')
+        worker.enforcer.load_policy()
+        assert not worker.probably_has_role('healthy')
+
+        worker.check_endpoint_permission('healthy', '/users', 'GET')
+
+        assert worker.probably_has_role('healthy')
+
+    def test_the_cap_warning_is_rate_limited(self, policy_db):
+        """It is the line that says repairs are being dropped. Once per TTL.
+
+        Unrated, a burst repeats it per request and it reads as a worsening
+        incident rather than one condition.
+        """
+        worker = policy_db()
+        worker._repair_in_flight = {
+            f'u{i}' for i in range(permission._REPAIR_MAX_IN_FLIGHT)
+        }
+        with mock.patch.object(permission.logger, 'warning') as warn:
+            for i in range(5):
+                worker._schedule_role_repair(f'late{i}')
+        assert len(
+            [c for c in warn.call_args_list if 'Not queueing' in c[0][0]]) == 1
+
+    def test_queueing_never_raises(self, policy_db):
+        """A repair nobody waits for must not turn a login into a 500.
+
+        `Thread.start()` raises when the process is out of threads, and the
+        login and provisioning paths call this with no guard of their own.
+        """
+        worker = policy_db()
+        with mock.patch.object(worker,
+                               '_schedule_role_repair',
+                               side_effect=RuntimeError('out of threads')):
+            worker.queue_role_repair('ghost')
+
     def test_no_thread_until_one_is_needed(self):
         """The CLI imports this module; it must not start a thread."""
         assert permission.PermissionService()._repair_worker is None
@@ -2815,30 +2862,3 @@ class TestDefaultRoleCasing:
         with mock.patch('sky.users.rbac.skypilot_config.get_nested',
                         return_value=configured):
             assert rbac.get_default_role() == expected
-
-
-class TestReseedRoleIfMissing:
-    """The repair entry point the middlewares call from a worker thread."""
-
-    def test_swallows_a_failure_so_a_request_is_not_a_500(self, policy_db):
-        worker = policy_db()
-        worker.enforcer.load_policy()
-        with mock.patch.object(permission,
-                               'permission_service',
-                               worker), \
-             mock.patch.object(permission,
-                               'seed_new_user_role',
-                               side_effect=RuntimeError('lock timeout')):
-            # A second lock timeout must not surface: the next request retries.
-            permission.reseed_role_if_missing('stranded')
-
-    def test_seeds_when_the_role_is_missing(self, policy_db):
-        worker = policy_db()
-        worker.enforcer.load_policy()
-        seeded = []
-        with mock.patch.object(permission, 'permission_service', worker), \
-             mock.patch.object(permission,
-                               'seed_new_user_role',
-                               side_effect=lambda uid: seeded.append(uid)):
-            permission.reseed_role_if_missing('stranded')
-        assert seeded == ['stranded']

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2833,9 +2833,9 @@ class TestBoundedClaimCache:
         service = permission.PermissionService()
         cap = permission._NO_ROLE_PROBE_CACHE_MAX
         for i in range(cap):
-            service._remember_role_seen(f'u{i}')
+            service.remember_role_seen(f'u{i}')
 
-        service._remember_role_seen('one-more')
+        service.remember_role_seen('one-more')
 
         assert len(service._role_seen) > cap // 4, (
             f'{len(service._role_seen)} left: the set was cleared, not halved')

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2474,6 +2474,33 @@ class TestDenialScope:
         assert worker.check_endpoint_permission(viewer_id, '/users/create',
                                                 'POST')
 
+    def test_every_reader_agrees_about_a_system_identity(self, policy_db):
+        """The role is a property of the identity, not a row that may be gone.
+
+        `sky.users.server` refuses to delete these users or change their role,
+        so a decision that reads casbin and finds nothing must not conclude
+        they are role-less -- which is what left the endpoint gate and the
+        workspace checks disagreeing about the same principal.
+        """
+        worker = policy_db()
+        worker.enforcer.load_policy()
+
+        # The fixture seeds no rows for them, standing in for a boot-time seed
+        # that never landed.
+        assert worker.enforcer.get_roles_for_user(common.SERVER_ID) == []
+        assert worker.get_user_roles(common.SERVER_ID) == ['admin']
+        assert worker.roles_in_memory(common.SERVER_ID) == ['admin']
+        assert worker.roles_in_memory(
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID) == ['viewer']
+
+    def test_an_ordinary_principal_is_untouched(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('someone', 'user')
+        worker.enforcer.load_policy()
+
+        assert worker.get_user_roles('someone') == ['user']
+        assert worker.get_user_roles('ghost') == []
+
     def test_the_denial_is_logged_once_per_principal(self, policy_db):
         """Persistent state, so an unrated log would repeat on every request."""
         worker = policy_db()

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2612,20 +2612,37 @@ class TestScheduledRoleRepair:
         assert worker._repair_queue.empty()
         assert worker._repair_worker is None
 
-    def test_a_dead_worker_is_replaced(self, policy_db):
-        """Otherwise every later repair queues into a thread nobody reads."""
+    @pytest.mark.parametrize(
+        'in_flight,asking',
+        [
+            # Waiting its turn. The stranded set is usually small and fixed, so
+            # a brand-new principal may never arrive to trigger the restart.
+            ({'ghost'}, 'ghost'),
+            # Full, which is the state a dead worker produces: every caller
+            # stops at the cap, the symptom a restart exists to end.
+            ({f'u{i}' for i in range(permission._REPAIR_MAX_IN_FLIGHT)}, 'new'),
+        ],
+        ids=['already-queued', 'cap-full'])
+    def test_a_dead_worker_is_replaced(self, policy_db, in_flight, asking):
+        """Otherwise every later repair queues into a thread nobody reads.
+
+        Both callers below decline to queue, so a restart that sits after those
+        returns never runs -- and nothing else ever reads the queue.
+        """
         worker = policy_db()
         worker.enforcer.load_policy()
         with mock.patch.object(worker, '_run_role_repair'):
-            worker._schedule_role_repair('ghost1')
+            worker._schedule_role_repair('seed')
             worker._repair_queue.join()
         dead = worker._repair_worker
         assert dead is not None
-        with mock.patch.object(dead, 'is_alive', return_value=False), \
-             mock.patch.object(worker, '_run_role_repair'):
-            worker._schedule_role_repair('ghost2')
-            worker._repair_queue.join()
+
+        worker._repair_in_flight = set(in_flight)
+        with mock.patch.object(dead, 'is_alive', return_value=False):
+            worker._schedule_role_repair(asking)
+
         assert worker._repair_worker is not dead
+        assert worker._repair_worker.is_alive()
 
     def test_a_queued_principal_is_not_logged_as_turned_away(self, policy_db):
         """A full queue must not report the principals already in it as dropped.

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2506,12 +2506,176 @@ class TestDenialScope:
         worker = policy_db()
         worker.enforcer.load_policy()
 
-        with mock.patch.object(permission.logger, 'warning') as warn:
+        # The repair the denial queues logs too, and would seed a role midway
+        # through the loop; this test is about the denial's own line.
+        with mock.patch.object(worker, '_schedule_role_repair'), \
+             mock.patch.object(permission.logger, 'warning') as warn:
             for _ in range(5):
                 worker.check_endpoint_permission('ghost', '/users/export',
                                                  'GET')
-        assert warn.call_count == 1
-        assert 'ghost' in warn.call_args[0][0]
+        denials = [c for c in warn.call_args_list if 'Denying' in c[0][0]]
+        assert len(denials) == 1
+        assert 'ghost' in denials[0][0][0]
+
+
+class TestScheduledRoleRepair:
+    """The denial queues the repair instead of performing it.
+
+    `check_endpoint_permission` runs inside the auth executor's 5s deadline
+    while the policy lock waits up to 20s, so seeding inline would answer 503
+    under exactly the contention that strands principals -- and hold an auth
+    thread for the duration.
+    """
+
+    def test_a_denial_queues_a_repair(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        queued = []
+        with mock.patch.object(worker,
+                               '_schedule_role_repair',
+                               side_effect=queued.append):
+            assert worker.check_endpoint_permission('ghost', '/users/export',
+                                                    'GET')
+        assert queued == ['ghost']
+
+    def test_the_repair_runs_off_the_request(self, policy_db):
+        """Nothing blocking happens on the caller's thread."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        submitted = []
+        with mock.patch.object(worker, '_run_role_repair', submitted.append):
+            worker._schedule_role_repair('ghost')
+            assert worker._repair_executor is not None
+            worker._repair_executor.shutdown(wait=True)
+        assert submitted == ['ghost']
+
+    def test_queueing_is_claimed_once_per_ttl(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker, '_run_role_repair') as run:
+            for _ in range(5):
+                worker._schedule_role_repair('ghost')
+            assert worker._repair_executor is not None
+            worker._repair_executor.shutdown(wait=True)
+        assert run.call_count == 1
+
+    def test_a_burst_is_bounded(self, policy_db):
+        """The per-principal claim bounds the rate; this bounds the burst."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker, '_run_role_repair'):
+            for i in range(permission._REPAIR_MAX_IN_FLIGHT + 10):
+                worker._schedule_role_repair(f'ghost{i}')
+            in_flight = len(worker._repair_in_flight)
+            assert worker._repair_executor is not None
+            worker._repair_executor.shutdown(wait=True)
+        assert in_flight <= permission._REPAIR_MAX_IN_FLIGHT
+
+    def test_no_thread_until_one_is_needed(self):
+        """The CLI imports this module; it must not start a thread pool."""
+        assert permission.PermissionService()._repair_executor is None
+
+    def test_the_repair_seeds_and_the_next_check_passes(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+
+        with mock.patch.object(permission, 'seed_new_user_role') as seed:
+            worker._run_role_repair('ghost')
+        seed.assert_called_once_with('ghost')
+
+    def test_a_failed_repair_is_swallowed(self, policy_db):
+        """Nothing awaits it, and the next request tries again."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(permission,
+                               'seed_new_user_role',
+                               side_effect=RuntimeError('lock timeout')):
+            worker._run_role_repair('ghost')  # must not raise
+        assert 'ghost' not in worker._repair_in_flight
+
+
+class TestProbeThrottle:
+    """Reload-on-miss is bounded per worker, not only per principal.
+
+    The per-principal memo is cleared wholesale on overflow and expires by TTL,
+    and the failure this feature exists for strands many principals at once --
+    so without a global bound, N of them means N reloads per TTL, each holding
+    the enforcer's write lock.
+    """
+
+    def test_a_second_principal_does_not_reload_immediately(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        loads = []
+        with mock.patch.object(worker,
+                               '_load_policy_no_lock',
+                               side_effect=lambda: loads.append(1)):
+            worker._probe_unknown_principal('ghost1')
+            worker._probe_unknown_principal('ghost2')
+        assert len(loads) == 1, f'reloaded {len(loads)} times, expected 1'
+
+    def test_the_cooldown_scales_with_the_reload(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+
+        def slow_load():
+            time.sleep(0.05)
+
+        before = time.time()
+        with mock.patch.object(worker, '_load_policy_no_lock', slow_load):
+            worker._probe_unknown_principal('ghost1')
+        # duty cycle 0.1 => a 50ms reload buys ~450ms of cooldown.
+        assert worker._probe_cooldown_until - before > 0.3
+
+    def test_a_failed_reload_answers_role_less(self, policy_db):
+        """Raising would leave the middleware with a bare 500."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker,
+                               '_load_policy_no_lock',
+                               side_effect=RuntimeError('db down')):
+            assert worker._probe_unknown_principal('ghost') == []
+
+    def test_a_failed_reload_still_sets_the_cooldown(self, policy_db):
+        """Otherwise a broken database is retried on every request."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker,
+                               '_load_policy_no_lock',
+                               side_effect=RuntimeError('db down')):
+            worker._probe_unknown_principal('ghost')
+        assert worker._probe_cooldown_until > time.time() - 1
+
+
+class TestBoundedClaimCache:
+    """Over the cap, drop what expired -- never the whole cache.
+
+    These entries all expire, so clearing them wholesale would send every
+    principal back through the work the rate limit exists to space out, at the
+    same moment.
+    """
+
+    def test_an_expired_entry_is_dropped_before_a_live_one(self):
+        cache = {'old': time.time() - 10.0, 'fresh': time.time()}
+        assert permission._claim_within_ttl(cache, 'new', ttl=5.0, cap=2)
+        assert 'old' not in cache
+        assert 'fresh' in cache, 'a live entry was dropped'
+        assert 'new' in cache
+
+    def test_a_live_entry_survives_an_eviction(self):
+        """`fresh` keeping its stamp is what stops the herd."""
+        now = time.time()
+        cache = {f'u{i}': now for i in range(4)}
+        permission._claim_within_ttl(cache, 'new', ttl=60.0, cap=4)
+        # All live and over the cap: half go, the rest keep their rate limit.
+        assert 2 <= len(cache) <= 4
+        assert not permission._claim_within_ttl(cache, 'new', ttl=60.0, cap=4)
+
+    def test_the_claim_is_consumed(self):
+        cache: dict = {}
+        assert permission._claim_within_ttl(cache, 'u', ttl=60.0, cap=8)
+        assert not permission._claim_within_ttl(cache, 'u', ttl=60.0, cap=8)
 
 
 class TestDefaultRoleCasing:

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -2113,6 +2113,10 @@ def policy_db(tmp_path):
         adapter = sqlalchemy_adapter.Adapter(
             engine, db_class=sqlalchemy_adapter.CasbinRule)
         service.enforcer = casbin.SyncedEnforcer(model_path, adapter)
+        # The viewer allowlist is in-process state, not casbin policy. Without
+        # it every path looks disallowed and the viewer branch would block
+        # everything for the wrong reason.
+        service._build_viewer_allowlist_no_lock()
         return service
 
     seed = _worker()
@@ -2201,3 +2205,88 @@ class TestNeedsRoleSeed:
         writer.enforcer.save_policy()
 
         assert not worker.needs_role_seed('elsewhere')
+
+    def test_false_for_an_unrecognized_role(self, policy_db):
+        """Seeding cannot repair this, so asking for it is a pure lock storm.
+
+        `_add_user_if_not_exists_no_lock` only adds a role when there is none,
+        so it is a no-op for a principal holding `pwned` -- every request would
+        take the distributed lock and change nothing. Confinement in
+        `check_endpoint_permission` handles them instead.
+        """
+        worker = policy_db()
+        worker.enforcer.add_grouping_policy('weird', 'pwned')
+        worker.enforcer.load_policy()
+
+        assert not worker.needs_role_seed('weird')
+
+    def test_attempts_are_rate_limited(self, policy_db):
+        """A seed that keeps failing must not be retried on every request."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        # First ask says yes; the seed is assumed to have failed, so the role is
+        # still missing -- but the next asks must back off.
+        assert worker.needs_role_seed('stranded')
+        assert not worker.needs_role_seed('stranded')
+        assert not worker.needs_role_seed('stranded')
+
+    def test_probably_has_role_never_initializes(self):
+        """Safe on the event loop: no enforcer, no database, no answer but False."""
+        service = permission.PermissionService()
+        assert service.enforcer is None
+        assert not service.probably_has_role('anyone')
+        assert service.enforcer is None
+
+
+class TestConfinementRole:
+    """An unidentified principal is held to the deployment's own default."""
+
+    @mock.patch('sky.users.rbac.get_default_role', return_value='viewer')
+    def test_viewer_default_confines_via_the_allowlist(self, _default,
+                                                       policy_db):
+        # `/users` is on the viewer allowlist, `/dashboard/x` is not... but the
+        # allowlist is what decides, not the blocklist.
+        worker = policy_db()
+        worker.enforcer.load_policy()
+
+        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+        assert not worker.check_endpoint_permission('ghost', '/users', 'GET')
+        # Outside the viewer allowlist: blocked, where the `user` blocklist
+        # would have allowed it.
+        assert worker.check_endpoint_permission('ghost', '/jobs/launch', 'POST')
+
+    @mock.patch('sky.users.rbac.get_default_role', return_value='admin')
+    def test_unconfigured_default_never_confines_to_admin(
+            self, _default, policy_db):
+        """`rbac.default_role` falls back to admin; confinement must not."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+
+        assert worker.check_endpoint_permission('ghost', '/users/export', 'GET')
+
+
+class TestReseedRoleIfMissing:
+    """The repair entry point the middlewares call from a worker thread."""
+
+    def test_swallows_a_failure_so_a_request_is_not_a_500(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(permission,
+                               'permission_service',
+                               worker), \
+             mock.patch.object(permission,
+                               'seed_new_user_role',
+                               side_effect=RuntimeError('lock timeout')):
+            # A second lock timeout must not surface: the next request retries.
+            permission.reseed_role_if_missing('stranded')
+
+    def test_seeds_when_the_role_is_missing(self, policy_db):
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        seeded = []
+        with mock.patch.object(permission, 'permission_service', worker), \
+             mock.patch.object(permission,
+                               'seed_new_user_role',
+                               side_effect=lambda uid: seeded.append(uid)):
+            permission.reseed_role_if_missing('stranded')
+        assert seeded == ['stranded']


### PR DESCRIPTION
## Problem

Endpoint permissions are a Casbin **blocklist** — the only `p` rules are the
deny entries attached to the `user` role, so a principal matching none of them
is permitted everywhere. That makes an absent role, and an unrecognized one,
*more* privileged than `admin`:

```
admin_user   ['admin']    blocked(/users/export GET) = False
known        ['user']     blocked = True
weird        ['pwned']    blocked = False     <- non-empty, still wide open
nobody       []           blocked = False
```

`['pwned']` and `[]` are indistinguishable to the enforcer, so the test has to
be "holds nothing in `rbac.get_supported_roles()`", not `if not roles`. A
database predating the update-role validation (#10482) can still carry an
arbitrary string as a role.

Where a role-less principal actually comes from, other than the
no-identity-at-all case that never reaches this code:
`seed_new_user_role` calls `add_user_if_not_exists` **outside** its `try`, and
every caller is gated on `newly_added`. A policy-lock timeout during a user's
first request therefore leaves the `users` row committed, the role unseeded,
and nothing that will ever retry it — the account stays role-less, and
therefore unrestricted, until the next restart re-seeds it. Lock contention is
the same thing the HA discussion in #10488 is about.

## Fix

**Deny.** A principal the policy holds no recognized role for is refused,
which is what an unbound principal gets in Kubernetes RBAC (no RoleBinding) and
in the IAMs (no policy, implicit deny). This started out as *confinement* to
the deployment's default role; the reasons it became a denial:

- After reload-on-miss and the re-seed below, the population is narrow,
  transient and self-healing — one producer (the seed that never completed),
  and it repairs itself on a later request.
- Confinement is **silent**: a stranded account runs as `user` indefinitely and
  nobody learns the seed is failing. A denial is loud, and the operator hears
  about it in seconds.
- It removes a split-brain downstream. `sky/server/requests/role_filter.py`
  decides viewer-ness from the raw model, so a principal confined to `viewer`
  was *not* a viewer there: it kept `include_credentials` on `POST /status`
  (read-only SSH keys a real viewer is refused) and `refresh` on `/status`,
  `/jobs/queue{,/v2}`, `/jobs/logs`, `/jobs/download_logs`, `GET /volumes`.
  Those are all middleware-gated paths, so they now 403 outright. What remains
  is `/api/*`, which `RBACMiddleware.dispatch` skips entirely and where
  `request_owner_scope` already scopes a non-admin to their own requests.

**Two prerequisites, both in this PR.**

`rbac.default_role` is validated with `case_insensitive_enum`, which validates
without normalizing (`sky/utils/validator.py`), so `default_role: Viewer` is a
legal config whose literal string gets seeded as a role name. Under confinement
that was a fail-open (`enforce('Viewer', …)` matches nothing); under denial it
locks out every user in that deployment. `get_default_role()` now normalizes.

The server's own identities (`common.SERVER_ID`, `skypilot-system`,
`skypilot-system-viewer`) are resolved from the identity, not from the policy.
`sky/users/server.py` already refuses to delete these users or change their
role, so the role is not a default an operator may override — reading it out of
casbin only adds a way to get it wrong, and the denial makes that concrete: if
the boot-time seed never landed, the server would refuse its own internal calls
(the HA replica-to-replica authorize included).

That resolution is shared, not local to the gate. `get_user_roles`,
`check_endpoint_permission` and the new `roles_in_memory` (which
`sky/server/requests/role_filter.py` now uses instead of reaching for the
enforcer) all go through one helper, so a workspace check, an admin check and a
request filter cannot reach different conclusions about the same principal — as
they did while only the gate knew about system identities.

**Reload once on a miss.** Denying alone would trade a silent over-permit for
an outage: a freshly created admin whose request lands on a worker that has not
seen them yet would be refused every admin endpoint until something unrelated
reloaded that worker.

**Memoize the miss.** The other case is permanent, and without a memo a
role-less principal reloads the entire policy on every request it makes — 400 ms
at 20k rows, on the middleware path. One reload per user per TTL per worker
instead, in a bounded per-process dict like `_read_only_endpoint_cache`.

**Report it.** The enforcement path was silent, which is exactly what made the
confinement failure mode invisible. Denials are logged at warning with the
principal and path, rate-limited per principal per worker so a client retrying
in a loop cannot flood the log.

**Retry the seed, off the request.** A seed that never completed is never
retried otherwise: the `users` row exists, so `newly_added` stays False forever.
The retry is queued rather than performed inline, because the seed takes the
distributed policy lock (up to `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS`, 20s) and
the contention that strands principals is exactly when a login would be waiting
for it. `queue_role_repair` is the whole public surface: an in-memory claim plus
a queue put, bounded by a per-principal TTL claim and a cap on how many can be
in flight, drained by one serial daemon worker (parallel repairs would feed the
contention that caused them). It never raises, so no caller needs a guard.

Both the gate and the two auth middlewares queue through it. The seed assigns
`rbac.get_default_role()`, which is right for the dominant cause (the user was
always going to get the default role) but would promote someone whose role row
was *destroyed* rather than never written. Those are indistinguishable at that
moment; the way rows got destroyed is fixed in #10488.

**A brand-new user is different**, and keeps an await: the gate would otherwise
deny the account just created. That one is bounded — the same 5s deadline as the
user upsert beside it — and a timeout answers a retryable 503 rather than
proceeding without a role, after queueing the repair so the account heals even
if the client never comes back. Any failure answers that 503, not only a
timeout: an exception raised in a middleware is a bare 500, which clients do not
retry.

It runs on the **request** executor, not the auth one. The auth executor is 32
threads for the short DB lookups authentication does on the request path, and
`wait_for` releases the caller rather than the thread — it cannot cancel a
thread parked on a lock — so a seed that waits out
`POLICY_UPDATE_LOCK_TIMEOUT_SECONDS` holds an auth thread for 20s regardless of
the deadline. 32 concurrent first logins under contention would then answer
*every* authenticated request with a 503. A test pins that the seed never
touches that pool.

Both middlewares share one function for this
(`db_lookup.ensure_role_for_authenticated_user`), which also gave the
oauth2-proxy copy of the branch its first tests: that class is wrapped by
`websocket_aware`, so its real methods are unreachable from the exported name
and every test for this logic had targeted `AuthProxyMiddleware` only.

**What a first login looks like under contention**, so a 403 in the logs is not
mistaken for a misconfigured role: the seed times out and the request gets a
**503**; the `users` row is already committed, so the client's retry finds
`newly_added=False` and takes the returning-user branch, which queues rather
than waits — the gate answers **403** until the queued repair lands, then
**200**. Every step is bounded (5s deadline, 30s claim TTL, one serial repair
worker), and the account heals without an operator touching it.

**Nothing blocking on the event loop.** The loop-side guard
(`probably_has_role`) is a plain set lookup. It deliberately does not call
`get_roles_for_user`: that takes the enforcer's *read* lock, and a concurrent
`load_policy()` holds the write lock for the length of a full reload (402 ms at
20k rows) — the stall `RBACMiddleware` offloads its own check to avoid. The set
is fed by the gate whenever it resolves a recognized role, so it warms from
ordinary traffic; when only the repair path wrote it, it answered False for
every healthy principal until one had been repaired, which made every login
after a restart queue a pointless repair and could fire the in-flight cap
warning on plain warm-up. That warning is rate-limited too, for the same reason
the denial log is: it is the line that says repairs are being dropped.

## Test plan

```bash
pytest tests/unit_tests/test_sky/users/
# 271 passed
```

The new tests drive a real sqlite-backed enforcer, so the blocklist semantics
are the real ones rather than a mock's. Reverting each part in turn:

| reverted | fails |
| --- | --- |
| deny → confine to `user` | `test_unrecognized_or_absent_role_is_denied[…]` (4 params) |
| the rate limit on the denial log | `test_the_denial_is_logged_once_per_principal` |
| the lock-free guard | `test_probably_has_role_never_touches_the_enforcer`, `test_a_seen_role_is_remembered_for_the_loop_side_guard` |
| lowercasing `get_default_role()` | `test_get_default_role_is_normalized[Viewer-viewer]`, `[ADMIN-admin]` |
| the shared resolution | `test_every_reader_agrees_about_a_system_identity`, `test_system_identities_keep_their_seeded_role` |
| resolving in `get_user_roles` specifically | `test_every_reader_agrees_about_a_system_identity` |
| reload-on-miss | `test_a_role_assigned_elsewhere_is_picked_up`, `test_false_when_only_this_worker_is_stale`, `test_reload_is_not_repeated_per_request` |
| the memo | `test_reload_is_not_repeated_per_request` (reloads 5 times, not 1) |

### End to end

Against a local multi-worker server (`--deploy`, 10 processes) with its own
runtime directory, driving real HTTP with a service-account token whose account
has no role row at all:

| check | this branch | master |
| --- | --- | --- |
| role `user` on `GET /users/export` | 403 | 403 |
| **role-less on `GET /users/export`** | **403** | **200** |
| **role-less on `GET /users`** | **403** | 200 |
| role `user` on `GET /users` | 200 | 200 |

The third row is what makes the denial observable — the earlier confine-to-`user`
behaviour answered 200 there. The fourth is the control that keeps it honest:
the same endpoint must still answer for an account that does hold a role, or
this would be a blanket outage rather than a fix.

The system-identity resolution is not reachable over HTTP (those accounts cannot
be authenticated as), so it is unit-tested instead.

### Hot path

Alternating samples between master and this branch, five each, at 1001 policy
rows. Running all of one build then all of the other reported the build that
*adds* work as 20% faster — ordering bias — so the two are interleaved and the
spread is printed alongside:

| case | master | this branch | delta | spread |
| --- | --- | --- | --- | --- |
| allowed | 1053853 ns | 1044715 ns | −0.9% | ±2.4% |
| blocked | 69034 ns | 68827 ns | −0.3% | ±5.4% |
| admin | 1020419 ns | 1020830 ns | +0.0% | ±5.4% |

Every delta is inside the run-to-run spread. For a role-less principal the
first call costs one reload (0.9 ms → 13.0 ms) and every call after it is
**945 µs → 1.9 µs**: denying returns before `enforce`, and `enforce` is where
the millisecond goes (it scans every rule before concluding nothing matched).
Confinement paid that on every request such a principal made.

## What this does not fix

**A mass stranding heals slowly.** Repairs run one at a time, and each takes the
distributed policy lock, so a queue that filled up (64) drains in minutes rather
than seconds, and principals arriving while it is full get a warning instead of a
slot. That is deliberate -- running them in parallel would feed the contention
that stranded them -- but if a provisioning incident strands hundreds, a restart
re-seeds everyone faster than the repair path will.

**A system identity whose role row is already wrong stays wrong.** The boot path
no longer lets `default_role` land on `SERVER_ID` and friends (the generic
per-user seed used to win, then the explicit one found a role and did nothing),
but rows written before this change are not corrected. Authorization is
unaffected -- those identities resolve from the identity now -- so the residue is
cosmetic: `get_users_for_role('admin')` and the users list show the stale value.
Correcting them would mean writing to the policy on every boot to fix a state
nobody has reported.

## Not in scope

A **role change** still does not propagate: a demoted admin holds a non-empty,
recognized role, so nothing here looks like a miss and no reload is triggered.
That needs change detection rather than a miss trigger — a policy epoch, so the
window is bounded — and is a separate change.

Filtered per-user loading is not an option for it, incidentally:
`load_incremental_filtered_policy` does not exist on the installed pycasbin,
`load_filtered_policy` clears the whole model (every other user's role and
every blocklist rule), and `save_policy()` afterwards raises
`cannot save a filtered policy`.


