### PR TITLE
[Core] Validate the volume where it is created, not only in /volumes/validate

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1532,8 +1532,10 @@ class Kubernetes(clouds.Cloud):
                              volume_name: str) -> Tuple[bool, Optional[str]]:
         """Validates that the volume name is valid for this cloud.
 
-        Follows Kubernetes DNS-1123 subdomain rules:
-        - must be <= 253 characters
+        Follows Kubernetes DNS-1123 subdomain rules, with a shorter length
+        cap: the name is also used as a pod spec.volumes[].name, which is an
+        RFC 1123 *label*.
+        - must be <= 63 characters (_MAX_VOLUME_NAME_LEN_LIMIT)
         - must match: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*' # pylint: disable=line-too-long
         """
         # Max length per DNS-1123 subdomain

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -775,14 +775,15 @@ def handle_request_error(response: 'requests.Response') -> None:
 
 
 def raise_if_rejected_synchronously(response: 'requests.Response') -> None:
-    """Raises the server's own error for a synchronous 400.
+    """Raises the server's error for a synchronous 400.
 
     An endpoint that validates before enqueuing replies 400 with a serialized
     exception instead of a request id; without this the SDK would surface a raw
-    HTTPError. Guarded like the 403 branch of `handle_request_error`: a non-JSON
-    body (a proxy's HTML error page) leaves the caller's normal path alone.
+    HTTPError. Endpoints opt in by calling this before `get_request_id`.
 
-    Endpoints opt in by calling this before `get_request_id`.
+    Always raises on a 400. A body this cannot decode -- a proxy's HTML error
+    page -- falls back to `handle_request_error`, because a caller with nothing
+    after this call would otherwise read the 400 as success.
     """
     if response.status_code != 400:
         return
@@ -791,9 +792,14 @@ def raise_if_rejected_synchronously(response: 'requests.Response') -> None:
         payload = response.json()
         if isinstance(payload, dict):
             detail = payload.get('detail')
-    except Exception:  # pylint: disable=broad-except
-        detail = None
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not parse the body of a 400 from '
+                     f'{response.url}: {e}')
     if detail is None:
+        logger.debug(f'A 400 from {response.url} carried no error detail; '
+                     f'falling back to the generic error. '
+                     f'Body: {response.text[:200]}')
+        handle_request_error(response)
         return
     with ux_utils.print_exception_no_traceback():
         raise exceptions.deserialize_exception(detail)

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -774,6 +774,31 @@ def handle_request_error(response: 'requests.Response') -> None:
                 f'{response.text}')
 
 
+def raise_if_rejected_synchronously(response: 'requests.Response') -> None:
+    """Raises the server's own error for a synchronous 400.
+
+    An endpoint that validates before enqueuing replies 400 with a serialized
+    exception instead of a request id; without this the SDK would surface a raw
+    HTTPError. Guarded like the 403 branch of `handle_request_error`: a non-JSON
+    body (a proxy's HTML error page) leaves the caller's normal path alone.
+
+    Endpoints opt in by calling this before `get_request_id`.
+    """
+    if response.status_code != 400:
+        return
+    detail = None
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            detail = payload.get('detail')
+    except Exception:  # pylint: disable=broad-except
+        detail = None
+    if detail is None:
+        return
+    with ux_utils.print_exception_no_traceback():
+        raise exceptions.deserialize_exception(detail)
+
+
 def get_request_id(response: 'requests.Response') -> RequestId[T]:
     handle_request_error(response)
     request_id = response.headers.get('X-Skypilot-Request-ID')

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -799,8 +799,10 @@ def raise_if_rejected_synchronously(response: 'requests.Response') -> None:
         logger.debug(f'A 400 from {response.url} carried no error detail; '
                      f'falling back to the generic error. '
                      f'Body: {response.text[:200]}')
+        # No `return`: this raises today, but falling through keeps the
+        # always-raises promise from depending on that. deserialize_exception
+        # turns a None detail into a generic RuntimeError.
         handle_request_error(response)
-        return
     with ux_utils.print_exception_no_traceback():
         raise exceptions.deserialize_exception(detail)
 

--- a/sky/utils/validator.py
+++ b/sky/utils/validator.py
@@ -4,6 +4,8 @@ The main motivation behind extending the existing JSON Schema validator is to
 allow for case-insensitive enum matching since this is currently not supported
 by the JSON Schema specification.
 """
+import functools
+
 import jsonschema
 
 
@@ -21,7 +23,10 @@ def case_sensitive_enum(validator, enums, instance, schema):
             f'{instance!r} is not one of {enums!r}')
 
 
-# Move this to a function to delay initialization
+# Move this to a function to delay initialization. Cached because
+# jsonschema.validators.extend() rebuilds the validator class on every call,
+# which dominates the cost of validate_schema().
+@functools.lru_cache(maxsize=1)
 def get_schema_validator():
     """Get the schema validator class, initializing it only when needed."""
     return jsonschema.validators.extend(

--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -3,7 +3,6 @@ import json
 import typing
 from typing import List, Optional
 
-from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.schemas.api import responses
@@ -13,7 +12,6 @@ from sky.server.requests import payloads
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import context
-from sky.utils import ux_utils
 from sky.volumes import volume as volume_lib
 
 if typing.TYPE_CHECKING:
@@ -87,12 +85,7 @@ def apply(
     )
     response = server_common.make_authenticated_request(
         'POST', '/volumes/apply', json=json.loads(body.model_dump_json()))
-    # The server rejects an invalid volume synchronously; surface its message
-    # instead of the raw HTTPError get_request_id would raise.
-    if response.status_code == 400:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.deserialize_exception(
-                response.json().get('detail'))
+    server_common.raise_if_rejected_synchronously(response)
     return server_common.get_request_id(response)
 
 
@@ -123,10 +116,7 @@ def validate(volume: volume_lib.Volume) -> None:
     )
     response = server_common.make_authenticated_request(
         'POST', '/volumes/validate', json=json.loads(body.model_dump_json()))
-    if response.status_code == 400:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.deserialize_exception(
-                response.json().get('detail'))
+    server_common.raise_if_rejected_synchronously(response)
 
 
 @context.contextual

--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -69,6 +69,9 @@ def apply(
 
     Returns:
         The request ID of the apply request.
+
+    Raises:
+        ValueError: If the volume is invalid.
     """
     body = payloads.VolumeApplyBody(
         name=volume.name,
@@ -84,6 +87,12 @@ def apply(
     )
     response = server_common.make_authenticated_request(
         'POST', '/volumes/apply', json=json.loads(body.model_dump_json()))
+    # The server rejects an invalid volume synchronously; surface its message
+    # instead of the raw HTTPError get_request_id would raise.
+    if response.status_code == 400:
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.deserialize_exception(
+                response.json().get('detail'))
     return server_common.get_request_id(response)
 
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -388,6 +388,9 @@ def volume_apply(
 ) -> None:
     """Creates or registers a volume.
 
+    Callers validate the volume themselves; /volumes/apply does it for API
+    clients, and the in-process callers construct their own names and configs.
+
     Args:
         name: The name of the volume.
         volume_type: The type of the volume.

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -111,6 +111,10 @@ async def volume_apply(request: fastapi.Request,
     volume_config = volume_apply_body.config
     if volume_config is None:
         volume_config = {}
+    # Clients send explicit nulls for optional config fields (the dashboard
+    # posts `namespace: null` when it is not set). validate_schema only drops
+    # None at the top level, so drop them here or the schema rejects them.
+    volume_config = {k: v for k, v in volume_config.items() if v is not None}
     volume_config['use_existing'] = volume_apply_body.use_existing
 
     supported_volume_types = [

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -162,10 +162,13 @@ async def volume_apply(request: fastapi.Request,
             },
         )
         volume.validate()
-    # Apply exactly what was validated: a size carrying a unit ('100Gi')
-    # normalizes to a different number, and the PVC spec appends 'Gi' to
-    # whatever it is given.
+    # Apply exactly what was validated. A size carrying a unit ('100Gi')
+    # normalizes to a different number and the PVC spec appends 'Gi' to
+    # whatever it is given; and when the client sends no config at all, the
+    # dict holding the defaulted access mode is local to this handler, so
+    # without this the worker gets None and cannot build a VolumeConfig.
     volume_apply_body.size = volume.size
+    volume_apply_body.config = volume_config
 
     await executor.schedule_request_async(
         request_id=request.state.request_id,

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -78,6 +78,10 @@ def _volume_errors_as_400() -> Iterator[None]:
         # Already a chosen HTTP response; do not re-wrap it as a volume error.
         raise
     except Exception as e:
+        # A malformed volume is the common case, but an internal fault lands
+        # here too and would otherwise be reported as the user's mistake with
+        # nothing in the server log.
+        logger.info(f'Rejecting volume request: {e}', exc_info=True)
         requests_lib.set_exception_stacktrace(e)
         raise fastapi.HTTPException(
             status_code=400, detail=exceptions.serialize_exception(e)) from e

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -77,11 +77,16 @@ def _volume_errors_as_400() -> Iterator[None]:
     except fastapi.HTTPException:
         # Already a chosen HTTP response; do not re-wrap it as a volume error.
         raise
+    except ValueError as e:
+        # The common case: the volume really is malformed. No stack trace.
+        logger.debug(f'Rejecting invalid volume: {e}')
+        requests_lib.set_exception_stacktrace(e)
+        raise fastapi.HTTPException(
+            status_code=400, detail=exceptions.serialize_exception(e)) from e
     except Exception as e:
-        # A malformed volume is the common case, but an internal fault lands
-        # here too and would otherwise be reported as the user's mistake with
-        # nothing in the server log.
-        logger.info(f'Rejecting volume request: {e}', exc_info=True)
+        # An internal fault lands here too, and would otherwise be reported as
+        # the user's mistake with nothing in the server log.
+        logger.exception(f'Unexpected error validating a volume: {e}')
         requests_lib.set_exception_stacktrace(e)
         raise fastapi.HTTPException(
             status_code=400, detail=exceptions.serialize_exception(e)) from e

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -1,5 +1,8 @@
 """REST API for storage management."""
 
+import contextlib
+from typing import Iterator
+
 import fastapi
 
 from sky import clouds
@@ -12,6 +15,7 @@ from sky.server.requests import requests as requests_lib
 from sky.server.requests import role_filter
 from sky.utils import registry
 from sky.utils import volume as volume_utils
+from sky.volumes import volume as volume_lib
 from sky.volumes.server import core
 
 logger = sky_logging.init_logger(__name__)
@@ -61,15 +65,30 @@ async def volume_delete(request: fastapi.Request,
     )
 
 
+@contextlib.contextmanager
+def _volume_errors_as_400() -> Iterator[None]:
+    """Reports volume build/validation failures as a synchronous 400.
+
+    Shared by /validate and /apply so the two cannot disagree on which volumes
+    are legal, or on the error shape clients have to parse.
+    """
+    try:
+        yield
+    except fastapi.HTTPException:
+        # Already a chosen HTTP response; do not re-wrap it as a volume error.
+        raise
+    except Exception as e:
+        requests_lib.set_exception_stacktrace(e)
+        raise fastapi.HTTPException(
+            status_code=400, detail=exceptions.serialize_exception(e)) from e
+
+
 @router.post('/validate')
 async def volume_validate(
         _: fastapi.Request,
         volume_validate_body: payloads.VolumeValidateBody) -> None:
     """Validates a volume."""
-    # pylint: disable=import-outside-toplevel
-    from sky.volumes import volume as volume_lib
-
-    try:
+    with _volume_errors_as_400():
         volume_config = {
             'name': volume_validate_body.name,
             'type': volume_validate_body.volume_type,
@@ -81,10 +100,6 @@ async def volume_validate(
         }
         volume = volume_lib.Volume.from_yaml_config(volume_config)
         volume.validate()
-    except Exception as e:
-        requests_lib.set_exception_stacktrace(e)
-        raise fastapi.HTTPException(status_code=400,
-                                    detail=exceptions.serialize_exception(e))
 
 
 @router.post('/apply')
@@ -128,6 +143,30 @@ async def volume_apply(request: fastapi.Request,
             raise fastapi.HTTPException(
                 status_code=400,
                 detail='Runpod network volume is only supported on Runpod')
+    # Validate here rather than trusting each client to call /validate first:
+    # the dashboard posts straight to this endpoint.
+    with _volume_errors_as_400():
+        volume = volume_lib.Volume.from_components(
+            name=volume_apply_body.name,
+            type=volume_type,
+            cloud=volume_cloud,
+            region=volume_apply_body.region,
+            zone=volume_apply_body.zone,
+            size=volume_apply_body.size,
+            labels=volume_apply_body.labels,
+            use_existing=volume_apply_body.use_existing,
+            # `use_existing` was folded into the config above for core; it is
+            # not part of the volume config schema.
+            config={
+                k: v for k, v in volume_config.items() if k != 'use_existing'
+            },
+        )
+        volume.validate()
+    # Apply exactly what was validated: a size carrying a unit ('100Gi')
+    # normalizes to a different number, and the PVC spec appends 'Gi' to
+    # whatever it is given.
+    volume_apply_body.size = volume.size
+
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.VOLUME_APPLY,

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -1,4 +1,5 @@
 """Volume types and access modes."""
+import os
 from typing import Any, Dict, Optional
 
 from sky import clouds
@@ -116,16 +117,23 @@ class Volume:
         `from_yaml_config` takes an `infra` string; callers that hold the
         resolved components instead (e.g. the volume apply request body) come
         through here so both end up in the same constructor.
+
+        Only the cloud goes through `infra`. Round-tripping a region through
+        that string is lossy -- a Kubernetes context named `ssh-<pool>` comes
+        back as `<pool>` -- so region and zone are assigned directly.
         """
-        return cls.from_yaml_config({
+        volume = cls.from_yaml_config({
             'name': name,
             'type': type,
-            'infra': infra_utils.InfraInfo(cloud, region, zone).to_str(),
+            'infra': cloud,
             'size': size,
             'labels': labels,
             'use_existing': use_existing,
             'config': config,
         })
+        volume.region = region
+        volume.zone = zone
+        return volume
 
     def to_yaml_config(self) -> Dict[str, Any]:
         """Convert the Volume to a dictionary."""
@@ -259,8 +267,12 @@ class HostPathVolume(Volume):
         if not host_path.startswith('/'):
             raise ValueError(
                 f'host_path must be an absolute path, got: {host_path!r}')
-        if host_path == '/':
-            raise ValueError('host_path must not be the root directory \'/\'')
+        # Normalize first: '/..' and '/mnt/../..' are absolute paths that
+        # resolve to the root, so a literal comparison misses them.
+        if os.path.normpath(host_path) == '/':
+            raise ValueError(
+                f'host_path must not resolve to the root directory: '
+                f'{host_path!r}')
 
 
 class RunpodNetworkVolume(Volume):

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -133,6 +133,15 @@ class Volume:
         })
         volume.region = region
         volume.zone = zone
+        # `infra` stays cloud-only and must not be read back off a Volume built
+        # this way -- cloud/region/zone are the truth here. Rebuilding it from
+        # the components would be worse than leaving it partial: the string
+        # cannot represent every region, so `ssh-mypool` would come back as
+        # `kubernetes/mypool` and read as authoritative. The one caller that
+        # sends `infra` (volumes.validate) builds its Volume from YAML instead.
+        #
+        # Assigning region/zone directly also means they skip the schema's infra
+        # pattern; fine here, they come from an already-validated request body.
         return volume
 
     def to_yaml_config(self) -> Dict[str, Any]:
@@ -268,8 +277,13 @@ class HostPathVolume(Volume):
             raise ValueError(
                 f'host_path must be an absolute path, got: {host_path!r}')
         # Normalize first: '/..' and '/mnt/../..' are absolute paths that
-        # resolve to the root, so a literal comparison misses them.
-        if os.path.normpath(host_path) == '/':
+        # resolve to the root, so a literal comparison misses them. Collapse
+        # the leading slashes too -- normpath keeps exactly two of them ('//'
+        # stays '//') because POSIX leaves that implementation-defined, but on
+        # Linux '//' is the root.
+        # This is a string check: a host_path pointing at a symlink to / still
+        # resolves to the root on the node, which cannot be seen from here.
+        if os.path.normpath('/' + host_path.lstrip('/')) == '/':
             raise ValueError(
                 f'host_path must not resolve to the root directory: '
                 f'{host_path!r}')

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -99,6 +99,34 @@ class Volume:
 
         raise ValueError(f'Invalid volume type: {vol_type_val}')
 
+    @classmethod
+    def from_components(
+            cls,
+            name: Optional[str] = None,
+            type: Optional[str] = None,  # pylint: disable=redefined-builtin
+            cloud: Optional[str] = None,
+            region: Optional[str] = None,
+            zone: Optional[str] = None,
+            size: Optional[str] = None,
+            labels: Optional[Dict[str, str]] = None,
+            use_existing: Optional[bool] = None,
+            config: Optional[Dict[str, Any]] = None) -> 'Volume':
+        """Creates a Volume from already-resolved cloud, region and zone.
+
+        `from_yaml_config` takes an `infra` string; callers that hold the
+        resolved components instead (e.g. the volume apply request body) come
+        through here so both end up in the same constructor.
+        """
+        return cls.from_yaml_config({
+            'name': name,
+            'type': type,
+            'infra': infra_utils.InfraInfo(cloud, region, zone).to_str(),
+            'size': size,
+            'labels': labels,
+            'use_existing': use_existing,
+            'config': config,
+        })
+
     def to_yaml_config(self) -> Dict[str, Any]:
         """Convert the Volume to a dictionary."""
         return {
@@ -167,7 +195,8 @@ class Volume:
 
     def validate_name(self) -> None:
         """Validates if the volume name is set."""
-        assert self.name is not None, 'Volume name must be set'
+        if not self.name:
+            raise ValueError('Volume name must be set.')
 
     def validate_size(self) -> None:
         """Validates that size is specified for new volumes."""
@@ -177,13 +206,13 @@ class Volume:
                              'use the --size flag.')
 
     def validate_cloud_compatibility(self) -> None:
-        """Validates region, zone, name, labels with the cloud."""
+        """Validates the name and labels against the cloud."""
         cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
         assert cloud_obj is not None
 
         valid, err_msg = cloud_obj.is_volume_name_valid(self.name)
         if not valid:
-            raise ValueError(f'Invalid volume name: {err_msg}')
+            raise ValueError(f'Invalid volume name {self.name!r}: {err_msg}')
 
         if self.labels:
             for key, value in self.labels.items():

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -133,15 +133,8 @@ class Volume:
         })
         volume.region = region
         volume.zone = zone
-        # `infra` stays cloud-only and must not be read back off a Volume built
-        # this way -- cloud/region/zone are the truth here. Rebuilding it from
-        # the components would be worse than leaving it partial: the string
-        # cannot represent every region, so `ssh-mypool` would come back as
-        # `kubernetes/mypool` and read as authoritative. The one caller that
-        # sends `infra` (volumes.validate) builds its Volume from YAML instead.
-        #
-        # Assigning region/zone directly also means they skip the schema's infra
-        # pattern; fine here, they come from an already-validated request body.
+        # `infra` stays cloud-only here and must not be read back: the string
+        # cannot represent every region. cloud/region/zone are the truth.
         return volume
 
     def to_yaml_config(self) -> Dict[str, Any]:
@@ -276,13 +269,9 @@ class HostPathVolume(Volume):
         if not host_path.startswith('/'):
             raise ValueError(
                 f'host_path must be an absolute path, got: {host_path!r}')
-        # Normalize first: '/..' and '/mnt/../..' are absolute paths that
-        # resolve to the root, so a literal comparison misses them. Collapse
-        # the leading slashes too -- normpath keeps exactly two of them ('//'
-        # stays '//') because POSIX leaves that implementation-defined, but on
-        # Linux '//' is the root.
-        # This is a string check: a host_path pointing at a symlink to / still
-        # resolves to the root on the node, which cannot be seen from here.
+        # normpath alone is not enough: it keeps exactly two leading slashes,
+        # and Linux reads '//' as the root. Still only a string check -- a
+        # host_path symlinked to / cannot be seen from here.
         if os.path.normpath('/' + host_path.lstrip('/')) == '/':
             raise ValueError(
                 f'host_path must not resolve to the root directory: '

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -2532,7 +2532,7 @@ class TestKubernetesVolumeNameValidation(unittest.TestCase):
             self.assertTrue(ok, msg=f'{name} should be valid, got: {reason}')
 
     def test_invalid_due_to_length(self):
-        too_long = 'a' * 254  # > 253
+        too_long = 'a' * 254  # > 63, the pod-label cap
         ok, reason = kubernetes.Kubernetes.is_volume_name_valid(too_long)
         self.assertFalse(ok)
         self.assertIn('maximum length', reason or '')

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -76,6 +76,23 @@ def client_and_executor(monkeypatch):
     return TestClient(app), scheduled
 
 
+def _http_response(status, json_body=None, text=''):
+    """A response whose raise_for_status behaves like the real one."""
+    response = mock.MagicMock(spec=requests.Response)
+    response.status_code = status
+    response.url = 'http://test/volumes/apply'
+    response.text = text if json_body is None else json.dumps(json_body)
+    response.headers = {}
+    if json_body is None:
+        response.json.side_effect = ValueError('not JSON')
+    else:
+        response.json.return_value = json_body
+    if status >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f'{status} Client Error', response=response)
+    return response
+
+
 def post_apply(client, body):
     with mock.patch.object(fastapi.Request, 'state') as mock_state:
         mock_state.request_id = 'test-request-id'
@@ -338,6 +355,28 @@ class TestSdkValidateRejection:
         assert volumes_sdk.validate(vol) is None
 
 
+class TestSyncRejectionAlwaysRaises:
+    """The helper's promise must not depend on handle_request_error raising."""
+
+    def test_raises_even_if_the_fallback_returns(self, monkeypatch):
+        # handle_request_error raises for every non-200 today. If a later change
+        # gives it an early return for some status, the helper must still raise
+        # rather than silently reporting an invalid volume as valid.
+        monkeypatch.setattr(server_common, 'handle_request_error',
+                            lambda response: None)
+        response = _http_response(400, text='<html>Bad Request</html>')
+        with pytest.raises(RuntimeError, match='Unknown server error'):
+            server_common.raise_if_rejected_synchronously(response)
+
+    def test_returns_for_a_non_400(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(server_common, 'handle_request_error',
+                            lambda response: called.append(1))
+        assert server_common.raise_if_rejected_synchronously(
+            _http_response(200, json_body={})) is None
+        assert not called
+
+
 class TestFromComponents:
     """from_components must preserve the resolved cloud/region/zone exactly."""
 
@@ -368,23 +407,6 @@ class TestFromComponents:
                                                 size=size)
         vol.validate()
         assert (vol.cloud, vol.region, vol.zone) == (cloud, region, zone)
-
-
-def _http_response(status, json_body=None, text=''):
-    """A response whose raise_for_status behaves like the real one."""
-    response = mock.MagicMock(spec=requests.Response)
-    response.status_code = status
-    response.url = 'http://test/volumes/apply'
-    response.text = text if json_body is None else json.dumps(json_body)
-    response.headers = {}
-    if json_body is None:
-        response.json.side_effect = ValueError('not JSON')
-    else:
-        response.json.return_value = json_body
-    if status >= 400:
-        response.raise_for_status.side_effect = requests.HTTPError(
-            f'{status} Client Error', response=response)
-    return response
 
 
 class TestSdkApplyRejection:

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -1,0 +1,225 @@
+"""Unit tests for the validation /volumes/apply enforces.
+
+These use the real cloud registry rather than a mocked cloud: the point is that
+the actual rules apply on the write path, not that a mocked verdict is
+forwarded.
+"""
+
+from unittest import mock
+
+import fastapi
+from fastapi.testclient import TestClient
+import pytest
+
+from sky import exceptions
+from sky.server import common as server_common
+from sky.server.requests import executor
+from sky.utils import infra_utils
+from sky.utils import volume
+from sky.volumes import volume as volume_lib
+from sky.volumes.client import sdk as volumes_sdk
+from sky.volumes.server import server
+
+
+def _pvc_body(**overrides):
+    body = {
+        'name': 'ok-vol3',
+        'volume_type': volume.VolumeType.PVC.value,
+        'cloud': 'kubernetes',
+        'region': 'my-context',
+        'size': '100Gi',
+        'config': {
+            'access_mode': volume.VolumeAccessMode.READ_WRITE_MANY.value,
+        },
+    }
+    body.update(overrides)
+    return body
+
+
+def _hostpath_body(**overrides):
+    body = {
+        'name': 'ok-hostpath',
+        'volume_type': volume.VolumeType.HOSTPATH.value,
+        'cloud': 'kubernetes',
+        'region': 'my-context',
+        'config': {
+            'host_path': '/mnt/data'
+        },
+    }
+    body.update(overrides)
+    return body
+
+
+def _runpod_body(**overrides):
+    body = {
+        'name': 'ok-runpod',
+        'volume_type': volume.VolumeType.RUNPOD_NETWORK_VOLUME.value,
+        'cloud': 'runpod',
+        'zone': 'CA-MTL-1',
+        'size': '100',
+        'config': {},
+    }
+    body.update(overrides)
+    return body
+
+
+class TestVolumeApplyValidation:
+    """/volumes/apply rejects what /volumes/validate rejects."""
+
+    @pytest.fixture
+    def client_and_executor(self, monkeypatch):
+        scheduled = mock.AsyncMock()
+        monkeypatch.setattr(executor, 'schedule_request_async', scheduled)
+        app = fastapi.FastAPI()
+        app.include_router(server.router, prefix='/volumes')
+        return TestClient(app), scheduled
+
+    @staticmethod
+    def _post(client, body):
+        with mock.patch.object(fastapi.Request, 'state') as mock_state:
+            mock_state.request_id = 'test-request-id'
+            mock_state.auth_user = None
+            return client.post('/volumes/apply', json=body)
+
+    @staticmethod
+    def _detail_message(response):
+        # /apply returns a serialized exception for volume errors and a bare
+        # string for its own type/cloud checks.
+        detail = response.json()['detail']
+        if isinstance(detail, str):
+            return detail
+        return detail.get('message', str(detail))
+
+    @pytest.mark.parametrize(
+        'body,expected',
+        [
+            # The bug this file exists for: a name the CLI refuses. The
+            # message has to name the volume, not just recite the rule.
+            (_pvc_body(name='ok_vol3'), "'ok_vol3'"),
+            (_pvc_body(name='ok_vol3'), 'DNS-1123'),
+            (_pvc_body(name='UPPER'), 'DNS-1123'),
+            (_pvc_body(name='-leading-dash'), 'DNS-1123'),
+            (_pvc_body(name=''), 'Volume name must be set'),
+            # A new volume needs a size.
+            (_pvc_body(size=None), 'Size is required for new volumes'),
+            # Labels are checked against the cloud.
+            (_pvc_body(labels={'bad key': 'v'}), 'Invalid label'),
+            # hostPath: absolute, and not the node root.
+            (_hostpath_body(config={'host_path': '/'}), 'root directory'),
+            (_hostpath_body(config={'host_path': 'relative/path'}),
+             'absolute path'),
+            (_hostpath_body(config={}), 'host_path is required'),
+            # RunPod carries the DataCenterId in the zone.
+            (_runpod_body(zone=None), 'DataCenterId is required'),
+        ])
+    def test_invalid_volume_is_rejected(self, client_and_executor, body,
+                                        expected):
+        client, scheduled = client_and_executor
+        response = self._post(client, body)
+        assert response.status_code == 400, response.text
+        assert expected in self._detail_message(response)
+        # Rejected before a request row is created.
+        scheduled.assert_not_called()
+
+    @pytest.mark.parametrize('sent,applied', [
+        ('100', '100'),
+        ('100Gi', '100'),
+        ('1Ti', '1024'),
+        ('2048Mi', '2'),
+    ])
+    def test_size_forwarded_is_the_size_validated(self, client_and_executor,
+                                                  sent, applied):
+        # _get_pvc_spec appends 'Gi', so forwarding a unit-carrying size
+        # verbatim would build an unusable quantity like '100GiGi'.
+        client, scheduled = client_and_executor
+        response = self._post(client, _pvc_body(size=sent))
+        assert response.status_code == 200, response.text
+        body = scheduled.call_args[1]['request_body']
+        assert body.size == applied
+
+    @pytest.mark.parametrize('body', [
+        _pvc_body(),
+        _pvc_body(name='dotted.name'),
+        _hostpath_body(),
+        _runpod_body(),
+        _pvc_body(size=None, use_existing=True),
+    ])
+    def test_valid_volume_is_accepted(self, client_and_executor, body):
+        client, scheduled = client_and_executor
+        response = self._post(client, body)
+        assert response.status_code == 200, response.text
+        scheduled.assert_called_once()
+
+
+class TestFromComponents:
+    """from_components must round-trip cloud/region/zone via the infra string."""
+
+    @pytest.mark.parametrize('cloud,region,zone', [
+        ('kubernetes', 'my-context', None),
+        ('kubernetes', 'arn:aws:eks:us-west-2:1:cluster/prod', None),
+        ('kubernetes', None, None),
+        ('aws', 'us-east-1', 'us-east-1a'),
+        ('aws', 'us-east-1', None),
+        ('runpod', None, 'CA-MTL-1'),
+    ])
+    def test_infra_string_round_trip(self, cloud, region, zone):
+        infra = infra_utils.InfraInfo(cloud, region, zone).to_str()
+        parsed = infra_utils.InfraInfo.from_str(infra)
+        assert (parsed.cloud, parsed.region, parsed.zone) == (cloud, region,
+                                                              zone)
+
+    @pytest.mark.parametrize('cloud,region,zone,vol_type,size', [
+        ('kubernetes', 'my-context', None, volume.VolumeType.PVC.value, '1Gi'),
+        ('kubernetes', 'arn:aws:eks:us-west-2:1:cluster/prod', None,
+         volume.VolumeType.PVC.value, '1Gi'),
+        ('runpod', None, 'CA-MTL-1',
+         volume.VolumeType.RUNPOD_NETWORK_VOLUME.value, '100'),
+    ])
+    def test_volume_keeps_resolved_components(self, cloud, region, zone,
+                                              vol_type, size):
+        vol = volume_lib.Volume.from_components(name='ok-vol',
+                                                type=vol_type,
+                                                cloud=cloud,
+                                                region=region,
+                                                zone=zone,
+                                                size=size)
+        vol.validate()
+        assert (vol.cloud, vol.region, vol.zone) == (cloud, region, zone)
+
+
+class TestSdkApplyRejection:
+    """The SDK surfaces a synchronous rejection as the server's error."""
+
+    @staticmethod
+    def _response(detail):
+        response = mock.MagicMock()
+        response.status_code = 400
+        response.json.return_value = {'detail': detail}
+        return response
+
+    def _volume(self, monkeypatch, detail):
+        # The SDK entrypoint would otherwise try to start a real API server.
+        monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(server_common, 'make_authenticated_request',
+                            lambda *a, **kw: self._response(detail))
+        vol = volume_lib.Volume.from_components(
+            name='ok-vol',
+            type=volume.VolumeType.PVC.value,
+            cloud='kubernetes',
+            region='my-context',
+            size='1Gi')
+        return vol
+
+    def test_serialized_exception_detail(self, monkeypatch):
+        detail = exceptions.serialize_exception(
+            ValueError('Invalid volume name: nope'))
+        vol = self._volume(monkeypatch, detail)
+        with pytest.raises(ValueError, match='Invalid volume name'):
+            volumes_sdk.apply(vol)
+
+    def test_plain_string_detail(self, monkeypatch):
+        # The pre-existing 400s on this endpoint return a bare string.
+        vol = self._volume(monkeypatch, 'Invalid volume type: nope')
+        with pytest.raises(RuntimeError, match='Invalid volume type'):
+            volumes_sdk.apply(vol)

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -196,13 +196,7 @@ class TestVolumeApplyValidation:
 
 
 class TestDottedNameIsAcceptedToday:
-    """Pins current dot handling so #10514 flipping it is a deliberate edit.
-
-    A dot passes the server's rule, but Kubernetes rejects a dotted
-    spec.volumes[].name, so such a volume cannot be mounted. When #10514
-    tightens the charset this test fails -- which is the point: it is the signal
-    to update the dashboard's client-side mirror in the same change.
-    """
+    """Pins dot handling so #10514 flipping it is a deliberate edit."""
 
     def test_dotted_name_still_accepted(self, client_and_executor):
         client, scheduled = client_and_executor
@@ -380,10 +374,9 @@ class TestSdkApplyRejection:
             cloud='kubernetes',
             region='my-context',
             size='1Gi')
-        # get_request_id's own error, not a decode error from the guard.
-        with pytest.raises(Exception) as exc_info:
+        # The fall-through's own error, not a decode error from the guard.
+        with pytest.raises(RuntimeError, match='Failed to process response'):
             volumes_sdk.apply(vol)
-        assert 'JSONDecode' not in type(exc_info.value).__name__
 
     def test_detail_absent_keeps_the_normal_error_path(self, monkeypatch):
         # Valid JSON with no `detail` must fall through too.
@@ -401,9 +394,8 @@ class TestSdkApplyRejection:
             cloud='kubernetes',
             region='my-context',
             size='1Gi')
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(RuntimeError, match='Failed to process response'):
             volumes_sdk.apply(vol)
-        assert 'no detail here' not in str(exc_info.value)
 
     def test_plain_string_detail(self, monkeypatch):
         # The pre-existing 400s on this endpoint return a bare string.

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -117,6 +117,11 @@ class TestVolumeApplyValidation:
             (_hostpath_body(config={'host_path': '/./..'}), 'root directory'),
             (_hostpath_body(config={'host_path': '/../../..'}),
              'root directory'),
+            # normpath keeps exactly two leading slashes, but Linux reads '//'
+            # as the root.
+            (_hostpath_body(config={'host_path': '//'}), 'root directory'),
+            (_hostpath_body(config={'host_path': '//..'}), 'root directory'),
+            (_hostpath_body(config={'host_path': '//.'}), 'root directory'),
             (_hostpath_body(config={'host_path': 'relative/path'}),
              'absolute path'),
             (_hostpath_body(config={}), 'host_path is required'),
@@ -176,20 +181,32 @@ class TestVolumeApplyValidation:
                             size='1Gi',
                             config=forwarded)
 
-    @pytest.mark.parametrize(
-        'body',
-        [
-            _pvc_body(),
-            # No dotted-name case on purpose: the rule permits dots but Kubernetes
-            # rejects a dotted spec.volumes[].name. See #10514.
-            _pvc_body(name='ok-vol-2'),
-            _hostpath_body(),
-            _runpod_body(),
-            _pvc_body(size=None, use_existing=True),
-        ])
+    @pytest.mark.parametrize('body', [
+        _pvc_body(),
+        _pvc_body(name='ok-vol-2'),
+        _hostpath_body(),
+        _runpod_body(),
+        _pvc_body(size=None, use_existing=True),
+    ])
     def test_valid_volume_is_accepted(self, client_and_executor, body):
         client, scheduled = client_and_executor
         response = post_apply(client, body)
+        assert response.status_code == 200, response.text
+        scheduled.assert_called_once()
+
+
+class TestDottedNameIsAcceptedToday:
+    """Pins current dot handling so #10514 flipping it is a deliberate edit.
+
+    A dot passes the server's rule, but Kubernetes rejects a dotted
+    spec.volumes[].name, so such a volume cannot be mounted. When #10514
+    tightens the charset this test fails -- which is the point: it is the signal
+    to update the dashboard's client-side mirror in the same change.
+    """
+
+    def test_dotted_name_still_accepted(self, client_and_executor):
+        client, scheduled = client_and_executor
+        response = post_apply(client, _pvc_body(name='dotted.name'))
         assert response.status_code == 200, response.text
         scheduled.assert_called_once()
 
@@ -343,6 +360,50 @@ class TestSdkApplyRejection:
         vol = self._volume(monkeypatch, detail)
         with pytest.raises(ValueError, match='Invalid volume name'):
             volumes_sdk.apply(vol)
+
+    def test_non_json_400_keeps_the_normal_error_path(self, monkeypatch):
+        # The guard exists for a 400 from something that is not this handler --
+        # a proxy returning an HTML error page. It must not become a
+        # JSONDecodeError, which would be worse than the HTTPError it replaced.
+        monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
+                            lambda *a, **kw: None)
+        response = mock.MagicMock()
+        response.status_code = 400
+        response.json.side_effect = ValueError('not JSON')
+        response.headers = {}
+        response.text = '<html>Bad Request</html>'
+        monkeypatch.setattr(server_common, 'make_authenticated_request',
+                            lambda *a, **kw: response)
+        vol = volume_lib.Volume.from_components(
+            name='ok-vol',
+            type=volume.VolumeType.PVC.value,
+            cloud='kubernetes',
+            region='my-context',
+            size='1Gi')
+        # get_request_id's own error, not a decode error from the guard.
+        with pytest.raises(Exception) as exc_info:
+            volumes_sdk.apply(vol)
+        assert 'JSONDecode' not in type(exc_info.value).__name__
+
+    def test_detail_absent_keeps_the_normal_error_path(self, monkeypatch):
+        # Valid JSON with no `detail` must fall through too.
+        monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
+                            lambda *a, **kw: None)
+        response = mock.MagicMock()
+        response.status_code = 400
+        response.json.return_value = {'oops': 'no detail here'}
+        response.headers = {}
+        monkeypatch.setattr(server_common, 'make_authenticated_request',
+                            lambda *a, **kw: response)
+        vol = volume_lib.Volume.from_components(
+            name='ok-vol',
+            type=volume.VolumeType.PVC.value,
+            cloud='kubernetes',
+            region='my-context',
+            size='1Gi')
+        with pytest.raises(Exception) as exc_info:
+            volumes_sdk.apply(vol)
+        assert 'no detail here' not in str(exc_info.value)
 
     def test_plain_string_detail(self, monkeypatch):
         # The pre-existing 400s on this endpoint return a bare string.

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -180,6 +180,108 @@ class TestVolumeApplyValidation:
         scheduled.assert_called_once()
 
 
+class TestRealDashboardPayloads:
+    """Bodies captured from the Add Volume dialog, verbatim.
+
+    The dialog sends explicit nulls for unset optional config fields, which
+    hand-written fixtures do not, and which the config schema rejects.
+    """
+
+    @pytest.fixture
+    def client_and_executor(self, monkeypatch):
+        scheduled = mock.AsyncMock()
+        monkeypatch.setattr(executor, 'schedule_request_async', scheduled)
+        app = fastapi.FastAPI()
+        app.include_router(server.router, prefix='/volumes')
+        return TestClient(app), scheduled
+
+    @staticmethod
+    def _post(client, body):
+        with mock.patch.object(fastapi.Request, 'state') as mock_state:
+            mock_state.request_id = 'test-request-id'
+            mock_state.auth_user = None
+            return client.post('/volumes/apply', json=body)
+
+    # Create, new PVC: namespace is null whenever the user does not set one.
+    CREATE_PVC = {
+        'name': 'ok-0',
+        'volume_type': 'k8s-pvc',
+        'cloud': 'kubernetes',
+        'region': 'a-context',
+        'size': '100',
+        'config': {
+            'storage_class_name': 'standard-rwx',
+            'access_mode': 'ReadWriteMany',
+            'namespace': None,
+        },
+        'use_existing': False,
+    }
+
+    # Create, hostPath: size is null and cleanup_on_deletion is present.
+    CREATE_HOSTPATH = {
+        'name': 'ok-host',
+        'volume_type': 'k8s-hostpath',
+        'cloud': 'kubernetes',
+        'region': 'a-context',
+        'size': None,
+        'config': {
+            'host_path': '/mnt/data',
+            'cleanup_on_deletion': True
+        },
+        'use_existing': False,
+    }
+
+    # Import an existing PVC: every field is populated from the real PVC.
+    IMPORT_PVC = {
+        'name': 'imported',
+        'volume_type': 'k8s-pvc',
+        'cloud': 'kubernetes',
+        'region': 'a-context',
+        'size': None,
+        'config': {
+            'storage_class_name': 'standard-rwx',
+            'access_mode': 'ReadWriteMany',
+            'namespace': 'default',
+        },
+        'use_existing': True,
+    }
+
+    # No storage class chosen yet -- both optional fields arrive as null.
+    CREATE_PVC_ALL_NULL = {
+        'name': 'ok-1',
+        'volume_type': 'k8s-pvc',
+        'cloud': 'kubernetes',
+        'region': 'a-context',
+        'size': '100',
+        'config': {
+            'storage_class_name': None,
+            'access_mode': 'ReadWriteMany',
+            'namespace': None,
+        },
+        'use_existing': False,
+    }
+
+    @pytest.mark.parametrize('body', [
+        CREATE_PVC,
+        CREATE_HOSTPATH,
+        IMPORT_PVC,
+        CREATE_PVC_ALL_NULL,
+    ])
+    def test_dialog_payload_is_accepted(self, client_and_executor, body):
+        client, scheduled = client_and_executor
+        response = self._post(client, body)
+        assert response.status_code == 200, response.text
+        scheduled.assert_called_once()
+
+    def test_null_config_fields_are_dropped_not_forwarded(
+            self, client_and_executor):
+        client, scheduled = client_and_executor
+        assert self._post(client, self.CREATE_PVC).status_code == 200
+        forwarded = scheduled.call_args[1]['request_body'].config
+        assert 'namespace' not in forwarded
+        assert forwarded['storage_class_name'] == 'standard-rwx'
+
+
 class TestFromComponents:
     """from_components must round-trip cloud/region/zone via the infra string."""
 

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -64,23 +64,25 @@ def _runpod_body(**overrides):
     return body
 
 
+@pytest.fixture
+def client_and_executor(monkeypatch):
+    """A /volumes test client plus the mocked executor it would enqueue to."""
+    scheduled = mock.AsyncMock()
+    monkeypatch.setattr(executor, 'schedule_request_async', scheduled)
+    app = fastapi.FastAPI()
+    app.include_router(server.router, prefix='/volumes')
+    return TestClient(app), scheduled
+
+
+def post_apply(client, body):
+    with mock.patch.object(fastapi.Request, 'state') as mock_state:
+        mock_state.request_id = 'test-request-id'
+        mock_state.auth_user = None
+        return client.post('/volumes/apply', json=body)
+
+
 class TestVolumeApplyValidation:
     """/volumes/apply rejects what /volumes/validate rejects."""
-
-    @pytest.fixture
-    def client_and_executor(self, monkeypatch):
-        scheduled = mock.AsyncMock()
-        monkeypatch.setattr(executor, 'schedule_request_async', scheduled)
-        app = fastapi.FastAPI()
-        app.include_router(server.router, prefix='/volumes')
-        return TestClient(app), scheduled
-
-    @staticmethod
-    def _post(client, body):
-        with mock.patch.object(fastapi.Request, 'state') as mock_state:
-            mock_state.request_id = 'test-request-id'
-            mock_state.auth_user = None
-            return client.post('/volumes/apply', json=body)
 
     @staticmethod
     def _detail_message(response):
@@ -107,6 +109,14 @@ class TestVolumeApplyValidation:
             (_pvc_body(labels={'bad key': 'v'}), 'Invalid label'),
             # hostPath: absolute, and not the node root.
             (_hostpath_body(config={'host_path': '/'}), 'root directory'),
+            # Absolute paths that resolve to the root: a literal '/' check
+            # misses these.
+            (_hostpath_body(config={'host_path': '/..'}), 'root directory'),
+            (_hostpath_body(config={'host_path': '/mnt/../..'}),
+             'root directory'),
+            (_hostpath_body(config={'host_path': '/./..'}), 'root directory'),
+            (_hostpath_body(config={'host_path': '/../../..'}),
+             'root directory'),
             (_hostpath_body(config={'host_path': 'relative/path'}),
              'absolute path'),
             (_hostpath_body(config={}), 'host_path is required'),
@@ -116,7 +126,7 @@ class TestVolumeApplyValidation:
     def test_invalid_volume_is_rejected(self, client_and_executor, body,
                                         expected):
         client, scheduled = client_and_executor
-        response = self._post(client, body)
+        response = post_apply(client, body)
         assert response.status_code == 400, response.text
         assert expected in self._detail_message(response)
         # Rejected before a request row is created.
@@ -133,7 +143,7 @@ class TestVolumeApplyValidation:
         # _get_pvc_spec appends 'Gi', so forwarding a unit-carrying size
         # verbatim would build an unusable quantity like '100GiGi'.
         client, scheduled = client_and_executor
-        response = self._post(client, _pvc_body(size=sent))
+        response = post_apply(client, _pvc_body(size=sent))
         assert response.status_code == 200, response.text
         body = scheduled.call_args[1]['request_body']
         assert body.size == applied
@@ -150,7 +160,7 @@ class TestVolumeApplyValidation:
             body['config'] = None
         else:
             body.pop('config')
-        response = self._post(client, body)
+        response = post_apply(client, body)
         assert response.status_code == 200, response.text
         forwarded = scheduled.call_args[1]['request_body'].config
         assert forwarded is not None
@@ -166,16 +176,20 @@ class TestVolumeApplyValidation:
                             size='1Gi',
                             config=forwarded)
 
