### PR TITLE
[Core] Redact credentials from SkyPilot config debug logs

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -65,7 +65,6 @@ from sky.utils import context_utils
 from sky.utils import subprocess_utils
 from sky.utils import tempstore
 from sky.utils import timeline
-from sky.utils import yaml_utils
 from sky.utils.db import db_utils
 from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -59,6 +59,7 @@ from sky.server.requests.queues import base as queue_base
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import context
 from sky.utils import context_utils
 from sky.utils import subprocess_utils
@@ -826,7 +827,7 @@ def _request_execution_wrapper(request_id: str,
                 if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
                     config = skypilot_config.to_dict()
                     logger.debug(f'request config: \n'
-                                 f'{yaml_utils.dump_yaml_str(dict(config))}')
+                                 f'{config_utils.dump_redacted_yaml(config)}')
                 (metrics_utils.SKY_APISERVER_PROCESS_EXECUTION_START_TOTAL.
                  labels(request=request_name, pid=pid).inc())
                 with metrics_utils.time_it(name=request_name,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -88,6 +88,19 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
+
+def _dump_for_log(config: config_utils.Config) -> str:
+    """Serializes a config for a log line or an error message.
+
+    Never use yaml_utils.dump_yaml_str() directly on a config for that purpose:
+    a config can carry credentials (see
+    config_utils.SENSITIVE_CONFIG_PATHS), and a debug dump is the one place
+    they escape into somewhere durable and widely readable.
+    """
+    return yaml_utils.dump_yaml_str(
+        config_utils.redact_sensitive_values(config))
+
+
 # The config is generated as described below:
 #
 # (*) (Used internally) If env var {ENV_VAR_SKYPILOT_CONFIG} exists, use its
@@ -750,7 +763,7 @@ def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
             os.environ[constants.ENV_VAR_DB_CONNECTION_URI] = db_url
         if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
             logger.debug(f'Config loaded from {config_path}:\n'
-                         f'{yaml_utils.dump_yaml_str(dict(config))}')
+                         f'{_dump_for_log(config)}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -849,7 +862,7 @@ def _reload_config_as_server() -> None:
             server_config = overlay_skypilot_config(server_config, db_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'server config: \n'
-                     f'{yaml_utils.dump_yaml_str(dict(server_config))}')
+                     f'{_dump_for_log(server_config)}')
     _set_loaded_config(server_config)
     _set_loaded_config_path(server_config_path)
 
@@ -873,9 +886,8 @@ def _reload_config_as_client() -> None:
         overlaid_client_config = overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
-        logger.debug(
-            f'client config (before task and CLI overrides): \n'
-            f'{yaml_utils.dump_yaml_str(dict(overlaid_client_config))}')
+        logger.debug(f'client config (before task and CLI overrides): \n'
+                     f'{_dump_for_log(overlaid_client_config)}')
     _set_loaded_config(overlaid_client_config)
     _set_loaded_config_path([user_config_path, project_config_path])
 
@@ -985,9 +997,9 @@ def override_skypilot_config(
                 'Failed to override the SkyPilot config on API '
                 'server with your local SkyPilot config:\n'
                 '=== SkyPilot config on API server ===\n'
-                f'{yaml_utils.dump_yaml_str(dict(original_config))}\n'
+                f'{_dump_for_log(original_config)}\n'
                 '=== Your local SkyPilot config ===\n'
-                f'{yaml_utils.dump_yaml_str(dict(override_configs))}\n'
+                f'{_dump_for_log(override_configs)}\n'
                 f'Details: {e}') from e
     finally:
         _set_loaded_config(original_config)
@@ -1293,8 +1305,7 @@ def remove_queue_name_from_config() -> Iterator[None]:
         pop_if_set(('workspaces', workspace_name, 'kubernetes'))
         remove_from_context_configs(
             ('workspaces', workspace_name, 'kubernetes'))
-    logger.debug(
-        f'config without local queue: {yaml_utils.dump_yaml_str(dict(config))}')
+    logger.debug(f'config without local queue: {_dump_for_log(config)}')
     with replace_skypilot_config(config):
         yield
 
@@ -1345,7 +1356,7 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     parsed_config = _compose_cli_config(cli_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'applying following CLI overrides: \n'
-                     f'{yaml_utils.dump_yaml_str(dict(parsed_config))}')
+                     f'{_dump_for_log(parsed_config)}')
     _set_loaded_config(
         overlay_skypilot_config(original_config=_get_loaded_config(),
                                 override_configs=parsed_config))
