### PR TITLE
[Dashboard] Name the filter params on users, volumes, recipes and infra

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -14,6 +14,7 @@ import {
   ChevronDownIcon,
 } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 import {
   checkGrafanaAvailability,
   getGrafanaUrl,
@@ -110,6 +111,11 @@ const INFRA_PAGE_SIZE_STORAGE_KEY = 'skypilot-infra-page-size';
 // The unified infra table's Name column is wide; allow much longer names
 // before middle-ellipsis truncation kicks in (full name stays in the tooltip).
 const INFRA_NAME_TRUNCATE_LENGTH = 45;
+
+// Non-filter state that belongs in a shared link. `all` is the default and
+// stays out of the URL. The selected context is already a route segment
+// (`/infra/[...context]`), so it needs nothing here.
+const INFRA_VIEW_SCHEMA = [{ key: 'workspace', default: 'all' }];
 
 // Skeleton badge for loading cells - replaces CircularProgress size={12}
 const SkeletonBadge = () => (
@@ -2559,7 +2565,14 @@ export function GPUs() {
 
   // Workspace-aware infrastructure state
   const [workspaceInfrastructure, setWorkspaceInfrastructure] = useState({});
-  const [selectedWorkspace, setSelectedWorkspace] = useState('all');
+  // The workspace scope belongs in the link: it decides which contexts and
+  // clouds the page shows, so a URL without it points somewhere else.
+  const { view, setView } = useUrlFilterState([], INFRA_VIEW_SCHEMA);
+  const selectedWorkspace = view.workspace;
+  const setSelectedWorkspace = useCallback(
+    (next) => setView('workspace', next),
+    [setView]
+  );
   const [availableWorkspaces, setAvailableWorkspaces] = useState([]);
 
   // SSH Node Pool state

--- a/sky/dashboard/src/components/recipe-hub.jsx
+++ b/sky/dashboard/src/components/recipe-hub.jsx
@@ -78,12 +78,26 @@ import {
   usePluginRoutes,
   usePluginRecipeTypes,
 } from '@/plugins/PluginProvider';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 
-// Define filter options for the YAML filter dropdown
-const RECIPE_PROPERTY_OPTIONS = [
-  { label: 'Name', value: 'name' },
-  { label: 'Type', value: 'recipe_type' },
-  { label: 'Owner', value: 'user_name' },
+// The filterable properties, declared once. `key` is the URL parameter and the
+// key into the typeahead's option lists; `label` is what lands on a chip.
+const RECIPE_FILTER_SCHEMA = [
+  { key: 'name', label: 'Name', kind: 'text' },
+  { key: 'type', label: 'Type', kind: 'text' },
+  { key: 'owner', label: 'Owner', kind: 'text' },
+];
+
+const RECIPE_PROPERTY_OPTIONS = RECIPE_FILTER_SCHEMA.map(({ key, label }) => ({
+  label,
+  value: key,
+}));
+
+// Every recipe property is single-valued, so a second chip on one property
+// replaces the first rather than stacking.
+const addRecipeFilter = (prevFilters, property, value) => [
+  ...prevFilters.filter((f) => f.property !== property),
+  { property, operator: ':', value },
 ];
 
 // Generate URL slug from recipe
@@ -252,7 +266,8 @@ function TemplateRow({
 function AllRecipesSection({ recipes, onPin, onDelete }) {
   const pluginRecipeTypes = usePluginRecipeTypes();
   const [deleteTarget, setDeleteTarget] = useState(null);
-  const [filters, setFilters] = useState([]);
+  // Filters live in the URL, keyed by name, so a filtered view is shareable.
+  const { filters, setFilters } = useUrlFilterState(RECIPE_FILTER_SCHEMA);
   const [sortConfig, setSortConfig] = useState({
     key: 'updated_at',
     direction: 'descending',
@@ -273,8 +288,8 @@ function AllRecipesSection({ recipes, onPin, onDelete }) {
 
     return {
       name: Array.from(names).sort(),
-      recipe_type: Array.from(types).sort(),
-      user_name: Array.from(owners).sort(),
+      type: Array.from(types).sort(),
+      owner: Array.from(owners).sort(),
     };
   }, [recipes]);
 
@@ -693,14 +708,9 @@ const RecipeFilterDropdown = ({
       property: getPropertyLabel(propertyValue),
       value: option,
     });
-    setFilters((prevFilters) => [
-      ...prevFilters,
-      {
-        property: getPropertyLabel(propertyValue),
-        operator: ':',
-        value: option,
-      },
-    ]);
+    setFilters((prevFilters) =>
+      addRecipeFilter(prevFilters, getPropertyLabel(propertyValue), option)
+    );
     setIsOpen(false);
     setValue('');
     inputRef.current.focus();
@@ -712,14 +722,9 @@ const RecipeFilterDropdown = ({
         property: getPropertyLabel(propertyValue),
         value: value,
       });
-      setFilters((prevFilters) => [
-        ...prevFilters,
-        {
-          property: getPropertyLabel(propertyValue),
-          operator: ':',
-          value: value,
-        },
-      ]);
+      setFilters((prevFilters) =>
+        addRecipeFilter(prevFilters, getPropertyLabel(propertyValue), value)
+      );
       setValue('');
       setIsOpen(false);
     } else if (e.key === 'Escape') {

--- a/sky/dashboard/src/components/shared/filterSchema.js
+++ b/sky/dashboard/src/components/shared/filterSchema.js
@@ -168,6 +168,40 @@ export const buildQueryString = (query) => {
   return parts.length ? `?${parts.join('&')}` : '';
 };
 
+/**
+ * Parse a `location.search` string into the `{ key: value }` shape the helpers
+ * above use, collapsing a repeated key into an array.
+ */
+export const parseSearch = (search) => {
+  const params = new URLSearchParams(search);
+  const query = {};
+  for (const key of new Set(params.keys())) {
+    const all = params.getAll(key);
+    query[key] = all.length > 1 ? all : all[0];
+  }
+  return query;
+};
+
+/**
+ * Build an href for a same-page navigation that changes one query key, keeping
+ * every other key the address bar already carries.
+ *
+ * Pages whose filters live in the URL write them straight to history, so
+ * `router.query` can lag behind and rebuilding the query from it drops them.
+ * Reading `location.search` avoids that, and going back out through
+ * `buildQueryString` keeps a comma list readable rather than percent-encoding
+ * it the way `URLSearchParams.toString()` would.
+ */
+export const hrefWithQueryKey = (pathname, search, key, value) => {
+  const query = parseSearch(search);
+  if (value === undefined || value === null || value === '') {
+    delete query[key];
+  } else {
+    query[key] = value;
+  }
+  return `${pathname}${buildQueryString(query)}`;
+};
+
 /** Strip the legacy triple keys from a query object. */
 export const withoutLegacyKeys = (query) => {
   const next = { ...query };

--- a/sky/dashboard/src/components/shared/filterSchema.js
+++ b/sky/dashboard/src/components/shared/filterSchema.js
@@ -5,6 +5,9 @@
  *
  *   [{ key: 'status', label: 'Status', kind: 'enum', multi: true }, ...]
  *
+ * An entry may also carry `legacyKeys: ['old spelling']` for a property whose
+ * old `property=` value was neither its key nor its lowercased label.
+ *
  * and that one declaration drives the dropdown, the URL, and the chip bar, so
  * the key a page writes is by construction the key it can read back.
  *
@@ -112,12 +115,17 @@ export const legacyFiltersToQuery = (schema, query) => {
 
   const filters = [];
   properties.forEach((property, i) => {
-    // Legacy URLs carry the lowercased label, which for every page except the
-    // users GPU filter equals the schema key. Match either, so both survive.
+    // Legacy URLs carry the lowercased label, which for most pages equals the
+    // schema key. Where it does not -- the users page wrote `gpu type` for a
+    // property now keyed `gpu` -- the entry declares the old spelling in
+    // `legacyKeys`. Match all three so links already pasted somewhere survive.
     const lower = String(property ?? '').toLowerCase();
     const entry =
       entryByKey(schema, lower) ||
-      schema.find((e) => e.label.toLowerCase() === lower);
+      schema.find((e) => e.label.toLowerCase() === lower) ||
+      schema.find((e) =>
+        (e.legacyKeys || []).some((k) => k.toLowerCase() === lower)
+      );
     const value = properties.length === 1 ? values[0] : values[i];
     if (!entry || value === undefined || value === null || value === '') {
       return;

--- a/sky/dashboard/src/components/shared/filterSchema.test.jsx
+++ b/sky/dashboard/src/components/shared/filterSchema.test.jsx
@@ -1,5 +1,6 @@
 import {
   buildQueryString,
+  hrefWithQueryKey,
   filtersToQuery,
   hasLegacyFilters,
   legacyFiltersToQuery,
@@ -224,5 +225,50 @@ describe('buildQueryString', () => {
   it('returns an empty string when nothing is set', () => {
     expect(buildQueryString({})).toBe('');
     expect(buildQueryString({ user: '' })).toBe('');
+  });
+});
+
+// Switching a tab is a same-page navigation that changes one query key. It must
+// not drop the filter params the hook wrote straight to history, and must not
+// percent-encode a comma list on the way through.
+describe('hrefWithQueryKey', () => {
+  it('keeps the other keys when setting one', () => {
+    expect(
+      hrefWithQueryKey(
+        '/users',
+        '?gpu=A100&role=admin',
+        'tab',
+        'service-accounts'
+      )
+    ).toBe('/users?gpu=A100&role=admin&tab=service-accounts');
+  });
+
+  it('keeps a comma list readable', () => {
+    expect(
+      hrefWithQueryKey('/volumes', '?status=READY,IN_USE', 'tab', 'buckets')
+    ).toBe('/volumes?status=READY,IN_USE&tab=buckets');
+  });
+
+  it('removes the key when the value is dropped', () => {
+    expect(
+      hrefWithQueryKey(
+        '/users',
+        '?gpu=A100&tab=service-accounts',
+        'tab',
+        undefined
+      )
+    ).toBe('/users?gpu=A100');
+  });
+
+  it('returns a bare path when nothing is left', () => {
+    expect(
+      hrefWithQueryKey('/users', '?tab=service-accounts', 'tab', undefined)
+    ).toBe('/users');
+  });
+
+  it('preserves a repeated key', () => {
+    expect(
+      hrefWithQueryKey('/clusters', '?labels=a%3D1&labels=b%3D2', 'tab', 'x')
+    ).toBe('/clusters?labels=a%3D1&labels=b%3D2&tab=x');
   });
 });

--- a/sky/dashboard/src/components/shared/filterSchema.test.jsx
+++ b/sky/dashboard/src/components/shared/filterSchema.test.jsx
@@ -14,6 +14,13 @@ const SCHEMA = [
   { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
 ];
 
+// Properties whose URL key was renamed, so the old `property=` value is
+// neither the new key nor the lowercased label.
+const RENAMED_SCHEMA = [
+  { key: 'gpu', label: 'GPU', kind: 'text', legacyKeys: ['gpu type'] },
+  { key: 'userId', label: 'User ID', kind: 'text', legacyKeys: ['user id'] },
+];
+
 const chip = (property, value) => ({ property, operator: ':', value });
 
 describe('filtersToQuery', () => {
@@ -119,6 +126,30 @@ describe('legacy triple links', () => {
         value: 'alice',
       })
     ).toEqual({ user: 'alice' });
+  });
+
+  it('matches the lowercased label when it differs from the key', () => {
+    // Legacy links carried `filter.property` lowercased, which is the label,
+    // not the key.
+    expect(
+      legacyFiltersToQuery(RENAMED_SCHEMA, {
+        property: 'user id',
+        operator: ':',
+        value: 'hash-alice',
+      })
+    ).toEqual({ userId: 'hash-alice' });
+  });
+
+  it('matches a declared legacy spelling that is neither key nor label', () => {
+    // The users page wrote `gpu type` for a property whose label is `GPU` and
+    // whose key is now `gpu`; without `legacyKeys` such a link is dropped.
+    expect(
+      legacyFiltersToQuery(RENAMED_SCHEMA, {
+        property: 'gpu type',
+        operator: ':',
+        value: 'A100',
+      })
+    ).toEqual({ gpu: 'A100' });
   });
 
   it('translates several triples, pairing arrays by index', () => {

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -87,6 +87,7 @@ import {
   filterData,
 } from '@/components/shared/FilterSystem';
 import { useUrlFilterState } from '@/hooks/useUrlFilterState';
+import { hrefWithQueryKey } from '@/components/shared/filterSchema';
 import { trackUserAction, trackFilterUsed } from '@/lib/analytics';
 
 const ACTIVE_JOB_STATUSES = new Set(statusGroups.active);
@@ -111,10 +112,21 @@ const GPU_CONSUMING_JOB_STATUSES = new Set([
 // `evaluateCondition` lowercases to look up the field on each row.
 // `legacyKeys` are the spellings the old triple-array URLs carried, which the
 // dropdown chose to match a suggestion-list key rather than to read well.
-const USER_FILTER_SCHEMA = [
+//
+// GPU and Infra are multi-valued: the table's counting path already reads
+// several values on either as alternatives (see `getFilteredCounts`), so they
+// join with a comma. The rest are single-valued -- a user has one name, one id,
+// one role -- and a second value could only ever empty the table.
+export const USER_FILTER_SCHEMA = [
   { key: 'name', label: 'Name', kind: 'text' },
-  { key: 'gpu', label: 'GPU', kind: 'text', legacyKeys: ['gpu type'] },
-  { key: 'infra', label: 'Infra', kind: 'text' },
+  {
+    key: 'gpu',
+    label: 'GPU',
+    kind: 'enum',
+    multi: true,
+    legacyKeys: ['gpu type'],
+  },
+  { key: 'infra', label: 'Infra', kind: 'enum', multi: true },
   { key: 'userId', label: 'User ID', kind: 'text', legacyKeys: ['user id'] },
   { key: 'role', label: 'Role', kind: 'text' },
 ];
@@ -128,13 +140,19 @@ const PROPERTY_OPTIONS = USER_FILTER_SCHEMA.map(({ key, label }) => ({
   value: key,
 }));
 
-// Every user property is single-valued, so a second chip on one property
-// replaces the first rather than stacking: the chip bar can never show a
-// filter the URL is unable to carry.
-const addFilter = (prevFilters, property, value) => [
-  ...prevFilters.filter((f) => f.property !== property),
-  { property, operator: ':', value },
-];
+const MULTI_VALUE_LABELS = new Set(
+  USER_FILTER_SCHEMA.filter((e) => e.multi).map((e) => e.label)
+);
+
+// A multi-valued property stacks -- two GPU chips mean "either" -- and ignores
+// an exact duplicate. Everything else replaces, so the chip bar can never show
+// a filter the URL is unable to carry.
+const addFilter = (prevFilters, property, value) => {
+  const base = MULTI_VALUE_LABELS.has(property)
+    ? prevFilters.filter((f) => !(f.property === property && f.value === value))
+    : prevFilters.filter((f) => f.property !== property);
+  return [...base, { property, operator: ':', value }];
+};
 
 // Helper function to get GPU count with validation
 const getGPUCount = (accelerators, source) => {
@@ -710,11 +728,19 @@ export function Users() {
     (tab) => {
       trackUserAction('tab_change', { tab });
       setActiveMainTab(tab);
-      if (tab === 'users') {
-        router.push('/users', undefined, { shallow: true });
-      } else {
-        router.push(`/users?tab=${tab}`, undefined, { shallow: true });
-      }
+      // Keep whatever else the address bar carries: the filter params are
+      // written straight to history, so rebuilding the query from scratch here
+      // would drop them and leave the chip bar describing an unshareable URL.
+      router.push(
+        hrefWithQueryKey(
+          '/users',
+          window.location.search,
+          'tab',
+          tab === 'users' ? undefined : tab
+        ),
+        undefined,
+        { shallow: true }
+      );
     },
     [router]
   );

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -109,11 +109,13 @@ const GPU_CONSUMING_JOB_STATUSES = new Set([
 // The filterable properties, declared once. `key` is the URL parameter and the
 // `valueList` key for the typeahead; `label` is what lands on a chip, which
 // `evaluateCondition` lowercases to look up the field on each row.
+// `legacyKeys` are the spellings the old triple-array URLs carried, which the
+// dropdown chose to match a suggestion-list key rather than to read well.
 const USER_FILTER_SCHEMA = [
   { key: 'name', label: 'Name', kind: 'text' },
-  { key: 'gpu', label: 'GPU', kind: 'text' },
+  { key: 'gpu', label: 'GPU', kind: 'text', legacyKeys: ['gpu type'] },
   { key: 'infra', label: 'Infra', kind: 'text' },
-  { key: 'userId', label: 'User ID', kind: 'text' },
+  { key: 'userId', label: 'User ID', kind: 'text', legacyKeys: ['user id'] },
   { key: 'role', label: 'Role', kind: 'text' },
 ];
 

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -84,10 +84,9 @@ import { statusGroups } from '@/components/jobs';
 import {
   FilterDropdown,
   Filters,
-  updateURLParams as sharedUpdateURLParams,
-  updateFiltersByURLParams as sharedUpdateFiltersByURLParams,
   filterData,
 } from '@/components/shared/FilterSystem';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 import { trackUserAction, trackFilterUsed } from '@/lib/analytics';
 
 const ACTIVE_JOB_STATUSES = new Set(statusGroups.active);
@@ -107,28 +106,32 @@ const GPU_CONSUMING_JOB_STATUSES = new Set([
   'CANCELLING',
 ]);
 
-// Define filter options for the filter dropdown
-const PROPERTY_OPTIONS = [
-  {
-    label: 'Name',
-    value: 'name',
-  },
-  {
-    label: 'GPU',
-    value: 'gpu type', // Match valueList key
-  },
-  {
-    label: 'Infra',
-    value: 'infra',
-  },
-  {
-    label: 'User ID',
-    value: 'user id', // Match valueList key
-  },
-  {
-    label: 'Role',
-    value: 'role',
-  },
+// The filterable properties, declared once. `key` is the URL parameter and the
+// `valueList` key for the typeahead; `label` is what lands on a chip, which
+// `evaluateCondition` lowercases to look up the field on each row.
+const USER_FILTER_SCHEMA = [
+  { key: 'name', label: 'Name', kind: 'text' },
+  { key: 'gpu', label: 'GPU', kind: 'text' },
+  { key: 'infra', label: 'Infra', kind: 'text' },
+  { key: 'userId', label: 'User ID', kind: 'text' },
+  { key: 'role', label: 'Role', kind: 'text' },
+];
+
+// Non-filter state that also belongs in a shared link. Deduplication defaults
+// to on, so only the off state needs to travel.
+const USER_VIEW_SCHEMA = [{ key: 'deduplicate', default: 'true' }];
+
+const PROPERTY_OPTIONS = USER_FILTER_SCHEMA.map(({ key, label }) => ({
+  label,
+  value: key,
+}));
+
+// Every user property is single-valued, so a second chip on one property
+// replaces the first rather than stacking: the chip bar can never show a
+// filter the URL is unable to carry.
+const addFilter = (prevFilters, property, value) => [
+  ...prevFilters.filter((f) => f.property !== property),
+  { property, operator: ':', value },
 ];
 
 // Helper function to get GPU count with validation
@@ -356,92 +359,39 @@ export function Users() {
   const [userSearchQuery, setUserSearchQuery] = useState('');
   const [serviceAccountSearchQuery, setServiceAccountSearchQuery] =
     useState('');
-  const [filters, setFilters] = useState([]);
+  // Filters and the shareable view state both live in the URL, keyed by name.
+  const { filters, setFilters, view, setView, initialQuery } =
+    useUrlFilterState(USER_FILTER_SCHEMA, USER_VIEW_SCHEMA);
   const [valueList, setValueList] = useState({
     name: [],
-    'user id': [],
+    userId: [],
     role: [],
-    'gpu type': [],
+    gpu: [],
     infra: [],
   });
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
 
-  // Initialize deduplicateUsers from URL parameter
-  const getInitialDeduplicateUsers = () => {
-    if (typeof window !== 'undefined' && router.isReady) {
-      const deduplicateParam = router.query.deduplicate;
-      // If parameter is explicitly set, use it; otherwise default to true
-      if (deduplicateParam !== undefined) {
-        return deduplicateParam === 'true';
-      }
-    }
-    return true; // Default to deduplicated view
-  };
-
-  const [deduplicateUsers, setDeduplicateUsers] = useState(
-    getInitialDeduplicateUsers
+  // Deduplication is view state: on by default, so only the off state has to
+  // travel in the link.
+  const deduplicateUsers = view.deduplicate !== 'false';
+  const setDeduplicateUsers = useCallback(
+    (next) => setView('deduplicate', next ? 'true' : 'false'),
+    [setView]
   );
 
-  // Sync deduplicateUsers state with URL parameter
+  // An SSO deployment is more useful undeduplicated, since one person can hold
+  // several identities. Applied once, and only when the link did not say
+  // otherwise, so a shared URL always wins over the deployment default.
+  const ssoDefaultApplied = useRef(false);
   useEffect(() => {
-    if (router.isReady) {
-      const deduplicateParam = router.query.deduplicate;
-
-      // If URL has no deduplicate parameter, set it to the default
-      // Default to false for SSO (userEmail exists), true for non-SSO
-      if (deduplicateParam === undefined) {
-        const defaultValue = !userEmail; // false for SSO, true for non-SSO
-        updateDeduplicateURL(defaultValue);
-      } else {
-        const expectedState = deduplicateParam === 'true';
-        if (deduplicateUsers !== expectedState) {
-          setDeduplicateUsers(expectedState);
-        }
-      }
+    if (ssoDefaultApplied.current || !userEmail) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, router.query.deduplicate, userEmail]);
-
-  // Helper function to update deduplicate in URL
-  const updateDeduplicateURL = (deduplicateValue) => {
-    const query = { ...router.query };
-    query.deduplicate = deduplicateValue.toString();
-
-    // Use replace to avoid adding to browser history
-    router.replace(
-      {
-        pathname: router.pathname,
-        query,
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
-
-  // Helper function to update URL query parameters for filters
-  const updateURLParams = (filters) => {
-    sharedUpdateURLParams(router, filters);
-  };
-
-  // Create property map for filter URL parameters
-  const propertyMap = new Map([
-    ['name', 'Name'],
-    ['user id', 'User ID'], // Note: lowercase with space to match URL encoding
-    ['role', 'Role'],
-    ['gpu type', 'GPU'], // Note: lowercase with space to match URL encoding
-    ['infra', 'Infra'],
-  ]);
-
-  // Initialize filters from URL parameters
-  useEffect(() => {
-    if (router.isReady && activeMainTab === 'users') {
-      const urlFilters = sharedUpdateFiltersByURLParams(router, propertyMap);
-      if (urlFilters.length > 0) {
-        setFilters(urlFilters);
-      }
+    ssoDefaultApplied.current = true;
+    if (initialQuery.deduplicate === undefined) {
+      setView('deduplicate', 'false');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, activeMainTab]);
+  }, [userEmail, initialQuery, setView]);
 
   // Handle URL parameters for tab selection
   useEffect(() => {
@@ -874,7 +824,7 @@ export function Users() {
               propertyList={PROPERTY_OPTIONS}
               valueList={valueList}
               setFilters={setFilters}
-              updateURLParams={updateURLParams}
+              addFilter={addFilter}
               onFilterAdd={(property, value) =>
                 trackFilterUsed('user', { property, value })
               }
@@ -933,7 +883,6 @@ export function Users() {
               onChange={(e) => {
                 const newValue = e.target.checked;
                 setDeduplicateUsers(newValue);
-                updateDeduplicateURL(newValue);
               }}
               className="sr-only"
             />
@@ -979,11 +928,7 @@ export function Users() {
 
       {/* Display Active Filters - only for users tab */}
       {activeMainTab === 'users' && (
-        <Filters
-          filters={filters}
-          setFilters={setFilters}
-          updateURLParams={updateURLParams}
-        />
+        <Filters filters={filters} setFilters={setFilters} />
       )}
 
       {/* Error/Success messages positioned at top right, below navigation bar */}
@@ -1729,9 +1674,9 @@ function UsersTable({
 
         setValueList({
           name: Array.from(names).sort(),
-          'user id': Array.from(userIds).sort(),
+          userId: Array.from(userIds).sort(),
           role: Array.from(roles).sort(),
-          'gpu type': Array.from(gpuTypes).sort(),
+          gpu: Array.from(gpuTypes).sort(),
           infra: Array.from(infras).sort(),
         });
 
@@ -1795,7 +1740,10 @@ function UsersTable({
         usersWithCounts.map((user) => ({
           ...user,
           name: user.usernameDisplay,
-          'user id': user.userId, // Note: space to match "User ID" -> "user id" from toLowerCase()
+          // `evaluateCondition` looks the field up by the chip's label
+          // lowercased, so the User ID chip needs a matching field name. The
+          // URL key is `userId`; only this in-memory alias keeps the space.
+          'user id': user.userId,
         })),
         standardFilters
       );

--- a/sky/dashboard/src/components/users.test.jsx
+++ b/sky/dashboard/src/components/users.test.jsx
@@ -1,4 +1,9 @@
-import { getJobGpuCount } from '@/components/users';
+import { getJobGpuCount, USER_FILTER_SCHEMA } from '@/components/users';
+import {
+  filtersToQuery,
+  legacyFiltersToQuery,
+  queryToFilters,
+} from '@/components/shared/filterSchema';
 
 // getJobGpuCount decides how many GPUs a managed job contributes to a user's
 // GPU total on the Users page. The critical regression it guards against:
@@ -78,5 +83,60 @@ describe('getJobGpuCount', () => {
   it('returns 0 for a null or undefined job', () => {
     expect(getJobGpuCount(null)).toBe(0);
     expect(getJobGpuCount(undefined)).toBe(0);
+  });
+});
+
+// The Users page GPU and Infra filters are multi-valued: the table's counting
+// path reads several values on either as alternatives. That has to survive the
+// trip through the URL, or a link asking for two GPUs comes back showing one.
+describe('USER_FILTER_SCHEMA', () => {
+  const chip = (property, value) => ({ property, operator: ':', value });
+
+  it('joins several GPU values into one readable parameter', () => {
+    expect(
+      filtersToQuery(USER_FILTER_SCHEMA, [
+        chip('GPU', 'A100'),
+        chip('GPU', 'A10G'),
+      ])
+    ).toEqual({ gpu: 'A100,A10G' });
+  });
+
+  it('reads a GPU list back as one chip per value', () => {
+    expect(queryToFilters(USER_FILTER_SCHEMA, { gpu: 'A100,A10G' })).toEqual([
+      chip('GPU', 'A100'),
+      chip('GPU', 'A10G'),
+    ]);
+  });
+
+  it('keeps both values of a legacy two-triple GPU link', () => {
+    // What the old dropdown wrote for "either of these GPUs". Collapsing it to
+    // one value silently narrows an already-shared link.
+    expect(
+      legacyFiltersToQuery(USER_FILTER_SCHEMA, {
+        property: ['gpu type', 'gpu type'],
+        operator: [':', ':'],
+        value: ['A100', 'A10G'],
+      })
+    ).toEqual({ gpu: 'A100,A10G' });
+  });
+
+  it('treats infra the same way', () => {
+    expect(
+      filtersToQuery(USER_FILTER_SCHEMA, [
+        chip('Infra', 'AWS'),
+        chip('Infra', 'GCP'),
+      ])
+    ).toEqual({ infra: 'AWS,GCP' });
+  });
+
+  it('keeps the single-valued properties single', () => {
+    // A user has one name, one id, one role; a second value could only ever
+    // empty the table, so the last one wins.
+    expect(
+      filtersToQuery(USER_FILTER_SCHEMA, [
+        chip('Name', 'alice'),
+        chip('Name', 'bob'),
+      ])
+    ).toEqual({ name: 'bob' });
   });
 });

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -55,6 +55,7 @@ import {
   filterData,
 } from '@/components/shared/FilterSystem';
 import { useUrlFilterState } from '@/hooks/useUrlFilterState';
+import { hrefWithQueryKey } from '@/components/shared/filterSchema';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents, useTableColumns } from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
@@ -121,15 +122,13 @@ export function Volumes() {
       // Keep whatever else the address bar carries -- the filter params are
       // written straight to history, so `router.query` may not have caught up
       // and rebuilding the query from it would drop them.
-      const params = new URLSearchParams(window.location.search);
-      if (tab === 'volumes') {
-        params.delete('tab');
-      } else {
-        params.set('tab', tab);
-      }
-      const search = params.toString();
       router.replace(
-        `${router.pathname}${search ? `?${search}` : ''}`,
+        hrefWithQueryKey(
+          router.pathname,
+          window.location.search,
+          'tab',
+          tab === 'volumes' ? undefined : tab
+        ),
         undefined,
         { shallow: true }
       );

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -54,6 +54,7 @@ import {
   Filters,
   filterData,
 } from '@/components/shared/FilterSystem';
+import { useUrlFilterState } from '@/hooks/useUrlFilterState';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents, useTableColumns } from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
@@ -65,19 +66,36 @@ const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 const VOLUMES_PAGE_SIZE_OPTIONS = [10, 30, 50, 100, 200];
 const VOLUMES_PAGE_SIZE_STORAGE_KEY = 'skypilot-volumes-page-size';
 
-// Properties offered by the filter dropdown. `value` keys into `valueList` for
-// the typeahead; `label` is what lands in `filter.property`, which
-// `evaluateCondition` lowercases to look up the field on each volume.
-const PROPERTY_OPTIONS = [
-  { label: 'Name', value: 'name' },
-  { label: 'Status', value: 'status' },
-  { label: 'Infra', value: 'infra' },
-  { label: 'Type', value: 'type' },
-  { label: 'User', value: 'user' },
+// The filterable properties, declared once. `key` is the URL parameter and the
+// `valueList` key for the typeahead; `label` is what lands in
+// `filter.property`, which `evaluateCondition` lowercases to look up the field
+// on each volume.
+const VOLUME_FILTER_SCHEMA = [
+  { key: 'name', label: 'Name', kind: 'text' },
+  { key: 'status', label: 'Status', kind: 'enum', multi: true },
+  { key: 'infra', label: 'Infra', kind: 'text' },
+  { key: 'type', label: 'Type', kind: 'enum', multi: true },
+  { key: 'user', label: 'User', kind: 'text' },
 ];
 
-// Filters are kept in local state only, so there is nothing to sync to the URL.
-const noopUpdateURLParams = () => {};
+const PROPERTY_OPTIONS = VOLUME_FILTER_SCHEMA.map(({ key, label }) => ({
+  label,
+  value: key,
+}));
+
+// Properties whose values are alternatives rather than extra conditions: two
+// Status chips mean "either", every other property replaces.
+const OR_PROPERTIES = VOLUME_FILTER_SCHEMA.filter((e) => e.multi === true).map(
+  (e) => e.label
+);
+const MULTI_VALUE_LABELS = new Set(OR_PROPERTIES);
+
+const addFilter = (prevFilters, property, value) => {
+  const base = MULTI_VALUE_LABELS.has(property)
+    ? prevFilters.filter((f) => !(f.property === property && f.value === value))
+    : prevFilters.filter((f) => f.property !== property);
+  return [...base, { property, operator: ':', value }];
+};
 
 export function Volumes() {
   const router = useRouter();
@@ -100,10 +118,21 @@ export function Volumes() {
   const handleTabChange = useCallback(
     (tab) => {
       setActiveTab(tab);
-      const query = tab === 'volumes' ? {} : { tab };
-      router.replace({ pathname: router.pathname, query }, undefined, {
-        shallow: true,
-      });
+      // Keep whatever else the address bar carries -- the filter params are
+      // written straight to history, so `router.query` may not have caught up
+      // and rebuilding the query from it would drop them.
+      const params = new URLSearchParams(window.location.search);
+      if (tab === 'volumes') {
+        params.delete('tab');
+      } else {
+        params.set('tab', tab);
+      }
+      const search = params.toString();
+      router.replace(
+        `${router.pathname}${search ? `?${search}` : ''}`,
+        undefined,
+        { shallow: true }
+      );
     },
     [router]
   );
@@ -495,7 +524,8 @@ export function VolumesTable({
   preloadingComplete,
 }) {
   const [data, setData] = useState([]);
-  const [filters, setFilters] = useState([]);
+  // Filters live in the URL, keyed by name, so a filtered view is shareable.
+  const { filters, setFilters } = useUrlFilterState(VOLUME_FILTER_SCHEMA);
   const [sortConfig, setSortConfig] = useState({
     key: null,
     direction: 'ascending',
@@ -577,7 +607,8 @@ export function VolumesTable({
     // resolve the property name to a field.
     return filterData(
       data.map((volume) => ({ ...volume, user: volume.user_name })),
-      filters
+      filters,
+      { orProperties: OR_PROPERTIES }
     );
   }, [data, filters]);
 
@@ -866,18 +897,14 @@ export function VolumesTable({
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}
             setFilters={setFilters}
-            updateURLParams={noopUpdateURLParams}
+            addFilter={addFilter}
             placeholder="Filter volumes"
           />
         </div>
       </div>
       {filters.length > 0 && (
         <div className="mb-2">
-          <Filters
-            filters={filters}
-            setFilters={setFilters}
-            updateURLParams={noopUpdateURLParams}
-          />
+          <Filters filters={filters} setFilters={setFilters} />
         </div>
       )}
 

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -1,5 +1,10 @@
 // The volumes table reaches for its data through the shared cache rather than
 // taking it as a prop, so the cache is where a fixed set of volumes goes in.
+// The table keeps its filters in the URL now, so it reads the router.
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: () => ({ isReady: true, query: {}, asPath: '/volumes' }),
+}));
 jest.mock('@/lib/cache', () => ({
   __esModule: true,
   default: { get: jest.fn(), invalidate: jest.fn(), setPreloader: jest.fn() },

--- a/sky/dashboard/src/components/volumes.urlfilters.test.jsx
+++ b/sky/dashboard/src/components/volumes.urlfilters.test.jsx
@@ -1,0 +1,144 @@
+// The volumes table keeps its filter chips in the address bar, so a filtered
+// view can be shared. These cover the round trip -- a link arrives as chips and
+// rows, a click leaves as a named parameter -- and the two rules that keep the
+// chip bar and the URL from disagreeing: a single-valued property replaces,
+// and a multi-valued one means "either".
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: () => ({ isReady: true, query: {}, asPath: '/volumes' }),
+}));
+jest.mock('@/lib/cache', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), invalidate: jest.fn(), setPreloader: jest.fn() },
+}));
+jest.mock('@/plugins/PluginSlot', () => ({
+  __esModule: true,
+  PluginSlot: () => null,
+}));
+jest.mock('@/plugins/PluginProvider', () => ({
+  __esModule: true,
+  usePluginComponents: () => [],
+  useTableColumns: () => [],
+}));
+
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import dashboardCache from '@/lib/cache';
+import { VolumesTable } from '@/components/volumes';
+
+const volume = (name, status, user = 'alice') => ({
+  name,
+  status,
+  error_message: null,
+  type: 'k8s-pvc',
+  infra: 'Kubernetes/ctx',
+  size: 1,
+  user_name: user,
+});
+
+// Statuses deliberately share no substring: the shared `evaluateCondition`
+// matches on substring, so `READY` would otherwise also select `NOT_READY`
+// and the assertions below would not mean what they say.
+const VOLUMES = [
+  volume('ready-one', 'READY'),
+  volume('ready-two', 'READY', 'bob'),
+  volume('inuse-one', 'IN_USE'),
+  volume('failed-one', 'FAILED', 'bob'),
+];
+
+const openAt = async (search) => {
+  window.history.replaceState({}, '', `/volumes${search}`);
+  dashboardCache.get.mockResolvedValue(VOLUMES);
+  render(
+    <VolumesTable
+      refreshInterval={100000}
+      setLoading={() => {}}
+      refreshDataRef={{ current: null }}
+      onDeleteVolume={() => {}}
+      preloadingComplete={true}
+    />
+  );
+  await waitFor(() => expect(dashboardCache.get).toHaveBeenCalled());
+};
+
+// Scoped to the table: a chip renders its value too, so an unscoped query
+// would match the filter bar as well as the row it selected.
+const volumeNames = () => {
+  const table = within(screen.getByRole('table'));
+  return VOLUMES.map((v) => v.name).filter(
+    (name) => table.queryAllByText(name).length > 0
+  );
+};
+
+const search = () => window.location.search;
+
+// Type into the dropdown and press Enter, the way a user adds a chip. The
+// property selector is a Radix listbox that jsdom cannot drive, so this always
+// adds on the default property, `Name`.
+const addNameChip = async (value) => {
+  const input = screen.getByPlaceholderText('Filter volumes');
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  await waitFor(() => expect(search()).toContain(value));
+};
+
+describe('volumes filters in the URL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, '', '/volumes');
+  });
+
+  it('opens a shared link already filtered', async () => {
+    await openAt('?status=READY');
+    await waitFor(() =>
+      expect(volumeNames()).toEqual(['ready-one', 'ready-two'])
+    );
+  });
+
+  it('reads several values on one property as alternatives', async () => {
+    await openAt('?status=READY,FAILED');
+    await waitFor(() =>
+      expect(volumeNames()).toEqual(['ready-one', 'ready-two', 'failed-one'])
+    );
+  });
+
+  it('combines different properties as conditions', async () => {
+    await openAt('?status=READY&user=bob');
+    await waitFor(() => expect(volumeNames()).toEqual(['ready-two']));
+  });
+
+  it('names the parameter after the property when a chip is added', async () => {
+    await openAt('');
+    await addNameChip('ready-one');
+    expect(search()).toBe('?name=ready-one');
+    await waitFor(() => expect(volumeNames()).toEqual(['ready-one']));
+  });
+
+  it('replaces rather than stacks a single-valued property', async () => {
+    await openAt('?name=ready-one');
+    await addNameChip('failed-one');
+    // One chip, one value: the chip bar cannot show a filter that the URL and
+    // the table would disagree about.
+    expect(search()).toBe('?name=failed-one');
+    await waitFor(() => expect(volumeNames()).toEqual(['failed-one']));
+  });
+
+  it('keeps a comma readable rather than percent-encoding it', async () => {
+    // The hook rewrites the address bar from its own state on mount, so this
+    // is the round trip, not just the link it was handed.
+    await openAt('?status=READY,FAILED');
+    await waitFor(() => expect(search()).toBe('?status=READY,FAILED'));
+  });
+
+  it('ignores a parameter no property claims', async () => {
+    await openAt('?nonsense=1&status=READY');
+    await waitFor(() =>
+      expect(volumeNames()).toEqual(['ready-one', 'ready-two'])
+    );
+  });
+});

--- a/sky/dashboard/src/components/volumes.urlfilters.test.jsx
+++ b/sky/dashboard/src/components/volumes.urlfilters.test.jsx
@@ -41,14 +41,15 @@ const volume = (name, status, user = 'alice') => ({
   user_name: user,
 });
 
-// Statuses deliberately share no substring: the shared `evaluateCondition`
-// matches on substring, so `READY` would otherwise also select `NOT_READY`
-// and the assertions below would not mean what they say.
+// The real VolumeStatus values. The shared `evaluateCondition` matches on
+// substring, and `READY` is a substring of `NOT_READY`, so the assertions below
+// filter on `IN_USE` / `NOT_READY`. Names are chosen the same way -- none is a
+// substring of another.
 const VOLUMES = [
   volume('ready-one', 'READY'),
-  volume('ready-two', 'READY', 'bob'),
   volume('inuse-one', 'IN_USE'),
-  volume('failed-one', 'FAILED', 'bob'),
+  volume('inuse-two', 'IN_USE', 'bob'),
+  volume('blocked-one', 'NOT_READY', 'bob'),
 ];
 
 const openAt = async (search) => {
@@ -94,22 +95,22 @@ describe('volumes filters in the URL', () => {
   });
 
   it('opens a shared link already filtered', async () => {
-    await openAt('?status=READY');
+    await openAt('?status=IN_USE');
     await waitFor(() =>
-      expect(volumeNames()).toEqual(['ready-one', 'ready-two'])
+      expect(volumeNames()).toEqual(['inuse-one', 'inuse-two'])
     );
   });
 
   it('reads several values on one property as alternatives', async () => {
-    await openAt('?status=READY,FAILED');
+    await openAt('?status=IN_USE,NOT_READY');
     await waitFor(() =>
-      expect(volumeNames()).toEqual(['ready-one', 'ready-two', 'failed-one'])
+      expect(volumeNames()).toEqual(['inuse-one', 'inuse-two', 'blocked-one'])
     );
   });
 
   it('combines different properties as conditions', async () => {
-    await openAt('?status=READY&user=bob');
-    await waitFor(() => expect(volumeNames()).toEqual(['ready-two']));
+    await openAt('?status=IN_USE&user=bob');
+    await waitFor(() => expect(volumeNames()).toEqual(['inuse-two']));
   });
 
   it('names the parameter after the property when a chip is added', async () => {
@@ -121,24 +122,24 @@ describe('volumes filters in the URL', () => {
 
   it('replaces rather than stacks a single-valued property', async () => {
     await openAt('?name=ready-one');
-    await addNameChip('failed-one');
+    await addNameChip('blocked-one');
     // One chip, one value: the chip bar cannot show a filter that the URL and
     // the table would disagree about.
-    expect(search()).toBe('?name=failed-one');
-    await waitFor(() => expect(volumeNames()).toEqual(['failed-one']));
+    expect(search()).toBe('?name=blocked-one');
+    await waitFor(() => expect(volumeNames()).toEqual(['blocked-one']));
   });
 
   it('keeps a comma readable rather than percent-encoding it', async () => {
     // The hook rewrites the address bar from its own state on mount, so this
     // is the round trip, not just the link it was handed.
-    await openAt('?status=READY,FAILED');
-    await waitFor(() => expect(search()).toBe('?status=READY,FAILED'));
+    await openAt('?status=IN_USE,NOT_READY');
+    await waitFor(() => expect(search()).toBe('?status=IN_USE,NOT_READY'));
   });
 
   it('ignores a parameter no property claims', async () => {
-    await openAt('?nonsense=1&status=READY');
+    await openAt('?nonsense=1&status=IN_USE');
     await waitFor(() =>
-      expect(volumeNames()).toEqual(['ready-one', 'ready-two'])
+      expect(volumeNames()).toEqual(['inuse-one', 'inuse-two'])
     );
   });
 });


### PR DESCRIPTION
## Problem

The Users page still encodes its filters as three parallel arrays zipped by
index, and Volumes, Recipes and the Infra workspace scope keep their state in
component state only. So a filtered view cannot be shared: the address bar
either says nothing about what the reader will see, or says it in a form that
carries a property name the page invented for an internal lookup.

On Users the property name is the visible symptom. The dropdown's `value` was
chosen to match a suggestion-list key rather than to read as a URL, so the
address bar ends up carrying a key with a space in it, alongside an `operator`
that no UI can vary.

## What a link looks like

| What the user does | Before | After |
|---|---|---|
| Filter users by GPU | `?property=gpu+type&operator=%3A&value=A100&deduplicate=true` | `?gpu=A100` |
| Users: either of two GPUs | `?property=gpu+type&property=gpu+type&operator=%3A&operator=%3A&value=A100&value=A10G&deduplicate=true` | `?gpu=A100,A10G` |
| Filter users by User ID | `?property=user+id&operator=%3A&value=hash-alice&deduplicate=true` | `?userId=hash-alice` |
| Turn deduplication off | `?deduplicate=false` | `?deduplicate=false` — unchanged, but the default no longer travels |
| Filter volumes by name | `/dashboard/volumes` — unchanged | `?name=datasets` |
| Volumes: two statuses | not expressible | `?status=READY,IN_USE` |
| Volumes + user | not expressible | `?status=READY,IN_USE&user=alice` |
| Filter recipes | `/dashboard/recipes` — unchanged | `?name=basic-p&type=Pool` |
| Scope Infra to a workspace | `/dashboard/infra` — unchanged | `?workspace=team-ml` |

Old links keep working: a `property`/`operator`/`value` URL is translated once
on arrival and the address bar is rewritten to the named form.

### Before

<!-- BEFORE screenshots -->

1. user page, GPU filter A100: `http://100.86.230.128:46631/dashboard/users?deduplicate=true&property=gpu&operator=%3A&value=A100`

<img width="3000" height="1054" alt="image" src="https://github.com/user-attachments/assets/8bf05b41-5713-4fbf-abf5-2b919c76e3a1" />

2. recipe page, name filter: `http://100.86.230.128:46631/dashboard/recipes`

<img width="2992" height="1302" alt="image" src="https://github.com/user-attachments/assets/dc0a6320-73ee-4533-9fd6-77ec08744807" />

3. infra page, workspace filter: `http://100.86.230.128:46631/dashboard/infra`

<img width="3012" height="1140" alt="image" src="https://github.com/user-attachments/assets/f6a8c56b-267b-42c5-bbeb-0bbdb0fdd43d" />

4. volumes, name filter: `http://100.86.230.128:46631/dashboard/volumes`

<img width="3008" height="1068" alt="image" src="https://github.com/user-attachments/assets/7637c4eb-befd-4763-8512-199613b78b35" />



### After

1. user page, GPU filter A100: `http://100.86.230.128:46633/dashboard/users?gpu=A100`

<img width="3024" height="1254" alt="image" src="https://github.com/user-attachments/assets/82b72936-f140-4965-99ff-a680e927d665" />


2. recipe page, name filter: `http://100.86.230.128:46633/dashboard/recipes?name=basic-cluster`

<img width="3020" height="1370" alt="image" src="https://github.com/user-attachments/assets/89c7075a-7379-47d9-80a1-510ec3930893" />

3. infra page, workspace filter: `http://100.86.230.128:46633/dashboard/infra?workspace=team-infra`

<img width="2990" height="1004" alt="image" src="https://github.com/user-attachments/assets/0b661265-bac4-4450-967c-23d5dae74788" />

4. volumes, name filter: `http://100.86.230.128:46633/dashboard/volumes?name=datasets`

<img width="2978" height="1046" alt="image" src="https://github.com/user-attachments/assets/daf46b41-f2a0-4652-abbb-95aeeabe61fb" />


<!-- AFTER screenshots -->

## Change

Each page declares its filterable properties once, and that declaration drives
the dropdown, the URL and the chip bar — so the key a page writes is by
construction the key it reads back.

- **Users** — `name`, `gpu`, `infra`, `userId`, `role`. This retires the
  label/value split: the dropdown carried `gpu type` and `user id` purely to
  match a suggestion-list key, and those spaces reached the URL. `gpu` and
  `infra` are multi-valued, since the page's counting path already reads several
  values on either as alternatives; name, id and role are single-valued, because
  a user has one of each and a second value could only ever empty the table.
  `deduplicate` becomes view state, so the default (on) stays out of the link
  instead of being written eagerly on load. Under SSO the useful default is the
  undeduplicated view, and that is applied only when the link did not say
  otherwise.
- **Volumes** and **Recipes** had no URL state at all. Volumes reads several
  values on `status` or `type` as alternatives; every other property is
  single-valued and replaces.
- **Infra** — the workspace scope joins the URL, since it decides which
  contexts and clouds the page shows and a link without it points somewhere
  else. The selected context is already a route segment and needs nothing.

Two changes fall out of this:

- The shared filter widgets take the URL writer as an **optional** prop, since a
  page that keeps its filters in the URL owns the writing. They also accept an
  `addFilter` reducer, so a single-valued property replaces rather than stacks —
  otherwise the chip bar shows two values where the URL carries one, and the two
  disagree about what the table is showing. (#10459 landed this part first; this branch
  has been rebased onto it, so `FilterSystem.jsx` is no longer in the diff.)
- Switching tabs used to drop every query key, because the target href was
  rebuilt from scratch while the chip bar kept its state — so the two described
  different views. Both pages that have tabs now build the href from
  `location.search` through a shared `hrefWithQueryKey`, which also keeps a
  comma list readable where `URLSearchParams.toString()` would percent-encode
  it. Pre-existing, but easy to hit once the filters are named.
- A schema entry can declare `legacyKeys` for a property whose URL key was
  renamed. Without it, an already-shared `?property=gpu%20type&...` link was
  dropped on arrival — the address bar came back empty and the table showed
  every user — because `gpu type` is neither the new key nor the lowercased
  label. This is the same mechanism the view schema already uses for
  `historyDays`.

Sort, page and page size stay out of scope on every page, matching #10455 and
#10459: that state lives in the table components and wants its own change.

## Verification

Both directions were checked against a build of `master` with identical seeded
data — 4 volumes, 4 clusters, 6 users, 3 workspaces, the 4 built-in recipes:

- Every link in the table above, arriving cold in a fresh tab.
- A legacy triple URL for `gpu type` and `user id`, which master produces and
  this branch must still honour, including the two-triple form for "either of
  these GPUs". All return the same rows as master.
- A tab round trip with the service-accounts tab enabled: master loses the
  filter params while leaving the chips on screen; this branch keeps both, and
  the comma survives the navigation.
- Chips replacing rather than stacking on a single-valued property, and reading
  as alternatives on `status`.
- The jobs page, which is the remaining caller passing `updateURLParams`: it
  still writes its current URL form, and adding or clearing a chip does not
  throw.

`volumes.urlfilters.test.jsx` covers the round trip through the real components:
a link arrives as chips and rows, a click leaves as a named parameter, several
values on one property mean "either", a comma stays readable, and an unknown
parameter is ignored. Each of the three mechanisms is independently covered —
reverting the hook fails 6 of 7, dropping `addFilter` fails the replace test,
dropping `orProperties` fails the alternatives test. `filterSchema.test.jsx`
gains the two legacy-spelling cases.

`npx jest` → 12 suites pass, 146 tests. `version-display` and `jobs.test.jsx` fail
identically on master without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

