### PR TITLE
fix(slurm): run skylet under an allocation-owned keeper step

### DIFF
--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -934,18 +934,11 @@ class SlurmCodeGen(TaskCodeGen):
                     #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
                     #   fetch_config: DNS SRV lookup failed
                     #   fatal: Could not establish a configuration source
-                    cmd_parts = []
-                    # Only unset SKY_RUNTIME_DIR for container runs. For non-container
-                    # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
-                    # SlurmCommandRunner to avoid SQLite WAL issues on shared filesystems.
-                    if {True if container_flags else False}:
-                        cmd_parts.append('unset SKY_RUNTIME_DIR;')
-                    cmd_parts.extend([
+                    bash_cmd = shlex.quote(' '.join([
                         constants.SKY_SLURM_PYTHON_CMD,
                         '-m sky.skylet.executor.slurm',
                         runner_args,
-                    ])
-                    bash_cmd = shlex.quote(' '.join(cmd_parts))
+                    ]))
                     srun_cmd = (
                         "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {{print $1}}') && "
                         f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid={self._slurm_job_id} '

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -530,8 +530,6 @@ def _create_virtual_instance(
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
     ready_signal = f'{sky_cluster_home_dir}/.sky_sbatch_ready'
-    slurm_marker_file = (
-        f'{sky_cluster_home_dir}/{slurm_utils.SLURM_MARKER_FILE}')
 
     # For non-Docker Hub registries, pyxis/enroot requires '#' separator
     # between registry and path. See:
@@ -586,7 +584,11 @@ def _create_virtual_instance(
         mount_paths = [
             f'{remote_home_dir}:{remote_home_dir}',
             f'{host_ccache_dir}:{container_ccache_dir}',
-            f'{skypilot_runtime_dir}:{skypilot_runtime_dir}',
+            # Share only skylet state between the host and container.
+            # Mounting the full runtime dir exposes the host venv.
+            # The container then skips its own venv.
+            # The host python symlink is invalid inside the container.
+            f'{skypilot_runtime_dir}/.sky:{skypilot_runtime_dir}/.sky',
         ]
         # When workdir differs from remote_home_dir (e.g. workdir is on
         # NFS at /home/ubuntu while $HOME is /home_local/ubuntu), mount
@@ -677,8 +679,8 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
     # the Slurm CLIs, munge, and slurm.conf exist only on the host.
     keeper_start_file = (
         f'{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}')
-    # attempt_skylet may run in-container where HOME is /root; the keeper
-    # sets the host-correct HOME.
+    # A spec written in the container inherits HOME=/root.
+    # The keeper restores the host HOME before running it.
     keeper_loop = (f'while true; do '
                    f'if [ -f {keeper_start_file} ]; then '
                    f'HOME={sky_cluster_home_dir} bash {keeper_start_file}; '
@@ -704,9 +706,6 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
         # GB convention.
         mem_in_mb = int(float(resources['memory']) * 1024)
         mem_directive = f'#SBATCH --mem={mem_in_mb}M\n'
-    # TODO(kevin): Pass --overlap to the cleanup sruns below so cleanup can
-    # proceed even when task steps that survived SIGTERM still hold the
-    # allocation's resources.
     # pylint: disable=line-too-long
     # fmt: off
     provision_script = f"""\
@@ -724,8 +723,8 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {{
     saved_exit=$?
-    # The Skylet is daemonized, so it is not automatically terminated when
-    # the Slurm job is terminated, we need to kill it manually.
+    # Prevent the keeper from restarting Skylet during cleanup.
+    rm -f "{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}"
     echo "Terminating Skylet..."
     if [ -f "{skypilot_runtime_dir}/.sky/skylet_pid" ]; then
         kill $(cat "{skypilot_runtime_dir}/.sky/skylet_pid") 2>/dev/null || true
@@ -735,13 +734,13 @@ cleanup() {{
     # This is only needed when container_scope=global.
     # When container_scope=job, named containers are removed automatically
     # at the end of the Slurm job, see: https://github.com/NVIDIA/pyxis/wiki/Setup#slurm-epilog
-    srun --nodes={num_nodes} --ntasks-per-node=1 enroot remove -f {shlex.quote(_enroot_container_name_global_scope(cluster_name_on_cloud))} 2>/dev/null || true
+    srun --overlap --nodes={num_nodes} --ntasks-per-node=1 enroot remove -f {shlex.quote(_enroot_container_name_global_scope(cluster_name_on_cloud))} 2>/dev/null || true
     # Clean up sky runtime directory on each node.
     # NOTE: We can do this because --nodes for both this srun and the
     # sbatch is the same number. Otherwise, there are no guarantees
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
-    srun --nodes={num_nodes} rm -rf {skypilot_runtime_dir}
+    srun --overlap --nodes={num_nodes} rm -rf {skypilot_runtime_dir}
     rm -rf {sky_cluster_home_dir}
     exit $saved_exit
 }}
@@ -754,21 +753,18 @@ trap 'exit 0' TERM
 # Create sky home directory and subdirectories for the cluster.
 mkdir -p {sky_cluster_home_dir}/sky_logs {sky_cluster_home_dir}/sky_workdir {sky_cluster_home_dir}/.sky
 # Create sky runtime directory on each node.
-srun --nodes={num_nodes} mkdir -p {skypilot_runtime_dir}
-# Slurm marker in the runtime dir: resolvable in both shapes.
-srun --nodes={num_nodes} touch {skypilot_runtime_dir}/{slurm_utils.SLURM_MARKER_FILE}
+srun --nodes={num_nodes} mkdir -p {skypilot_runtime_dir}/.sky
 # Marker file to indicate we're in a Slurm cluster.
-touch {slurm_marker_file}
+srun --nodes={num_nodes} touch {skypilot_runtime_dir}/.sky/{slurm_utils.SLURM_MARKER_FILE}
 # Store proctrack type for task executor to read.
 echo '{proctrack_type or "unknown"}' > {sky_cluster_home_dir}/{skylet_constants.SLURM_PROCTRACK_TYPE_FILE}
 # Suppress login messages.
 touch {sky_cluster_home_dir}/.hushlogin
 {container_block}
 {f'touch {ready_signal}' if container_image is None else ''}
-# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
-# restarts the step.
+# Host-side keeper step that starts skylet and restarts it if it dies.
 {skylet_keeper_block}
-{'sleep infinity' if container_image is None else 'wait'}
+{'sleep infinity' if container_image is None else 'wait "$CONTAINER_PID"'}
 """
     # fmt: on
     # pylint: enable=line-too-long

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -586,6 +586,7 @@ def _create_virtual_instance(
         mount_paths = [
             f'{remote_home_dir}:{remote_home_dir}',
             f'{host_ccache_dir}:{container_ccache_dir}',
+            f'{skypilot_runtime_dir}:{skypilot_runtime_dir}',
         ]
         # When workdir differs from remote_home_dir (e.g. workdir is on
         # NFS at /home/ubuntu while $HOME is /home_local/ubuntu), mount
@@ -661,6 +662,37 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
             f'echo "[container] Ready in $((SECONDS - CONTAINER_START))s"\n'
             f'touch {container_marker_file} {ready_signal}')
 
+    # sbatch batch script ── lives as long as the allocation
+    #   └─ keeper srun client (host side, never enters the container)
+    #        └─ keeper step ── outer loop restarts the step
+    #             └─ run the start spec FOREGROUND ── inner loop restarts skylet
+    #                  └─ skylet (the step cgroup owns it)
+    #
+    # attempt_skylet (any shape, possibly in-container)
+    #   └─ writes <runtime_dir>/.sky/skylet_start ──► read by the keeper loop
+    #        (runtime dir = the same host path in both shapes)
+    #
+    # A nohup'd skylet dies here: proctrack/cgroup reaps whatever a short-lived
+    # step leaves behind. The keeper stays out of the workload container because
+    # the Slurm CLIs, munge, and slurm.conf exist only on the host.
+    keeper_start_file = (
+        f'{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}')
+    # attempt_skylet may run in-container where HOME is /root; the keeper
+    # sets the host-correct HOME.
+    keeper_loop = (f'while true; do '
+                   f'if [ -f {keeper_start_file} ]; then '
+                   f'HOME={sky_cluster_home_dir} bash {keeper_start_file}; '
+                   f'fi; '
+                   f'sleep 5; done')
+    skylet_keeper_block = (
+        'SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" '
+        '| head -n1)\n'
+        f'( while true; do '
+        f'srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 '
+        f'--nodelist=$SKY_HEAD_NODE '
+        f'bash -c {shlex.quote(keeper_loop)}; '
+        f'sleep 5; done ) &')
+
     # By default stdout and stderr will be written to $HOME/slurm-%j.out
     # (because we invoke sbatch from $HOME). Redirect elsewhere to not pollute
     # the home directory.
@@ -723,6 +755,8 @@ trap 'exit 0' TERM
 mkdir -p {sky_cluster_home_dir}/sky_logs {sky_cluster_home_dir}/sky_workdir {sky_cluster_home_dir}/.sky
 # Create sky runtime directory on each node.
 srun --nodes={num_nodes} mkdir -p {skypilot_runtime_dir}
+# Slurm marker in the runtime dir: resolvable in both shapes.
+srun --nodes={num_nodes} touch {skypilot_runtime_dir}/{slurm_utils.SLURM_MARKER_FILE}
 # Marker file to indicate we're in a Slurm cluster.
 touch {slurm_marker_file}
 # Store proctrack type for task executor to read.
@@ -731,6 +765,9 @@ echo '{proctrack_type or "unknown"}' > {sky_cluster_home_dir}/{skylet_constants.
 touch {sky_cluster_home_dir}/.hushlogin
 {container_block}
 {f'touch {ready_signal}' if container_image is None else ''}
+# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
+# restarts the step.
+{skylet_keeper_block}
 {'sleep infinity' if container_image is None else 'wait'}
 """
     # fmt: on

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -15,6 +15,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import gpu_names
@@ -1318,9 +1319,10 @@ def slurm_node_info(
 
 
 def is_inside_slurm_cluster() -> bool:
-    # Check for the marker file in the current home directory. When run by
-    # the skylet on a compute node, the HOME environment variable is set to
-    # the cluster's sky home directory by the SlurmCommandRunner.
+    # Runtime-dir marker works in every shape; home-dir marker is the
+    # legacy fallback.
+    if os.path.exists(runtime_utils.get_runtime_dir_path(SLURM_MARKER_FILE)):
+        return True
     marker_file = os.path.join(os.path.expanduser('~'), SLURM_MARKER_FILE)
     return os.path.exists(marker_file)
 

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1319,9 +1319,12 @@ def slurm_node_info(
 
 
 def is_inside_slurm_cluster() -> bool:
-    # Runtime-dir marker works in every shape; home-dir marker is the
-    # legacy fallback.
-    if os.path.exists(runtime_utils.get_runtime_dir_path(SLURM_MARKER_FILE)):
+    # New allocations write the marker under the runtime dir's .sky/.
+    # That path resolves in both the host and container shapes.
+    # Older allocations only wrote it to $HOME, so keep that as a fallback.
+    if os.path.exists(
+            runtime_utils.get_runtime_dir_path(
+                os.path.join('.sky', SLURM_MARKER_FILE))):
         return True
     marker_file = os.path.join(os.path.expanduser('~'), SLURM_MARKER_FILE)
     return os.path.exists(marker_file)

--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -75,7 +75,8 @@ def _start_skylet_via_keeper(port: int) -> None:
 
     # Require this cluster's PID file.
     # A process scan can match another cluster's skylet.
-    # Enroot shares the PID namespace, so the host PID is valid in the container.
+    # Enroot shares the PID namespace, so the host PID is valid in the
+    # container.
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         try:

--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -19,19 +19,18 @@ PID_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PID_FILE)
 PORT_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PORT_FILE)
 START_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_START_FILE)
 
-# Keep in sync with SLURM_MARKER_FILE in sky/provision/slurm/utils.py; that
-# module is too heavy to import here.
+# Duplicated from sky/provision/slurm/utils.py to avoid importing that module.
 _SLURM_MARKER_FILE = '.sky_slurm_cluster'
 
-# SKYPILOT_ does not start with SKY_; serialize both prefixes.
+# Serialize both prefixes because SKYPILOT_ does not start with SKY_.
 _SKY_ENV_VAR_PREFIX = 'SKY_'
 
 
 def _serialize_launch_env() -> str:
-    """Export lines reproducing this process's env for the keeper's shell.
+    """Serialize the launch environment for the host-side keeper.
 
-    No shape-dependent values (HOME is excluded); PATH is prepended to the
-    keeper's own PATH, never replaced.
+    HOME is excluded because it differs between the host and container.
+    PATH is prepended to the keeper's PATH rather than replacing it.
     """
     export_lines = []
     path_value = os.environ.get('PATH')
@@ -45,10 +44,14 @@ def _serialize_launch_env() -> str:
 
 
 def _is_inside_slurm_cluster() -> bool:
-    if os.path.exists(runtime_utils.get_runtime_dir_path(_SLURM_MARKER_FILE)):
-        return True
+    """Whether this allocation's sbatch script supports the skylet keeper.
+
+    Only the runtime marker proves that the sbatch script reads the start spec.
+    The generic Slurm check keeps the HOME fallback for older allocations.
+    """
     return os.path.exists(
-        os.path.join(os.path.expanduser('~'), _SLURM_MARKER_FILE))
+        runtime_utils.get_runtime_dir_path(
+            os.path.join('.sky', _SLURM_MARKER_FILE)))
 
 
 def _start_skylet_via_keeper(port: int) -> None:
@@ -56,32 +59,31 @@ def _start_skylet_via_keeper(port: int) -> None:
     launch_env = _serialize_launch_env()
     start_spec = (
         '#!/bin/bash\n'
-        '# Written by attempt_skylet.py; run in the foreground by the\n'
-        '# skylet keeper step.\n'
+        '# Run by the Slurm skylet keeper.\n'
         f'{launch_env}\n'
-        # $$ then exec: the PID file records the real skylet PID, matching
-        # the nohup path's `echo $!`.
+        # exec preserves $$, so the PID file records skylet itself.
         f'echo $$ > {PID_FILE}\n'
         f'exec {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
         f'--port={port} >> {SKYLET_LOG_FILE} 2>&1\n')
-    # 0600 before the content lands; os.replace keeps the mode.
+    # The spec may contain secrets.
+    # Create it as 0600 before writing. os.replace preserves the mode.
     tmp_file = START_FILE + '.tmp'
     fd = os.open(tmp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, 'w', encoding='utf-8') as spec_file:
         spec_file.write(start_spec)
     os.replace(tmp_file, START_FILE)
 
-    # Poll only our PID file: the global scan can match another cluster's
-    # skylet. The host-written PID is valid here; enroot shares the PID
-    # namespace.
-    deadline = time.time() + 30
-    while time.time() < deadline:
+    # Require this cluster's PID file.
+    # A process scan can match another cluster's skylet.
+    # Enroot shares the PID namespace, so the host PID is valid in the container.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
         try:
             with open(PID_FILE, 'r', encoding='utf-8') as pid_file:
                 pid = int(pid_file.read().strip())
         except (OSError, ValueError):
             pid = -1
-        if pid > 0 and _is_running_skylet_process(pid):
+        if _is_running_skylet_process(pid):
             return
         time.sleep(0.5)
     raise RuntimeError(
@@ -170,12 +172,13 @@ def restart_skylet():
 
     on_slurm = _is_inside_slurm_cluster()
     if on_slurm:
-        # Remove the spec before killing, or the keeper could relaunch the
-        # old version/port before the new spec lands.
+        # Remove the old spec before killing skylet.
+        # This prevents the keeper from relaunching it.
+        # Any removal error except a missing file aborts before the kill.
         try:
             os.remove(START_FILE)
-        except OSError:
-            pass  # Best effort cleanup
+        except FileNotFoundError:
+            pass
 
     # Find and kill running skylet processes
     for pid in _find_running_skylet_pids():

--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -1,8 +1,10 @@
 """Restarts skylet if version does not match"""
 
 import os
+import shlex
 import signal
 import subprocess
+import time
 from typing import List, Optional, Tuple
 
 import psutil
@@ -15,6 +17,78 @@ VERSION_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_VERSION_FILE)
 SKYLET_LOG_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_LOG_FILE)
 PID_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PID_FILE)
 PORT_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PORT_FILE)
+START_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_START_FILE)
+
+# Keep in sync with SLURM_MARKER_FILE in sky/provision/slurm/utils.py; that
+# module is too heavy to import here.
+_SLURM_MARKER_FILE = '.sky_slurm_cluster'
+
+# SKYPILOT_ does not start with SKY_; serialize both prefixes.
+_SKY_ENV_VAR_PREFIX = 'SKY_'
+
+
+def _serialize_launch_env() -> str:
+    """Export lines reproducing this process's env for the keeper's shell.
+
+    No shape-dependent values (HOME is excluded); PATH is prepended to the
+    keeper's own PATH, never replaced.
+    """
+    export_lines = []
+    path_value = os.environ.get('PATH')
+    if path_value is not None:
+        export_lines.append(f'export PATH={shlex.quote(path_value)}:"$PATH"')
+    for key in sorted(os.environ):
+        if key.startswith(
+            (constants.SKYPILOT_ENV_VAR_PREFIX, _SKY_ENV_VAR_PREFIX)):
+            export_lines.append(f'export {key}={shlex.quote(os.environ[key])}')
+    return '\n'.join(export_lines)
+
+
+def _is_inside_slurm_cluster() -> bool:
+    if os.path.exists(runtime_utils.get_runtime_dir_path(_SLURM_MARKER_FILE)):
+        return True
+    return os.path.exists(
+        os.path.join(os.path.expanduser('~'), _SLURM_MARKER_FILE))
+
+
+def _start_skylet_via_keeper(port: int) -> None:
+    """Write the start spec and wait for the keeper to start skylet."""
+    launch_env = _serialize_launch_env()
+    start_spec = (
+        '#!/bin/bash\n'
+        '# Written by attempt_skylet.py; run in the foreground by the\n'
+        '# skylet keeper step.\n'
+        f'{launch_env}\n'
+        # $$ then exec: the PID file records the real skylet PID, matching
+        # the nohup path's `echo $!`.
+        f'echo $$ > {PID_FILE}\n'
+        f'exec {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
+        f'--port={port} >> {SKYLET_LOG_FILE} 2>&1\n')
+    # 0600 before the content lands; os.replace keeps the mode.
+    tmp_file = START_FILE + '.tmp'
+    fd = os.open(tmp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, 'w', encoding='utf-8') as spec_file:
+        spec_file.write(start_spec)
+    os.replace(tmp_file, START_FILE)
+
+    # Poll only our PID file: the global scan can match another cluster's
+    # skylet. The host-written PID is valid here; enroot shares the PID
+    # namespace.
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        try:
+            with open(PID_FILE, 'r', encoding='utf-8') as pid_file:
+                pid = int(pid_file.read().strip())
+        except (OSError, ValueError):
+            pid = -1
+        if pid > 0 and _is_running_skylet_process(pid):
+            return
+        time.sleep(0.5)
+    raise RuntimeError(
+        'Skylet keeper did not start skylet within 30 seconds: no live '
+        f'skylet process appeared in {PID_FILE}. Check that the keeper '
+        'step is running in the sbatch job (sbatch log) and see '
+        f'{SKYLET_LOG_FILE} for skylet errors.')
 
 
 def _is_running_skylet_process(pid: int) -> bool:
