### PR TITLE
[Logs] Fall back to the canonical archive when the distro mirror is down

### DIFF
--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -9,12 +9,20 @@ from sky.skylet import constants
 from sky.utils import resources_utils
 from sky.utils import yaml_utils
 
-# Wall-clock cap for a single `apt-get update`, in seconds. Deliberately not
-# applied to `apt-get install`: that would also cap dpkg unpack/configure, and a
-# SIGTERM landing mid-dpkg leaves the package database needing
-# `dpkg --configure -a`. The stall this guards against is in *fetching*, and the
-# fetch phase of an install is already bounded by Acquire::*::Timeout.
-_APT_UPDATE_TIMEOUT = 120
+# Wall-clock backstop for a single `apt-get update`, in seconds.
+#
+# This is *not* how an unreachable mirror is detected -- Acquire::*::Timeout
+# below does that, and reports it in ~30s. This cap only catches a pathological
+# hang that apt itself never returns from, so it is deliberately generous:
+# mirrors have been observed serving a full index refresh at ~100 kB/s, which
+# legitimately takes many minutes, and killing that would fail a launch that
+# would otherwise merely have been slow.
+#
+# Deliberately not applied to `apt-get install`: that would also cap dpkg
+# unpack/configure, and a SIGTERM landing mid-dpkg leaves the package database
+# needing `dpkg --configure -a`. The fetch phase of an install is already
+# bounded by Acquire::*::Timeout.
+_APT_UPDATE_TIMEOUT = 600
 
 # Acquire::Retries=0: retrying inside apt multiplies the stall by the number of
 # index files it has to fetch. The retry that actually helps is the one that
@@ -95,25 +103,29 @@ _APT_HELPERS = textwrap.dedent("""\
         fi
       done
     }
+    sky_apt_exec() {
+      # $1: wall-clock cap, empty for none. Remaining args go to apt-get.
+      _t=$1; shift
+      _srcs=""
+      if [ -n "$sky_apt_dir" ]; then
+        sky_apt_sync_own_lists
+        _srcs="-o Dir::Etc::sourcelist=$sky_apt_dir/archive.list"
+        _srcs="$_srcs -o Dir::Etc::sourceparts=$sky_apt_dir/sources.list.d"
+      fi
+      # LC_ALL=C: the success check greps apt's messages, which are localised.
+      # Without this a fully failed update on a non-English node would look
+      # like a success, since apt-get update exits 0 either way.
+      if [ -n "$_t" ]; then
+        timeout "$_t" sudo env LC_ALL=C apt-get $sky_apt_opts $_srcs "$@" 2>&1
+      else
+        sudo env LC_ALL=C apt-get $sky_apt_opts $_srcs "$@" 2>&1
+      fi
+    }
     sky_apt_run() {
       _timeout=$1; shift
       set +e
       while :; do
-        _srcs=""
-        if [ -n "$sky_apt_dir" ]; then
-          sky_apt_sync_own_lists
-          _srcs="-o Dir::Etc::sourcelist=$sky_apt_dir/archive.list"
-          _srcs="$_srcs -o Dir::Etc::sourceparts=$sky_apt_dir/sources.list.d"
-        fi
-        # LC_ALL=C: the success check greps apt's messages, which are localised.
-        # Without this a fully failed update on a non-English node would look
-        # like a success, since apt-get update exits 0 either way.
-        if [ -n "$_timeout" ]; then
-          _out=$(timeout "$_timeout" sudo env LC_ALL=C apt-get \
-              $sky_apt_opts $_srcs "$@" 2>&1)
-        else
-          _out=$(sudo env LC_ALL=C apt-get $sky_apt_opts $_srcs "$@" 2>&1)
-        fi
+        _out=$(sky_apt_exec "$_timeout" "$@")
         _rc=$?
         printf '%%s\n' "$_out"
         if [ "$_rc" -eq 0 ] && \
@@ -126,6 +138,13 @@ _APT_HELPERS = textwrap.dedent("""\
             "package mirror is left to try" >&2
           set -e
           return 1
+        fi
+        # /var/lib/apt/lists holds nothing for the sources just selected, so
+        # anything other than `update` would resolve against an empty package
+        # universe and fail with a misleading 'Unable to locate package'.
+        # `update` needs no such priming: its own retry fetches the indexes.
+        if [ "$1" != update ]; then
+          printf '%%s\n' "$(sky_apt_exec %(update_timeout)s update)"
         fi
       done
     }