-    @pytest.mark.parametrize('body', [
-        _pvc_body(),
-        _pvc_body(name='dotted.name'),
-        _hostpath_body(),
-        _runpod_body(),
-        _pvc_body(size=None, use_existing=True),
-    ])
+    @pytest.mark.parametrize(
+        'body',
+        [
+            _pvc_body(),
+            # No dotted-name case on purpose: the rule permits dots but Kubernetes
+            # rejects a dotted spec.volumes[].name. See #10514.
+            _pvc_body(name='ok-vol-2'),
+            _hostpath_body(),
+            _runpod_body(),
+            _pvc_body(size=None, use_existing=True),
+        ])
     def test_valid_volume_is_accepted(self, client_and_executor, body):
         client, scheduled = client_and_executor
-        response = self._post(client, body)
+        response = post_apply(client, body)
         assert response.status_code == 200, response.text
         scheduled.assert_called_once()
 
@@ -186,21 +200,6 @@ class TestRealDashboardPayloads:
     The dialog sends explicit nulls for unset optional config fields, which
     hand-written fixtures do not, and which the config schema rejects.
     """
-
-    @pytest.fixture
-    def client_and_executor(self, monkeypatch):
-        scheduled = mock.AsyncMock()
-        monkeypatch.setattr(executor, 'schedule_request_async', scheduled)
-        app = fastapi.FastAPI()
-        app.include_router(server.router, prefix='/volumes')
-        return TestClient(app), scheduled
-
-    @staticmethod
-    def _post(client, body):
-        with mock.patch.object(fastapi.Request, 'state') as mock_state:
-            mock_state.request_id = 'test-request-id'
-            mock_state.auth_user = None
-            return client.post('/volumes/apply', json=body)
 
     # Create, new PVC: namespace is null whenever the user does not set one.
     CREATE_PVC = {
@@ -269,45 +268,41 @@ class TestRealDashboardPayloads:
     ])
     def test_dialog_payload_is_accepted(self, client_and_executor, body):
         client, scheduled = client_and_executor
-        response = self._post(client, body)
+        response = post_apply(client, body)
         assert response.status_code == 200, response.text
         scheduled.assert_called_once()
 
     def test_null_config_fields_are_dropped_not_forwarded(
             self, client_and_executor):
         client, scheduled = client_and_executor
-        assert self._post(client, self.CREATE_PVC).status_code == 200
+        assert post_apply(client, self.CREATE_PVC).status_code == 200
         forwarded = scheduled.call_args[1]['request_body'].config
         assert 'namespace' not in forwarded
         assert forwarded['storage_class_name'] == 'standard-rwx'
 
 
 class TestFromComponents:
-    """from_components must round-trip cloud/region/zone via the infra string."""
+    """from_components must preserve the resolved cloud/region/zone exactly."""
 
-    @pytest.mark.parametrize('cloud,region,zone', [
-        ('kubernetes', 'my-context', None),
-        ('kubernetes', 'arn:aws:eks:us-west-2:1:cluster/prod', None),
-        ('kubernetes', None, None),
-        ('aws', 'us-east-1', 'us-east-1a'),
-        ('aws', 'us-east-1', None),
-        ('runpod', None, 'CA-MTL-1'),
-    ])
-    def test_infra_string_round_trip(self, cloud, region, zone):
-        infra = infra_utils.InfraInfo(cloud, region, zone).to_str()
-        parsed = infra_utils.InfraInfo.from_str(infra)
-        assert (parsed.cloud, parsed.region, parsed.zone) == (cloud, region,
-                                                              zone)
-
-    @pytest.mark.parametrize('cloud,region,zone,vol_type,size', [
-        ('kubernetes', 'my-context', None, volume.VolumeType.PVC.value, '1Gi'),
-        ('kubernetes', 'arn:aws:eks:us-west-2:1:cluster/prod', None,
-         volume.VolumeType.PVC.value, '1Gi'),
-        ('runpod', None, 'CA-MTL-1',
-         volume.VolumeType.RUNPOD_NETWORK_VOLUME.value, '100'),
-    ])
-    def test_volume_keeps_resolved_components(self, cloud, region, zone,
-                                              vol_type, size):
+    @pytest.mark.parametrize(
+        'cloud,region,zone,vol_type,size',
+        [
+            ('kubernetes', 'my-context', None, volume.VolumeType.PVC.value,
+             '1Gi'),
+            ('kubernetes', 'arn:aws:eks:us-west-2:1:cluster/prod', None,
+             volume.VolumeType.PVC.value, '1Gi'),
+            # An SSH node pool is a context named ssh-<pool>. Serializing this
+            # through an infra string dropped the prefix.
+            ('kubernetes', 'ssh-mypool', None, volume.VolumeType.PVC.value,
+             '1Gi'),
+            ('kubernetes', None, None, volume.VolumeType.PVC.value, '1Gi'),
+            ('runpod', None, 'CA-MTL-1',
+             volume.VolumeType.RUNPOD_NETWORK_VOLUME.value, '100'),
+            ('runpod', 'us-east', 'CA-MTL-1',
+             volume.VolumeType.RUNPOD_NETWORK_VOLUME.value, '100'),
+        ])
+    def test_resolved_components_survive(self, cloud, region, zone, vol_type,
+                                         size):
         vol = volume_lib.Volume.from_components(name='ok-vol',
                                                 type=vol_type,
                                                 cloud=cloud,

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 from sky import exceptions
+from sky import models
 from sky.server import common as server_common
 from sky.server.requests import executor
 from sky.utils import infra_utils
@@ -136,6 +137,34 @@ class TestVolumeApplyValidation:
         assert response.status_code == 200, response.text
         body = scheduled.call_args[1]['request_body']
         assert body.size == applied
+
+    @pytest.mark.parametrize('sent', [None, 'omitted'])
+    def test_defaulted_config_reaches_the_worker(self, client_and_executor,
+                                                 sent):
+        # The handler defaults access_mode into a dict that is local when the
+        # client sends no config, and VolumeConfig rejects None -- so without
+        # stamping it back the request dies in the worker.
+        client, scheduled = client_and_executor
+        body = _pvc_body()
+        if sent is None:
+            body['config'] = None
+        else:
+            body.pop('config')
+        response = self._post(client, body)
+        assert response.status_code == 200, response.text
+        forwarded = scheduled.call_args[1]['request_body'].config
+        assert forwarded is not None
+        assert forwarded['access_mode'] == (
+            volume.VolumeAccessMode.READ_WRITE_ONCE.value)
+        # Proves it can actually be turned into a VolumeConfig downstream.
+        models.VolumeConfig(name='n',
+                            type=volume.VolumeType.PVC.value,
+                            cloud='kubernetes',
+                            region='r',
+                            zone=None,
+                            name_on_cloud='noc',
+                            size='1Gi',
+                            config=forwarded)
 
     @pytest.mark.parametrize('body', [
         _pvc_body(),

--- a/tests/unit_tests/test_sky/volumes/test_apply_validation.py
+++ b/tests/unit_tests/test_sky/volumes/test_apply_validation.py
@@ -5,11 +5,13 @@ the actual rules apply on the write path, not that a mocked verdict is
 forwarded.
 """
 
