### PR TITLE
[Jobs] Elect the managed-job refresh leader via leader_election

### DIFF
--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -13,7 +13,7 @@ from sky.jobs import scheduler as managed_job_scheduler
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
 from sky.skylet import events
-from sky.utils import locks
+from sky.utils import leader_election
 
 if typing.TYPE_CHECKING:
     pass
@@ -23,10 +23,50 @@ logger = sky_logging.init_logger(__name__)
 _LOCK_PROBE_INTERVAL_SECONDS = 5
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 
-# How long to wait after acquiring the consolidation-mode lock before running
-# recovery. During a rolling update the new leader blocks on acquire() while
-# the old API server still holds the lock. The lock is released when the old
-# main process exits, but that pod's job controllers are detached subprocesses
+# Lease timing for the consolidation role, deliberately looser than the
+# `leader_election` defaults (ttl 60 / interval 10 / deadline 30). Both loose
+# knobs buy the same thing -- more waiting, fewer chances of two leaders --
+# which is the right trade for this role and the wrong one for the idempotent
+# per-tick daemons those defaults are sized for:
+#
+#   - ttl bounds how long a follower must wait before it may take a lease whose
+#     holder stopped renewing, i.e. the failover latency after a hard crash.
+#     This leader owns the job-controller process group, so a second leader does
+#     not merely repeat a tick: it restarts controllers for jobs whose
+#     controllers may still be running elsewhere, leaving two controllers
+#     driving one job. Waiting longer is strictly preferable to racing.
+#   - renew_deadline is how long a leader keeps trying before it concludes the
+#     role is gone. Here that conclusion is a suicide timer, not a step-down:
+#     losing the role means SIGTERMing this API server so its detached
+#     controllers go down with it (see `_suicide_on_role_loss`). A server
+#     restart costs far more than the leaderless gap it prevents, so the
+#     deadline is sized to ride out a database failover or restart (tens of
+#     seconds) rather than to react to one.
+#
+# The renew cadence stays at `_LOCK_PROBE_INTERVAL_SECONDS`, the interval this
+# daemon has always probed at, so the advisory backend behaves exactly as
+# before and the lease still gets ~17 attempts inside its deadline.
+#
+# The margin (ttl - deadline) is what a stepping-down leader has to get its
+# controllers dead before any other replica may adopt their jobs, on top of the
+# `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS` the new leader waits anyway. Delivering
+# the signals is a handful of `os.kill` calls, so the margin is really there to
+# absorb a stop-the-world pause.
+#
+# Cost of the loose ttl, stated plainly: a leader that exits *without*
+# releasing -- a crash, or a pod that is simply gone -- holds the role for the
+# rest of the ttl, so that handoff is slower than the advisory lock's, which
+# came free as soon as the old main process exited. That is the same trade as
+# above, and the gap is not job-visible: the FAILED_CONTROLLER sweep only runs
+# inside a leader's own tick, and the recovery signal file is touched *before*
+# the acquire, so a contending replica starts no controllers in the meantime.
+_LEASE_TTL_SECONDS = 150.0
+_RENEW_DEADLINE_SECONDS = 90.0
+
+# How long to wait after acquiring the consolidation-mode role before running
+# recovery. During a rolling update the new leader contends while the old API
+# server still holds the role. The role is released when the old main process
+# exits, but that pod's job controllers are detached subprocesses
 # (start_new_session=True), so they are not killed until the container itself
 # is torn down a moment later. If recovery ran in that residual window, it would
 # reset jobs that the still-alive (but about-to-die) old controllers can briefly
@@ -49,66 +89,77 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # daemon=True: when the main interpreter exits we want this thread
         # to go with it; the leader role is meant to track main's lifecycle.
         super().__init__(name='managed-job-refresh', daemon=True)
-        self._lock: Optional[locks.DistributedLock] = None
+        self._elector: Optional[leader_election.LeaderElector] = None
+        self._renewer: Optional[leader_election.LeadershipRenewer] = None
 
     def run(self) -> None:
-        self._lock = locks.get_lock(
-            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
+        # Elect through `sky.utils.leader_election` so this role honours the
+        # same `SKYPILOT_LEADER_ELECTION_BACKEND` switch as every other
+        # fleet-wide singleton: `advisory` (the default) is the historical
+        # Postgres session-scoped advisory lock on the same lock id, so old and
+        # new pods still contend together across a rolling upgrade; `lease` is
+        # a renewable `leader_leases` row, which pins no connection for the
+        # leadership term and carries an expiry the holder must keep extending.
+        # The timing is this role's own (see `_LEASE_TTL_SECONDS`) rather than
+        # the module defaults.
+        self._elector = leader_election.get_elector(
+            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID,
+            ttl_seconds=_LEASE_TTL_SECONDS,
+            renew_interval_seconds=_LOCK_PROBE_INTERVAL_SECONDS,
+            renew_deadline_seconds=_RENEW_DEADLINE_SECONDS)
 
         while True:
             try:
                 self._become_leader_and_run()
                 # _become_leader_and_run only returns normally after
-                # _suicide_on_lock_loss sent SIGTERM. Re-entering would
-                # skip the lock acquire (stale local `_acquired` flag),
-                # touch the signal file, and call ha_recovery →
-                # maybe_start_controllers — which would spawn fresh
-                # controllers under a now-released lock while the new
-                # leader on another replica is doing the same. Stop the
-                # thread instead so the SIGTERM-driven drain runs to
-                # completion without further controller churn.
+                # _suicide_on_role_loss sent SIGTERM. Re-entering would
+                # re-contend for a role we just gave up on, touch the signal
+                # file, and call ha_recovery -> maybe_start_controllers --
+                # spawning fresh controllers while the new leader on another
+                # replica is doing the same. Stop the thread instead so the
+                # SIGTERM-driven drain runs to completion without further
+                # controller churn.
                 return
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
                     'managed-job refresh error; '
                     f'retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
-                # If we previously held the lock and lost the session
-                # mid-recovery, retrying would run as a stale leader
-                # (local `_acquired` flag still True, server-side lock
-                # released, another replica can grab it).  Hand off via
-                # SIGTERM, same as the steady-state probe path.
-                if self._lock.is_locked() and not self._lock_still_held():
-                    self._suicide_on_lock_loss()
+                # If we were leading and lost the role mid-recovery, retrying
+                # would run as a stale leader (our renewer has stopped, another
+                # replica can take over). Hand off via SIGTERM, same as the
+                # steady-state probe path. Still holding it, or never having
+                # held it, is an ordinary retry.
+                if self._renewer is not None and not self._renewer.holding:
+                    self._suicide_on_role_loss()
                     return
                 time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
 
     def _become_leader_and_run(self) -> None:
-        assert self._lock is not None
+        assert self._elector is not None
 
-        # Touch the signal file BEFORE acquiring the lock: new controllers
+        # Touch the signal file BEFORE acquiring the role: new controllers
         # must not be started until recovery has run. During a rolling
-        # update we block on acquire() while the old API server still holds
-        # the lock; if a controller were started on this replica in that
-        # window, the old server's update_managed_jobs_statuses wouldn't see
-        # its process and could mark the job FAILED_CONTROLLER. The signal
-        # file makes update_managed_jobs_statuses and the scheduler's
-        # controller-start path early-return until recovery completes.
+        # update we contend while the old API server still holds the role;
+        # if a controller were started on this replica in that window, the
+        # old server's update_managed_jobs_statuses wouldn't see its process
+        # and could mark the job FAILED_CONTROLLER. The signal file makes
+        # update_managed_jobs_statuses and the scheduler's controller-start
+        # path early-return until recovery completes.
         # NOTE: the acquire is deliberately NOT inside the try/finally that
         # wraps recovery below. The finally unlinks the signal file, but the
-        # lock-loss step-down path (_suicide_on_lock_loss) re-touches it to
+        # role-loss step-down path (_suicide_on_role_loss) re-touches it to
         # keep controllers gated through the shutdown drain — so that path must
         # not be followed by an unlink. Scoping the finally to recovery only
         # keeps those two concerns from fighting. It also means a raise from
-        # acquire() leaves the gate file in place while run() retries, which is
-        # what we want (controller starts stay gated until we hold the lock).
+        # the acquire leaves the gate file in place while run() retries, which
+        # is what we want (controller starts stay gated until we hold the role).
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
 
-        if not self._lock.is_locked():
-            logger.info(f'Acquiring the consolidation mode lock: {self._lock}')
-            self._lock.acquire()
-            logger.info('Consolidation mode lock acquired')
+        if self._renewer is None:
+            self._acquire_role()
+        assert self._renewer is not None
 
         # Wait before recovery so a prior leader (e.g. the old pod during a
         # rolling update) is fully gone first; see the comment on
@@ -117,19 +168,20 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # sweep until recovery completes.
         logger.info(
             f'Waiting {_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS}s after acquiring '
-            'the consolidation mode lock before running recovery, to let any '
+            'the consolidation mode role before running recovery, to let any '
             'previous leader finish shutting down')
         time.sleep(_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS)
 
-        # The wait above widens the window between acquiring the lock and
-        # running recovery, during which the lock's underlying session could go
-        # silently stale (PostgresLock only). Re-verify we still hold the lock
-        # before recovery; otherwise another replica may have taken it and
-        # could be recovering concurrently, so step down rather than run a
-        # second recovery loop. _suicide_on_lock_loss re-touches the signal
-        # file and SIGTERMs the process, so leave the file in place here.
-        if not self._lock_still_held():
-            self._suicide_on_lock_loss()
+        # The wait above widens the window between acquiring the role and
+        # running recovery, during which the role could be lost underneath us —
+        # an advisory lock's session going silently stale, or a lease we stopped
+        # being able to renew. Re-verify before recovery; otherwise another
+        # replica may have taken it and could be recovering concurrently, so
+        # step down rather than run a second recovery loop.
+        # _suicide_on_role_loss re-touches the signal file and SIGTERMs the
+        # process, so leave the file in place here.
+        if not self._renewer.holding:
+            self._suicide_on_role_loss()
             return
 
         try:
@@ -138,16 +190,18 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             signal_file.unlink(missing_ok=True)
 
         # Event-loop tick at events.EVENT_CHECKING_INTERVAL_SECONDS,
-        # lock probe at _LOCK_PROBE_INTERVAL_SECONDS, sleep 1s between.
+        # role probe at _LOCK_PROBE_INTERVAL_SECONDS, sleep 1s between.
         refresh_event = events.ManagedJobEvent()
         now = time.monotonic()
-        last_probe = now
+        # Probe on the very first pass rather than one interval in: recovery
+        # above walks every managed job, so it can have outlasted the role.
+        last_probe = now - _LOCK_PROBE_INTERVAL_SECONDS
         last_event = now - events.EVENT_CHECKING_INTERVAL_SECONDS
         while True:
             now = time.monotonic()
             if now - last_probe >= _LOCK_PROBE_INTERVAL_SECONDS:
-                if not self._lock_still_held():
-                    self._suicide_on_lock_loss()
+                if not self._renewer.holding:
+                    self._suicide_on_role_loss()
                     return
                 last_probe = now
             if now - last_event >= events.EVENT_CHECKING_INTERVAL_SECONDS:
@@ -158,19 +212,65 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                 last_event = now
             time.sleep(1)
 
-    def _lock_still_held(self) -> bool:
-        """True iff we are confident this replica still owns the lock."""
-        assert self._lock is not None
-        if isinstance(self._lock, locks.PostgresLock):
-            # Check is only relevant for PG lock
-            return self._lock.is_session_alive()
-        return True
+    def _acquire_role(self) -> None:
+        """Contend until this replica wins the role, then keep it renewed.
 
-    def _suicide_on_lock_loss(self) -> None:
+        Replaces the historical blocking `lock.acquire()`. The elector's bid is
+        non-blocking, so a bid that raises (a database blip) is retried on the
+        next pass instead of killing this thread for the lifetime of the pod —
+        the old `acquire()` sat outside the retry loop's try.
+        """
+        assert self._elector is not None
+        logger.info('Contending for the consolidation mode role: '
+                    f'{self._elector.lock_id}')
+        while True:
+            try:
+                acquired = self._elector.try_acquire()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Consolidation mode role bid failed: {e}; retrying in '
+                    f'{_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
+                acquired = False
+            if acquired:
+                break
+            time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
+        logger.info('Consolidation mode role acquired')
+        # Renew on its own thread, not between the steps below. The wait before
+        # recovery, recovery itself (it walks every managed job) and each
+        # ManagedJobEvent tick are all long blocking calls, and a lease is only
+        # as alive as its last renew: renewing between steps would let a slow
+        # recovery lapse the lease and hand the role to another replica *while
+        # recovery is running*, which is the worst possible moment. The thread
+        # keeps the role alive throughout and this daemon just polls `holding`.
+        # Published only once the thread is actually running: a `start()` that
+        # raises (thread exhaustion is a real failure mode) would otherwise
+        # leave a renewer that never renews, and on the advisory backend --
+        # which has no deadline to catch it -- `holding` would stay True
+        # forever, so we would run as leader with nothing probing the role.
+        # Leaving it None instead makes the retry in `run()` bid again.
+        renewer = leader_election.LeadershipRenewer(self._elector)
+        renewer.start()
+        self._renewer = renewer
+
+    def _suicide_on_role_loss(self) -> None:
         """SIGTERM the API server process so the pod can restart cleanly."""
+        assert self._elector is not None
         logger.error(
-            f'Lost consolidation mode lock {self._lock}; sending SIGTERM '
-            'to the API server to step down')
+            f'Lost the consolidation mode role {self._elector.lock_id}; '
+            'sending SIGTERM to the API server to step down')
+        # Stop renewing first, so nothing re-establishes a role this process has
+        # already decided to give up.
+        #
+        # Deliberately no `elector.release()` here. Releasing would let a
+        # follower take the role immediately, which is exactly what must not
+        # happen: the controllers killed below have to be gone before another
+        # replica adopts their jobs. Sitting out the rest of the lease's
+        # `ttl - renew_deadline` margin is the guarantee, not an oversight. (On
+        # the advisory backend there is nothing to release anyway — the role is
+        # already gone, which is why we are here.)
+        if self._renewer is not None:
+            self._renewer.stop()
+            self._renewer = None
         # Re-touch the recovery signal file so no new controllers will be
         # started
         try:
@@ -179,14 +279,14 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             signal_file.parent.mkdir(parents=True, exist_ok=True)
             signal_file.touch()
         except OSError:
-            logger.warning('Failed to touch recovery signal file on lock-loss')
-        # The lock is already released, kill job controllers to avoid split
-        # brain, e.g. new job controllers might have been launched on the new
-        # replica during rolling-update
+            logger.warning('Failed to touch recovery signal file on role loss')
+        # The role is gone, kill job controllers to avoid split brain, e.g. new
+        # job controllers might have been launched on the new replica during
+        # rolling-update
         try:
             managed_job_scheduler.kill_local_job_controllers()
         except Exception:  # pylint: disable=broad-except
-            logger.exception('Failed to kill local controllers on lock-loss')
+            logger.exception('Failed to kill local controllers on role loss')
         # SIGTERM to trigger graceful shutdown
         os.kill(os.getpid(), signal.SIGTERM)
 

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_LOCK_PROBE_INTERVAL_SECONDS = 5
+_ROLE_RENEW_INTERVAL_SECONDS = 5
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 
 # Lease timing for the consolidation role, deliberately looser than the
@@ -43,9 +43,13 @@ _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 #     deadline is sized to ride out a database failover or restart (tens of
 #     seconds) rather than to react to one.
 #
-# The renew cadence stays at `_LOCK_PROBE_INTERVAL_SECONDS`, the interval this
-# daemon has always probed at, so the advisory backend behaves exactly as
-# before and the lease still gets ~17 attempts inside its deadline.
+# The renew cadence stays at the 5s this daemon has always probed its lock at,
+# so the lease gets ~17 attempts inside its deadline. Advisory keeps the same
+# cadence but is not quite byte-identical any more: a step-down is noticed by
+# the renewer (within one cadence) and then by the loop (within a second)
+# rather than by one inline probe, and a follower re-bids every
+# `_ACQUIRE_RETRY_INTERVAL_SECONDS` instead of the blocking acquire's 1s poll.
+# Both are dominated by `_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS`.
 #
 # The margin (ttl - deadline) is what a stepping-down leader has to get its
 # controllers dead before any other replica may adopt their jobs, on top of the
@@ -105,7 +109,7 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         self._elector = leader_election.get_elector(
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID,
             ttl_seconds=_LEASE_TTL_SECONDS,
-            renew_interval_seconds=_LOCK_PROBE_INTERVAL_SECONDS,
+            renew_interval_seconds=_ROLE_RENEW_INTERVAL_SECONDS,
             renew_deadline_seconds=_RENEW_DEADLINE_SECONDS)
 
         while True:
