### PR TITLE
[Dashboard] Suppress managed job request amplification

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -958,18 +958,6 @@ export function ManagedJobsTable({
     }
   }, [sortConfig, fetchData, preloadingComplete]);
 
-  // Use faster refresh when there are running batch jobs with incomplete progress
-  const hasRunningBatches = React.useMemo(() => {
-    return data.some(
-      (job) =>
-        job.batch_total_batches != null &&
-        (job.status === 'RUNNING' || job.status === 'WINDING_DOWN') &&
-        (job.batch_completed_batches || 0) < job.batch_total_batches
-    );
-  }, [data]);
-
-  const effectiveRefreshInterval = hasRunningBatches ? 1000 : refreshInterval;
-
   // Set up periodic refresh interval only after preloading is complete
   useEffect(() => {
     if (!preloadingComplete) {
@@ -981,20 +969,16 @@ export function ManagedJobsTable({
         fetchDataRef.current &&
         window.document.visibilityState === 'visible'
       ) {
-        // Invalidate cache for fast refresh so we get fresh data
-        if (hasRunningBatches) {
-          jobsCacheManager.invalidateCache();
-        }
-        fetchDataRef.current({ includeStatus: !hasRunningBatches });
+        fetchDataRef.current({ includeStatus: true });
       }
-    }, effectiveRefreshInterval);
+    }, refreshInterval);
 
     return () => {
       clearInterval(interval);
       // Don't invalidate cache on component unmount - this causes premature cache invalidation
       // Cache should only be invalidated on manual refresh or TTL expiration
     };
-  }, [effectiveRefreshInterval, hasRunningBatches, preloadingComplete]);
+  }, [refreshInterval, preloadingComplete]);
 
   // Reset to first page when activeTab, filters, pageSize, or sort changes.
   // Guard with isInitialFetch so the page number read from the URL isn't

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -29,28 +29,6 @@ function getStatusTooltip(job) {
   return null;
 }
 
-// ============ Pagination Plugin Integration ============
-
-/**
- * Check if the jobs pagination plugin is available.
- * The plugin sets window.__skyJobsPaginationFetch when loaded.
- * With requires_early_init=True, the plugin is guaranteed to be
- * loaded before any API calls complete.
- */
-function isJobsPaginationPluginAvailable() {
-  return (
-    typeof window !== 'undefined' &&
-    typeof window.__skyJobsPaginationFetch === 'function'
-  );
-}
-
-/**
- * Get the jobs pagination plugin fetch function
- */
-function getJobsPaginationFetch() {
-  return typeof window !== 'undefined' ? window.__skyJobsPaginationFetch : null;
-}
-
 // Configuration
 const DEFAULT_TAIL_LINES = 5000;
 const DEFAULT_FIELDS = [
@@ -145,6 +123,8 @@ export async function getManagedJobs(options = {}) {
       statuses,
       fields,
       jobIDs,
+      sortBy,
+      sortOrder,
     } = options;
 
     const body = {
@@ -158,6 +138,10 @@ export async function getManagedJobs(options = {}) {
     if (poolMatch !== undefined) body.pool_match = poolMatch;
     if (page !== undefined) body.page = page;
     if (limit !== undefined) body.limit = limit;
+    if (sortBy !== undefined) {
+      body.sort_by = sortBy === 'cluster' ? 'resources' : sortBy;
+    }
+    if (sortOrder !== undefined) body.sort_order = sortOrder;
     if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
     // Support both jobIdMatch (from filter UI) and jobIDs (direct usage)
     const resolvedJobIDs = jobIdMatch ? [jobIdMatch] : jobIDs;
@@ -356,85 +340,6 @@ export async function getManagedJobs(options = {}) {
   } catch (error) {
     console.error('Error fetching managed job data:', error);
     // Signal to the cache to not overwrite previously cached data
-    throw error;
-  }
-}
-
-/**
- * Enhanced getManagedJobs function that supports client-side pagination
- * This function fetches all jobs data once and caches it, then performs filtering and pagination on the client side
- * @param {Object} options - Query options
- * @param {boolean} options.allUsers - Whether to fetch jobs for all users
- * @param {string} options.nameMatch - Filter by job name
- * @param {string} options.userMatch - Filter by user
- * @param {string} options.workspaceMatch - Filter by workspace
- * @param {string} options.poolMatch - Filter by pool
- * @param {Array} options.jobIDs - Filter by job IDs
- * @param {number} options.page - Page page (1-based)
- * @param {number} options.limit - Page size
- * @param {Array} options.fields - Fields to return
- * @param {boolean} options.allFields - Whether to return all fields (default: false)
- * @param {boolean} options.useClientPagination - Whether to use client-side pagination (default: true)
- * @returns {Promise<{jobs: Array, total: number, controllerStopped: boolean, __skipCache?: boolean}>}
- */
-export async function getManagedJobsWithClientPagination(options) {
-  const {
-    allUsers = true,
-    nameMatch,
-    userMatch,
-    workspaceMatch,
-    poolMatch,
-    page = 1,
-    limit = 10,
-    jobIDs,
-    fields,
-    allFields = false,
-    useClientPagination = true,
-  } = options || {};
-
-  try {
-    // If client pagination is disabled, fall back to server-side pagination
-    if (!useClientPagination) {
-      return await getManagedJobs(options);
-    }
-
-    // Create cache key for full dataset (without pagination params)
-    const cacheKey = {
-      allUsers,
-      nameMatch,
-      userMatch,
-      workspaceMatch,
-      poolMatch,
-      jobIDs,
-      fields,
-      allFields,
-    };
-
-    // Fetch all data without pagination parameters
-    const fullDataResponse = await getManagedJobs(cacheKey);
-
-    if (fullDataResponse.controllerStopped || !fullDataResponse.jobs) {
-      return fullDataResponse;
-    }
-
-    const allJobs = fullDataResponse.jobs;
-    const total = allJobs.length;
-
-    // Apply client-side pagination
-    const startIndex = (page - 1) * limit;
-    const endIndex = startIndex + limit;
-    const paginatedJobs = allJobs.slice(startIndex, endIndex);
-
-    return {
-      jobs: paginatedJobs,
-      total: total,
-      controllerStopped: false,
-    };
-  } catch (error) {
-    console.error(
-      'Error fetching managed job data with client pagination:',
-      error
-    );
     throw error;
   }
 }

--- a/sky/dashboard/src/data/connectors/jobs.test.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.test.jsx
@@ -14,7 +14,15 @@ jest.mock('@/lib/cache', () => ({
   },
 }));
 
+jest.mock('@/data/connectors/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
 import dashboardCache from '@/lib/cache';
+import { apiClient } from '@/data/connectors/client';
 import { useSingleManagedJob, getManagedJobs } from '@/data/connectors/jobs';
 
 describe('useSingleManagedJob manual-refresh cache invalidation', () => {
@@ -85,5 +93,54 @@ describe('useSingleManagedJob manual-refresh cache invalidation', () => {
 
     await waitFor(() => expect(dashboardCache.get).toHaveBeenCalledTimes(1));
     expect(dashboardCache.invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('getManagedJobs sorting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiClient.post.mockResolvedValue({
+      ok: true,
+      headers: { get: jest.fn(() => 'request-id') },
+    });
+    apiClient.get.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: jest.fn(async () => ({
+        return_value: JSON.stringify({ jobs: [], total: 0 }),
+      })),
+    });
+  });
+
+  it('sends supported sort fields to the managed-jobs API', async () => {
+    // Browser sort selection must become server sorting instead of a cache-only value.
+    await getManagedJobs({
+      allUsers: true,
+      page: 2,
+      limit: 20,
+      sortBy: 'workspace',
+      sortOrder: 'asc',
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/jobs/queue/v2',
+      expect.objectContaining({
+        page: 2,
+        limit: 20,
+        sort_by: 'workspace',
+        sort_order: 'asc',
+      })
+    );
+  });
+
+  it('maps the requested-resources UI column to the backend sort field', async () => {
+    // The UI calls this column cluster while the managed-jobs API calls it resources.
+    await getManagedJobs({ sortBy: 'cluster', sortOrder: 'desc' });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/jobs/queue/v2',
+      expect.objectContaining({ sort_by: 'resources', sort_order: 'desc' })
+    );
   });
 });