+import json
 from unittest import mock
 
 import fastapi
 from fastapi.testclient import TestClient
 import pytest
+import requests
 
 from sky import exceptions
 from sky import models
@@ -292,6 +294,50 @@ class TestRealDashboardPayloads:
         assert forwarded['storage_class_name'] == 'standard-rwx'
 
 
+class TestSdkValidateRejection:
+    """validate() has nothing after the helper, so it must never return on 400.
+
+    apply() is covered by get_request_id raising afterwards; validate() is not,
+    so a 400 it cannot decode would read as "the volume is valid".
+    """
+
+    @staticmethod
+    def _volume(monkeypatch, response):
+        monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(server_common, 'make_authenticated_request',
+                            lambda *a, **kw: response)
+        return volume_lib.Volume.from_components(
+            name='ok-vol',
+            type=volume.VolumeType.PVC.value,
+            cloud='kubernetes',
+            region='my-context',
+            size='1Gi')
+
+    def test_raises_the_servers_message(self, monkeypatch):
+        detail = exceptions.serialize_exception(ValueError('nope, invalid'))
+        vol = self._volume(monkeypatch,
+                           _http_response(400, json_body={'detail': detail}))
+        with pytest.raises(ValueError, match='nope, invalid'):
+            volumes_sdk.validate(vol)
+
+    def test_raises_on_a_non_json_400(self, monkeypatch):
+        vol = self._volume(monkeypatch,
+                           _http_response(400, text='<html>Bad Request</html>'))
+        with pytest.raises(requests.HTTPError):
+            volumes_sdk.validate(vol)
+
+    def test_raises_when_the_400_has_no_detail(self, monkeypatch):
+        vol = self._volume(monkeypatch,
+                           _http_response(400, json_body={'oops': 'no detail'}))
+        with pytest.raises(requests.HTTPError):
+            volumes_sdk.validate(vol)
+
+    def test_returns_on_a_200(self, monkeypatch):
+        vol = self._volume(monkeypatch, _http_response(200, json_body={}))
+        assert volumes_sdk.validate(vol) is None
+
+
 class TestFromComponents:
     """from_components must preserve the resolved cloud/region/zone exactly."""
 