@@ -196,7 +200,7 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         # interval because `holding` is now an in-memory read -- the renewer
         # owns the round trip. Historically this probe *was* the round trip
         # (`is_session_alive()` per probe), which is why it was rate-limited to
-        # `_LOCK_PROBE_INTERVAL_SECONDS`; keeping that gate now would only add
+        # `_ROLE_RENEW_INTERVAL_SECONDS`; keeping that gate now would only add
         # latency to the step-down for no saving. And that latency is not free:
         # the point of stepping down is to get this replica's controllers killed
         # before anyone else can adopt their jobs, so every second of detection

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -189,21 +189,28 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         finally:
             signal_file.unlink(missing_ok=True)
 
-        # Event-loop tick at events.EVENT_CHECKING_INTERVAL_SECONDS,
-        # role probe at _LOCK_PROBE_INTERVAL_SECONDS, sleep 1s between.
+        # Event-loop tick at events.EVENT_CHECKING_INTERVAL_SECONDS, role check
+        # every pass, sleep 1s between.
+        #
+        # The role is checked on every pass rather than on its own slower
+        # interval because `holding` is now an in-memory read -- the renewer
+        # owns the round trip. Historically this probe *was* the round trip
+        # (`is_session_alive()` per probe), which is why it was rate-limited to
+        # `_LOCK_PROBE_INTERVAL_SECONDS`; keeping that gate now would only add
+        # latency to the step-down for no saving. And that latency is not free:
+        # the point of stepping down is to get this replica's controllers killed
+        # before anyone else can adopt their jobs, so every second of detection
+        # lag is spent out of the `ttl - deadline` margin.
         refresh_event = events.ManagedJobEvent()
         now = time.monotonic()
-        # Probe on the very first pass rather than one interval in: recovery
-        # above walks every managed job, so it can have outlasted the role.
-        last_probe = now - _LOCK_PROBE_INTERVAL_SECONDS
         last_event = now - events.EVENT_CHECKING_INTERVAL_SECONDS
         while True:
             now = time.monotonic()
-            if now - last_probe >= _LOCK_PROBE_INTERVAL_SECONDS:
-                if not self._renewer.holding:
-                    self._suicide_on_role_loss()
-                    return
-                last_probe = now
+            # Checked before the first tick too: recovery above walks every
+            # managed job, so it can have outlasted the role.
+            if not self._renewer.holding:
+                self._suicide_on_role_loss()
+                return
             if now - last_event >= events.EVENT_CHECKING_INTERVAL_SECONDS:
                 try:
                     refresh_event.run()

--- a/sky/utils/leader_election.py
+++ b/sky/utils/leader_election.py
@@ -19,6 +19,8 @@ import abc
 import logging
 import os
 import socket
+import threading
+import time
 from typing import Optional
 import uuid
 
@@ -95,6 +97,11 @@ class LeaderElector(abc.ABC):
     def __init__(self, lock_id: str):
         self._lock_id = lock_id
 
+    @property
+    def lock_id(self) -> str:
+        """The role this elector contends for."""
+        return self._lock_id
+
     @abc.abstractmethod
     def try_acquire(self) -> bool:
         """Non-blocking bid for leadership. True iff this candidate leads."""
@@ -149,9 +156,21 @@ class AdvisoryLockElector(LeaderElector):
     process-local lock, which is exactly right for single-node deployments.
     """
 
-    def __init__(self, lock_id: str):
+    def __init__(
+            self,
+            lock_id: str,
+            renew_interval_seconds: float = DEFAULT_RENEW_INTERVAL_SECONDS):
         super().__init__(lock_id)
         self._lock: Optional[locks.DistributedLock] = None
+        # Only the probe cadence is tunable here; there is deliberately no
+        # deadline (see ``renew_deadline_seconds`` on the base class), so a
+        # caller that wants both backends to check at the same rate can ask for
+        # it without changing what a failed probe means.
+        self._renew_interval = renew_interval_seconds
+
+    @property
+    def renew_interval_seconds(self) -> float:
+        return self._renew_interval
 
     def try_acquire(self) -> bool:
         # Build a fresh lock object each bid so a prior term's closed connection
@@ -377,6 +396,132 @@ class PgLeaseElector(LeaderElector):
         return self._epoch
 
 
+# How long to wait before retrying a renew that just failed, while the renew
+# deadline has not passed yet. Short relative to any sane deadline so a brief
+# database blip is ridden out over many attempts instead of costing the role on
+# the first failure.
+_RENEW_RETRY_SECONDS = 1.0
+
+
+class LeadershipRenewer(threading.Thread):
+    """Keep a held role renewed on its own thread for a whole leadership term.
+
+    Renewal has to be decoupled from the leader's work whenever that work is a
+    long blocking call. A lease is only as alive as its last renew, so a leader
+    that renews *between* its steps lets a step longer than the TTL lapse the
+    lease and hand the role to a follower while that step is still running --
+    and the failure lands where it hurts most, because the slow steps (a
+    recovery pass, a status sweep over every job) are exactly the ones that
+    mutate shared state. Renewing on a separate thread makes the role's
+    liveness independent of what the leader happens to be doing, the same shape
+    as client-go's leader-election ``renewLoop``.
+
+    The leader polls :attr:`holding` at whatever cadence suits it and steps down
+    once it reads False. A lost role is never re-acquired here: this thread
+    stops instead, so ``holding`` only ever goes True -> False and a caller may
+    treat the first False as final.
+
+    A failed renew is retried until ``renew_deadline_seconds`` has passed since
+    the last *successful* renew, so a transient database blip costs retries
+    rather than the role -- which matters when a step-down is expensive. A
+    backend with no deadline (the advisory lock, whose ``renew`` is a
+    session-liveness probe rather than an extension) gives the role up on the
+    first failed probe, exactly as that backend has always done.
+    """
+
+    def __init__(self, elector: LeaderElector) -> None:
+        super().__init__(name=f'leader-renew-{elector.lock_id}', daemon=True)
+        self._elector = elector
+        self._interval = elector.renew_interval_seconds
+        self._deadline = elector.renew_deadline_seconds
+        self._stop_event = threading.Event()
+        self._lost = threading.Event()
+        # Anchored at construction rather than at the first renew: the caller
+        # has just acquired the role, and the acquire extended it exactly as a
+        # renew would.
+        self._last_renew = time.monotonic()
+
+    @property
+    def holding(self) -> bool:
+        """False once the role is gone -- stop acting on it immediately."""
+        if self._lost.is_set():
+            return False
+        # Safety net for a renewer that is itself wedged -- blocked in a socket
+        # read past the statement/connect timeouts, or starved of CPU -- rather
+        # than one getting failed renews: judge the role by the clock, not by
+        # whether this thread got around to noticing. Without it a stuck
+        # renewer would keep the caller acting as leader indefinitely. Only the
+        # lease backend has a clock to be judged by.
+        if (self._deadline is not None and
+                time.monotonic() - self._last_renew > self._deadline):
+            return False
+        return True
+
+    def stop(self, join_timeout: Optional[float] = None) -> None:
+        """Stop renewing; optionally wait for the thread to notice.
+
+        Does not release the role. Whether a step-down should hand over
+        immediately (``release``) or sit out the rest of the lease as a safety
+        margin depends on what the leader was doing, so that stays the caller's
+        decision.
+        """
+        self._stop_event.set()
+        if join_timeout is not None and threading.current_thread() is not self:
+            self.join(timeout=join_timeout)
+
+    def run(self) -> None:
+        failures = 0
+        try:
+            while not self._stop_event.is_set():
+                # Anchor before the round trip, not after: the server stamps
+                # the new expiry from its own clock when the statement starts,
+                # so timing the deadline from before the call understates our
+                # runway and keeps the ``ttl - deadline`` margin intact however
+                # slow the renew was.
+                before = time.monotonic()
+                try:
+                    renewed = self._elector.renew()
+                except Exception as e:  # pylint: disable=broad-except
+                    # Both shipped electors already swallow their own errors
+                    # into a False; this is here so a backend that does not
+                    # cannot take the renewer down with it -- a dead renewer is
+                    # a role nothing is watching.
+                    logger.debug('%s: renew raised: %s', self._elector.lock_id,
+                                 e)
+                    renewed = False
+                if renewed:
+                    self._last_renew = before
+                    failures = 0
+                    self._stop_event.wait(self._interval)
+                    continue
+                failures += 1
+                stale_for = time.monotonic() - self._last_renew
+                if self._deadline is None or stale_for > self._deadline:
+                    logger.error(
+                        '%s: giving up the leader role after %d failed '
+                        'renew(s) over %.1fs', self._elector.lock_id, failures,
+                        stale_for)
+                    return
+                if failures == 1:
+                    # Only the first failure of a run is a warning: retries run
+                    # at _RENEW_RETRY_SECONDS, so logging each one would emit a
+                    # line a second for the whole deadline.
+                    logger.warning(
+                        '%s: renew failed, retrying until the %.1fs deadline',
+                        self._elector.lock_id, self._deadline)
+                else:
+                    logger.debug('%s: renew failed %d times (%.1fs stale)',
+                                 self._elector.lock_id, failures, stale_for)
+                self._stop_event.wait(_RENEW_RETRY_SECONDS)
+        finally:
+            # Any exit other than a requested stop means the role is gone --
+            # including an unexpected exception, which would otherwise leave the
+            # caller believing it still leads (nothing is renewing any more, and
+            # on the advisory backend there is no clock to catch it).
+            if not self._stop_event.is_set():
+                self._lost.set()
+
+
 def get_backend() -> str:
     """Resolve the configured leader-election backend name."""
     value = os.environ.get(ENV_VAR_BACKEND, BACKEND_ADVISORY).strip().lower()
@@ -393,18 +538,36 @@ def _postgres_available() -> bool:
 
 
 def get_elector(
-        lock_id: str,
-        backend: Optional[str] = None,
-        holder: Optional[str] = None,
-        ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS) -> LeaderElector:
+    lock_id: str,
+    backend: Optional[str] = None,
+    holder: Optional[str] = None,
+    ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+    renew_interval_seconds: float = DEFAULT_RENEW_INTERVAL_SECONDS,
+    renew_deadline_seconds: float = DEFAULT_RENEW_DEADLINE_SECONDS
+) -> LeaderElector:
     """Return a :class:`LeaderElector` for ``lock_id``.
 
     The lease backend is used only when it is both selected (via ``backend`` or
     ``SKYPILOT_LEADER_ELECTION_BACKEND``) and viable (Postgres configured);
     otherwise this falls back to the advisory backend, which itself degrades to
     a local file lock on single-node SQLite.