@@ -94,6 +168,15 @@ def restart_skylet():
     # TODO(zhwu): make the killing graceful, e.g., use a signal to tell
     # skylet to exit, instead of directly killing it.
 
+    on_slurm = _is_inside_slurm_cluster()
+    if on_slurm:
+        # Remove the spec before killing, or the keeper could relaunch the
+        # old version/port before the new spec lands.
+        try:
+            os.remove(START_FILE)
+        except OSError:
+            pass  # Best effort cleanup
+
     # Find and kill running skylet processes
     for pid in _find_running_skylet_pids():
         try:
@@ -117,15 +200,18 @@ def restart_skylet():
     # one network namespace. For other clouds, the behaviour will be that
     # it always gets port 46590 (default port).
     port = common_utils.find_free_port(constants.SKYLET_GRPC_PORT)
-    subprocess.run(
-        # We have made sure that `attempt_skylet.py` is executed with the
-        # skypilot runtime env activated, so that skylet can access the cloud
-        # CLI tools.
-        f'nohup {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
-        f'--port={port} '
-        f'>> {SKYLET_LOG_FILE} 2>&1 & echo $! > {PID_FILE}',
-        shell=True,
-        check=True)
+    if on_slurm:
+        _start_skylet_via_keeper(port)
+    else:
+        subprocess.run(
+            # We have made sure that `attempt_skylet.py` is executed with the
+            # skypilot runtime env activated, so that skylet can access the
+            # cloud CLI tools.
+            f'nohup {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
+            f'--port={port} '
+            f'>> {SKYLET_LOG_FILE} 2>&1 & echo $! > {PID_FILE}',
+            shell=True,
+            check=True)
 
     with open(PORT_FILE, 'w', encoding='utf-8') as pf:
         pf.write(str(port))

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -181,6 +181,8 @@ SKYLET_VERSION_FILE = '.sky/skylet_version'
 SKYLET_LOG_FILE = '.sky/skylet.log'
 SKYLET_PID_FILE = '.sky/skylet_pid'
 SKYLET_PORT_FILE = '.sky/skylet_port'
