### PR TITLE
[Core] Escape special characters in task env substitutions

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -118,7 +118,12 @@ def _fill_in_env_vars(
     def replace_var(match):
         var_name = match.group(1)
         # If the variable isn't in the dictionary, return it unchanged
-        return task_envs.get(var_name, match.group(0))
+        value = task_envs.get(var_name)
+        if value is None:
+            return match.group(0)
+        # The replacement is inserted into an existing JSON string, so escape
+        # its contents without adding another pair of quotes.
+        return json.dumps(value)[1:-1]
 
     # Pattern for valid env var names in bash.
     pattern = r'\$\{?\b([a-zA-Z_][a-zA-Z0-9_]*)\b\}?'

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -589,6 +589,32 @@ def test_from_yaml_config_env_and_secrets_overrides_independent():
     assert combined == expected_combined
 
 
+@pytest.mark.parametrize('value', [
+    'say "hello"',
+    'models\\bitnet',
+    'first line\nsecond line',
+    'column\tvalue',
+])
+def test_from_yaml_config_escapes_substituted_env_values(value):
+    config = {
+        'envs': {
+            'PROMPT': value,
+        },
+        'service': {
+            'readiness_probe': {
+                'path': '/health',
+                'post_data': {
+                    'prompt': '$PROMPT',
+                },
+            },
+        },
+    }
+
+    task_obj = task.Task.from_yaml_config(config)
+
+    assert task_obj.service.post_data == {'prompt': value}
+
+
 def test_docker_login_config_all_in_envs_or_secrets():
     """Test Docker login config when all variables are in envs OR all in secrets."""
 


### PR DESCRIPTION
Task environment variables are substituted into structured YAML fields by serializing those fields to JSON, replacing placeholders, and parsing the result. The replacement previously inserted environment values verbatim, so valid values containing JSON-special characters such as quotes, backslashes, newlines, or tabs corrupted the intermediate JSON and raised `JSONDecodeError` during `Task.from_yaml_config()`.

This change JSON-escapes each substituted value before inserting it into the existing JSON string. It preserves the current placeholder syntax and leaves unknown variables unchanged.

Regression coverage exercises the public task parsing path through `service.readiness_probe.post_data` with each affected character class.

Tested (run the relevant ones):

- [x] Code formatting: `PATH="$PWD/.venv/bin:$PATH" bash format.sh --files sky/task.py tests/unit_tests/test_sky/test_task.py`
- [x] Any manual or new tests for this PR:
  - `python -m pytest -q -n 0 tests/unit_tests/test_sky/test_task.py`
  - `python -m pytest -q tests/unit_tests/test_sky/test_task.py::test_from_yaml_config_escapes_substituted_env_values`
  - `python -m py_compile sky/task.py tests/unit_tests/test_sky/test_task.py`
- [ ] All smoke tests: not required; this change only affects local task configuration parsing
- [ ] Relevant individual smoke tests: not required; no cloud resources are involved
- [ ] Backward compatibility: no client/server API or serialized payload changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->