@@ -324,15 +370,29 @@ class TestFromComponents:
         assert (vol.cloud, vol.region, vol.zone) == (cloud, region, zone)
 
 
+def _http_response(status, json_body=None, text=''):
+    """A response whose raise_for_status behaves like the real one."""
+    response = mock.MagicMock(spec=requests.Response)
+    response.status_code = status
+    response.url = 'http://test/volumes/apply'
+    response.text = text if json_body is None else json.dumps(json_body)
+    response.headers = {}
+    if json_body is None:
+        response.json.side_effect = ValueError('not JSON')
+    else:
+        response.json.return_value = json_body
+    if status >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f'{status} Client Error', response=response)
+    return response
+
+
 class TestSdkApplyRejection:
     """The SDK surfaces a synchronous rejection as the server's error."""
 
     @staticmethod
     def _response(detail):
-        response = mock.MagicMock()
-        response.status_code = 400
-        response.json.return_value = {'detail': detail}
-        return response
+        return _http_response(400, json_body={'detail': detail})
 
     def _volume(self, monkeypatch, detail):
         # The SDK entrypoint would otherwise try to start a real API server.
@@ -361,11 +421,7 @@ class TestSdkApplyRejection:
         # JSONDecodeError, which would be worse than the HTTPError it replaced.
         monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
                             lambda *a, **kw: None)