+# Start spec written by attempt_skylet.py; run by the Slurm keeper step.
+SKYLET_START_FILE = '.sky/skylet_start'
 SKYLET_GRPC_PORT = 46590
 SKYLET_GRPC_TIMEOUT_SECONDS = 10
 # TODO(zpoint): legacy autostop-hook log path, kept so the new

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -181,7 +181,7 @@ SKYLET_VERSION_FILE = '.sky/skylet_version'
 SKYLET_LOG_FILE = '.sky/skylet.log'
 SKYLET_PID_FILE = '.sky/skylet_pid'
 SKYLET_PORT_FILE = '.sky/skylet_port'
-# Start spec written by attempt_skylet.py; run by the Slurm keeper step.
+# The Slurm skylet keeper consumes this start spec.
 SKYLET_START_FILE = '.sky/skylet_start'
 SKYLET_GRPC_PORT = 46590
 SKYLET_GRPC_TIMEOUT_SECONDS = 10

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -2295,7 +2295,11 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
             assert self.container_args is not None, (
                 '_run_via_srun with in_container=True called but '
                 'container_args not set')
-            inner_cmd = f'{self._ENV_SETUP} && {cmd}'
+            # The start spec, PID file, and marker live in the runtime dir;
+            # it must resolve identically on host and in the container.
+            inner_cmd = (f'export {constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
+                         f'"{self.skypilot_runtime_dir}" && '
+                         f'{self._ENV_SETUP} && {cmd}')
             extra_srun_args = f'{self.container_args} '
         else:
             inner_cmd = (f'export {constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -2295,8 +2295,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
             assert self.container_args is not None, (
                 '_run_via_srun with in_container=True called but '
                 'container_args not set')
-            # The start spec, PID file, and marker live in the runtime dir;
-            # it must resolve identically on host and in the container.
+            # Export the runtime dir for keeper files.
+            # They must resolve to the same paths on the host and container.
             inner_cmd = (f'export {constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
                          f'"{self.skypilot_runtime_dir}" && '
                          f'{self._ENV_SETUP} && {cmd}')

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
@@ -553,18 +553,11 @@ if script or False:
         #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
         #   fetch_config: DNS SRV lookup failed
         #   fatal: Could not establish a configuration source
-        cmd_parts = []
-        # Only unset SKY_RUNTIME_DIR for container runs. For non-container
-        # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
-        # SlurmCommandRunner to avoid SQLite WAL issues on shared filesystems.
-        if True:
-            cmd_parts.append('unset SKY_RUNTIME_DIR;')
-        cmd_parts.extend([
+        bash_cmd = shlex.quote(' '.join([
             constants.SKY_SLURM_PYTHON_CMD,
             '-m sky.skylet.executor.slurm',
             runner_args,
-        ])
-        bash_cmd = shlex.quote(' '.join(cmd_parts))
+        ]))
         srun_cmd = (
             "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -555,18 +555,11 @@ if script or True:
         #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
         #   fetch_config: DNS SRV lookup failed
         #   fatal: Could not establish a configuration source
-        cmd_parts = []
-        # Only unset SKY_RUNTIME_DIR for container runs. For non-container
-        # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
-        # SlurmCommandRunner to avoid SQLite WAL issues on shared filesystems.
-        if False:
-            cmd_parts.append('unset SKY_RUNTIME_DIR;')
-        cmd_parts.extend([
+        bash_cmd = shlex.quote(' '.join([
             constants.SKY_SLURM_PYTHON_CMD,
             '-m sky.skylet.executor.slurm',
             runner_args,
-        ])
-        bash_cmd = shlex.quote(' '.join(cmd_parts))
+        ]))
         srun_cmd = (
             "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -774,6 +774,35 @@ class TestSlurmGPUDefaults:
         assert instance_type.memory == expected_memory
 
 
+class TestIsInsideSlurmCluster:
+    """Test the two-layer Slurm marker resolution in slurm_utils."""
+
+    def test_runtime_dir_marker_detects_container_shape(self, tmp_path,
+                                                        monkeypatch):
+        """Marker in the runtime dir is found through SKY_RUNTIME_DIR."""
+        runtime_dir = tmp_path / 'rt'
+        runtime_dir.mkdir()
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(runtime_dir))
+        monkeypatch.setenv('HOME', str(tmp_path / 'home-without-marker'))
+
+        assert not slurm_utils.is_inside_slurm_cluster()
+        (runtime_dir / slurm_utils.SLURM_MARKER_FILE).touch()
+        assert slurm_utils.is_inside_slurm_cluster()
+
+    def test_home_marker_fallback(self, tmp_path, monkeypatch):
+        """Clusters without the runtime-dir marker still detect via HOME."""
+        home = tmp_path / 'cluster-home'
+        home.mkdir()
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(tmp_path / 'rt-without-marker'))
+        monkeypatch.setenv('HOME', str(home))
+
+        assert not slurm_utils.is_inside_slurm_cluster()
+        (home / slurm_utils.SLURM_MARKER_FILE).touch()
+        assert slurm_utils.is_inside_slurm_cluster()
+
+
 class TestGRESGPUParsing:
     """Test slurm_utils.get_gpu_type_and_count."""
 
@@ -1478,6 +1507,7 @@ class TestCreateVirtualInstance:
                                                       config)
         assert ('--container-mounts="/home/testuser:/home/testuser,'
                 '/tmp/ccache_$(id -u):/var/cache/ccache,'
+                '/tmp/test-cluster-mounted:/tmp/test-cluster-mounted,'
                 '/host/data:/data:ro,/nvme/$SLURM_JOB_ID:/scratch,'
                 '/host/models:/models:ro"' in mounted_script)
 
