### PR TITLE
[Server] Attribute event loop stalls to the code that caused them

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -220,6 +220,18 @@ SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS = prom.Gauge(
     multiprocess_mode='liveall',
 )
 
+# Source attribution for the stalls the two series above only measure: one
+# increment per stall, labeled with the code that was blocking the loop. The
+# writer caps how many distinct label values it will emit per process
+# (collapsing the rest into 'other'), so this stays low cardinality even if a
+# deployment manages to stall in many different places. See
+# sky/server/loop_stall.py.
+SKY_APISERVER_EVENT_LOOP_STALL_TOTAL = prom.Counter(
+    'sky_apiserver_event_loop_stall_total',
+    'Event loop stalls, by the code that was blocking the loop',
+    ['source'],
+)
+
 SKY_APISERVER_WEBSOCKET_CONNECTIONS = prom.Gauge(
     'sky_apiserver_websocket_connections',
     'Number of websocket connections',
@@ -481,6 +493,16 @@ def record_federation_payload(context: str, route: str, num_bytes: int) -> None:
     if METRICS_ENABLED:
         SKY_APISERVER_FEDERATION_PAYLOAD_BYTES.labels(
             context=context, route=route).observe(num_bytes)
+
+
+def record_event_loop_stall(source: str) -> None:
+    """Records one event loop stall attributed to `source` (non-blocking).
+
+    Called from the stall watchdog thread, so it must not block: a pure
+    in-memory inc() with no I/O.
+    """
+    if METRICS_ENABLED:
+        SKY_APISERVER_EVENT_LOOP_STALL_TOTAL.labels(source=source).inc()
 
 
 def record_federation_outcome(context: str, route: str, outcome: str) -> None:

--- a/sky/server/loop_stall.py
+++ b/sky/server/loop_stall.py
@@ -33,7 +33,9 @@ would otherwise attribute every such stall to whichever frame happened to call
 """
 import asyncio
 import collections
+import json
 import math
+import re
 import sys
 import threading
 import time
@@ -57,8 +59,16 @@ _POLL_INTERVAL = 0.05
 # Frames deeper than this are dropped. A stack this deep is pathological on its
 # own and we only need the innermost frames to attribute the stall.
 _MAX_STACK_DEPTH = 200
-# Application frames included in the logged stack.
-_MAX_LOGGED_FRAMES = 12
+# Application frames kept in the logged stack, after same-module runs have been
+# collapsed. If even that is exceeded, both *ends* are kept: the innermost
+# frames say what was blocking, the outermost ones say which request got there,
+# and dropping either end loses half the answer.
+_MAX_LOGGED_FRAMES = 24
+_KEEP_OUTERMOST = 8
+# A consecutive run of at least this many frames from one top-level module is
+# collapsed to its first and last frame. Library internals (a dozen SQLAlchemy
+# layers, say) would otherwise crowd out the caller that matters.
+_COLLAPSE_RUN = 4
 
 # At most one dump per source per this many seconds, so a source that stalls
 # repeatedly is reported without filling the log.
@@ -209,8 +219,80 @@ def _walk_stack(frame: Optional[types.FrameType],
     return stack
 
 
+_SITE_PACKAGES = 'site-packages/'
+_STDLIB_RE = re.compile(r'/lib/python3\.\d+/')
+
+
+def _short_path(filename: str) -> str:
+    """Trims install-location noise from a filename.
+
+    `/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py`
+    becomes `sqlalchemy/engine/default.py`, which is both unambiguous and short
+    enough that the interesting part of a stack is not pushed off the line.
+    """
+    index = filename.rfind(_SITE_PACKAGES)
+    if index != -1:
+        return filename[index + len(_SITE_PACKAGES):]
+    match = _STDLIB_RE.search(filename)
+    if match is not None:
+        return filename[match.end():]
+    return filename
+
+
 def _format_frame(frame: _FrameInfo) -> str:
-    return f'{frame.filename}:{frame.lineno} in {frame.function}'
+    return f'{_short_path(frame.filename)}:{frame.lineno} in {frame.function}'
+
+
+def _top_level(module: str) -> str:
+    return module.split('.', 1)[0]
+
+
+def _collapse_frames(frames: List[_FrameInfo]) -> List[str]:
+    """Renders frames outermost-first, collapsing same-module runs.
+
+    Takes frames innermost-first (as sampled) and returns display strings
+    outermost-first, so it reads like a traceback. A run of consecutive frames
+    from one top-level module is reduced to its first and last frame plus a
+    marker, because a dozen intermediate library layers say nothing that the
+    two ends do not.
+    """
+    ordered = list(reversed(frames))
+    out: List[str] = []
+    i = 0
+    while i < len(ordered):
+        module = _top_level(ordered[i].module)
+        j = i + 1
+        while j < len(ordered) and _top_level(ordered[j].module) == module:
+            j += 1
+        run = ordered[i:j]
+        if len(run) >= _COLLAPSE_RUN:
+            out.append(_format_frame(run[0]))
+            out.append(f'... {len(run) - 2} more {module} frame(s) ...')
+            out.append(_format_frame(run[-1]))
+        else:
+            out.extend(_format_frame(f) for f in run)
+        i = j
+    if len(out) > _MAX_LOGGED_FRAMES:
+        head = out[:_KEEP_OUTERMOST]
+        tail = out[_KEEP_OUTERMOST - _MAX_LOGGED_FRAMES:]
+        dropped = len(out) - len(head) - len(tail)
+        out = head + [f'... {dropped} more frame(s) ...'] + tail
+    return out
+
+
+def _as_json(detail: Dict[str, object]) -> str:
+    """Serializes the stall detail as one compact line.
+
+    A stall report used to span a dozen log lines, which meant every line
+    carried its own timestamp prefix, the record interleaved with other
+    workers' output, and no single grep could pull one report out whole.
+    Putting the detail in a trailing JSON object keeps the record greppable as
+    one line and lets `... | grep -o '{.*}' | jq` expand it on demand.
+    """
+    try:
+        return json.dumps(detail, separators=(',', ':'), default=str)
+    except (TypeError, ValueError) as e:  # pragma: no cover - defensive
+        return f'{{"json_error":"{e}"}}'
 
 
 def _source_of(frame: _FrameInfo) -> str:
@@ -464,43 +546,46 @@ class LoopStallWatchdog:
 
     def _log_stall(self, lag: float, innermost: _FrameInfo,
                    app_frames: List[_FrameInfo], source: str,
-                   other_threads: Optional[str]) -> None:
-        # Outermost first, so it reads like a traceback.
-        shown = list(reversed(app_frames[:_MAX_LOGGED_FRAMES]))
-        rendered = '\n'.join(f'    {_format_frame(f)}' for f in shown)
-        elided = len(app_frames) - len(shown)
-        if elided > 0:
-            rendered = f'    ... {elided} more application frame(s)\n{rendered}'
-        message = (
-            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
-            f'in {source}\n'
-            f'  blocking frame: {_format_frame(app_frames[0])}\n'
-            f'  innermost frame: {_format_frame(innermost)}\n'
-            f'  in-flight task: {_describe_current_task(self._loop)}\n'
-            f'  application frames (outermost first):\n{rendered}')
+                   other_threads: Optional[List[Dict[str, object]]]) -> None:
+        detail: Dict[str, object] = {
+            'lag_s': round(lag, 3),
+            'threshold_s': round(self._threshold, 3),
+            'kind': 'waiting' if other_threads is not None else 'on_loop',
+            'source': source,
+            'blocking': _format_frame(app_frames[0]),
+            'innermost': _format_frame(innermost),
+            'task': _describe_current_task(self._loop),
+            'frames': _collapse_frames(app_frames),
+        }
         if other_threads is not None:
-            message = (f'{message}\n  the loop is waiting on another thread; '
-                       f'other threads in this process:\n{other_threads}')
-        logger.warning(message)
+            detail['other_threads'] = other_threads
+        logger.warning(
+            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
+            f'in {source} {_as_json(detail)}')
 
     def _log_starved(self, lag: float, innermost: _FrameInfo,
                      all_frames: Mapping[int, types.FrameType],
                      loop_thread_id: int) -> None:
-        message = (
-            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
-            'but the loop was parked in its own poll (innermost frame '
-            f'{_format_frame(innermost)}), so the delay came from outside the '
-            'loop - GIL contention with another thread in this process, or the '
-            'process not being scheduled.')
+        detail: Dict[str, object] = {
+            'lag_s': round(lag, 3),
+            'threshold_s': round(self._threshold, 3),
+            'kind': 'parked',
+            'source': _STARVED_SOURCE,
+            'innermost': _format_frame(innermost),
+            'note': ('loop was parked in its own poll; the delay came from '
+                     'outside the loop - GIL contention with another thread '
+                     'in this process, or the process not being scheduled'),
+        }
         other_threads = self._render_other_threads(all_frames, loop_thread_id)
-        if other_threads is None:
-            logger.warning(message)
-            return
-        logger.warning(f'{message}\n'
-                       f'  busiest other threads:\n{other_threads}')
+        if other_threads is not None:
+            detail['other_threads'] = other_threads
+        logger.warning(
+            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
+            f'but the loop was parked in its own poll {_as_json(detail)}')
 
-    def _render_other_threads(self, all_frames: Mapping[int, types.FrameType],
-                              loop_thread_id: int) -> Optional[str]:
+    def _render_other_threads(
+            self, all_frames: Mapping[int, types.FrameType],
+            loop_thread_id: int) -> Optional[List[Dict[str, object]]]:
         """Renders the other threads' stacks, subject to its own rate limit.
 
         Much larger than a single stack, so it is throttled separately from the
@@ -514,9 +599,12 @@ class LoopStallWatchdog:
         if not groups:
             return None
         self._last_all_thread_dump_at = now
-        return '\n'.join(
-            f'    {count} thread(s) in {source} (e.g. {thread_name}) at '
-            f'{location}' for source, count, thread_name, location in groups)
+        return [{
+            'count': count,
+            'source': source,
+            'example_thread': thread_name,
+            'at': location,
+        } for source, count, thread_name, location in groups]
 
     def _group_other_threads(
             self, all_frames: Mapping[int, types.FrameType],

--- a/sky/server/loop_stall.py
+++ b/sky/server/loop_stall.py
@@ -349,7 +349,6 @@ class LoopStallWatchdog:
         # is the only part of this that runs on the hot path.
         self._last_beat = time.monotonic()
         self._loop_thread_id: Optional[int] = None
-        self._beating = False
         # Not named `_stop`: that shadows a private attribute of
         # threading.Thread on some versions and only fails at join() time.
         self._stop_event = threading.Event()
@@ -367,16 +366,14 @@ class LoopStallWatchdog:
     # -- lifecycle ---------------------------------------------------------
 
     def start(self) -> None:
-        """Starts the heartbeat and the watchdog thread.
+        """Starts the watchdog thread.
 
-        Must be called from the loop thread, which is how the loop's thread id
-        gets recorded without having to guess at loop internals.
+        The heartbeat it watches is driven from outside, by whichever timer the
+        loop already runs to measure its own lag; `beat` is what feeds it.
         """
         if self._thread is not None:
             return
         self._stop_event.clear()
-        self._beating = True
-        self._beat()
         self._thread = threading.Thread(target=self._watch,
                                         name='loop-stall-watchdog',
                                         daemon=True)
@@ -385,7 +382,6 @@ class LoopStallWatchdog:
                      f'{self._threshold}s')
 
     def stop(self) -> None:
-        self._beating = False
         self._stop_event.set()
         thread = self._thread
         if thread is not None:
@@ -395,12 +391,15 @@ class LoopStallWatchdog:
 
     # -- loop thread -------------------------------------------------------
 
-    def _beat(self) -> None:
+    def beat(self) -> None:
+        """Marks the loop as alive. Must be called from the loop thread.
+
+        Called from the loop's lag timer, which is also where the loop thread's
+        id gets recorded without having to guess at loop internals.
+        """
         if self._loop_thread_id is None:
             self._loop_thread_id = threading.get_ident()
         self._last_beat = time.monotonic()
-        if self._beating:
-            self._loop.call_later(self._heartbeat_interval, self._beat)
 
     # -- watchdog thread ---------------------------------------------------
 
@@ -649,15 +648,20 @@ class LoopStallWatchdog:
                              location) in ranked[:_MAX_THREAD_GROUPS]]
 
 
-def start_watchdog() -> Optional[LoopStallWatchdog]:
+def start_watchdog(
+    heartbeat_interval: float = _HEARTBEAT_INTERVAL
+) -> Optional[LoopStallWatchdog]:
     """Starts stall attribution for the running loop, if it is enabled.
 
-    Must be called from the loop thread. Returns None when disabled, so the
-    caller has nothing to stop.
+    Returns None when disabled, so the caller has nothing to stop and nothing
+    to feed. `heartbeat_interval` must match the cadence of the timer that
+    calls `beat`, since it is what separates normal scheduling slack from lag.
     """
     threshold = perf_utils.get_loop_stall_threshold()
     if threshold is None:
         return None
-    watchdog = LoopStallWatchdog(asyncio.get_running_loop(), threshold)
+    watchdog = LoopStallWatchdog(asyncio.get_running_loop(),
+                                 threshold,
+                                 heartbeat_interval=heartbeat_interval)
     watchdog.start()
     return watchdog

--- a/sky/server/loop_stall.py
+++ b/sky/server/loop_stall.py
@@ -1,0 +1,558 @@
+"""Source attribution for API server event loop stalls.
+
+`loop_lag_monitor` in `sky/server/server.py` answers *how long* the event loop
+stalled. This module answers *where*.
+
+The mechanism is inverted relative to asyncio's own debug mode. Rather than
+instrumenting every callback so that a slow one can be reported after it
+returns, a watchdog thread watches a heartbeat that the loop refreshes on a
+timer. When the heartbeat goes stale the loop thread is - by definition - stuck
+inside whatever it is currently running, while the watchdog thread is not, so
+the watchdog can read the loop thread's Python stack via
+`sys._current_frames()` and see the frame that is actually blocking, mid-stall.
+
+Two properties follow from that:
+
+- The cost is on the stall path only. Nothing is instrumented per callback, so
+  unlike `loop.set_debug(True)` (which captures a source traceback on every
+  handle creation) this can be left on by default, which means it is already
+  running when an incident starts instead of being switched on afterwards.
+- The blocking frame is reported while the loop is still stuck, so a stall in
+  progress is visible rather than only being reported once it ends.
+
+The stack is reduced to a `source` label - the innermost frame that is not
+framework dispatch plumbing - which is stable enough to aggregate on. The full
+elided stack goes to the log so the actual call site is never lost.
+
+When the loop thread's innermost frame is the loop's own poll, the loop was
+parked and the lag came from outside it - GIL contention with another thread in
+the process, or the process not being scheduled. The other threads' stacks are
+dumped in that case, because the loop thread's own stack has nothing to say: it
+would otherwise attribute every such stall to whichever frame happened to call
+`run_forever`.
+"""
+import asyncio
+import collections
+import sys
+import threading
+import time
+import types
+from typing import Deque, Dict, List, Mapping, Optional, Tuple
+
+from sky import sky_logging
+from sky.metrics import utils as metrics_utils
+from sky.utils import perf_utils
+
+logger = sky_logging.init_logger(__name__)
+
+# How often the loop refreshes the heartbeat. One no-op callback per interval;
+# matches the cadence of loop_lag_monitor.
+_HEARTBEAT_INTERVAL = 0.1
+# How often the watchdog thread checks the heartbeat. Each check is a float
+# read and a subtraction, so this can be tighter than the heartbeat itself and
+# bounds how late a stall is noticed.
+_POLL_INTERVAL = 0.05
+
+# Frames deeper than this are dropped. A stack this deep is pathological on its
+# own and we only need the innermost frames to attribute the stall.
+_MAX_STACK_DEPTH = 200
+# Application frames included in the logged stack.
+_MAX_LOGGED_FRAMES = 12
+
+# At most one dump per source per this many seconds, so a source that stalls
+# repeatedly is reported without filling the log.
+_DEDUP_SECONDS = 60.0
+# Ceiling on dumps per minute across all sources, so a stall storm involving
+# many distinct sources cannot amplify into a logging storm either.
+_MAX_DUMPS_PER_MINUTE = 10
+# The all-thread dump is much larger than a single stack, so it is rate limited
+# separately and far more aggressively.
+_ALL_THREAD_DUMP_INTERVAL = 300.0
+_MAX_THREADS_SCANNED = 512
+_MAX_THREAD_GROUPS = 5
+
+# Distinct `source` label values a process will emit before collapsing the
+# rest into _OVERFLOW_SOURCE, so the metric's cardinality stays bounded no
+# matter how many distinct call sites stall.
+_MAX_SOURCE_LABELS = 32
+_OVERFLOW_SOURCE = 'other'
+# Used when the loop thread held no application frames - see module docstring.
+_STARVED_SOURCE = 'starved'
+
+# Modules that only dispatch, never block on their own behalf. Frames from
+# these are skipped when picking the source, because attributing a stall to
+# them is what the asyncio handle repr already does and it is exactly the
+# non-answer this module exists to replace.
+#
+# Note that this is deliberately not an allowlist of first-party packages:
+# anything not listed here is fair game as a source, so a stall inside a
+# third-party library or the standard library (`gzip`, `ssl`, `yaml`, ...) is
+# named directly, and so are frames from code loaded into the server through
+# plugins, without this list having to know about any of it.
+_PLUMBING_ROOTS = (
+    'asyncio',
+    'uvloop',
+    'uvicorn',
+    'anyio',
+    'concurrent.futures',
+)
+_PLUMBING_MODULES = frozenset({
+    'threading',
+    'selectors',
+    'contextlib',
+    'functools',
+    'starlette.applications',
+    'starlette.routing',
+    'starlette.concurrency',
+    'starlette._exception_handler',
+    'starlette._utils',
+    'starlette.middleware.base',
+    'starlette.middleware.errors',
+    'starlette.middleware.exceptions',
+    'fastapi.applications',
+    'fastapi.routing',
+    __name__,
+})
+
+# Innermost-frame locations that mean the loop is not running anything at all -
+# it is sitting in its own poll. Lag observed with the loop here was not caused
+# by work on the loop, so the loop thread's stack has nothing to offer and the
+# other threads are dumped instead.
+_PARKED_ROOTS = (
+    'asyncio',
+    'uvloop',
+    'selectors',
+)
+
+# Innermost-frame locations that mean the loop is blocked waiting on another
+# thread rather than doing work of its own. The frame that entered the wait is
+# still the right attribution - blocking the loop on a lock is a bug at the
+# call site - but the reason it is waiting lives in another thread, so those
+# get dumped as well. Observed in practice: `run_in_executor` on a loop whose
+# executor thread then holds the GIL inside a single long C call, which leaves
+# the loop stuck in `Thread.start`'s `Event.wait`.
+_WAITING_ROOTS = (
+    'threading',
+    'concurrent.futures',
+    'multiprocessing.synchronize',
+    'multiprocessing.connection',
+    'queue',
+)
+
+_FrameInfo = collections.namedtuple(
+    '_FrameInfo', ['module', 'function', 'filename', 'lineno'])
+
+
+def _module_matches(module: str, roots: Tuple[str, ...]) -> bool:
+    return any(
+        module == root or module.startswith(f'{root}.') for root in roots)
+
+
+def _is_plumbing(module: str) -> bool:
+    return (module in _PLUMBING_MODULES or
+            _module_matches(module, _PLUMBING_ROOTS))
+
+
+def _is_parked(innermost: _FrameInfo) -> bool:
+    """Whether the loop was polling rather than executing something."""
+    return _module_matches(innermost.module, _PARKED_ROOTS)
+
+
+def _is_waiting_on_another_thread(innermost: _FrameInfo) -> bool:
+    """Whether the loop is blocked on a cross-thread synchronization wait."""
+    return _module_matches(innermost.module, _WAITING_ROOTS)
+
+
+def _trim_to_current_callback(stack: List[_FrameInfo]) -> List[_FrameInfo]:
+    """Drops the frames that got the loop running in the first place.
+
+    Everything outside the outermost asyncio frame is process bootstrap - the
+    uvicorn entry point, multiprocessing's spawn machinery, `<module>` - which
+    is on the stack for the entire life of the worker and says nothing about
+    this stall. Keeping it would push the frames that matter off the end of a
+    depth-capped log line.
+    """
+    boundary = None
+    for index, frame in enumerate(stack):
+        if _module_matches(frame.module, _PARKED_ROOTS):
+            boundary = index
+    if boundary is None:
+        return stack
+    return stack[:boundary]
+
+
+def _walk_stack(frame: Optional[types.FrameType],
+                max_depth: int = _MAX_STACK_DEPTH) -> List[_FrameInfo]:
+    """Summarizes a frame's stack, innermost frame first.
+
+    Deliberately avoids `traceback.extract_stack`, which resolves source lines
+    through `linecache` - that is filesystem I/O, and this runs while holding a
+    reference into another thread's live stack.
+
+    The stack being walked belongs to a running thread, so it can shift under
+    us and yield a slightly torn view. That is acceptable for attribution: the
+    innermost frames are the ones we care about and they are read first.
+    """
+    stack: List[_FrameInfo] = []
+    while frame is not None and len(stack) < max_depth:
+        code = frame.f_code
+        module = frame.f_globals.get('__name__') or '<unknown>'
+        stack.append(
+            _FrameInfo(module=module,
+                       function=code.co_name,
+                       filename=code.co_filename,
+                       lineno=frame.f_lineno))
+        frame = frame.f_back
+    return stack
+
+
+def _format_frame(frame: _FrameInfo) -> str:
+    return f'{frame.filename}:{frame.lineno} in {frame.function}'
+
+
+def _source_of(frame: _FrameInfo) -> str:
+    """Renders a stable, low-cardinality label for a frame.
+
+    The line number is deliberately excluded: it changes whenever the file
+    above it changes, which would churn the metric's label values on every
+    release. It is kept in the log line, where it is useful and costs nothing.
+    """
+    return f'{frame.module}:{frame.function}'
+
+
+def _describe_current_task(loop: asyncio.AbstractEventLoop) -> str:
+    """Best-effort name of the task the loop is currently running.
+
+    `asyncio.current_task(loop)` is documented to take an explicit loop, which
+    makes it readable from another thread. It only narrows the stall down to a
+    coroutine - the stack is what identifies the blocking frame - so every
+    failure here is swallowed.
+    """
+    try:
+        task = asyncio.current_task(loop)
+        if task is None:
+            return 'none'
+        name = task.get_name()
+        coro = task.get_coro()
+        qualname = str(
+            getattr(coro, '__qualname__', None) or
+            getattr(getattr(coro, 'cr_code', None), 'co_name', None) or
+            '<unknown>')
+        if qualname in name:
+            # Some frameworks name their tasks after the coroutine.
+            return name
+        return f'{name} coro={qualname}'
+    except Exception:  # pylint: disable=broad-except
+        return 'unavailable'
+
+
+class LoopStallWatchdog:
+    """Watches an event loop's heartbeat and attributes stalls to a frame."""
+
+    def __init__(self,
+                 loop: asyncio.AbstractEventLoop,
+                 threshold: float,
+                 heartbeat_interval: float = _HEARTBEAT_INTERVAL,
+                 poll_interval: float = _POLL_INTERVAL) -> None:
+        self._loop = loop
+        self._threshold = threshold
+        self._heartbeat_interval = heartbeat_interval
+        self._poll_interval = poll_interval
+        # Written only by the loop thread, read only by the watchdog thread.
+        # A float attribute store and load are each atomic under the GIL, so
+        # the heartbeat needs no lock - which is the point, since the heartbeat
+        # is the only part of this that runs on the hot path.
+        self._last_beat = time.monotonic()
+        self._loop_thread_id: Optional[int] = None
+        self._beating = False
+        # Not named `_stop`: that shadows a private attribute of
+        # threading.Thread on some versions and only fails at join() time.
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Everything below is touched by the watchdog thread only.
+        self._last_dump_at: Dict[str, float] = {}
+        self._recent_dumps: Deque[float] = collections.deque()
+        self._suppressing = False
+        self._last_all_thread_dump_at = 0.0
+        self._known_sources: Dict[str, None] = {}
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        """Starts the heartbeat and the watchdog thread.
+
+        Must be called from the loop thread, which is how the loop's thread id
+        gets recorded without having to guess at loop internals.
+        """
+        if self._thread is not None:
+            return
+        self._beating = True
+        self._beat()
+        self._thread = threading.Thread(target=self._watch,
+                                        name='loop-stall-watchdog',
+                                        daemon=True)
+        self._thread.start()
+        logger.debug('Event loop stall watchdog started with threshold '
+                     f'{self._threshold}s')
+
+    def stop(self) -> None:
+        self._beating = False
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            # Bounded: the watchdog only ever sleeps for one poll interval.
+            thread.join(timeout=self._poll_interval * 10)
+        self._thread = None
+
+    # -- loop thread -------------------------------------------------------
+
+    def _beat(self) -> None:
+        if self._loop_thread_id is None:
+            self._loop_thread_id = threading.get_ident()
+        self._last_beat = time.monotonic()
+        if self._beating:
+            self._loop.call_later(self._heartbeat_interval, self._beat)
+
+    # -- watchdog thread ---------------------------------------------------
+
+    def _current_lag(self) -> float:
+        # The heartbeat is refreshed every _heartbeat_interval, so a healthy
+        # loop leaves `now - last_beat` anywhere in [0, interval]. Only the
+        # excess is lag, which matches how loop_lag_monitor measures it.
+        return max(
+            0.0,
+            time.monotonic() - self._last_beat - self._heartbeat_interval)
+
+    def _watch(self) -> None:
+        in_stall = False
+        logged_this_stall = False
+        peak_lag = 0.0
+        # Within one stall, sample at the threshold and then at each doubling,
+        # so a 30s stall produces a handful of progressively deeper snapshots
+        # instead of one snapshot or hundreds. This matters when the loop moves
+        # through several blocking calls inside one stall - decode, then
+        # render, then compress - which a single snapshot cannot show.
+        next_sample_at = self._threshold
+        while not self._stop_event.wait(self._poll_interval):
+            if self._loop_thread_id is None:
+                continue
+            lag = self._current_lag()
+            if lag <= self._threshold:
+                if in_stall:
+                    logger.warning(
+                        f'Event loop recovered after stalling {peak_lag:.3f}s.')
+                in_stall = False
+                logged_this_stall = False
+                peak_lag = 0.0
+                next_sample_at = self._threshold
+                continue
+            peak_lag = max(peak_lag, lag)
+            if lag < next_sample_at:
+                continue
+            next_sample_at = lag * 2
+            first_of_stall = not in_stall
+            in_stall = True
+            try:
+                # Later samples of a stall we are already reporting bypass the
+                # per-source dedup - they are the rest of one story, not a
+                # repeat of it - but still count against the global cap.
+                logged = self._capture(lag,
+                                       first_of_stall,
+                                       allow_repeat=logged_this_stall)
+            except Exception as e:  # pylint: disable=broad-except
+                # A diagnostic must never be able to take down the server.
+                logger.debug(f'Event loop stall capture failed: {e}')
+                continue
+            logged_this_stall = logged_this_stall or logged
+
+    def _capture(self,
+                 lag: float,
+                 first_of_stall: bool,
+                 allow_repeat: bool = False) -> bool:
+        """Samples the loop thread's stack and reports the stall.
+
+        Returns whether anything was logged, so the caller can tell a stall it
+        is already reporting from one it has not reported at all.
+        """
+        loop_thread_id = self._loop_thread_id
+        assert loop_thread_id is not None
+        # pylint: disable-next=protected-access
+        all_frames = sys._current_frames()
+        try:
+            loop_frame = all_frames.get(loop_thread_id)
+            if loop_frame is None:
+                return False
+            stack = _walk_stack(loop_frame)
+            # Do not keep the frame alive past the walk.
+            del loop_frame
+            if not stack:
+                return False
+            innermost = stack[0]
+            parked = _is_parked(innermost)
+            callback_stack = _trim_to_current_callback(stack)
+            app_frames = [
+                f for f in callback_stack if not _is_plumbing(f.module)
+            ]
+            if parked:
+                source = _STARVED_SOURCE
+            elif app_frames:
+                source = _source_of(app_frames[0])
+            else:
+                # Every frame is plumbing, yet the loop is not polling: the
+                # innermost frame is the most specific answer available.
+                source = _source_of(innermost)
+            if first_of_stall:
+                metrics_utils.record_event_loop_stall(self._label_for(source))
+            if not self._should_log(source, allow_repeat):
+                return False
+            if parked:
+                self._log_starved(lag, innermost, all_frames, loop_thread_id)
+            else:
+                # A loop blocked on a lock or on another thread's result is
+                # held up by whoever owns it, so name them too.
+                other_threads = (
+                    self._render_other_threads(all_frames, loop_thread_id)
+                    if _is_waiting_on_another_thread(innermost) else None)
+                self._log_stall(lag, innermost, app_frames or callback_stack,
+                                source, other_threads)
+            return True
+        finally:
+            # Frame objects keep their locals alive; drop the whole mapping as
+            # soon as we are done with it.
+            del all_frames
+
+    def _label_for(self, source: str) -> str:
+        if source in self._known_sources:
+            return source
+        if len(self._known_sources) >= _MAX_SOURCE_LABELS:
+            return _OVERFLOW_SOURCE
+        self._known_sources[source] = None
+        return source
+
+    def _should_log(self, source: str, allow_repeat: bool = False) -> bool:
+        now = time.monotonic()
+        if (not allow_repeat and
+                now - self._last_dump_at.get(source, 0.0) < _DEDUP_SECONDS):
+            return False
+        while self._recent_dumps and now - self._recent_dumps[0] > 60.0:
+            self._recent_dumps.popleft()
+        if len(self._recent_dumps) >= _MAX_DUMPS_PER_MINUTE:
+            if not self._suppressing:
+                self._suppressing = True
+                logger.warning(
+                    f'Event loop stalled; more than {_MAX_DUMPS_PER_MINUTE} '
+                    'stack dumps in the last minute, suppressing further '
+                    'dumps. Stall counts are still recorded in '
+                    'sky_apiserver_event_loop_stall_total.')
+            return False
+        self._suppressing = False
+        self._last_dump_at[source] = now
+        self._recent_dumps.append(now)
+        return True
+
+    def _log_stall(self, lag: float, innermost: _FrameInfo,
+                   app_frames: List[_FrameInfo], source: str,
+                   other_threads: Optional[str]) -> None:
+        # Outermost first, so it reads like a traceback.
+        shown = list(reversed(app_frames[:_MAX_LOGGED_FRAMES]))
+        rendered = '\n'.join(f'    {_format_frame(f)}' for f in shown)
+        elided = len(app_frames) - len(shown)
+        if elided > 0:
+            rendered = f'    ... {elided} more application frame(s)\n{rendered}'
+        message = (
+            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
+            f'in {source}\n'
+            f'  blocking frame: {_format_frame(app_frames[0])}\n'
+            f'  innermost frame: {_format_frame(innermost)}\n'
+            f'  in-flight task: {_describe_current_task(self._loop)}\n'
+            f'  application frames (outermost first):\n{rendered}')
+        if other_threads is not None:
+            message = (f'{message}\n  the loop is waiting on another thread; '
+                       f'other threads in this process:\n{other_threads}')
+        logger.warning(message)
+
+    def _log_starved(self, lag: float, innermost: _FrameInfo,
+                     all_frames: Mapping[int, types.FrameType],
+                     loop_thread_id: int) -> None:
+        message = (
+            f'Event loop stalled {lag:.3f}s (threshold {self._threshold:.3f}s) '
+            'but the loop was parked in its own poll (innermost frame '
+            f'{_format_frame(innermost)}), so the delay came from outside the '
+            'loop - GIL contention with another thread in this process, or the '
+            'process not being scheduled.')
+        other_threads = self._render_other_threads(all_frames, loop_thread_id)
+        if other_threads is None:
+            logger.warning(message)
+            return
+        logger.warning(f'{message}\n'
+                       f'  busiest other threads:\n{other_threads}')
+
+    def _render_other_threads(self, all_frames: Mapping[int, types.FrameType],
+                              loop_thread_id: int) -> Optional[str]:
+        """Renders the other threads' stacks, subject to its own rate limit.
+
+        Much larger than a single stack, so it is throttled separately from the
+        per-source dedup. Returns None when throttled or when there is nothing
+        to report.
+        """
+        now = time.monotonic()
+        if now - self._last_all_thread_dump_at < _ALL_THREAD_DUMP_INTERVAL:
+            return None
+        groups = self._group_other_threads(all_frames, loop_thread_id)
+        if not groups:
+            return None
+        self._last_all_thread_dump_at = now
+        return '\n'.join(
+            f'    {count} thread(s) in {source} (e.g. {thread_name}) at '
+            f'{location}' for source, count, thread_name, location in groups)
+
+    def _group_other_threads(
+            self, all_frames: Mapping[int, types.FrameType],
+            loop_thread_id: int) -> List[Tuple[str, int, str, str]]:
+        """Buckets the other threads in this process by their innermost frame.
+
+        Returns (source, thread count, one thread name, one location), for the
+        largest buckets. Threads doing the same thing collapse into one line,
+        which is what makes this readable on a server with dozens of worker
+        threads.
+        """
+        thread_names = {t.ident: t.name for t in threading.enumerate()}
+        watchdog_thread_id = threading.get_ident()
+        buckets: Dict[str, Tuple[int, str, str]] = {}
+        scanned = 0
+        for thread_id, frame in all_frames.items():
+            if thread_id in (loop_thread_id, watchdog_thread_id):
+                continue
+            scanned += 1
+            if scanned > _MAX_THREADS_SCANNED:
+                break
+            stack = _walk_stack(frame)
+            if not stack:
+                continue
+            app_frames = [f for f in stack if not _is_plumbing(f.module)]
+            leaf = app_frames[0] if app_frames else stack[0]
+            source = _source_of(leaf)
+            existing = buckets.get(source)
+            if existing is None:
+                buckets[source] = (1, thread_names.get(thread_id, 'unknown'),
+                                   _format_frame(leaf))
+            else:
+                buckets[source] = (existing[0] + 1, existing[1], existing[2])
+        ranked = sorted(buckets.items(), key=lambda kv: -kv[1][0])
+        return [(source, count, thread_name, location)
+                for source, (count, thread_name,
+                             location) in ranked[:_MAX_THREAD_GROUPS]]
+
+
+def start_watchdog() -> Optional[LoopStallWatchdog]:
+    """Starts stall attribution for the running loop, if it is enabled.
+
+    Must be called from the loop thread. Returns None when disabled, so the
+    caller has nothing to stop.
+    """
+    threshold = perf_utils.get_loop_stall_threshold()
+    if threshold is None:
+        return None
+    watchdog = LoopStallWatchdog(asyncio.get_running_loop(), threshold)
+    watchdog.start()
+    return watchdog

--- a/sky/server/loop_stall.py
+++ b/sky/server/loop_stall.py
@@ -33,6 +33,7 @@ would otherwise attribute every such stall to whichever frame happened to call
 """
 import asyncio
 import collections
+import math
 import sys
 import threading
 import time
@@ -62,9 +63,11 @@ _MAX_LOGGED_FRAMES = 12
 # At most one dump per source per this many seconds, so a source that stalls
 # repeatedly is reported without filling the log.
 _DEDUP_SECONDS = 60.0
-# Ceiling on dumps per minute across all sources, so a stall storm involving
-# many distinct sources cannot amplify into a logging storm either.
+# Ceiling on dumps across all sources within _DUMP_WINDOW_SECONDS, so a stall
+# storm involving many distinct sources cannot amplify into a logging storm
+# either.
 _MAX_DUMPS_PER_MINUTE = 10
+_DUMP_WINDOW_SECONDS = 60.0
 # The all-thread dump is much larger than a single stack, so it is rate limited
 # separately and far more aggressively.
 _ALL_THREAD_DUMP_INTERVAL = 300.0
@@ -76,7 +79,7 @@ _MAX_THREAD_GROUPS = 5
 # matter how many distinct call sites stall.
 _MAX_SOURCE_LABELS = 32
 _OVERFLOW_SOURCE = 'other'
-# Used when the loop thread held no application frames - see module docstring.
+# Used when the loop was parked in its own poll - see module docstring.
 _STARVED_SOURCE = 'starved'
 
 # Modules that only dispatch, never block on their own behalf. Frames from
@@ -269,11 +272,14 @@ class LoopStallWatchdog:
         # threading.Thread on some versions and only fails at join() time.
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        # Everything below is touched by the watchdog thread only.
+        # Everything below is touched by the watchdog thread only. The rate
+        # limit timestamps start at -inf rather than 0 because time.monotonic()
+        # has an arbitrary origin - on a freshly booted host it can be smaller
+        # than the intervals below, which would suppress the very first dump.
         self._last_dump_at: Dict[str, float] = {}
         self._recent_dumps: Deque[float] = collections.deque()
         self._suppressing = False
-        self._last_all_thread_dump_at = 0.0
+        self._last_all_thread_dump_at = -math.inf
         self._known_sources: Dict[str, None] = {}
 
     # -- lifecycle ---------------------------------------------------------
@@ -338,7 +344,11 @@ class LoopStallWatchdog:
                 continue
             lag = self._current_lag()
             if lag <= self._threshold:
-                if in_stall:
+                # Only paired with a stall we actually reported: unlike the
+                # dumps this line has no rate limit of its own, and a loop
+                # oscillating around the threshold would otherwise emit
+                # recoveries for stalls that were deduped away.
+                if in_stall and logged_this_stall:
                     logger.warning(
                         f'Event loop recovered after stalling {peak_lag:.3f}s.')
                 in_stall = False
@@ -432,9 +442,11 @@ class LoopStallWatchdog:
     def _should_log(self, source: str, allow_repeat: bool = False) -> bool:
         now = time.monotonic()
         if (not allow_repeat and
-                now - self._last_dump_at.get(source, 0.0) < _DEDUP_SECONDS):
+                now - self._last_dump_at.get(source, -math.inf) <
+                _DEDUP_SECONDS):
             return False
-        while self._recent_dumps and now - self._recent_dumps[0] > 60.0:
+        while (self._recent_dumps and
+               now - self._recent_dumps[0] > _DUMP_WINDOW_SECONDS):
             self._recent_dumps.popleft()
         if len(self._recent_dumps) >= _MAX_DUMPS_PER_MINUTE:
             if not self._suppressing:

--- a/sky/server/loop_stall.py
+++ b/sky/server/loop_stall.py
@@ -374,6 +374,7 @@ class LoopStallWatchdog:
         """
         if self._thread is not None:
             return
+        self._stop_event.clear()
         self._beating = True
         self._beat()
         self._thread = threading.Thread(target=self._watch,
@@ -480,11 +481,15 @@ class LoopStallWatchdog:
             if not stack:
                 return False
             innermost = stack[0]
-            parked = _is_parked(innermost)
             callback_stack = _trim_to_current_callback(stack)
             app_frames = [
                 f for f in callback_stack if not _is_plumbing(f.module)
             ]
+            # A poll frame only means the loop is idle when there is nothing of
+            # ours above it. Blocking calls bottom out in the same selector -
+            # `subprocess.run` with a pipe, for one - and those are on-loop work
+            # belonging to their caller.
+            parked = _is_parked(innermost) and not app_frames
             if parked:
                 source = _STARVED_SOURCE
             elif app_frames:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -67,6 +67,7 @@ from sky.server import config as server_config
 from sky.server import constants as server_constants
 from sky.server import csp_utils
 from sky.server import daemons
+from sky.server import loop_stall
 from sky.server import metrics
 from sky.server import middleware_utils
 from sky.server import plugins
@@ -949,7 +950,17 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
         # Start monitoring the event loop lag in each server worker
         # event loop (process).
         asyncio.create_task(loop_lag_monitor(asyncio.get_event_loop()))
-    yield
+    # Attribute event loop stalls to the code that caused them. Not gated on
+    # METRICS_ENABLED: its primary output is a log line, which is the only
+    # thing available when debugging a deployment after the fact.
+    stall_watchdog = loop_stall.start_watchdog()
+    try:
+        yield
+    finally:
+        # Runs after uvicorn has drained its connections, so a stall during
+        # the drain itself is still attributed.
+        if stall_watchdog is not None:
+            stall_watchdog.stop()
 
 
 class SecurityHeadersMiddleware(starlette.middleware.base.BaseHTTPMiddleware):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -877,8 +877,21 @@ async def cleanup_sky_logs():
         await asyncio.sleep(3600)
 
 
-async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
-                           interval: float = 0.1) -> None:
+# Cadence of the per-worker loop lag timer. Also the heartbeat interval the
+# stall watchdog measures against, so the two must agree.
+LOOP_LAG_INTERVAL = 0.1
+
+
+async def loop_lag_monitor(
+        loop: asyncio.AbstractEventLoop,
+        interval: float = LOOP_LAG_INTERVAL,
+        stall_watchdog: Optional[loop_stall.LoopStallWatchdog] = None) -> None:
+    """Measures the loop's own scheduling lag on a fixed timer.
+
+    The single tick on the loop for this: it feeds the lag metrics when those
+    are enabled, and the stall watchdog's heartbeat when that is enabled. Each
+    consumer is gated on its own, so neither can silently disable the other.
+    """
     target = loop.time() + interval
 
     pid = str(os.getpid())
@@ -894,17 +907,21 @@ async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
         nonlocal target, lag_max_window_end, lag_max_in_window
         now = loop.time()
         lag = max(0.0, now - target)
-        if lag_threshold is not None and lag > lag_threshold:
-            logger.warning(f'Event loop lag {lag} seconds exceeds threshold '
-                           f'{lag_threshold} seconds.')
-        metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_SECONDS.observe(lag)
-        if now >= lag_max_window_end:
-            lag_max_window_end = now + lag_max_window_seconds
-            lag_max_in_window = lag
-        else:
-            lag_max_in_window = max(lag_max_in_window, lag)
-        metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS.labels(
-            pid=pid).set(lag_max_in_window)
+        if stall_watchdog is not None:
+            stall_watchdog.beat()
+        if metrics_utils.METRICS_ENABLED:
+            if lag_threshold is not None and lag > lag_threshold:
+                logger.warning(
+                    f'Event loop lag {lag} seconds exceeds threshold '
+                    f'{lag_threshold} seconds.')
+            metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_SECONDS.observe(lag)
+            if now >= lag_max_window_end:
+                lag_max_window_end = now + lag_max_window_seconds
+                lag_max_in_window = lag
+            else:
+                lag_max_in_window = max(lag_max_in_window, lag)
+            metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS.labels(
+                pid=pid).set(lag_max_in_window)
         target = now + interval
         loop.call_at(target, tick)
 
@@ -946,14 +963,17 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
     asyncio.create_task(cleanup_upload_ids())
     # Start periodic version check task (runs daily)
     asyncio.create_task(version_check.check_versions_periodically())
-    if metrics_utils.METRICS_ENABLED:
-        # Start monitoring the event loop lag in each server worker
-        # event loop (process).
-        asyncio.create_task(loop_lag_monitor(asyncio.get_event_loop()))
     # Attribute event loop stalls to the code that caused them. Not gated on
     # METRICS_ENABLED: its primary output is a log line, which is the only
     # thing available when debugging a deployment after the fact.
-    stall_watchdog = loop_stall.start_watchdog()
+    stall_watchdog = loop_stall.start_watchdog(
+        heartbeat_interval=LOOP_LAG_INTERVAL)
+    if metrics_utils.METRICS_ENABLED or stall_watchdog is not None:
+        # One timer per worker loop, shared by the lag metrics and the stall
+        # watchdog's heartbeat.
+        asyncio.create_task(
+            loop_lag_monitor(asyncio.get_event_loop(),
+                             stall_watchdog=stall_watchdog))
     try:
         yield
     finally:

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -283,12 +283,6 @@ class Server(uvicorn.Server):
         # (e.g. event-loop-lag peaks recorded just before the worker died)
         # to every subsequent /metrics scrape and liveall-based probe.
         metrics_lib.register_multiproc_cleanup_atexit()
-        lag_threshold = perf_utils.get_loop_lag_threshold()
-        if lag_threshold is not None:
-            event_loop = asyncio.get_event_loop()
-            # Same as set PYTHONASYNCIODEBUG=1, but with custom threshold.
-            event_loop.set_debug(True)
-            event_loop.slow_callback_duration = lag_threshold
         stop_monitor = threading.Event()
         monitor = threading.Thread(
             target=metrics_lib.process_monitor,
@@ -298,10 +292,29 @@ class Server(uvicorn.Server):
         monitor.start()
         try:
             with self.capture_signals():
-                asyncio.run(self.serve(*args, **kwargs))
+                asyncio.run(self._serve_with_debug(*args, **kwargs))
         finally:
             stop_monitor.set()
             monitor.join()
+
+    async def _serve_with_debug(self, *args, **kwargs):
+        """Applies asyncio debug settings to the loop that actually serves.
+
+        These have to be applied from inside the coroutine: `asyncio.run()`
+        builds its own loop and closes it afterwards, so anything configured on
+        the loop that `asyncio.get_event_loop()` returns before the call is
+        thrown away along with that loop.
+        """
+        lag_threshold = perf_utils.get_loop_lag_threshold()
+        if lag_threshold is not None:
+            loop = asyncio.get_running_loop()
+            # Same as setting PYTHONASYNCIODEBUG=1, but with a custom
+            # threshold. Opt-in only: debug mode captures a source traceback
+            # on every handle creation. For always-on stall attribution see
+            # sky/server/loop_stall.py.
+            loop.set_debug(True)
+            loop.slow_callback_duration = lag_threshold
+        await self.serve(*args, **kwargs)
 
 
 def run(config: uvicorn.Config, max_db_connections: Optional[int] = None):

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -825,6 +825,14 @@ COST_REPORT_DEFAULT_DAYS = 30
 ENV_VAR_LOOP_LAG_THRESHOLD_MS = (SKYPILOT_ENV_VAR_PREFIX +
                                  'DEBUG_LOOP_LAG_THRESHOLD_MS')
 
+# Lag above which the event loop stall watchdog dumps the loop thread's stack
+# to attribute the stall. Unlike the debug variable above this is on by
+# default, because its cost falls on the stall path only; set it to 0 to turn
+# the watchdog off.
+ENV_VAR_LOOP_STALL_THRESHOLD_MS = (SKYPILOT_ENV_VAR_PREFIX +
+                                   'LOOP_STALL_THRESHOLD_MS')
+DEFAULT_LOOP_STALL_THRESHOLD_MS = 1000.0
+
 ARM64_ARCH = 'arm64'
 X86_64_ARCH = 'x86_64'
 

--- a/sky/utils/perf_utils.py
+++ b/sky/utils/perf_utils.py
@@ -20,3 +20,29 @@ def get_loop_lag_threshold() -> Optional[float]:
                 f' {lag_threshold}')
             return None
     return None
+
+
+def get_loop_stall_threshold() -> Optional[float]:
+    """Returns the event loop stall attribution threshold, in seconds.
+
+    Defaults to DEFAULT_LOOP_STALL_THRESHOLD_MS rather than to off: the
+    watchdog it gates only does work while the loop is already stalled, so
+    leaving it on means attribution is available for the first incident rather
+    than only for the second one. Returns None when disabled, which is either a
+    non-positive value or an unparseable one.
+    """
+    raw = os.getenv(constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS)
+    if raw is None:
+        threshold_ms = constants.DEFAULT_LOOP_STALL_THRESHOLD_MS
+    else:
+        try:
+            threshold_ms = float(raw)
+        except ValueError:
+            logger.warning(
+                f'Invalid value for '
+                f'{constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS}: {raw}. Event '
+                'loop stall attribution is disabled.')
+            return None
+    if threshold_ms <= 0:
+        return None
+    return threshold_ms / 1000.0

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -38,11 +38,13 @@ def _run_with_watchdog(
                                           poll_interval=0.02)
         watchdog.append(wd)
         wd.start()
+        stop_beat = _drive_heartbeat(asyncio.get_running_loop(), wd)
         try:
             await asyncio.sleep(settle)
             stall_fn()
             await asyncio.sleep(recover)
         finally:
+            stop_beat()
             wd.stop()
 
     if use_uvloop:
@@ -51,6 +53,25 @@ def _run_with_watchdog(
     else:
         asyncio.run(main())
     return watchdog[0]
+
+
+def _drive_heartbeat(loop, watchdog, interval: float = 0.05):
+    """Feeds watchdog.beat() from a loop timer.
+
+    Mirrors the server, where the loop's existing lag timer is the single tick
+    and the watchdog only reads the heartbeat it publishes. Returns a callable
+    that stops the timer.
+    """
+    running = [True]
+
+    def tick():
+        if not running[0]:
+            return
+        watchdog.beat()
+        loop.call_later(interval, tick)
+
+    tick()
+    return lambda: running.__setitem__(0, False)
 
 
 def _blocking_business_code(seconds: float) -> None:
@@ -220,6 +241,7 @@ def test_deduped_stall_emits_no_orphan_recovery(stall_logs):
                                                 heartbeat_interval=0.05,
                                                 poll_interval=0.02)
         watchdog.start()
+        stop_beat = _drive_heartbeat(asyncio.get_running_loop(), watchdog)
         try:
             await asyncio.sleep(0.4)
             _blocking_business_code(0.5)
@@ -228,6 +250,7 @@ def test_deduped_stall_emits_no_orphan_recovery(stall_logs):
             _blocking_business_code(0.5)
             await asyncio.sleep(0.4)
         finally:
+            stop_beat()
             watchdog.stop()
 
     asyncio.run(main())
@@ -428,11 +451,13 @@ def test_watchdog_can_be_restarted_after_stop(stall_logs):
         watchdog.start()
         watchdog.stop()
         watchdog.start()
+        stop_beat = _drive_heartbeat(asyncio.get_running_loop(), watchdog)
         try:
             await asyncio.sleep(0.3)
             _blocking_business_code(0.5)
             await asyncio.sleep(0.4)
         finally:
+            stop_beat()
             watchdog.stop()
 
     asyncio.run(main())
@@ -573,11 +598,13 @@ def _run_counting_watchdog(captures: List[float], stall_fn,
                                 heartbeat_interval=0.05,
                                 poll_interval=0.02)
         watchdog.start()
+        stop_beat = _drive_heartbeat(asyncio.get_running_loop(), watchdog)
         try:
             await asyncio.sleep(0.3)
             stall_fn()
             await asyncio.sleep(0.3)
         finally:
+            stop_beat()
             watchdog.stop()
 
     asyncio.run(main())
@@ -599,11 +626,13 @@ def test_no_dumps_when_the_loop_is_healthy(stall_logs):
             heartbeat_interval=0.05,
             poll_interval=0.02)
         watchdog.start()
+        stop_beat = _drive_heartbeat(asyncio.get_running_loop(), watchdog)
         try:
             # Plenty of loop iterations, none of them blocking.
             for _ in range(60):
                 await asyncio.sleep(0.01)
         finally:
+            stop_beat()
             watchdog.stop()
 
     asyncio.run(main())

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -376,6 +376,45 @@ def test_source_labels_are_capped():
     assert watchdog._label_for('mod0:fn') == 'mod0:fn'  # pylint: disable=protected-access
 
 
+def _counting_watchdog_class(captures: List[float]):
+    """A watchdog subclass that records every sample it takes.
+
+    The override's signature must match the production call in `_watch`
+    exactly. If it did not, the TypeError would be swallowed by `_watch`'s
+    except clause and `captures` would stay empty - which would make
+    test_no_dumps_when_the_loop_is_healthy pass even if a healthy loop were
+    being sampled on every poll.
+    """
+
+    class CountingWatchdog(loop_stall.LoopStallWatchdog):
+
+        def _capture(self, lag, first_of_stall, allow_repeat=False):
+            captures.append(lag)
+            return super()._capture(lag, first_of_stall, allow_repeat)
+
+    return CountingWatchdog
+
+
+def _run_counting_watchdog(captures: List[float], stall_fn,
+                           threshold: float) -> None:
+    watchdog_cls = _counting_watchdog_class(captures)
+
+    async def main():
+        watchdog = watchdog_cls(asyncio.get_running_loop(),
+                                threshold=threshold,
+                                heartbeat_interval=0.05,
+                                poll_interval=0.02)
+        watchdog.start()
+        try:
+            await asyncio.sleep(0.3)
+            stall_fn()
+            await asyncio.sleep(0.3)
+        finally:
+            watchdog.stop()
+
+    asyncio.run(main())
+
+
 def test_no_dumps_when_the_loop_is_healthy(stall_logs):
     """A healthy loop is never sampled at all.
 
@@ -383,19 +422,14 @@ def test_no_dumps_when_the_loop_is_healthy(stall_logs):
     walk, and everything else that costs more than a float comparison, happens
     only once the loop is already stalled.
     """
-    captures = []
-
-    class CountingWatchdog(loop_stall.LoopStallWatchdog):
-
-        def _capture(self, lag, first_of_stall):
-            captures.append(lag)
-            return super()._capture(lag, first_of_stall)
+    captures: List[float] = []
 
     async def main():
-        watchdog = CountingWatchdog(asyncio.get_running_loop(),
-                                    threshold=0.3,
-                                    heartbeat_interval=0.05,
-                                    poll_interval=0.02)
+        watchdog = _counting_watchdog_class(captures)(
+            asyncio.get_running_loop(),
+            threshold=0.3,
+            heartbeat_interval=0.05,
+            poll_interval=0.02)
         watchdog.start()
         try:
             # Plenty of loop iterations, none of them blocking.
@@ -407,6 +441,20 @@ def test_no_dumps_when_the_loop_is_healthy(stall_logs):
     asyncio.run(main())
     assert not captures, f'sampled a healthy loop {len(captures)} time(s)'
     assert not _messages_matching(stall_logs, 'Event loop stalled')
+
+
+def test_counting_harness_does_observe_a_real_stall(stall_logs):
+    """Positive control for the test above.
+
+    Without this, `assert not captures` would also hold if the override were
+    never reached at all, and the healthy-loop test would prove nothing.
+    """
+    del stall_logs  # Only here to keep the watchdog's output off the console.
+    captures: List[float] = []
+    _run_counting_watchdog(captures,
+                           lambda: _blocking_business_code(0.5),
+                           threshold=0.2)
+    assert captures, 'the counting override was never reached'
 
 
 # -- plumbing classification ----------------------------------------------

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -1,0 +1,498 @@
+"""Tests for event loop stall attribution (sky/server/loop_stall.py)."""
+import asyncio
+import gzip
+import io
+import logging
+import threading
+import time
+from typing import List, Optional
+
+import pytest
+
+from sky.server import loop_stall
+from sky.skylet import constants
+from sky.utils import perf_utils
+
+
+def _run_with_watchdog(
+        stall_fn,
+        threshold: float = 0.2,
+        settle: float = 0.6,
+        recover: float = 0.5,
+        use_uvloop: bool = False) -> loop_stall.LoopStallWatchdog:
+    """Runs `stall_fn` on an event loop guarded by a watchdog.
+
+    `settle` gives the heartbeat time to establish itself before the stall, and
+    `recover` gives the watchdog time to notice the loop coming back so the
+    recovery path is exercised too.
+    """
+    watchdog: List[loop_stall.LoopStallWatchdog] = []
+
+    async def main():
+        wd = loop_stall.LoopStallWatchdog(asyncio.get_running_loop(),
+                                          threshold=threshold,
+                                          heartbeat_interval=0.05,
+                                          poll_interval=0.02)
+        watchdog.append(wd)
+        wd.start()
+        try:
+            await asyncio.sleep(settle)
+            stall_fn()
+            await asyncio.sleep(recover)
+        finally:
+            wd.stop()
+
+    if use_uvloop:
+        import uvloop  # pylint: disable=import-outside-toplevel
+        uvloop.run(main())
+    else:
+        asyncio.run(main())
+    return watchdog[0]
+
+
+def _blocking_business_code(seconds: float) -> None:
+    """A named, non-framework function that blocks the loop."""
+    time.sleep(seconds)
+
+
+def _messages_matching(records: List[logging.LogRecord],
+                       needle: str) -> List[str]:
+    messages = [r.getMessage() for r in records]
+    return [m for m in messages if needle in m]
+
+
+@pytest.fixture(name='stall_logs')
+def stall_logs_fixture():
+    """Collects the watchdog's log records.
+
+    SkyPilot disables logger propagation (sky_logging.py), so caplog never sees
+    these; attach a handler to the module's own logger instead. Records arrive
+    from the watchdog thread, but logging serializes emit() and every test
+    joins that thread before asserting.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Collector(level=logging.WARNING)
+    previous_level = loop_stall.logger.level
+    loop_stall.logger.addHandler(handler)
+    loop_stall.logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        loop_stall.logger.removeHandler(handler)
+        loop_stall.logger.setLevel(previous_level)
+
+
+# -- attribution -----------------------------------------------------------
+
+
+def test_synthetic_stall_names_the_blocking_function(stall_logs):
+    """A stall in a known function is attributed to that function."""
+    _run_with_watchdog(lambda: _blocking_business_code(0.5))
+
+    stalls = _messages_matching(stall_logs, 'Event loop stalled')
+    assert stalls, 'no stall was reported'
+    message = stalls[0]
+    assert 'test_loop_stall:_blocking_business_code' in message
+    # file:line of the frame that was actually blocking, not of the asyncio
+    # handle that scheduled it.
+    assert 'test_loop_stall.py:' in message
+    assert 'in _blocking_business_code' in message
+    # The innermost frame is time.sleep's caller, so the blocking frame and
+    # the innermost frame coincide here.
+    assert 'blocking frame:' in message
+    assert 'in-flight task:' in message
+
+    assert _messages_matching(
+        stall_logs, 'Event loop recovered'), ('recovery was not reported')
+
+
+@pytest.mark.parametrize('use_uvloop', [False, True])
+def test_attribution_works_under_both_loop_implementations(
+        stall_logs, use_uvloop):
+    """sys._current_frames is CPython level, so uvloop changes nothing."""
+    if use_uvloop:
+        pytest.importorskip('uvloop')
+    _run_with_watchdog(lambda: _blocking_business_code(0.5),
+                       use_uvloop=use_uvloop)
+
+    stalls = _messages_matching(stall_logs, 'Event loop stalled')
+    assert stalls
+    assert 'test_loop_stall:_blocking_business_code' in stalls[0]
+
+
+def test_gzip_stall_names_the_compression_call_site(stall_logs):
+    """Replays the shape of the gzip-on-the-event-loop stall.
+
+    zlib releases the GIL while compressing, which is what made this invisible
+    to a sampling profiler run without --idle. The watchdog does not care: the
+    loop thread's innermost Python frame is the caller of the C code.
+    """
+
+    # Varied keys, so level 9 actually has to work for its matches. A payload
+    # of repeated bytes compresses an order of magnitude faster and would not
+    # stall at all.
+    chunk = b'{' + b','.join(
+        f'"{i:08d}":"value-{i}"'.encode() for i in range(200000)) + b'}'
+
+    def compress_on_loop():
+        buffer = io.BytesIO()
+        # compresslevel=9 is what Starlette's GZipMiddleware defaults to, and
+        # the chunked writes are the streaming response path.
+        with gzip.GzipFile(fileobj=buffer, mode='wb', compresslevel=9) as f:
+            for _ in range(8):
+                f.write(chunk)
+
+    _run_with_watchdog(compress_on_loop, threshold=0.2, recover=0.6)
+
+    gzip_stalls = _messages_matching(stall_logs, 'gzip:write')
+    assert gzip_stalls, ('gzip stall not attributed, got: '
+                         f'{[r.getMessage() for r in stall_logs]}')
+    message = gzip_stalls[0]
+    # gzip is not framework plumbing, so it is named directly rather than
+    # being collapsed into its caller.
+    assert 'gzip.py:' in message
+    # The chain back to the code that chose to compress on the loop is kept.
+    assert 'in compress_on_loop' in message
+
+
+def test_long_stall_is_sampled_more_than_once(stall_logs):
+    """One stall yields progressively deeper snapshots, not just the first.
+
+    The per-source dedup must not swallow these: they are the rest of one
+    story, and a stall that moves through several blocking calls is only
+    visible if it is sampled more than once.
+    """
+    _run_with_watchdog(lambda: _blocking_business_code(1.6),
+                       threshold=0.15,
+                       recover=0.5)
+
+    stalls = _messages_matching(stall_logs, 'Event loop stalled')
+    assert len(stalls) >= 2, f'expected repeated samples, got {len(stalls)}'
+    # Sampling doubles, so the reported lag grows.
+    lags = [float(m.split('stalled ')[1].split('s ')[0]) for m in stalls]
+    assert lags == sorted(lags), lags
+    assert lags[-1] > lags[0] * 1.5, lags
+
+
+def _wait_for_another_thread(event: threading.Event, seconds: float) -> None:
+    """Blocks the loop on a cross-thread wait, the way Future.result() does."""
+    event.wait(seconds)
+
+
+def test_loop_blocked_on_a_thread_names_both_sides(stall_logs):
+    """A loop waiting on another thread reports the caller *and* the threads.
+
+    Attributing this to the caller alone answers where the loop is stuck but
+    not why - the reason is in whichever thread is not releasing it.
+    """
+    event = threading.Event()
+    marker = threading.Event()
+
+    def holder_thread():
+        marker.wait(2)
+
+    holder = threading.Thread(target=holder_thread,
+                              name='fake-holder',
+                              daemon=True)
+    holder.start()
+    try:
+        _run_with_watchdog(lambda: _wait_for_another_thread(event, 0.6),
+                           threshold=0.2)
+    finally:
+        marker.set()
+        holder.join(timeout=5)
+
+    stalls = _messages_matching(stall_logs, 'Event loop stalled')
+    assert stalls, 'no stall was reported'
+    message = stalls[0]
+    # The call site that chose to block the loop.
+    assert 'test_loop_stall:_wait_for_another_thread' in message
+    # The innermost frame is the wait itself, which is kept verbatim.
+    assert 'threading.py:' in message
+    # And the other threads, since one of them is the reason for the wait.
+    assert 'waiting on another thread' in message
+    assert 'fake-holder' in message
+
+
+def test_bootstrap_frames_are_trimmed():
+    """Frames outside the outermost asyncio frame are process bootstrap."""
+    stack = [
+        _frame('sky.server.server', 'api_get'),
+        _frame('starlette.routing', 'app'),
+        _frame('asyncio.events', '_run'),
+        _frame('asyncio.base_events', '_run_once'),
+        _frame('asyncio.runners', 'run'),
+        _frame('sky.server.uvicorn', 'run'),
+        _frame('__main__', '<module>'),
+    ]
+    trimmed = loop_stall._trim_to_current_callback(stack)  # pylint: disable=protected-access
+    modules = [f.module for f in trimmed]
+    assert 'sky.server.server' in modules
+    # The uvicorn entry point is on the stack for the worker's whole life and
+    # is not what stalled.
+    assert 'sky.server.uvicorn' not in modules
+    assert '__main__' not in modules
+
+
+def test_trimming_keeps_a_stack_with_no_loop_frames():
+    stack = [_frame('sky.server.server', 'api_get'), _frame('gzip', 'write')]
+    assert loop_stall._trim_to_current_callback(stack) == stack  # pylint: disable=protected-access
+
+
+def test_starved_loop_dumps_other_threads(stall_logs):
+    """A parked loop is reported as starved, with the other threads' stacks.
+
+    The stall is simulated rather than provoked: a loop that is genuinely
+    parked in its selector holds only asyncio frames, which is the condition
+    under test, and a real GIL-starvation race would be flaky.
+    """
+    loop = asyncio.new_event_loop()
+    loop_ready = threading.Event()
+
+    def park_the_loop():
+        asyncio.set_event_loop(loop)
+        loop.call_soon(loop_ready.set)
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=park_the_loop,
+                                   name='parked-loop',
+                                   daemon=True)
+    loop_thread.start()
+    assert loop_ready.wait(timeout=5)
+
+    stop = threading.Event()
+    workers_ready = threading.Barrier(4, timeout=5)
+
+    def worker_thread():
+        workers_ready.wait()
+        stop.wait()
+
+    workers = [
+        threading.Thread(target=worker_thread,
+                         name=f'fake-worker-{i}',
+                         daemon=True) for i in range(3)
+    ]
+    for worker in workers:
+        worker.start()
+    workers_ready.wait()
+
+    watchdog = loop_stall.LoopStallWatchdog(loop, threshold=0.1)
+    try:
+        watchdog._loop_thread_id = loop_thread.ident  # pylint: disable=protected-access
+        # Give the loop a moment to settle into the selector.
+        time.sleep(0.2)
+        watchdog._capture(5.0, first_of_stall=True)  # pylint: disable=protected-access
+    finally:
+        stop.set()
+        for worker in workers:
+            worker.join(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+    starved = _messages_matching(stall_logs, 'parked in its own poll')
+    assert starved, ('starved stall not reported, got: '
+                     f'{[r.getMessage() for r in stall_logs]}')
+    assert 'busiest other threads' in starved[0]
+    assert 'fake-worker-' in starved[0]
+    # Threads doing the same thing collapse into one line with a count.
+    assert '3 thread(s) in' in starved[0]
+    # The frame that called run_forever is still on the loop thread's stack.
+    # Classifying on "does the stack hold any application frame" would blame
+    # it for every starvation stall; classification is on the innermost frame.
+    assert 'park_the_loop' not in starved[0]
+
+
+# -- rate limiting and cardinality ----------------------------------------
+
+
+def _watchdog_for_limits() -> loop_stall.LoopStallWatchdog:
+    return loop_stall.LoopStallWatchdog(asyncio.new_event_loop(), threshold=1.0)
+
+
+def test_repeated_stalls_from_one_source_are_deduped():
+    watchdog = _watchdog_for_limits()
+    assert watchdog._should_log('a:b')  # pylint: disable=protected-access
+    assert not watchdog._should_log('a:b')  # pylint: disable=protected-access
+    # A different source is not suppressed by the first one's dedup window.
+    assert watchdog._should_log('c:d')  # pylint: disable=protected-access
+
+
+def test_stall_storm_is_capped_per_minute(stall_logs):
+    watchdog = _watchdog_for_limits()
+    allowed = sum(1 for i in range(50) if watchdog._should_log(f'mod{i}:fn')  # pylint: disable=protected-access
+                 )
+    assert allowed == loop_stall._MAX_DUMPS_PER_MINUTE  # pylint: disable=protected-access
+    assert _messages_matching(stall_logs, 'suppressing further dumps')
+
+
+def test_source_labels_are_capped():
+    watchdog = _watchdog_for_limits()
+    labels = {
+        watchdog._label_for(f'mod{i}:fn')  # pylint: disable=protected-access
+        for i in range(loop_stall._MAX_SOURCE_LABELS * 4)  # pylint: disable=protected-access
+    }
+    assert len(labels) == loop_stall._MAX_SOURCE_LABELS + 1  # pylint: disable=protected-access
+    assert loop_stall._OVERFLOW_SOURCE in labels  # pylint: disable=protected-access
+    # A source already seen keeps its own label rather than being collapsed.
+    assert watchdog._label_for('mod0:fn') == 'mod0:fn'  # pylint: disable=protected-access
+
+
+def test_no_dumps_when_the_loop_is_healthy(stall_logs):
+    """A healthy loop is never sampled at all.
+
+    This is what makes the watchdog safe to leave on by default: the stack
+    walk, and everything else that costs more than a float comparison, happens
+    only once the loop is already stalled.
+    """
+    captures = []
+
+    class CountingWatchdog(loop_stall.LoopStallWatchdog):
+
+        def _capture(self, lag, first_of_stall):
+            captures.append(lag)
+            return super()._capture(lag, first_of_stall)
+
+    async def main():
+        watchdog = CountingWatchdog(asyncio.get_running_loop(),
+                                    threshold=0.3,
+                                    heartbeat_interval=0.05,
+                                    poll_interval=0.02)
+        watchdog.start()
+        try:
+            # Plenty of loop iterations, none of them blocking.
+            for _ in range(60):
+                await asyncio.sleep(0.01)
+        finally:
+            watchdog.stop()
+
+    asyncio.run(main())
+    assert not captures, f'sampled a healthy loop {len(captures)} time(s)'
+    assert not _messages_matching(stall_logs, 'Event loop stalled')
+
+
+# -- plumbing classification ----------------------------------------------
+
+
+@pytest.mark.parametrize('module', [
+    'asyncio',
+    'asyncio.base_events',
+    'uvloop',
+    'uvloop.loop',
+    'uvicorn.protocols.http.httptools_impl',
+    'anyio.to_thread',
+    'starlette.middleware.base',
+    'starlette.routing',
+    'fastapi.routing',
+    'concurrent.futures.thread',
+    'threading',
+    'selectors',
+    'contextlib',
+])
+def test_dispatch_modules_are_not_used_as_a_source(module):
+    assert loop_stall._is_plumbing(module)  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize('module', [
+    'sky.server.server',
+    'sky.jobs.utils',
+    'gzip',
+    'ssl',
+    'sqlalchemy.engine.base',
+    'casbin.core_enforcer',
+    'starlette.middleware.gzip',
+    'some_plugin_package.middleware',
+])
+def test_application_and_library_modules_are_used_as_a_source(module):
+    """Not an allowlist: third-party, stdlib and plugin frames all count."""
+    assert not loop_stall._is_plumbing(module)  # pylint: disable=protected-access
+
+
+def _frame(module: str, function: str = 'fn') -> 'loop_stall._FrameInfo':
+    return loop_stall._FrameInfo(  # pylint: disable=protected-access
+        module=module,
+        function=function,
+        filename=f'{module}.py',
+        lineno=1)
+
+
+@pytest.mark.parametrize('module,function', [
+    ('selectors', 'select'),
+    ('asyncio.base_events', '_run_once'),
+    ('asyncio.runners', 'run'),
+    ('uvloop.loop', 'run_forever'),
+])
+def test_poll_frames_mean_the_loop_was_parked(module, function):
+    assert loop_stall._is_parked(_frame(module, function))  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    'module,function',
+    [
+        # Blocking on a lock or a thread result from the loop is a real on-loop
+        # stall and belongs to the caller, not to "the loop was idle".
+        ('threading', 'wait'),
+        ('concurrent.futures._base', 'result'),
+        ('gzip', 'write'),
+        ('sky.server.server', 'api_get'),
+    ])
+def test_blocking_frames_are_not_treated_as_parked(module, function):
+    assert not loop_stall._is_parked(_frame(module, function))  # pylint: disable=protected-access
+
+
+def test_module_matching_does_not_match_on_a_name_prefix():
+    """`asyncio_helpers` is not asyncio."""
+    assert not loop_stall._is_parked(_frame('asyncio_helpers'))  # pylint: disable=protected-access
+    assert not loop_stall._is_plumbing('anyio_extras')  # pylint: disable=protected-access
+    assert not loop_stall._is_plumbing('uvicornish')  # pylint: disable=protected-access
+
+
+# -- configuration ---------------------------------------------------------
+
+
+def test_threshold_defaults_to_on(monkeypatch):
+    monkeypatch.delenv(constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS, raising=False)
+    expected = constants.DEFAULT_LOOP_STALL_THRESHOLD_MS / 1000.0
+    assert perf_utils.get_loop_stall_threshold() == expected
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('2500', 2.5),
+    ('250', 0.25),
+    ('0', None),
+    ('-1', None),
+    ('not-a-number', None),
+])
+def test_threshold_parsing(monkeypatch, value: str, expected: Optional[float]):
+    monkeypatch.setenv(constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS, value)
+    assert perf_utils.get_loop_stall_threshold() == expected
+
+
+def test_start_watchdog_returns_none_when_disabled(monkeypatch):
+    monkeypatch.setenv(constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS, '0')
+
+    async def main():
+        return loop_stall.start_watchdog()
+
+    assert asyncio.run(main()) is None
+
+
+def test_start_watchdog_is_idempotent(monkeypatch):
+    monkeypatch.setenv(constants.ENV_VAR_LOOP_STALL_THRESHOLD_MS, '1000')
+
+    async def main():
+        watchdog = loop_stall.start_watchdog()
+        assert watchdog is not None
+        thread = watchdog._thread  # pylint: disable=protected-access
+        watchdog.start()
+        assert watchdog._thread is thread  # pylint: disable=protected-access
+        watchdog.stop()
+        assert not thread.is_alive()
+
+    asyncio.run(main())

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -2,6 +2,7 @@
 import asyncio
 import gzip
 import io
+import json
 import logging
 import threading
 import time
@@ -61,6 +62,24 @@ def _messages_matching(records: List[logging.LogRecord],
     return [m for m in messages if needle in m]
 
 
+def _details(records: List[logging.LogRecord]) -> List[dict]:
+    """Parses the trailing JSON detail out of each stall record.
+
+    Each stall is one log line: a human-readable head plus a JSON object. The
+    tests assert on the parsed object rather than on the head, so wording
+    changes do not break them and the payload is checked for real.
+    """
+    out = []
+    for record in records:
+        message = record.getMessage()
+        if 'Event loop stalled' not in message:
+            continue
+        start = message.find('{')
+        assert start != -1, f'stall record carries no JSON: {message}'
+        out.append(json.loads(message[start:]))
+    return out
+
+
 @pytest.fixture(name='stall_logs')
 def stall_logs_fixture():
     """Collects the watchdog's log records.
@@ -105,8 +124,13 @@ def test_synthetic_stall_names_the_blocking_function(stall_logs):
     assert 'in _blocking_business_code' in message
     # The innermost frame is time.sleep's caller, so the blocking frame and
     # the innermost frame coincide here.
-    assert 'blocking frame:' in message
-    assert 'in-flight task:' in message
+    detail = _details(stall_logs)[0]
+    assert detail['kind'] == 'on_loop'
+    assert detail['source'] == 'test_loop_stall:_blocking_business_code'
+    assert 'in _blocking_business_code' in detail['blocking']
+    assert detail['task']
+    # The stack is reported outermost-first, so the blocking frame is last.
+    assert 'in _blocking_business_code' in detail['frames'][-1]
 
     assert _messages_matching(
         stall_logs, 'Event loop recovered'), ('recovery was not reported')
@@ -248,8 +272,88 @@ def test_loop_blocked_on_a_thread_names_both_sides(stall_logs):
     # The innermost frame is the wait itself, which is kept verbatim.
     assert 'threading.py:' in message
     # And the other threads, since one of them is the reason for the wait.
-    assert 'waiting on another thread' in message
-    assert 'fake-holder' in message
+    detail = _details(stall_logs)[0]
+    assert detail['kind'] == 'waiting'
+    holders = [t['example_thread'] for t in detail['other_threads']]
+    assert any('fake-holder' in h for h in holders), holders
+
+
+def test_one_log_line_per_stall_with_parsable_json(stall_logs):
+    """A stall is one greppable record, not a dozen interleaved lines."""
+    _run_with_watchdog(lambda: _blocking_business_code(0.5))
+
+    stalls = [r for r in stall_logs if 'Event loop stalled' in r.getMessage()]
+    assert stalls
+    for record in stalls:
+        message = record.getMessage()
+        assert '\n' not in message, f'record spans lines: {message!r}'
+        detail = json.loads(message[message.find('{'):])
+        assert set(detail) >= {
+            'lag_s', 'threshold_s', 'kind', 'source', 'blocking', 'innermost',
+            'task', 'frames'
+        }, sorted(detail)
+        # The head stays human-readable and carries the source for grepping.
+        assert message.startswith('Event loop stalled')
+        assert detail['source'] in message[:message.find('{')]
+
+
+def test_library_internals_collapse_but_the_caller_survives():
+    """The frame budget must not be spent on library plumbing.
+
+    Regression: the cap used to keep the innermost N frames, so a deep
+    SQLAlchemy stack filled the budget with its own internals and dropped the
+    outermost frames -- which are the request handler that got there. Both ends
+    have to survive.
+    """
+    site = '/usr/local/lib/python3.10/site-packages/'
+    frames = [_frame('sqlalchemy.engine.default', 'do_execute')]
+    frames[0] = frames[0]._replace(filename=site +
+                                   'sqlalchemy/engine/default.py')
+    # Ten more SQLAlchemy layers between the leaf and our code.
+    for i in range(10):
+        frames.append(
+            loop_stall._FrameInfo(  # pylint: disable=protected-access
+                module='sqlalchemy.orm.session',
+                function=f'_layer{i}',
+                filename=site + 'sqlalchemy/orm/session.py',
+                lineno=100 + i))
+    frames.append(
+        loop_stall._FrameInfo(  # pylint: disable=protected-access
+            module='sky.global_user_state',
+            function='get_all_users',
+            filename='/sky/global_user_state.py',
+            lineno=657))
+    frames.append(
+        loop_stall._FrameInfo(  # pylint: disable=protected-access
+            module='sky.server.server',
+            function='all_contexts',
+            filename='/sky/server/server.py',
+            lineno=3701))
+
+    rendered = loop_stall._collapse_frames(frames)  # pylint: disable=protected-access
+    joined = '\n'.join(rendered)
+    # The endpoint that triggered it is the whole point and must be present.
+    assert 'all_contexts' in joined, rendered
+    assert 'get_all_users' in joined, rendered
+    # So must the frame that was actually blocking.
+    assert 'do_execute' in joined, rendered
+    # The intermediate library layers are summarised, not enumerated.
+    assert any(
+        'more sqlalchemy frame(s)' in line for line in rendered), rendered
+    assert '_layer5' not in joined
+    # Outermost first, so it reads like a traceback.
+    assert 'all_contexts' in rendered[0]
+    assert 'do_execute' in rendered[-1]
+
+
+@pytest.mark.parametrize('path,expected', [
+    ('/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py',
+     'sqlalchemy/engine/default.py'),
+    ('/usr/local/lib/python3.10/asyncio/runners.py', 'asyncio/runners.py'),
+    ('/skypilot/sky/server/server.py', '/skypilot/sky/server/server.py'),
+])
+def test_install_prefixes_are_trimmed(path, expected):
+    assert loop_stall._short_path(path) == expected  # pylint: disable=protected-access
 
 
 def test_bootstrap_frames_are_trimmed():
@@ -331,10 +435,14 @@ def test_starved_loop_dumps_other_threads(stall_logs):
     starved = _messages_matching(stall_logs, 'parked in its own poll')
     assert starved, ('starved stall not reported, got: '
                      f'{[r.getMessage() for r in stall_logs]}')
-    assert 'busiest other threads' in starved[0]
-    assert 'fake-worker-' in starved[0]
-    # Threads doing the same thing collapse into one line with a count.
-    assert '3 thread(s) in' in starved[0]
+    detail = _details(stall_logs)[0]
+    assert detail['kind'] == 'parked'
+    assert detail['source'] == 'starved'
+    groups = {t['source']: t for t in detail['other_threads']}
+    worker = groups['test_loop_stall:worker_thread']
+    # Threads doing the same thing collapse into one entry with a count.
+    assert worker['count'] == 3, detail['other_threads']
+    assert 'fake-worker-' in worker['example_thread']
     # The frame that called run_forever is still on the loop thread's stack.
     # Classifying on "does the stack hold any application frame" would blame
     # it for every starvation stall; classification is on the innermost frame.

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -180,6 +180,38 @@ def test_long_stall_is_sampled_more_than_once(stall_logs):
     assert lags[-1] > lags[0] * 1.5, lags
 
 
+def test_deduped_stall_emits_no_orphan_recovery(stall_logs):
+    """A stall whose dump was deduped must not log a recovery either.
+
+    The recovery line has no rate limit of its own, so without this a loop
+    stalling repeatedly in one place would emit a stream of `recovered` lines
+    with no matching `stalled` line - reading as a phantom stall.
+    """
+
+    async def main():
+        watchdog = loop_stall.LoopStallWatchdog(asyncio.get_running_loop(),
+                                                threshold=0.2,
+                                                heartbeat_interval=0.05,
+                                                poll_interval=0.02)
+        watchdog.start()
+        try:
+            await asyncio.sleep(0.4)
+            _blocking_business_code(0.5)
+            await asyncio.sleep(0.4)
+            # Same source, well inside the dedup window.
+            _blocking_business_code(0.5)
+            await asyncio.sleep(0.4)
+        finally:
+            watchdog.stop()
+
+    asyncio.run(main())
+
+    assert _messages_matching(stall_logs, 'Event loop stalled')
+    recoveries = _messages_matching(stall_logs, 'Event loop recovered')
+    assert len(recoveries) == 1, (
+        f'expected one recovery for the one reported stall, got {recoveries}')
+
+
 def _wait_for_another_thread(event: threading.Event, seconds: float) -> None:
     """Blocks the loop on a cross-thread wait, the way Future.result() does."""
     event.wait(seconds)

--- a/tests/unit_tests/test_loop_stall.py
+++ b/tests/unit_tests/test_loop_stall.py
@@ -4,6 +4,8 @@ import gzip
 import io
 import json
 import logging
+import subprocess
+import sys
 import threading
 import time
 from typing import List, Optional
@@ -379,6 +381,64 @@ def test_bootstrap_frames_are_trimmed():
 def test_trimming_keeps_a_stack_with_no_loop_frames():
     stack = [_frame('sky.server.server', 'api_get'), _frame('gzip', 'write')]
     assert loop_stall._trim_to_current_callback(stack) == stack  # pylint: disable=protected-access
+
+
+def _piped_subprocess_on_the_loop() -> None:
+    """Blocks the loop in a way that bottoms out in the selector."""
+    subprocess.run([sys.executable, '-c', 'import time; time.sleep(0.6)'],
+                   stdout=subprocess.PIPE,
+                   stderr=subprocess.PIPE,
+                   check=False)
+
+
+@pytest.mark.parametrize('use_uvloop', [False, True])
+def test_blocking_call_that_ends_in_the_selector_is_not_called_parked(
+        stall_logs, use_uvloop):
+    """A poll frame alone does not mean the loop is idle.
+
+    `subprocess.run` with pipes waits in `selectors.select`, the same frame a
+    parked loop sits in. It is on-loop work and must be attributed to its
+    caller, not reported as the loop being starved from outside.
+    """
+    if use_uvloop:
+        pytest.importorskip('uvloop')
+    _run_with_watchdog(_piped_subprocess_on_the_loop,
+                       threshold=0.2,
+                       recover=0.6,
+                       use_uvloop=use_uvloop)
+
+    details = _details(stall_logs)
+    assert details, 'no stall was reported'
+    kinds = {d['kind'] for d in details}
+    assert 'parked' not in kinds, details
+    on_loop = [d for d in details if d['kind'] == 'on_loop']
+    assert on_loop, details
+    joined = '\n'.join('\n'.join(d['frames']) for d in on_loop)
+    assert '_piped_subprocess_on_the_loop' in joined, joined
+
+
+def test_watchdog_can_be_restarted_after_stop(stall_logs):
+    """A second start() must produce a live watchdog, not a dead thread."""
+
+    async def main():
+        watchdog = loop_stall.LoopStallWatchdog(asyncio.get_running_loop(),
+                                                threshold=0.2,
+                                                heartbeat_interval=0.05,
+                                                poll_interval=0.02)
+        watchdog.start()
+        watchdog.stop()
+        watchdog.start()
+        try:
+            await asyncio.sleep(0.3)
+            _blocking_business_code(0.5)
+            await asyncio.sleep(0.4)
+        finally:
+            watchdog.stop()
+
+    asyncio.run(main())
+    assert _messages_matching(
+        stall_logs,
+        'Event loop stalled'), ('the restarted watchdog reported nothing')
 
 
 def test_starved_loop_dumps_other_threads(stall_logs):


### PR DESCRIPTION
We can see *that* the event loop stalled, not *what* stalled it. `loop_lag_monitor` gives magnitude only; asyncio's `slow_callback_duration` names the handle repr, which under uvicorn/starlette/anyio is framework code, and only after the callback returns. `set_debug(True)` costs a traceback per handle creation, so it is never on when a stall actually happens.

Inverted: the loop refreshes a heartbeat, a watchdog thread watches it. Stale heartbeat means the loop thread is stuck and the watchdog thread is not, so it reads `sys._current_frames()[loop_tid]` and names the blocking frame **mid-stall**. Nothing is per-callback, so it is on by default — `SKYPILOT_LOOP_STALL_THRESHOLD_MS`, default 1000 ms, `0` disables.

One line per stall — a greppable head plus a JSON detail, so a report cannot interleave with other workers' output and `| grep -o '{.*}' | jq` expands it:

```
Event loop stalled 0.255s (threshold 0.100s) in sqlalchemy.engine.default:do_execute {"lag_s":0.255,
 "threshold_s":0.1,"kind":"on_loop","source":"sqlalchemy.engine.default:do_execute",
 "blocking":"sqlalchemy/engine/default.py:952 in do_execute","task":"Task-8123 coro=...run_asgi",
 "frames":["sky/server/server.py:3701 in all_contexts","sky/global_user_state.py:657 in get_all_users",
           "sqlalchemy/orm/query.py:2711 in all","... 9 more sqlalchemy frame(s) ...",
           "sqlalchemy/engine/default.py:952 in do_execute"]}
```

(wrapped here for readability; it is emitted as a single line). Consecutive frames from one module collapse to their two ends, and if the stack is still too long both ends are kept — the innermost frames say what blocked, the outermost say which request got there. `kind` is `on_loop`, `waiting` or `parked`.

## Results on a live 4-worker deployment

`get_loop_stall_threshold()` returned `1.0` in the pod with no env var set, and stalls were attributed from logs alone — no profiler attached, and none could be (`py-spy` cannot attach on that cluster). At a 100 ms threshold a few hundred concurrent requests gave 23 stalls over 14 sources:

| lag | source | call site |
|---|---|---|
| 255 ms | `sqlalchemy…do_execute` | `sky/global_user_state.py:657 get_all_users` — sync ORM query on the serving loop |
| 244 ms | `sky.utils.common_utils:get_user_hash` | `payloads.py:85 request_body_env_vars` — sync file I/O in a request-payload constructor |
| 103 ms | `psycopg2:connect` | `sqlalchemy/pool/impl.py:307 _do_get` — new Postgres connection opened on the loop |
| 1.09 s | `pydantic…_resolve_definition` | `fastapi/utils.py:73 create_model_field` — schema build; **one-time per worker**, confirmed by 768 further requests giving zero new stalls |

The parked-loop branch also fired at 1.23 s: loop in its own poll, so it declined to blame whatever called `run_forever` and dumped the other threads grouped by innermost frame instead.

Noise: 23 stall + 18 recovery lines out of 3,339 (~1.2%), zero suppression notices, 14 of 32 allowed labels. Fewer recovery than stall lines is intentional — a deduped stall emits no orphan `recovered`.

## Performance impact

An HTTP throughput benchmark cannot resolve a 10 Hz callback: arms differ by more than the effect and the sign flips between repeats. Measured on the loop instead — one process, no client, fixed async workload, OFF/ON in alternating 10 s arms, first arm discarded as warm-up.

| | OFF | ON |
|---|---|---|
| completions (median of 3) | 292,071 | 288,936 → **−1.07%** |
| within-arm spread | 4.56% | 2.02% |
| scheduling lag p50 / p99 | 13.2 / 37.5 µs | 13.5 / 38.8 µs |

−1.07% is inside the 4.56% noise floor and a repeat gave +1.70%: no measurable effect either way.

Absolute cost in **CPU** time — wall time is the wrong clock, since a callback in a GIL-contended process is descheduled mid-call and reads as ~1 ms of "cost" that is not work:

| | per second | of one core |
|---|---|---|
| `beat()` on the loop thread (10/s @ 0.065 µs) | 0.65 µs | 0.00007% |
| the shared timer itself, when metrics are off and it exists only for this | 52–58 µs | 0.006% |
| watchdog thread (20 wakeups/s) | 311–351 µs | 0.035% |

`loop_lag_monitor` is the single timer on each worker loop and starts if either the lag metrics or the watchdog wants it, so with metrics enabled the watchdog adds no timer — only the `beat()` call in the first row. Each consumer is gated inside the tick, so `SKYPILOT_LOOP_STALL_THRESHOLD_MS=0` leaves the lag histogram and per-pid gauge intact, and metrics off still gives attribution; both directions verified on a running server.

The rest is paid only while stalled, and only the all-thread dump scales with thread count — hence its separate 300 s throttle:

| live threads | normal sample | all-thread grouping |
|---|---|---|
| 11 | 5.9 µs | 39 µs |
| 41 (a real worker) | 8.0 µs | 152 µs |
| 201 | 14.8 µs | 792 µs |

A healthy loop is never sampled; `test_no_dumps_when_the_loop_is_healthy` asserts this by counting `_capture` calls, with a positive control so it cannot pass vacuously.

## Unit tests

`tests/unit_tests/test_loop_stall.py`, 61 tests: attribution under stock asyncio and uvloop; a level-9 gzip stall reported as `gzip:write` (GIL-releasing C code, missed by a sampling profiler without `--idle`); parked-loop and cross-thread-wait dumps; bootstrap-frame trimming; dedup, per-minute cap, label cap; repeated sampling within one stall; threshold parsing; and that each stall is one line whose JSON payload parses, with a deep library run collapsing while the outermost caller survives.

## Design notes

- **`source`** = innermost non-dispatch frame, minus the line number so it stays stable across releases (the log keeps it). Not an allowlist of first-party packages — hence `gzip`, `sqlalchemy`, `psycopg2` named directly above.
- **Parked loop** (innermost frame is the loop's own poll) → dump the other threads. **Cross-thread wait** (`threading`, `concurrent.futures`) → call site says where, other threads say why.
- **Noise control**: bootstrap frames trimmed; deduped per source (60 s), capped 10/min; all-thread dump 300 s; sampled at each doubling of the lag so a stall moving through several calls does not collapse to its first frame.
- **Metric** `sky_apiserver_event_loop_stall_total{source}`, labels capped per process (rest collapse to `other`).

## Also fixes dead code

`Server.run` configured `set_debug(True)` and `slow_callback_duration` on the loop from `asyncio.get_event_loop()`, but `asyncio.run()` builds and closes its own loop, so both were discarded — verified on 3.11 with and without uvloop (pre-run `debug=True`, in-run `debug=False`, `slow_callback_duration=0.1`). `SKYPILOT_DEBUG_LOOP_LAG_THRESHOLD_MS` therefore produced no output at all. Setting them inside the coroutine fixes it; still opt-in.

## Scope

One watchdog per uvicorn worker, from `lifespan`. The main process's `background` loop is not covered — its stalls delay daemons, not requests, and doing it right wants a `loop` label. Route-from-contextvar is unreachable from the watchdog thread (`Task.get_context()` is 3.12+, repo supports 3.9+) and the stack already carries the route handler frame. `asyncio.all_tasks()` omitted: iterates a WeakSet, can raise under concurrent mutation.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
