### PR TITLE
[CI] Notify the downstream nightly on no-op cycles too

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -322,13 +322,24 @@ jobs:
           git push origin "${TAG}"
           echo "Created and pushed ${TAG} -> ${{ github.sha }}"
 
-  # After a nightly is published, dispatch the downstream repo's workflow so it
-  # can react without polling PyPI. Fail-loud: a missing secret, bad App creds,
-  # or a non-204 turns the run red rather than silently skipping.
+  # Dispatch the downstream repo's workflow so it can react to this nightly
+  # cycle without polling PyPI. Two paths, so *every* scheduled cycle hands off
+  # exactly once:
+  #   - published: a new nightly cleared publish-and-validate-both. The new
+  #     version travels in the payload.
+  #   - no-op: check-date found no new commits in the last 24h, so nothing was
+  #     built and there is no version to hand over. `no_new_nightly=true` says
+  #     so explicitly, leaving it to the downstream workflow to decide what
+  #     base to use -- this job does not guess one on its behalf.
+  # A cycle that *did* build and then failed notifies nobody: neither branch of
+  # the condition holds, so nothing downstream is built on an unvalidated
+  # nightly.
+  # Fail-loud: a missing secret, bad App creds, or a non-204 turns the run red
+  # rather than silently skipping.
   notify-downstream:
     runs-on: ubuntu-latest
     needs: [check-date, nightly-build-pypi, publish-and-validate-both]
-    if: ${{ always() && needs.publish-and-validate-both.result == 'success' }}
+    if: ${{ always() && (needs.publish-and-validate-both.result == 'success' || needs.check-date.outputs.should_run == 'false') }}
     steps:
       - name: Parse downstream repo
         id: parse
@@ -363,15 +374,29 @@ jobs:
           DISPATCH_WORKFLOW: ${{ secrets.NIGHTLY_DOWNSTREAM_WORKFLOW }}
           DISPATCH_REF: ${{ secrets.NIGHTLY_DOWNSTREAM_REF || 'main' }}
           NIGHTLY_VERSION: ${{ needs.nightly-build-pypi.outputs.version }}
+          # 'true' only on the no-op path, where nightly-build-pypi was skipped
+          # and NIGHTLY_VERSION is therefore empty.
+          NO_NEW_NIGHTLY: ${{ needs.check-date.outputs.should_run == 'false' }}
         run: |
-          echo "Dispatching ${DISPATCH_WORKFLOW} on ${DISPATCH_REPO}@${DISPATCH_REF} (version=${NIGHTLY_VERSION})"
+          echo "Dispatching ${DISPATCH_WORKFLOW} on ${DISPATCH_REPO}@${DISPATCH_REF}" \
+               "(version=${NIGHTLY_VERSION:-<none>}, no_new_nightly=${NO_NEW_NIGHTLY})"
+          # Build the payload with jq rather than hand-escaped JSON: the inputs
+          # are interpolated secrets/outputs, and a stray quote in any of them
+          # would otherwise produce a malformed body and a confusing 422.
+          # workflow_dispatch inputs must be strings over the REST API, so the
+          # boolean is sent as "true"/"false" for the callee to compare as text.
+          payload=$(jq -n \
+            --arg ref "${DISPATCH_REF}" \
+            --arg version "${NIGHTLY_VERSION}" \
+            --arg no_new_nightly "${NO_NEW_NIGHTLY}" \
+            '{ref: $ref, inputs: {version: $version, no_new_nightly: $no_new_nightly}}')
           http_code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' \
             -X POST \
             -H 'Accept: application/vnd.github+json' \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             "https://api.github.com/repos/${DISPATCH_REPO}/actions/workflows/${DISPATCH_WORKFLOW}/dispatches" \
-            -d "{\"ref\":\"${DISPATCH_REF}\",\"inputs\":{\"version\":\"${NIGHTLY_VERSION}\"}}")
+            -d "${payload}")
           if [[ "${http_code}" != "204" ]]; then
             echo "::error::Downstream dispatch to ${DISPATCH_REPO} (${DISPATCH_WORKFLOW}) failed with HTTP ${http_code}."
             echo "Response body:"


### PR DESCRIPTION
## Problem

`notify-downstream` only fires after a nightly is published:

```yaml
if: ${{ always() && needs.publish-and-validate-both.result == 'success' }}
```

So a scheduled cycle that `check-date` short-circuits — no new commits on `master` in the last 24h — builds nothing and hands off to nobody. There are three possible cycle outcomes and only one of them notifies:

| Cycle outcome | `check-date` | Published | Dispatch today |
|---|---|---|---|
| New commits, tests pass | `should_run=true` | yes | ✅ |
| New commits, tests fail | `should_run=true` | no | ❌ (correct) |
| **No new commits** | `should_run=false` | no | ❌ **(the gap)** |

A consumer that needs exactly one signal per cycle is forced to infer that third row by polling this repo's run list. That poll cannot distinguish *"today's run is a no-op"* from *"today's run has not been created yet"* — both look like an empty result. And the window in which it's wrong is not small: GitHub's dispatch latency for this `0 0 * * *` schedule has ranged from **~17 to ~80 minutes** over the last two weeks, with the cron value unchanged since May. No lookback window fixes this, because early enough the run simply does not exist yet.

## Change

Report the no-op case explicitly rather than leaving it to be inferred.

- `notify-downstream` now runs on both the published path and the no-op path.
- The dispatch payload carries a `no_new_nightly` flag, so the callee knows the cycle produced no version. This job deliberately **does not** pick a base on the callee's behalf — it reports state, nothing more.
- A cycle that built and then **failed** still notifies nobody, so no consumer is nudged toward an unvalidated nightly. Neither branch of the condition holds in that case.

Payloads sent:

```jsonc
// published
{"ref":"main","inputs":{"version":"1.0.0.dev20260820","no_new_nightly":"false"}}
// no-op
{"ref":"main","inputs":{"version":"","no_new_nightly":"true"}}
```

Drive-by: the payload is now built with `jq` instead of hand-escaped JSON. Every value is an interpolated secret or job output, and a stray quote produced a malformed body and a confusing 422.

## Rollout note

The downstream workflow must declare the `no_new_nightly` input **before** this lands — `workflow_dispatch` rejects an undeclared input with a 422.

## Test plan

- `actionlint` on the workflow: no new findings (the two pre-existing `smoke-tests-runpod-minimal` / SC2086 reports are unchanged, only shifted by line offset).
- Both payload shapes verified by running the `jq` invocation with the published and no-op env values.
- `if:` condition traced against all three cycle outcomes in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JemgnhogrKymDkTJgku9Va
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->