@@ -1540,6 +1570,109 @@ class TestCreateVirtualInstance:
             'test-cluster-fractional-cpus', config)
 
         assert '#SBATCH --cpus-per-task=2' in written_script
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_skylet_keeper_block_non_container(self, mock_ssh_runner,
+                                               mock_slurm_client,
+                                               mock_get_partition_info,
+                                               mock_get_proctrack_type,
+                                               mock_wait_for_job_nodes):
+        """Keeper step precedes the final anchor and runs the start spec."""
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'cpus')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = self._make_non_container_config(cpus=2)
+        script = self._run_and_capture_script('test-keeper', config)
+
+        keeper_idx = script.index(
+            '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
+            '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
+        anchor_idx = script.rindex('sleep infinity\n')
+        # The keeper is backgrounded before the allocation-lifetime anchor.
+        assert keeper_idx < anchor_idx
+        keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]
+        # Outer retry loop: the batch script restarts the step itself.
+        assert keeper_line.endswith('sleep 5; done ) &')
+        # Head node is resolved in-script from the allocation.
+        head_idx = script.index(
+            'SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" '
+            '| head -n1)')
+        assert head_idx < keeper_idx
+        # The loop runs the start spec from the runtime dir, foreground.
+        assert constants.SKYLET_START_FILE in keeper_line
+        assert 'while true; do' in keeper_line
+        # The keeper sets HOME; attempt_skylet may write the spec
+        # in-container where HOME is /root.
+        assert ('HOME=/home/testuser/.sky_clusters/test-keeper bash'
+                in keeper_line)
+        # Non-container keeper must not attach to a pyxis container.
+        assert '--container-name' not in keeper_line
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_skylet_keeper_block_container(self, mock_ssh_runner,
+                                           mock_slurm_client,
+                                           mock_get_partition_info,
+                                           mock_get_proctrack_type,
+                                           mock_wait_for_job_nodes):
+        """Container keeper stays host-side: no container attach args."""
+        from sky.provision import common
+
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'gpu')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'testuser',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'gpu',
+                'provision_timeout': 300,
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': 4,
+                'memory': 16,
+                'image_id': 'nvcr.io/nvidia/pytorch:24.01-py3',
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+        script = self._run_and_capture_script('test-keeper-ctr', config)
+
+        keeper_idx = script.index(
+            '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
+            '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
+        anchor_idx = script.rindex('\nwait\n')
+        assert keeper_idx < anchor_idx
+        keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]
+        # The keeper never attaches the container: Slurm CLIs are host-only.
+        assert '--container-name' not in keeper_line
+        assert '--container-remap-root' not in keeper_line
+        assert constants.SKYLET_START_FILE in keeper_line
+        # The keeper sets the host-correct HOME when running the spec.
+        assert ('HOME=/home/testuser/.sky_clusters/test-keeper-ctr bash'
+                in keeper_line)
+        # Outer retry loop: the batch script restarts the step itself.
+        assert keeper_line.endswith('sleep 5; done ) &')
 
     @pytest.mark.parametrize('memory_gb,expected_mem_mb', [
         (0.5, 512),

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -781,13 +781,13 @@ class TestIsInsideSlurmCluster:
                                                         monkeypatch):
         """Marker in the runtime dir is found through SKY_RUNTIME_DIR."""
         runtime_dir = tmp_path / 'rt'
-        runtime_dir.mkdir()
+        (runtime_dir / '.sky').mkdir(parents=True)
         monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
                            str(runtime_dir))
         monkeypatch.setenv('HOME', str(tmp_path / 'home-without-marker'))
 
         assert not slurm_utils.is_inside_slurm_cluster()
