### PR TITLE
[Server] Serve /metrics on its own event loop

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1254,11 +1254,16 @@ def start_metrics_server(host: str, port: int) -> uvicorn.Server:
     def _serve() -> None:
         try:
             asyncio.run(server.serve())
+        except SystemExit:
+            # uvicorn calls sys.exit(1) when it cannot bind, and
+            # threading.excepthook drops SystemExit on the floor, so
+            # without this a metrics server that never came up would leave
+            # nothing behind but uvicorn's own bind error -- the scrape
+            # target just looks down, with no hint of why.
+            logger.error('Metrics server failed to start on %s:%s', host, port)
         except Exception:  # pylint: disable=broad-except
-            # Without this the traceback would only reach
-            # threading.excepthook, i.e. a metrics server that died on
-            # startup (port already bound, say) would look like a silently
-            # down scrape target.
+            # Likewise: an unhandled error here would otherwise only reach
+            # threading.excepthook.
             logger.exception('Metrics server exited unexpectedly')
 
     threading.Thread(target=_serve, daemon=True, name='metrics-server').start()

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -970,8 +970,11 @@ def maybe_register_managed_jobs_collector():
 metrics_app = fastapi.FastAPI()
 
 
-# Serve /metrics in dedicated thread to avoid blocking the event loop
-# of metrics server.
+# Declared sync on purpose: the collection below is CPU-bound and would
+# stall the event loop of whatever server is running it, so Starlette
+# hands it to a worker thread instead. That makes the scrape latency
+# depend on the serving loop's thread pool, which is why the metrics app
+# gets an event loop to itself -- see start_metrics_server().
 @metrics_app.get('/metrics')
 def metrics() -> fastapi.Response:
     """Expose aggregated Prometheus metrics from all worker processes."""
@@ -1213,6 +1216,59 @@ def build_metrics_server(host: str, port: int) -> uvicorn.Server:
     )
     metrics_server_instance = uvicorn.Server(metrics_config)
     return metrics_server_instance
+
+
+# The metrics server, so stop_metrics_server() can reach the instance
+# started on the private thread.
+_metrics_server: Optional[uvicorn.Server] = None
+
+
+def start_metrics_server(host: str, port: int) -> uvicorn.Server:
+    """Serve the metrics app on an event loop of its own, in its own thread.
+
+    The metrics app must not share an event loop with anything else.
+    ``/metrics`` is a sync endpoint, so Starlette runs it through
+    ``anyio.to_thread.run_sync()``, which takes a token from the *default*
+    thread limiter of the loop serving the request -- 40 tokens, one such
+    limiter per loop. Every other coroutine on that loop that fans out
+    ``anyio`` thread work draws from the same 40, and the limiter hands
+    tokens out FIFO, so a scrape that arrives while a background task has
+    thousands of ``anyio.Path`` calls queued up waits behind all of them
+    before it even starts collecting.
+
+    The API server's background loop hosts exactly that kind of task: the
+    request GC unlinks a log file per deleted request, a batch at a time.
+    While one runs, a scrape can take tens of seconds -- past any sane
+    ``scrape_timeout`` -- so the target flaps to ``up == 0`` and every
+    API server metric disappears for the duration, even though the server
+    is otherwise healthy. Isolating the loop removes the coupling: the
+    only thing contending for this loop's thread limiter is the scrape.
+
+    Returns the server, whose ``should_exit`` the caller may set directly;
+    stop_metrics_server() does that for the instance started here.
+    """
+    global _metrics_server
+    server = build_metrics_server(host, port)
+    _metrics_server = server
+
+    def _serve() -> None:
+        try:
+            asyncio.run(server.serve())
+        except Exception:  # pylint: disable=broad-except
+            # Without this the traceback would only reach
+            # threading.excepthook, i.e. a metrics server that died on
+            # startup (port already bound, say) would look like a silently
+            # down scrape target.
+            logger.exception('Metrics server exited unexpectedly')
+
+    threading.Thread(target=_serve, daemon=True, name='metrics-server').start()
+    return server
+
+
+def stop_metrics_server() -> None:
+    """Ask the metrics server started by start_metrics_server() to exit."""
+    if _metrics_server is not None:
+        _metrics_server.should_exit = True
 
 
 def _get_status_code_group(status_code: int) -> str:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4064,9 +4064,11 @@ if __name__ == '__main__':
         background = uvloop.new_event_loop()
         if os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED):
             metrics.maybe_register_managed_jobs_collector()