+
+    All three timing knobs are passed through so a caller whose role has a
+    different cost of failover can tune them together -- they are only
+    meaningful as a set, and the lease constructor enforces
+    ``0 < interval < deadline < ttl``. ``renew_interval_seconds`` reaches the
+    advisory backend too (there it is the liveness-probe cadence), so asking
+    for a cadence gives the same answer whichever backend is configured;
+    ``ttl_seconds`` and ``renew_deadline_seconds`` are inherently lease
+    concepts and are ignored by the advisory backend, whose leadership is not
+    time-bounded.
     """
     backend = backend or get_backend()
     if backend == BACKEND_LEASE and _postgres_available():
-        return PgLeaseElector(lock_id, holder=holder, ttl_seconds=ttl_seconds)
-    return AdvisoryLockElector(lock_id)
+        return PgLeaseElector(lock_id,
+                              holder=holder,
+                              ttl_seconds=ttl_seconds,
+                              renew_interval_seconds=renew_interval_seconds,
+                              renew_deadline_seconds=renew_deadline_seconds)
+    return AdvisoryLockElector(lock_id,
+                               renew_interval_seconds=renew_interval_seconds)

--- a/tests/unit_tests/test_leader_election.py
+++ b/tests/unit_tests/test_leader_election.py
@@ -6,6 +6,7 @@ exercised where a Postgres fixture is available.
 """
 import os
 import re
+import time
 from unittest import mock
 
 import pytest
@@ -256,3 +257,171 @@ def test_pg_release_hands_over_immediately(lease_db):
     assert a.fencing_token() is None
     assert b.try_acquire() is True
     assert b.fencing_token() == 2
+
+
+def test_get_elector_passes_timing_to_the_lease_backend(monkeypatch):
+    """A role whose failover is expensive tunes all three knobs together, so
+    ``get_elector`` must carry them through rather than silently shipping the
+    module defaults with only the TTL overridden."""
+    monkeypatch.setenv(leader_election.ENV_VAR_BACKEND,
+                       leader_election.BACKEND_LEASE)
+    with mock.patch.object(leader_election,
+                           '_postgres_available',
+                           return_value=True):
+        elector = leader_election.get_elector('lock',
+                                              ttl_seconds=150,
+                                              renew_interval_seconds=5,
+                                              renew_deadline_seconds=90)
+    assert isinstance(elector, leader_election.PgLeaseElector)
+    assert elector.renew_interval_seconds == 5
+    assert elector.renew_deadline_seconds == 90
+
+
+def test_get_elector_passes_the_probe_cadence_to_the_advisory_backend(
+        monkeypatch):
+    """Asking for a cadence must give the same answer on either backend, so a
+    caller that has always probed at its own interval keeps doing so when the
+    deployment is on the default advisory path. The deadline is still None --
+    advisory leadership is not time-bounded, so a failed probe is terminal."""
+    monkeypatch.delenv(leader_election.ENV_VAR_BACKEND, raising=False)
+    elector = leader_election.get_elector('lock',
+                                          ttl_seconds=150,
+                                          renew_interval_seconds=5,
+                                          renew_deadline_seconds=90)
+    assert isinstance(elector, leader_election.AdvisoryLockElector)
+    assert elector.renew_interval_seconds == 5
+    assert elector.renew_deadline_seconds is None
+
+
+class _ScriptedElector(leader_election.LeaderElector):
+    """An elector whose ``renew`` replays a scripted sequence of outcomes.
+
+    ``True``/``False`` are returned; an exception instance is raised. When the
+    script runs out the renewer is stopped, so ``run()`` returns instead of
+    looping forever -- which lets these tests drive the loop synchronously.
+    """
+
+    def __init__(self, script, interval=0.0, deadline=None):
+        super().__init__('scripted-role')
+        self._script = list(script)
+        self._interval = interval
+        self._deadline = deadline
+        self.renewer: 'leader_election.LeadershipRenewer' = None  # type: ignore
+        self.calls = 0
+        self.released = False
+
+    def try_acquire(self) -> bool:
+        return True
+
+    def renew(self) -> bool:
+        self.calls += 1
+        if not self._script:
+            # Out of script: end the term the way a caller would.
+            self.renewer.stop()
+            return True
+        outcome = self._script.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def release(self) -> None:
+        self.released = True
+
+    @property
+    def renew_interval_seconds(self) -> float:
+        return self._interval
+
+    @property
+    def renew_deadline_seconds(self):
+        return self._deadline
+
+
+def _renewer_for(script, **kwargs):
+    elector = _ScriptedElector(script, **kwargs)
+    renewer = leader_election.LeadershipRenewer(elector)
+    elector.renewer = renewer
+    return elector, renewer
+
+
+class TestLeadershipRenewer:
+    """The renewer decouples a role's liveness from the leader's work."""
+
+    def test_holds_the_role_while_renews_succeed(self):
+        elector, renewer = _renewer_for([True, True, True], deadline=30)
+        renewer.run()
+        assert elector.calls == 4  # three scripted, then the stop
+        assert renewer.holding is True
+
+    def test_rides_out_a_transient_failure_within_the_deadline(
+            self, monkeypatch):
+        """One failed renew must not cost the role: the lease is still valid
+        until its deadline, so retry rather than hand over on a database blip.
+        """
+        monkeypatch.setattr(leader_election, '_RENEW_RETRY_SECONDS', 0.0)
+        elector, renewer = _renewer_for([False, False, True], deadline=30)
+        renewer.run()
+        assert elector.calls == 4
+        assert renewer.holding is True
+
+    def test_a_raising_renew_is_treated_as_a_failed_renew(self, monkeypatch):
+        monkeypatch.setattr(leader_election, '_RENEW_RETRY_SECONDS', 0.0)
+        elector, renewer = _renewer_for([RuntimeError('db blip'), True],
+                                        deadline=30)
+        renewer.run()
+        assert elector.calls == 3
+        assert renewer.holding is True
+
+    def test_gives_up_once_the_deadline_is_exceeded(self, monkeypatch):
+        monkeypatch.setattr(leader_election, '_RENEW_RETRY_SECONDS', 0.0)
+        # A deadline already in the past on the first failure: give up at once
+        # rather than retrying forever.
+        elector, renewer = _renewer_for([False], deadline=30)
+        renewer._last_renew = time.monotonic() - 1000
+        renewer.run()
+        assert elector.calls == 1
+        assert renewer.holding is False
+
+    def test_gives_up_on_the_first_failure_with_no_deadline(self):
+        """The advisory backend's ``renew`` is a session-liveness probe, not an
+        extension: there is no lease left to ride out, so a failed probe is
+        terminal -- the behaviour that backend has always had."""
+        elector, renewer = _renewer_for([False], deadline=None)
+        renewer.run()
+        assert elector.calls == 1
+        assert renewer.holding is False
+
+    def test_holding_is_false_when_the_renewer_itself_is_wedged(self):
+        """Safety net: a renewer blocked past the deadline (socket blackhole,
+        CPU starvation) leaves no failed renew to notice, so judge the role by
+        the clock. Without this the caller would keep acting as leader while
+        another replica is free to take the lease."""
+        _, renewer = _renewer_for([True], deadline=30)
+        assert renewer.holding is True
+        renewer._last_renew = time.monotonic() - 31
+        assert renewer.holding is False
+
+    def test_an_unexpected_crash_marks_the_role_lost(self):
+        """Nothing is renewing after the thread dies, so the caller must not be
+        left believing it still leads -- on the advisory backend there is no
+        clock that would catch it."""
+        _, renewer = _renewer_for([True], deadline=None)
+        renewer._stop_event = mock.Mock()
+        renewer._stop_event.is_set.return_value = False
+        renewer._stop_event.wait.side_effect = RuntimeError('boom')
+        with pytest.raises(RuntimeError, match='boom'):
+            renewer.run()
+        assert renewer.holding is False
+
+    def test_stop_keeps_the_role_and_never_releases_it(self):
+        """``stop`` means "quit renewing", not "hand over". Whether a
+        step-down should release or sit out the rest of the lease is the
+        caller's decision, and the two differ by exactly the safety margin."""
+        elector, renewer = _renewer_for([True, True], deadline=30)
+        renewer.run()
+        assert renewer.holding is True
+        assert elector.released is False
+
+    def test_thread_is_a_daemon_named_after_the_role(self):
+        _, renewer = _renewer_for([True])
+        assert renewer.daemon is True
+        assert 'scripted-role' in renewer.name

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -518,6 +518,64 @@ class TestEventLoopProbe:
         suicide.assert_called_once()
         refresh_event.run.assert_not_called()
 
