### PR TITLE
[Test] Harden test_managed_jobs_inline_env against debug log lines on stdout

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1851,8 +1851,15 @@ def test_managed_jobs_inline_env(generic_cloud: str):
             f'echo "JOB_ID=$JOB_ID" && '
             # Test that logs are still available after the job finishes.
             's=$(sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && '
-            # Make sure we skip the unnecessary logs.
-            'echo "$s" | head -n2 | grep "Waiting for"',
+            # Make sure we skip the unnecessary logs. Drop SkyPilot's own log
+            # records first: they are written to stdout, so the command
+            # substitution above captures them alongside the task log. The
+            # local `unset SKYPILOT_DEBUG` only quiets this client -- records
+            # streamed back from an API server whose own level is debug still
+            # arrive here, and would push the marker past the first lines.
+            'echo "$s" | grep -vE '
+            '"^[A-Z] [0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3} '
+            'PID=[0-9]+ " | head -n2 | grep "Waiting for"',
         ],
         f'sky jobs cancel -y -n {name}',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1837,12 +1837,20 @@ def test_managed_jobs_inline_env(generic_cloud: str):
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.SUCCEEDED],
                 timeout=55),
-            f'JOB_ROW=$(sky jobs queue -v | grep {name} | head -n1) && '
+            # Unset debug logging up front, so it covers every `sky` call
+            # below: log records go to stdout, so with debug logging on the
+            # command substitutions capture log lines along with the real
+            # output.
+            'unset SKYPILOT_DEBUG && '
+            # Anchor the match to a table data row (the first column is the
+            # numeric job ID) instead of matching any line that mentions the
+            # job name.
+            f'JOB_ROW=$(sky jobs queue -v | grep -E "^[0-9]+[[:space:]].*{name}" | head -n1) && '
             f'echo "$JOB_ROW" && echo "$JOB_ROW" | grep -E "DONE|ALIVE" | grep "SUCCEEDED" && '
             f'JOB_ID=$(echo "$JOB_ROW" | awk \'{{print $1}}\') && '
             f'echo "JOB_ID=$JOB_ID" && '
             # Test that logs are still available after the job finishes.
-            'unset SKYPILOT_DEBUG; s=$(sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && '
+            's=$(sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && '
             # Make sure we skip the unnecessary logs.
             'echo "$s" | head -n2 | grep "Waiting for"',
         ],


### PR DESCRIPTION
`test_managed_jobs_inline_env` resolves the job ID by grepping the `sky jobs queue -v` output for the job name. That grep can match a log line instead of the table row, because SkyPilot's default log handler writes to stdout (`sky/sky_logging.py:112` — `EnvAwareHandler(sys.stdout)`) and the pytest config sets `SKYPILOT_DEBUG=1` for the whole session (`pyproject.toml:16`), while `sky jobs queue` also streams the server-side request log to stdout via `sdk.stream_and_get`. So `$(sky jobs queue -v)` captures debug log lines together with the table, log lines come first, and `grep <name> | head -n1` can return one of them — after which `grep -E "DONE|ALIVE"` fails and the test looks like a product bug.

Three independent fixes:

- `unset SKYPILOT_DEBUG` sat near the end of the chain, so it only covered `sky jobs logs`, not the earlier `sky jobs queue -v`. Moved to the front of the command so it covers every `sky` invocation.
- `grep <job-name>` was unanchored. Anchored it to a table data row, whose first column is the numeric job ID: `grep -E "^[0-9]+[[:space:]].*<name>"`. This is robust regardless of log level, and adds no new assumption — the existing `awk '{print $1}'` already relies on the job ID being the first field. (Data rows start at column 0: `log_utils.create_table` uses `border=False, left_padding_width=0`.)
- The `;` before `s=$(sky jobs logs $JOB_ID --refresh)` let that command run even when the `&&` chain had already broken, streaming whichever job is latest with an empty `$JOB_ID`; the reported failure then became the final `head -n2 | grep "Waiting for"`, hiding the real breakage several steps upstream. Changed to `&&` so the reported failing command is the one that actually failed.

Test-only change, confined to this one test's command list. No product code touched.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual verification without a cluster:

- `python -c "import ast; ast.parse(open('tests/smoke_tests/test_managed_job.py').read())"` and `compile(...)` both succeed.
- Rendered the command literal out of the AST with `name='t-abc'` and ran `bash -n` on it — valid shell, quoting/escaping intact:
  `unset SKYPILOT_DEBUG && JOB_ROW=$(sky jobs queue -v | grep -E "^[0-9]+[[:space:]].*t-abc" | head -n1) && echo "$JOB_ROW" && echo "$JOB_ROW" | grep -E "DONE|ALIVE" | grep "SUCCEEDED" && JOB_ID=$(echo "$JOB_ROW" | awk '{print $1}') && echo "JOB_ID=$JOB_ID" && s=$(sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && echo "$s" | head -n2 | grep "Waiting for"`
- Replayed both patterns against a synthetic `sky jobs queue -v` output containing a debug line that mentions the job name followed by the table: the old `grep t-abc | head -n1` returns the debug line; the anchored pattern returns the table row and `awk '{print $1}'` yields the job ID.
- Reproduced the table shape with `prettytable` using `create_table`'s settings to confirm data rows begin with the job ID at column 0 and the header (`ID  TASK  ...`) does not match the anchor.
- `unset SKYPILOT_DEBUG && ...` returns 0 whether or not the variable is set, in `bash` (including `set -u`) and `sh`.
- pre-commit (`yapf`, `isort`, `mypy`) passed.

The smoke test itself needs a cloud/cluster and was not run locally.

Claude-Session: https://claude.ai/code/session_01QyMrGbkUnGLLC9rnCXoU8N

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->