-            metrics_server = metrics.build_metrics_server(
-                cmd_args.host, cmd_args.metrics_port)
-            global_tasks.append(background.create_task(metrics_server.serve()))
+            # Deliberately not on `background`: the scrape shares that
+            # loop's anyio thread limiter with every daemon below, and the
+            # ones that unlink files a batch at a time can hold the scrape
+            # off for tens of seconds. See metrics.start_metrics_server().
+            metrics.start_metrics_server(cmd_args.host, cmd_args.metrics_port)
             # Reap per-pid prometheus multiproc files left behind by
             # workers that crashed (SIGKILL, OOM, hard crash) and never
             # called mark_process_dead. Without this, MultiProcessCollector
@@ -4131,6 +4133,7 @@ if __name__ == '__main__':
 
         for gt in global_tasks:
             gt.cancel()
+        metrics.stop_metrics_server()
         for plugin in plugins.get_plugins():
             plugin.shutdown()
         subprocess_utils.run_in_parallel(lambda worker: worker.cancel(),

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import urllib.request
 
 import fastapi
 from prometheus_client import CollectorRegistry
@@ -302,9 +303,12 @@ async def test_multiproc_reaper_daemon_loops_and_cancels(tmp_path):
                side_effect=fake_reap):
         task = asyncio.create_task(
             metrics.multiproc_reaper_daemon(interval_seconds=0))
-        # Yield enough times for several ticks to run.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        # The daemon reaps on a worker thread (asyncio.to_thread), so
+        # yielding a fixed number of times races that thread getting
+        # scheduled -- under load it loses. Wait for the first tick.
+        deadline = time.time() + 10
+        while call_count['n'] < 1 and time.time() < deadline:
+            await asyncio.sleep(0.01)
         task.cancel()
         try:
             await task
@@ -1297,3 +1301,55 @@ def test_metrics_endpoint_responsive_with_hung_plugin_collector():
         prom.REGISTRY.unregister(wrapper)
         metrics._plugin_collectors.remove(wrapper)
         metrics._resilient_collectors.remove(wrapper)
+
+
+def _live_thread_named(name):
+    for thread in threading.enumerate():
+        if thread.name == name:
+            return thread
+    return None
+
+
+def test_start_metrics_server_serves_from_its_own_thread(monkeypatch):
+    """The metrics app must be served from a thread, hence an event loop,
+    of its own.
+
+    A sync endpoint is dispatched through the serving loop's *default*
+    anyio thread limiter, so sharing a loop with the API server's
+    background daemons makes a scrape queue behind however much
+    ``anyio`` thread work they have outstanding -- enough to push it past
+    the Prometheus scrape timeout and flap the target to ``up == 0``.
+    Keeping the server on a private thread is what decouples them, so
+    assert on the thread rather than only on the response.
+    """
+    monkeypatch.delenv('PROMETHEUS_MULTIPROC_DIR', raising=False)
+    # Port 0: let the kernel pick, then read the bound port back, so the
+    # test cannot lose a race for a hardcoded port.
+    server = metrics.start_metrics_server('127.0.0.1', 0)
+    try:
+        assert _wait_until(lambda: server.started), 'server never started'
+        thread = _live_thread_named('metrics-server')
+        assert thread is not None, 'no dedicated metrics-server thread'
+        assert thread is not threading.main_thread()
+
+        port = server.servers[0].sockets[0].getsockname()[1]
+        with urllib.request.urlopen(f'http://127.0.0.1:{port}/metrics',
+                                    timeout=30) as response:
+            body = response.read()
+            assert response.status == 200
+            assert response.headers['content-type'] == CONTENT_TYPE_LATEST
+        assert body  # the collectors produced something
+    finally:
+        metrics.stop_metrics_server()
+    assert _wait_until(lambda: not thread.is_alive()), 'thread did not exit'
+
+
+def test_stop_metrics_server_without_start_is_noop():
+    """Shutdown runs unconditionally, including when metrics are disabled
+    and no server was ever started."""
+    saved = metrics._metrics_server
+    metrics._metrics_server = None
+    try:
+        metrics.stop_metrics_server()
+    finally:
+        metrics._metrics_server = saved

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -2,6 +2,7 @@
 
 import base64
 import os
