### PR TITLE
[Slurm] Make login-node SSH commands robust to non-POSIX login shells (tcsh/csh)

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1,4 +1,5 @@
 """Runner for commands to be executed on the cluster."""
+import base64
 import enum
 import fcntl
 import hashlib
@@ -2059,6 +2060,37 @@ class SlurmLoginNodeCommandRunner(SSHCommandRunner):
         super().__init__(node, ssh_user, ssh_private_key, **kwargs)
         self.slurm_user = slurm_user
         self._use_sudo = ssh_user != 'root'
+
+    def _get_command_to_run(
+        self,
+        cmd: Union[str, List[str]],
+        process_stream: bool,
+        separate_stderr: bool,
+        skip_num_lines: int,
+        source_bashrc: bool = False,
+        use_login: bool = True,
+        run_in_background: bool = False,
+    ) -> str:
+        # A Slurm login node is user-managed, and the SSH user's login shell
+        # may be csh/tcsh/fish rather than a POSIX shell. The command built by
+        # the base implementation places POSIX-only constructs (`2>&1`,
+        # `; exit ${PIPESTATUS[0]}`, trailing `&`) *outside* the
+        # `/bin/bash -c` quoting, so the remote login shell parses them:
+        # csh treats `2>&1` as a redirect to a file literally named `1` and
+        # rejects `${PIPESTATUS[0]}` with "Illegal variable name".
+        # Encode the whole command and decode it inside bash, so the login
+        # shell only ever parses a simple pipeline, which every shell
+        # (POSIX, csh family, fish) accepts.
+        command_str = super()._get_command_to_run(
+            cmd,
+            process_stream,
+            separate_stderr,
+            skip_num_lines,
+            source_bashrc=source_bashrc,
+            use_login=use_login,
+            run_in_background=run_in_background)
+        encoded = base64.b64encode(command_str.encode('utf-8')).decode('ascii')
+        return f'echo {encoded} | base64 -d | /bin/bash'
 
     def _inline_command_quote_levels(self) -> int:
         # wrap_command_as_user adds one inner login-shell `-c` command.


### PR DESCRIPTION
Fixes SkyPilot's Slurm backend on clusters whose login node gives users a non-POSIX login shell (csh/tcsh - still common on academic clusters).

## Problem

`CommandRunner._get_command_to_run()` builds the remote command as `/bin/bash --login -c '<payload>'` and then appends `2>&1`, `| stdbuf -o0 tail -n +N`, `; exit ${PIPESTATUS[0]}`, or `nohup ... &` **outside** the `-c` quoting. Over SSH, the whole string is parsed by the remote user's *login shell* before bash ever runs. Under tcsh:

- `2>&1` is parsed as "redirect stdout to a file literally named `1`" - the command "succeeds" but all output lands in `~/1`, so every output-capturing step (e.g. the `SKYPILOT_HOME_DIR` probe during provisioning) gets an empty string and the launch fails.
- `; exit ${PIPESTATUS[0]}` fails with `Illegal variable name`.

Cloud VMs are unaffected because SkyPilot provisions them with bash. A Slurm login node is user-managed, so the backend cannot assume the login shell.

## Fix

`SlurmLoginNodeCommandRunner` (and therefore `SlurmCommandRunner`) now base64-encodes the fully built command and decodes it into `/bin/bash` on the remote side:

```
echo <base64> | base64 -d | /bin/bash
```

A plain pipeline is valid in every shell (POSIX, csh family, fish), so the login shell no longer parses any bash-only syntax. The wrapper is scoped to the Slurm runners; other clouds are untouched.

Notes:
- `wrap_command_as_user` output is also covered, since the wrap is applied last in `_get_command_to_run`.
- rsync is unaffected (its remote command contains no POSIX-only constructs) and continues to work unchanged.

## Tested

- [x] Code formatting: `yapf==0.32.0` + `isort==5.12.0` on the changed file (no diff)
- [x] Manual tests: on a live Slurm 23.02.2 cluster whose login node defaults to tcsh: without this change, `sky launch` fails at the remote home directory probe (output redirected to a file named `1` on the login node); with it, `sky launch`, `sky exec`, `sky queue`, `sky logs`, and `sky jobs launch` (consolidation mode) all work, including managed-job recovery after preemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->