### PR TITLE
[Core] Allow passing arbitrary environment variables to `rclone` in `MOUNT_CACHED`

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -455,10 +455,10 @@ FAQ
 
   AWS SSO credentials are only supported when accessing S3 from EC2 or EKS clusters with ``mode: MOUNT_CACHED``.
   ``mode: MOUNT`` is not supported when using AWS SSO credentials.
-  
-  On EKS clusters, you must set up IAM roles (via Pod Identity or IRSA) to 
-  allow SkyPilot pods to access S3 buckets without static AWS credentials. 
-  See :ref:`aws-eks-iam-roles` for setup instructions. 
+
+  On EKS clusters, you must set up IAM roles (via Pod Identity or IRSA) to
+  allow SkyPilot pods to access S3 buckets without static AWS credentials.
+  See :ref:`aws-eks-iam-roles` for setup instructions.
 
   When accessing S3 buckets outside of EC2 or EKS, static AWS credentials
   (e.g., ``~/.aws/credentials``) are required.
@@ -617,5 +617,7 @@ Storage YAML reference
                 Delay before uploading dirty files to remote.
             - read_only: bool; default: false
                 Whether the mount is read-only.
+            - env_vars: dict of str; e.g. {"RCLONE_S3_UPLOAD_CONCURRENCY": "8"}
+                Environment variables exported for the mount process.
             Size values accept suffixes: K, M, G, T, P (e.g. "64M", "10G").
             Duration values accept suffixes: ns, us, ms, s, m, h (e.g. "5s", "1h").

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -621,6 +621,7 @@ def validate(
     omit_priority_class = _omit(43)
     omit_max_hourly_cost = _omit(44)
     omit_mount_config = _omit(48)
+    omit_mount_cached_env_vars = _omit(58)
 
     for task in dag.tasks:
         if omit_user_specified_yaml:
@@ -650,6 +651,12 @@ def validate(
                 storage.mount_config = None
             logger.debug('`mount_config` is ignored because the server '
                          'does not support it yet.')
+        if omit_mount_cached_env_vars:
+            for storage in task.storage_mounts.values():
+                if storage.mount_cached_config is not None:
+                    storage.mount_cached_config.env_vars = None
+            logger.debug('`mount_cached.env_vars` is ignored because the '
+                         'server does not support it yet.')
         if omit_priority_class:
             for resource in task.resources:
                 if resource.priority_class:

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '57';
+export const CLIENT_API_VERSION = '58';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -736,13 +736,22 @@ def get_mount_cached_cmd(
     if sequential_upload and mount_cached_config.transfers is None:
         mount_cached_config.transfers = 1
 
+    # User-provided environment variables for the rclone process, exported
+    # inline so the backgrounded (--daemon) rclone process inherits them. An
+    # escape hatch for rclone options settable via RCLONE_* env vars.
+    env_prefix = ''
+    if mount_cached_config.env_vars:
+        env_prefix = ''.join(
+            f'{key}={shlex.quote(value)} '
+            for key, value in mount_cached_config.env_vars.items())
+
     # when mounting multiple directories with vfs cache mode, it's handled by
     # rclone to create separate cache directories at ~/.cache/rclone/vfs. It is
     # not necessary to specify separate cache directories.
     mount_cmd = (
         f'{create_log_cmd} && '
         f'{configure_rclone_profile} && '
-        'rclone mount '
+        f'{env_prefix}rclone mount '
         f'{rclone_profile_name}:{bucket_name} {mount_path} '
         # '--daemon' keeps the mounting process running in the background.
         # fail in 10 seconds if mount cannot complete by then,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -459,6 +459,10 @@ class MountCachedConfig:
     # Mount as read-only.
     # rclone flag: --read-only
     read_only: Optional[bool] = None
+    # Environment variables exported for the `rclone mount` process. An escape
+    # hatch for rclone options not modeled above, which can all be set via
+    # RCLONE_* env vars (e.g. {"RCLONE_S3_UPLOAD_CONCURRENCY": "8"}).
+    env_vars: Optional[Dict[str, str]] = None
 
     def to_rclone_flags(self) -> str:
         """Convert non-None fields to rclone CLI flag string."""

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 57  # Slurm inline host path volume mounts
+API_VERSION = 58  # mount_cached env_vars
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -813,6 +813,18 @@ def get_storage_schema():
                             'read_only': {
                                 'type': 'boolean',
                             },
+                            # Environment variables exported for the rclone
+                            # mount process (e.g. RCLONE_* options).
+                            'env_vars': {
+                                'type': 'object',
+                                'patternProperties': {
+                                    # Checks env keys are valid env var names.
+                                    '^[a-zA-Z_][a-zA-Z0-9_]*$': {
+                                        'type': 'string',
+                                    },
+                                },
+                                'additionalProperties': False,
+                            },
                         },
                     },
                     'mount': {

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -196,6 +196,7 @@ class TestMountCachedConfig:
             vfs_read_chunk_streams=4,
             vfs_write_back='5s',
             read_only=True,
+            env_vars={'RCLONE_S3_UPLOAD_CONCURRENCY': '8'},
         )
         yaml_dict = config.to_yaml_config()
         restored = storage_lib.MountCachedConfig.from_yaml_config(yaml_dict)
@@ -617,6 +618,22 @@ class TestMountCachedSchemaValidation:
         with pytest.raises(ValueError):
             storage_lib.Storage.from_yaml_config(config)
 
+    def test_env_vars_accepted(self):
+        config = self._make_yaml_config(
+            {'env_vars': {
+                'RCLONE_S3_UPLOAD_CONCURRENCY': '8'
+            }})
+        storage_obj = storage_lib.Storage.from_yaml_config(config)
+        assert storage_obj.mount_cached_config.env_vars == {
+            'RCLONE_S3_UPLOAD_CONCURRENCY': '8'
+        }
+
+    def test_env_vars_invalid_key_rejected(self):
+        # Keys must be valid env var names (no spaces/shell metacharacters).
+        config = self._make_yaml_config({'env_vars': {'BAD KEY': 'v'}})
+        with pytest.raises(ValueError):
+            storage_lib.Storage.from_yaml_config(config)
+
 
 class TestGetMountCachedCmdWithConfig:
     """Tests for mounting_utils.get_mount_cached_cmd with MountCachedConfig."""
@@ -706,6 +723,41 @@ class TestGetMountCachedCmdWithConfig:
         assert 'rclone mount myprofile:my-bucket /mnt/data' in cmd
         assert '--daemon' in cmd
         assert '> /dev/null 2>&1' in cmd
+
+    def test_env_vars_exported_before_rclone(self):
+        config = storage_lib.MountCachedConfig(env_vars={
+            'RCLONE_S3_UPLOAD_CONCURRENCY': '8',
+            'RCLONE_S3_ENV_AUTH': 'true',
+        })
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_cached_config=config)
+        # Exported inline immediately before the rclone invocation so the
+        # backgrounded daemon inherits them.
+        assert ('RCLONE_S3_UPLOAD_CONCURRENCY=8 RCLONE_S3_ENV_AUTH=true '
+                'rclone mount') in cmd
+
+    def test_env_vars_values_are_quoted(self):
+        config = storage_lib.MountCachedConfig(
+            env_vars={'RCLONE_CONFIG_PASS': 'a b;rm -rf'})
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_cached_config=config)
+        assert "RCLONE_CONFIG_PASS='a b;rm -rf' rclone mount" in cmd
+
+    def test_no_env_prefix_when_unset(self):
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data')
+        assert '&& rclone mount' in cmd
 
 
 class TestVastDataStorage:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #10494

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->