+import socket
 import threading
 import time
 from unittest.mock import AsyncMock
@@ -1353,3 +1354,27 @@ def test_stop_metrics_server_without_start_is_noop():
         metrics.stop_metrics_server()
     finally:
         metrics._metrics_server = saved
+
+
+def test_metrics_server_reports_a_bind_failure(monkeypatch):
+    """A metrics server that never came up must say so.
+
+    uvicorn answers an unbindable port with sys.exit(1), i.e. SystemExit,
+    which is not an Exception and which threading.excepthook drops
+    silently -- so the thread would just vanish and the scrape target
+    would look down for no stated reason.
+    """
+    monkeypatch.delenv('PROMETHEUS_MULTIPROC_DIR', raising=False)
+    blocker = socket.socket()
+    blocker.bind(('127.0.0.1', 0))
+    blocker.listen(1)
+    port = blocker.getsockname()[1]
+    try:
+        with patch.object(metrics, 'logger') as mock_logger:
+            server = metrics.start_metrics_server('127.0.0.1', port)
+            assert _wait_until(lambda: _live_thread_named('metrics-server') is
+                               None), ('thread outlived the failed bind')
+            assert not server.started
+            assert mock_logger.error.called, 'bind failure was not reported'
+    finally:
+        blocker.close()


### PR DESCRIPTION
`/metrics` is a sync endpoint, so Starlette dispatches it through `anyio.to_thread.run_sync()`, which draws a token from the **default** thread limiter of the loop serving the request — 40 tokens, one limiter per loop, handed out FIFO. Today the metrics server shares the API server's background loop with every GC/retention daemon, so scrape latency is coupled to whatever `anyio` thread work those daemons have outstanding. The request GC has plenty: it unlinks a log file per deleted request, thousands of `anyio.Path` calls queued per 1000-request batch. A scrape landing mid-batch waits behind all of them before it even starts collecting.

Observed on a long-running server: for the ~30 minutes the request GC ran, `/metrics` went from sub-second to 25–35s, well past a 10s `scrape_timeout`, so the target sat at `up == 0` and every API server metric disappeared for the duration — while the server itself was healthy and serving API traffic normally. `/gpu-metrics` on the same app was unaffected, because it is `async` and never touches the thread limiter. This needs no unusual configuration: the default `requests_retention_hours` of 24 makes the GC sleep 24h between runs, so a busy server hits it once a day.

Fix: give the metrics app an event loop of its own, in its own thread (`metrics.start_metrics_server()` / `stop_metrics_server()`), so the only thing contending for that loop's thread limiter is the scrape. This decouples it from every background task, current and future, instead of requiring each one to remember to pass its own limiter.

Two deliberate non-changes:
- `multiproc_reaper_daemon` stays on the background loop — it does `to_thread` work, which is exactly what we are keeping off the metrics loop.
- The GC's unlink fan-out is left as-is; it is only pathological because it shared a loop with the scrape.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New tests in `tests/unit_tests/test_sky/server/test_metrics.py`:
- `test_start_metrics_server_serves_from_its_own_thread` — starts the server on an ephemeral port, asserts a live dedicated `metrics-server` thread, scrapes `/metrics` over real HTTP (200 + prometheus content type), then asserts `stop_metrics_server()` makes the thread exit. Fails if the server is moved back onto a shared loop.
- `test_stop_metrics_server_without_start_is_noop` — shutdown runs unconditionally, including when metrics are disabled.

`pytest tests/unit_tests/test_sky/server/test_metrics.py` → 51 passed, three consecutive runs. `pytest tests/unit_tests/test_sky/server` → green (excluding `test_mp_queue.py`, which needs `memory_profiler`, absent from my env).

While adding the above I found `test_multiproc_reaper_daemon_loops_and_cancels` waits a fixed number of event-loop yields for an `asyncio.to_thread` tick to land, which loses under load — it flaked reproducibly once the new test added machine load. Made it poll with a deadline instead.

https://claude.ai/code/session_01T1kfFyAXSq4XNX9D2EstaA

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->