+    def test_checks_the_role_on_every_pass_not_on_a_slower_interval(
+            self, tmp_path, monkeypatch):
+        """`holding` is an in-memory read -- the renewer owns the round trip --
+        so rate-limiting it would only add latency to the step-down, and that
+        latency is spent out of the margin for killing this replica's
+        controllers before anyone else adopts their jobs.
+
+        Pinned by counting sleeps, not by wall clock: the loop must consult the
+        role once per 1s sleep. A version that gated the check behind an
+        interval would sleep many times per check -- and, because the tests
+        stub `time.sleep` while `time.monotonic` keeps running for real, it
+        would still eventually reach the same read count, just slower. So the
+        sleep budget is the assertion that actually discriminates.
+        """
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+
+        class _Stop(Exception):
+            pass
+
+        counts = {'reads': 0, 'sleeps': 0}
+        renewer = _fake_renewer()
+
+        def _holding(_self):
+            counts['reads'] += 1
+            if counts['reads'] >= 3:
+                raise _Stop()
+            return True
+
+        type(renewer).holding = property(_holding)
+
+        def _sleep(_seconds):
+            counts['sleeps'] += 1
+            # Escape hatch: a gated implementation would spin here instead of
+            # reaching the third read, so bound the run rather than hang.
+            if counts['sleeps'] > 4:
+                raise _Stop()
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._elector = _fake_elector()
+        thread._renewer = renewer
+
+        refresh_event = mock.Mock()
+        with mock.patch.object(mjrt.time, 'sleep', _sleep), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'ha_recovery_for_consolidation_mode'), \
+                mock.patch.object(mjrt.events,
+                                  'ManagedJobEvent',
+                                  return_value=refresh_event):
+            with pytest.raises(_Stop):
+                thread._become_leader_and_run()
+
+        # Three passes, each consulting the role, cost at most one sleep each.
+        assert counts['reads'] == 3, counts
+        assert counts['sleeps'] <= 3, counts
+
 
 class TestStart:
     """`start_managed_job_refresh_daemon` honors consolidation mode."""

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -3,11 +3,15 @@
 These tests cover the state machine of the leader-elected refresh thread,
 not the full daemon loop:
 
-* ``_lock_still_held`` dispatches correctly between ``PostgresLock``
-  (probes the underlying PG session) and any other ``DistributedLock``
-  (trusts the local ``is_locked`` flag).
-* ``_suicide_on_lock_loss`` sends ``SIGTERM`` to the API server PID so
-  K8s restarts the pod and the leader is re-elected on another replica.
+* the role is elected through ``sky.utils.leader_election`` (so the deployment's
+  backend switch applies to it) with timing looser than that module's defaults.
+* the bid loop keeps re-bidding instead of dying on a transient failure, and a
+  won bid starts a renewer that keeps the role alive across the long blocking
+  steps that follow.
+* ``_suicide_on_role_loss`` sends ``SIGTERM`` to the API server PID so
+  K8s restarts the pod and the leader is re-elected on another replica -- and
+  does *not* release the role, so the remaining lease margin keeps another
+  replica out until the controllers killed here are gone.
 * ``start_managed_job_refresh_daemon`` gates on consolidation mode,
   preserving the historical ``should_skip_managed_job_status_refresh``
   semantics now that the daemon no longer lives in
@@ -18,66 +22,158 @@ from unittest import mock
 
 import pytest
 
+from sky.jobs import constants as managed_job_constants
 from sky.jobs import managed_job_refresh_thread as mjrt
-from sky.utils import locks
+from sky.utils import leader_election
 
 
-class TestLockStillHeld:
-    """`_lock_still_held` dispatches on lock type."""
+def _fake_elector():
+    elector = mock.create_autospec(leader_election.LeaderElector, instance=True)
+    elector.lock_id = managed_job_constants.CONSOLIDATION_MODE_LOCK_ID
+    return elector
 
-    def test_postgres_lock_session_alive(self):
+
+def _fake_renewer(holding: bool = True):
+    renewer = mock.create_autospec(leader_election.LeadershipRenewer,
+                                   instance=True)
+    renewer.holding = holding
+    return renewer
+
+
+def _leading_thread(holding: bool = True):
+    """A thread that already holds the role, so `_acquire_role` is skipped."""
+    thread = mjrt.ManagedJobRefreshDaemonThread()
+    thread._elector = _fake_elector()
+    thread._renewer = _fake_renewer(holding)
+    return thread
+
+
+class TestElectorConfiguration:
+    """The role goes through leader_election, with this role's own timing."""
+
+    def test_run_elects_through_leader_election(self):
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
-        thread._lock.is_session_alive.return_value = True
-        assert thread._lock_still_held() is True
-        thread._lock.is_session_alive.assert_called_once_with()
+        with mock.patch.object(mjrt.leader_election,
+                               'get_elector') as get_elector, \
+                mock.patch.object(mjrt.ManagedJobRefreshDaemonThread,
+                                  '_become_leader_and_run'):
+            thread.run()
+        get_elector.assert_called_once_with(
+            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID,
+            ttl_seconds=mjrt._LEASE_TTL_SECONDS,
+            renew_interval_seconds=mjrt._LOCK_PROBE_INTERVAL_SECONDS,
+            renew_deadline_seconds=mjrt._RENEW_DEADLINE_SECONDS)
 