@@ -1399,6 +1410,9 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
 
             def _set_config_yaml_to_db(key: str, config: config_utils.Config):
                 engine = _db_manager.get_engine()
+                # Persisting, not logging: this value is read back as the
+                # server config, so it must be the real one. Do not route it
+                # through _dump_for_log().
                 config_str = yaml_utils.dump_yaml_str(dict(config))
                 with orm.Session(engine) as session:
                     if (engine.dialect.name ==

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -88,19 +88,6 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
-
-def _dump_for_log(config: config_utils.Config) -> str:
-    """Serializes a config for a log line or an error message.
-
-    Never use yaml_utils.dump_yaml_str() directly on a config for that purpose:
-    a config can carry credentials (see
-    config_utils.SENSITIVE_CONFIG_PATHS), and a debug dump is the one place
-    they escape into somewhere durable and widely readable.
-    """
-    return yaml_utils.dump_yaml_str(
-        config_utils.redact_sensitive_values(config))
-
-
 # The config is generated as described below:
 #
 # (*) (Used internally) If env var {ENV_VAR_SKYPILOT_CONFIG} exists, use its
@@ -763,7 +750,7 @@ def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
             os.environ[constants.ENV_VAR_DB_CONNECTION_URI] = db_url
         if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
             logger.debug(f'Config loaded from {config_path}:\n'
-                         f'{_dump_for_log(config)}')
+                         f'{config_utils.dump_redacted_yaml(config)}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -862,7 +849,7 @@ def _reload_config_as_server() -> None:
             server_config = overlay_skypilot_config(server_config, db_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'server config: \n'
-                     f'{_dump_for_log(server_config)}')
+                     f'{config_utils.dump_redacted_yaml(server_config)}')
     _set_loaded_config(server_config)
     _set_loaded_config_path(server_config_path)
 
@@ -886,8 +873,9 @@ def _reload_config_as_client() -> None:
         overlaid_client_config = overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
-        logger.debug(f'client config (before task and CLI overrides): \n'
-                     f'{_dump_for_log(overlaid_client_config)}')
+        logger.debug(
+            f'client config (before task and CLI overrides): \n'
+            f'{config_utils.dump_redacted_yaml(overlaid_client_config)}')
     _set_loaded_config(overlaid_client_config)
     _set_loaded_config_path([user_config_path, project_config_path])
 
@@ -997,9 +985,9 @@ def override_skypilot_config(
                 'Failed to override the SkyPilot config on API '
                 'server with your local SkyPilot config:\n'
                 '=== SkyPilot config on API server ===\n'
-                f'{_dump_for_log(original_config)}\n'
+                f'{config_utils.dump_redacted_yaml(original_config)}\n'
                 '=== Your local SkyPilot config ===\n'
-                f'{_dump_for_log(override_configs)}\n'
+                f'{config_utils.dump_redacted_yaml(override_configs)}\n'
                 f'Details: {e}') from e
     finally:
         _set_loaded_config(original_config)
@@ -1305,7 +1293,9 @@ def remove_queue_name_from_config() -> Iterator[None]:
         pop_if_set(('workspaces', workspace_name, 'kubernetes'))
         remove_from_context_configs(
             ('workspaces', workspace_name, 'kubernetes'))
-    logger.debug(f'config without local queue: {_dump_for_log(config)}')
+    logger.debug(
+        f'config without local queue: {config_utils.dump_redacted_yaml(config)}'
+    )
     with replace_skypilot_config(config):
         yield
 
@@ -1356,7 +1346,7 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     parsed_config = _compose_cli_config(cli_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'applying following CLI overrides: \n'
-                     f'{_dump_for_log(parsed_config)}')
+                     f'{config_utils.dump_redacted_yaml(parsed_config)}')
     _set_loaded_config(
         overlay_skypilot_config(original_config=_get_loaded_config(),
                                 override_configs=parsed_config))
@@ -1412,7 +1402,7 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 engine = _db_manager.get_engine()
                 # Persisting, not logging: this value is read back as the
                 # server config, so it must be the real one. Do not route it
