### PR TITLE
[GCP] Map all single-GPU G4 shapes for RTX PRO 6000

### DIFF
--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -129,7 +129,12 @@ _ACC_INSTANCE_TYPE_DICTS = {
         8: ['a4-highgpu-8g'],
     },
     'RTXPRO6000': {
-        1: ['g4-standard-48'],
+        1: [
+            'g4-standard-6',
+            'g4-standard-12',
+            'g4-standard-24',
+            'g4-standard-48',
+        ],
         2: ['g4-standard-96'],
         4: ['g4-standard-192'],
         8: ['g4-standard-384'],

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -23,14 +23,25 @@ from sky.utils import resources_utils
 
 
 def test_gcp_rtxpro6000_instance_type_mapping():
-    # RTXPRO6000 (GCP G4) maps to g4-standard-{48,96,192,384} for 1/2/4/8 GPUs.
+    # RTXPRO6000 (GCP G4) maps to every g4-standard-* shape GCP bundles the GPU
+    # with. All four of g4-standard-{6,12,24,48} carry exactly one GPU, so a
+    # 1-GPU request must not be forced onto the 48-vCPU host (8x the price of
+    # g4-standard-6 for the same accelerator). Mirrors the L4/G2 entry.
     assert gcp_catalog._ACC_INSTANCE_TYPE_DICTS['RTXPRO6000'] == {
-        1: ['g4-standard-48'],
+        1: [
+            'g4-standard-6',
+            'g4-standard-12',
+            'g4-standard-24',
+            'g4-standard-48',
+        ],
         2: ['g4-standard-96'],
         4: ['g4-standard-192'],
         8: ['g4-standard-384'],
     }
     expected = {
+        'g4-standard-6': 1,
+        'g4-standard-12': 1,
+        'g4-standard-24': 1,
         'g4-standard-48': 1,
         'g4-standard-96': 2,
         'g4-standard-192': 4,
@@ -42,9 +53,10 @@ def test_gcp_rtxpro6000_instance_type_mapping():
         }
 
 
-@pytest.mark.parametrize(
-    'instance_type',
-    ['g4-standard-48', 'g4-standard-96', 'g4-standard-192', 'g4-standard-384'])
+@pytest.mark.parametrize('instance_type', [
+    'g4-standard-6', 'g4-standard-12', 'g4-standard-24', 'g4-standard-48',
+    'g4-standard-96', 'g4-standard-192', 'g4-standard-384'
+])
 def test_gcp_g4_uses_hyperdisk_balanced(instance_type):
     # G4 only supports hyperdisk-balanced (no pd-* support), like n4/a4.
     tier2name = gcp_volume_utils.get_data_disk_tier_mapping(instance_type)


### PR DESCRIPTION
## Summary

`_ACC_INSTANCE_TYPE_DICTS['RTXPRO6000']` maps 1 GPU to `g4-standard-48` only, so a single-GPU request is forced onto the 48-vCPU host even though GCP bundles one RTX PRO 6000 with **four** different G4 shapes. This PR adds the three missing ones.

The 2/4/8 entries were already correct and are unchanged.

### Ground truth

From GCP's own `machineTypes.list` rather than docs:

```console
$ gcloud compute machine-types list --filter="zone:us-west1-a AND name~^g4-" \
    --format="table(name,guestCpus,memoryMb,accelerators[].guestAcceleratorCount)"
NAME             CPUS  MEMORY_GB  GUEST_ACCELERATOR_COUNT
g4-standard-6      6      22.00   [1]
g4-standard-12    12      45.00   [1]
g4-standard-24    24      90.00   [1]
g4-standard-48    48     180.00   [1]
g4-standard-96    96     360.00   [2]
g4-standard-192  192     720.00   [4]
g4-standard-384  384    1440.00   [8]
```

### Impact

All four 1-GPU shapes are already in the published catalog, so this needs no fetcher or catalog change. Since the optimizer picks the cheapest candidate, the mapping gap is a straight overcharge for a 1-GPU request (us-west1, on-demand, catalog v8):

| | instance | host $/hr | accelerator $/hr | **all-in $/hr** |
|---|---|---|---|---|
| before | `g4-standard-48` | 3.40428 | 1.09565 | **4.49993** |
| after | `g4-standard-6` | 0.42260 | 1.09565 | **1.51825** |

That is **2.96x** for the same accelerator. The accelerator component is identical either way — the entire difference is host vCPU/RAM the request never asked for. Users who want the larger host still get it via `--cpus` / `--memory`, which `get_instance_type_for_cpus_mem_impl` continues to honour.

> **Correction (2026-08-21).** An earlier revision of this description said **8.06x**, comparing `3.40428` with `0.42260`. Those are the **host** components only: `get_hourly_cost()` on GCP returns the host VM price with the accelerator factored out, so neither figure is what a user pays. The all-in comparison is 4.49993 vs 1.51825 = 2.96x. The defect and the fix are unchanged; only the magnitude was overstated.

### Why this shape

It mirrors the existing `L4` entry, which likewise lists every 1-GPU G2 shape rather than only the largest, so no new mechanism is introduced. The call sites that consume the dict (`get_instance_type_for_accelerator`, `get_gpu_df`, `check_accelerator_attachable_to_host`) already handle multi-shape lists.

The G4 hyperdisk-balanced rule in `sky/provision/gcp/volume_utils.py` keys on the `g4` series prefix, so the added shapes are already covered there. The existing test is widened from four shapes to all seven.

Follow-up to #9634, which added G4/RTX PRO 6000 support.

Tested (run the relevant ones):

- [x] Code formatting: `yapf==0.32.0 --diff` clean, `isort==5.12.0 --check-only` clean, `mypy==1.19.1 --check-untyped-defs` clean on the changed file, and `pylint==2.14.5 --load-plugins pylint_quotes` introduces **no new findings** (identical 23-message set before and after the change).
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

**Manual tests**

`pytest tests/unit_tests/test_gcp.py tests/unit_tests/test_catalog.py` — 90 passed.

`test_gcp_rtxpro6000_instance_type_mapping` and `test_gcp_g4_uses_hyperdisk_balanced` were updated to cover all seven G4 shapes. I mutation-tested the updated assertion by reverting `gcp_catalog.py` to the previous 1-GPU list: the test fails (exit 1), and passes again once restored (exit 0), so it genuinely guards the mapping.

Against a live catalog read, `1x RTXPRO6000` in `us-west1`:

```
get_instance_type_for_accelerator('RTXPRO6000', 1, region='us-west1', zone='us-west1-a')
  before -> ['g4-standard-48']
  after  -> ['g4-standard-6']

# all-in, host + accelerator (get_hourly_cost is HOST ONLY on GCP):
  g4-standard-48  $3.40428 host + $1.09565 accel = $4.49993/hr
  g4-standard-6   $0.42260 host + $1.09565 accel = $1.51825/hr
```

No live launch was performed; a launch smoke test needs a project holding `GPUS_PER_GPU_FAMILY` / `gpu_family=NVIDIA_RTX_PRO_6000` quota in the target region.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