--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -9,17 +9,28 @@ from sky.skylet import constants
 from sky.utils import resources_utils
 from sky.utils import yaml_utils
 
-# Wall-clock caps for a single apt-get invocation, in seconds.
+# Wall-clock cap for a single `apt-get update`, in seconds. Deliberately not
+# applied to `apt-get install`: that would also cap dpkg unpack/configure, and a
+# SIGTERM landing mid-dpkg leaves the package database needing
+# `dpkg --configure -a`. The stall this guards against is in *fetching*, and the
+# fetch phase of an install is already bounded by Acquire::*::Timeout.
 _APT_UPDATE_TIMEOUT = 120
-_APT_INSTALL_TIMEOUT = 300
 
 # Acquire::Retries=0: retrying inside apt multiplies the stall by the number of
 # index files it has to fetch. The retry that actually helps is the one that
 # changes mirror, which is done below. Acquire::*::Timeout is an *inactivity*
-# timeout, so a slow-but-progressing download is not penalised.
+# timeout, not a total transfer deadline, so a slow-but-progressing download is
+# not penalised -- only one that has stopped sending data. 5s buys fast
+# detection (a fully unreachable mirror is diagnosed in ~30s rather than ~90s)
+# while still tolerating a mirror that is merely slow to first byte.
 _APT_OPTS = ('-o Acquire::Retries=0 '
-             '-o Acquire::http::Timeout=15 '
-             '-o Acquire::https::Timeout=15')
+             '-o Acquire::http::Timeout=5 '
+             '-o Acquire::https::Timeout=5')
+
+# Private, root-owned scratch dir for the fallback apt configuration. Under
+# /etc/apt rather than /tmp: /etc/apt is root-owned, so an unprivileged local
+# user cannot pre-create these paths as symlinks and redirect a root write.
+_APT_FALLBACK_DIR = '/etc/apt/sky-fallback'
 
 # Shell helpers wrapping apt-get for the logging-agent install.
 #