-    def test_postgres_lock_session_dead(self):
-        """Silent PG conn loss: PostgresLock thinks acquired locally but
-        ``is_session_alive`` says otherwise.  Probe must return False so
-        the caller can SIGTERM the process."""
+    def test_timing_is_looser_than_the_module_defaults(self):
+        """Pin the intent, not the numbers.
+
+        This role tolerates a slow failover far better than two leaders (it
+        owns the controller process group) and a step-down here costs an API
+        server restart, so both the lease TTL and the renew deadline must stay
+        strictly looser than the defaults sized for idempotent per-tick
+        daemons. Tightening either back to the default is the regression this
+        guards.
+        """
+        assert (mjrt._LEASE_TTL_SECONDS >
+                leader_election.DEFAULT_LEASE_TTL_SECONDS)
+        assert (mjrt._RENEW_DEADLINE_SECONDS >
+                leader_election.DEFAULT_RENEW_DEADLINE_SECONDS)
+        # The lease constructor enforces this too, but a violation here would
+        # only surface on a Postgres deployment with the lease backend on.
+        assert (0 < mjrt._LOCK_PROBE_INTERVAL_SECONDS <
+                mjrt._RENEW_DEADLINE_SECONDS < mjrt._LEASE_TTL_SECONDS)
+
+
+class TestAcquireRole:
+    """The bid loop replaces the historical blocking `lock.acquire()`."""
+
+    def test_rebids_until_it_wins_then_starts_renewing(self):
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
-        thread._lock.is_session_alive.return_value = False
-        assert thread._lock_still_held() is False
+        thread._elector = _fake_elector()
+        thread._elector.try_acquire.side_effect = [False, False, True]
+        renewer = _fake_renewer()
+        slept = []
+        with mock.patch.object(mjrt.leader_election,
+                               'LeadershipRenewer',
+                               return_value=renewer) as renewer_cls, \
+                mock.patch.object(mjrt.time, 'sleep', slept.append):
+            thread._acquire_role()
+        assert thread._elector.try_acquire.call_count == 3
+        assert slept == [mjrt._ACQUIRE_RETRY_INTERVAL_SECONDS] * 2
+        renewer_cls.assert_called_once_with(thread._elector)
+        renewer.start.assert_called_once_with()
+        assert thread._renewer is renewer
 
-    def test_non_postgres_lock_returns_true(self):
-        """Non-PG locks (FileLock in non-HA) have no session concept;
-        _lock_still_held returns True unconditionally."""
+    def test_a_raising_bid_is_retried_not_fatal(self):
+        """The old blocking acquire() sat outside the retry loop, so a database
+        blip while bidding ended the thread for the lifetime of the pod."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.FileLock,
-                                            instance=True,
-                                            spec_set=True)
-        assert thread._lock_still_held() is True
+        thread._elector = _fake_elector()
+        thread._elector.try_acquire.side_effect = [
+            RuntimeError('db blip'), True
+        ]
+        with mock.patch.object(mjrt.leader_election,
+                               'LeadershipRenewer',
+                               return_value=_fake_renewer()), \
+                mock.patch.object(mjrt.time, 'sleep'):
+            thread._acquire_role()
+        assert thread._elector.try_acquire.call_count == 2
+        assert thread._renewer is not None
+
+    def test_renewer_starts_only_after_the_bid_is_won(self):
+        """Renewing before we hold the role would log failures forever; more
+        importantly the renewer's clock must start from the acquisition."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._elector = _fake_elector()
+        order = []
+        thread._elector.try_acquire.side_effect = (
+            lambda: order.append('acquire') or True)
+        renewer = _fake_renewer()
+        renewer.start.side_effect = lambda: order.append('renew')
+        with mock.patch.object(mjrt.leader_election,
+                               'LeadershipRenewer',
+                               return_value=renewer), \
+                mock.patch.object(mjrt.time, 'sleep'):
+            thread._acquire_role()
+        assert order == ['acquire', 'renew']
 
 
-class TestSuicideOnLockLoss:
-    """Lock-loss must SIGTERM the current process, not the thread."""
+class TestSuicideOnRoleLoss:
+    """Role loss must SIGTERM the current process, not the thread."""
 
     def test_sends_sigterm_to_current_pid(self):
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _leading_thread()
         with mock.patch.object(mjrt.os, 'kill') as kill_mock, \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345), \
                 mock.patch.object(mjrt.managed_job_scheduler,
                                   'kill_local_job_controllers'):
-            thread._suicide_on_lock_loss()
+            thread._suicide_on_role_loss()
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_stops_renewing_and_never_releases_the_role(self):
+        """Two halves of the same invariant.
+
+        Stop renewing, so nothing re-establishes a role this process has
+        decided to give up. But do NOT release: releasing hands the role to a
+        follower immediately, and the controllers killed just below have to be
+        gone before another replica adopts their jobs. Sitting out the rest of
+        the lease (ttl - renew_deadline) is what buys that time.
+        """
+        thread = _leading_thread()
+        renewer = thread._renewer
+        elector = thread._elector
+        with mock.patch.object(mjrt.os, 'kill'), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers'):
+            thread._suicide_on_role_loss()
+        renewer.stop.assert_called_once()
+        elector.release.assert_not_called()
 
     def test_kills_local_controllers_before_sigterm(self):
         """Controllers must be SIGTERMed before the API server SIGTERM —
-        the lock is already released here, so a new leader can schedule
-        within milliseconds. Killing first prevents split-brain."""
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        the role is on its way out here, so another replica can schedule
+        soon after. Killing first prevents split-brain."""
+        thread = _leading_thread()
         call_order = []
         with mock.patch.object(
                 mjrt.managed_job_scheduler,
@@ -87,23 +183,20 @@ class TestSuicideOnLockLoss:
                     mjrt.os, 'kill',
                     side_effect=lambda *a, **kw: call_order.append('sigterm')), \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
+            thread._suicide_on_role_loss()
         assert call_order == ['kill_controllers', 'sigterm']
 
     def test_sigterm_still_sent_when_controller_kill_raises(self):
         """A failure killing controllers must not block the SIGTERM —
         otherwise the replica would stay up holding nothing useful."""
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _leading_thread()
         with mock.patch.object(
                 mjrt.managed_job_scheduler,
                 'kill_local_job_controllers',
                 side_effect=RuntimeError('boom')), \
                 mock.patch.object(mjrt.os, 'kill') as kill_mock, \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
+            thread._suicide_on_role_loss()
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)
 
     def test_touches_recovery_signal_file(self, tmp_path, monkeypatch):
@@ -116,10 +209,7 @@ class TestSuicideOnLockLoss:
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(signal_file))
 
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _leading_thread()
         order = []
         with mock.patch.object(
                 mjrt.managed_job_scheduler,
@@ -129,7 +219,7 @@ class TestSuicideOnLockLoss:
                     mjrt.os, 'kill',
                     side_effect=lambda *a, **kw: order.append('sigterm')), \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
+            thread._suicide_on_role_loss()
 
         assert signal_file.exists()
         # File must be created BEFORE kill_controllers and SIGTERM,
@@ -145,43 +235,34 @@ class TestSuicideOnLockLoss:
         def boom_touch(self, *args, **kwargs):  # pylint: disable=unused-argument
             raise OSError('read-only fs')
 
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        thread._lock = mock.create_autospec(locks.PostgresLock,
-                                            instance=True,
-                                            spec_set=True)
+        thread = _leading_thread()
         with mock.patch.object(mjrt.pathlib.Path, 'touch', boom_touch), \
                 mock.patch.object(mjrt.managed_job_scheduler,
                                   'kill_local_job_controllers'), \
                 mock.patch.object(mjrt.os, 'kill') as kill_mock, \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
-            thread._suicide_on_lock_loss()
+            thread._suicide_on_role_loss()
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)
 
 
 class TestOuterLoopStopsAfterSuicide:
-    """Normal return from _become_leader_and_run only happens after the
-    inner loop's probe detected lock loss and called _suicide_on_lock_loss.
-    The outer run() loop must stop the thread instead of re-entering —
-    otherwise the next iteration would skip the lock acquire (the local
-    _acquired flag is stale) and run ha_recovery_for_consolidation_mode,
-    which would spawn fresh controllers under a now-released lock while
-    the new leader on another replica is doing the same.
+    """Normal return from _become_leader_and_run only happens after a probe
+    detected role loss and called _suicide_on_role_loss. The outer run() loop
+    must stop the thread instead of re-entering — otherwise the next iteration
+    would re-contend, run ha_recovery_for_consolidation_mode and spawn fresh
+    controllers while the new leader on another replica is doing the same.
     """
 
     def test_run_returns_after_become_leader_returns_normally(self):
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        lock = mock.create_autospec(locks.PostgresLock,
-                                    instance=True,
-                                    spec_set=True)
         # If the outer loop incorrectly iterates, _become_leader_and_run
-        # would be called more than once. Use a side_effect that fails
-        # the test if that happens.
+        # would be called more than once. Count the calls.
         call_count = {'n': 0}
 
         def normal_return(self):
             call_count['n'] += 1
 
-        with mock.patch('sky.utils.locks.get_lock', return_value=lock), \
+        with mock.patch.object(mjrt.leader_election, 'get_elector'), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
                     '_become_leader_and_run',