-        (runtime_dir / slurm_utils.SLURM_MARKER_FILE).touch()
+        (runtime_dir / '.sky' / slurm_utils.SLURM_MARKER_FILE).touch()
         assert slurm_utils.is_inside_slurm_cluster()
 
     def test_home_marker_fallback(self, tmp_path, monkeypatch):
@@ -1507,7 +1507,7 @@ class TestCreateVirtualInstance:
                                                       config)
         assert ('--container-mounts="/home/testuser:/home/testuser,'
                 '/tmp/ccache_$(id -u):/var/cache/ccache,'
-                '/tmp/test-cluster-mounted:/tmp/test-cluster-mounted,'
+                '/tmp/test-cluster-mounted/.sky:/tmp/test-cluster-mounted/.sky,'
                 '/host/data:/data:ro,/nvme/$SLURM_JOB_ID:/scratch,'
                 '/host/models:/models:ro"' in mounted_script)
 
@@ -1661,7 +1661,7 @@ class TestCreateVirtualInstance:
         keeper_idx = script.index(
             '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
             '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
-        anchor_idx = script.rindex('\nwait\n')
+        anchor_idx = script.rindex('\nwait "$CONTAINER_PID"\n')
         assert keeper_idx < anchor_idx
         keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]
         # The keeper never attaches the container: Slurm CLIs are host-only.

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -45,6 +45,8 @@ trap 'exit 0' TERM
 mkdir -p /home/testuser/.sky_clusters/test-cluster-no-container/sky_logs /home/testuser/.sky_clusters/test-cluster-no-container/sky_workdir /home/testuser/.sky_clusters/test-cluster-no-container/.sky
 # Create sky runtime directory on each node.
 srun --nodes=1 mkdir -p /tmp/test-cluster-no-container
+# Slurm marker in the runtime dir: resolvable in both shapes.
+srun --nodes=1 touch /tmp/test-cluster-no-container/.sky_slurm_cluster
 # Marker file to indicate we're in a Slurm cluster.
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.sky_slurm_cluster
 # Store proctrack type for task executor to read.