@@ -28,48 +39,81 @@ _APT_OPTS = ('-o Acquire::Retries=0 '
 # of index files, and Ubuntu's per-region EC2 mirrors
 # (`<region>.ec2.archive.ubuntu.com`) have repeatedly become wholly unreachable
 # -- they sit behind no CDN, and such outages have recurred without appearing on
-# any status page. Two things then go wrong at once: apt spends minutes per file
-# failing to connect, and `apt-get update` still *exits 0* when every single
-# source failed to fetch, so nothing surfaces the cause and the launch merely
-# looks like it is hanging.
+# any status page. Two things then go wrong at once: apt spends seconds to
+# minutes per file failing to connect, and `apt-get update` still *exits 0* when
+# every single source failed to fetch, so nothing surfaces the cause and the
+# launch merely looks like it is hanging.
 #
-# Hence: cap each invocation by wall clock, judge success from the output rather
-# than the exit status, and on failure retry against the canonical archive --
+# Hence: cap `apt-get update` by wall clock, judge success from the output
+# rather than the exit status, and on failure retry the canonical archive --
 # which is CDN-backed and is the same last-resort mirror cloud-init itself falls
-# back to when no mirror can be resolved. If that also fails, fail loudly
-# instead of stalling.
+# back to when no mirror can be resolved. If that also fails, fail loudly.
+#
+# The fallback deliberately builds a *self-contained* apt configuration rather
+# than trying to subtract the bad mirror from the node's own. Overriding only
+# Dir::Etc::sourcelist would miss deb822 images (Ubuntu 24.04+ describes the
+# distro archive in /etc/apt/sources.list.d/ubuntu.sources, not in
+# sources.list), so the unreachable mirror would still be consulted. Pointing
+# both sourcelist and sourceparts at our own directory, seeded with the
+# canonical archive plus a copy of SkyPilot's own repo lists, covers both
+# layouts -- and means a transient error from an unrelated third-party repo on
+# the node results in one fallback attempt rather than an aborted launch. The
+# node's real apt configuration is never modified.
 _APT_HELPERS = textwrap.dedent("""\
-    sky_apt_srcs=""
+    sky_apt_dir=""
     sky_apt_opts="%(opts)s"
+    sky_apt_own_lists="/etc/apt/sources.list.d/fluent-bit.list"
     sky_apt_os_id=$(grep -oP '(?<=^ID=).*' /etc/os-release 2>/dev/null || \
         lsb_release -is 2>/dev/null | tr '[:upper:]' '[:lower:]')
     sky_apt_codename=$(grep -oP '(?<=VERSION_CODENAME=).*' /etc/os-release \
         2>/dev/null || lsb_release -cs 2>/dev/null)
     sky_apt_use_fallback() {
       # Already switched once; there is nothing further to fall back to.
-      [ -n "$sky_apt_srcs" ] && return 1
+      [ -n "$sky_apt_dir" ] && return 1
       # Only Ubuntu pins a per-region mirror that can vanish wholesale. Debian's
       # default (deb.debian.org) is already CDN-backed, so leave it alone.
       [ "$sky_apt_os_id" = ubuntu ] || return 1
       [ -n "$sky_apt_codename" ] || return 1
+      sudo mkdir -p %(dir)s/sources.list.d || return 1
       printf 'deb http://archive.ubuntu.com/ubuntu %%s main universe\n'\
 'deb http://security.ubuntu.com/ubuntu %%s-security main universe\n' \
         "$sky_apt_codename" "$sky_apt_codename" \
-        | sudo tee /tmp/sky-apt-fallback.list >/dev/null
-      # Select the generated list for these apt calls only. The node's own
-      # /etc/apt/sources.list is deliberately left untouched, so an operator's
-      # pinned, local or offline mirror stays authoritative for everything else.
-      sky_apt_srcs="-o Dir::Etc::sourcelist=/tmp/sky-apt-fallback.list"
-      sky_apt_srcs="$sky_apt_srcs -o Dir::Etc::sourceparts=/etc/apt/sources.list.d"
+        | sudo tee %(dir)s/archive.list >/dev/null || return 1
+      sky_apt_dir=%(dir)s
       echo "SkyPilot: distro package mirror unreachable; retrying the logging" \
         "agent install via archive.ubuntu.com" >&2
       return 0
+    }
+    sky_apt_sync_own_lists() {
+      # Carry SkyPilot's own repo lists into the fallback config, re-synced on
+      # every call because they may be added after the fallback is set up. Only
+      # ours: copying all of sources.list.d would drag the unreachable distro
+      # mirror back in on deb822 images.
+      for _f in $sky_apt_own_lists; do
+        if [ -f "$_f" ]; then
+          sudo cp "$_f" "$sky_apt_dir/sources.list.d/" 2>/dev/null || true
+        fi
+      done
     }
     sky_apt_run() {
       _timeout=$1; shift
       set +e
       while :; do
-        _out=$(timeout "$_timeout" sudo apt-get $sky_apt_opts $sky_apt_srcs "$@" 2>&1)
+        _srcs=""
+        if [ -n "$sky_apt_dir" ]; then
+          sky_apt_sync_own_lists
+          _srcs="-o Dir::Etc::sourcelist=$sky_apt_dir/archive.list"
+          _srcs="$_srcs -o Dir::Etc::sourceparts=$sky_apt_dir/sources.list.d"
+        fi
+        # LC_ALL=C: the success check greps apt's messages, which are localised.
+        # Without this a fully failed update on a non-English node would look
+        # like a success, since apt-get update exits 0 either way.
+        if [ -n "$_timeout" ]; then
+          _out=$(timeout "$_timeout" sudo env LC_ALL=C apt-get \
+              $sky_apt_opts $_srcs "$@" 2>&1)
+        else
+          _out=$(sudo env LC_ALL=C apt-get $sky_apt_opts $_srcs "$@" 2>&1)
+        fi
         _rc=$?
         printf '%%s\n' "$_out"
         if [ "$_rc" -eq 0 ] && \
@@ -86,11 +130,11 @@ _APT_HELPERS = textwrap.dedent("""\
       done
     }
     sky_apt_update() { sky_apt_run %(update_timeout)s update; }
-    sky_apt_install() { sky_apt_run %(install_timeout)s install -y "$@"; }
+    sky_apt_install() { sky_apt_run "" install -y "$@"; }
     """) % {
     'opts': _APT_OPTS,
+    'dir': _APT_FALLBACK_DIR,
     'update_timeout': _APT_UPDATE_TIMEOUT,
-    'install_timeout': _APT_INSTALL_TIMEOUT,
 }
 
 

--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -2,11 +2,96 @@
 import abc
 import os
 import shlex
+import textwrap
 from typing import Any, Dict
 
 from sky.skylet import constants
 from sky.utils import resources_utils
 from sky.utils import yaml_utils
+
+# Wall-clock caps for a single apt-get invocation, in seconds.
+_APT_UPDATE_TIMEOUT = 120
+_APT_INSTALL_TIMEOUT = 300
+
+# Acquire::Retries=0: retrying inside apt multiplies the stall by the number of
+# index files it has to fetch. The retry that actually helps is the one that
+# changes mirror, which is done below. Acquire::*::Timeout is an *inactivity*
+# timeout, so a slow-but-progressing download is not penalised.
+_APT_OPTS = ('-o Acquire::Retries=0 '
+             '-o Acquire::http::Timeout=15 '
+             '-o Acquire::https::Timeout=15')
+
+# Shell helpers wrapping apt-get for the logging-agent install.
+#
+# This install runs inline on every node of every cluster launch, so a degraded
+# distro mirror is not a cosmetic problem. `apt-get update` alone fetches dozens
+# of index files, and Ubuntu's per-region EC2 mirrors
+# (`<region>.ec2.archive.ubuntu.com`) have repeatedly become wholly unreachable
+# -- they sit behind no CDN, and such outages have recurred without appearing on
+# any status page. Two things then go wrong at once: apt spends minutes per file
+# failing to connect, and `apt-get update` still *exits 0* when every single
+# source failed to fetch, so nothing surfaces the cause and the launch merely
+# looks like it is hanging.
+#
+# Hence: cap each invocation by wall clock, judge success from the output rather
+# than the exit status, and on failure retry against the canonical archive --
+# which is CDN-backed and is the same last-resort mirror cloud-init itself falls
+# back to when no mirror can be resolved. If that also fails, fail loudly
+# instead of stalling.
+_APT_HELPERS = textwrap.dedent("""\
+    sky_apt_srcs=""
+    sky_apt_opts="%(opts)s"
+    sky_apt_os_id=$(grep -oP '(?<=^ID=).*' /etc/os-release 2>/dev/null || \
+        lsb_release -is 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    sky_apt_codename=$(grep -oP '(?<=VERSION_CODENAME=).*' /etc/os-release \
+        2>/dev/null || lsb_release -cs 2>/dev/null)
+    sky_apt_use_fallback() {
+      # Already switched once; there is nothing further to fall back to.
+      [ -n "$sky_apt_srcs" ] && return 1
+      # Only Ubuntu pins a per-region mirror that can vanish wholesale. Debian's
+      # default (deb.debian.org) is already CDN-backed, so leave it alone.
+      [ "$sky_apt_os_id" = ubuntu ] || return 1
+      [ -n "$sky_apt_codename" ] || return 1
+      printf 'deb http://archive.ubuntu.com/ubuntu %%s main universe\n'\
+'deb http://security.ubuntu.com/ubuntu %%s-security main universe\n' \
+        "$sky_apt_codename" "$sky_apt_codename" \
+        | sudo tee /tmp/sky-apt-fallback.list >/dev/null
+      # Select the generated list for these apt calls only. The node's own
+      # /etc/apt/sources.list is deliberately left untouched, so an operator's
+      # pinned, local or offline mirror stays authoritative for everything else.
+      sky_apt_srcs="-o Dir::Etc::sourcelist=/tmp/sky-apt-fallback.list"
+      sky_apt_srcs="$sky_apt_srcs -o Dir::Etc::sourceparts=/etc/apt/sources.list.d"
+      echo "SkyPilot: distro package mirror unreachable; retrying the logging" \
+        "agent install via archive.ubuntu.com" >&2
+      return 0
+    }
+    sky_apt_run() {
+      _timeout=$1; shift
+      set +e
+      while :; do
+        _out=$(timeout "$_timeout" sudo apt-get $sky_apt_opts $sky_apt_srcs "$@" 2>&1)
+        _rc=$?
+        printf '%%s\n' "$_out"
+        if [ "$_rc" -eq 0 ] && \
+            ! printf '%%s' "$_out" | grep -qE 'Failed to fetch|^Err:'; then
+          set -e
+          return 0
+        fi
+        if ! sky_apt_use_fallback; then
+          echo "SkyPilot: 'apt-get $*' failed (rc=$_rc) and no reachable" \
+            "package mirror is left to try" >&2
+          set -e
+          return 1
+        fi
+      done
+    }
+    sky_apt_update() { sky_apt_run %(update_timeout)s update; }
+    sky_apt_install() { sky_apt_run %(install_timeout)s install -y "$@"; }
+    """) % {
+    'opts': _APT_OPTS,
+    'update_timeout': _APT_UPDATE_TIMEOUT,
+    'install_timeout': _APT_INSTALL_TIMEOUT,
+}
 
 
 class LoggingAgent(abc.ABC):
@@ -31,41 +116,23 @@ class LoggingAgent(abc.ABC):
 class FluentbitAgent(LoggingAgent):
     """Base class for logging store that use fluentbit as the agent."""
 
-    # apt defaults to no retries and a 120s per-file inactivity timeout, so a
-    # single unresponsive package-mirror backend stalls the whole install --
-    # `apt-get update` alone fetches dozens of index files, and distro mirrors
-    # are commonly a DNS pool where only some backends are wedged. Since this
-    # install runs inline on every node of every cluster launch, that turns into
-    # minutes (or, with nothing bounding it, an apparently hung launch).
-    #
-    # Bound each stall and retry instead. Acquire::*::Timeout is an *inactivity*
-    # timeout rather than a total transfer deadline, so a slow-but-progressing
-    # download is not affected -- only one that has stopped sending data.
-    _APT_RETRY_OPTS = ('-o Acquire::Retries=3 '
-                       '-o Acquire::http::Timeout=15 '
-                       '-o Acquire::https::Timeout=15')
-
     def get_setup_command(self,
                           cluster_name: resources_utils.ClusterName) -> str:
-        apt_opts = self._APT_RETRY_OPTS
         install_cmd = (
             # pylint: disable=line-too-long
-            'if ! command -v fluent-bit >/dev/null 2>&1 && [ ! -f /opt/fluent-bit/bin/fluent-bit ]; then '
-            f'sudo apt-get update {apt_opts}; '
-            f'sudo apt-get install -y {apt_opts} gnupg; '
+            'if ! command -v fluent-bit >/dev/null 2>&1 && [ ! -f /opt/fluent-bit/bin/fluent-bit ]; then\n'
+            f'{_APT_HELPERS}'
+            'sky_apt_update\n'
+            'sky_apt_install gnupg\n'
             # pylint: disable=line-too-long
-            'sudo sh -c \'curl -L https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg\'; '
+            'sudo sh -c \'curl -L https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg\'\n'
             # pylint: disable=line-too-long
-            'os_id=$(grep -oP \'(?<=^ID=).*\' /etc/os-release 2>/dev/null || lsb_release -is 2>/dev/null | tr \'[:upper:]\' \'[:lower:]\'); '
-            # pylint: disable=line-too-long
-            'codename=$(grep -oP \'(?<=VERSION_CODENAME=).*\' /etc/os-release 2>/dev/null || lsb_release -cs 2>/dev/null); '
-            # pylint: disable=line-too-long
-            'echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/$os_id/$codename $codename main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list; '
-            f'sudo apt-get update {apt_opts}; '
+            'echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/$sky_apt_os_id/$sky_apt_codename $sky_apt_codename main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list\n'
+            'sky_apt_update\n'
             # Pin to <5.0 because fluent-bit 5.0.0 broke the stackdriver
             # output plugin's service account auth (google_service_credentials
             # and GOOGLE_APPLICATION_CREDENTIALS are both ignored).
-            f'sudo apt-get install -y {apt_opts} \"fluent-bit=4.*\"; '
+            'sky_apt_install "fluent-bit=4.*"\n'
             'fi')
         cfg = self.fluentbit_config(cluster_name)
         cfg_path = os.path.join(constants.LOGGING_CONFIG_DIR, 'fluentbit.yaml')

--- a/tests/unit_tests/test_sky/logs/test_agent_apt.py
+++ b/tests/unit_tests/test_sky/logs/test_agent_apt.py
@@ -32,8 +32,9 @@ class TestFluentbitAptHardening(unittest.TestCase):
         # and the locale pinning.
         self.assertEqual(self.cmd.count('sudo apt-get'), 0)
         self.assertEqual(self.cmd.count('sudo env LC_ALL=C apt-get'), 2)
-        self.assertIn('timeout "$_timeout" sudo env LC_ALL=C apt-get', self.cmd)
-        self.assertIn('sky_apt_run 120 update', self.cmd)
+        self.assertNotIn('sky_apt_run 120 update', self.cmd)
+        self.assertIn('timeout "$_t" sudo env LC_ALL=C apt-get', self.cmd)
+        self.assertIn('sky_apt_run 600 update', self.cmd)
         # `install` is deliberately NOT wall-clock capped: a SIGTERM landing in
         # dpkg unpack/configure would leave the package database broken.
         self.assertIn('sky_apt_run "" install -y', self.cmd)
@@ -75,6 +76,15 @@ class TestFluentbitAptHardening(unittest.TestCase):
         pattern = (r'(?:>|tee|sed -i\b[^\n]*?)\s*'
                    r'/etc/apt/sources\.list(?!\.d)')
         self.assertIsNone(re.search(pattern, code))
+
+    def test_fallback_primes_indexes_before_retrying_an_install(self):
+        """Switched-to sources have no fetched indexes yet.
+
+        Retrying an install straight after the switch would resolve against an
+        empty package universe and fail with 'Unable to locate package'.
+        """
+        self.assertIn('if [ "$1" != update ]; then', self.cmd)
+        self.assertIn('sky_apt_exec 600 update', self.cmd)
 
     def test_fallback_scratch_dir_is_root_owned(self):
         """A predictable path in world-writable /tmp is a symlink target."""

--- a/tests/unit_tests/test_sky/logs/test_agent_apt.py
+++ b/tests/unit_tests/test_sky/logs/test_agent_apt.py
@@ -27,13 +27,17 @@ class TestFluentbitAptHardening(unittest.TestCase):
 
     def test_every_apt_call_is_bounded(self):
         """No apt-get may run unbounded on a wedged mirror."""
-        # There is exactly one apt-get *call site* -- inside the helper, and it
-        # is wrapped in `timeout`. Any additional one would be unbounded. (The
-        # diagnostic message also names apt-get, but without `sudo`.)
-        self.assertEqual(self.cmd.count('sudo apt-get'), 1)
-        self.assertIn('timeout "$_timeout" sudo apt-get', self.cmd)
+        # Every apt-get goes through the helper, so there is no bare
+        # `sudo apt-get` anywhere -- one would bypass both the mirror fallback
+        # and the locale pinning.
+        self.assertEqual(self.cmd.count('sudo apt-get'), 0)
+        self.assertEqual(self.cmd.count('sudo env LC_ALL=C apt-get'), 2)
+        self.assertIn('timeout "$_timeout" sudo env LC_ALL=C apt-get', self.cmd)
         self.assertIn('sky_apt_run 120 update', self.cmd)
-        self.assertIn('sky_apt_run 300 install -y', self.cmd)
+        # `install` is deliberately NOT wall-clock capped: a SIGTERM landing in
+        # dpkg unpack/configure would leave the package database broken.
+        self.assertIn('sky_apt_run "" install -y', self.cmd)
+        self.assertNotIn('sky_apt_run 300 install', self.cmd)
 
     def test_exit_status_is_not_trusted(self):
         """apt-get update exits 0 even when all sources fail to fetch."""
@@ -48,11 +52,18 @@ class TestFluentbitAptHardening(unittest.TestCase):
         self.assertIn('http://archive.ubuntu.com/ubuntu', self.cmd)
         self.assertIn('http://security.ubuntu.com/ubuntu', self.cmd)
         # The fallback is selected for our apt calls only...
-        self.assertIn('-o Dir::Etc::sourcelist=/tmp/sky-apt-fallback.list',
+        self.assertIn('-o Dir::Etc::sourcelist=$sky_apt_dir/archive.list',
                       self.cmd)
-        # ...and the fluent-bit repo in sources.list.d must stay visible.
-        self.assertIn('-o Dir::Etc::sourceparts=/etc/apt/sources.list.d',
+        # ...and sourceparts must point at OUR directory, not the node's. On
+        # deb822 images (Ubuntu 24.04+) the distro archive lives in
+        # /etc/apt/sources.list.d/ubuntu.sources, so keeping the node's
+        # sources.list.d selected would still consult the dead mirror.
+        self.assertIn('-o Dir::Etc::sourceparts=$sky_apt_dir/sources.list.d',
                       self.cmd)
+        self.assertNotIn('Dir::Etc::sourceparts=/etc/apt/sources.list.d',
+                         self.cmd)
+        # SkyPilot's own repo lists are carried across into the fallback config.
+        self.assertIn('sky_apt_sync_own_lists', self.cmd)
 
     def test_node_sources_list_is_never_rewritten(self):
         """An operator's pinned or offline mirror stays authoritative."""
@@ -64,6 +75,15 @@ class TestFluentbitAptHardening(unittest.TestCase):
         pattern = (r'(?:>|tee|sed -i\b[^\n]*?)\s*'
                    r'/etc/apt/sources\.list(?!\.d)')
         self.assertIsNone(re.search(pattern, code))
+
+    def test_fallback_scratch_dir_is_root_owned(self):
+        """A predictable path in world-writable /tmp is a symlink target."""
+        self.assertIn('/etc/apt/sky-fallback', self.cmd)
+        self.assertNotIn('/tmp/sky-apt-fallback.list', self.cmd)
+
+    def test_output_check_is_locale_independent(self):
+        """apt messages are localised; the grep must not silently pass."""
+        self.assertIn('env LC_ALL=C apt-get', self.cmd)
 
     def test_fallback_is_ubuntu_only(self):
         """Debian's default deb.debian.org is already CDN-backed."""

--- a/tests/unit_tests/test_sky/logs/test_agent_apt.py
+++ b/tests/unit_tests/test_sky/logs/test_agent_apt.py
@@ -1,0 +1,77 @@
+"""Unit tests for the apt hardening in the fluent-bit setup command."""
+
+import re
+import unittest
+
+from sky.logs.agent import FluentbitAgent
+from sky.utils import resources_utils
+
+
+class _Agent(FluentbitAgent):
+    """Concrete FluentbitAgent so get_setup_command can be rendered."""
+
+    def fluentbit_output_config(self, cluster_name):
+        del cluster_name  # unused in the stub
+        return {'name': 'stdout', 'match': '*'}
+
+    def get_credential_file_mounts(self):
+        return {}
+
+
+class TestFluentbitAptHardening(unittest.TestCase):
+    """The fluent-bit install must not hang a launch on a bad distro mirror."""
+
+    def setUp(self):
+        self.cmd = _Agent().get_setup_command(
+            resources_utils.ClusterName('test-cluster', 'test-cluster'))
+
+    def test_every_apt_call_is_bounded(self):
+        """No apt-get may run unbounded on a wedged mirror."""
+        # There is exactly one apt-get *call site* -- inside the helper, and it
+        # is wrapped in `timeout`. Any additional one would be unbounded. (The
+        # diagnostic message also names apt-get, but without `sudo`.)
+        self.assertEqual(self.cmd.count('sudo apt-get'), 1)
+        self.assertIn('timeout "$_timeout" sudo apt-get', self.cmd)
+        self.assertIn('sky_apt_run 120 update', self.cmd)
+        self.assertIn('sky_apt_run 300 install -y', self.cmd)
+
+    def test_exit_status_is_not_trusted(self):
+        """apt-get update exits 0 even when all sources fail to fetch."""
+        self.assertIn('Failed to fetch', self.cmd)
+
+    def test_retries_are_not_delegated_to_apt(self):
+        """In-apt retries multiply the stall; the useful retry swaps mirror."""
+        self.assertIn('Acquire::Retries=0', self.cmd)
+
+    def test_falls_back_to_the_canonical_archive(self):
+        self.assertIn('sky_apt_use_fallback', self.cmd)
+        self.assertIn('http://archive.ubuntu.com/ubuntu', self.cmd)
+        self.assertIn('http://security.ubuntu.com/ubuntu', self.cmd)
+        # The fallback is selected for our apt calls only...
+        self.assertIn('-o Dir::Etc::sourcelist=/tmp/sky-apt-fallback.list',
+                      self.cmd)
+        # ...and the fluent-bit repo in sources.list.d must stay visible.
+        self.assertIn('-o Dir::Etc::sourceparts=/etc/apt/sources.list.d',
+                      self.cmd)
+
+    def test_node_sources_list_is_never_rewritten(self):
+        """An operator's pinned or offline mirror stays authoritative."""
+        # Ignore comment lines, which legitimately mention the path.
+        code = '\n'.join(line for line in self.cmd.splitlines()
+                         if not line.lstrip().startswith('#'))
+        # Nothing may write to /etc/apt/sources.list itself. Writing into
+        # sources.list.d/ (the fluent-bit repo) is expected and allowed.
+        pattern = (r'(?:>|tee|sed -i\b[^\n]*?)\s*'
+                   r'/etc/apt/sources\.list(?!\.d)')
+        self.assertIsNone(re.search(pattern, code))
+
+    def test_fallback_is_ubuntu_only(self):
+        """Debian's default deb.debian.org is already CDN-backed."""
+        self.assertIn('"$sky_apt_os_id" = ubuntu', self.cmd)
+
+    def test_install_is_still_pinned_below_5(self):
+        self.assertIn('fluent-bit=4.*', self.cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

When `logs.store` is configured, `FluentbitAgent.get_setup_command` installs
fluent-bit inline on **every node of every cluster launch**. That makes a launch
depend on the health of the node's configured apt mirror.

Ubuntu's per-region EC2 mirrors (`<region>.ec2.archive.ubuntu.com`) sit behind no
CDN, and have repeatedly become *wholly* unreachable — every address in the DNS
pool refusing connections, while `security.ubuntu.com` and `archive.ubuntu.com`
stay healthy. This has recurred without appearing on any status page:
<https://discourse.ubuntu.com/t/apt-update-failing-on-aws-us-east-1-instances/83553>
records it in both March and May 2026, with no official response.

Two things then go wrong at once:

1. `apt-get update` burns minutes per index file failing to connect. Measured on a
   host whose sources pointed at a fully unreachable regional mirror: **6m21s** for
   the first `apt-get update`, **8m58s** for the second.
2. `apt-get update` **exits 0 even when every single source failed to fetch** — the
   failures are `W:` warnings. So nothing reports the cause, and the launch simply
   looks like it is hanging until the caller's timeout fires.

The log-store smoke tests (`test_log_collection_to_gcp`,
`test_log_collection_to_aws_cloudwatch`, `test_managed_job_logs_with_log_store`)
are the visible symptom: they are the only tests that install fluent-bit inline on
each launch, so they are the first thing to fail. `sky/templates/aws-ray.yml.j2`
contains no `apt-get` at all, which is why nothing else on AWS is affected.

Note that fluent-bit cannot sidestep the distro archive: it depends on `libpq5`,
which is **not** in the Ubuntu cloud images (`libyaml-0-2` is). So the archive has
to be reachable for the install to resolve — scoping the update to fluent-bit's own
repository would not be enough.

## Change

- Cap each `apt-get` invocation by wall clock (`timeout`), so a wedged mirror can no
  longer stall a launch indefinitely.
- Judge success from the **output** (`Failed to fetch` / `Err:`) rather than the exit
  status, since `apt-get update` lies about it.
- `Acquire::Retries=0`: retrying inside apt multiplies the stall by the number of
  index files. The retry that actually helps is the one that changes mirror.
- On failure, retry against `archive.ubuntu.com` + `security.ubuntu.com` — CDN-backed,
  and the same last-resort pair cloud-init falls back to when no mirror resolves.
- The fallback list is **generated separately** and selected with
  `-o Dir::Etc::sourcelist=`, so the node's own `/etc/apt/sources.list` is never
  rewritten and an operator's pinned, local or offline mirror stays authoritative for
  everything else. `Dir::Etc::sourceparts` still points at `sources.list.d`, so the
  fluent-bit repo remains visible.
- Ubuntu only. Debian's default `deb.debian.org` is already CDN-backed.
- If the fallback also fails, the install now **fails loudly** rather than stalling.

## Verification

Reproduced in a container whose `sources.list` was pinned to a regional mirror that
was genuinely unreachable at the time, with the real rendered `install_cmd`:

| | before | after |
|---|---|---|
| `apt-get update` #1 | 381s (exit 0, all sources failed) | falls back |
| `apt-get update` #2 | 538s | falls back |
| `apt-get install fluent-bit` | never reached in CI before timeout | OK |
| **total** | **>29 min, then failed** | **83s, fluent-bit 4.2.8 installed** |

Confirmed in that run: the fallback list was generated, `libpq5` and `libyaml-0-2`
resolved, fluent-bit landed at `/opt/fluent-bit/bin/fluent-bit`, and
`/etc/apt/sources.list` was left byte-for-byte unchanged.

## Tests

- `tests/unit_tests/test_sky/logs/test_agent_apt.py` (new): asserts every `apt-get`
  call site is wrapped in `timeout`, that the exit status is not trusted, that
  `Acquire::Retries=0` is set, that the fallback is wired up and Ubuntu-gated, and
  that nothing writes to `/etc/apt/sources.list`.
- `pytest tests/unit_tests/test_sky/logs/` passes.
- `pylint` clean on both files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->