@@ -195,42 +276,31 @@ class TestOuterLoopStopsAfterSuicide:
 
 class TestOuterLoopExceptionHandling:
     """When _become_leader_and_run throws, decide between SIGTERM and retry
-    based on whether we previously held a now-dead lock."""
+    based on whether we were leading and have since lost the role."""
 
-    @staticmethod
-    def _patches(is_locked: bool, session_alive: bool):
-        """run() overwrites self._lock via locks.get_lock; we have to
-        substitute the lock at that boundary instead of post-init."""
-        lock = mock.create_autospec(locks.PostgresLock,
-                                    instance=True,
-                                    spec_set=True)
-        lock.is_locked.return_value = is_locked
-        lock.is_session_alive.return_value = session_alive
-        return mock.patch('sky.utils.locks.get_lock', return_value=lock), lock
-
-    def test_sigterm_when_was_leader_and_session_dead(self):
-        """Acquired the lock, then recovery threw because the underlying
-        PG session died — running again would race the new leader."""
+    def test_sigterm_when_was_leader_and_role_is_gone(self):
+        """Acquired the role, then recovery threw because we could no longer
+        renew — running again would race the new leader."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=True, session_alive=False)
-        with get_lock_p, \
+        thread._renewer = _fake_renewer(holding=False)
+        with mock.patch.object(mjrt.leader_election, 'get_elector'), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
                     '_become_leader_and_run',
                     side_effect=RuntimeError('recovery boom')), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_suicide_on_role_loss') as suicide, \
                 mock.patch.object(mjrt.time, 'sleep'):
             thread.run()
         suicide.assert_called_once()
 
-    def test_retry_when_acquire_threw(self):
-        """acquire() itself failed (e.g. another replica holds the lock,
-        or transient PG hiccup); is_locked stays False, just retry."""
+    def test_retry_when_the_bid_threw(self):
+        """We never won the role (another replica holds it, or a transient
+        database hiccup); there is nothing to step down from, just retry."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=False, session_alive=False)
-        with get_lock_p, \
+        assert thread._renewer is None
+        with mock.patch.object(mjrt.leader_election, 'get_elector'), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
                     '_become_leader_and_run',
@@ -239,18 +309,18 @@ class TestOuterLoopExceptionHandling:
                                  SystemExit()]), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_suicide_on_role_loss') as suicide, \
                 mock.patch.object(mjrt.time, 'sleep'):
             with pytest.raises(SystemExit):
                 thread.run()
         suicide.assert_not_called()
 
-    def test_retry_when_lock_still_held(self):
-        """Recovery threw on transient error but our lock session is
-        still alive — keep retrying as leader."""
+    def test_retry_when_the_role_is_still_held(self):
+        """Recovery threw on a transient error but we are still renewing —
+        keep retrying as leader."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        get_lock_p, lock = self._patches(is_locked=True, session_alive=True)
-        with get_lock_p, \
+        thread._renewer = _fake_renewer(holding=True)
+        with mock.patch.object(mjrt.leader_election, 'get_elector'), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
                     '_become_leader_and_run',
@@ -258,7 +328,7 @@ class TestOuterLoopExceptionHandling:
                                  SystemExit()]), \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide, \
+                    '_suicide_on_role_loss') as suicide, \
                 mock.patch.object(mjrt.time, 'sleep'):
             with pytest.raises(SystemExit):
                 thread.run()
@@ -266,47 +336,41 @@ class TestOuterLoopExceptionHandling:
 
 
 class TestBecomeLeaderOrdering:
-    """The recovery signal file must exist BEFORE the lock is acquired, and
+    """The recovery signal file must exist BEFORE the role is acquired, and
     recovery must wait briefly after acquiring it.
 
-    During a rolling update we block on acquire() while the old API server
-    still holds the lock. If the gate file is missing in that window, a
-    controller started on this replica would be invisible to the old
-    server's update_managed_jobs_statuses, which could mark the job
-    FAILED_CONTROLLER. The signal file gates controller starts, so it must
-    be touched up-front, not after we win the lock.
+    During a rolling update we contend while the old API server still holds
+    the role. If the gate file is missing in that window, a controller started
+    on this replica would be invisible to the old server's
+    update_managed_jobs_statuses, which could mark the job FAILED_CONTROLLER.
+    The signal file gates controller starts, so it must be touched up-front,
+    not after we win the role.
 
