### PR TITLE
[Core] Don't serialize an absent config path as the JSON string 'null'

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -247,7 +247,12 @@ def _get_loaded_config_path() -> List[Optional[str]]:
 def _set_loaded_config_path(
         path: Optional[Union[str, List[Optional[str]]]]) -> None:
     if not path:
+        # Store the empty case as None rather than the serialized string
+        # 'null': the latter travels to the API server on every request that
+        # carries a config override, where json.loads() turns it back into
+        # None instead of a list.
         _get_config_context().config_path = None
+        return
     if isinstance(path, str):
         path = [path]
     _get_config_context().config_path = json.dumps(path)
@@ -926,7 +931,13 @@ def override_skypilot_config(
     if override_config_path_serialized is None:
         override_config_path = []
     else:
+        # A client may serialize the absence of a config path as the JSON
+        # string 'null', which json.loads() turns into None. Normalize it the
+        # same way _get_loaded_config_path() does, so the value stays a list
+        # for the concatenation below.
         override_config_path = json.loads(override_config_path_serialized)
+        if override_config_path is None:
+            override_config_path = []
 
     disallowed_diff_keys = []
     for key in constants.SKIPPED_CLIENT_OVERRIDE_KEYS:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Test skypilot_config"""
 import copy
+import json
 import os
 import pathlib
 import shutil
@@ -737,6 +738,40 @@ def test_override_skypilot_config_without_original_config(
         ('aws', 'ssh_proxy_command'), None) is None
     assert os.environ.get(skypilot_config.ENV_VAR_SKYPILOT_CONFIG) is None
     assert not skypilot_config._get_loaded_config()
+
+
+def test_set_loaded_config_path_empty_is_not_serialized_null():
+    """An absent config path must be stored as None, not the string 'null'."""
+    original = skypilot_config.loaded_config_path_serialized()
+    try:
+        skypilot_config._set_loaded_config_path(None)
+        assert skypilot_config.loaded_config_path_serialized() is None
+        assert skypilot_config._get_loaded_config_path() == []
+    finally:
+        skypilot_config._set_loaded_config_path_serialized(original)
+
+
+def test_override_skypilot_config_with_null_config_path(monkeypatch, tmp_path):
+    """override_skypilot_config tolerates a config path serialized as 'null'.
+
+    A client with no config file (e.g. one whose config comes from the DB
+    backend) can send the JSON string 'null' as its config path. json.loads()
+    turns that into None, which used to be concatenated with a list.
+    """
+    os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
+    config_path = tmp_path / 'config.yaml'
+    _create_config_file(config_path)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    skypilot_config.reload_config()
+
+    override_configs = {'aws': {'vpc_name': 'override-vpc'}}
+    with skypilot_config.override_skypilot_config(override_configs,
+                                                  json.dumps(None)):
+        assert skypilot_config.get_nested(('aws', 'vpc_name'),
+                                          None) == 'override-vpc'
+        loaded_paths = skypilot_config._get_loaded_config_path()
+        assert isinstance(loaded_paths, list)
+        assert str(config_path) in loaded_paths
 
 
 def test_hierarchical_client_config(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

A client with no SkyPilot config *file* — e.g. one whose config comes from the DB backend (`SKYPILOT_DB_CONNECTION_URI`) — serializes its config path as the JSON string `"null"`, and every request it makes that carries a config override then fails server-side with `TypeError: can only concatenate list (not "NoneType") to list`.

Two one-line-ish causes, both in `sky/skypilot_config.py`:

- **`_set_loaded_config_path()` produces the `"null"`.** The `if not path:` branch assigns `config_path = None` but does not return, so execution falls through to `_get_config_context().config_path = json.dumps(path)` — i.e. `json.dumps(None)` == `"null"` — immediately overwriting it. `_reload_config_as_server()` calls it with `server_config_path`, which is `None` when the config lives in the DB rather than a file.
- **`override_skypilot_config()` doesn't normalize the parsed value.** It guards only the *missing* case (`... is None`), then does a bare `json.loads(override_config_path_serialized)`; `json.loads("null")` is `None`, which is later concatenated with a list at `_set_loaded_config_path(_get_loaded_config_path() + override_config_path)`.

The sibling reader in the same file, `_get_loaded_config_path()`, already has exactly the guard that's missing here:

```python
config_paths = json.loads(serialized)
if config_paths is None:
    return []
```

Fixing the producer alone would leave already-deployed clients broken, so this does both: the setter returns after storing the empty case, and the server-side parse normalizes `None` to `[]` the same way the existing reader does. That keeps old clients that still send `"null"` working.

Closes #10520.

## Tested

- `pytest tests/test_config.py` — 47 passed. (`test_k8s_config_with_override` and `test_k8s_config_with_invalid_config` fail identically on unmodified `master` in my environment; they need a Kubernetes setup I don't have.)
- Two new regression tests in `tests/test_config.py`, both verified **red before / green after** the `skypilot_config.py` change:
  - `test_set_loaded_config_path_empty_is_not_serialized_null` — pins that an absent path is stored as `None`, not `"null"`.
  - `test_override_skypilot_config_with_null_config_path` — drives `override_skypilot_config()` with `json.dumps(None)` as the serialized path and asserts the override still applies (previously `TypeError`).
- `yapf` and `isort` report no changes to the added lines.

Manual verification of the root cause, independent of SkyPilot:

```python
>>> import json
>>> json.dumps(None)          # what _set_loaded_config_path fell through to
'null'
>>> json.loads('null')        # what override_skypilot_config got back
>>> json.loads('null') + []
TypeError: can only concatenate list (not "NoneType") to list
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->