@@ -53,4 +55,8 @@ echo 'cgroup' > /home/testuser/.sky_clusters/test-cluster-no-container/.sky_proc
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.hushlogin
 
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.sky_sbatch_ready
+# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
+# restarts the step.
+SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster-no-container/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster-no-container bash /tmp/test-cluster-no-container/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
 sleep infinity

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -14,8 +14,8 @@
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {
     saved_exit=$?
-    # The Skylet is daemonized, so it is not automatically terminated when
-    # the Slurm job is terminated, we need to kill it manually.
+    # Prevent the keeper from restarting Skylet during cleanup.
+    rm -f "/tmp/test-cluster-no-container/.sky/skylet_start"
     echo "Terminating Skylet..."
     if [ -f "/tmp/test-cluster-no-container/.sky/skylet_pid" ]; then
         kill $(cat "/tmp/test-cluster-no-container/.sky/skylet_pid") 2>/dev/null || true
@@ -25,13 +25,13 @@ cleanup() {
     # This is only needed when container_scope=global.
     # When container_scope=job, named containers are removed automatically
     # at the end of the Slurm job, see: https://github.com/NVIDIA/pyxis/wiki/Setup#slurm-epilog
-    srun --nodes=1 --ntasks-per-node=1 enroot remove -f pyxis_test-cluster-no-container 2>/dev/null || true
+    srun --overlap --nodes=1 --ntasks-per-node=1 enroot remove -f pyxis_test-cluster-no-container 2>/dev/null || true
     # Clean up sky runtime directory on each node.
     # NOTE: We can do this because --nodes for both this srun and the
     # sbatch is the same number. Otherwise, there are no guarantees
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
-    srun --nodes=1 rm -rf /tmp/test-cluster-no-container
+    srun --overlap --nodes=1 rm -rf /tmp/test-cluster-no-container
     rm -rf /home/testuser/.sky_clusters/test-cluster-no-container
     exit $saved_exit
 }
@@ -44,19 +44,16 @@ trap 'exit 0' TERM
 # Create sky home directory and subdirectories for the cluster.
 mkdir -p /home/testuser/.sky_clusters/test-cluster-no-container/sky_logs /home/testuser/.sky_clusters/test-cluster-no-container/sky_workdir /home/testuser/.sky_clusters/test-cluster-no-container/.sky
 # Create sky runtime directory on each node.
-srun --nodes=1 mkdir -p /tmp/test-cluster-no-container
-# Slurm marker in the runtime dir: resolvable in both shapes.
-srun --nodes=1 touch /tmp/test-cluster-no-container/.sky_slurm_cluster
+srun --nodes=1 mkdir -p /tmp/test-cluster-no-container/.sky
 # Marker file to indicate we're in a Slurm cluster.
-touch /home/testuser/.sky_clusters/test-cluster-no-container/.sky_slurm_cluster
+srun --nodes=1 touch /tmp/test-cluster-no-container/.sky/.sky_slurm_cluster
 # Store proctrack type for task executor to read.
 echo 'cgroup' > /home/testuser/.sky_clusters/test-cluster-no-container/.sky_proctrack_type
 # Suppress login messages.
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.hushlogin
 
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.sky_sbatch_ready
-# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
-# restarts the step.
+# Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
 ( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster-no-container/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster-no-container bash /tmp/test-cluster-no-container/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
 sleep infinity

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -14,8 +14,8 @@
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {
     saved_exit=$?
-    # The Skylet is daemonized, so it is not automatically terminated when
-    # the Slurm job is terminated, we need to kill it manually.
+    # Prevent the keeper from restarting Skylet during cleanup.
+    rm -f "/tmp/test-cluster/.sky/skylet_start"
     echo "Terminating Skylet..."
     if [ -f "/tmp/test-cluster/.sky/skylet_pid" ]; then
         kill $(cat "/tmp/test-cluster/.sky/skylet_pid") 2>/dev/null || true
@@ -25,13 +25,13 @@ cleanup() {
     # This is only needed when container_scope=global.
     # When container_scope=job, named containers are removed automatically
     # at the end of the Slurm job, see: https://github.com/NVIDIA/pyxis/wiki/Setup#slurm-epilog
-    srun --nodes=1 --ntasks-per-node=1 enroot remove -f pyxis_test-cluster 2>/dev/null || true
+    srun --overlap --nodes=1 --ntasks-per-node=1 enroot remove -f pyxis_test-cluster 2>/dev/null || true
     # Clean up sky runtime directory on each node.
     # NOTE: We can do this because --nodes for both this srun and the
     # sbatch is the same number. Otherwise, there are no guarantees
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
-    srun --nodes=1 rm -rf /tmp/test-cluster
+    srun --overlap --nodes=1 rm -rf /tmp/test-cluster
     rm -rf /home/testuser/.sky_clusters/test-cluster
     exit $saved_exit
 }
@@ -44,11 +44,9 @@ trap 'exit 0' TERM
 # Create sky home directory and subdirectories for the cluster.
 mkdir -p /home/testuser/.sky_clusters/test-cluster/sky_logs /home/testuser/.sky_clusters/test-cluster/sky_workdir /home/testuser/.sky_clusters/test-cluster/.sky
 # Create sky runtime directory on each node.
-srun --nodes=1 mkdir -p /tmp/test-cluster
-# Slurm marker in the runtime dir: resolvable in both shapes.
-srun --nodes=1 touch /tmp/test-cluster/.sky_slurm_cluster
+srun --nodes=1 mkdir -p /tmp/test-cluster/.sky
 # Marker file to indicate we're in a Slurm cluster.
-touch /home/testuser/.sky_clusters/test-cluster/.sky_slurm_cluster
+srun --nodes=1 touch /tmp/test-cluster/.sky/.sky_slurm_cluster
 # Store proctrack type for task executor to read.
 echo 'cgroup' > /home/testuser/.sky_clusters/test-cluster/.sky_proctrack_type
 # Suppress login messages.
@@ -58,7 +56,7 @@ CONTAINER_START=$SECONDS
 echo "[container] Initializing test-cluster on all nodes"
 rm -rf /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
 mkdir -p /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
-srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster:/tmp/test-cluster" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
+srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster/.sky:/tmp/test-cluster/.sky" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
 echo "[container-init] Starting..."
 INIT_START=$SECONDS
 apt-get update
@@ -83,8 +81,7 @@ done
 echo "[container] Ready in $((SECONDS - CONTAINER_START))s"
 touch /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 
-# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
-# restarts the step.
+# Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
 ( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster bash /tmp/test-cluster/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
-wait
+wait "$CONTAINER_PID"

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -45,6 +45,8 @@ trap 'exit 0' TERM
 mkdir -p /home/testuser/.sky_clusters/test-cluster/sky_logs /home/testuser/.sky_clusters/test-cluster/sky_workdir /home/testuser/.sky_clusters/test-cluster/.sky
 # Create sky runtime directory on each node.
 srun --nodes=1 mkdir -p /tmp/test-cluster
+# Slurm marker in the runtime dir: resolvable in both shapes.
+srun --nodes=1 touch /tmp/test-cluster/.sky_slurm_cluster
 # Marker file to indicate we're in a Slurm cluster.
 touch /home/testuser/.sky_clusters/test-cluster/.sky_slurm_cluster
 # Store proctrack type for task executor to read.
@@ -56,7 +58,7 @@ CONTAINER_START=$SECONDS
 echo "[container] Initializing test-cluster on all nodes"
 rm -rf /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
 mkdir -p /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
-srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
+srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster:/tmp/test-cluster" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
 echo "[container-init] Starting..."
 INIT_START=$SECONDS
 apt-get update
@@ -81,4 +83,8 @@ done
 echo "[container] Ready in $((SECONDS - CONTAINER_START))s"
 touch /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 
+# Skylet keeper: foreground skylet; inner loop restarts skylet, outer loop
+# restarts the step.
+SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster bash /tmp/test-cluster/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
 wait

--- a/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
+++ b/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
@@ -228,3 +228,199 @@ class TestRestartSkylet:
         assert self.env['port_file'].read_text() == str(
             constants.SKYLET_GRPC_PORT)
         assert self.env['version_file'].read_text() == constants.SKYLET_VERSION
+
+
+class TestRestartSkyletOnSlurm:
+    """Test the Slurm (keeper-based) branch of restart_skylet()."""
+
+    KEEPER_PID = 4242
+
+    @pytest.fixture(autouse=True)
+    def setup(self, skylet_env, tmp_path, monkeypatch):
+        self.env = skylet_env
+        self.start_file = tmp_path / 'skylet.start'
+        monkeypatch.setattr(attempt_skylet, 'START_FILE', str(self.start_file))
+        monkeypatch.setattr(attempt_skylet, '_is_inside_slurm_cluster',
+                            lambda: True)
+        monkeypatch.setattr('sky.utils.common_utils.find_free_port',
+                            lambda port: constants.SKYLET_GRPC_PORT)
+
+        # The nohup path must never run on Slurm.
+        def forbid_run(cmd, **kwargs):
+            raise AssertionError(f'unexpected subprocess.run on Slurm: {cmd}')
+
+        monkeypatch.setattr('subprocess.run', forbid_run)
+        # No real 30s waits: virtual clock, instant sleeps.
+        self.clock = [0.0]
+        fake_time = mock.Mock()
+        fake_time.time = lambda: self.clock[0]
+
+        def fake_sleep(seconds):
+            self.clock[0] += seconds
+
+        fake_time.sleep = fake_sleep
+        monkeypatch.setattr(attempt_skylet, 'time', fake_time)
+
+    def _simulate_keeper(self, monkeypatch):
+        """Write the PID file once the start spec has landed, like the
+        keeper's `bash spec` would, and validate only that exact PID."""
+
+        # Kill scan finds nothing; the handshake must not use this either
+        # way (see test_foreign_skylet_does_not_satisfy_handshake).
+        monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
+                            lambda: [])
+
+        def fake_is_running(pid):
+            return pid == self.KEEPER_PID
+
+        monkeypatch.setattr(attempt_skylet, '_is_running_skylet_process',
+                            fake_is_running)
+
+        def fake_sleep_and_spawn(seconds):
+            self.clock[0] += seconds
+            if self.start_file.exists() and not self.env['pid_file'].exists():
+                self.env['pid_file'].write_text(str(self.KEEPER_PID))
+
+        # The keeper "runs" during the handshake's sleeps.
+        monkeypatch.setattr(attempt_skylet.time, 'sleep', fake_sleep_and_spawn)
+
+    def test_writes_spec_and_handshakes(self, monkeypatch):
+        """Slurm branch writes the start spec and awaits the PID handshake."""
+        self._simulate_keeper(monkeypatch)
+
+        attempt_skylet.restart_skylet()
+
+        spec = self.start_file.read_text()
+        # PID-file semantics: the spec shell records $$, then exec replaces
+        # the shell with skylet, so the file holds the real skylet PID.
+        assert f'echo $$ > {self.env["pid_file"]}' in spec
+        assert (f'exec {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
+                f'--port={constants.SKYLET_GRPC_PORT} '
+                f'>> {self.env["log_file"]} 2>&1') in spec
+        # Atomic write: no temp file left behind.
+        assert not self.start_file.with_suffix(self.start_file.suffix +
+                                               '.tmp').exists()
+        assert not (self.start_file.parent /
+                    (self.start_file.name + '.tmp')).exists()
+        # Port/version files written in the usual order.
+        assert self.env['port_file'].read_text() == str(
+            constants.SKYLET_GRPC_PORT)
+        assert self.env['version_file'].read_text() == constants.SKYLET_VERSION
+
+    def test_removes_stale_spec_before_killing(self, monkeypatch):
+        """A stale spec is removed before the kill, closing the relaunch race."""
+        self.start_file.write_text('stale spec')
+        stale_seen_at_kill_scan = []
+
+        def fake_find_pids():
+            # Only the kill scan uses this; the handshake must not.
+            stale_seen_at_kill_scan.append(self.start_file.exists())
+            return []
+
+        self._simulate_keeper(monkeypatch)
+        monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
+                            fake_find_pids)
+
+        attempt_skylet.restart_skylet()
+
+        # The stale spec was already gone when the kill scan ran.
+        assert stale_seen_at_kill_scan == [False]
+        # And the fresh spec replaced it.
+        assert 'stale spec' not in self.start_file.read_text()
+        assert 'exec' in self.start_file.read_text()
+
+    def test_handshake_timeout_raises_clear_error(self, monkeypatch):
+        """No keeper response -> RuntimeError naming the keeper and files."""
+        monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
+                            lambda: [])
+
+        with pytest.raises(RuntimeError, match='keeper'):
+            attempt_skylet.restart_skylet()
+
+        # The spec was still written; only the handshake failed.
+        assert self.start_file.exists()
+
+    def test_foreign_skylet_does_not_satisfy_handshake(self, monkeypatch):
+        """Another cluster's skylet in the global ps scan is not a handshake."""
+        # Global scan "sees" a foreign skylet the whole time; our PID file
+        # never appears, and the foreign PID would pass a liveness check.
+        monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
+                            lambda: [9999])
+        monkeypatch.setattr(attempt_skylet, '_is_running_skylet_process',
+                            lambda pid: True)
+        monkeypatch.setattr('os.kill', lambda p, s: None)
+        monkeypatch.setattr('psutil.Process',
+                            lambda p: mock.Mock(wait=lambda timeout: None))
+
+        with pytest.raises(RuntimeError, match='keeper'):
+            attempt_skylet.restart_skylet()
+
+    def test_spec_is_written_with_owner_only_permissions(self, monkeypatch):
+        """The spec can carry secrets in shared /tmp: mode must be 0600."""
+        self._simulate_keeper(monkeypatch)
+
+        attempt_skylet.restart_skylet()
+
+        mode = self.start_file.stat().st_mode & 0o777
+        assert mode == 0o600, oct(mode)
+
+    def test_spec_serializes_launch_environment(self, monkeypatch):
+        """The spec exports PATH (merged) and SKYPILOT_*/SKY_* vars, quoted."""
+        import shlex
+
+        self._simulate_keeper(monkeypatch)
+        path_value = '/opt/cloud cli/bin:/usr/bin'
+        monkeypatch.setenv('PATH', path_value)
+        monkeypatch.setenv('HOME', '/root')
+        monkeypatch.setenv('SKYPILOT_USER_ID', 'user-1')
+        monkeypatch.setenv('SKY_RUNTIME_DIR', '/tmp/rt dir')
+        monkeypatch.setenv('UNRELATED_SECRET', 'must-not-leak')
+
+        attempt_skylet.restart_skylet()
+
+        spec = self.start_file.read_text()
+        exec_idx = spec.index('\nexec ')
+        # PATH is prepended to the keeper's own PATH, not replaced: the spec
+        # may be written in-container but runs on the host.
+        path_line = f'export PATH={shlex.quote(path_value)}:"$PATH"'
+        assert path_line in spec, path_line
+        assert spec.index(path_line) < exec_idx
+        # Every other export lands before the exec line, values shell-quoted.
+        for key, value in (('SKYPILOT_USER_ID', 'user-1'), ('SKY_RUNTIME_DIR',
+                                                            '/tmp/rt dir')):
+            export_line = f'export {key}={shlex.quote(value)}'
+            assert export_line in spec, export_line
+            assert spec.index(export_line) < exec_idx
+        # HOME is shape-dependent (in-container it is the isolated /root);
+        # the keeper sets the host-correct HOME, so the spec must not.
+        assert 'export HOME=' not in spec
+        assert 'UNRELATED_SECRET' not in spec
+
+
+class TestSlurmDetection:
+    """Test _is_inside_slurm_cluster() marker resolution in both shapes."""
+
+    def test_detects_slurm_via_runtime_dir_marker(self, tmp_path, monkeypatch):
+        """Container shape: marker resolves through SKY_RUNTIME_DIR."""
+        runtime_dir = tmp_path / 'rt'
+        runtime_dir.mkdir()
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(runtime_dir))
+        monkeypatch.setenv('HOME', str(tmp_path / 'empty-home'))
+
+        assert not attempt_skylet._is_inside_slurm_cluster()
+        (runtime_dir / attempt_skylet._SLURM_MARKER_FILE).touch()
+        assert attempt_skylet._is_inside_slurm_cluster()
+
+    def test_detects_slurm_via_home_marker_fallback(self, tmp_path,
+                                                    monkeypatch):
+        """Host shape / pre-existing clusters: HOME marker still works."""
+        home = tmp_path / 'cluster-home'
+        home.mkdir()
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
+                           str(tmp_path / 'rt-no-marker'))
+        monkeypatch.setenv('HOME', str(home))
+
+        assert not attempt_skylet._is_inside_slurm_cluster()
+        (home / attempt_skylet._SLURM_MARKER_FILE).touch()
+        assert attempt_skylet._is_inside_slurm_cluster()