-                # through _dump_for_log().
+                # through config_utils.dump_redacted_yaml().
                 config_str = yaml_utils.dump_yaml_str(dict(config))
                 with orm.Session(engine) as session:
                     if (engine.dialect.name ==

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -223,9 +223,9 @@ def apply(
     # repr shape, so this keeps working if the request grows a field.
     logger.debug(
         'Mutated user request: %s',
-        dataclasses.replace(
-            mutated_user_request,
-            skypilot_config=config_utils.redact_sensitive_values(
-                mutated_user_request.skypilot_config)))
+        dataclasses.replace(mutated_user_request,
+                            skypilot_config=config_utils.Config(
+                                config_utils.redact_sensitive_values(
+                                    mutated_user_request.skypilot_config))))
     mutated_dag.policy_applied = True
     return mutated_dag, mutated_config

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -1,6 +1,7 @@
 """Admin policy utils."""
 import contextlib
 import copy
+import dataclasses
 import importlib
 import typing
 from typing import Iterator, Optional, Tuple, Union
@@ -216,6 +217,15 @@ def apply(
         mutated_dag.graph.add_edge(mutated_dag.tasks[u_idx],
                                    mutated_dag.tasks[v_idx])
 
-    logger.debug(f'Mutated user request: {mutated_user_request}')
+    # MutatedUserRequest carries the whole SkyPilot config, so its repr would
+    # print api_server.service_account_token and any docker-login password in
+    # full. Log a copy whose config is redacted; dataclasses.replace keeps the
+    # repr shape, so this keeps working if the request grows a field.
+    logger.debug(
+        'Mutated user request: %s',
+        dataclasses.replace(
+            mutated_user_request,
+            skypilot_config=config_utils.redact_sensitive_values(
+                mutated_user_request.skypilot_config)))
     mutated_dag.policy_applied = True
     return mutated_dag, mutated_config

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sky import exceptions
 from sky import sky_logging
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -193,6 +194,18 @@ def redact_sensitive_values(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     for path in SENSITIVE_CONFIG_PATHS:
         _redact_path(redacted, path)
     return redacted
+
+
+def dump_redacted_yaml(config: Optional[Dict[str, Any]]) -> str:
+    """Serializes a config for a log line or an error message.
+
+    Never call yaml_utils.dump_yaml_str() on a config for that purpose: a
+    config can carry credentials (see SENSITIVE_CONFIG_PATHS), and a debug dump
+    is the one place they escape into somewhere durable and widely readable.
+    Use this instead, wherever the destination is a log or a message rather
+    than storage.
+    """
+    return yaml_utils.dump_yaml_str(redact_sensitive_values(config))
 
 
 def _check_allowed_and_disallowed_override_keys(

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -136,6 +136,19 @@ for _controller in ('jobs', 'serve'):
 del _controller, _resources_path
 
 
+def register_sensitive_config_paths(paths: List[Tuple[str, ...]]) -> None:
+    """Registers additional config paths whose values must not be logged.
+
+    For config keys added outside this schema -- see
+    schemas.register_plugin_property() and its siblings, and
+    skypilot_config.register_task_overrideable_config_key(). A path registered
+    here is redacted by redact_sensitive_values() like any built-in one, so a
+    plugin that adds a credential-bearing key can keep it out of logs without
+    editing this list. Mirrors provision.common.register_sensitive_fields().
+    """
+    SENSITIVE_CONFIG_PATHS.extend(paths)
+
+
 def _redact_path(node: Any, path: Tuple[str, ...]) -> None:
     """Replaces `node`'s value at `path` with REDACTED_VALUE, in place.
 

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -103,6 +103,85 @@ class Config(Dict[str, Any]):
         return cls(**config)
 
 
+# What a redacted secret is replaced with. Matches
+# provision.common.ProvisionConfig.get_redacted_config().
+REDACTED_VALUE = '<redacted>'
+
+# Config paths whose *value* is a credential, and so must never reach a log
+# line or an error message. Only values are hidden -- the key stays, so a dump
+# still shows that the field was set.
+#
+# A path component of '*' matches every key of a mapping and every element of a
+# sequence. It is needed because `resources` accepts `any_of`/`ordered` lists,
+# each element of which can carry its own docker login.
+#
+# Deliberately excluded: fields naming a credential rather than holding one --
+# logs.{aws,gcp}.credentials_file and workspaces.*.nebius.credentials_file_path
+# are filesystem paths, and hiding them costs debuggability while revealing
+# nothing.
+SENSITIVE_CONFIG_PATHS: List[Tuple[str, ...]] = [
+    # A connection URI, so it embeds the database password.
+    (
+        'db',),
+    # A bearer token for the API server: whoever reads it holds the roles of
+    # the service account it was minted for.
+    ('api_server', 'service_account_token'),
+]
+for _controller in ('jobs', 'serve'):
+    for _resources_path in (('resources',), ('resources', 'any_of', '*'),
+                            ('resources', 'ordered', '*')):
+        SENSITIVE_CONFIG_PATHS.append((_controller, 'controller') +
+                                      _resources_path +
+                                      ('_docker_login_config', 'password'))
+del _controller, _resources_path
+
+
+def _redact_path(node: Any, path: Tuple[str, ...]) -> None:
+    """Replaces `node`'s value at `path` with REDACTED_VALUE, in place.
+
+    Missing intermediate keys are not an error: the paths describe every field
+    that *could* hold a secret, and a given config sets few of them.
+    """
+    if not path:
+        return
+    key, rest = path[0], path[1:]
+    if key == '*':
+        children: Any
+        if isinstance(node, dict):
+            children = node.values()
+        elif isinstance(node, (list, tuple)):
+            children = node
+        else:
+            return
+        for child in children:
+            _redact_path(child, rest)
+        return
+    if not isinstance(node, dict) or key not in node:
+        return
+    if not rest:
+        # Leave an unset field unset, so redaction cannot be mistaken for a
+        # value that was actually configured.
+        if node[key] is not None:
+            node[key] = REDACTED_VALUE
+        return
+    _redact_path(node[key], rest)
+
+
+def redact_sensitive_values(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Returns a copy of `config` safe to log, secret values replaced.
+
+    Use this for every dump of a SkyPilot config into a log line or an error
+    message. The input is not modified, so the live config keeps the values it
+    needs.
+    """
+    if not config:
+        return {}
+    redacted = copy.deepcopy(dict(config))
+    for path in SENSITIVE_CONFIG_PATHS:
+        _redact_path(redacted, path)
+    return redacted
+
+
 def _check_allowed_and_disallowed_override_keys(
     key: str,
     allowed_override_keys: Optional[List[Tuple[str, ...]]] = None,

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -1359,7 +1359,14 @@ def services_account_token_configured_in_env_file() -> bool:
     if file_path is not None:
         with open(file_path, 'r') as f:
             content = f.read()
-            print(content, file=sys.stderr, flush=True)
+            # Which env-file config a run picked up is worth seeing in the
+            # log, but the file is a client config: it carries
+            # api_server.service_account_token in plaintext. Print it through
+            # the same redaction the config dumps use, never raw.
+            print(config_utils.dump_redacted_yaml(
+                yaml_utils.safe_load(content)),
+                  file=sys.stderr,
+                  flush=True)
             return 'service_account_token' in content
     return False
 

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -1,6 +1,8 @@
 import contextlib
 import copy
 import importlib
+import io
+import logging
 import os
 import subprocess
 import sys
@@ -979,3 +981,42 @@ def test_add_volumes_policy_server_side_vs_client_side(add_volumes_policy_cls,
             server_mutated_request.task.volumes)
     assert client_mutated_request.task.volumes['/mnt/data0'] == 'pvc0'
     assert server_mutated_request.task.volumes['/mnt/data0'] == 'pvc0'
+
+
+def test_mutated_user_request_log_redacts_secrets(add_example_policy_paths,
+                                                  task, tmp_path):
+    """The mutated-request debug log must not carry the API server token.
+
+    MutatedUserRequest holds the whole SkyPilot config, so logging it renders
+    the config as a dict repr -- a different path from the YAML config dumps,
+    and one that leaked the token into CI logs until it was redacted too.
+    """
+    token = 'sky_eyJhbGciOiJIUzI1NiJ9.CANARYTOKENVALUE.sig'
+    config_path = tmp_path / 'config.yaml'
+    config_path.write_text('admin_policy: example_policy.AddLabelsPolicy\n'
+                           'api_server:\n'
+                           '  endpoint: https://api.example.com\n'
+                           f'  service_account_token: {token}\n')
+
+    # sky loggers do not propagate to root, so caplog cannot see them; attach
+    # a handler to the emitting logger directly.
+    emitter = logging.getLogger('sky.utils.admin_policy_utils')
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.DEBUG)
+    previous_level = emitter.level
+    emitter.addHandler(handler)
+    emitter.setLevel(logging.DEBUG)
+    try:
+        _load_task_and_apply_policy(task, str(config_path))
+    finally:
+        emitter.removeHandler(handler)
+        emitter.setLevel(previous_level)
+
+    logged = stream.getvalue()
+    assert 'Mutated user request:' in logged, (
+        f'expected the debug line to be emitted, got: {logged!r}')
+    assert token not in logged, 'the API token reached a log line'
+    assert '<redacted>' in logged, (
+        'the token should be replaced, not dropped, so the log still shows '
+        'that the field was set')

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -1212,3 +1212,105 @@ def test_merge_k8s_configs_claims_merged_by_name():
     assert len(claims) == 3
     assert names == ['roce-claim', 'cd', 'extra-claim']
     assert len(names) == len(set(names))
+
+
+def test_redact_sensitive_values() -> None:
+    """Secret values are hidden from a config that is about to be logged."""
+    token = 'sky_eyJhbGciOiJIUzI1NiJ9.payload.signature'
+    config = {
+        'api_server': {
+            'endpoint': 'https://api.example.com',
+            'service_account_token': token,
+        },
+        'db': 'postgresql://user:hunter2@host:5432/state',
+        'active_workspace': 'default',
+        'logs': {
+            'aws': {
+                'credentials_file': '~/.aws/credentials'
+            }
+        },
+    }
+    original = copy.deepcopy(config)
+
+    redacted = config_utils.redact_sensitive_values(config)
+
+    assert redacted['api_server'][
+        'service_account_token'] == config_utils.REDACTED_VALUE
+    assert redacted['db'] == config_utils.REDACTED_VALUE
+    # Non-secrets survive, including a field that merely names a credential
+    # file rather than holding one.
+    assert redacted['api_server']['endpoint'] == 'https://api.example.com'
+    assert redacted['active_workspace'] == 'default'
+    assert redacted['logs']['aws']['credentials_file'] == '~/.aws/credentials'
+    # The caller still needs the real values, so the input is untouched.
+    assert config == original
+
+
+def test_redact_sensitive_values_docker_login_lists() -> None:
+    """A docker login password is hidden inside any_of / ordered entries."""
+    config = {
+        'jobs': {
+            'controller': {
+                'resources': {
+                    '_docker_login_config': {
+                        'username': 'u',
+                        'password': 'direct',
+                    },
+                    'any_of': [
+                        {
+                            '_docker_login_config': {
+                                'password': 'in-any-of'
+                            }
+                        },
+                        {
+                            'infra': 'aws'
+                        },
+                    ],
+                    'ordered': [{
+                        '_docker_login_config': {
+                            'password': 'in-ordered'
+                        }
+                    }],
+                }
+            }
+        }
+    }
+
+    redacted = config_utils.redact_sensitive_values(config)
+
+    resources = redacted['jobs']['controller']['resources']
+    assert resources['_docker_login_config'][
+        'password'] == config_utils.REDACTED_VALUE
+    assert resources['any_of'][0]['_docker_login_config'][
+        'password'] == config_utils.REDACTED_VALUE
+    assert resources['ordered'][0]['_docker_login_config'][
+        'password'] == config_utils.REDACTED_VALUE
+    # The username is not a secret and identifies which login was used.
+    assert resources['_docker_login_config']['username'] == 'u'
+    # An entry without a docker login is left alone.
+    assert resources['any_of'][1] == {'infra': 'aws'}
+
+
+def test_redact_sensitive_values_absent_and_empty() -> None:
+    """Redaction neither invents keys nor trips over missing ones."""
+    assert config_utils.redact_sensitive_values(None) == {}
+    assert config_utils.redact_sensitive_values({}) == {}
+
+    # An unset secret stays unset, so a redaction marker never implies that a
+    # value was configured.
+    config = {'api_server': {'service_account_token': None}}
+    assert config_utils.redact_sensitive_values(config) == {
+        'api_server': {
+            'service_account_token': None
+        }
+    }
+
+    # Paths that do not exist are simply skipped.
+    assert config_utils.redact_sensitive_values(
+        {'kubernetes': {
+            'autoscaler': 'karpenter'
+        }}) == {
+            'kubernetes': {
+                'autoscaler': 'karpenter'
+            }
+        }

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -1314,3 +1314,36 @@ def test_redact_sensitive_values_absent_and_empty() -> None:
                 'autoscaler': 'karpenter'
             }
         }
+
+
+def test_register_sensitive_config_paths() -> None:
+    """A plugin-registered path is redacted like a built-in one."""
+    original = list(config_utils.SENSITIVE_CONFIG_PATHS)
+    try:
+        config_utils.register_sensitive_config_paths([
+            ('my_plugin', 'api_key'),
+            ('my_plugin', 'endpoints', '*', 'token'),
+        ])
+        config = {
+            'my_plugin': {
+                'api_key': 'plugin-secret',
+                'name': 'keep-me',
+                'endpoints': {
+                    'east': {
+                        'token': 'east-secret',
+                        'url': 'https://east.example.com',
+                    },
+                },
+            },
+        }
+
+        redacted = config_utils.redact_sensitive_values(config)
+
+        plugin = redacted['my_plugin']
+        assert plugin['api_key'] == config_utils.REDACTED_VALUE
+        assert plugin['endpoints']['east'][
+            'token'] == config_utils.REDACTED_VALUE
+        assert plugin['name'] == 'keep-me'
+        assert plugin['endpoints']['east']['url'] == 'https://east.example.com'
+    finally:
+        config_utils.SENSITIVE_CONFIG_PATHS[:] = original

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -1347,3 +1347,18 @@ def test_register_sensitive_config_paths() -> None:
         assert plugin['endpoints']['east']['url'] == 'https://east.example.com'
     finally:
         config_utils.SENSITIVE_CONFIG_PATHS[:] = original
+
+
+def test_dump_redacted_yaml() -> None:
+    """The log-facing serializer hides secrets and keeps the rest readable."""
+    dumped = config_utils.dump_redacted_yaml({
+        'api_server': {
+            'endpoint': 'https://api.example.com',
+            'service_account_token': 'sky_eyJhbGciOiJIUzI1NiJ9.canary.sig',
+        },
+    })
+
+    assert 'canary' not in dumped
+    assert 'service_account_token: <redacted>' in dumped
+    assert 'endpoint: https://api.example.com' in dumped
+    assert config_utils.dump_redacted_yaml(None) == '{}\n'


### PR DESCRIPTION
## Summary

A SkyPilot config gets rendered into a log line or an error message in nine places, and every one of them printed credentials verbatim. The one that matters most is `api_server.service_account_token`, a bearer token for the API server that can be created with no expiry:

```
D skypilot_config.py:752] Config loaded from ~/.sky/config.yaml:
D skypilot_config.py:752] api_server:
D skypilot_config.py:752]   endpoint: https://api.example.com
D skypilot_config.py:752]   service_account_token: sky_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ...
```

Whoever reads that line holds the roles of the service account it was minted for, until someone explicitly rotates it.

This is not only a `SKYPILOT_DEBUG=1` concern. `sky api start` tells the user where to look:

```
└── View API server logs at: ~/.sky/api_server/server.log
```

and on current master that file contains the credential from server boot onward. CI is the acute case: debug logging is commonly on, the config carries a token so the client can reach a remote API server, and job logs outlive the run and are broadly readable.

`db` was already recognised as sensitive, handled by popping it out before one of the dumps:

```python
# pop the db url from the config, and set it to the env var.
# this is to avoid db url (considered a sensitive value)
# being printed with the rest of the config.
db_url = config.pop_nested(('db',), None)
```

That fixes one field at one site, so it does not generalize — and two of the nine sites are error messages rather than debug logs.

## Three different shapes, not one

The leak did not have a single form, which is why this touches more than one module:

| shape | where | example |
|---|---|---|
| YAML config dump | 7 sites in `skypilot_config.py`, 1 in `sky/server/requests/executor.py` | `service_account_token: sky_eyJ...` |
| Python dict repr | `admin_policy_utils.py` logging `MutatedUserRequest`, which holds the whole config | `skypilot_config={'api_server': {'service_account_token': 'sky_eyJ...'}}` |
| raw `print` | `tests/smoke_tests/smoke_tests_utils.py` reading the env file to answer a boolean and dumping it on the way past | the whole client config, verbatim |

A YAML-only fix covers the first row and misses the other two.

## What changes

- `config_utils.SENSITIVE_CONFIG_PATHS` — the paths whose *value* is a credential: `db`, `api_server.service_account_token`, and the `jobs`/`serve` controller `_docker_login_config.password`, including inside `any_of` / `ordered` resource lists (a `*` path component matches every mapping value and sequence element).
- `config_utils.redact_sensitive_values()` / `dump_redacted_yaml()` — return a copy with those values replaced by `<redacted>`. Modelled on the existing `provision.common.ProvisionConfig.get_redacted_config()`.
- `config_utils.register_sensitive_config_paths()` — config keys arrive from outside this schema via `schemas.register_plugin_property()` and friends, and `skypilot_config.register_task_overrideable_config_key()`. This is the counterpart to `provision.common.register_sensitive_fields()` so such a key can be declared without editing the core list.
- Every log/error serialization in `skypilot_config.py` and `executor.py` now goes through the one helper.
- `admin_policy_utils.py` logs a copy of the request whose config is redacted. `dataclasses.replace` keeps the repr shape, so the line reads the same and survives the dataclass gaining a field.
- `smoke_tests_utils.py` prints the env-file config through the same redaction rather than raw.

Keys are kept and only values replaced, so a dump still shows which fields were set. Inputs are never modified — callers keep the real values.

## What deliberately does not change

- **The config persisted to the database.** Redacting there would write `<redacted>` back as the live server config. It is the only remaining `dump_yaml_str(dict(config))` in `skypilot_config.py`, and is commented as such.
- **Fields that name a credential rather than hold one** — `logs.{aws,gcp}.credentials_file`, `workspaces.*.nebius.credentials_file_path`. They are filesystem paths; hiding them costs debuggability and reveals nothing.
- **An unset secret stays unset** rather than becoming `<redacted>`, so the marker never implies a value was configured.
- **Ordinary command output.** A `sky launch` without debug logging is byte-identical before and after; nothing dumps config at INFO level. This PR changes what debug output and log files contain, not what a normal command prints.

A known gap, stated plainly: `kubernetes.pod_config` is `additionalProperties: true`, so a credential typed into it at an arbitrary path still dumps. A key-name heuristic does not solve that — on realistic configs it scores five false positives (a daemon's interval config, a bool, a list of Kubernetes secret *names*) to one true positive, and misses a secret in a `pod_config` env entry entirely, because there the credential's key is literally `value`. `register_sensitive_config_paths()` is the extension point; value-shaped detection would be a separate change.

## Test plan

**Unit tests** — `pytest tests/unit_tests/test_sky/utils/test_config_utils.py`, 50 passed. New cases cover the `api_server`/`db` values, docker-login passwords nested in `any_of`/`ordered`, plugin-registered paths including a wildcard, the absent/empty/`None` edges, and `dump_redacted_yaml`.

`pytest tests/unit_tests/test_admin_policy.py`, 22 passed. A new case applies a policy with a token-bearing config, captures what `admin_policy_utils` logs, and asserts the token is absent and `<redacted>` present. Reverting the redaction makes it fail with `the API token reached a log line`, so it is a real guard rather than a tautology. (`sky` loggers set `propagate = False`, so it attaches a handler to the emitting logger instead of using `caplog`.)

**Local A/B against two API servers**, one per commit, each confirmed via `/api/health` to be running its own code, same config carrying a fake docker-login password:

```bash
SKYPILOT_DEBUG=1 sky launch -y --dryrun -c demo task.yaml
grep -r 'password: ' ~/.sky/api_server/
```

|  | before | after |
|---|---|---|
| client debug output | 158 lines, 3 with the secret | 158 lines, 0 |
| `server.log` + `request_logs/` | 78 occurrences across 13 files | 0 across 0 files |
| `sky launch` without debug | identical output, no secret | identical output, no secret |

Surrounding lines are unchanged — same sites, same order, same content, only the secret differs.

**Smoke run against a remote API server** (29 test jobs, config carrying a real service-account token), grepping every job log for the token:

| | raw token occurrences | jobs containing it |
|---|---|---|
| before | 92 | 28 / 29 |
| after the config-dump + env-file fixes | 41 | 20 / 29 |
| after the `MutatedUserRequest` fix | **0** | **0 / 29** |

The remaining 41 were found by attributing every occurrence to its emitter rather than by inspection; all 41 turned out to be one source. The final run also finds no `sky_ey...` JWT of any shape, and the suite passes.

`yapf`, `isort` and `mypy` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