-        response = mock.MagicMock()
-        response.status_code = 400
-        response.json.side_effect = ValueError('not JSON')
-        response.headers = {}
-        response.text = '<html>Bad Request</html>'
+        response = _http_response(400, text='<html>Bad Request</html>')
         monkeypatch.setattr(server_common, 'make_authenticated_request',
                             lambda *a, **kw: response)
         vol = volume_lib.Volume.from_components(
@@ -375,17 +431,14 @@ class TestSdkApplyRejection:
             region='my-context',
             size='1Gi')
         # The fall-through's own error, not a decode error from the guard.
-        with pytest.raises(RuntimeError, match='Failed to process response'):
+        with pytest.raises(requests.HTTPError):
             volumes_sdk.apply(vol)
 
     def test_detail_absent_keeps_the_normal_error_path(self, monkeypatch):
         # Valid JSON with no `detail` must fall through too.
         monkeypatch.setattr(server_common, 'check_server_healthy_or_start_fn',
                             lambda *a, **kw: None)
-        response = mock.MagicMock()
-        response.status_code = 400
-        response.json.return_value = {'oops': 'no detail here'}
-        response.headers = {}
+        response = _http_response(400, json_body={'oops': 'no detail here'})
         monkeypatch.setattr(server_common, 'make_authenticated_request',
                             lambda *a, **kw: response)
         vol = volume_lib.Volume.from_components(
@@ -394,7 +447,7 @@ class TestSdkApplyRejection:
             cloud='kubernetes',
             region='my-context',
             size='1Gi')
