### PR TITLE
fix(jobs): apply worker autodown after cloud selection

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -463,8 +463,12 @@ def _execute_dag(
                 stages.remove(Stage.DOWN)
             if idle_minutes_to_autostop >= 0:
                 if down:
-                    requested_features.add(
-                        clouds.CloudImplementationFeatures.AUTODOWN)
+                    if not _is_launched_by_jobs_controller:
+                        requested_features.add(
+                            clouds.CloudImplementationFeatures.AUTODOWN)
+                    # Managed-job worker autodown is a best-effort leak
+                    # failsafe. It must not constrain cloud selection; support
+                    # is checked against the launched resources below.
                 else:
                     requested_features.add(
                         clouds.CloudImplementationFeatures.AUTOSTOP)
@@ -643,13 +647,39 @@ def _execute_dag(
             if idle_minutes_to_autostop is not None:
                 assert isinstance(backend, backends.CloudVmRayBackend)
                 assert isinstance(handle, backends.CloudVmRayResourceHandle)
-                backend.set_autostop(handle,
-                                     idle_minutes_to_autostop,
-                                     wait_for,
-                                     down,
-                                     hook=hook,
-                                     hook_timeout=hook_timeout,
-                                     hooks=hooks_payload)
+                set_autostop = True
+                if down and _is_launched_by_jobs_controller:
+                    launched_resources = (
+                        handle.launched_resources.assert_launchable())
+                    cloud = launched_resources.cloud
+                    assert cloud is not None
+                    try:
+                        cloud.check_features_are_supported(
+                            launched_resources,
+                            {clouds.CloudImplementationFeatures.AUTODOWN})
+                    except exceptions.NotSupportedError as e:
+                        # Worker autodown only guards against controller
+                        # failure; normal job completion tears down the
+                        # cluster. Do not reject or move an otherwise valid
+                        # worker solely to install this failsafe.
+                        set_autostop = False
+                        job_logger.debug(
+                            'Skipping managed-job worker autodown on '
+                            f'{cloud}: {common_utils.format_exception(e)}')
+                if set_autostop:
+                    backend.set_autostop(handle,
+                                         idle_minutes_to_autostop,
+                                         wait_for,
+                                         down,
+                                         hook=hook,
+                                         hook_timeout=hook_timeout,
+                                         hooks=hooks_payload)
+                elif hooks_payload is not None:
+                    # Autodown may be unsupported, but lifecycle hooks are
+                    # independent and still need to be persisted.
+                    kwargs = _compute_set_autostop_args_for_hooks_only_relaunch(
+                        handle.cluster_name, hooks_payload)
+                    backend.set_autostop(handle, **kwargs)
             elif hooks_payload is not None:
                 # Hooks can fire on preemption/down independent of
                 # autostop — persist them even when autostop is disabled.

--- a/tests/unit_tests/test_execution.py
+++ b/tests/unit_tests/test_execution.py
@@ -1,0 +1,180 @@
+"""Unit tests for execution internals."""
+
+from unittest import mock
+
+import pytest
+
+from sky import backends
+from sky import clouds
+from sky import dag as dag_lib
+from sky import execution
+from sky import resources as resources_lib
+from sky import task as task_lib
+
+
+def _execute_dag(task,
+                 backend,
+                 handle,
+                 *,
+                 jobs_controller,
+                 stages,
+                 dryrun=False):
+    dag = dag_lib.Dag()
+    dag.add(task)
+    return execution._execute_dag(
+        dag,
+        dryrun=dryrun,
+        stream_logs=False,
+        handle=handle,
+        backend=backend,
+        retry_until_up=False,
+        optimize_target=execution.common.OptimizeTarget.COST,
+        stages=stages,
+        cluster_name=None,
+        detach_setup=False,
+        no_setup=False,
+        clone_disk_from=None,
+        skip_unnecessary_provisioning=False,
+        resize=False,
+        _quiet_optimizer=True,
+        _is_launched_by_jobs_controller=jobs_controller,
+        _is_launched_by_sky_serve_controller=False,
+        _extra_launch_context={})
+
+
+@pytest.mark.parametrize(
+    'jobs_controller,expected_feature',
+    [(False, clouds.CloudImplementationFeatures.AUTODOWN), (True, None)],
+)
+def test_managed_job_autodown_does_not_constrain_cloud_selection(
+        monkeypatch, jobs_controller, expected_feature):
+    resource = resources_lib.Resources(cloud=clouds.AWS(),
+                                       autostop={
+                                           'idle_minutes': 10,
+                                           'down': True
+                                       })
+    task = task_lib.Task().set_resources(resource)
+    task.best_resources = resource
+    backend = backends.CloudVmRayBackend()
+    backend.register_info = mock.MagicMock()
+    backend.provision = mock.MagicMock(return_value=(None, False))
+
+    _execute_dag(task,
+                 backend,
+                 None,
+                 jobs_controller=jobs_controller,
+                 stages=[execution.Stage.PROVISION],
+                 dryrun=True)
+
+    features = backend.register_info.call_args.kwargs['requested_features']
+    if expected_feature is None:
+        assert clouds.CloudImplementationFeatures.AUTODOWN not in features
+        assert clouds.CloudImplementationFeatures.AUTOSTOP not in features
+    else:
+        assert expected_feature in features
+
+
+@pytest.mark.parametrize('cloud,supported', [(clouds.AWS(), True),
+                                             (clouds.Verda(), False)])
+def test_managed_job_autodown_is_applied_after_cloud_selection(
+        monkeypatch, cloud, supported):
+    resource = resources_lib.Resources(cloud=cloud,
+                                       instance_type='test-instance',
+                                       autostop={
+                                           'idle_minutes': 10,
+                                           'down': True
+                                       })
+    task = task_lib.Task().set_resources(resource)
+    task.best_resources = resource
+    backend = backends.CloudVmRayBackend()
+    backend.register_info = mock.MagicMock()
+    backend.set_autostop = mock.MagicMock()
+
+    class FakeHandle:
+        launched_resources = resource
+
+    monkeypatch.setattr(backends, 'CloudVmRayResourceHandle', FakeHandle)
+    _execute_dag(task,
+                 backend,
+                 FakeHandle(),
+                 jobs_controller=True,
+                 stages=[execution.Stage.PRE_EXEC])
+
+    assert backend.set_autostop.called is supported
+
+
+@pytest.mark.parametrize('resources', [
+    [resources_lib.Resources(autostop={
+        'idle_minutes': 10,
+        'down': True
+    })],
+    [
+        resources_lib.Resources(cloud=clouds.Verda(),
+                                autostop={
+                                    'idle_minutes': 10,
+                                    'down': True
+                                }),
+        resources_lib.Resources(cloud=clouds.AWS(),
+                                autostop={
+                                    'idle_minutes': 10,
+                                    'down': True
+                                }),
+    ],
+])
+def test_managed_job_implicit_and_fallback_candidates_remain_feasible(
+        resources):
+    task = task_lib.Task().set_resources(resources)
+    task.best_resources = resources[0]
+    backend = backends.CloudVmRayBackend()
+    backend.register_info = mock.MagicMock()
+    backend.provision = mock.MagicMock(return_value=(None, False))
+
+    _execute_dag(task,
+                 backend,
+                 None,
+                 jobs_controller=True,
+                 stages=[execution.Stage.PROVISION],
+                 dryrun=True)
+
+    features = backend.register_info.call_args.kwargs['requested_features']
+    assert clouds.CloudImplementationFeatures.AUTODOWN not in features
+    assert clouds.CloudImplementationFeatures.AUTOSTOP not in features
+
+
+def test_unsupported_managed_job_autodown_still_persists_hooks(monkeypatch):
+    hooks = [{'events': ['down'], 'run': 'echo cleanup'}]
+    resource = resources_lib.Resources(cloud=clouds.Verda(),
+                                       instance_type='test-instance',
+                                       autostop={
+                                           'idle_minutes': 10,
+                                           'down': True
+                                       },
+                                       hooks=hooks)
+    task = task_lib.Task().set_resources(resource)
+    task.best_resources = resource
+    backend = backends.CloudVmRayBackend()
+    backend.register_info = mock.MagicMock()
+    backend.set_autostop = mock.MagicMock()
+
+    class FakeHandle:
+        cluster_name = 'worker'
+        launched_resources = resource
+
+    normalized_hooks = resource.hooks
+    assert normalized_hooks is not None
+    hooks_only_args = {'idle_minutes': -1, 'hooks': normalized_hooks}
+    compute_args = mock.MagicMock(return_value=hooks_only_args)
+    monkeypatch.setattr(backends, 'CloudVmRayResourceHandle', FakeHandle)
+    monkeypatch.setattr(execution,
+                        '_compute_set_autostop_args_for_hooks_only_relaunch',
+                        compute_args)
+
+    handle = FakeHandle()
+    _execute_dag(task,
+                 backend,
+                 handle,
+                 jobs_controller=True,
+                 stages=[execution.Stage.PRE_EXEC])
+
+    compute_args.assert_called_once_with('worker', normalized_hooks)
+    backend.set_autostop.assert_called_once_with(handle, **hooks_only_args)


### PR DESCRIPTION
## Problem

Fixes #10390. Supersedes #10394.

Managed-job worker autodown is a best-effort leak failsafe, but passing `down=True` currently adds `AUTODOWN` to required cloud features before optimization. This causes two problems on clouds such as Verda that do not support autodown:

- an implicit/unpinned request can fail after selecting Verda;
- a request with Verda and an autodown-capable fallback can be pushed off Verda because the failsafe filters candidates.

## Fix

Keep managed-job worker autodown out of `requested_features`, so it cannot affect cloud selection. During `PRE_EXEC`, after provisioning resolves the launched resources:

- install autodown when the selected cloud supports it;
- skip only the failsafe when `AUTODOWN` is unsupported;
- continue persisting lifecycle hooks on the unsupported path.

Normal user-requested autodown remains strict and continues requiring `AUTODOWN` before provisioning.

## Tests

Added credential-free unit/dry-run coverage for:

- managed jobs excluding autodown from required features;
- normal launches retaining strict autodown requirements;
- implicit/unpinned and mixed Verda/AWS candidates remaining feasible;
- AWS installing worker autodown after selection;
- Verda skipping worker autodown after selection;
- lifecycle hooks surviving the unsupported-autodown path.

Validated locally:

- `tests/unit_tests/test_execution.py`
- `tests/unit_tests/test_lifecycle_hooks.py`
- `tests/unit_tests/test_sky/jobs/test_recovery_strategy.py`
- `tests/unit_tests/test_sky/jobs/test_controller.py`

---

*This code was generated using GPT-5.6 in Pi Coding Agent.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->