### PR TITLE
[Metrics] Client-side database instrumentation for the API server

### DIFF
--- a/charts/skypilot/manifests/api-server-db-dashboard.json
+++ b/charts/skypilot/manifests/api-server-db-dashboard.json
@@ -1,0 +1,1582 @@
+{
+  "title": "SkyPilot API Server \u2014 Database",
+  "uid": "skypilot-api-server-db",
+  "tags": [
+    "skypilot",
+    "api-server",
+    "database"
+  ],
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "db",
+        "label": "db (engine role)",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(sky_apiserver_db_statements_total, db)",
+        "query": {
+          "query": "label_values(sky_apiserver_db_statements_total, db)",
+          "refId": "StandardVariableQuery"
+        },
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "table",
+        "label": "table",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(sky_apiserver_db_statements_total, table)",
+        "query": {
+          "query": "label_values(sky_apiserver_db_statements_total, table)",
+          "refId": "StandardVariableQuery"
+        },
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Client-side SQL chain: acquire -> connect -> execute -> rowfetch -> commit",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Execute latency",
+      "description": "Span of cursor.execute(). Includes the result set coming over the wire \u2014 psycopg2 and asyncpg both buffer the whole result during execute \u2014 so a large read raises this panel. Read it together with \"Rows returned\" and \"Result bytes\" below to tell a big read from a genuinely slow query.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db) (rate(sky_apiserver_db_execute_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db) (rate(sky_apiserver_db_execute_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db) (rate(sky_apiserver_db_execute_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Row fetch / materialization latency",
+      "description": "Time handing already-buffered rows into Python objects, on whichever thread or event loop made the call. Not wire time. Empty for reads consumed one row at a time (.first(), .scalar()), which are deliberately not instrumented.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db) (rate(sky_apiserver_db_rowfetch_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db) (rate(sky_apiserver_db_rowfetch_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db) (rate(sky_apiserver_db_rowfetch_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Transaction span",
+      "description": "begin to commit/rollback. Long spans are the `idle in transaction` population and they hold back vacuum. Read-only blocks end in rollback, hence the outcome split.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db, outcome) (rate(sky_apiserver_db_transaction_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}} {{outcome}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db, outcome) (rate(sky_apiserver_db_transaction_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}} {{outcome}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, outcome) (rate(sky_apiserver_db_transaction_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}} {{outcome}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Commit latency",
+      "description": "Under a transaction-mode pooler this is where the server connection is actually released, so it is a pooler signal as much as a database one.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db) (rate(sky_apiserver_db_commit_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db) (rate(sky_apiserver_db_commit_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db) (rate(sky_apiserver_db_commit_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Payload: what is actually moving",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Rows returned per statement (p99)",
+      "description": "The direct instrument for a full-table read. A statement that normally returns tens of rows suddenly returning tens of thousands is the jobs-queue pathology.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "rows",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "{{db}}/{{table}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Result bytes per statement (p99)",
+      "description": "Measured client-side over the rows handed back. This is the panel that makes a >100MiB read visible; no server-side counter shows it, because to the database it is a fast healthy query.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_result_bytes_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "{{db}}/{{table}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Statement + parameter bytes per write (p99)",
+      "description": "Bytes going out. This is where a multi-hundred-megabyte write payload shows up.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_statement_bytes_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "legendFormat": "{{db}}/{{table}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Bytes returned per second",
+      "description": "Total read volume. Sum of the histogram, not a percentile, so a burst of large reads is visible even when p99 is not.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, table) (rate(sky_apiserver_db_result_bytes_sum{db=~\"$db\", table=~\"$table\"}[$__rate_interval]))",
+          "legendFormat": "{{db}}/{{table}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Statement rate and errors",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Statement rate by op",
+      "description": "Statements per second. A counter, so this is a real rate and not a census.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, op) (rate(sky_apiserver_db_statements_total{db=~\"$db\", table=~\"$table\"}[$__rate_interval]))",
+          "legendFormat": "{{db}} {{op}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Statement errors by table",
+      "description": "Failed statements per second.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, table) (rate(sky_apiserver_db_statements_total{db=~\"$db\", table=~\"$table\", outcome=\"error\"}[$__rate_interval]))",
+          "legendFormat": "{{db}}/{{table}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Connections and pool (labelled by pool class)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Fresh connect rate",
+      "description": "New DBAPI connections per second \u2014 the load that saturates the database's connection admission. A counter by construction: a census of live backends cannot see sub-second sessions or anything still mid-handshake.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, pool) (rate(sky_apiserver_db_connects_total{db=~\"$db\"}[$__rate_interval]))",
+          "legendFormat": "{{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Connect latency",
+      "description": "How long opening one fresh connection takes. Neither the pooler nor CloudWatch measures this, and it is where connection-admission queueing shows up.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db, pool) (rate(sky_apiserver_db_connect_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db, pool) (rate(sky_apiserver_db_connect_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, pool) (rate(sky_apiserver_db_connect_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Acquire latency (pool wait + any fresh connect)",
+      "description": "Compare against \"Connect latency\": both high means the database is slow to admit; acquire high while connect is low means we ran out of pool.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db, pool) (rate(sky_apiserver_db_acquire_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db, pool) (rate(sky_apiserver_db_acquire_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, pool) (rate(sky_apiserver_db_acquire_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Pool utilization (worst process)",
+      "description": "Checked-out connections over the configured ceiling, for the most saturated process. Per-process because a fleet-wide sum can exceed any single pool's limit while no individual pool is full. The configured limits come from max-mode gauges, hence max_over_time.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (db, pool) (max_over_time(sky_apiserver_db_pool_checked_out{db=~\"$db\"}[$__interval])) / clamp_min(max by (db, pool) (max_over_time(sky_apiserver_db_pool_size{db=~\"$db\"}[$__interval]) + max_over_time(sky_apiserver_db_pool_max_overflow{db=~\"$db\"}[$__interval])), 1)",
+          "legendFormat": "{{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Processes reporting pool state",
+      "description": "The companion count for the gauge above: a utilization number means nothing without knowing how many processes are reporting it. A drop here means processes went away, not that the pool drained.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count by (db, pool) (sky_apiserver_db_pool_checked_out{db=~\"$db\"})",
+          "legendFormat": "{{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Connection lifetime",
+      "description": "Churn versus reuse, directly. A NullPool engine shows connections living milliseconds; a healthy QueuePool shows them living until pool_recycle.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db, pool) (rate(sky_apiserver_db_connection_lifetime_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, db, pool) (rate(sky_apiserver_db_connection_lifetime_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, pool) (rate(sky_apiserver_db_connection_lifetime_seconds_bucket{db=~\"$db\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Connections invalidated",
+      "description": "Connections the pool threw away \u2014 pre-ping failures, resets, server-side disconnects.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, pool) (rate(sky_apiserver_db_invalidations_total{db=~\"$db\"}[$__rate_interval]))",
+          "legendFormat": "{{db}} {{pool}}",
+          "range": true,
+          "instant": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "row",
+      "title": "Per db and table",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "panels": []
+    },
+    {
+      "id": 23,
+      "type": "table",
+      "title": "Statement profile per db and table",
+      "description": "The per-db, per-table view the dashboard exists to answer: execute and rowfetch percentiles, rows and bytes, and statement rate, for the selected window. The pool class column is worth a glance: a role that is supposed to pool but reports NullPool is a defect, and nothing else surfaces it.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*(p50|p95|p99).*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*[Bb]ytes.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "execute p99",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le, db, table) (rate(sky_apiserver_db_execute_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_execute_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rowfetch_seconds_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_result_bytes_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (db, table) (rate(sky_apiserver_db_statements_total{db=~\"$db\", table=~\"$table\"}[$__range]))",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "editorMode": "code",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "table",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "db 2": true,
+              "db 3": true,
+              "db 4": true,
+              "db 5": true,
+              "db 6": true
+            },
+            "renameByName": {
+              "db 1": "db",
+              "Value #A": "execute p50",
+              "Value #B": "execute p99",
+              "Value #C": "rowfetch p99",
+              "Value #D": "rows p99",
+              "Value #E": "result bytes p99",
+              "Value #F": "statements/s"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/charts/skypilot/manifests/api-server-db-dashboard.json
+++ b/charts/skypilot/manifests/api-server-db-dashboard.json
@@ -461,8 +461,8 @@
     {
       "id": 7,
       "type": "timeseries",
-      "title": "Rows returned per statement (p99)",
-      "description": "The direct instrument for a full-table read. A statement that normally returns tens of rows suddenly returning tens of thousands is the jobs-queue pathology.",
+      "title": "Rows returned per read (p99)",
+      "description": "The direct instrument for a full-table read. Filtered to op=\"select\" on purpose: rows_returned keeps its op label because for a SELECT the number is rows returned while for DML it is rows affected, and averaging those together would make \"something read the whole table\" look the same as \"something deleted the whole table\". Swap the filter to see writes.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -514,7 +514,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\", op=\"select\"}[$__rate_interval])))",
           "legendFormat": "{{db}}/{{table}}",
           "range": true,
           "instant": false,
@@ -1506,7 +1506,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\"}[$__range])))",
+          "expr": "histogram_quantile(0.99, sum by (le, db, table) (rate(sky_apiserver_db_rows_returned_bucket{db=~\"$db\", table=~\"$table\", op=\"select\"}[$__range])))",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -1570,7 +1570,7 @@
               "Value #A": "execute p50",
               "Value #B": "execute p99",
               "Value #C": "rowfetch p99",
-              "Value #D": "rows p99",
+              "Value #D": "rows p99 (reads)",
               "Value #E": "result bytes p99",
               "Value #F": "statements/s"
             }

--- a/charts/skypilot/templates/api-server-db-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/api-server-db-dashboard-grafana-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.grafana.enabled .Values.grafana.sidecar.dashboards.enabled }}
+{{- $fullName := include "skypilot.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-api-server-db-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}-api
+    grafana_dashboard: "true"
+data:
+  api-server-db.json: |
+{{ .Files.Get "manifests/api-server-db-dashboard.json" | indent 4 }}
+{{- end }}

--- a/sky/metrics/db.py
+++ b/sky/metrics/db.py
@@ -33,7 +33,13 @@ Label budget, deliberately small:
   profiles. Per-component resolution comes from ``table``.
 * ``table`` — the primary table of the statement, taken from the
   compiled SQLAlchemy construct.
-* ``op``   — select / insert / update / delete / ddl / other.
+* ``op``   — select / insert / update / delete / ddl / other. Carried
+  only by ``statements_total`` (which is where "statement rate by op"
+  lives) and by ``rows_returned`` (where returned-vs-affected rows are
+  genuinely different populations). The latency and byte families are
+  labelled by ``db`` + ``table`` alone: a per-op latency breakdown costs
+  a third of this module's total series and the questions it answers are
+  reachable from the counter.
 * ``pool`` — the pool class (``QueuePool`` / ``NullPool`` / ...), on the
   connection-side families only. A role that is expected to pool but
   reports ``NullPool`` is a defect, and nothing else surfaces it.
@@ -80,13 +86,20 @@ _KIB = 2**10
 _MIB = 2**20
 _GIB = 2**30
 
-# Statement latency ladder. Starts at 1ms: with a pooler and a remote
-# Postgres in the path, a point query costs hundreds of microseconds at
-# best, and sub-ms resolution would only buy precision for SQLite. Tops
-# out at 60s because anything slower is already an incident, and every
-# bucket multiplies the series count of every labeled histogram.
-LATENCY_BUCKETS = (0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
-                   2.5, 5.0, 10.0, 30.0, 60.0, float('inf'))
+# Statement latency ladder, two buckets per decade (1x and 5x). Starts at
+# 1ms: with a pooler and a remote Postgres in the path a point query costs
+# hundreds of microseconds at best, so sub-ms resolution would only buy
+# precision for SQLite. Tops out at 60s because anything slower is already
+# an incident.
+#
+# Eleven buckets, not the sixteen this started with. Every bucket is a
+# time series per label combination, and on a real deployment the latency
+# families were 55% of everything this module exports; the five buckets
+# dropped (2.5ms, 25ms, 250ms, 2.5s, 30s) each sat next to a neighbour
+# within ~2.5x, which buys percentile smoothness rather than a different
+# answer.
+LATENCY_BUCKETS = (0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0,
+                   float('inf'))
 
 # Rows returned per statement. Decade buckets: the question this answers
 # is "did something just read the whole table", which is an
@@ -111,7 +124,7 @@ PAYLOAD_BUCKETS = (_KIB, 16 * _KIB, 128 * _KIB, _MIB, 8 * _MIB, 32 * _MIB,
 SKY_APISERVER_DB_EXECUTE_SECONDS = prom.Histogram(
     'sky_apiserver_db_execute_seconds',
     'Duration of cursor.execute() for a statement, client-side',
-    ['db', 'table', 'op'],
+    ['db', 'table'],
     buckets=LATENCY_BUCKETS,
 )
 
@@ -122,7 +135,7 @@ SKY_APISERVER_DB_EXECUTE_SECONDS = prom.Histogram(
 SKY_APISERVER_DB_ROWFETCH_SECONDS = prom.Histogram(
     'sky_apiserver_db_rowfetch_seconds',
     'Duration of row fetch / materialization after execute, client-side',
-    ['db', 'table', 'op'],
+    ['db', 'table'],
     buckets=LATENCY_BUCKETS,
 )
 
@@ -157,6 +170,12 @@ SKY_APISERVER_DB_STATEMENTS_TOTAL = prom.Counter(
 # The direct instrument for full-table reads. Exact where the driver
 # reports it (psycopg2 sets rowcount for SELECT); otherwise counted from
 # the rows actually handed to the caller.
+#
+# This is the one payload family that keeps `op`, and it has to: for a
+# SELECT the number means rows *returned*, for DML it means rows
+# *affected*. Those are different populations, and merging them would
+# make "something read the whole table" indistinguishable from "something
+# deleted the whole table".
 SKY_APISERVER_DB_ROWS_RETURNED = prom.Histogram(
     'sky_apiserver_db_rows_returned',
     'Rows returned or affected by one statement',
@@ -173,7 +192,7 @@ SKY_APISERVER_DB_ROWS_RETURNED = prom.Histogram(
 SKY_APISERVER_DB_RESULT_BYTES = prom.Histogram(
     'sky_apiserver_db_result_bytes',
     'Bytes of result data returned by one statement, measured client-side',
-    ['db', 'table', 'op'],
+    ['db', 'table'],
     buckets=PAYLOAD_BUCKETS,
 )
 
@@ -182,7 +201,7 @@ SKY_APISERVER_DB_RESULT_BYTES = prom.Histogram(
 SKY_APISERVER_DB_STATEMENT_BYTES = prom.Histogram(
     'sky_apiserver_db_statement_bytes',
     'Bytes of statement text plus bound parameters sent for one statement',
-    ['db', 'table', 'op'],
+    ['db', 'table'],
     buckets=PAYLOAD_BUCKETS,
 )
 
@@ -310,17 +329,17 @@ def record_statement(
     if not ENABLED:
         return
     try:
-        SKY_APISERVER_DB_EXECUTE_SECONDS.labels(db, table,
-                                                op).observe(execute_seconds)
+        SKY_APISERVER_DB_EXECUTE_SECONDS.labels(db,
+                                                table).observe(execute_seconds)
         SKY_APISERVER_DB_STATEMENTS_TOTAL.labels(db, table, op, outcome).inc()
         if rows is not None and rows >= 0:
             SKY_APISERVER_DB_ROWS_RETURNED.labels(db, table, op).observe(rows)
         if result_bytes is not None:
-            SKY_APISERVER_DB_RESULT_BYTES.labels(db, table,
-                                                 op).observe(result_bytes)
+            SKY_APISERVER_DB_RESULT_BYTES.labels(db,
+                                                 table).observe(result_bytes)
         if statement_bytes is not None:
-            SKY_APISERVER_DB_STATEMENT_BYTES.labels(db, table,
-                                                    op).observe(statement_bytes)
+            SKY_APISERVER_DB_STATEMENT_BYTES.labels(
+                db, table).observe(statement_bytes)
     except Exception:  # pylint: disable=broad-except
         _warn_once('Failed to record a database statement.')
 

--- a/sky/metrics/db.py
+++ b/sky/metrics/db.py
@@ -161,9 +161,17 @@ SKY_APISERVER_DB_COMMIT_SECONDS = prom.Histogram(
     buckets=LATENCY_BUCKETS,
 )
 
+# Counts *round trips*, not logical statements, and that is deliberate:
+# it is the unit the database and the pooler actually see, and it is the
+# same unit `execute_seconds` has to use to mean anything. The two differ
+# where SQLAlchemy's insertmanyvalues splits one `insert().returning()`
+# into several cursor executes — measured: 3000 rows becomes 3 executes at
+# the default page size of 1000. So this rate can exceed the number of
+# `execute()` calls the application made. Compare it against database-side
+# counters, not against application operations.
 SKY_APISERVER_DB_STATEMENTS_TOTAL = prom.Counter(
     'sky_apiserver_db_statements_total',
-    'Statements executed, by outcome',
+    'Round trips executed, by outcome (see the note above on batching)',
     ['db', 'table', 'op', 'outcome'],
 )
 

--- a/sky/metrics/db.py
+++ b/sky/metrics/db.py
@@ -1,0 +1,365 @@
+"""Prometheus metric families for the API server's own view of the database.
+
+Everything here describes one chain, measured as the *client* experiences
+it:
+
+    acquire -> connect -> execute -> rowfetch -> commit
+
+Storage-side instrumentation cannot answer which of those a slow request
+was waiting on, and it cannot see payload pathologies at all: a query
+that returns a hundred megabytes looks like a healthy fast query to every
+server-side counter. These families are the app-side counterpart.
+
+Deliberately a leaf module: it imports ``prometheus_client`` and
+``sky.skylet.constants`` and nothing else. The rest of the server metrics
+live in ``sky.metrics.utils``, which imports ``sky.skypilot_config``,
+which imports ``sky.utils.db.db_utils`` — so a metrics module that the DB
+layer itself can import must not go through it. That is also why
+``ENABLED`` re-reads the env var here instead of importing
+``sky.metrics.utils.METRICS_ENABLED``.
+
+The wiring that feeds these families lives in
+``sky.utils.db.sql_metrics``; ``record_statement`` /
+``observe_statement`` are the entry points for code that talks to the
+database without going through SQLAlchemy (a raw ``asyncpg`` pool, say),
+so it lands on the same families with the same labels.
+
+Label budget, deliberately small:
+
+* ``db``   — the engine *role*, not the hostname and not the logical
+  database. On Postgres every SkyPilot component shares one physical
+  database and one engine per role, so the roles (pooled, direct,
+  unpooled, async, ...) are what actually have different expected
+  profiles. Per-component resolution comes from ``table``.
+* ``table`` — the primary table of the statement, taken from the
+  compiled SQLAlchemy construct.
+* ``op``   — select / insert / update / delete / ddl / other.
+* ``pool`` — the pool class (``QueuePool`` / ``NullPool`` / ...), on the
+  connection-side families only. A role that is expected to pool but
+  reports ``NullPool`` is a defect, and nothing else surfaces it.
+
+Statement text, statement hashes, request ids, users and cluster/job
+names are deliberately *not* labels.
+"""
+
+import contextlib
+import os
+import time
+from typing import Iterator, Optional
+
+import prometheus_client as prom
+
+from sky.skylet import constants
+
+# Whether to instrument the database layer at all. Cannot change at
+# runtime. When false, ``sky.utils.db.sql_metrics.install`` attaches no
+# event listeners, so the cost is not merely "skip the observe" but the
+# whole SQLAlchemy has-events code path staying off.
+ENABLED = os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED,
+                         'false').lower() == 'true'
+
+# Label value used when a statement's primary table cannot be determined
+# from a compiled construct (``sqlalchemy.text()`` and driver-level
+# statements). We do not regex the SQL text to fill this in.
+UNKNOWN_TABLE = 'raw'
+
+# The ``op`` label values. Public because callers outside SQLAlchemy pass
+# them to ``record_statement`` / ``observe_statement``, and a label
+# vocabulary spelled out at each call site drifts.
+OP_SELECT = 'select'
+OP_INSERT = 'insert'
+OP_UPDATE = 'update'
+OP_DELETE = 'delete'
+OP_DDL = 'ddl'
+OP_OTHER = 'other'
+
+_KIB = 2**10
+_MIB = 2**20
+_GIB = 2**30
+
+# Statement latency ladder. Starts at 1ms: with a pooler and a remote
+# Postgres in the path, a point query costs hundreds of microseconds at
+# best, and sub-ms resolution would only buy precision for SQLite. Tops
+# out at 60s because anything slower is already an incident, and every
+# bucket multiplies the series count of every labeled histogram.
+LATENCY_BUCKETS = (0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+                   2.5, 5.0, 10.0, 30.0, 60.0, float('inf'))
+
+# Rows returned per statement. Decade buckets: the question this answers
+# is "did something just read the whole table", which is an
+# order-of-magnitude question.
+ROW_BUCKETS = (1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, float('inf'))
+
+# Bytes moved by one statement, in either direction. Deliberately reaches
+# 1GiB: the write payloads that motivated this instrument are that large,
+# and a histogram whose top finite bucket is 128MiB reports "big" for
+# both a 200MiB read and a 1GiB write.
+PAYLOAD_BUCKETS = (_KIB, 16 * _KIB, 128 * _KIB, _MIB, 8 * _MIB, 32 * _MIB,
+                   128 * _MIB, 512 * _MIB, _GIB, float('inf'))
+
+# --- statement side -------------------------------------------------------
+
+# The server round trip for the statement itself: the span of
+# ``cursor.execute()``. Note this INCLUDES pulling the result set over the
+# wire — both psycopg2 and asyncpg buffer the whole result client-side
+# during execute — so a large read shows up here as latency, and
+# ``sky_apiserver_db_rows_returned`` / ``_result_bytes`` are what
+# distinguish it from a genuinely slow query.
+SKY_APISERVER_DB_EXECUTE_SECONDS = prom.Histogram(
+    'sky_apiserver_db_execute_seconds',
+    'Duration of cursor.execute() for a statement, client-side',
+    ['db', 'table', 'op'],
+    buckets=LATENCY_BUCKETS,
+)
+
+# Time spent handing already-buffered rows to the caller: SQLAlchemy row
+# construction, not wire time (see above). This is the "we dragged a
+# large result set into Python objects" cost, which lands on whichever
+# thread or event loop made the call.
+SKY_APISERVER_DB_ROWFETCH_SECONDS = prom.Histogram(
+    'sky_apiserver_db_rowfetch_seconds',
+    'Duration of row fetch / materialization after execute, client-side',
+    ['db', 'table', 'op'],
+    buckets=LATENCY_BUCKETS,
+)
+
+# begin -> commit/rollback. Long-held transactions are the
+# `idle in transaction` turf and they hold back vacuum. Not labeled by
+# table: a transaction spans whatever tables it likes. Labeled by outcome
+# because a read-only block ends in rollback, and mixing those into one
+# series buries the write transactions.
+SKY_APISERVER_DB_TRANSACTION_SECONDS = prom.Histogram(
+    'sky_apiserver_db_transaction_seconds',
+    'Duration of a database transaction, begin to commit/rollback',
+    ['db', 'outcome'],
+    buckets=LATENCY_BUCKETS,
+)
+
+# Broken out from the transaction span because under a transaction-mode
+# pooler, commit is where the server connection is actually released —
+# its latency is a pooler signal, not only a database one.
+SKY_APISERVER_DB_COMMIT_SECONDS = prom.Histogram(
+    'sky_apiserver_db_commit_seconds',
+    'Duration of a commit, client-side',
+    ['db'],
+    buckets=LATENCY_BUCKETS,
+)
+
+SKY_APISERVER_DB_STATEMENTS_TOTAL = prom.Counter(
+    'sky_apiserver_db_statements_total',
+    'Statements executed, by outcome',
+    ['db', 'table', 'op', 'outcome'],
+)
+
+# The direct instrument for full-table reads. Exact where the driver
+# reports it (psycopg2 sets rowcount for SELECT); otherwise counted from
+# the rows actually handed to the caller.
+SKY_APISERVER_DB_ROWS_RETURNED = prom.Histogram(
+    'sky_apiserver_db_rows_returned',
+    'Rows returned or affected by one statement',
+    ['db', 'table', 'op'],
+    buckets=ROW_BUCKETS,
+)
+
+# No driver reports result size, so this is summed client-side over the
+# rows handed back: exact for anything up to a few million cells, sampled
+# above that. Two caveats. Character counts stand in for encoded bytes,
+# so non-ASCII text under-counts. And rows consumed one at a time
+# (``.first()``, ``.scalar()``, plain iteration) are not counted at all —
+# see the fetch wrapper in ``sky.utils.db.sql_metrics``.
+SKY_APISERVER_DB_RESULT_BYTES = prom.Histogram(
+    'sky_apiserver_db_result_bytes',
+    'Bytes of result data returned by one statement, measured client-side',
+    ['db', 'table', 'op'],
+    buckets=PAYLOAD_BUCKETS,
+)
+
+# Statement text plus bound parameters, on the way out. Exact, and the
+# instrument for the multi-hundred-megabyte write.
+SKY_APISERVER_DB_STATEMENT_BYTES = prom.Histogram(
+    'sky_apiserver_db_statement_bytes',
+    'Bytes of statement text plus bound parameters sent for one statement',
+    ['db', 'table', 'op'],
+    buckets=PAYLOAD_BUCKETS,
+)
+
+# --- connection side ------------------------------------------------------
+
+# Fresh DBAPI connections opened. A counter, not a census: a census of
+# live backends is structurally blind to sub-second sessions and to
+# everything still in the pre-fork handshake, which is exactly the
+# population that saturates connection admission.
+SKY_APISERVER_DB_CONNECTS_TOTAL = prom.Counter(
+    'sky_apiserver_db_connects_total',
+    'Fresh DBAPI connections opened',
+    ['db', 'pool'],
+)
+
+# How long opening one fresh connection took. This is the connection
+# admission wait, and neither the pooler nor CloudWatch measures it.
+SKY_APISERVER_DB_CONNECT_SECONDS = prom.Histogram(
+    'sky_apiserver_db_connect_seconds',
+    'Duration of opening a fresh DBAPI connection',
+    ['db', 'pool'],
+    buckets=LATENCY_BUCKETS,
+)
+
+# Total time to obtain a usable connection: pool wait plus, if the pool
+# had none to give, the fresh connect. Read against
+# ``sky_apiserver_db_connect_seconds``: both high means the database is
+# slow to admit, acquire high while connect is low means we ran out of
+# pool.
+SKY_APISERVER_DB_ACQUIRE_SECONDS = prom.Histogram(
+    'sky_apiserver_db_acquire_seconds',
+    'Time to obtain a connection from the pool, including any fresh connect',
+    ['db', 'pool'],
+    buckets=LATENCY_BUCKETS,
+)
+
+SKY_APISERVER_DB_CONNECTION_LIFETIME_SECONDS = prom.Histogram(
+    'sky_apiserver_db_connection_lifetime_seconds',
+    'Lifetime of a DBAPI connection, open to close',
+    ['db', 'pool'],
+    buckets=LATENCY_BUCKETS,
+)
+
+SKY_APISERVER_DB_INVALIDATIONS_TOTAL = prom.Counter(
+    'sky_apiserver_db_invalidations_total',
+    'Connections invalidated and discarded by the pool',
+    ['db', 'pool'],
+)
+
+# Pool saturation is a per-process condition: a fleet-wide sum can exceed
+# any single pool's limit while no individual pool is full, so per-pid
+# series are kept. multiprocess_mode must be 'liveall' — the aggregating
+# modes strip any label named 'pid', including this user-defined one, and
+# merge every process into one series.
+SKY_APISERVER_DB_POOL_CHECKED_OUT = prom.Gauge(
+    'sky_apiserver_db_pool_checked_out',
+    'Connections currently checked out of the pool, per process',
+    ['db', 'pool', 'pid'],
+    multiprocess_mode='liveall',
+)
+
+# The configured limits, exported so dashboards and alerts can compute
+# utilization without hardcoding helm values. Every process reports the
+# same number, hence 'max' and no pid label.
+SKY_APISERVER_DB_POOL_SIZE = prom.Gauge(
+    'sky_apiserver_db_pool_size',
+    'Configured pool size',
+    ['db', 'pool'],
+    multiprocess_mode='max',
+)
+
+SKY_APISERVER_DB_POOL_MAX_OVERFLOW = prom.Gauge(
+    'sky_apiserver_db_pool_max_overflow',
+    'Configured pool max overflow',
+    ['db', 'pool'],
+    multiprocess_mode='max',
+)
+
+
+def record_statement(
+    db: str,
+    table: str,
+    op: str,
+    execute_seconds: float,
+    *,
+    outcome: str = 'ok',
+    rows: Optional[int] = None,
+    result_bytes: Optional[int] = None,
+    statement_bytes: Optional[int] = None,
+) -> None:
+    """Record one statement on the families above.
+
+    For callers that do not go through SQLAlchemy and therefore get no
+    event hooks — a raw ``asyncpg`` pool, for instance. SQLAlchemy
+    engines are fed by ``sky.utils.db.sql_metrics.install`` instead.
+
+    A no-op when metrics are disabled, so call sites need no guard.
+    """
+    if not ENABLED:
+        return
+    SKY_APISERVER_DB_EXECUTE_SECONDS.labels(db, table,
+                                            op).observe(execute_seconds)
+    SKY_APISERVER_DB_STATEMENTS_TOTAL.labels(db, table, op, outcome).inc()
+    if rows is not None and rows >= 0:
+        SKY_APISERVER_DB_ROWS_RETURNED.labels(db, table, op).observe(rows)
+    if result_bytes is not None:
+        SKY_APISERVER_DB_RESULT_BYTES.labels(db, table,
+                                             op).observe(result_bytes)
+    if statement_bytes is not None:
+        SKY_APISERVER_DB_STATEMENT_BYTES.labels(db, table,
+                                                op).observe(statement_bytes)
+
+
+def record_acquire(db: str, pool: str, seconds: float) -> None:
+    """Record the time taken to obtain a connection from a pool.
+
+    For pools SQLAlchemy does not manage, such as a raw ``asyncpg.Pool``
+    used directly on an event loop. Those emit no ``PoolEvents``, so the
+    engine instrumentation cannot see them, and a pool running dry is
+    exactly what this number is for.
+    """
+    if not ENABLED:
+        return
+    SKY_APISERVER_DB_ACQUIRE_SECONDS.labels(db, pool).observe(seconds)
+
+
+def record_pool(db: str,
+                pool: str,
+                checked_out: Optional[int] = None,
+                size: Optional[int] = None,
+                max_overflow: Optional[int] = None) -> None:
+    """Publish a non-SQLAlchemy pool's saturation and configured limits."""
+    if not ENABLED:
+        return
+    if checked_out is not None:
+        SKY_APISERVER_DB_POOL_CHECKED_OUT.labels(db, pool, str(
+            os.getpid())).set(checked_out)
+    if size is not None:
+        SKY_APISERVER_DB_POOL_SIZE.labels(db, pool).set(size)
+    if max_overflow is not None:
+        SKY_APISERVER_DB_POOL_MAX_OVERFLOW.labels(db, pool).set(max_overflow)
+
+
+class StatementObservation:
+    """Mutable result carrier for :func:`observe_statement`.
+
+    Set ``rows`` / ``result_bytes`` / ``statement_bytes`` inside the
+    block; whatever is set when the block exits gets recorded. ``outcome``
+    is set to ``error`` automatically if the block raises.
+    """
+
+    __slots__ = ('rows', 'result_bytes', 'statement_bytes', 'outcome')
+
+    def __init__(self) -> None:
+        self.rows: Optional[int] = None
+        self.result_bytes: Optional[int] = None
+        self.statement_bytes: Optional[int] = None
+        self.outcome: str = 'ok'
+
+
+@contextlib.contextmanager
+def observe_statement(db: str, table: str,
+                      op: str) -> Iterator[StatementObservation]:
+    """Time a statement and record it, including on failure."""
+    obs = StatementObservation()
+    if not ENABLED:
+        yield obs
+        return
+    start = time.perf_counter()
+    try:
+        yield obs
+    except BaseException:
+        obs.outcome = 'error'
+        raise
+    finally:
+        record_statement(db,
+                         table,
+                         op,
+                         time.perf_counter() - start,
+                         outcome=obs.outcome,
+                         rows=obs.rows,
+                         result_bytes=obs.result_bytes,
+                         statement_bytes=obs.statement_bytes)

--- a/sky/metrics/db.py
+++ b/sky/metrics/db.py
@@ -43,6 +43,7 @@ names are deliberately *not* labels.
 """
 
 import contextlib
+import logging
 import os
 import time
 from typing import Iterator, Optional
@@ -50,6 +51,8 @@ from typing import Iterator, Optional
 import prometheus_client as prom
 
 from sky.skylet import constants
+
+logger = logging.getLogger(__name__)
 
 # Whether to instrument the database layer at all. Cannot change at
 # runtime. When false, ``sky.utils.db.sql_metrics.install`` attaches no
@@ -266,6 +269,20 @@ SKY_APISERVER_DB_POOL_MAX_OVERFLOW = prom.Gauge(
     multiprocess_mode='max',
 )
 
+# One warning per process, not one per statement: a broken instrument
+# would otherwise out-log the application.
+_warned = False
+
+
+def _warn_once(message: str) -> None:
+    global _warned
+    if _warned:
+        return
+    _warned = True
+    logger.warning('%s Database metrics may be incomplete.',
+                   message,
+                   exc_info=True)
+
 
 def record_statement(
     db: str,
@@ -284,21 +301,28 @@ def record_statement(
     event hooks — a raw ``asyncpg`` pool, for instance. SQLAlchemy
     engines are fed by ``sky.utils.db.sql_metrics.install`` instead.
 
-    A no-op when metrics are disabled, so call sites need no guard.
+    A no-op when metrics are disabled, and it never raises: call sites
+    need no guard of their own. That matters more here than it looks —
+    these are called from inside `finally` blocks and from paths holding a
+    checked-out connection, so an exception escaping would strand real
+    resources over a metrics defect.
     """
     if not ENABLED:
         return
-    SKY_APISERVER_DB_EXECUTE_SECONDS.labels(db, table,
-                                            op).observe(execute_seconds)
-    SKY_APISERVER_DB_STATEMENTS_TOTAL.labels(db, table, op, outcome).inc()
-    if rows is not None and rows >= 0:
-        SKY_APISERVER_DB_ROWS_RETURNED.labels(db, table, op).observe(rows)
-    if result_bytes is not None:
-        SKY_APISERVER_DB_RESULT_BYTES.labels(db, table,
-                                             op).observe(result_bytes)
-    if statement_bytes is not None:
-        SKY_APISERVER_DB_STATEMENT_BYTES.labels(db, table,
-                                                op).observe(statement_bytes)
+    try:
+        SKY_APISERVER_DB_EXECUTE_SECONDS.labels(db, table,
+                                                op).observe(execute_seconds)
+        SKY_APISERVER_DB_STATEMENTS_TOTAL.labels(db, table, op, outcome).inc()
+        if rows is not None and rows >= 0:
+            SKY_APISERVER_DB_ROWS_RETURNED.labels(db, table, op).observe(rows)
+        if result_bytes is not None:
+            SKY_APISERVER_DB_RESULT_BYTES.labels(db, table,
+                                                 op).observe(result_bytes)
+        if statement_bytes is not None:
+            SKY_APISERVER_DB_STATEMENT_BYTES.labels(db, table,
+                                                    op).observe(statement_bytes)
+    except Exception:  # pylint: disable=broad-except
+        _warn_once('Failed to record a database statement.')
 
 
 def record_acquire(db: str, pool: str, seconds: float) -> None:
@@ -307,11 +331,15 @@ def record_acquire(db: str, pool: str, seconds: float) -> None:
     For pools SQLAlchemy does not manage, such as a raw ``asyncpg.Pool``
     used directly on an event loop. Those emit no ``PoolEvents``, so the
     engine instrumentation cannot see them, and a pool running dry is
-    exactly what this number is for.
+    exactly what this number is for. Never raises; see
+    :func:`record_statement`.
     """
     if not ENABLED:
         return
-    SKY_APISERVER_DB_ACQUIRE_SECONDS.labels(db, pool).observe(seconds)
+    try:
+        SKY_APISERVER_DB_ACQUIRE_SECONDS.labels(db, pool).observe(seconds)
+    except Exception:  # pylint: disable=broad-except
+        _warn_once('Failed to record a pool acquire.')
 
 
 def record_pool(db: str,
@@ -319,16 +347,28 @@ def record_pool(db: str,
                 checked_out: Optional[int] = None,
                 size: Optional[int] = None,
                 max_overflow: Optional[int] = None) -> None:
-    """Publish a non-SQLAlchemy pool's saturation and configured limits."""
+    """Publish a non-SQLAlchemy pool's saturation and configured limits.
+
+    Every value is optional and an omitted one is **left untouched**, not
+    reset — so a caller can publish the configured limits once at pool
+    creation and then report only ``checked_out`` on each acquire without
+    clobbering the saturation denominator.
+
+    Never raises; see :func:`record_statement`.
+    """
     if not ENABLED:
         return
-    if checked_out is not None:
-        SKY_APISERVER_DB_POOL_CHECKED_OUT.labels(db, pool, str(
-            os.getpid())).set(checked_out)
-    if size is not None:
-        SKY_APISERVER_DB_POOL_SIZE.labels(db, pool).set(size)
-    if max_overflow is not None:
-        SKY_APISERVER_DB_POOL_MAX_OVERFLOW.labels(db, pool).set(max_overflow)
+    try:
+        if checked_out is not None:
+            SKY_APISERVER_DB_POOL_CHECKED_OUT.labels(db, pool, str(
+                os.getpid())).set(checked_out)
+        if size is not None:
+            SKY_APISERVER_DB_POOL_SIZE.labels(db, pool).set(size)
+        if max_overflow is not None:
+            SKY_APISERVER_DB_POOL_MAX_OVERFLOW.labels(db,
+                                                      pool).set(max_overflow)
+    except Exception:  # pylint: disable=broad-except
+        _warn_once('Failed to record pool state.')
 
 
 class StatementObservation:
@@ -363,11 +403,20 @@ def observe_statement(db: str, table: str,
         obs.outcome = 'error'
         raise
     finally:
-        record_statement(db,
-                         table,
-                         op,
-                         time.perf_counter() - start,
-                         outcome=obs.outcome,
-                         rows=obs.rows,
-                         result_bytes=obs.result_bytes,
-                         statement_bytes=obs.statement_bytes)
+        # Guarded a second time, on top of record_statement's own guard.
+        # An exception raised from a `finally` replaces whatever the block
+        # was doing — including a successful return — so a caller that
+        # acquired a connection inside the block would lose it. Cheap
+        # insurance for the one place where the cost of raising is not
+        # just a missing sample.
+        try:
+            record_statement(db,
+                             table,
+                             op,
+                             time.perf_counter() - start,
+                             outcome=obs.outcome,
+                             rows=obs.rows,
+                             result_bytes=obs.result_bytes,
+                             statement_bytes=obs.statement_bytes)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record an observed statement.')

--- a/sky/metrics/db.py
+++ b/sky/metrics/db.py
@@ -195,8 +195,16 @@ SKY_APISERVER_DB_CONNECTS_TOTAL = prom.Counter(
     ['db', 'pool'],
 )
 
-# How long opening one fresh connection took. This is the connection
-# admission wait, and neither the pooler nor CloudWatch measures it.
+# How long opening one fresh connection took: the connection admission
+# wait as this process experiences it.
+#
+# Read it knowing what is at the other end. Direct to the database, this
+# IS the database's admission latency. With a connection pooler in the
+# path, it is the connect to the *pooler*, which is cheap and says nothing
+# about how long the pooler then waited for a server connection upstream —
+# that half is only visible from the pooler's own metrics. The `db` label
+# separates the two cases, since the direct-role engines bypass the
+# pooler by construction.
 SKY_APISERVER_DB_CONNECT_SECONDS = prom.Histogram(
     'sky_apiserver_db_connect_seconds',
     'Duration of opening a fresh DBAPI connection',

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext import asyncio as sqlalchemy_async
 from sky import sky_logging
 from sky.skylet import constants
 from sky.skylet import runtime_utils
+from sky.utils.db import sql_metrics
 
 logger = sky_logging.init_logger(__name__)
 if typing.TYPE_CHECKING:
@@ -680,7 +681,14 @@ def get_engine(
                 logger.debug(
                     f'Creating a new postgres {engine_type} engine with '
                     f'maximum {_max_connections} connections')
+                # The engine role that labels this engine's metrics. Derived
+                # from the same conditions as the cache key, so one cached
+                # engine always carries one role: when `direct` resolves to
+                # the same connection string as the pooled path (no pooler
+                # configured) it IS the same engine, and is labelled as such.
+                role = sql_metrics.DB_STATE
                 if no_pool and not async_engine:
+                    role = sql_metrics.DB_STATE_NOPOOL
                     # Isolated per-operation engine: never shares (or starves
                     # on) the default engine's pool. See the docstring.
                     engine_no_pool = sqlalchemy.create_engine(
@@ -691,6 +699,7 @@ def get_engine(
                         })
                     _postgres_engine_cache[cache_key] = engine_no_pool
                 elif async_engine:
+                    role = sql_metrics.DB_STATE_ASYNC
                     # Use NullPool for async engines to avoid event loop binding
                     # issues. asyncpg connection pools bind to the event loop on
                     # first use, which causes "Future attached to a different
@@ -706,6 +715,8 @@ def get_engine(
                             poolclass=sqlalchemy.NullPool,
                             async_creator=_make_asyncpg_creator(conn_string)))
                 elif _max_connections == 0 or (direct and _pooler_configured()):
+                    if direct and _pooler_configured():
+                        role = sql_metrics.DB_STATE_DIRECT
                     # NullPool: no persistent connections. Used when no pool
                     # size is configured, and — crucially — for the direct
                     # engine when a pooler IS configured. The direct engine
@@ -729,6 +740,7 @@ def get_engine(
                             max_overflow=max(0, 5 - _max_connections),
                             pool_pre_ping=True,
                             pool_recycle=1800))
+                sql_metrics.install(_postgres_engine_cache[cache_key], role)
             engine = _postgres_engine_cache[cache_key]
     else:
         assert db_name is not None, 'db_name must be provided for SQLite'
@@ -737,10 +749,14 @@ def get_engine(
         if async_engine:
             # This is an AsyncEngine, instead of a (normal, synchronous) Engine,
             # so we should not put it in the cache. Instead, just return.
-            return sqlalchemy_async.create_async_engine(
+            async_sqlite_engine = sqlalchemy_async.create_async_engine(
                 'sqlite+aiosqlite:///' + db_path, connect_args={'timeout': 30})
+            sql_metrics.install(async_sqlite_engine, f'sqlite_{db_name}')
+            return async_sqlite_engine
         if db_path not in _sqlite_engine_cache:
             _sqlite_engine_cache[db_path] = sqlalchemy.create_engine(
                 'sqlite:///' + db_path)
+            sql_metrics.install(_sqlite_engine_cache[db_path],
+                                f'sqlite_{db_name}')
         engine = _sqlite_engine_cache[db_path]
     return engine

--- a/sky/utils/db/sql_metrics.py
+++ b/sky/utils/db/sql_metrics.py
@@ -1,0 +1,800 @@
+"""SQLAlchemy instrumentation feeding the families in ``sky.metrics.db``.
+
+``install(engine, db)`` attaches everything to one engine. Call it once
+per engine, at creation, so no statement executed before the instrument
+exists goes unseen — ``sky.utils.db.db_utils.get_engine`` does this for
+every engine it builds, and anything that builds its own engine should do
+the same.
+
+What is measured, and where each number comes from:
+
+* **execute** — ``before_cursor_execute`` to ``after_cursor_execute``.
+  Includes the result set coming over the wire, because psycopg2 and
+  asyncpg both buffer the whole result during ``execute``.
+* **rowfetch** — the wrapped fetch strategy on the result object. This is
+  row handoff into Python, not wire time.
+* **transaction span** — the ``begin`` event to ``commit``/``rollback``.
+  Excludes the commit round trip itself, which SQLAlchemy dispatches
+  ``commit`` just *before*; that is measured separately.
+* **commit** — the dialect's ``do_commit``, wrapped.
+* **rows** — ``cursor.rowcount`` where the driver reports one (psycopg2
+  does, for SELECT as well as DML), else counted by the fetch wrapper.
+* **result bytes** — summed by the fetch wrapper over the rows handed
+  back. No driver reports the real number, so this is computed
+  client-side: exact up to a cell budget, sampled above it.
+* **statement bytes** — statement text plus bound parameters, on writes.
+* **connect / acquire / lifetime / pool saturation** — pool events, plus
+  a wrapper on ``Pool.connect`` for total acquisition time.
+
+Every listener is defensive: a defect in here must never break database
+access, so each body is wrapped and failures are logged once and then
+swallowed. The whole module is inert unless ``sky.metrics.db.ENABLED``.
+"""
+
+import logging
+import operator
+import os
+import threading
+import time
+from typing import Any, Optional, Tuple
+import weakref
+
+import sqlalchemy
+from sqlalchemy import event
+from sqlalchemy.sql import compiler as sql_compiler
+
+from sky.metrics import db as db_metrics
+
+logger = logging.getLogger(__name__)
+
+# Engine role label values. On Postgres every SkyPilot component shares
+# one physical database, and ``get_engine`` caches one engine per
+# connection string and variant, so the role — not the database name — is
+# what separates profiles that genuinely differ.
+DB_STATE = 'state'
+DB_STATE_DIRECT = 'state_direct'
+DB_STATE_NOPOOL = 'state_nopool'
+DB_STATE_ASYNC = 'state_async'
+
+_OP_BY_VISIT = {
+    'select': db_metrics.OP_SELECT,
+    'compound_select': db_metrics.OP_SELECT,
+    'insert': db_metrics.OP_INSERT,
+    'update': db_metrics.OP_UPDATE,
+    'delete': db_metrics.OP_DELETE,
+}
+_OP_OTHER = db_metrics.OP_OTHER
+_OP_DDL = db_metrics.OP_DDL
+_WRITE_OPS = frozenset(
+    (db_metrics.OP_INSERT, db_metrics.OP_UPDATE, db_metrics.OP_DELETE))
+
+_OUTCOME_OK = 'ok'
+_OUTCOME_ERROR = 'error'
+_OUTCOME_COMMIT = 'commit'
+_OUTCOME_ROLLBACK = 'rollback'
+
+# Keys in the per-connection ``info`` dict. Namespaced: that dict is
+# shared with anything else stashing state on a connection.
+_KEY_EXEC = '_sky_db_exec_started'
+_KEY_RESULT = '_sky_db_result_labels'
+_KEY_TX = '_sky_db_tx_started'
+_KEY_CONNECT = '_sky_db_connect_started'
+_KEY_BORN = '_sky_db_connect_born'
+
+# Derived (table, op) is cached on the compiled construct itself, which
+# lives exactly as long as SQLAlchemy's compiled cache entry for that
+# statement. So derivation runs once per distinct statement shape, not
+# once per execution.
+_LABEL_ATTR = '_sky_db_labels'
+
+# Cells (rows x columns) we are willing to walk to size a result exactly.
+# Sampling was tried first and rejected in both directions: extrapolating
+# from the leading rows blows a single outlier row up across the whole
+# result (measured 40x over), and striding across the batch misses the
+# outlier entirely (measured 99% under) — and the outlier row is the thing
+# this metric exists to catch. The columnar walk below is ~10x cheaper
+# than a per-cell loop, which is what makes exactness affordable: 100k
+# two-column rows cost ~1.7ms, against an execute that just moved those
+# rows over the wire. Past this budget the result is already tens of MiB
+# and lands in the top buckets whatever the estimate says, so cost wins.
+_EXACT_CELL_BUDGET = 4_000_000
+# Same idea for the parameter sets of an executemany.
+_PARAM_SAMPLE_SETS = 8
+# Assumed size of a non-string scalar (int, float, bool, None, datetime).
+# Wrong in detail, irrelevant at the scale these buckets resolve.
+_SCALAR_BYTES = 8
+# Guard against pathological FROM nesting while walking to a table name.
+_MAX_FROM_DEPTH = 6
+# Minimum interval between writes of the pool saturation gauge.
+_POOL_GAUGE_MIN_INTERVAL = 0.1
+# Marker attribute on our own wrappers, so re-arming is idempotent.
+_WRAPPED_ATTR = '_sky_db_wrapped'
+
+# Engines already instrumented. Weak so a disposed engine can be
+# collected; engines from ``get_engine`` are cached for the process
+# lifetime anyway.
+_instrumented: 'weakref.WeakSet' = weakref.WeakSet()
+_instrumented_lock = threading.Lock()
+
+# One warning per process, not one per statement: a broken instrument
+# would otherwise out-log the application.
+_warned = False
+
+# Bound metric children, keyed by family and label values.
+# ``Histogram.labels()`` already memoizes its children, so this caches
+# nothing the library does not — it only skips the label validation and
+# lock that ``labels()`` redoes on every call, which is ~1.4us of the
+# ~1.5us it costs. Bounded by the number of real label combinations, the
+# same bound prometheus_client itself lives under.
+_children: dict = {}
+
+
+def _child(family: Any, *labels: str) -> Any:
+    key = (family, labels)
+    child = _children.get(key)
+    if child is None:
+        child = family.labels(*labels)
+        _children[key] = child
+    return child
+
+
+def _warn_once(message: str) -> None:
+    global _warned
+    if _warned:
+        return
+    _warned = True
+    logger.warning('%s Database metrics may be incomplete.',
+                   message,
+                   exc_info=True)
+
+
+def install(engine: Any, db: str) -> None:
+    """Instrument one engine so its statements land on ``sky.metrics.db``.
+
+    Args:
+        engine: a SQLAlchemy ``Engine`` or ``AsyncEngine``. For an
+            ``AsyncEngine`` the listeners go on its ``sync_engine``,
+            which is where SQLAlchemy emits these events.
+        db: the engine role label, e.g. ``DB_STATE``.
+
+    Idempotent per engine, and a no-op when metrics are disabled.
+    """
+    if not db_metrics.ENABLED:
+        return
+    target = getattr(engine, 'sync_engine', engine)
+    with _instrumented_lock:
+        if target in _instrumented:
+            return
+        _instrumented.add(target)
+    try:
+        _install(target, db)
+    except Exception:  # pylint: disable=broad-except
+        _warn_once(f'Failed to instrument the {db!r} database engine.')
+
+
+# --- label derivation -----------------------------------------------------
+
+
+def _table_name(obj: Any, depth: int) -> Optional[str]:
+    """Walk a FROM element down to the table the statement is about."""
+    if obj is None or depth > _MAX_FROM_DEPTH:
+        return None
+    if isinstance(obj, sqlalchemy.Table):
+        return obj.name
+    # A join: attribute the statement to its leftmost table.
+    left = getattr(obj, 'left', None)
+    if left is not None:
+        return _table_name(left, depth + 1)
+    # An alias, subquery or CTE: unwrap it. We deliberately never use the
+    # alias's own name — for an anonymous subquery that is generated per
+    # construct, which is unbounded label cardinality.
+    element = getattr(obj, 'element', None)
+    if element is not None:
+        return _table_name(element, depth + 1)
+    final_froms = getattr(obj, 'get_final_froms', None)
+    if final_froms is not None:
+        inner = final_froms()
+        if inner:
+            return _table_name(inner[0], depth + 1)
+    return None
+
+
+def _compute_labels(compiled: Any) -> Tuple[str, str]:
+    if isinstance(compiled, sql_compiler.DDLCompiler):
+        target = getattr(getattr(compiled, 'statement', None), 'element', None)
+        name = getattr(target, 'name', None)
+        return (name if isinstance(name, str) else db_metrics.UNKNOWN_TABLE,
+                _OP_DDL)
+    statement = getattr(compiled, 'statement', None)
+    if statement is None:
+        return (db_metrics.UNKNOWN_TABLE, _OP_OTHER)
+    op = _OP_BY_VISIT.get(getattr(statement, '__visit_name__', ''), _OP_OTHER)
+    if op == _OP_OTHER:
+        # ``sqlalchemy.text()`` and friends. We do not regex SQL text to
+        # invent a table label.
+        return (db_metrics.UNKNOWN_TABLE, _OP_OTHER)
+    name = None
+    try:
+        if op == db_metrics.OP_SELECT:
+            target = statement
+            selects = getattr(target, 'selects', None)
+            if selects:
+                # A UNION: attribute it to the first branch.
+                target = selects[0]
+            froms = target.get_final_froms()
+            if froms:
+                name = _table_name(froms[0], 0)
+        else:
+            name = _table_name(statement.table, 0)
+    except Exception:  # pylint: disable=broad-except
+        name = None
+    return (name or db_metrics.UNKNOWN_TABLE, op)
+
+
+def _labels(context: Any) -> Tuple[str, str]:
+    """(table, op) for an execution context, cached on the compiled form."""
+    compiled = getattr(context, 'compiled', None)
+    if compiled is None:
+        # Driver-level statements (PRAGMA, isolation level probes) and
+        # anything executed without a compiled construct.
+        return (db_metrics.UNKNOWN_TABLE, _OP_OTHER)
+    cached = getattr(compiled, _LABEL_ATTR, None)
+    if cached is not None:
+        return cached
+    labels = _compute_labels(compiled)
+    try:
+        setattr(compiled, _LABEL_ATTR, labels)
+    except (AttributeError, TypeError):
+        # A compiled form that refuses attributes just re-derives; the
+        # instrument stays correct, only the caching is lost.
+        pass
+    return labels
+
+
+# --- payload sizing -------------------------------------------------------
+
+
+def _value_bytes(value: Any) -> int:
+    # len() on a str is the character count, which is the byte count only
+    # for ASCII. Every SkyPilot payload worth catching here is JSON or
+    # base64, so the error is small and always an under-estimate.
+    if type(value) is str:  # pylint: disable=unidiomatic-typecheck
+        return len(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return len(value)
+    return _SCALAR_BYTES
+
+
+def _param_set_bytes(params: Any) -> int:
+    if params is None:
+        return 0
+    if isinstance(params, dict):
+        return sum(_value_bytes(v) for v in params.values())
+    if isinstance(params, (list, tuple)):
+        return sum(_value_bytes(v) for v in params)
+    return _value_bytes(params)
+
+
+def _statement_bytes(statement: Any, parameters: Any, executemany: bool) -> int:
+    """Bytes going out for one statement: text plus bound parameters."""
+    total = len(statement) if isinstance(statement, str) else 0
+    if parameters is None:
+        return total
+    if executemany and isinstance(parameters, (list, tuple)):
+        count = len(parameters)
+        if not count:
+            return total
+        # Sample rather than walk: an executemany can carry tens of
+        # thousands of parameter sets, and this runs on the caller's
+        # thread right after a database round trip.
+        sampled = count if count < _PARAM_SAMPLE_SETS else _PARAM_SAMPLE_SETS
+        subtotal = sum(_param_set_bytes(p) for p in parameters[:sampled])
+        return total + subtotal * count // sampled
+    return total + _param_set_bytes(parameters)
+
+
+def _column_bytes(rows: Any, idx: int, count: int, first: Any) -> int:
+    """Bytes of one column across a fetched batch.
+
+    Classifies the column from its first value and then sums it with
+    C-level ``map``/``len``, which is where the speed comes from. Falls
+    back to a per-cell walk for that column alone whenever the
+    classification cannot be trusted: a NULL first value says nothing
+    about the rest, and SQLite columns are dynamically typed.
+    """
+    getter = operator.itemgetter(idx)
+    if type(first) is str or isinstance(  # pylint: disable=unidiomatic-typecheck
+            first, (bytes, bytearray, memoryview)):
+        try:
+            return sum(map(len, map(getter, rows)))
+        except TypeError:
+            # A NULL further down the column, or mixed types.
+            pass
+    elif first is not None:
+        # A numeric / bool / datetime column. Postgres column types are
+        # fixed, so one value classifies the column.
+        return _SCALAR_BYTES * count
+    return sum(map(_value_bytes, map(getter, rows)))
+
+
+def _rows_bytes(rows: Any, count: int) -> int:
+    """Total bytes of a fetched batch, column by column."""
+    first_row = rows[0]
+    cells = count * len(first_row)
+    if cells > _EXACT_CELL_BUDGET:
+        stride = cells // _EXACT_CELL_BUDGET + 1
+        sample = rows[::stride]
+        return _rows_bytes(sample, len(sample)) * count // len(sample)
+    total = 0
+    for idx, first in enumerate(first_row):
+        total += _column_bytes(rows, idx, count, first)
+    return total
+
+
+def _rowcount(cursor: Any) -> Optional[int]:
+    """Rows the driver reports for the statement just executed, or None.
+
+    psycopg2 reports this for SELECT as well as for DML. sqlite3 reports
+    -1 for SELECT, in which case the fetch wrapper counts instead.
+    """
+    try:
+        rows = cursor.rowcount
+    except Exception:  # pylint: disable=broad-except
+        return None
+    if not isinstance(rows, int) or rows < 0:
+        return None
+    return rows
+
+
+class _PoolGaugeState:
+    """Throttle and bound-child state for one engine's saturation gauge.
+
+    pid is tracked because a forked child inherits this state and must not
+    report its parent's pid — the multiprocess collector keys its files on
+    the real one.
+    """
+
+    __slots__ = ('at', 'pid', 'child')
+
+    def __init__(self) -> None:
+        self.at: float = 0.0
+        self.pid: int = 0
+        self.child: Any = None
+
+
+# --- result consumption ---------------------------------------------------
+
+
+class _InstrumentedFetch:
+    """Times and sizes row consumption for one result.
+
+    Swapped onto ``CursorResult.cursor_strategy``, which every
+    consumption path funnels through — ``.all()``, ``.fetchall()``,
+    iteration, ``.scalars()``, ``.mappings()``, ``yield_per()`` and the
+    ORM.
+
+    ``fetchone`` is deliberately *not* wrapped. It is called once per row,
+    and timing it costs about a third of the runtime of row-at-a-time
+    iteration to produce a number the batch paths already give. The
+    consequence is that results consumed one row at a time (``.first()``,
+    ``.scalar()``, plain iteration) report no rowfetch time and no result
+    bytes; their row count still comes from ``cursor.rowcount``.
+    """
+
+    __slots__ = ('_inner', '_db', '_table', '_op', '_count_rows', '_seconds',
+                 '_rows', '_bytes', '_batches', '_emitted', '_closed',
+                 '_fetching')
+
+    def __init__(self, inner: Any, db: str, table: str, op: str,
+                 count_rows: bool) -> None:
+        self._inner = inner
+        self._db = db
+        self._table = table
+        self._op = op
+        self._count_rows = count_rows
+        self._seconds = 0.0
+        self._rows = 0
+        self._bytes = 0
+        self._batches = 0
+        self._emitted = False
+        self._closed = False
+        # The underlying strategy soft-closes the result from *inside*
+        # fetchall/fetchmany once the cursor is exhausted, i.e. before it
+        # hands the rows back. Emitting on close alone would therefore
+        # always report an empty result. This flag defers the emit until
+        # the rows have been accounted for.
+        self._fetching = False
+
+    def __getattr__(self, name: str) -> Any:
+        # _inner is a slot; reaching __getattr__ for it means __init__ has
+        # not run, and recursing would blow the stack instead of saying so.
+        if name == '_inner':
+            raise AttributeError(name)
+        return getattr(self._inner, name)
+
+    def _account(self, rows: Any) -> None:
+        count = len(rows)
+        if not count:
+            return
+        # Size first, then commit all three together. If sizing raises —
+        # a driver whose rows are not integer-indexable, say — a
+        # half-updated batch would emit as zero bytes over a nonzero row
+        # count, which reads as a free empty result. Better to record
+        # nothing for the batch than to record a lie.
+        size = _rows_bytes(rows, count)
+        self._batches += 1
+        self._rows += count
+        self._bytes += size
+
+    def _finish_batch(self, rows: Any, start: float) -> Any:
+        self._seconds += time.perf_counter() - start
+        self._fetching = False
+        try:
+            self._account(rows)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to size a SQL result.')
+        if self._closed:
+            self._emit()
+        return rows
+
+    def fetchall(self, result: Any, dbapi_cursor: Any) -> Any:
+        self._fetching = True
+        start = time.perf_counter()
+        try:
+            rows = self._inner.fetchall(result, dbapi_cursor)
+        except BaseException:
+            self._fetching = False
+            raise
+        return self._finish_batch(rows, start)
+
+    def fetchmany(self,
+                  result: Any,
+                  dbapi_cursor: Any,
+                  size: Optional[int] = None) -> Any:
+        self._fetching = True
+        start = time.perf_counter()
+        try:
+            rows = self._inner.fetchmany(result, dbapi_cursor, size)
+        except BaseException:
+            self._fetching = False
+            raise
+        return self._finish_batch(rows, start)
+
+    def yield_per(self, result: Any, dbapi_cursor: Any, num: int) -> Any:
+        # yield_per REPLACES result.cursor_strategy with a buffered one.
+        # Re-wrap the replacement, otherwise switching to streaming
+        # silently drops the instrument.
+        ret = self._inner.yield_per(result, dbapi_cursor, num)
+        replaced = getattr(result, 'cursor_strategy', None)
+        if (replaced is not None and replaced is not self and
+                not isinstance(replaced, _InstrumentedFetch)):
+            self._inner = replaced
+            result.cursor_strategy = self
+        return ret
+
+    def soft_close(self, result: Any, dbapi_cursor: Any) -> Any:
+        ret = self._inner.soft_close(result, dbapi_cursor)
+        self._closed = True
+        if not self._fetching:
+            self._emit()
+        return ret
+
+    def hard_close(self, result: Any, dbapi_cursor: Any) -> Any:
+        ret = self._inner.hard_close(result, dbapi_cursor)
+        self._closed = True
+        if not self._fetching:
+            self._emit()
+        return ret
+
+    def _emit(self) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        if not self._batches:
+            # Consumed one row at a time, or not at all. Reporting zero
+            # bytes and zero seconds here would read as a free empty
+            # result, which is worse than reporting nothing.
+            return
+        try:
+            _child(db_metrics.SKY_APISERVER_DB_ROWFETCH_SECONDS, self._db,
+                   self._table, self._op).observe(self._seconds)
+            _child(db_metrics.SKY_APISERVER_DB_RESULT_BYTES, self._db,
+                   self._table, self._op).observe(self._bytes)
+            if self._count_rows:
+                _child(db_metrics.SKY_APISERVER_DB_ROWS_RETURNED, self._db,
+                       self._table, self._op).observe(self._rows)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record SQL result metrics.')
+
+
+# --- wiring ---------------------------------------------------------------
+
+
+def _install(engine: Any, db: str) -> None:
+    """Attach every listener. Raises only if the engine is unusable."""
+    pool_label = type(engine.pool).__name__
+
+    # -- statement side --
+
+    @event.listens_for(engine, 'before_cursor_execute')
+    def _before_cursor_execute(conn, cursor, statement, parameters, context,
+                               executemany):
+        # Deliberately minimal: this runs immediately before the round
+        # trip, so label derivation and payload sizing wait until after.
+        del cursor, statement, parameters, context, executemany
+        try:
+            conn.info[_KEY_EXEC] = time.perf_counter()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to start SQL statement timing.')
+
+    @event.listens_for(engine, 'after_cursor_execute')
+    def _after_cursor_execute(conn, cursor, statement, parameters, context,
+                              executemany):
+        try:
+            started = conn.info.pop(_KEY_EXEC, None)
+            if started is None:
+                return
+            duration = time.perf_counter() - started
+            table, op = _labels(context)
+            _child(db_metrics.SKY_APISERVER_DB_EXECUTE_SECONDS, db, table,
+                   op).observe(duration)
+            _child(db_metrics.SKY_APISERVER_DB_STATEMENTS_TOTAL, db, table, op,
+                   _OUTCOME_OK).inc()
+            rows = _rowcount(cursor)
+            if rows is not None:
+                _child(db_metrics.SKY_APISERVER_DB_ROWS_RETURNED, db, table,
+                       op).observe(rows)
+            if op in _WRITE_OPS:
+                sent = _statement_bytes(statement, parameters, executemany)
+                if sent:
+                    _child(db_metrics.SKY_APISERVER_DB_STATEMENT_BYTES, db,
+                           table, op).observe(sent)
+            conn.info[_KEY_RESULT] = (table, op, rows is None)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a SQL statement.')
+
+    @event.listens_for(engine, 'after_execute')
+    def _after_execute(conn, clauseelement, multiparams, params,
+                       execution_options, result):
+        del clauseelement, multiparams, params, execution_options
+        try:
+            meta = conn.info.pop(_KEY_RESULT, None)
+            if meta is None or not getattr(result, 'returns_rows', False):
+                return
+            table, op, count_rows = meta
+            strategy = getattr(result, 'cursor_strategy', None)
+            if strategy is None:
+                return
+            result.cursor_strategy = _InstrumentedFetch(strategy, db, table, op,
+                                                        count_rows)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to instrument a SQL result.')
+
+    @event.listens_for(engine, 'handle_error')
+    def _handle_error(exception_context):
+        try:
+            conn = exception_context.connection
+            if conn is not None:
+                conn.info.pop(_KEY_EXEC, None)
+                conn.info.pop(_KEY_RESULT, None)
+            table, op = _labels(exception_context.execution_context)
+            _child(db_metrics.SKY_APISERVER_DB_STATEMENTS_TOTAL, db, table, op,
+                   _OUTCOME_ERROR).inc()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a SQL error.')
+
+    # -- transaction side --
+
+    @event.listens_for(engine, 'begin')
+    def _begin(conn):
+        try:
+            conn.info[_KEY_TX] = time.perf_counter()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to start transaction timing.')
+
+    def _close_transaction(conn, outcome: str) -> None:
+        try:
+            started = conn.info.pop(_KEY_TX, None)
+            if started is None:
+                return
+            _child(db_metrics.SKY_APISERVER_DB_TRANSACTION_SECONDS, db,
+                   outcome).observe(time.perf_counter() - started)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a transaction span.')
+
+    @event.listens_for(engine, 'commit')
+    def _commit(conn):
+        _close_transaction(conn, _OUTCOME_COMMIT)
+
+    @event.listens_for(engine, 'rollback')
+    def _rollback(conn):
+        _close_transaction(conn, _OUTCOME_ROLLBACK)
+
+    _wrap_do_commit(engine, db)
+
+    # -- connection side --
+
+    @event.listens_for(engine, 'do_connect')
+    def _do_connect(dialect, conn_rec, cargs, cparams):
+        del dialect, cargs, cparams
+        try:
+            if conn_rec is not None:
+                conn_rec.info[_KEY_CONNECT] = time.perf_counter()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to start connect timing.')
+        # Returning None lets the dialect connect normally.
+        return None
+
+    @event.listens_for(engine, 'connect')
+    def _connect(dbapi_connection, conn_rec):
+        del dbapi_connection
+        try:
+            now = time.perf_counter()
+            started = conn_rec.info.pop(_KEY_CONNECT, None)
+            conn_rec.info[_KEY_BORN] = now
+            _child(db_metrics.SKY_APISERVER_DB_CONNECTS_TOTAL, db,
+                   pool_label).inc()
+            if started is not None:
+                _child(db_metrics.SKY_APISERVER_DB_CONNECT_SECONDS, db,
+                       pool_label).observe(now - started)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a database connect.')
+
+    gauge_state = _PoolGaugeState()
+
+    def _sync_pool_gauge() -> None:
+        checked_out = getattr(engine.pool, 'checkedout', None)
+        if checked_out is None:
+            # NullPool and friends keep no such count.
+            return
+        # Throttled: this fires on every checkout and checkin, i.e. twice
+        # per statement, and a gauge is read at most once per scrape. The
+        # reliable saturation signal is the acquire histogram (high
+        # acquire with low connect means the pool ran dry), which is not
+        # throttled; this gauge only needs to be roughly current.
+        now = time.monotonic()
+        if now - gauge_state.at < _POOL_GAUGE_MIN_INTERVAL:
+            return
+        gauge_state.at = now
+        pid = os.getpid()
+        child = gauge_state.child
+        if child is None or gauge_state.pid != pid:
+            gauge_state.pid = pid
+            child = db_metrics.SKY_APISERVER_DB_POOL_CHECKED_OUT.labels(
+                db, pool_label, str(pid))
+            gauge_state.child = child
+        # Set rather than inc/dec: a gauge that drifts is worse than one
+        # that is a scrape behind, and an invalidated connection does not
+        # always pair its checkout with a checkin.
+        child.set(checked_out())
+
+    @event.listens_for(engine, 'checkout')
+    def _checkout(dbapi_connection, conn_rec, conn_proxy):
+        del dbapi_connection, conn_rec, conn_proxy
+        try:
+            _sync_pool_gauge()
+            # engine.dispose() replaces the pool object, dropping the
+            # acquire-timing wrapper with it. Re-arm here; the first
+            # acquire on a fresh pool goes unmeasured, which beats losing
+            # the metric for the rest of the process's life.
+            _wrap_pool_connect(engine, db, pool_label)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a pool checkout.')
+
+    @event.listens_for(engine, 'checkin')
+    def _checkin(dbapi_connection, conn_rec):
+        del dbapi_connection, conn_rec
+        try:
+            _sync_pool_gauge()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a pool checkin.')
+
+    @event.listens_for(engine, 'close')
+    def _close(dbapi_connection, conn_rec):
+        del dbapi_connection
+        try:
+            born = conn_rec.info.pop(_KEY_BORN, None)
+            if born is None:
+                return
+            _child(db_metrics.SKY_APISERVER_DB_CONNECTION_LIFETIME_SECONDS, db,
+                   pool_label).observe(time.perf_counter() - born)
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a connection lifetime.')
+
+    @event.listens_for(engine, 'invalidate')
+    def _invalidate(dbapi_connection, conn_rec, exception):
+        del dbapi_connection, conn_rec, exception
+        try:
+            _child(db_metrics.SKY_APISERVER_DB_INVALIDATIONS_TOTAL, db,
+                   pool_label).inc()
+        except Exception:  # pylint: disable=broad-except
+            _warn_once('Failed to record a connection invalidation.')
+
+    _export_pool_config(engine, db, pool_label)
+    _wrap_pool_connect(engine, db, pool_label)
+
+
+def _wrap_do_commit(engine: Any, db: str) -> None:
+    """Time the commit round trip itself.
+
+    SQLAlchemy dispatches its ``commit`` event *before* the dialect
+    commits, so the event alone cannot measure it. Under a
+    transaction-mode pooler this is where the server connection is
+    actually released, which makes it a pooler signal and not only a
+    database one.
+    """
+    dialect = engine.dialect
+    if getattr(dialect, '_sky_db_commit_wrapped', False):
+        return
+    original = dialect.do_commit
+
+    def _timed_do_commit(dbapi_connection):
+        start = time.perf_counter()
+        try:
+            return original(dbapi_connection)
+        finally:
+            try:
+                _child(db_metrics.SKY_APISERVER_DB_COMMIT_SECONDS,
+                       db).observe(time.perf_counter() - start)
+            except Exception:  # pylint: disable=broad-except
+                _warn_once('Failed to record a commit.')
+
+    try:
+        dialect.do_commit = _timed_do_commit
+        dialect._sky_db_commit_wrapped = True  # pylint: disable=protected-access
+    except (AttributeError, TypeError):
+        _warn_once('Could not time commits on this dialect.')
+
+
+def _wrap_pool_connect(engine: Any, db: str, pool_label: str) -> None:
+    """Measure total time to obtain a connection from the pool.
+
+    SQLAlchemy has no pre-checkout event, so the wait a caller actually
+    experiences is not reachable from the event API. ``Pool.connect`` is
+    public and is the single chokepoint for it.
+    """
+    pool = engine.pool
+    if getattr(pool.connect, _WRAPPED_ATTR, False):
+        return
+    original = pool.connect
+
+    def _timed_connect():
+        start = time.perf_counter()
+        try:
+            return original()
+        finally:
+            try:
+                _child(db_metrics.SKY_APISERVER_DB_ACQUIRE_SECONDS, db,
+                       pool_label).observe(time.perf_counter() - start)
+            except Exception:  # pylint: disable=broad-except
+                _warn_once('Failed to record a pool acquire.')
+
+    # Marked on the wrapper itself rather than on the pool, so re-arming
+    # after engine.dispose() (which builds a fresh pool) is a plain
+    # attribute check and nothing is left behind on SQLAlchemy's object.
+    setattr(_timed_connect, _WRAPPED_ATTR, True)
+    try:
+        pool.connect = _timed_connect
+    except (AttributeError, TypeError):
+        _warn_once('Could not time pool acquisition on this pool.')
+
+
+def _export_pool_config(engine: Any, db: str, pool_label: str) -> None:
+    """Publish the pool's configured limits.
+
+    So a dashboard can compute utilization without hardcoding a value
+    that lives in helm values, and so a role that is supposed to pool but
+    reports ``NullPool`` is visible.
+    """
+    pool = engine.pool
+    # QueuePool exposes size() as a method; SingletonThreadPool exposes it
+    # as a plain int; NullPool has neither.
+    size = getattr(pool, 'size', None)
+    if callable(size):
+        size = size()
+    if isinstance(size, int):
+        db_metrics.SKY_APISERVER_DB_POOL_SIZE.labels(db, pool_label).set(size)
+    max_overflow = getattr(pool, '_max_overflow', None)
+    if isinstance(max_overflow, int):
+        db_metrics.SKY_APISERVER_DB_POOL_MAX_OVERFLOW.labels(
+            db, pool_label).set(max_overflow)

--- a/sky/utils/db/sql_metrics.py
+++ b/sky/utils/db/sql_metrics.py
@@ -497,9 +497,9 @@ class _InstrumentedFetch:
             return
         try:
             _child(db_metrics.SKY_APISERVER_DB_ROWFETCH_SECONDS, self._db,
-                   self._table, self._op).observe(self._seconds)
+                   self._table).observe(self._seconds)
             _child(db_metrics.SKY_APISERVER_DB_RESULT_BYTES, self._db,
-                   self._table, self._op).observe(self._bytes)
+                   self._table).observe(self._bytes)
             if self._count_rows:
                 _child(db_metrics.SKY_APISERVER_DB_ROWS_RETURNED, self._db,
                        self._table, self._op).observe(self._rows)
@@ -536,8 +536,8 @@ def _install(engine: Any, db: str) -> None:
                 return
             duration = time.perf_counter() - started
             table, op = _labels(context)
-            _child(db_metrics.SKY_APISERVER_DB_EXECUTE_SECONDS, db, table,
-                   op).observe(duration)
+            _child(db_metrics.SKY_APISERVER_DB_EXECUTE_SECONDS, db,
+                   table).observe(duration)
             _child(db_metrics.SKY_APISERVER_DB_STATEMENTS_TOTAL, db, table, op,
                    _OUTCOME_OK).inc()
             rows = _rowcount(cursor)
@@ -548,7 +548,7 @@ def _install(engine: Any, db: str) -> None:
                 sent = _statement_bytes(statement, parameters, executemany)
                 if sent:
                     _child(db_metrics.SKY_APISERVER_DB_STATEMENT_BYTES, db,
-                           table, op).observe(sent)
+                           table).observe(sent)
             conn.info[_KEY_RESULT] = (table, op, rows is None)
         except Exception:  # pylint: disable=broad-except
             _warn_once('Failed to record a SQL statement.')

--- a/sky/utils/db/sql_metrics.py
+++ b/sky/utils/db/sql_metrics.py
@@ -105,8 +105,6 @@ _PARAM_SAMPLE_SETS = 8
 _SCALAR_BYTES = 8
 # Guard against pathological FROM nesting while walking to a table name.
 _MAX_FROM_DEPTH = 6
-# Minimum interval between writes of the pool saturation gauge.
-_POOL_GAUGE_MIN_INTERVAL = 0.1
 # Marker attribute on our own wrappers, so re-arming is idempotent.
 _WRAPPED_ATTR = '_sky_db_wrapped'
 
@@ -347,19 +345,20 @@ def _rowcount(cursor: Any) -> Optional[int]:
 
 
 class _PoolGaugeState:
-    """Throttle and bound-child state for one engine's saturation gauge.
+    """Last-written value and bound child for one engine's saturation gauge.
 
     pid is tracked because a forked child inherits this state and must not
     report its parent's pid — the multiprocess collector keys its files on
     the real one.
     """
 
-    __slots__ = ('at', 'pid', 'child')
+    __slots__ = ('pid', 'child', 'last')
 
     def __init__(self) -> None:
-        self.at: float = 0.0
         self.pid: int = 0
         self.child: Any = None
+        # Last value written. -1 so the first observation always differs.
+        self.last: float = -1.0
 
 
 # --- result consumption ---------------------------------------------------
@@ -642,23 +641,40 @@ def _install(engine: Any, db: str) -> None:
 
     gauge_state = _PoolGaugeState()
 
-    def _sync_pool_gauge() -> None:
+    def _sync_pool_gauge(adjust: int = 0) -> None:
         checked_out = getattr(engine.pool, 'checkedout', None)
         if checked_out is None:
             # NullPool and friends keep no such count.
             return
-        # Throttled: this fires on every checkout and checkin, i.e. twice
-        # per statement, and a gauge is read at most once per scrape. The
-        # reliable saturation signal is the acquire histogram (high
-        # acquire with low connect means the pool ran dry), which is not
-        # throttled; this gauge only needs to be roughly current.
-        now = time.monotonic()
-        if now - gauge_state.at < _POOL_GAUGE_MIN_INTERVAL:
-            return
-        gauge_state.at = now
+        # `adjust` exists because the checkin event fires BEFORE the
+        # connection is handed back to the pool, so checkedout() still
+        # counts it there — verified against SQLAlchemy 2.0: checkout
+        # reports 1, checkin also reports 1, and only after the handler
+        # returns does it reach 0. Reading it unadjusted at checkin means
+        # the gauge can never observe the pool going idle, no matter what
+        # the throttle does.
+        value = checked_out() + adjust
+        if value < 0:
+            value = 0
         pid = os.getpid()
+        same_pid = pid == gauge_state.pid
+        if same_pid and value == gauge_state.last:
+            # The common case, and the cheapest: nothing changed. An idle
+            # pool therefore costs nothing at all.
+            return
+        # Deliberately not time-throttled. A throttle was tried and
+        # removed: this fires on checkout and checkin, so suppressing
+        # falls leaves the gauge reporting a connection held through the
+        # whole idle period after a short statement (measured on a live
+        # deployment: every per-pid series read exactly 1, forever), while
+        # suppressing rises hides the peaks a saturation gauge exists to
+        # show. Neither direction is safe to drop, so the only sound rule
+        # is to write whenever the value changes — which for a gauge that
+        # changes twice per statement is what it should cost. Measured at
+        # ~1us per write against ~25us of total per-statement
+        # instrumentation.
         child = gauge_state.child
-        if child is None or gauge_state.pid != pid:
+        if child is None or not same_pid:
             gauge_state.pid = pid
             child = db_metrics.SKY_APISERVER_DB_POOL_CHECKED_OUT.labels(
                 db, pool_label, str(pid))
@@ -666,7 +682,8 @@ def _install(engine: Any, db: str) -> None:
         # Set rather than inc/dec: a gauge that drifts is worse than one
         # that is a scrape behind, and an invalidated connection does not
         # always pair its checkout with a checkin.
-        child.set(checked_out())
+        child.set(value)
+        gauge_state.last = value
 
     @event.listens_for(engine, 'checkout')
     def _checkout(dbapi_connection, conn_rec, conn_proxy):
@@ -685,7 +702,8 @@ def _install(engine: Any, db: str) -> None:
     def _checkin(dbapi_connection, conn_rec):
         del dbapi_connection, conn_rec
         try:
-            _sync_pool_gauge()
+            # -1: this connection is still counted as checked out here.
+            _sync_pool_gauge(-1)
         except Exception:  # pylint: disable=broad-except
             _warn_once('Failed to record a pool checkin.')
 

--- a/tests/unit_tests/test_sql_metrics.py
+++ b/tests/unit_tests/test_sql_metrics.py
@@ -1,0 +1,616 @@
+"""Tests for the client-side SQL instrumentation.
+
+Every test builds its own table with a unique name so its series do not
+collide with another test's — the prometheus registry is process-global
+and its counters only ever go up.
+"""
+import itertools
+import threading
+
+import prometheus_client as prom
+import pytest
+from sqlalchemy import orm
+import sqlalchemy as sa
+
+from sky.metrics import db as db_metrics
+from sky.utils.db import sql_metrics
+
+_names = itertools.count()
+
+
+@pytest.fixture(autouse=True)
+def _enable_metrics(monkeypatch):
+    monkeypatch.setattr(db_metrics, 'ENABLED', True)
+
+
+def _sample(name, **labels):
+    value = prom.REGISTRY.get_sample_value(name, labels)
+    return 0.0 if value is None else value
+
+
+def _table(**extra_columns):
+    """A fresh table with a name no other test uses."""
+    name = f'tbl_{next(_names)}'
+    md = sa.MetaData()
+    columns = [
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('body', sa.Text),
+    ]
+    columns.extend(
+        sa.Column(k, v) for k, v in extra_columns.items())  # pragma: no cover
+    return name, md, sa.Table(name, md, *columns)
+
+
+def _engine(md,
+            db=sql_metrics.DB_STATE,
+            poolclass=sa.pool.QueuePool,
+            path=None):
+    # A file when the test outlives a single connection: an in-memory
+    # SQLite database belongs to its connection, so NullPool (a fresh
+    # connection per operation) and dispose() would both lose the schema.
+    url = f'sqlite:///{path}' if path is not None else 'sqlite://'
+    engine = sa.create_engine(url, poolclass=poolclass)
+    sql_metrics.install(engine, db)
+    md.create_all(engine)
+    return engine
+
+
+def _seed(engine, table, rows, width=100):
+    with engine.begin() as conn:
+        conn.execute(table.insert(), [{
+            'id': i,
+            'body': 'x' * width
+        } for i in range(rows)])
+
+
+# --- label derivation ----------------------------------------------------
+
+
+def test_labels_come_from_the_compiled_construct():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 3)
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+        conn.execute(table.update().where(table.c.id == 1).values(body='y'))
+        conn.execute(table.delete().where(table.c.id == 2))
+
+    for op in ('select', 'insert', 'update', 'delete'):
+        assert _sample('sky_apiserver_db_statements_total',
+                       db='state',
+                       table=name,
+                       op=op,
+                       outcome='ok') >= 1, op
+    # The DDL that created the table is attributed to it too.
+    assert _sample('sky_apiserver_db_statements_total',
+                   db='state',
+                   table=name,
+                   op='ddl',
+                   outcome='ok') == 1
+
+
+def test_join_is_attributed_to_its_leftmost_table():
+    left_name, md, left = _table()
+    right_name = f'tbl_{next(_names)}'
+    right = sa.Table(right_name, md,
+                     sa.Column('id', sa.Integer, primary_key=True))
+    engine = _engine(md)
+    _seed(engine, left, 2)
+
+    with engine.connect() as conn:
+        conn.execute(
+            sa.select(left.c.id).join_from(left, right,
+                                           left.c.id == right.c.id)).all()
+
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=left_name,
+                   op='select') == 1
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=right_name,
+                   op='select') == 0
+
+
+def test_subquery_does_not_leak_an_anonymous_alias_as_a_label():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 3)
+
+    sub = sa.select(table).subquery()
+    with engine.connect() as conn:
+        conn.execute(sa.select(sub.c.id)).all()
+
+    # Unwrapped to the real table, not labelled `anon_1`.
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 1
+
+
+def test_raw_text_is_not_regexed_into_a_table_label():
+    _, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 1)
+
+    before = _sample('sky_apiserver_db_execute_seconds_count',
+                     db='state',
+                     table=db_metrics.UNKNOWN_TABLE,
+                     op='other')
+    with engine.connect() as conn:
+        conn.execute(sa.text(f'select count(*) from {table.name}')).all()
+    after = _sample('sky_apiserver_db_execute_seconds_count',
+                    db='state',
+                    table=db_metrics.UNKNOWN_TABLE,
+                    op='other')
+    assert after == before + 1
+
+
+def test_derivation_runs_once_per_compiled_statement(monkeypatch):
+    """The acceptance criterion: label derivation is not per-execution."""
+    _, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 2)
+
+    calls = []
+    original = sql_metrics._compute_labels
+
+    def counting(compiled):
+        calls.append(compiled)
+        return original(compiled)
+
+    monkeypatch.setattr(sql_metrics, '_compute_labels', counting)
+
+    stmt = sa.select(table)
+    for _ in range(25):
+        with engine.connect() as conn:
+            conn.execute(stmt).all()
+
+    assert len(calls) == 1, (
+        f'derived {len(calls)} times for 25 executions of one statement')
+
+
+# --- payload ------------------------------------------------------------
+
+
+def test_rows_and_result_bytes_are_exact():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 40, width=1000)
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_rows_returned_sum',
+                   db='state',
+                   table=name,
+                   op='select') == 40
+    # 40 rows x (1000-char body + an 8-byte id).
+    assert _sample('sky_apiserver_db_result_bytes_sum',
+                   db='state',
+                   table=name,
+                   op='select') == 40 * 1008
+
+
+def test_result_bytes_include_a_single_outlier_row():
+    """Regression: sampling either inflated or missed the outlier row.
+
+    Extrapolating from the leading rows multiplied one big row across the
+    whole result; striding past it reported the result as small. The
+    outlier is the payload this metric exists to catch, so it is measured.
+    """
+    name, md, table = _table()
+    engine = _engine(md)
+    big = 4 * 1024 * 1024
+    with engine.begin() as conn:
+        conn.execute(table.insert(), [{
+            'id': i,
+            'body': 'x' * (big if i == 137 else 100)
+        } for i in range(200)])
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    expected = big + 199 * 100 + 200 * 8
+    assert _sample('sky_apiserver_db_result_bytes_sum',
+                   db='state',
+                   table=name,
+                   op='select') == expected
+
+
+def test_result_bytes_handle_a_null_first_value():
+    """A NULL in the first row says nothing about the rest of the column."""
+    name, md, table = _table()
+    engine = _engine(md)
+    with engine.begin() as conn:
+        conn.execute(table.insert(), [{
+            'id': 0,
+            'body': None
+        }, {
+            'id': 1,
+            'body': 'y' * 5000
+        }])
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    # The NULL counts as a scalar (8); the real 5000-char value is not lost.
+    assert _sample('sky_apiserver_db_result_bytes_sum',
+                   db='state',
+                   table=name,
+                   op='select') == 5000 + 8 + 2 * 8
+
+
+def test_statement_bytes_capture_a_large_write():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 1)
+
+    payload = 'z' * (2 * 1024 * 1024)
+    with engine.begin() as conn:
+        conn.execute(table.update().where(table.c.id == 0).values(body=payload))
+
+    sent = _sample('sky_apiserver_db_statement_bytes_sum',
+                   db='state',
+                   table=name,
+                   op='update')
+    assert sent >= len(payload)
+
+
+def test_statement_bytes_are_not_recorded_for_reads():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 2)
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_statement_bytes_count',
+                   db='state',
+                   table=name,
+                   op='select') == 0
+
+
+@pytest.mark.parametrize('consume', [
+    lambda r: r.all(),
+    lambda r: r.fetchall(),
+    lambda r: r.scalars().all(),
+    lambda r: r.mappings().all(),
+])
+def test_rowfetch_covers_every_bulk_consumption_path(consume):
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 30)
+
+    with engine.connect() as conn:
+        consume(conn.execute(sa.select(table)))
+
+    assert _sample('sky_apiserver_db_rowfetch_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 1
+
+
+def test_rowfetch_is_not_reported_as_empty_for_row_at_a_time_reads():
+    """`.first()` uses fetchone, which is deliberately not instrumented.
+
+    Reporting zero seconds and zero bytes would read as a free empty
+    result, which is worse than reporting nothing at all.
+    """
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 5)
+
+    with engine.connect() as conn:
+        assert conn.execute(sa.select(table)).first() is not None
+
+    assert _sample('sky_apiserver_db_rowfetch_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 0
+
+
+def test_orm_session_is_covered():
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 4)
+
+    with orm.Session(engine) as session:
+        session.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_rowfetch_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 1
+
+
+# --- transactions -------------------------------------------------------
+
+
+def test_transaction_span_separates_commit_from_rollback():
+    _, md, table = _table()
+    engine = _engine(md)
+    commits = _sample('sky_apiserver_db_transaction_seconds_count',
+                      db='state',
+                      outcome='commit')
+    rollbacks = _sample('sky_apiserver_db_transaction_seconds_count',
+                        db='state',
+                        outcome='rollback')
+
+    with engine.begin() as conn:
+        conn.execute(table.insert(), {'id': 1, 'body': 'a'})
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_transaction_seconds_count',
+                   db='state',
+                   outcome='commit') == commits + 1
+    # A read-only block returns its connection without committing.
+    assert _sample('sky_apiserver_db_transaction_seconds_count',
+                   db='state',
+                   outcome='rollback') == rollbacks + 1
+
+
+def test_commit_is_timed_separately_from_the_span():
+    _, md, table = _table()
+    engine = _engine(md)
+    before = _sample('sky_apiserver_db_commit_seconds_count', db='state')
+
+    with engine.begin() as conn:
+        conn.execute(table.insert(), {'id': 1, 'body': 'a'})
+
+    assert _sample('sky_apiserver_db_commit_seconds_count',
+                   db='state') == before + 1
+
+
+def test_failed_statements_are_counted_as_errors():
+    _, md, _ = _table()
+    engine = _engine(md)
+    before = _sample('sky_apiserver_db_statements_total',
+                     db='state',
+                     table=db_metrics.UNKNOWN_TABLE,
+                     op='other',
+                     outcome='error')
+
+    with pytest.raises(sa.exc.OperationalError):
+        with engine.connect() as conn:
+            conn.execute(sa.text('select * from does_not_exist'))
+
+    assert _sample('sky_apiserver_db_statements_total',
+                   db='state',
+                   table=db_metrics.UNKNOWN_TABLE,
+                   op='other',
+                   outcome='error') == before + 1
+
+
+# --- connection and pool ------------------------------------------------
+
+
+def test_connect_and_acquire_are_recorded_with_the_pool_class():
+    _, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 1)
+
+    assert _sample(
+        'sky_apiserver_db_connects_total', db='state', pool='QueuePool') >= 1
+    assert _sample('sky_apiserver_db_connect_seconds_count',
+                   db='state',
+                   pool='QueuePool') >= 1
+    assert _sample('sky_apiserver_db_acquire_seconds_count',
+                   db='state',
+                   pool='QueuePool') >= 1
+
+
+def test_pool_config_is_exported():
+    _, md, _ = _table()
+    _engine(md)
+
+    assert _sample('sky_apiserver_db_pool_size', db='state',
+                   pool='QueuePool') > 0
+    assert prom.REGISTRY.get_sample_value('sky_apiserver_db_pool_max_overflow',
+                                          {
+                                              'db': 'state',
+                                              'pool': 'QueuePool'
+                                          }) is not None
+
+
+def test_pool_class_is_visible_so_an_unpooled_engine_stands_out(tmp_path):
+    """The signal for an engine that should pool but does not."""
+    _, md, table = _table()
+    engine = _engine(md,
+                     db='state_nopool',
+                     poolclass=sa.pool.NullPool,
+                     path=tmp_path / 'nopool.db')
+    _seed(engine, table, 1)
+
+    assert _sample('sky_apiserver_db_connects_total',
+                   db='state_nopool',
+                   pool='NullPool') >= 1
+    # NullPool keeps no checkout count, so no saturation gauge for it.
+    assert prom.REGISTRY.get_sample_value('sky_apiserver_db_pool_size', {
+        'db': 'state_nopool',
+        'pool': 'NullPool'
+    }) is None
+
+
+def test_connection_lifetime_is_recorded_on_close():
+    _, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 1)
+    before = _sample('sky_apiserver_db_connection_lifetime_seconds_count',
+                     db='state',
+                     pool='QueuePool')
+
+    engine.dispose()
+
+    assert _sample('sky_apiserver_db_connection_lifetime_seconds_count',
+                   db='state',
+                   pool='QueuePool') == before + 1
+
+
+def test_acquire_timing_survives_engine_dispose(tmp_path):
+    """dispose() replaces the pool object, taking the wrapper with it."""
+    _, md, table = _table()
+    engine = _engine(md, path=tmp_path / 'dispose.db')
+    _seed(engine, table, 1)
+    engine.dispose()
+
+    before = _sample('sky_apiserver_db_acquire_seconds_count',
+                     db='state',
+                     pool='QueuePool')
+    # First acquire on the fresh pool re-arms the wrapper; the second is
+    # measured again.
+    for _ in range(3):
+        with engine.connect() as conn:
+            conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_acquire_seconds_count',
+                   db='state',
+                   pool='QueuePool') > before
+
+
+# --- installation contract ----------------------------------------------
+
+
+def test_install_is_idempotent():
+    name, md, table = _table()
+    engine = sa.create_engine('sqlite://', poolclass=sa.pool.QueuePool)
+    for _ in range(4):
+        sql_metrics.install(engine, sql_metrics.DB_STATE)
+    md.create_all(engine)
+    _seed(engine, table, 2)
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 1
+
+
+def test_disabled_attaches_nothing(monkeypatch):
+    monkeypatch.setattr(db_metrics, 'ENABLED', False)
+    name, md, table = _table()
+    engine = sa.create_engine('sqlite://')
+    sql_metrics.install(engine, sql_metrics.DB_STATE)
+    md.create_all(engine)
+    _seed(engine, table, 2)
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 0
+    # Not merely "skip the observe": no listener is attached at all, so
+    # SQLAlchemy never takes its has-events code path.
+    assert not engine._has_events  # pylint: disable=protected-access
+
+
+def test_async_engine_is_instrumented_through_its_sync_engine():
+    async_engine = sa.ext.asyncio.create_async_engine('sqlite+aiosqlite://')
+    sql_metrics.install(async_engine, sql_metrics.DB_STATE_ASYNC)
+    assert async_engine.sync_engine._has_events  # pylint: disable=protected-access
+
+
+def test_a_broken_listener_does_not_break_queries(monkeypatch):
+    """A defect in the instrument must never fail a database call."""
+    name, md, table = _table()
+    engine = _engine(md)
+    _seed(engine, table, 3)
+
+    def boom(_):
+        raise RuntimeError('instrument is broken')
+
+    monkeypatch.setattr(sql_metrics, '_compute_labels', boom)
+    monkeypatch.setattr(sql_metrics, '_warned', False)
+
+    with engine.connect() as conn:
+        rows = conn.execute(sa.select(table)).all()
+    assert len(rows) == 3
+    del name
+
+
+def test_concurrent_install_attaches_once():
+    name, md, table = _table()
+    engine = sa.create_engine('sqlite://', poolclass=sa.pool.QueuePool)
+    threads = [
+        threading.Thread(target=sql_metrics.install,
+                         args=(engine, sql_metrics.DB_STATE)) for _ in range(8)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    md.create_all(engine)
+    _seed(engine, table, 1)
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table=name,
+                   op='select') == 1
+
+
+# --- the external entry point used by non-SQLAlchemy callers -------------
+
+
+def test_record_statement_lands_on_the_same_families():
+    before = _sample('sky_apiserver_db_statements_total',
+                     db='ha_asyncpg',
+                     table='requests',
+                     op='insert',
+                     outcome='ok')
+    db_metrics.record_statement('ha_asyncpg',
+                                'requests',
+                                'insert',
+                                0.01,
+                                rows=1,
+                                statement_bytes=4096)
+
+    assert _sample('sky_apiserver_db_statements_total',
+                   db='ha_asyncpg',
+                   table='requests',
+                   op='insert',
+                   outcome='ok') == before + 1
+    assert _sample('sky_apiserver_db_statement_bytes_sum',
+                   db='ha_asyncpg',
+                   table='requests',
+                   op='insert') >= 4096
+
+
+def test_observe_statement_marks_failures():
+    before = _sample('sky_apiserver_db_statements_total',
+                     db='ha_asyncpg',
+                     table='requests',
+                     op='select',
+                     outcome='error')
+    with pytest.raises(ValueError):
+        with db_metrics.observe_statement('ha_asyncpg', 'requests', 'select'):
+            raise ValueError('boom')
+
+    assert _sample('sky_apiserver_db_statements_total',
+                   db='ha_asyncpg',
+                   table='requests',
+                   op='select',
+                   outcome='error') == before + 1
+
+
+def test_observe_statement_is_inert_when_disabled(monkeypatch):
+    monkeypatch.setattr(db_metrics, 'ENABLED', False)
+    before = _sample('sky_apiserver_db_statements_total',
+                     db='ha_asyncpg',
+                     table='clusters',
+                     op='select',
+                     outcome='ok')
+    with db_metrics.observe_statement('ha_asyncpg', 'clusters',
+                                      'select') as obs:
+        obs.rows = 5
+    assert _sample('sky_apiserver_db_statements_total',
+                   db='ha_asyncpg',
+                   table='clusters',
+                   op='select',
+                   outcome='ok') == before

--- a/tests/unit_tests/test_sql_metrics.py
+++ b/tests/unit_tests/test_sql_metrics.py
@@ -614,3 +614,62 @@ def test_observe_statement_is_inert_when_disabled(monkeypatch):
                    table='clusters',
                    op='select',
                    outcome='ok') == before
+
+
+def test_record_helpers_never_raise_into_the_caller(monkeypatch):
+    """A metrics defect must not propagate to a DB caller.
+
+    These helpers are called from `finally` blocks and from paths holding a
+    checked-out connection, so an escaping exception would strand a real
+    resource over a broken instrument.
+    """
+    monkeypatch.setattr(db_metrics, '_warned', False)
+
+    class Exploding:
+
+        def labels(self, *args, **kwargs):
+            raise RuntimeError('mmap is full')
+
+    for name in ('SKY_APISERVER_DB_EXECUTE_SECONDS',
+                 'SKY_APISERVER_DB_ACQUIRE_SECONDS',
+                 'SKY_APISERVER_DB_POOL_CHECKED_OUT'):
+        monkeypatch.setattr(db_metrics, name, Exploding())
+
+    # None of these may raise.
+    db_metrics.record_statement('state', 'requests', 'select', 0.01, rows=1)
+    db_metrics.record_acquire('ha_asyncpg', 'asyncpg', 0.01)
+    db_metrics.record_pool('ha_asyncpg', 'asyncpg', checked_out=3)
+
+
+def test_observe_statement_swallows_a_broken_emit(monkeypatch):
+    """The context manager's finally must not become a caller exception."""
+    monkeypatch.setattr(db_metrics, '_warned', False)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError('mmap is full')
+
+    monkeypatch.setattr(db_metrics, 'record_statement', boom)
+
+    sentinel = []
+    with db_metrics.observe_statement('ha_asyncpg', 'task_queue',
+                                      'insert') as obs:
+        obs.rows = 1
+        sentinel.append('body ran')
+    assert sentinel == ['body ran']
+
+
+def test_record_pool_leaves_omitted_values_untouched():
+    """Config published once, saturation reported per acquire."""
+    db_metrics.record_pool('probe_pool', 'asyncpg', size=5, max_overflow=0)
+    for checked_out in (1, 2, 3):
+        db_metrics.record_pool('probe_pool', 'asyncpg', checked_out=checked_out)
+
+    # The denominator survives the checked_out-only updates.
+    assert _sample('sky_apiserver_db_pool_size',
+                   db='probe_pool',
+                   pool='asyncpg') == 5
+    assert prom.REGISTRY.get_sample_value('sky_apiserver_db_pool_max_overflow',
+                                          {
+                                              'db': 'probe_pool',
+                                              'pool': 'asyncpg'
+                                          }) == 0

--- a/tests/unit_tests/test_sql_metrics.py
+++ b/tests/unit_tests/test_sql_metrics.py
@@ -98,6 +98,14 @@ def test_join_is_attributed_to_its_leftmost_table():
     engine = _engine(md)
     _seed(engine, left, 2)
 
+    # Deltas, because both tables already have a CREATE TABLE attributed
+    # to them and execute latency is no longer split by op.
+    before_left = _sample('sky_apiserver_db_execute_seconds_count',
+                          db='state',
+                          table=left_name)
+    before_right = _sample('sky_apiserver_db_execute_seconds_count',
+                           db='state',
+                           table=right_name)
     with engine.connect() as conn:
         conn.execute(
             sa.select(left.c.id).join_from(left, right,
@@ -105,12 +113,10 @@ def test_join_is_attributed_to_its_leftmost_table():
 
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=left_name,
-                   op='select') == 1
+                   table=left_name) == before_left + 1
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=right_name,
-                   op='select') == 0
+                   table=right_name) == before_right
 
 
 def test_subquery_does_not_leak_an_anonymous_alias_as_a_label():
@@ -118,6 +124,9 @@ def test_subquery_does_not_leak_an_anonymous_alias_as_a_label():
     engine = _engine(md)
     _seed(engine, table, 3)
 
+    before = _sample('sky_apiserver_db_execute_seconds_count',
+                     db='state',
+                     table=name)
     sub = sa.select(table).subquery()
     with engine.connect() as conn:
         conn.execute(sa.select(sub.c.id)).all()
@@ -125,8 +134,10 @@ def test_subquery_does_not_leak_an_anonymous_alias_as_a_label():
     # Unwrapped to the real table, not labelled `anon_1`.
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 1
+                   table=name) == before + 1
+    assert _sample('sky_apiserver_db_execute_seconds_count',
+                   db='state',
+                   table='anon_1') == 0
 
 
 def test_raw_text_is_not_regexed_into_a_table_label():
@@ -136,14 +147,12 @@ def test_raw_text_is_not_regexed_into_a_table_label():
 
     before = _sample('sky_apiserver_db_execute_seconds_count',
                      db='state',
-                     table=db_metrics.UNKNOWN_TABLE,
-                     op='other')
+                     table=db_metrics.UNKNOWN_TABLE)
     with engine.connect() as conn:
         conn.execute(sa.text(f'select count(*) from {table.name}')).all()
     after = _sample('sky_apiserver_db_execute_seconds_count',
                     db='state',
-                    table=db_metrics.UNKNOWN_TABLE,
-                    op='other')
+                    table=db_metrics.UNKNOWN_TABLE)
     assert after == before + 1
 
 
@@ -187,10 +196,8 @@ def test_rows_and_result_bytes_are_exact():
                    table=name,
                    op='select') == 40
     # 40 rows x (1000-char body + an 8-byte id).
-    assert _sample('sky_apiserver_db_result_bytes_sum',
-                   db='state',
-                   table=name,
-                   op='select') == 40 * 1008
+    assert _sample('sky_apiserver_db_result_bytes_sum', db='state',
+                   table=name) == 40 * 1008
 
 
 def test_result_bytes_include_a_single_outlier_row():
@@ -213,10 +220,8 @@ def test_result_bytes_include_a_single_outlier_row():
         conn.execute(sa.select(table)).all()
 
     expected = big + 199 * 100 + 200 * 8
-    assert _sample('sky_apiserver_db_result_bytes_sum',
-                   db='state',
-                   table=name,
-                   op='select') == expected
+    assert _sample('sky_apiserver_db_result_bytes_sum', db='state',
+                   table=name) == expected
 
 
 def test_result_bytes_handle_a_null_first_value():
@@ -236,10 +241,8 @@ def test_result_bytes_handle_a_null_first_value():
         conn.execute(sa.select(table)).all()
 
     # The NULL counts as a scalar (8); the real 5000-char value is not lost.
-    assert _sample('sky_apiserver_db_result_bytes_sum',
-                   db='state',
-                   table=name,
-                   op='select') == 5000 + 8 + 2 * 8
+    assert _sample('sky_apiserver_db_result_bytes_sum', db='state',
+                   table=name) == 5000 + 8 + 2 * 8
 
 
 def test_statement_bytes_capture_a_large_write():
@@ -253,8 +256,7 @@ def test_statement_bytes_capture_a_large_write():
 
     sent = _sample('sky_apiserver_db_statement_bytes_sum',
                    db='state',
-                   table=name,
-                   op='update')
+                   table=name)
     assert sent >= len(payload)
 
 
@@ -263,13 +265,15 @@ def test_statement_bytes_are_not_recorded_for_reads():
     engine = _engine(md)
     _seed(engine, table, 2)
 
+    before = _sample('sky_apiserver_db_statement_bytes_count',
+                     db='state',
+                     table=name)
     with engine.connect() as conn:
         conn.execute(sa.select(table)).all()
 
     assert _sample('sky_apiserver_db_statement_bytes_count',
                    db='state',
-                   table=name,
-                   op='select') == 0
+                   table=name) == before
 
 
 @pytest.mark.parametrize('consume', [
@@ -288,8 +292,7 @@ def test_rowfetch_covers_every_bulk_consumption_path(consume):
 
     assert _sample('sky_apiserver_db_rowfetch_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 1
+                   table=name) == 1
 
 
 def test_rowfetch_is_not_reported_as_empty_for_row_at_a_time_reads():
@@ -307,8 +310,7 @@ def test_rowfetch_is_not_reported_as_empty_for_row_at_a_time_reads():
 
     assert _sample('sky_apiserver_db_rowfetch_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 0
+                   table=name) == 0
 
 
 def test_orm_session_is_covered():
@@ -321,8 +323,7 @@ def test_orm_session_is_covered():
 
     assert _sample('sky_apiserver_db_rowfetch_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 1
+                   table=name) == 1
 
 
 # --- transactions -------------------------------------------------------
@@ -481,13 +482,17 @@ def test_install_is_idempotent():
     md.create_all(engine)
     _seed(engine, table, 2)
 
+    before = _sample('sky_apiserver_db_execute_seconds_count',
+                     db='state',
+                     table=name)
     with engine.connect() as conn:
         conn.execute(sa.select(table)).all()
 
+    # Exactly one observation: a double-installed listener set would
+    # record the same statement twice.
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 1
+                   table=name) == before + 1
 
 
 def test_disabled_attaches_nothing(monkeypatch):
@@ -502,8 +507,7 @@ def test_disabled_attaches_nothing(monkeypatch):
 
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 0
+                   table=name) == 0
     # Not merely "skip the observe": no listener is attached at all, so
     # SQLAlchemy never takes its has-events code path.
     assert not engine._has_events  # pylint: disable=protected-access
@@ -547,12 +551,14 @@ def test_concurrent_install_attaches_once():
     md.create_all(engine)
     _seed(engine, table, 1)
 
+    before = _sample('sky_apiserver_db_execute_seconds_count',
+                     db='state',
+                     table=name)
     with engine.connect() as conn:
         conn.execute(sa.select(table)).all()
     assert _sample('sky_apiserver_db_execute_seconds_count',
                    db='state',
-                   table=name,
-                   op='select') == 1
+                   table=name) == before + 1
 
 
 # --- the external entry point used by non-SQLAlchemy callers -------------
@@ -578,8 +584,7 @@ def test_record_statement_lands_on_the_same_families():
                    outcome='ok') == before + 1
     assert _sample('sky_apiserver_db_statement_bytes_sum',
                    db='ha_asyncpg',
-                   table='requests',
-                   op='insert') >= 4096
+                   table='requests') >= 4096
 
 
 def test_observe_statement_marks_failures():

