### PR TITLE
[Kubernetes] Keep the uv-managed interpreter out of /home/sky

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -46,7 +46,8 @@ RUN existing_user=$(getent passwd 1000 | cut -d: -f1) && \
     if [ -n "$existing_group" ]; then groupdel "$existing_group" || true; fi && \
     groupadd -g 1000 sky && \
     useradd -m -s /bin/bash -u 1000 -g 1000 sky && \
-    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    mkdir -p /opt/uv-python && chown sky:sky /opt/uv-python
 
 # Switch to sky user
 USER sky
@@ -61,6 +62,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Install the SkyPilot runtime (uv-managed venv) and other dependencies based
 # on architecture.
+# UV_PYTHON_INSTALL_DIR keeps any interpreter uv downloads out of /home/sky: a
+# pod that mounts a volume over the home directory would otherwise shadow it and
+# break ~/skypilot-runtime. uv only downloads when the requested version is not
+# the system one -- python3.10 is system on 22.04 but not on 24.04.
 # Keep the Ray version below in sync with the one in skylet.constants
 # Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
 RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
@@ -69,6 +74,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         *) echo "$(uname -m)" ;; \
     esac)} && \
     export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
+    export UV_PYTHON_INSTALL_DIR=/opt/uv-python && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -51,7 +51,8 @@ RUN existing_user=$(getent passwd 1000 | cut -d: -f1) && \
     if [ -n "$existing_group" ]; then groupdel "$existing_group" || true; fi && \
     groupadd -g 1000 sky && \
     useradd -m -s /bin/bash -u 1000 -g 1000 sky && \
-    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    mkdir -p /opt/uv-python && chown sky:sky /opt/uv-python
 
 # Switch to sky user
 USER sky
@@ -66,6 +67,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Install the SkyPilot runtime (uv-managed venv) and other dependencies based
 # on architecture.
+# UV_PYTHON_INSTALL_DIR keeps any interpreter uv downloads out of /home/sky: a
+# pod that mounts a volume over the home directory would otherwise shadow it and
+# break ~/skypilot-runtime. uv only downloads when the requested version is not
+# the system one -- python3.10 is system on 22.04 but not on 24.04.
 # Keep the Ray version below in sync with the one in skylet.constants
 # Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
 RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
@@ -74,6 +79,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         *) echo "$(uname -m)" ;; \
     esac)} && \
     export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
+    export UV_PYTHON_INSTALL_DIR=/opt/uv-python && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \


### PR DESCRIPTION
## Summary

The runtime venv asks uv for python3.10. On Ubuntu 22.04 that is the system interpreter, so uv downloads nothing. On 24.04 it is not, so uv fetches a managed CPython 3.10 into `~/.local/share/uv/python` — about 4000 files landing in the home directory.

Measured on the images built from these Dockerfiles (files under `/home/sky`, excluding `skypilot-runtime` and `.cache`):

| base | OS | system python | files in home | `~/.local/share/uv` |
| --- | --- | --- | --- | --- |
| `skypilot:...` (22.04) | 22.04 | 3.10.12 | 1350 | absent |
| `skypilot:...-ubuntu2404` | 24.04 | 3.12.3 | 5064 | present, cpython-3.10 |

That breaks two ways:

- **A volume mounted over `/home/sky` shadows the interpreter**, leaving `~/skypilot-runtime/bin/python` a dangling symlink. This is latent for any pod that mounts a home volume, not only the image that first hit it.
- **Seeding a home volume from the image gets much slower.** Our downstream devspace images rsync the image's `/home/sky` into a ReadWriteMany volume on first boot; on networked storage that cost is driven by file count, not bytes. The step went from 17 files to several thousand and became very visibly slow.

This points `UV_PYTHON_INSTALL_DIR` at `/opt/uv-python` for the runtime install, so a downloaded interpreter lands outside the home directory — the same thing the downstream devspace images already do for exactly this reason. `/opt/uv-python` is created and chowned to `sky` in the root section, alongside the user setup.

Deliberately set **only for that `RUN`**, not as a persistent `ENV`: a user running `uv python install` inside a container keeps the default location, which is writable and survives in their home rather than in an image path.

## Test plan

On 22.04 (default base) this is a no-op — uv downloads nothing there, so the only observable change is an empty `/opt/uv-python`:

```bash
docker buildx build --load -t sky-2204 -f Dockerfile_k8s ./sky
docker run --rm sky-2204 bash -c '
  python3 -V                                    # 3.10.12, system interpreter
  ls /home/sky/.local/share/uv 2>/dev/null || echo "no managed python (expected)"
  readlink -f /home/sky/skypilot-runtime/bin/python'   # /usr/bin/python3.10
```

On 24.04, the interpreter moves out of the home directory:

```bash
docker buildx build --load --build-arg BASE_IMAGE=ubuntu:24.04 \
  -t sky-2404 -f Dockerfile_k8s ./sky
docker run --rm sky-2404 bash -c '
  ls /opt/uv-python                                     # cpython-3.10-...
  ls /home/sky/.local/share/uv 2>/dev/null || echo "not in home (the fix)"
  readlink -f /home/sky/skypilot-runtime/bin/python     # under /opt/uv-python
  /home/sky/skypilot-runtime/bin/python -V              # 3.10.x
  find /home/sky -type f -not -path "*/skypilot-runtime/*" -not -path "*/.cache/*" | wc -l'
```

Before this change the last count is ~5064; after, ~1350 — matching the 22.04 base.

Same two builds for `Dockerfile_k8s_gpu` with `BASE_IMAGE=nvidia/cuda:12.8.1-runtime-ubuntu24.04`.

No unit tests: the change is confined to the image recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->