-        with pytest.raises(RuntimeError, match='Failed to process response'):
+        with pytest.raises(requests.HTTPError):
             volumes_sdk.apply(vol)
 
     def test_plain_string_detail(self, monkeypatch):

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -840,6 +840,7 @@ class TestVolumeCore:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         mock_cloud.validate_region_zone.return_value = ('us-east-1',
@@ -897,6 +898,7 @@ class TestVolumeCore:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         mock_cloud.validate_region_zone.return_value = ('us-east-1',
@@ -938,6 +940,7 @@ class TestVolumeCore:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         mock_cloud.validate_region_zone.return_value = ('us-east-1',
@@ -1099,6 +1102,7 @@ class TestVolumeCore:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         mock_cloud.validate_region_zone.return_value = ('us-east-1',
@@ -2015,6 +2019,7 @@ class TestVolumeApplyRecordsInitialStatus:
     def _setup(monkeypatch):
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud.validate_region_zone.return_value = ('my-context', None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
@@ -2080,6 +2085,7 @@ class TestEphemeralVolumeSkipsStatusProbe:
     def test_probe_is_not_called(self, monkeypatch):
         mock_cloud = mock.MagicMock()
         mock_cloud.max_cluster_name_length.return_value = 63
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud.validate_region_zone.return_value = ('my-context', None)
         mock_registry = mock.MagicMock()
         mock_registry.from_str.return_value = mock_cloud

--- a/tests/unit_tests/test_sky/volumes/test_runpod_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_runpod_volume.py
@@ -184,7 +184,10 @@ class TestRunPodVolume:
         with pytest.raises(ValueError) as exc_info:
             vol = volume_lib.Volume.from_yaml_config(cfg)
             vol.validate()
-        assert 'Invalid volume name: Volume name exceeds' in str(exc_info.value)
+        # The message names the offending volume, then the rule.
+        assert 'Invalid volume name' in str(exc_info.value)
+        assert 'x' * 31 in str(exc_info.value)
+        assert 'Volume name exceeds' in str(exc_info.value)
         # Max length boundary (30) should pass
         ok_cfg = {
             'name': 'y' * 30,

--- a/tests/unit_tests/test_sky/volumes/test_server.py
+++ b/tests/unit_tests/test_sky/volumes/test_server.py
@@ -100,6 +100,7 @@ class TestVolumeServer:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.is_same_cloud.return_value = True
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
@@ -156,6 +157,7 @@ class TestVolumeServer:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.is_same_cloud.return_value = True
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
@@ -208,6 +210,7 @@ class TestVolumeServer:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.is_same_cloud.return_value = True
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
@@ -350,6 +353,7 @@ class TestVolumeServer:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.is_same_cloud.return_value = True  # Is Kubernetes
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
@@ -557,6 +561,7 @@ class TestVolumeServer:
         # Mock cloud registry
         mock_cloud = mock.MagicMock()
         mock_cloud.is_same_cloud.return_value = True
+        mock_cloud.is_volume_name_valid.return_value = (True, None)
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
@@ -572,12 +577,14 @@ class TestVolumeServer:
             mock_state.request_id = 'test-request-id'
             mock_state.auth_user = None
 
-            # Test data for RunPod network volume
+            # Test data for RunPod network volume. The zone carries the
+            # DataCenterId, which RunPod network volumes require.
             apply_body = {
                 'name': 'test-runpod-volume',
                 'volume_type': volume.VolumeType.RUNPOD_NETWORK_VOLUME.value,
                 'cloud': 'runpod',
                 'region': 'us-east',
+                'zone': 'CA-MTL-1',
                 'size': '100',
                 'config': {}
             }

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -148,11 +148,13 @@ class TestVolume:
         volume = volume_lib.Volume(name='test', type='k8s-pvc', size='100Gi')
         volume.validate_name()  # Should not raise
 
-        # Test with None name
-        volume.name = None
-        with pytest.raises(AssertionError) as exc_info:
-            volume.validate_name()
-        assert 'Volume name must be set' in str(exc_info.value)
+        # A missing name is a user-facing error, not an assertion: it has to
+        # survive serialization to the client.
+        for missing in (None, ''):
+            volume.name = missing
+            with pytest.raises(ValueError) as exc_info:
+                volume.validate_name()
+            assert 'Volume name must be set' in str(exc_info.value)
 
     def test_volume_validate_size_method(self):
         """Test Volume.validate_size method."""

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -896,8 +896,20 @@ class TestHostPathVolume:
 
     # '/..' and friends are absolute and resolve to the root, so a literal
     # '/' comparison lets them through.
-    @pytest.mark.parametrize('host_path',
-                             ['/', '/..', '/mnt/../..', '/./..', '/../../..'])
+    @pytest.mark.parametrize(
+        'host_path',
+        [
+            '/',
+            '/..',
+            '/mnt/../..',
+            '/./..',
+            '/../../..',
+            # normpath keeps exactly two leading slashes; Linux reads '//' as
+            # the root.
+            '//',
+            '//..',
+            '//.',
+        ])
     def test_hostpath_volume_root_path(self, host_path):
         """Test hostPath volume resolving to the root raises error."""
         with pytest.raises(ValueError, match='must not resolve to the root'):

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -894,15 +894,19 @@ class TestHostPathVolume:
             )
             vol.validate()
 
-    def test_hostpath_volume_root_path(self):
-        """Test hostPath volume with root path raises error."""
-        with pytest.raises(ValueError, match='must not be the root directory'):
+    # '/..' and friends are absolute and resolve to the root, so a literal
+    # '/' comparison lets them through.
+    @pytest.mark.parametrize('host_path',
+                             ['/', '/..', '/mnt/../..', '/./..', '/../../..'])
+    def test_hostpath_volume_root_path(self, host_path):
+        """Test hostPath volume resolving to the root raises error."""
+        with pytest.raises(ValueError, match='must not resolve to the root'):
             vol = volume_lib.HostPathVolume(
                 name='my-host-vol',
                 type='k8s-hostpath',
                 infra='k8s',
                 use_existing=True,
-                config={'host_path': '/'},
+                config={'host_path': host_path},
             )
             vol.validate()
 


### PR DESCRIPTION
## Summary

Volume validation lived only behind `POST /volumes/validate`, which every client had to remember to call first. The CLI calls it; the dashboard's Add Volume dialog posts straight to `/volumes/apply`, so a name the CLI refuses could be created from the UI and land in the database:

```
$ sky volumes apply -n ok_vol3 --infra k8s --type k8s-pvc --size 1GB
ValueError: Invalid volume name 'ok_vol3': Volume name must be a valid DNS-1123 subdomain: ...
```

The same name submitted through the dialog was accepted.

The name turned out to be the smallest part of it. **Everything** `Volume.validate()` checks was bypassed on the write path — the size requirement for new volumes, label validity, and the type-specific rules. That includes the hostPath checks, so a hostPath volume rooted at `/` could be registered and then bind-mount the node root into any pod that mounts it.

- `/volumes/apply` now runs `Volume.validate()`, sharing one error wrapper with `/volumes/validate` so the two cannot drift on which volumes are legal or on the error shape clients parse.
- `Volume.from_components()` builds a `Volume` from an already-resolved cloud/region/zone. Only the cloud goes through `infra`; region and zone are assigned directly, because serializing a region into that string is lossy — a Kubernetes context named `ssh-<pool>` comes back as `<pool>`.
- **hostPath paths that resolve to the root are now refused.** The check compared `host_path` to a literal `'/'`, so `/..`, `/mnt/../..` and `//` were accepted and bind-mounted the node root — verified against a live API server, which accepts `path: //`. (`os.path.normpath` alone is not enough: it preserves exactly two leading slashes, so `'//'` stays `'//'`.)
- Null config fields are dropped before validating. The dashboard posts `namespace: null` when it is not set, and `validate_schema` only drops `None` at the top level, so the config schema rejected every create from the dialog.
- The apply body is stamped with the **validated** size. `parse_memory_resource` is not the identity (`'100Gi' → '100'`, `'2048Mi' → '2'`) and `_get_pvc_spec` appends `'Gi'`, so forwarding a unit-carrying size verbatim built an unusable quantity like `'2048MiGi'`. The CLI already sent a normalized size; now both paths agree.
- `server_common.raise_if_rejected_synchronously()` turns a synchronous 400 into the server's own error instead of a raw `requests.HTTPError`. It lives next to `handle_request_error` and is opt-in per endpoint; both volume SDK calls use it, removing a copy that already existed. It **always raises on a 400**: a body it cannot decode — an ingress returning HTML — falls back to `handle_request_error` rather than returning, because `volumes.validate()` has nothing after the call and would otherwise read that 400 as "the volume is valid". The promise does not depend on the fallback raising — control falls through to a generic error either way — and a test pins that by stubbing the fallback to return. This also improves the endpoint's pre-existing 400s (`Invalid volume type`, `Invalid cloud`).
- `validate_name()` raises instead of asserting — an `AssertionError`'s message does not survive serialization to the client, and the empty string reaches here. The invalid-name error now names the offending volume.
- `get_schema_validator()` is cached. It rebuilt the extended validator class on **every** call: 145 µs of the ~190 µs that constructing a `Volume` costs, paid by all 19 `validate_schema()` callers. That more than covers the validation this adds to the apply path.

Validation stays at the API boundary. `core.volume_apply()` does not re-check: its in-process callers (ephemeral task volumes, plugins) build their own names and configs, and a bad one surfaces as that feature's own error. Its docstring now states that contract.

`/validate` stays useful for pre-submit feedback and is unchanged for clients; it is just no longer the only place the rules are enforced. Kubernetes works the same way — `--dry-run=server` runs the same validation chain as a real write rather than being a separate opt-in endpoint.

### Cost

`Volume.validate()` itself is 0.6 µs; the ~0.3 ms is constructing the `Volume` (schema validation), of which the cached validator class was ~145 µs. For context, the same handler already spends 25 µs parsing the body and 6.5 µs on `to_row()` before an awaited DB insert and a PVC create in the hundreds of ms.

### Behavior change worth noting

Two, both in the same direction — something previously accepted is now refused:

- A volume already stored under an illegal **name** can no longer be re-applied; apply was previously an idempotent no-op for an existing volume. Listing and deleting are untouched, so such volumes can still be cleaned up.
- A hostPath volume already stored with a **root-resolving path** (`/..`, `//`) can no longer be re-applied either. That volume mounts the node root, so refusing it is the point; it is called out here because it is a behaviour change, not only a hardening.

## Test plan

`pytest tests/unit_tests/test_sky/volumes/` — 423 tests, all passing. New `test_apply_validation.py` covers the endpoint rejections (name, empty name, size, labels, hostPath `/` / relative / missing, RunPod zone), the accept cases so the change cannot over-reject, the size stamping, `from_components` round-trips, and the SDK's 400 handling.

Every added test was revert-verified — reverting a change turns exactly its own cases red and nothing else:

| Reverted | Cases that fail |
|---|---|
| `volume.validate()` in `/apply` | exactly the 15 rejection cases |
| the size stamping | exactly the 3 unit-carrying sizes (the plain `'100'` control stays green) |
| the config stamping | exactly the 2 defaulted-config cases |
| null-config dropping | exactly the 3 real dialog payloads that carry nulls |
| leading-slash collapsing | exactly the 6 `'//'` cases |
| the SDK 400 branch | its 2 tests |
| the undecodable-400 fallback | exactly the 2 `validate()` tests (the `apply()` ones stay green — `get_request_id` still raises after them) |
| the `return` after that fallback | the self-enforcement test |

`test_resolved_components_survive` covers the `from_components` cases, including the `ssh-` context the old infra round-trip lost.

Existing tests that mocked the cloud with a bare `MagicMock` needed `is_volume_name_valid` stubbed. One existing test was asserting the bypass — it posted a RunPod network volume with no zone and expected 200 — and now carries a zone.

### Manual verification

Against a local API server, confirming the server's reported commit matches the branch first:

```bash
sky api stop && sky api start
curl -s localhost:46580/api/health   # check "commit"

# Rejected (each returns 400 with the rule and the offending name)
curl -X POST localhost:46580/volumes/apply -H 'Content-Type: application/json' \
  -d '{"name":"ok_vol3","volume_type":"k8s-pvc","cloud":"kubernetes","region":"<ctx>","size":"1Gi","config":{}}'
curl -X POST localhost:46580/volumes/apply -H 'Content-Type: application/json' \
  -d '{"name":"h","volume_type":"k8s-hostpath","cloud":"kubernetes","region":"<ctx>","config":{"host_path":"/"}}'
curl -X POST localhost:46580/volumes/apply -H 'Content-Type: application/json' \
  -d '{"name":"nosize","volume_type":"k8s-pvc","cloud":"kubernetes","region":"<ctx>","config":{}}'

# Accepted (200 + request id), proving no over-rejection
curl -X POST localhost:46580/volumes/apply -H 'Content-Type: application/json' \
  -d '{"name":"ok-vol3","volume_type":"k8s-pvc","cloud":"kubernetes","region":"<ctx>","size":"1Gi","config":{}}'

# Same bad name to /volumes/validate returns an identical detail
```

Results, run through a scripted harness against an isolated server on its own port and `SKY_RUNTIME_DIR` (plugins disabled, nothing created on a real cluster — the cases that must reach the worker use a bogus context, and the size/region assertions read the request row back to check what the worker was actually handed):

| Case | Asserts | This branch | master |
|---|---|---|---|
| name `ok_vol3` | 400, message names the volume | PASS | FAIL (200) |
| name `UPPER` | 400, DNS-1123 | PASS | FAIL (200) |
| empty name | 400 | PASS | FAIL (200) |
| hostPath `/` | 400, refuses the node root | PASS | FAIL (200) |
| hostPath relative / missing | 400 | PASS | FAIL (200) |
| new PVC, no size | 400 | PASS | FAIL (200) |
| invalid label key | 400 | PASS | FAIL (200) |
| RunPod, no zone | 400 | PASS | FAIL (200) |
| valid name, bogus context | **200** — must not over-reject | PASS | PASS |
| `use_existing`, no size | **200** | PASS | PASS |
| dotted DNS-1123 name | **200** | PASS | PASS |
| size `2048Mi` | worker handed `2` | PASS | FAIL (`2048Mi`) |
| k8s context containing `/` | survives the round-trip | PASS | PASS |
| `/apply` vs `/validate` | identical error detail | PASS | FAIL (differ) |
| SDK `apply()` on a bad name | clean `ValueError` | PASS | FAIL (no error raised) |
| hostPath `/..`, `/mnt/../..` | 400 | PASS | FAIL (200) |
| real dialog payloads (4, captured from the browser) | 200 | PASS | 2 of 4 FAIL (400 on `namespace: null`) |
| config omitted | worker gets the defaulted access mode | PASS | FAIL (`None`) |

23 passed / 0 failed on this branch; on master the rejection cases and the payload/stamping cases fail. The four that pass on master are exactly the controls asserting the change must not over-reject.

Also verified a task with a task-declared ephemeral volume still provisions.

### Follow-up (not in this PR)

[#10514](https://github.com/skypilot-org/skypilot/issues/10514) — a dotted name passes this validation but produces an invalid pod spec (`spec.volumes[].name: must not contain dots`), so the volume is created and cannot be mounted. Deliberately not fixed here: existing tests assert dotted names are valid, and tightening needs its own compatibility story for volumes already stored with a dot. A test in this PR pins current behaviour so that flip is a deliberate edit.

The enterprise dashboard's Add Volume dialog needed two changes, shipped in the companion PR: its error extractor only understands the asynchronous `/api/get` failure shape (`detail.error` as a JSON string), not the synchronous `serialize_exception` body this endpoint returns, so it would show a bare `HTTP 400` instead of the reason; and it should validate the name inline so the user is told before the round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