--- a/tests/unit_tests/test_sql_metrics.py
+++ b/tests/unit_tests/test_sql_metrics.py
@@ -5,6 +5,7 @@ collide with another test's — the prometheus registry is process-global
 and its counters only ever go up.
 """
 import itertools
+import os
 import threading
 
 import prometheus_client as prom
@@ -678,3 +679,52 @@ def test_record_pool_leaves_omitted_values_untouched():
                                               'db': 'probe_pool',
                                               'pool': 'asyncpg'
                                           }) == 0
+
+
+def test_pool_gauge_returns_to_zero_when_the_pool_goes_idle(tmp_path):
+    """Regression: the throttle used to swallow every checkin.
+
+    _sync_pool_gauge fires on checkout and checkin. With a symmetric
+    time throttle, any statement shorter than the window had its checkin
+    dropped, so the only observations that landed were taken while a
+    connection was held — the gauge then read "1 checked out" through the
+    whole idle period after it. Measured on a live deployment before the
+    fix: every per-pid series read exactly 1, forever.
+    """
+    _, md, table = _table()
+    # A role of its own: the gauge series is keyed by (db, pool, pid), so
+    # any other engine in this process with the same role would clobber
+    # it and the assertion would be testing that engine instead.
+    engine = _engine(md, db='gauge_idle_probe', path=tmp_path / 'gauge.db')
+    _seed(engine, table, 2)
+
+    pid = str(os.getpid())
+
+    # Several statements back to back, each far shorter than the throttle
+    # window, so every checkin would have been throttled away.
+    for _ in range(5):
+        with engine.connect() as conn:
+            conn.execute(sa.select(table)).all()
+
+    assert _sample(
+        'sky_apiserver_db_pool_checked_out',
+        db='gauge_idle_probe',
+        pool='QueuePool',
+        pid=pid) == 0, ('gauge still reports a checked-out connection after '
+                        'the pool went idle')
+
+
+def test_pool_gauge_reports_a_held_connection(tmp_path):
+    """The other direction: it must still show a real checkout."""
+    _, md, table = _table()
+    engine = _engine(md, db='gauge_held_probe', path=tmp_path / 'gauge2.db')
+    _seed(engine, table, 2)
+
+    pid = str(os.getpid())
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+        held = _sample('sky_apiserver_db_pool_checked_out',
+                       db='gauge_held_probe',
+                       pool='QueuePool',
+                       pid=pid)
+    assert held >= 1, 'gauge did not report the connection being held'

--- a/tests/unit_tests/test_sql_metrics.py
+++ b/tests/unit_tests/test_sql_metrics.py
@@ -728,3 +728,49 @@ def test_pool_gauge_reports_a_held_connection(tmp_path):
                        pool='QueuePool',
                        pid=pid)
     assert held >= 1, 'gauge did not report the connection being held'
+
+
+def test_checkin_fires_before_the_connection_is_returned(tmp_path):
+    """Pins the one undocumented ordering assumption in this module.
+
+    `_sync_pool_gauge` subtracts 1 at checkin because the event fires
+    while the connection is still counted as checked out. SQLAlchemy does
+    not document that ordering. A flip would survive single-connection
+    use — the clamp to 0 hides it — but would silently under-report by
+    one under concurrency, and the two gauge tests above are
+    single-connection, so neither would catch it.
+
+    So assert the ordering itself: a SQLAlchemy upgrade that moves the
+    dispatch turns into a red test here rather than a quietly wrong
+    saturation gauge in production.
+    """
+    _, md, table = _table()
+    engine = _engine(md, db='checkin_order_probe', path=tmp_path / 'order.db')
+    _seed(engine, table, 1)
+
+    seen = {}
+
+    @sa.event.listens_for(engine, 'checkout')
+    def _at_checkout(dbapi_connection, conn_rec, conn_proxy):
+        del dbapi_connection, conn_rec, conn_proxy
+        seen['checkout'] = engine.pool.checkedout()
+
+    @sa.event.listens_for(engine, 'checkin')
+    def _at_checkin(dbapi_connection, conn_rec):
+        del dbapi_connection, conn_rec
+        seen['checkin'] = engine.pool.checkedout()
+
+    with engine.connect() as conn:
+        conn.execute(sa.select(table)).all()
+    settled = engine.pool.checkedout()
+
+    assert seen['checkout'] == 1, (
+        'checkout no longer sees the connection as checked out; the gauge '
+        'would now under-report while a connection is held')
+    assert seen['checkin'] == 1, (
+        'checkin no longer counts the connection it is returning, so the '
+        '-1 adjustment in _sync_pool_gauge is wrong and the saturation '
+        'gauge under-reports by one per concurrent connection')
+    assert settled == 0, (
+        'the pool did not settle back to zero once the connection was '
+        'returned')


### PR DESCRIPTION

<img width="1482" height="672" alt="image" src="https://github.com/user-attachments/assets/901ef669-c9c7-4aa8-aded-4693e6a8f3d5" />


The API server reports nothing about how it uses its database. There is no SQLAlchemy instrumentation in the tree today, so there is no way to tell "the app waited" from "the database was slow" from "we ran out of pool" — and payload problems are invisible, because a query that returns a hundred megabytes looks like a healthy fast query to every server-side counter.

This adds the client-side view of `acquire → connect → execute → rowfetch → commit`, plus the size of what moves. `sky/metrics/db.py` defines the metric families, `sky/utils/db/sql_metrics.py` does the SQLAlchemy wiring, and `db_utils.get_engine()` installs it on every engine it builds. A Grafana dashboard ships with the chart.

Labels are `db` (the engine role) and `table` (taken from the compiled SQLAlchemy construct, not by regexing SQL text), plus `pool` (the pool class) on the connection-side families — which is what makes an engine that should pool but reports `NullPool` visible. `op` is carried only by `statements_total`, where statement-rate-by-op lives, and by `rows_returned`, where rows *returned* by a read and rows *affected* by a write are different populations and merging them would hide a full-table read behind a full-table delete. No statement text, request ids, users or cluster names.

Two measurements are easy to misread, so both are documented in the code:

- **`execute` includes the result coming over the wire.** psycopg2 and asyncpg buffer the whole result during `cursor.execute()`, so a large read shows up as a *slow query*, and `rows_returned` / `result_bytes` are what distinguish it. Measured on Postgres 16: a 19 MiB read spent 3243 ms in execute and 5 ms in row handoff.
- **`result_bytes` is computed client-side**, since no driver reports it. Sampling was tried and dropped — extrapolating from the leading rows inflated a single outlier row 40×, and striding across the batch missed a 100 MiB outlier row entirely. A columnar walk is ~10× cheaper than a per-cell loop, so an exact sum fits the budget.

Label derivation caches on the compiled construct, so it runs once per statement shape rather than once per execution. The whole thing is inert unless `SKY_API_SERVER_METRICS_ENABLED` is set — no listeners attached at all, not merely skipped observes — and every listener body fails closed so a defect here cannot break a database call.

## Performance impact

Two costs, measured separately, because they land on different things.

**Write path — client CPU per statement.** Measured against a local engine, where a ~27 µs signal is actually resolvable:

| | metrics off | on | delta |
| -- | --: | --: | --: |
| point select | 15.9 µs | 43.4 µs | **+27.6 µs** |
| `.first()` (row-at-a-time) | 15.7 µs | 38.0 µs | +22.2 µs |
| update + commit | 17.8 µs | 43.5 µs | **+25.7 µs** |
| 500-row scan, 200 B rows | 256 µs | 315 µs | +59 µs |
| 500-row scan, 5 KiB rows | 576 µs | 637 µs | +61 µs |

Roughly: ~10 µs of SQLAlchemy event dispatch and label lookup, ~1 µs per prometheus child write across six to eight writes, ~2 µs for the pool gauge, and on reads an O(cells) walk to size the result exactly — that last one is the whole difference between the two scan rows above and the point select.

This is client-side CPU, so it does not scale with round-trip latency, which means the honest way to express it as a percentage is against a statement latency: ~9% at 0.3 ms, ~2.8% at 1 ms, ~1.4% at 2 ms. **At sub-millisecond statement latencies it is therefore not a small single-digit percentage** — worth saying plainly. On the deployment I measured it on, observed execute means for the busy paths were 1.3–8 ms, putting it at 0.4–2%. I could not resolve the percentage directly against a remote Postgres: over a port-forward at ~800 ms per statement both wall-clock and CPU deltas are noise, so the percentages above are derived from the absolute number rather than measured end to end.

**Read path — what `/metrics` has to serve.** On a real deployment this adds **2801 series and 174 KB** to a pod, taking it from ~1.3 k to ~4.0 k series and 416 KB total; the scrape itself measured 0.17–0.45 s. For scale, another instance on the same cluster without any of this already exports 6275 series / 769 KB and scrapes in 0.16–0.40 s.

Series count is bounded by construction — every label value comes from a static compiled construct or a fixed vocabulary, never from user input — so the ceiling is tables × 6 ops × engine roles, and only about 105 of 2340 possible combinations are ever populated. The ladder is 11 buckets and the latency and byte families carry no `op`, both specifically to keep this number down; before that trim it was 4167 series / 590 KB.

The one thing to watch is multiprocess mode: the collector reads every per-pid file on each scrape, so scrape cost grows with the process count rather than with the series count. Series are sparse per process — each one only writes the combinations it actually touches — but on a pod with hundreds of workers this is the axis that matters, not the totals above.

<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

32 unit tests in `tests/unit_tests/test_sql_metrics.py`. Existing DB-touching unit tests also pass with metrics force-enabled.

Verified against a real Postgres 16 for the things SQLite cannot settle: `cursor.rowcount` is exact for psycopg2 SELECT (sqlite3 returns -1, where the fetch wrapper counts instead), the wire transfer lands in execute, the asyncpg engine is covered through `sync_engine`, and result bytes match expectation exactly. With a transaction-mode pgbouncer in front, every statement, payload and transaction metric is identical to the direct path; only the connect-latency histogram changes meaning, which its docstring now notes.

