### PR TITLE
[Volumes] Filter the volume listing to the caller's accessible workspaces

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2999,14 +2999,27 @@ def _volume_record_from_row(row: Any) -> Dict[str, Any]:
 
 
 @metrics_lib.time_me
-def get_volumes(is_ephemeral: Optional[bool] = None) -> List[Dict[str, Any]]:
+def get_volumes(
+    is_ephemeral: Optional[bool] = None,
+    workspaces_filter: Optional[Set[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Get volumes from the database.
+
+    Args:
+        is_ephemeral: If specified, only include volumes with this
+            ephemerality.
+        workspaces_filter: If specified, only include volumes whose workspace
+            is in this set. Use workspace names.
+    """
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
-        if is_ephemeral is None:
-            rows = session.query(volume_table).all()
-        else:
-            rows = session.query(volume_table).filter_by(
-                is_ephemeral=int(is_ephemeral)).all()
+        query = session.query(volume_table)
+        if is_ephemeral is not None:
+            query = query.filter_by(is_ephemeral=int(is_ephemeral))
+        if workspaces_filter is not None:
+            query = query.filter(
+                volume_table.c.workspace.in_(workspaces_filter))
+        rows = query.all()
     return [_volume_record_from_row(row) for row in rows]
 
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -19,6 +19,8 @@ from sky.utils import rich_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
 from sky.utils import volume as volume_utils
+from sky.workspaces import constants as workspace_constants
+from sky.workspaces import core as workspaces_core
 
 logger = sky_logging.init_logger(__name__)
 
@@ -206,6 +208,9 @@ def volume_list(
 ) -> List[responses.VolumeRecord]:
     """Gets volumes from the database.
 
+    Only volumes in workspaces the calling user can read are returned, matching
+    how clusters and managed jobs are already listed.
+
     Args:
         is_ephemeral: Whether to include ephemeral volumes.
         refresh: If True, refresh volume state from cloud APIs before returning.
@@ -238,8 +243,14 @@ def volume_list(
     """
     if refresh:
         volume_refresh()
+    # Visibility, not usability: read-only workspaces' volumes must be listed.
+    # See the same call in jobs/server/core.py for managed jobs and in
+    # backend_utils for clusters.
+    accessible_workspaces = workspaces_core.get_accessible_workspace_names(
+        action=workspace_constants.WORKSPACE_ACTION_READ)
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
-        volumes = global_user_state.get_volumes(is_ephemeral=is_ephemeral)
+        volumes = global_user_state.get_volumes(
+            is_ephemeral=is_ephemeral, workspaces_filter=accessible_workspaces)
         all_users = global_user_state.get_all_users()
         user_map = {user.id: user.name for user in all_users}
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -241,13 +241,22 @@ def volume_list(
             }
         ]
     """
-    if refresh:
-        volume_refresh()
     # Visibility, not usability: read-only workspaces' volumes must be listed.
     # See the same call in jobs/server/core.py for managed jobs and in
     # backend_utils for clusters.
     accessible_workspaces = workspaces_core.get_accessible_workspace_names(
         action=workspace_constants.WORKSPACE_ACTION_READ)
+    if refresh:
+        # Keep the reconcile proportional to what this caller can see: a user
+        # who reads one workspace should not drive cloud API calls against
+        # contexts reachable only from another. volume_refresh groups its cloud
+        # calls by the (context, namespace) pairs of the volumes it is handed,
+        # so narrowing the set narrows the calls. The daemon in
+        # sky/server/daemons.py still refreshes the whole table.
+        volume_refresh(volume_names=[
+            volume['name'] for volume in global_user_state.get_volumes(
+                workspaces_filter=accessible_workspaces)
+        ])
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
         volumes = global_user_state.get_volumes(
             is_ephemeral=is_ephemeral, workspaces_filter=accessible_workspaces)

--- a/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
+++ b/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
@@ -1,0 +1,112 @@
+"""Listing volumes must not cross a workspace boundary.
+
+Clusters and managed jobs are both filtered to the caller's accessible
+workspaces; these tests pin the same behavior for volumes.
+"""
+
+from unittest import mock
+
+import pytest
+import sqlalchemy
+
+from sky import global_user_state
+from sky import models
+from sky.utils import status_lib
+from sky.volumes.server import core as volumes_core
+from sky.workspaces import constants as workspace_constants
+
+_ACTIVE_WORKSPACE = 'sky.global_user_state.skypilot_config.get_active_workspace'
+
+
+@pytest.fixture()
+def isolated_database(tmp_path):
+    """A real database: these tests are about the query, not about mocks."""
+    global_user_state._db_manager._engine = sqlalchemy.create_engine(
+        f'sqlite:///{tmp_path / "state.db"}')
+    global_user_state.create_table(global_user_state._db_manager.get_engine())
+    yield
+    global_user_state._db_manager._engine = None
+
+
+def _add(name: str, workspace: str, is_ephemeral: bool = False) -> None:
+    """Adds a volume owned by ``workspace``.
+
+    add_volume records the workspace that is active at creation time, so the
+    only way to seed a table spanning workspaces is to move the active one.
+    """
+    with mock.patch(_ACTIVE_WORKSPACE, return_value=workspace):
+        global_user_state.add_volume(
+            name,
+            models.VolumeConfig(
+                name=name,
+                cloud='kubernetes',
+                type='k8s-pvc',
+                region='my-context',
+                zone=None,
+                size='1Gi',
+                config={},
+                name_on_cloud=f'{name}-on-cloud',
+            ),
+            status_lib.VolumeStatus.READY,
+            is_ephemeral=is_ephemeral,
+        )
+
+
+def _seed_two_workspaces() -> None:
+    _add('vol-a', workspace='ws-a')
+    _add('vol-b', workspace='ws-b')
+
+
+def test_filters_to_the_given_workspaces(isolated_database):
+    _seed_two_workspaces()
+
+    records = global_user_state.get_volumes(workspaces_filter={'ws-a'})
+
+    assert [r['name'] for r in records] == ['vol-a']
+
+
+def test_no_filter_returns_every_workspace(isolated_database):
+    """Callers that must see the whole table -- the refresh daemon and the
+    duplicate-backend-resource check -- pass no filter."""
+    _seed_two_workspaces()
+
+    records = global_user_state.get_volumes()
+
+    assert sorted(r['name'] for r in records) == ['vol-a', 'vol-b']
+
+
+def test_empty_filter_returns_nothing(isolated_database):
+    """An empty set means "no accessible workspaces", not "no filter": a
+    truthiness check here would show such a caller everything."""
+    _seed_two_workspaces()
+
+    assert global_user_state.get_volumes(workspaces_filter=set()) == []
+
+
+def test_composes_with_ephemerality(isolated_database):
+    _add('vol-a-persistent', workspace='ws-a', is_ephemeral=False)
+    _add('vol-a-ephemeral', workspace='ws-a', is_ephemeral=True)
+    _add('vol-b-persistent', workspace='ws-b', is_ephemeral=False)
+
+    records = global_user_state.get_volumes(is_ephemeral=False,
+                                            workspaces_filter={'ws-a'})
+
+    assert [r['name'] for r in records] == ['vol-a-persistent']
+
+
+def test_volume_list_only_returns_accessible_workspaces(isolated_database):
+    """End to end through volume_list: a caller who can read only ws-a must
+    not be told that ws-b's volume exists, nor who owns it."""
+    _seed_two_workspaces()
+
+    with mock.patch.object(volumes_core.workspaces_core,
+                           'get_accessible_workspace_names',
+                           return_value={'ws-a'}) as accessible:
+        records = volumes_core.volume_list()
+
+    assert [r.name for r in records] == ['vol-a']
+    # READ, not WRITE: a workspace that is only read-only-visible to a
+    # non-member still has its volumes listed, exactly as its clusters and
+    # jobs already are.
+    accessible.assert_called_once_with(
+        action=workspace_constants.WORKSPACE_ACTION_READ)

--- a/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
+++ b/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
@@ -110,3 +110,22 @@ def test_volume_list_only_returns_accessible_workspaces(isolated_database):
     # jobs already are.
     accessible.assert_called_once_with(
         action=workspace_constants.WORKSPACE_ACTION_READ)
+
+
+def test_refresh_is_scoped_to_the_accessible_workspaces(isolated_database):
+    """A caller who reads one workspace must not drive a full-table reconcile.
+
+    volume_refresh groups its cloud calls by (context, namespace) taken from
+    the volumes it was handed, so refreshing rows the caller cannot see means
+    touching contexts reachable only from another workspace.
+    """
+    _seed_two_workspaces()
+
+    with mock.patch.object(volumes_core.workspaces_core,
+                           'get_accessible_workspace_names',
+                           return_value={'ws-a'}):
+        with mock.patch.object(volumes_core,
+                               'volume_refresh') as volume_refresh:
+            volumes_core.volume_list(refresh=True)
+
+    volume_refresh.assert_called_once_with(volume_names=['vol-a'])


### PR DESCRIPTION
# Volumes: filter the volume listing to the caller's accessible workspaces

Fixes skypilot-org/skypilot#10530

## Problem

Cluster and managed job listings are both filtered to the workspaces the calling user can read. The volume listing is not.

`sky volumes ls` (and `GET /volumes`) returns every row of the API server's volume table to any authenticated user, regardless of workspace grants. Each record carries the volume's name, its workspace, the owner's identity, size, cloud/region, the backing resource name, and the clusters using it. On a shared API server that is cross-workspace metadata disclosure: a user granted one workspace can enumerate the volumes — and the owners — of every other one.

What this PR fixes is the listing. It is not a claim that the mount path is enforced: `VolumeMount.resolve()` has no workspace check either, so a cross-workspace mount fails only incidentally, when the two workspaces happen to resolve to different contexts or namespaces. See the "Remaining gaps" section.

This reads as an oversight rather than a design choice: both already-filtered call sites use the identical resolver, and the managed-jobs one carries a comment cross-referencing the clusters one, so the pattern was consciously carried from the first listing to a second. Volumes, added later, were skipped — and `get_accessible_workspace_names`' own docstring enumerates its consumers as "clusters/jobs".

## Changes

* `global_user_state.get_volumes()` gains `workspaces_filter: Optional[Set[str]]`, mirroring `get_clusters()`.
* `volume_list()` resolves the caller's readable workspaces with `get_accessible_workspace_names(action=WORKSPACE_ACTION_READ)` and passes them down.
* `volume_list(refresh=True)` resolves those workspaces **before** refreshing and passes the accessible volumes' names to `volume_refresh()`, which has taken a named subset since skypilot-org/skypilot#10452. Previously the refresh ran first and unscoped, so a caller who can read one workspace drove a whole-table reconcile — cloud API calls against contexts they cannot see — and then got a filtered list back. The refresh groups its cloud calls by the `(context, namespace)` pairs of the volumes it is handed, so narrowing the set narrows the calls, not only the database work.

`READ`, not `WRITE`: a workspace that is only read-only-visible to a non-member must still have its volumes listed, exactly as its clusters and jobs already are.

### Deliberately not filtered

* The background refresh daemon (`sky/server/daemons.py`) passes no names and keeps reconciling the whole table — it is not acting for a caller.
* `_check_duplicate_backend_resource()` must be able to detect a collision with a volume in another workspace.
* `get_volumes_from_names()` takes no new parameter — its callers are server-side paths that already know which names they want.

### Objections checked

* **Admins keep the full view for free.** When the permission service is disabled or the caller is an admin, `_writable_workspace_names` returns `None` and the resolver returns all requested workspace names, so no special-casing is needed here.
* **No backwards-compatibility hole.** `volume_table.workspace` carries `server_default=SKYPILOT_DEFAULT_WORKSPACE`, byte-identical to `cluster_table.workspace`, so there are no NULL-workspace rows to strand.
* **Empty set means "see nothing".** The check is `is not None`, not truthiness — a caller with no accessible workspaces must not fall through to an unfiltered query.
* **An empty accessible set refreshes nothing.** `get_volumes_from_names()` short-circuits on an empty list, so it does not fall through to the whole table.

### Remaining gaps, not addressed here

Filed separately during review, none of them regressions introduced by this PR:

* skypilot-org/skypilot#10535 — the candidate set comes from the loaded workspace config, so a volume whose workspace has left the config drops out of the filtered listing for every caller, admins included.
* skypilot-org/skypilot#10536 — the write side of the same boundary: `volume_delete()` resolves by name via the unfiltered `get_volume_by_name()` and never reads the record's workspace, and there is no `check_volume_write_permission` counterpart to `check_cluster_write_permission`. `VolumeMount.resolve()` uses the same unfiltered lookup.
* skypilot-org/skypilot#10537 — the dashboard volumes table has no Workspace column or filter, so this scoping is invisible in the UI.

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Six new unit tests in `tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py`, written against a real SQLite database rather than mock assertions:

* filters to the given workspaces
* no filter still returns every workspace (the daemon and duplicate-check callers)
* an empty filter returns nothing
* composes with the `is_ephemeral` filter
* `volume_list()` end to end, asserting the resolver is called with `WORKSPACE_ACTION_READ`
* `volume_list(refresh=True)` passes only the accessible workspaces' volume names to `volume_refresh()`

Negative control: with the two source files reverted to the merge base, 5 of the 6 fail; the one that passes is the intended backwards-compatibility guard (no filter returns every workspace).

The existing `tests/unit_tests/test_sky/volumes/` suite passes unmodified — including `test_get_volumes_filter_is_ephemeral`, which asserts `filter_by` is used for ephemerality, so that call is retained and the new predicate is chained after it. `format.sh` clean (yapf, isort, mypy, pylint 10.00/10).

Smoke tests not run — the `/`-prefixed CI commands are repo-member only, and this change is server-side listing logic with no provisioning path. Happy for a maintainer to trigger them.