--- a/sky/dashboard/src/lib/README.md
+++ b/sky/dashboard/src/lib/README.md
@@ -120,7 +120,7 @@ Time 200ms:  Jobs table fetches only its visible server-side page
 import dashboardCache from '@/lib/cache';
 import { getClustersAndJobsData } from '@/data/connectors/infra';
 
-// Simple usage with default TTL (5 minutes)
+// Simple usage with the default 30-second TTL
 const data = await dashboardCache.get(getClustersAndJobsData);
 
 // With custom TTL (2 minutes)
@@ -136,12 +136,16 @@ const data = await dashboardCache.get(getGPUs, [clustersAndJobsData], {
 
 ### Configuration
 
-The cache system supports configurable TTL values defined in `config.js`. Currently, all cache entries use the `DEFAULT_TTL` of 2 minutes, but the system can be extended to support different TTLs for different data types if needed.
+The cache system supports configurable TTL values defined in `config.js`. The
+default hard TTL is 30 seconds, matching the dashboard's normal periodic
+refresh cadence. It keeps visible pages current without making each fresh cache
+read start another background request. Callers can still use a longer TTL for
+data that is safe to refresh less often.
 
 ```javascript
 // Current configuration
 export const CACHE_CONFIG = {
-  DEFAULT_TTL: 2 * 60 * 1000, // 2 minutes
+  DEFAULT_TTL: REFRESH_INTERVALS.REFRESH_INTERVAL, // 30 seconds
 };
 
 // Example of how different TTLs could be configured:

--- a/sky/dashboard/src/lib/README.md
+++ b/sky/dashboard/src/lib/README.md
@@ -10,14 +10,14 @@ This directory contains the generalized caching mechanism for the SkyPilot dashb
 
 ## Cache Preloader
 
-The cache preloader is a smart utility that automatically populates the cache for all dashboard pages when any page is visited. This dramatically improves page switching performance by ensuring data is already cached when users navigate between pages.
+The cache preloader warms only the lightweight data required by the current page. Cross-page preloading is opt-in because speculative infrastructure scans and managed-job queries can delay the visible page.
 
 ### How It Works
 
 1. **Foreground Loading**: When a page loads, it immediately fetches the data required for that specific page
-2. **Background Preloading**: After the current page data is loaded, it automatically starts loading data for all other pages in parallel
-3. **Immediate Parallel Loading**: All background pages load simultaneously without delays for maximum speed
-4. **Shared Cache**: All pages benefit from the same cache, so data loaded for one page is immediately available to others
+2. **Opt-in Background Preloading**: Callers can explicitly request speculative loading for small, likely-next data sets
+3. **Server-side Jobs Pagination**: The jobs table owns its visible-page request and never preloads the full job history
+4. **Shared Cache**: Pages reuse fresh cache entries without issuing a new backend request
 
 ### Dashboard Cache Functions
 
@@ -26,7 +26,7 @@ The preloader manages these functions across all pages:
 **Base Functions (no arguments):**
 
 - `getClusters` - Used by: clusters, jobs, infra, workspaces, users
-- `getManagedJobs` - Used by: jobs, infra, workspaces, users
+- `getManagedJobsForOtherPages` - Trimmed job summary used by: infra, workspaces, users
 - `getWorkspaces` - Used by: clusters, jobs, workspaces
 - `getUsers` - Used by: users
 - `getVolumes` - Used by: volumes
@@ -38,7 +38,7 @@ The preloader manages these functions across all pages:
 **Page Requirements:**
 
 - **Clusters**: getClusters, getWorkspaces
-- **Jobs**: getManagedJobs, getClusters, getWorkspaces
+- **Jobs**: getWorkspaces, getUsers; the table fetches its own paginated data
 - **Infra**: getClusters, getManagedJobs
 - **Workspaces**: getWorkspaces, getClusters, getManagedJobs, getEnabledClouds
 - **Users**: getUsers, getClusters, getManagedJobs
@@ -49,12 +49,12 @@ The preloader manages these functions across all pages:
 ```javascript
 import cachePreloader from '@/lib/cache-preloader';
 
-// Preload for current page and background-load others
+// Preload only the current page's lightweight supporting data
 await cachePreloader.preloadForPage('clusters');
 
 // Preload with options
 await cachePreloader.preloadForPage('jobs', {
-  backgroundPreload: true, // Enable background preloading (default: true)
+  backgroundPreload: true, // Explicitly enable speculative background preloading
   force: false, // Force refresh even if cached (default: false)
 });
 
@@ -78,7 +78,7 @@ Each dashboard page automatically triggers preloading:
 // In page useEffect
 useEffect(() => {
   const initializeData = async () => {
-    // Trigger cache preloading for current page and background preload others
+    // Trigger cache preloading for the current page
     await cachePreloader.preloadForPage('clusters');
 
     // Continue with page-specific data loading
@@ -91,9 +91,9 @@ useEffect(() => {
 
 ### Performance Benefits
 
-- **Instant Page Switching**: Subsequent page loads are nearly instantaneous
-- **Parallel Loading**: All pages load simultaneously in the background for maximum speed
-- **Smart Caching**: Only loads fresh data when needed, reuses cached data otherwise
+- **Lower Request Volume**: Page loads do not fan out to unrelated dashboard endpoints
+- **Page-sized Jobs Reads**: Managed jobs stay server-paginated in browser memory
+- **Hard TTL Caching**: A fresh hit reuses data without extending its lifetime or refreshing in the background
 - **Graceful Degradation**: If preloading fails, pages still work normally
 
 ## Timeline Example
@@ -105,15 +105,12 @@ Time 0ms:    User visits /clusters
 Time 10ms:   cachePreloader.preloadForPage('clusters') called
 Time 50ms:   getClusters() and getWorkspaces() loaded (foreground)
 Time 100ms:  Clusters page renders with data
-Time 100ms:  Background loading starts for ALL other pages simultaneously
-Time 200ms:  'jobs' page data loaded (getManagedJobs, getClusters, getWorkspaces)
-Time 250ms:  'infra' page data loaded (getClusters, getManagedJobs)
-Time 400ms:  'users' page data loaded (getUsers, getClusters, getManagedJobs)
-Time 600ms:  'workspaces' page data loaded (including getEnabledClouds for all workspaces)
-Time 600ms:  All pages now cached and ready for instant switching!
+Time 100ms:  Current page renders with its foreground data
+Time 100ms:  No unrelated requests are started by default
+Time 200ms:  Jobs table fetches only its visible server-side page
 ```
 
-**Result**: By the time you would naturally switch to another page (typically 1-2 seconds), all pages are already loaded and cached, making navigation feel instant.
+**Result**: The visible page is not delayed by unrelated dashboard work. Callers may opt in to low-cost, likely-next preloads when measurements justify it.
 
 ## How to Use
 
@@ -155,8 +152,8 @@ export const CACHE_CONFIG = {
 ### Cache Behavior
 
 1. **Fresh Data**: If cached data exists and is within the TTL, it's returned immediately
-2. **Background Refresh**: When data is fetched and there is a cache hit, a
-   background refresh is triggered to pull fresh data
+2. **Hard TTL**: A cache hit neither refreshes the backend nor extends the TTL;
+   data expires based on its original fetch time
 3. **Stale Data**: If fresh data fetch fails but stale data exists, stale data is returned
 4. **Cache Miss**: If no cached data exists, fresh data is fetched and cached
 
@@ -177,7 +174,6 @@ dashboardCache.clear();
 // Get cache statistics for debugging
 const stats = dashboardCache.getStats();
 console.log('Cache size:', stats.cacheSize);
-console.log('Background jobs:', stats.backgroundJobs);
 console.log('Cache keys:', stats.keys);
 
 // Get detailed cache information for debugging
@@ -188,20 +184,6 @@ console.log('Detailed cache stats:', detailedStats);
 dashboardCache.setDebugMode(true);
 // Disable debug logging
 dashboardCache.setDebugMode(false);
-```
-
-### Cache TTL Refresh on Access
-
-By default, the cache refreshes the TTL (Time To Live) when data is accessed, preventing cache expiration during frequent page switching:
-
-```javascript
-// Default behavior - TTL is refreshed on access
-const data = await dashboardCache.get(fetchFunction);
-
-// Disable TTL refresh on access (data will expire based on original fetch time)
-const data = await dashboardCache.get(fetchFunction, [], {
-  refreshOnAccess: false,
-});
 ```
 
 ### Refresh Button Implementation
@@ -246,17 +228,15 @@ Cache keys are automatically generated based on:
 - Function name
 - Function arguments (JSON stringified)
 
-### Background Refresh
+### Request Deduplication
 
-- Triggered when cached data is past 50% of its TTL
-- Prevents multiple background jobs for the same key
-- Updates cache silently without affecting current requests
+- Concurrent cache misses for the same function and arguments share one request
+- Fresh cache hits do not start a new backend request
 
 ### Error Handling
 
 - If fresh data fetch fails and stale data exists, stale data is returned
 - If no cached data exists and fetch fails, the error is re-thrown
-- Background refresh failures are logged but don't affect the main flow
 
 ## Adding Cache to New Pages
 

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -4,10 +4,7 @@
 import dashboardCache from './cache';
 import { MANAGED_JOBS_SUMMARY_ARGS } from '@/data/connectors/constants';
 import { getClusters } from '@/data/connectors/clusters';
-import {
-  getManagedJobs,
-  getManagedJobsWithClientPagination,
-} from '@/data/connectors/jobs';
+import { getManagedJobs } from '@/data/connectors/jobs';
 import {
   getWorkspaces,
   getEnabledCloudsBatch,
@@ -22,18 +19,6 @@ import {
 } from '@/data/connectors/infra';
 import { getSSHNodePools } from '@/data/connectors/ssh-node-pools';
 
-// True when a server-side managed-jobs pagination plugin is loaded.
-// Inlined in this file rather than imported because the same one-line
-// check exists privately in jobs-cache-manager.js and the
-// data/connectors/jobs.jsx connector. Cross-file dedup is a follow-up;
-// the goal here is just to remove the duplication added by this PR.
-function isJobsPaginationPluginAvailable() {
-  return (
-    typeof window !== 'undefined' &&
-    typeof window.__skyJobsPaginationFetch === 'function'
-  );
-}
-
 /**
  * Complete list of all dashboard cache functions organized by page
  */
@@ -41,11 +26,6 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
   // Base functions used across multiple pages (no arguments)
   base: {
     getClusters: { fn: getClusters, args: [] },
-    // For jobs page - uses client-side pagination wrapper
-    getManagedJobs: {
-      fn: getManagedJobsWithClientPagination,
-      args: [{ allUsers: true }],
-    },
     // For infra/users/workspaces pages - shared cache entry.
     // Field-trimmed via MANAGED_JOBS_SUMMARY_ARGS: the untrimmed fetch
     // returns every non-finished job with full inline YAML (tens of MB at
@@ -83,18 +63,10 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
   // Page-specific function requirements
   pages: {
     clusters: ['getClusters', 'getWorkspaces'],
-    // getClusters is intentionally NOT a foreground requirement here. Its
-    // only /jobs consumer is the controller-stopped/launching banner
-    // (components/jobs.jsx), which runs only when the queue endpoint reports
-    // the controller unreachable — and fetchData already skips /status when
-    // it is reachable. Foreground-preloading it made every /jobs load await a
-    // /status -> /api/get round trip (and gate pagination re-fetches via
-    // preloadingComplete) to warm data a healthy page never reads. It is
-    // still warmed by _backgroundPreloadOtherPages (which always adds
-    // getClusters off the infra page), so the banner and Clusters-page
-    // navigation stay fast; a cold banner just falls back to an on-demand
-    // fetch.
-    jobs: ['getManagedJobs', 'getWorkspaces', 'getUsers'],
+    // The controller status banner fetches clusters only when the queue
+    // endpoint reports the controller unreachable, so a healthy jobs page
+    // does not preload it.
+    jobs: ['getWorkspaces', 'getUsers'],
     infra: [
       // Empty - infra page uses progressive loading via fetchData()
       // All infra functions are background-preloaded from other pages
@@ -116,9 +88,6 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
 class CachePreloader {
   constructor() {
     this.isPreloading = false;
-    this.preloadPromises = new Map();
-    this.recentlyPreloaded = new Map(); // Track recently preloaded functions with timestamps
-    this.PRELOAD_GRACE_PERIOD = 5000; // 5 seconds grace period
     this.pluginPages = new Map(); // Dynamically registered plugin page functions
   }
 
@@ -135,14 +104,14 @@ class CachePreloader {
   }
 
   /**
-   * Preload cache for a specific page and background-load other pages
+   * Preload cache for a specific page, with optional speculative page loading.
    * @param {string} currentPage - The page being loaded ('clusters', 'jobs', 'infra', 'workspaces', 'users')
    * @param {Object} [options] - Preload options
-   * @param {boolean} [options.backgroundPreload=true] - Whether to preload other pages in background
+   * @param {boolean} [options.backgroundPreload=false] - Whether to preload other pages in background
    * @param {boolean} [options.force=false] - Whether to force refresh even if cached
    */
   async preloadForPage(currentPage, options) {
-    const { backgroundPreload = true, force = false } = options || {};
+    const { backgroundPreload = false, force = false } = options || {};
 
     if (
       !DASHBOARD_CACHE_FUNCTIONS.pages[currentPage] &&
@@ -185,48 +154,18 @@ class CachePreloader {
         if (force) {
           dashboardCache.invalidate(fn, args);
         }
-        promises.push(
-          dashboardCache.get(fn, args).then((result) => {
-            this._markAsPreloaded(fn, args);
-            return result;
-          })
-        );
+        promises.push(dashboardCache.get(fn, args));
       }
     }
 
     for (const functionName of requiredFunctions) {
-      // Skip the unpaginated full-jobs preload when a server-side
-      // pagination plugin is loaded. Without this skip, mounting /jobs
-      // at scale (e.g. 50k+ jobs) issues a single blocking fetch for
-      // the entire job set — measured at ~26s / ~110 MB on a 50k-row
-      // PostgreSQL backend — that nothing on the page actually reads
-      // (the table reads its own paginated cache via the plugin path).
-      // The blocked executor pool then makes subsequent paginated
-      // page-click fetches feel slow even though each individual
-      // /plugins/api/pagination/jobs call is ~500 ms. The cache key
-      // the wrapper writes here ({allUsers: true} with no pagination
-      // args) doesn't match what the table or the
-      // dashboardCache.get(getManagedJobs, [{...filterOptions, page,
-      // limit}]) call sites read either, so dropping it costs nothing.
-      if (
-        functionName === 'getManagedJobs' &&
-        isJobsPaginationPluginAvailable()
-      ) {
-        continue;
-      }
       if (DASHBOARD_CACHE_FUNCTIONS.base[functionName]) {
         // Base function (no arguments)
         const { fn, args } = DASHBOARD_CACHE_FUNCTIONS.base[functionName];
         if (force) {
           dashboardCache.invalidate(fn, args);
         }
-        promises.push(
-          dashboardCache.get(fn, args).then((result) => {
-            // Mark this function as recently preloaded
-            this._markAsPreloaded(fn, args);
-            return result;
-          })
-        );
+        promises.push(dashboardCache.get(fn, args));
       } else if (functionName === 'getEnabledCloudsBatch') {
         // Dynamic function that requires workspace data
         promises.push(this._loadEnabledCloudsForAllWorkspaces(force));
@@ -346,23 +285,10 @@ class CachePreloader {
     const preloadPromises = Array.from(allOtherFunctions).map(
       async (functionName) => {
         try {
-          // Same skip as in _loadPageData: don't background-preload the
-          // unpaginated full-jobs cache when a server-side pagination
-          // plugin is present. The /jobs page reads its own paginated
-          // cache via the plugin path; nothing else reads the
-          // {allUsers: true} cache key this wrapper writes.
-          if (
-            functionName === 'getManagedJobs' &&
-            isJobsPaginationPluginAvailable()
-          ) {
-            return;
-          }
           if (DASHBOARD_CACHE_FUNCTIONS.base[functionName]) {
             // Base function (no arguments)
             const { fn, args } = DASHBOARD_CACHE_FUNCTIONS.base[functionName];
             await dashboardCache.get(fn, args);
-            // Mark this function as recently preloaded
-            this._markAsPreloaded(fn, args);
           } else if (functionName === 'getEnabledCloudsBatch') {
             // Dynamic function that requires workspace data
             await this._loadEnabledCloudsForAllWorkspaces(false);
@@ -390,7 +316,6 @@ class CachePreloader {
           dashboardCache
             .get(fn, args)
             .then(() => {
-              this._markAsPreloaded(fn, args);
               console.log(
                 `[CachePreloader] Background loaded plugin function for: ${pageName}`
               );
@@ -444,80 +369,17 @@ class CachePreloader {
   }
 
   /**
-   * Check if a function was recently preloaded (within grace period)
-   * @param {Function} fetchFunction - The function to check
-   * @param {Array} [args=[]] - Arguments to check
-   * @returns {boolean} - True if recently preloaded
-   */
-  wasRecentlyPreloaded(fetchFunction, args = []) {
-    const key = this._generateKey(fetchFunction, args);
-    const preloadTime = this.recentlyPreloaded.get(key);
-
-    if (!preloadTime) {
-      return false;
-    }
-
-    const now = Date.now();
-    const isRecent = now - preloadTime < this.PRELOAD_GRACE_PERIOD;
-
-    // Clean up expired entries
-    if (!isRecent) {
-      this.recentlyPreloaded.delete(key);
-    }
-
-    return isRecent;
-  }
-
-  /**
-   * Mark a function as recently preloaded
-   * @private
-   */
-  _markAsPreloaded(fetchFunction, args = []) {
-    const key = this._generateKey(fetchFunction, args);
-    this.recentlyPreloaded.set(key, Date.now());
-  }
-
-  /**
-   * Generate a cache key based on function name and arguments (same as DashboardCache)
-   * @private
-   */
-  _generateKey(fetchFunction, args) {
-    // Use same key generation logic as DashboardCache
-    const functionString = fetchFunction.toString();
-    const functionHash = this._simpleHash(functionString);
-    const argsHash = args.length > 0 ? JSON.stringify(args) : '';
-    return `${functionHash}_${argsHash}`;
-  }
-
-  /**
-   * Simple string hash function (same as DashboardCache)
-   * @private
-   */
-  _simpleHash(str) {
-    let hash = 5381;
-    for (let i = 0; i < str.length; i++) {
-      hash = (hash << 5) + hash + str.charCodeAt(i);
-    }
-    return hash >>> 0;
-  }
-
-  /**
    * Clear all cache and reset preloader state
    */
   clearCache() {
     dashboardCache.clear();
     this.isPreloading = false;
-    this.preloadPromises.clear();
-    this.recentlyPreloaded.clear();
     console.log('[CachePreloader] Cache cleared');
   }
 }
 
 // Create singleton instance
 const cachePreloader = new CachePreloader();
-
-// Set up coordination between cache and preloader
-dashboardCache.setPreloader(cachePreloader);
 
 export { CachePreloader, cachePreloader };
 export default cachePreloader;

--- a/sky/dashboard/src/lib/cache-preloader.test.js
+++ b/sky/dashboard/src/lib/cache-preloader.test.js
@@ -1,0 +1,47 @@
+jest.mock('./cache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() => Promise.resolve({})),
+    invalidate: jest.fn(),
+  },
+}));
+
+jest.mock('@/data/connectors/clusters', () => ({ getClusters: jest.fn() }));
+jest.mock('@/data/connectors/jobs', () => ({ getManagedJobs: jest.fn() }));
+jest.mock('@/data/connectors/workspaces', () => ({
+  getWorkspaces: jest.fn(),
+  getEnabledCloudsBatch: jest.fn(),
+}));
+jest.mock('@/data/connectors/users', () => ({ getUsers: jest.fn() }));
+jest.mock('@/data/connectors/volumes', () => ({ getVolumes: jest.fn() }));
+jest.mock('@/data/connectors/infra', () => ({
+  getEnabledCloudsList: jest.fn(),
+  getWorkspaceContexts: jest.fn(),
+  getContextGPUData: jest.fn(),
+  getSlurmInfrastructure: jest.fn(),
+}));
+jest.mock('@/data/connectors/ssh-node-pools', () => ({
+  getSSHNodePools: jest.fn(),
+}));
+
+import dashboardCache from './cache';
+import { getWorkspaces } from '@/data/connectors/workspaces';
+import { getUsers } from '@/data/connectors/users';
+import { CachePreloader } from './cache-preloader';
+
+describe('CachePreloader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('does not preload the unpaginated jobs dataset for the jobs page', async () => {
+    // The jobs table owns its paginated request; only its small supporting data is warmed.
+    const preloader = new CachePreloader();
+
+    await preloader.preloadForPage('jobs');
+
+    expect(dashboardCache.get).toHaveBeenCalledTimes(2);
+    expect(dashboardCache.get).toHaveBeenCalledWith(getWorkspaces, []);
+    expect(dashboardCache.get).toHaveBeenCalledWith(getUsers, []);
+  });
+});

--- a/sky/dashboard/src/lib/cache.js
+++ b/sky/dashboard/src/lib/cache.js
@@ -19,18 +19,8 @@ function simpleHash(str) {
 class DashboardCache {
   constructor() {
     this.cache = new Map();
-    this.backgroundJobs = new Map(); // Track ongoing background refresh jobs
     this.pendingRequests = new Map(); // Track in-flight requests to deduplicate concurrent calls
     this.debugMode = false; // Added for debug mode
-    this.preloader = null; // Reference to cache preloader for coordination
-  }
-
-  /**
-   * Set the cache preloader instance for coordination
-   * @param {Object} preloader - The cache preloader instance
-   */
-  setPreloader(preloader) {
-    this.preloader = preloader;
   }
 
   /**
@@ -39,47 +29,22 @@ class DashboardCache {
    * @param {Array} [args=[]] - Arguments to pass to the fetch function
    * @param {Object} [options={}] - Cache options
    * @param {number} [options.ttl] - Time to live in milliseconds
-   * @param {boolean} [options.refreshOnAccess] - Whether to refresh TTL on cache access (default: true)
    * @returns {Promise} - The cached or fresh data
    */
   async get(fetchFunction, args = [], options = {}) {
     const ttl = options.ttl || DEFAULT_CACHE_TTL;
-    const refreshOnAccess = options.refreshOnAccess !== false; // Default to true
     const key = this._generateKey(fetchFunction, args);
     const functionName = fetchFunction.name || 'anonymous';
 
     const cachedItem = this.cache.get(key);
     const now = Date.now();
 
-    // If we have cached data and it's not stale, return it and refresh in background
+    // A cache hit is read-only: its TTL is measured from the original fetch.
     if (cachedItem && now - cachedItem.lastUpdated < ttl) {
       const age = Math.round((now - cachedItem.lastUpdated) / 1000);
       this._debug(
         `Cache HIT for ${functionName} (age: ${age}s, TTL: ${Math.round(ttl / 1000)}s)`
       );
-
-      // Update the lastUpdated timestamp to extend the cache life on access
-      if (refreshOnAccess) {
-        this.cache.set(key, {
-          data: cachedItem.data,
-          lastUpdated: now,
-        });
-        this._debug(`Cache TTL refreshed for ${functionName}`);
-      }
-
-      // Launch background refresh if we're not already refreshing
-      // and if the data wasn't recently preloaded
-      if (!this.backgroundJobs.has(key)) {
-        const wasRecentlyPreloaded =
-          this.preloader?.wasRecentlyPreloaded(fetchFunction, args) || false;
-        if (!wasRecentlyPreloaded) {
-          this._refreshInBackground(fetchFunction, args, key);
-        } else {
-          this._debug(
-            `Skipping background refresh for ${functionName} - recently preloaded`
-          );
-        }
-      }
 
       return cachedItem.data;
     }
@@ -151,8 +116,6 @@ class DashboardCache {
   invalidate(fetchFunction, args = []) {
     const key = this._generateKey(fetchFunction, args);
     this.cache.delete(key);
-    // Also cancel any ongoing background job for this key
-    this.backgroundJobs.delete(key);
     // Also remove any pending requests
     this.pendingRequests.delete(key);
   }
@@ -176,7 +139,6 @@ class DashboardCache {
     // Delete all matching entries
     keysToDelete.forEach((key) => {
       this.cache.delete(key);
-      this.backgroundJobs.delete(key);
       this.pendingRequests.delete(key);
     });
   }
@@ -186,7 +148,6 @@ class DashboardCache {
    */
   clear() {
     this.cache.clear();
-    this.backgroundJobs.clear();
     this.pendingRequests.clear();
   }
 
@@ -215,7 +176,6 @@ class DashboardCache {
   getStats() {
     return {
       cacheSize: this.cache.size,
-      backgroundJobs: this.backgroundJobs.size,
       pendingRequests: this.pendingRequests.size,
       keys: Array.from(this.cache.keys()),
     };
@@ -234,14 +194,12 @@ class DashboardCache {
         key,
         age: Math.round(age / 1000), // Age in seconds
         lastUpdated: new Date(item.lastUpdated).toISOString(),
-        hasBackgroundJob: this.backgroundJobs.has(key),
         hasPendingRequest: this.pendingRequests.has(key),
       });
     }
 
     return {
       cacheSize: this.cache.size,
-      backgroundJobs: this.backgroundJobs.size,
       pendingRequests: this.pendingRequests.size,
       entries: entries.sort((a, b) => a.age - b.age),
     };
@@ -262,36 +220,6 @@ class DashboardCache {
     if (this.debugMode) {
       console.log(`[DashboardCache] ${message}`, ...args);
     }
-  }
-
-  /**
-   * Refresh data in the background without blocking the current request
-   * @private
-   */
-  _refreshInBackground(fetchFunction, args, key) {
-    // Mark that we have a background job running for this key
-    this.backgroundJobs.set(key, true);
-
-    // Execute the refresh asynchronously
-    fetchFunction(...args)
-      .then((freshData) => {
-        // Respect __skipCache signal from fetch function
-        if (freshData && freshData.__skipCache) {
-          return; // do not update cache
-        }
-        // Update cache with fresh data
-        this.cache.set(key, {
-          data: freshData,
-          lastUpdated: Date.now(),
-        });
-      })
-      .catch((error) => {
-        console.warn(`Background refresh failed for ${key}:`, error);
-      })
-      .finally(() => {
-        // Remove the background job marker
-        this.backgroundJobs.delete(key);
-      });
   }
 
   /**

--- a/sky/dashboard/src/lib/cache.test.js
+++ b/sky/dashboard/src/lib/cache.test.js
@@ -3,6 +3,7 @@
  */
 
 import { DashboardCache } from './cache';
+import { CACHE_CONFIG, REFRESH_INTERVALS } from './config';
 
 // Helper to create a mock async function that tracks calls
 function createMockFetch(returnValue, delay = 10) {
@@ -126,6 +127,19 @@ describe('DashboardCache', () => {
   });
 
   describe('Cache Behavior', () => {
+    test('should refresh default cache entries on the page refresh cadence', async () => {
+      // Default cache expiry preserves 30-second page updates without
+      // background requests on fresh cache hits.
+      const mockFetch = jest.fn(async () => ({ data: 'test' }));
+
+      await cache.get(mockFetch, ['arg1']);
+      jest.advanceTimersByTime(CACHE_CONFIG.DEFAULT_TTL + 1);
+      await cache.get(mockFetch, ['arg1']);
+
+      expect(CACHE_CONFIG.DEFAULT_TTL).toBe(REFRESH_INTERVALS.REFRESH_INTERVAL);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     test('should return cached data when available and fresh', async () => {
       // Fresh data is returned without extending its TTL or starting a refresh.
       jest.useRealTimers(); // Use real timers for this test

--- a/sky/dashboard/src/lib/cache.test.js
+++ b/sky/dashboard/src/lib/cache.test.js
@@ -72,6 +72,7 @@ describe('DashboardCache', () => {
     });
 
     test('should handle sequential requests using cache', async () => {
+      // A fresh cache hit must suppress backend work until the original TTL expires.
       const mockFetch = createMockFetch({ data: 'test' }, 50);
 
       // First request
@@ -83,9 +84,7 @@ describe('DashboardCache', () => {
       const promise2 = cache.get(mockFetch, ['arg1']);
       await promise2;
 
-      // Should use cache for second request, but cache also triggers
-      // a background refresh, so we expect 2 calls total
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     test('should cleanup pending requests after completion', async () => {
@@ -128,6 +127,7 @@ describe('DashboardCache', () => {
 
   describe('Cache Behavior', () => {
     test('should return cached data when available and fresh', async () => {
+      // Fresh data is returned without extending its TTL or starting a refresh.
       jest.useRealTimers(); // Use real timers for this test
       const mockFetch = createMockFetch({ data: 'test' }, 10);
 
@@ -139,8 +139,7 @@ describe('DashboardCache', () => {
 
       expect(result1).toEqual({ data: 'test' });
       expect(result2).toEqual({ data: 'test' });
-      // First call is the initial fetch, second is background refresh
-      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     test('should fetch fresh data when cache is stale', async () => {

--- a/sky/dashboard/src/lib/config.js
+++ b/sky/dashboard/src/lib/config.js
@@ -1,14 +1,15 @@
 // Configuration for dashboard cache and UI settings
 
-// Cache TTL durations (in milliseconds)
-export const CACHE_CONFIG = {
-  DEFAULT_TTL: 2 * 60 * 1000, // 2 minutes
-};
-
 // Refresh intervals for different data types (in milliseconds)
 export const REFRESH_INTERVALS = {
   REFRESH_INTERVAL: 30 * 1000, // 30 seconds - standard refresh interval for all pages
   GPU_REFRESH_INTERVAL: 30 * 1000, // 30 seconds - aligned with standard refresh interval
+};
+
+// Cache TTL durations (in milliseconds). A hard TTL matches the dashboard's
+// periodic refresh cadence without turning every cache hit into a request.
+export const CACHE_CONFIG = {
+  DEFAULT_TTL: REFRESH_INTERVALS.REFRESH_INTERVAL,
 };
 
 // UI configuration

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -1,8 +1,8 @@
 // Smart cache manager for managed jobs with pagination support
-// This manager handles both default path (fetch all, paginate client-side)
-// and plugin path (fetch exact page from server)
+// This manager fetches and caches only the requested server-side pages.
 
 import dashboardCache from './cache';
+import { REFRESH_INTERVALS } from './config';
 import { getManagedJobs } from '@/data/connectors/jobs';
 
 // Check if the jobs pagination plugin is available
@@ -22,14 +22,10 @@ class JobsCacheManager {
   constructor() {
     // Cache for paginated data, keyed by full options (including page, limit, sort)
     this.pageCache = new Map();
-    // Cache for full datasets (default path only), keyed by filter combination
-    this.fullDataCache = new Map();
     // Track ongoing requests to prevent duplicate fetches
     this.pendingRequests = new Map();
-    // Track background prefetch jobs for full datasets
-    this.backgroundPrefetching = new Map();
-    // TTL for cache entries (2 minutes)
-    this.cacheTTL = 2 * 60 * 1000;
+    // Keep normal table refreshes aligned with the configured 30-second cadence.
+    this.cacheTTL = REFRESH_INTERVALS.REFRESH_INTERVAL;
   }
 
   /**
@@ -71,7 +67,7 @@ class JobsCacheManager {
 
   /**
    * Generate a filter-only key (excludes pagination/sorting)
-   * Used for full dataset caching in default path
+   * Used to invalidate all cached pages for the same filters.
    */
   _generateFilterKey(options) {
     const {
@@ -107,25 +103,6 @@ class JobsCacheManager {
   }
 
   /**
-   * Group tasks by job_id and return unique job IDs in order
-   */
-  _groupTasksByJob(tasks) {
-    const jobMap = new Map();
-    const jobOrder = [];
-
-    for (const task of tasks) {
-      const jobId = task.id;
-      if (!jobMap.has(jobId)) {
-        jobMap.set(jobId, []);
-        jobOrder.push(jobId);
-      }
-      jobMap.get(jobId).push(task);
-    }
-
-    return { jobMap, jobOrder };
-  }
-
-  /**
    * Default path: Fetch a single page immediately for fast UI response
    * This fetches only the requested page, not the full dataset
    */
@@ -142,13 +119,19 @@ class JobsCacheManager {
     console.log('[JobsCacheManager] Default path: fetching single page', page);
 
     // Fetch the specific page using getManagedJobs with pagination params
-    const pageResponse = await dashboardCache.get(getManagedJobs, [
-      {
-        ...filterOptions,
-        page,
-        limit,
-      },
-    ]);
+    const pageResponse = await dashboardCache.get(
+      getManagedJobs,
+      [
+        {
+          ...filterOptions,
+          page,
+          limit,
+          sortBy,
+          sortOrder,
+        },
+      ],
+      { ttl: this.cacheTTL }
+    );
 
     if (pageResponse.__skipCache) {
       return pageResponse;
@@ -201,81 +184,6 @@ class JobsCacheManager {
       fromCache: false,
       cacheStatus: 'default_path_single_page',
     };
-  }
-
-  /**
-   * Default path background prefetch: Fetch ALL jobs and populate cache for all pages
-   * This is called in the background after the initial page load
-   */
-  async _loadFullDatasetAndCacheAllPages(options) {
-    const {
-      page = 1,
-      limit = 10,
-      sortBy,
-      sortOrder,
-      ...filterOptions
-    } = options;
-    const filterKey = this._generateFilterKey(filterOptions);
-
-    console.log('[JobsCacheManager] Background: fetching full dataset');
-
-    // Fetch all jobs without pagination
-    const fullDataResponse = await dashboardCache.get(getManagedJobs, [
-      filterOptions,
-    ]);
-
-    if (fullDataResponse.__skipCache || fullDataResponse.controllerStopped) {
-      return;
-    }
-
-    const allJobs = fullDataResponse.jobs || [];
-    const { jobMap, jobOrder } = this._groupTasksByJob(allJobs);
-    const totalJobs = jobOrder.length;
-
-    // Store the full dataset for future page calculations
-    this.fullDataCache.set(filterKey, {
-      jobs: allJobs,
-      jobMap,
-      jobOrder,
-      totalJobs,
-      totalNoFilter: fullDataResponse.totalNoFilter || totalJobs,
-      statusCounts: fullDataResponse.statusCounts || {},
-      timestamp: Date.now(),
-    });
-
-    // Calculate and cache all pages
-    const totalPages = Math.ceil(totalJobs / limit) || 1;
-    for (let p = 1; p <= totalPages; p++) {
-      const startIdx = (p - 1) * limit;
-      const endIdx = startIdx + limit;
-      const pageJobIds = jobOrder.slice(startIdx, endIdx);
-      const pageJobs = [];
-      for (const jobId of pageJobIds) {
-        pageJobs.push(...jobMap.get(jobId));
-      }
-
-      const pageCacheKey = this._generateCacheKey({
-        ...filterOptions,
-        page: p,
-        limit,
-        sortBy,
-        sortOrder,
-      });
-
-      this.pageCache.set(pageCacheKey, {
-        jobs: pageJobs,
-        total: totalJobs,
-        totalNoFilter: fullDataResponse.totalNoFilter || totalJobs,
-        totalPages,
-        hasNext: p < totalPages,
-        hasPrev: p > 1,
-        controllerStopped: false,
-        statusCounts: fullDataResponse.statusCounts || {},
-        timestamp: Date.now(),
-      });
-    }
-
-    console.log('[JobsCacheManager] Background: cached', totalPages, 'pages');
   }
 
   /**
@@ -394,7 +302,7 @@ class JobsCacheManager {
    * Get paginated jobs data with intelligent caching
    * - Checks cache first (keyed by all parameters including page, limit, sort)
    * - On cache miss, uses plugin path if available, otherwise default path
-   * - Default path: fetches single page immediately, then prefetches full dataset in background
+   * - Prefetches at most the immediately following server page
    *
    * @param {Object} options - Query options including pagination
    * @returns {Promise<{jobs: Array, total: number, totalNoFilter: number, totalPages: number, hasNext: boolean, hasPrev: boolean, controllerStopped: boolean, statusCounts: Object, fromCache: boolean, cacheStatus: string}>}
@@ -402,7 +310,6 @@ class JobsCacheManager {
   async getPaginatedJobs(options = {}) {
     const { page = 1, limit = 10 } = options;
     const cacheKey = this._generateCacheKey(options);
-    const filterKey = this._generateFilterKey(options);
 
     console.log('[JobsCacheManager] getPaginatedJobs called:', {
       page,
@@ -451,14 +358,6 @@ class JobsCacheManager {
       try {
         const result = await populatePromise;
 
-        // For default path, kick off background prefetch of full dataset
-        if (
-          !isPluginAvailable() &&
-          !this.backgroundPrefetching.has(filterKey)
-        ) {
-          this._kickOffBackgroundPrefetch(options, filterKey);
-        }
-
         return result;
       } finally {
         this.pendingRequests.delete(cacheKey);
@@ -467,23 +366,6 @@ class JobsCacheManager {
       console.error('[JobsCacheManager] Error in getPaginatedJobs:', error);
       throw error;
     }
-  }
-
-  /**
-   * Kick off background prefetch of full dataset (default path only)
-   */
-  _kickOffBackgroundPrefetch(options, filterKey) {
-    console.log('[JobsCacheManager] Kicking off background prefetch');
-
-    const prefetchPromise = this._loadFullDatasetAndCacheAllPages(options)
-      .catch((err) => {
-        console.warn('[JobsCacheManager] Background prefetch failed:', err);
-      })
-      .finally(() => {
-        this.backgroundPrefetching.delete(filterKey);
-      });
-
-    this.backgroundPrefetching.set(filterKey, prefetchPromise);
   }
 
   /**
@@ -507,11 +389,7 @@ class JobsCacheManager {
     console.log('[JobsCacheManager] Prefetching page', nextPage);
 
     try {
-      // For plugin path, prefetch the specific page
-      if (isPluginAvailable()) {
-        await this._populateCachePluginPath(nextOptions);
-      }
-      // For default path, all pages are already cached when we load full data
+      await this.getPaginatedJobs(nextOptions);
     } catch (error) {
       console.warn('[JobsCacheManager] Prefetch failed:', error);
     }
@@ -562,17 +440,10 @@ class JobsCacheManager {
       // Invalidate specific cache key
       const cacheKey = this._generateCacheKey(options);
       this.pageCache.delete(cacheKey);
-
-      // Also invalidate related filter key for full data cache and background prefetch
-      const filterKey = this._generateFilterKey(options);
-      this.fullDataCache.delete(filterKey);
-      this.backgroundPrefetching.delete(filterKey);
     } else {
       // Clear all cache
       this.pageCache.clear();
-      this.fullDataCache.clear();
       this.pendingRequests.clear();
-      this.backgroundPrefetching.clear();
     }
 
     // Also invalidate the underlying dashboard cache
@@ -606,9 +477,6 @@ class JobsCacheManager {
         // Skip malformed keys
       }
     }
-
-    // Also remove full data cache for this filter
-    this.fullDataCache.delete(filterKey);
   }
 
   /**
@@ -617,9 +485,7 @@ class JobsCacheManager {
   getCacheStats() {
     return {
       pageCacheSize: this.pageCache.size,
-      fullDataCacheSize: this.fullDataCache.size,
       pendingRequestsCount: this.pendingRequests.size,
-      backgroundPrefetchingCount: this.backgroundPrefetching.size,
       isPluginAvailable: isPluginAvailable(),
       cachedKeys: Array.from(this.pageCache.keys()).map((k) => {
         try {

--- a/sky/dashboard/src/lib/jobs-cache-manager.test.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.test.js
@@ -1,0 +1,69 @@
+jest.mock('./cache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    invalidateFunction: jest.fn(),
+  },
+}));
+
+jest.mock('@/data/connectors/jobs', () => ({
+  getManagedJobs: jest.fn(),
+}));
+
+import dashboardCache from './cache';
+import { getManagedJobs } from '@/data/connectors/jobs';
+import { JobsCacheManager } from './jobs-cache-manager';
+
+describe('JobsCacheManager', () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new JobsCacheManager();
+    jest.clearAllMocks();
+    dashboardCache.get.mockImplementation((_fetchFunction, [options]) =>
+      Promise.resolve({
+        jobs: [{ id: options.page }],
+        total: 3,
+        totalNoFilter: 3,
+        statusCounts: {},
+        controllerStopped: false,
+      })
+    );
+  });
+
+  test('forwards sort options when fetching a visible page', async () => {
+    // Sorting must reach the paginated backend query rather than fragmenting cache keys.
+    await manager.getPaginatedJobs({
+      allUsers: true,
+      page: 1,
+      limit: 10,
+      sortBy: 'workspace',
+      sortOrder: 'asc',
+    });
+
+    expect(dashboardCache.get).toHaveBeenCalledWith(
+      getManagedJobs,
+      [
+        expect.objectContaining({
+          page: 1,
+          limit: 10,
+          sortBy: 'workspace',
+          sortOrder: 'asc',
+        }),
+      ],
+      expect.any(Object)
+    );
+  });
+
+  test('prefetches only the next server page', async () => {
+    // Warming page two must not request the complete managed-job history.
+    await manager.prefetchNextPage({ allUsers: true, page: 1, limit: 10 });
+
+    expect(dashboardCache.get).toHaveBeenCalledWith(
+      getManagedJobs,
+      [expect.objectContaining({ page: 2, limit: 10 })],
+      expect.any(Object)
+    );
+    expect(dashboardCache.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1972,7 +1972,7 @@ def get_managed_jobs_with_filters(
         sort_by: Field to sort by. Valid values: 'job_id', 'id', 'job_name',
             'name', 'submitted_at', 'status', 'job_duration', 'duration',
             'recovery_count', 'recoveries', 'resources', 'user_hash', 'user',
-            'cloud', 'infra'.
+            'cloud', 'infra', 'workspace', 'pool'.
         sort_order: Sort direction, 'asc' or 'desc'. Defaults to 'desc'.
 
     Returns:
@@ -2000,6 +2000,8 @@ def get_managed_jobs_with_filters(
         'user': job_info_table.c.user_hash,
         'cloud': job_info_table.c.cloud,
         'infra': job_info_table.c.cloud,  # Sort by cloud for infra
+        'workspace': job_info_table.c.workspace,
+        'pool': job_info_table.c.pool,
     }
 
     engine = _db_manager.get_engine()

--- a/sky/skylet/services.py
+++ b/sky/skylet/services.py
@@ -497,6 +497,10 @@ class ManagedJobsServiceImpl(managed_jobsv1_pb2_grpc.ManagedJobsServiceServicer
                 if request.HasField('pool_match') else None,
                 page=request.page if request.HasField('page') else None,
                 limit=request.limit if request.HasField('limit') else None,
+                sort_by=request.sort_by
+                if request.HasField('sort_by') else None,
+                sort_order=request.sort_order
+                if request.HasField('sort_order') else None,
                 user_hashes=user_hashes,
                 statuses=statuses,
                 fields=fields,

--- a/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
+++ b/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
@@ -360,6 +360,39 @@ class TestGetJobTable:
         assert 'ws1' in workspaces
         assert 'ws2' in workspaces
 
+    def test_get_job_table_forwards_sort_fields(self):
+        """Forward optional gRPC sort fields to the queue query."""
+        request = managed_jobsv1_pb2.GetJobTableRequest(sort_by='workspace',
+                                                        sort_order='asc')
+        queue_result = {
+            'jobs': [],
+            'total': 0,
+            'total_no_filter': 0,
+            'status_counts': {},
+        }
+
+        with mock.patch(
+                'sky.skylet.services.managed_job_utils.get_managed_job_queue',
+                return_value=queue_result) as get_queue:
+            self.service.GetJobTable(request, mock.Mock())
+
+        assert get_queue.call_args.kwargs['sort_by'] == 'workspace'
+        assert get_queue.call_args.kwargs['sort_order'] == 'asc'
+
+    def test_get_job_table_sorts_by_workspace(self):
+        """Sort jobs by workspace through the RPC and database query path."""
+        request = managed_jobsv1_pb2.GetJobTableRequest(
+            accessible_workspaces=managed_jobsv1_pb2.Workspaces(
+                workspaces=['ws1', 'ws2']),
+            fields=managed_jobsv1_pb2.Fields(fields=['workspace']),
+            sort_by='workspace',
+            sort_order='asc')
+
+        response = self.service.GetJobTable(request, mock.Mock())
+
+        assert [job.workspace for job in response.jobs
+               ] == sorted(job.workspace for job in response.jobs)
+
     def test_get_job_table_no_accessible_workspaces(self):
         """Test basic GetJobTable functionality without specified accessible
          workspaces - should return all jobs."""


### PR DESCRIPTION
## Summary

- Remove unpaginated managed-job foreground and full-history background prefetches; warm at most the next server page.
- Make dashboard cache hits read-only and make cross-page preloading opt-in.
- Keep batch tables on the normal 30-second cadence instead of invalidating and reloading every second.
- Forward table sorting through the browser connector, controller RPC, and managed-job state query.

## Tested

- [x] Full dashboard Jest suite: 21 suites, 194 tests
- [x] Dashboard lint, Prettier format check, and production build
- [x] Focused managed-job controller/database tests: TestGetJobTable
- [x] Python formatting and mypy
- [ ] Cloud smoke tests (maintainer-only CI commands)

Note: pylint reports pre-existing violations throughout tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py; this PR introduces no new pylint finding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->