-    After acquiring the lock we also wait briefly before recovery: the old
-    pod's detached controllers can outlive the lock release by a moment, and
+    After acquiring the role we also wait briefly before recovery: the old
+    pod's detached controllers can outlive the handoff by a moment, and
     recovery resetting jobs while they are still alive lets them re-claim and
     re-stamp soon-dead PIDs (split brain across the upgrade overlap).
     """
 
-    def test_signal_file_touched_before_lock_acquire(self, tmp_path,
-                                                     monkeypatch):
+    def test_signal_file_touched_before_the_bid(self, tmp_path, monkeypatch):
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(signal_file))
 
         thread = mjrt.ManagedJobRefreshDaemonThread()
-        lock = mock.create_autospec(locks.PostgresLock,
-                                    instance=True,
-                                    spec_set=True)
-        lock.is_locked.return_value = False
-        lock.is_session_alive.return_value = True
-        thread._lock = lock
-
+        thread._elector = _fake_elector()
         order = []
 
-        def on_acquire(*args, **kwargs):
+        def on_bid():
             # The gate file must already be in place by the time we start
-            # blocking on acquire — that is the whole point of the fix.
+            # bidding — that is the whole point.
             assert signal_file.exists(), (
-                'signal file must be touched before acquiring the lock')
+                'signal file must be touched before bidding for the role')
             order.append('acquire')
+            return True
 
-        lock.acquire.side_effect = on_acquire
+        thread._elector.try_acquire.side_effect = on_bid
 
         def on_sleep(*args, **kwargs):
             order.append('sleep')
@@ -316,14 +380,17 @@ class TestBecomeLeaderOrdering:
             # Raise to skip the infinite event loop that follows recovery.
             raise RuntimeError('stop before event loop')
 
-        with mock.patch.object(mjrt.time, 'sleep', side_effect=on_sleep), \
+        with mock.patch.object(mjrt.leader_election,
+                               'LeadershipRenewer',
+                               return_value=_fake_renewer()), \
+                mock.patch.object(mjrt.time, 'sleep', side_effect=on_sleep), \
                 mock.patch.object(mjrt.managed_job_utils,
                                   'ha_recovery_for_consolidation_mode',
                                   side_effect=recovery_and_stop):
             with pytest.raises(RuntimeError, match='stop before event loop'):
                 thread._become_leader_and_run()
 
-        # Recovery runs only after the lock is acquired AND after the wait.
+        # Recovery runs only after the role is acquired AND after the wait.
         assert order == ['acquire', 'sleep', 'recovery']
         # The finally block removes the gate file even when recovery fails.
         assert not signal_file.exists()
@@ -339,14 +406,7 @@ class TestBecomeLeaderOrdering:
                             str(signal_file))
         monkeypatch.setattr(mjrt, '_RECOVERY_WAIT_AFTER_ACQUIRE_SECONDS', 7)
 
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        lock = mock.create_autospec(locks.PostgresLock,
-                                    instance=True,
-                                    spec_set=True)
-        lock.is_locked.return_value = False
-        lock.is_session_alive.return_value = True
-        thread._lock = lock
-
+        thread = _leading_thread()
         slept = []
 
         def on_sleep(seconds, *args, **kwargs):
@@ -365,24 +425,40 @@ class TestBecomeLeaderOrdering:
 
         assert slept == [7]
 
-    def test_steps_down_if_lock_lost_during_wait(self, tmp_path, monkeypatch):
-        """If the lock session goes stale during the post-acquire wait, we
-        must NOT run recovery — another replica may now hold the lock. Step
-        down via _suicide_on_lock_loss and leave the gate file in place (the
-        suicide path re-touches it to keep controllers gated)."""
+    def test_reuses_the_role_it_already_holds(self, tmp_path, monkeypatch):
+        """A retry after a transient error while still leading must not bid
+        again: a second renewer would double the renew traffic and leave the
+        first one running with nobody reading it."""
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+        thread = _leading_thread()
+        renewer = thread._renewer
+        with mock.patch.object(mjrt.time, 'sleep'), \
+                mock.patch.object(mjrt.leader_election,
+                                  'LeadershipRenewer') as renewer_cls, \
+                mock.patch.object(
+                    mjrt.managed_job_utils,
+                    'ha_recovery_for_consolidation_mode',
+                    side_effect=RuntimeError('stop before event loop')):
+            with pytest.raises(RuntimeError, match='stop before event loop'):
+                thread._become_leader_and_run()
+        thread._elector.try_acquire.assert_not_called()
+        renewer_cls.assert_not_called()
+        assert thread._renewer is renewer
+
+    def test_steps_down_if_role_lost_during_wait(self, tmp_path, monkeypatch):
+        """If the role goes away during the post-acquire wait, we must NOT run
+        recovery — another replica may now hold it. Step down via
+        _suicide_on_role_loss and leave the gate file in place (the suicide
+        path re-touches it to keep controllers gated)."""
         signal_file = tmp_path / 'restart_signal'
         monkeypatch.setattr(mjrt.constants,
                             'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
                             str(signal_file))
 
-        thread = mjrt.ManagedJobRefreshDaemonThread()
-        lock = mock.create_autospec(locks.PostgresLock,
-                                    instance=True,
-                                    spec_set=True)
-        lock.is_locked.return_value = False
-        # Session is dead by the time we re-check after the wait.
-        lock.is_session_alive.return_value = False
-        thread._lock = lock
+        thread = _leading_thread(holding=False)
 
         with mock.patch.object(mjrt.time, 'sleep'), \
                 mock.patch.object(
@@ -390,7 +466,7 @@ class TestBecomeLeaderOrdering:
                     'ha_recovery_for_consolidation_mode') as recovery, \
                 mock.patch.object(
                     mjrt.ManagedJobRefreshDaemonThread,
-                    '_suicide_on_lock_loss') as suicide:
+                    '_suicide_on_role_loss') as suicide:
             thread._become_leader_and_run()
 
         suicide.assert_called_once()
@@ -398,6 +474,49 @@ class TestBecomeLeaderOrdering:
         # The gate file is NOT removed on the step-down path; the suicide
         # routine owns re-touching it for the shutdown drain.
         assert signal_file.exists()
+
+
+class TestEventLoopProbe:
+    """The event loop confirms the role before it acts on it."""
+
+    def test_probes_before_the_first_event_tick(self, tmp_path, monkeypatch):
+        """Recovery walks every managed job, so it can outlast the role. If
+        the loop waited a probe interval before its first check it would run a
+        full status sweep — which mutates job rows — as a stale leader.
+        """
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._elector = _fake_elector()
+        # Holding through the pre-recovery check, gone by the time recovery
+        # returns.
+        holding = {'value': True}
+        renewer = _fake_renewer()
+        type(renewer).holding = property(lambda self: holding['value'])
+        thread._renewer = renewer
+
+        refresh_event = mock.Mock()
+
+        def recovery():
+            holding['value'] = False
+
+        with mock.patch.object(mjrt.time, 'sleep'), \
+                mock.patch.object(mjrt.managed_job_utils,
+                                  'ha_recovery_for_consolidation_mode',
+                                  side_effect=recovery), \
+                mock.patch.object(mjrt.events,
+                                  'ManagedJobEvent',
+                                  return_value=refresh_event), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_suicide_on_role_loss') as suicide:
+            thread._become_leader_and_run()
+
+        suicide.assert_called_once()
+        refresh_event.run.assert_not_called()
 
 
 class TestStart:

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -61,7 +61,7 @@ class TestElectorConfiguration:
         get_elector.assert_called_once_with(
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID,
             ttl_seconds=mjrt._LEASE_TTL_SECONDS,
-            renew_interval_seconds=mjrt._LOCK_PROBE_INTERVAL_SECONDS,
+            renew_interval_seconds=mjrt._ROLE_RENEW_INTERVAL_SECONDS,
             renew_deadline_seconds=mjrt._RENEW_DEADLINE_SECONDS)
 
     def test_timing_is_looser_than_the_module_defaults(self):
@@ -80,7 +80,7 @@ class TestElectorConfiguration:
                 leader_election.DEFAULT_RENEW_DEADLINE_SECONDS)
         # The lease constructor enforces this too, but a violation here would
         # only surface on a Postgres deployment with the lease backend on.
-        assert (0 < mjrt._LOCK_PROBE_INTERVAL_SECONDS <
+        assert (0 < mjrt._ROLE_RENEW_INTERVAL_SECONDS <
                 mjrt._RENEW_DEADLINE_SECONDS < mjrt._LEASE_TTL_SECONDS)
 
 


### PR DESCRIPTION
The consolidation leader — the manager of the job-controller process group — was the last fleet-wide singleton hardcoded to a Postgres advisory lock, so `SKYPILOT_LEADER_ELECTION_BACKEND` had no effect on it. Route it through `sky.utils.leader_election`: `advisory` (the default) keeps the same lock id and the same mutual exclusion, `lease` switches to a renewable `leader_leases` row that pins no connection for the leadership term.

Timing is this role's own (ttl 150 / interval 5 / deadline 90) rather than the module defaults (60/10/30). A second leader here restarts controllers for jobs whose controllers may still be running, and a lost role is a suicide timer (SIGTERM, so the detached controllers go down with this server) — so both knobs are deliberately loose. The renew cadence stays at the interval this daemon has always probed at.

Renewal runs on its own thread (`leader_election.LeadershipRenewer`): the post-acquire wait, recovery (it walks every managed job) and each `ManagedJobEvent` tick are all unbounded blocking calls, and renewing only between them would let a slow recovery lapse the lease mid-recovery. `holding` also fails on the clock, so a renewer wedged in a socket read cannot leave the caller acting as leader. The loop consults `holding` on every pass rather than on its own interval, since it is an in-memory read now — the renewer owns the round trip.

Two deliberate non-changes: the step-down path does not `release()` (releasing lets the next candidate in immediately, and the controllers killed there have to be gone first — sitting out the remaining `ttl - deadline` margin is the guarantee), and a leader that exits without releasing therefore holds the role for the rest of the ttl.

One behaviour deviation worth naming: the old blocking `acquire()` polled at `poll_interval=1`, the new non-blocking bid loop retries at 5s, so a takeover can be up to 4s later on the advisory backend. Kept at 5s because a bid on the lease backend is a real DB round trip and the 15s post-acquire recovery wait dominates either way.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Relevant individual tests: `pytest tests/unit_tests/test_leader_election.py tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py` — 41 tests green (5 lease-SQL cases skip without a Postgres fixture). Every new invariant mutation-checked.
- [x] Manual, against a Postgres-backed server with `SKYPILOT_LEADER_ELECTION_BACKEND=lease` and a second candidate contending for the role:
  - Steady state: one lease row for `~/.sky/consolidation_mode_lock`, `expires_at - now()` sampled every 20s over 3min stayed within 5s of the full 150s ttl (so the renew cadence is flowing) with `epoch` pinned at 1. `renew` keeps the epoch and `try_acquire` bumps it, so a stable epoch with a moving expiry is what proves the renew path rather than repeated re-acquisition. No advisory lock held for that lock id in the same database.
  - Exactly one leader: the holder logged `Contending … / role acquired / Waiting 15s …`; the other candidate logged only `Contending …` for its whole life.
  - Recovery really ran under the lease, 15s after the acquire, and started the job controllers.
  - Killing the holder without letting it release: `epoch` 1→2, and the role was picked up ~159s later = ~6s of shutdown drain (the renewer correctly keeps renewing while the process is going down, since it still owns its controllers) + the 150s ttl + ≤5s of bid granularity. That is the conservative-by-design number, not a stall.
  - Same again through a graceful restart: `epoch` 2→3, ~151s from the outgoing holder's last renew. The epoch sequence 1→2→3 never interleaved and no sample ever showed two holders.
  - Zero `renew failed` / `giving up the leader role` / `Lost the consolidation mode role` / `role bid failed` lines across both, and none in a 19h soak afterwards: same holder, `epoch` still 3, renewing on cadence, no restarts. No flapping and no leaked term.
- [x] Failover and restart scenarios from a private integration suite, on both backends. On `advisory` these were green before and after; the `lease` results are the manual numbers above. One case in that suite failed on the first run and turned out to be an unsound assertion in the case itself — a single no-wait `status == 'RUNNING'` read taken right after waiting out a leadership handoff, where a re-adopted managed job legitimately passes through `RECOVERING`, which that case's own failure set excludes. Fixed there to assert "never in a failure state" immediately and then wait for `RUNNING`; green on re-run. Nothing in this diff changed as a result.