--- a/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
+++ b/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
@@ -253,7 +253,7 @@ class TestRestartSkyletOnSlurm:
         # No real 30s waits: virtual clock, instant sleeps.
         self.clock = [0.0]
         fake_time = mock.Mock()
-        fake_time.time = lambda: self.clock[0]
+        fake_time.monotonic = lambda: self.clock[0]
 
         def fake_sleep(seconds):
             self.clock[0] += seconds
@@ -329,6 +329,23 @@ class TestRestartSkyletOnSlurm:
         assert 'stale spec' not in self.start_file.read_text()
         assert 'exec' in self.start_file.read_text()
 
+    def test_spec_removal_failure_aborts_before_killing(self, monkeypatch):
+        """If the stale spec cannot be removed, abort before killing skylet."""
+        self.start_file.write_text('stale spec')
+
+        def fail_remove(path):
+            raise PermissionError(f'cannot remove {path}')
+
+        monkeypatch.setattr(attempt_skylet.os, 'remove', fail_remove)
+        monkeypatch.setattr(
+            attempt_skylet, '_find_running_skylet_pids',
+            lambda: pytest.fail('kill scan ran after removal failed'))
+
+        with pytest.raises(PermissionError):
+            attempt_skylet.restart_skylet()
+
+        assert self.start_file.read_text() == 'stale spec'
+
     def test_handshake_timeout_raises_clear_error(self, monkeypatch):
         """No keeper response -> RuntimeError naming the keeper and files."""
         monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
