### PR TITLE
[Slurm] Do not request untyped step GRES when the task uses the whole allocation

### DIFF
--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -874,7 +874,19 @@ class SlurmCodeGen(TaskCodeGen):
                 setup_done_signal_file = os.path.expanduser(setup_done_signal_file)
 
                 # Start exclusive srun in a thread to reserve allocation (similar to ray.get(pg.ready()))
-                gpu_arg = f'--gpus-per-node={num_gpus}'
+                # A step-level `--gpus-per-node` asks for *untyped* gpu GRES.
+                # When the allocation holds typed GRES (e.g. `--gres=gpu:h100:1`),
+                # Slurm 23.02 rejects such a step with "Step requested GRES
+                # (gpu:(null)) not found in the job". A step with no GRES flag
+                # inherits all job GRES, typed or untyped, so omit the flag
+                # whenever the task uses every GPU of the allocation. Keep it
+                # only when the task uses a subset of the allocation's GPUs,
+                # where step-level GPU scheduling is actually needed.
+                allocated_gpus = int(os.environ.get('SLURM_GPUS_ON_NODE', '0') or '0')
+                if {num_gpus} >= allocated_gpus:
+                    gpu_arg = ''
+                else:
+                    gpu_arg = f'--gpus-per-node={num_gpus}'
 
                 def build_task_runner_cmd(user_script, extra_flags, log_dir, env_vars_dict,
                                           task_name=None, is_setup=False,


### PR DESCRIPTION
Fixes GPU tasks failing at `FAILED_SETUP` on Slurm clusters that use **typed** GRES (e.g. `gres/gpu:h100`).

## Problem

The generated Slurm driver reserves the allocation with an exclusive srun that passes `--gpus-per-node=<n>`. A step-level `--gpus-per-node` requests *untyped* gpu GRES. When the sbatch allocation was created with typed GRES (`--gres=gpu:<type>:<n>` - which the provisioner emits whenever the cluster defines GRES types), Slurm 23.02 rejects the step:

```
srun: error: Step requested GRES (gpu:(null)) not found in the job
```

so every GPU task on such a cluster fails during setup.

## Fix

A step started without any GRES flag inherits **all** job GRES, typed or untyped. So the driver now omits the step-level flag whenever the task requests every GPU of the allocation - the common case, and always the case for a task that fills its own cluster. The explicit `--gpus-per-node` is kept only when the task requests a subset of the allocation's GPUs (read from `SLURM_GPUS_ON_NODE` at driver runtime), where step-level GPU scheduling is actually needed.

CPU-only tasks now also stop emitting `--gpus-per-node=0`.

## Tested

- [x] Code formatting: `yapf==0.32.0` + `isort==5.12.0` on the changed file (no diff)
- [x] Manual tests: on a live Slurm 23.02.2 cluster with typed GRES (`gres/gpu:geforce_rtx_2080`): before the change every GPU task failed at setup with the error above; after it, GPU tasks run, `CUDA_VISIBLE_DEVICES` is set correctly inside the step, and multi-task `sky exec` reuse of one allocation works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->