@@ -347,7 +364,7 @@ class TestRestartSkyletOnSlurm:
         monkeypatch.setattr(attempt_skylet, '_find_running_skylet_pids',
                             lambda: [9999])
         monkeypatch.setattr(attempt_skylet, '_is_running_skylet_process',
-                            lambda pid: True)
+                            lambda pid: pid == 9999)
         monkeypatch.setattr('os.kill', lambda p, s: None)
         monkeypatch.setattr('psutil.Process',
                             lambda p: mock.Mock(wait=lambda timeout: None))
@@ -398,29 +415,28 @@ class TestRestartSkyletOnSlurm:
 
 
 class TestSlurmDetection:
-    """Test _is_inside_slurm_cluster() marker resolution in both shapes."""
+    """Test _is_inside_slurm_cluster() marker resolution."""
 
     def test_detects_slurm_via_runtime_dir_marker(self, tmp_path, monkeypatch):
         """Container shape: marker resolves through SKY_RUNTIME_DIR."""
         runtime_dir = tmp_path / 'rt'
-        runtime_dir.mkdir()
+        (runtime_dir / '.sky').mkdir(parents=True)
         monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
                            str(runtime_dir))
         monkeypatch.setenv('HOME', str(tmp_path / 'empty-home'))
 
         assert not attempt_skylet._is_inside_slurm_cluster()
-        (runtime_dir / attempt_skylet._SLURM_MARKER_FILE).touch()
+        (runtime_dir / '.sky' / attempt_skylet._SLURM_MARKER_FILE).touch()
         assert attempt_skylet._is_inside_slurm_cluster()
 
-    def test_detects_slurm_via_home_marker_fallback(self, tmp_path,
-                                                    monkeypatch):
-        """Host shape / pre-existing clusters: HOME marker still works."""
+    def test_home_marker_alone_does_not_enable_keeper(self, tmp_path,
+                                                      monkeypatch):
+        """A pre-keeper allocation's HOME marker must keep the nohup path."""
         home = tmp_path / 'cluster-home'
         home.mkdir()
         monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY,
                            str(tmp_path / 'rt-no-marker'))
         monkeypatch.setenv('HOME', str(home))
 
-        assert not attempt_skylet._is_inside_slurm_cluster()
         (home / attempt_skylet._SLURM_MARKER_FILE).touch()
-        assert attempt_skylet._is_inside_slurm_cluster()
+        assert not attempt_skylet._is_inside_slurm_cluster()


### PR DESCRIPTION
## Problem

Skylet dies seconds after starting on Slurm, so autostop and autodown never fire and idle allocations run indefinitely.

- `attempt_skylet.py` starts Skylet with `nohup ... &`.
- On Slurm, that command runs inside a short-lived `srun --overlap` step.
- `proctrack/cgroup` reaps the step's cgroup when the step exits, including Skylet.

Observed live: a dead PID in `skylet_pid`, an empty `skylet.log`, and an allocation running hours past its 30-minute autodown threshold.

## Fix

The sbatch job lives for the allocation's lifetime, so it now owns Skylet through a host-side keeper step.

- The sbatch script starts one host-side `srun --overlap` keeper on the allocation's head node.
- The keeper runs `skylet_start` in the foreground and restarts the step if it exits.
- `attempt_skylet.py` removes the old start spec, kills stale Skylet, selects a port, writes a new start spec, and waits for that cluster's exact PID file.
- Restart ignores only a missing old start spec; any other removal error aborts before Skylet is killed.
- The start spec is written atomically with mode `0600`.
- The spec preserves launch-time `SKYPILOT_*` and `SKY_*` variables, prepends the launch PATH, and leaves HOME for the host-side keeper to set.
- New allocations write one Slurm marker under the runtime directory's `.sky/`.
- Keeper detection requires that runtime marker, which proves the submitted sbatch script contains the start-spec loop.
- Generic Slurm detection keeps the HOME marker fallback for allocations created before this change.
- Container allocations mount only the runtime `.sky/` directory, so Skylet state is shared while host and container keep separate runtime virtual environments.
- Container allocations wait on `CONTAINER_PID`, so losing the workload container exits the batch script and runs cleanup.
- Cleanup removes the start spec before killing Skylet and uses overlapping `srun` steps so the keeper cannot block cleanup.
- The existing non-Slurm `nohup` path is unchanged.

The keeper remains outside the workload container because the Slurm CLI, munge, and `slurm.conf` are available only on the host.

## Alternatives considered

1. **Launch Skylet directly from the batch script.**
   This cannot support mid-allocation restarts.
   Every `sky launch` and `sky exec` may run `MAYBE_SKYLET_RESTART_CMD` after a version or port change, while the batch script's launch line runs only once.

2. **Detach Skylet with `setsid` or a double fork.**
   `proctrack/cgroup` tracks cgroup membership rather than the process tree, so it still reaps Skylet when the step exits.

3. **Launch the keeper from `attempt_skylet.py`.**
   The `srun` client would belong to the same short-lived step that currently kills Skylet, reproducing the original lifecycle problem.

## Testing

Unit tests cover:

- Rendered sbatch scripts for host and container allocations.
- The host-side keeper and exact-PID handshake.
- Runtime-marker detection and the legacy generic fallback.
- Start-spec environment serialization and mode `0600`.
- Start-spec removal before killing Skylet.
- Failure when a stale start spec cannot be removed.
- The `.sky/`-only container mount.
- `wait "$CONTAINER_PID"`.
- Overlapping cleanup steps.

Live, host shape with `proctrack/cgroup`:

- The keeper process chain was present inside the allocation.
- `kill -9` of Skylet produced a new PID in approximately four seconds.
- One-minute idle autodown removed both the cluster record and Slurm allocation.

Pending on the current revision:

- Rerun the container smoke test after the `.sky/`-only mount correction.
