### PR TITLE
[API] Tell the user why a parked request is still waiting

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1858,6 +1858,22 @@ def _parked_launch_reason(job_id: int, task_id: Optional[int]) -> Optional[str]:
         return None
 
 
+def _waiting_line_detail(provision_msg: Optional[str],
+                         parked_reason: Optional[str]) -> Optional[str]:
+    """The detail line shown under "Waiting for task to start", if any.
+
+    A live cluster-launch status wins: its headline is what the job is doing
+    right now. When there is none the launch may have parked -- which ends its
+    rich status, so nothing is relayed any more -- and then the parked request's
+    own message is the only thing that still says what the job waits for.
+    """
+    headline = (None if provision_msg is None else
+                _provision_status_headline(provision_msg))
+    if headline is not None:
+        return headline
+    return parked_reason
+
+
 def stream_logs_by_id(
         job_id: int,
         follow: bool = True,
@@ -2294,24 +2310,16 @@ def stream_logs_by_id(
                     # the live cluster-launch status, so it's clear the job is
                     # waiting on its cluster to be provisioned.
                     provision_msg = _latest_provision_status_msg()
-                    # Show only the blue headline of the cluster-launch status
-                    # as a secondary detail under the waiting line; show nothing
-                    # when there is no headline to display.
-                    headline = (None if provision_msg is None else
-                                _provision_status_headline(provision_msg))
-                    if headline is None:
-                        # No live launch status: the launch may have parked
-                        # (which ends its rich status), and then its own
-                        # message is the only thing that still says what the
-                        # job is waiting for. Read once per status check, not
-                        # once per second like this loop.
-                        if not parked_reason_read:
-                            parked_reason_read = True
-                            parked_reason = _parked_launch_reason(
-                                job_id, task_id)
-                        headline = parked_reason
-                    provision_str = (''
-                                     if headline is None else f'\n  {headline}')
+                    if (provision_msg is None or
+                            _provision_status_headline(provision_msg) is None
+                       ) and not parked_reason_read:
+                        # Nothing live to show: read the parked reason, once per
+                        # status check rather than once per second like this
+                        # loop.
+                        parked_reason_read = True
+                        parked_reason = _parked_launch_reason(job_id, task_id)
+                    detail = _waiting_line_detail(provision_msg, parked_reason)
+                    provision_str = ('' if detail is None else f'\n  {detail}')
                     msg = _JOB_WAITING_STATUS_MESSAGE.format(
                         status_str=status_str,
                         provision_str=provision_str,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1822,11 +1822,18 @@ def _parked_launch_reason(job_id: int, task_id: Optional[int]) -> Optional[str]:
     waiting line loses the one explanation it had. The parked request keeps
     carrying that explanation in its status message, so read it from there.
 
-    Best-effort by design: this runs wherever the log stream runs -- the API
-    server under consolidation, the controller host otherwise -- and any
-    failure (no requests database in this context, a schema difference, a
-    concurrent write) returns None, which leaves the caller showing exactly
-    what it showed before.
+    The request being read is co-located in both topologies, which is not
+    obvious: under consolidation the controller *is* the API server, and on a
+    dedicated controller this code runs on the controller host (the log stream
+    gets there via ``ManagedJobCodeGen.stream_logs`` + ``run_on_head``) while
+    the controller submits its launches to its own local API server -- see
+    ``recovery_strategy.ENV_VARS_TO_CLEAR``, which clears
+    ``SKY_API_SERVER_URL_ENV_VAR`` precisely so that a local server is used
+    there. So the launch request is in the store this reads, either way.
+
+    Best-effort regardless: any failure (no requests database in this context,
+    a schema difference, a concurrent write) returns None, which leaves the
+    caller showing exactly what it showed before.
     """
     try:
         task_name = managed_job_state.get_task_name(job_id, task_id or 0)

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1858,6 +1858,13 @@ def _parked_launch_reason(job_id: int, task_id: Optional[int]) -> Optional[str]:
         return None
 
 
+def _live_headline(provision_msg: Optional[str]) -> Optional[str]:
+    """The headline of a relayed cluster-launch status, if it has one."""
+    if provision_msg is None:
+        return None
+    return _provision_status_headline(provision_msg)
+
+
 def _waiting_line_detail(provision_msg: Optional[str],
                          parked_reason: Optional[str]) -> Optional[str]:
     """The detail line shown under "Waiting for task to start", if any.
@@ -1867,8 +1874,7 @@ def _waiting_line_detail(provision_msg: Optional[str],
     rich status, so nothing is relayed any more -- and then the parked request's
     own message is the only thing that still says what the job waits for.
     """
-    headline = (None if provision_msg is None else
-                _provision_status_headline(provision_msg))
+    headline = _live_headline(provision_msg)
     if headline is not None:
         return headline
     return parked_reason
@@ -2310,9 +2316,8 @@ def stream_logs_by_id(
                     # the live cluster-launch status, so it's clear the job is
                     # waiting on its cluster to be provisioned.
                     provision_msg = _latest_provision_status_msg()
-                    if (provision_msg is None or
-                            _provision_status_headline(provision_msg) is None
-                       ) and not parked_reason_read:
+                    if (_live_headline(provision_msg) is None and
+                            not parked_reason_read):
                         # Nothing live to show: read the parked reason, once per
                         # status check rather than once per second like this
                         # loop.

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -46,6 +46,7 @@ from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.schemas.api import responses
+from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
@@ -1812,6 +1813,44 @@ def _provision_status_headline(provision_msg: str) -> Optional[str]:
     return None
 
 
+def _parked_launch_reason(job_id: int, task_id: Optional[int]) -> Optional[str]:
+    """The status message of a parked cluster launch for this job, if any.
+
+    A launch that parks (``exceptions.ExecutionPausedError`` -- waiting on a
+    cluster lock, on queue admission, ...) ends its rich status, so the
+    provisioning headline relayed into the controller log goes away and the
+    waiting line loses the one explanation it had. The parked request keeps
+    carrying that explanation in its status message, so read it from there.
+
+    Best-effort by design: this runs wherever the log stream runs -- the API
+    server under consolidation, the controller host otherwise -- and any
+    failure (no requests database in this context, a schema difference, a
+    concurrent write) returns None, which leaves the caller showing exactly
+    what it showed before.
+    """
+    try:
+        task_name = managed_job_state.get_task_name(job_id, task_id or 0)
+        if task_name is None:
+            return None
+        cluster_name = generate_managed_job_cluster_name(task_name, job_id)
+        parked = requests_lib.get_request_tasks(
+            requests_lib.RequestTaskFilter(
+                status=[requests_lib.RequestStatus.WAITING],
+                cluster_names=[cluster_name],
+                include_request_names=['sky.launch'],
+                fields=['status_msg', 'created_at'],
+                sort=True,
+                limit=1,
+            ))
+        if not parked:
+            return None
+        return parked[0].status_msg or None
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not read the parked launch reason for job '
+                     f'{job_id}: {e}')
+        return None
+
+
 def stream_logs_by_id(
         job_id: int,
         follow: bool = True,
@@ -2233,6 +2272,7 @@ def stream_logs_by_id(
                 logger.debug(
                     f'INFO: The log is not ready yet{status_str}. '
                     f'Waiting for {JOB_STATUS_CHECK_GAP_SECONDS} seconds.')
+                parked_reason = _parked_launch_reason(job_id, task_id)
                 # Poll the controller log frequently for provisioning spinner
                 # updates, but only re-check the (more expensive) managed job
                 # status every JOB_STATUS_CHECK_GAP_SECONDS.
@@ -2248,6 +2288,13 @@ def stream_logs_by_id(
                     # when there is no headline to display.
                     headline = (None if provision_msg is None else
                                 _provision_status_headline(provision_msg))
+                    if headline is None:
+                        # No live launch status: the launch may have parked
+                        # (which ends its rich status), and then its own
+                        # message is the only thing that still says what the
+                        # job is waiting for. Read on the outer cadence only --
+                        # this loop spins once a second.
+                        headline = parked_reason
                     provision_str = (''
                                      if headline is None else f'\n  {headline}')
                     msg = _JOB_WAITING_STATUS_MESSAGE.format(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2272,7 +2272,11 @@ def stream_logs_by_id(
                 logger.debug(
                     f'INFO: The log is not ready yet{status_str}. '
                     f'Waiting for {JOB_STATUS_CHECK_GAP_SECONDS} seconds.')
-                parked_reason = _parked_launch_reason(job_id, task_id)
+                # Looked up lazily below: a normally provisioning job has a
+                # live headline and never needs it, and this runs once per
+                # status check per streaming client.
+                parked_reason: Optional[str] = None
+                parked_reason_read = False
                 # Poll the controller log frequently for provisioning spinner
                 # updates, but only re-check the (more expensive) managed job
                 # status every JOB_STATUS_CHECK_GAP_SECONDS.
@@ -2292,8 +2296,12 @@ def stream_logs_by_id(
                         # No live launch status: the launch may have parked
                         # (which ends its rich status), and then its own
                         # message is the only thing that still says what the
-                        # job is waiting for. Read on the outer cadence only --
-                        # this loop spins once a second.
+                        # job is waiting for. Read once per status check, not
+                        # once per second like this loop.
+                        if not parked_reason_read:
+                            parked_reason_read = True
+                            parked_reason = _parked_launch_reason(
+                                job_id, task_id)
                         headline = parked_reason
                     provision_str = (''
                                      if headline is None else f'\n  {headline}')

--- a/sky/server/requests/continue_condition.py
+++ b/sky/server/requests/continue_condition.py
@@ -8,7 +8,7 @@ fallback policy; instances are pickled onto the exception, so keep state
 picklable and define subclasses in a module importable by the scheduler.
 """
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 
 class ContinueCondition:
@@ -18,14 +18,25 @@ class ContinueCondition:
     before being rescheduled.
     """
 
-    def wait(self, *, is_cancelled: Callable[[], bool],
-             fallback_wait_seconds: float) -> bool:
+    def wait(self,
+             *,
+             is_cancelled: Callable[[], bool],
+             fallback_wait_seconds: float,
+             update_status_msg: Optional[Callable[[str], None]] = None) -> bool:
         """Block until the paused request should resume.
 
         Returns True to reschedule, False to drop it (e.g. cancelled while
         paused, per ``is_cancelled``). ``fallback_wait_seconds`` is the default
         wait when there is no better signal.
+
+        ``update_status_msg`` re-writes the parked request's status message
+        (shown while the client waits) with a fresh reason. A wait that can
+        last hours should call it whenever the reason changes, so the message
+        does not go stale; the scheduler owns the formatting, so pass the bare
+        reason. It is optional because the contract is duck-typed: the
+        scheduler omits it for implementations whose ``wait()`` predates it.
         """
+        del update_status_msg  # A fixed wait has no reason to report.
         # Default: one fixed wait, then reschedule unless cancelled.
         time.sleep(max(0, fallback_wait_seconds))
         return not is_cancelled()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -281,6 +281,11 @@ def _wait_for_continue_condition(
     separately versioned packages, so ``update_status_msg`` is passed only to
     a ``wait()`` that accepts it rather than raising TypeError on one that
     does not.
+
+    The probe reads the signature, so a ``wait()`` wrapped by a decorator that
+    neither ``functools.wraps`` it nor declares ``**kwargs`` is treated as not
+    accepting the callback: the wait still runs, it just never reports a
+    reason.
     """
     kwargs: Dict[str, Any] = {
         'is_cancelled': is_cancelled,

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -21,6 +21,8 @@ See the [README.md](../README.md) for detailed architecture of the executor.
 import asyncio
 import concurrent.futures
 import contextlib
+import functools
+import inspect
 import multiprocessing
 import os
 import signal
@@ -236,6 +238,62 @@ def _request_is_gone_or_cancelled(request_id: str) -> bool:
             request.status == api_requests.RequestStatus.CANCELLED)
 
 
+def _waiting_status_msg(reason: str, retry_suffix: str) -> str:
+    """Format a parked request's status message from a reason.
+
+    Single source of formatting for both the message written when the request
+    parks and the refreshes a continue condition pushes while it stays parked,
+    so the two cannot drift.
+    """
+    # status_msg is a single-line field, so strip color and collapse
+    # whitespace; the reason comes from an exception message or a live probe,
+    # so truncate to keep it readable.
+    reason = ' '.join(common_utils.remove_color(reason).split())
+    if len(reason) > _RETRY_STATUS_MSG_REASON_MAX_LEN:
+        reason = reason[:_RETRY_STATUS_MSG_REASON_MAX_LEN].rstrip() + '...'
+    return (f'{reason} ({retry_suffix})'
+            if reason else retry_suffix.capitalize())
+
+
+def _refresh_waiting_status_msg(request_id: str, retry_suffix: str,
+                                reason: str) -> None:
+    """Re-write a still-parked request's status message with a fresh reason.
+
+    Only touches a request that is still WAITING: the wait runs concurrently
+    with cancellation and with the resume that follows it, and a late refresh
+    must not resurrect a parked message on a request that has moved on.
+    """
+    with api_requests.update_request(request_id) as request_task:
+        if (request_task is None or
+                request_task.status != api_requests.RequestStatus.WAITING):
+            return
+        request_task.status_msg = _waiting_status_msg(reason, retry_suffix)
+
+
+def _wait_for_continue_condition(
+        condition: Any, *, is_cancelled: Callable[[], bool],
+        fallback_wait_seconds: float,
+        update_status_msg: Callable[[str], None]) -> bool:
+    """Run a continue condition's wait, tolerating an older ``wait()``.
+
+    The continue-condition contract is duck-typed (see
+    ``continue_condition.ContinueCondition``), and implementations live in
+    separately versioned packages, so ``update_status_msg`` is passed only to
+    a ``wait()`` that accepts it rather than raising TypeError on one that
+    does not.
+    """
+    kwargs: Dict[str, Any] = {
+        'is_cancelled': is_cancelled,
+        'fallback_wait_seconds': fallback_wait_seconds,
+    }
+    parameters = inspect.signature(condition.wait).parameters
+    if ('update_status_msg' in parameters or
+            any(parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters.values())):
+        kwargs['update_status_msg'] = update_status_msg
+    return condition.wait(**kwargs)
+
+
 class RequestWorker:
     """A worker that polls requests from the queue and runs them.
 
@@ -377,16 +435,10 @@ class RequestWorker:
             # a fixed backoff. Either way the wait runs in this monitor thread,
             # not an executor worker.
             condition = getattr(e, 'continue_condition', None)
-            # Surface why we are retrying, not just the wait time. status_msg
-            # is a single-line field, so strip color and collapse whitespace.
-            reason = ' '.join(common_utils.remove_color(str(e)).split())
-            if len(reason) > _RETRY_STATUS_MSG_REASON_MAX_LEN:
-                reason = reason[:_RETRY_STATUS_MSG_REASON_MAX_LEN].rstrip(
-                ) + '...'
             retry_suffix = ('waiting to resume' if condition is not None else
                             f'retrying in {retry_wait_seconds}s')
-            status_msg = (f'{reason} ({retry_suffix})'
-                          if reason else retry_suffix.capitalize())
+            # Surface why we are retrying, not just the wait time.
+            status_msg = _waiting_status_msg(str(e), retry_suffix)
             # Set request to WAITING status for visibility
             with api_requests.update_request(request_id) as request_task:
                 assert request_task is not None, request_id
@@ -394,10 +446,14 @@ class RequestWorker:
                 request_task.status_msg = status_msg
             try:
                 if condition is not None:
-                    should_reschedule = condition.wait(
+                    should_reschedule = _wait_for_continue_condition(
+                        condition,
                         is_cancelled=lambda: _request_is_gone_or_cancelled(
                             request_id),
-                        fallback_wait_seconds=retry_wait_seconds)
+                        fallback_wait_seconds=retry_wait_seconds,
+                        update_status_msg=functools.partial(
+                            _refresh_waiting_status_msg, request_id,
+                            retry_suffix))
                 else:
                     time.sleep(retry_wait_seconds)
                     should_reschedule = True

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -141,8 +141,8 @@ async def wait_for_request_to_start(
         elif plain_logs and waiting_msg != last_waiting_msg:
             # Only log when waiting message changes.
             last_waiting_msg = waiting_msg
-            # Padding forces browser rendering of the streamed chunk.
-            yield waiting_msg + ' ' * 4096 + '\n'
+            for chunk in _waiting_status_chunks(waiting_msg, plain_logs=True):
+                yield chunk
         # Sleep shortly to avoid storming the DB and CPU and allow other
         # coroutines to run.
         # TODO(aylei): we should use a better mechanism to avoid busy

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -229,6 +229,9 @@ async def _tail_log_file(
 
     last_heartbeat_time = asyncio.get_event_loop().time()
     last_status_check_time = asyncio.get_event_loop().time()
+    # The last parked-state message pushed to this stream; see the WAITING
+    # branch in the status check below.
+    last_waiting_msg: Optional[str] = None
 
     # Buffer the lines in memory and flush them in chunks to improve log
     # tailing throughput.
@@ -288,7 +291,30 @@ async def _tail_log_file(
             if request_id is not None and should_check_status:
                 last_status_check_time = current_time
                 req_status = await requests_lib.get_request_status_async(
-                    request_id)
+                    request_id, include_msg=True)
+                if req_status.status == requests_lib.RequestStatus.WAITING:
+                    # The request parked mid-execution (e.g. waiting on queue
+                    # admission or a cluster lock): it stops writing to the log,
+                    # so without this the client keeps showing the last line it
+                    # streamed -- frozen for as long as the wait lasts, and
+                    # stale as soon as the reason changes. Push the parked
+                    # message as the live status instead.
+                    waiting_msg = req_status.status_msg
+                    if waiting_msg and waiting_msg != last_waiting_msg:
+                        last_waiting_msg = waiting_msg
+                        if plain_logs:
+                            # Padding forces browser rendering of the chunk.
+                            buffer.append(waiting_msg + ' ' * 4096 + '\n')
+                        else:
+                            # INIT, not UPDATE: parking ended the request's own
+                            # rich status (an EXIT reached this client), and an
+                            # exited status ignores updates.
+                            buffer.append(
+                                rich_utils.EncodedStatusMessage(
+                                    f'[dim]{waiting_msg}[/dim]').init())
+                elif req_status.status == requests_lib.RequestStatus.RUNNING:
+                    # Resumed: the request drives its own status again.
+                    last_waiting_msg = None
                 if req_status.status > requests_lib.RequestStatus.RUNNING:
                     if (req_status.status ==
                             requests_lib.RequestStatus.CANCELLED):

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -48,6 +48,23 @@ async def _yield_log_file_with_payloads_skipped(
         yield line_str
 
 
+def _waiting_status_chunks(msg: str, plain_logs: bool) -> List[str]:
+    """Chunks that show ``msg`` as the stream's current waiting status.
+
+    For a rich client all three frames matter: INIT creates a status only when
+    the client holds none, START is what actually paints it (an INIT alone
+    leaves the Live stopped, so the message is never drawn), and UPDATE applies
+    the text to a status the client may already have had. START is idempotent,
+    so the trio is safe whatever state the client is in -- the same pairing
+    ``wait_for_request_to_start`` uses below.
+    """
+    if plain_logs:
+        # Padding forces browser rendering of the streamed chunk.
+        return [msg + ' ' * 4096 + '\n']
+    status = rich_utils.EncodedStatusMessage(f'[dim]{msg}[/dim]')
+    return [status.init(), status.enter(), status.update(f'[dim]{msg}[/dim]')]
+
+
 async def wait_for_request_to_start(
     request_id: str,
     plain_logs: bool = False,
@@ -292,6 +309,10 @@ async def _tail_log_file(
                 last_status_check_time = current_time
                 req_status = await requests_lib.get_request_status_async(
                     request_id, include_msg=True)
+                if req_status is None:
+                    # The record vanished (e.g. deleted while streaming); the
+                    # loop below dereferences it more than once.
+                    break
                 if req_status.status == requests_lib.RequestStatus.WAITING:
                     # The request parked mid-execution (e.g. waiting on queue
                     # admission or a cluster lock): it stops writing to the log,
@@ -302,24 +323,12 @@ async def _tail_log_file(
                     waiting_msg = req_status.status_msg
                     if waiting_msg and waiting_msg != last_waiting_msg:
                         last_waiting_msg = waiting_msg
-                        if plain_logs:
-                            # Padding forces browser rendering of the chunk.
-                            buffer.append(waiting_msg + ' ' * 4096 + '\n')
-                        else:
-                            # INIT *and* UPDATE. Parking ended the request's own
-                            # rich status (an EXIT reached this client), so a
-                            # status has to be re-initialized -- but on a client
-                            # that still holds one, INIT reuses it without
-                            # applying the new text (see rich_utils.
-                            # client_status / _RevertibleStatus), so the UPDATE
-                            # is what actually changes what the user reads.
-                            status = rich_utils.EncodedStatusMessage(
-                                f'[dim]{waiting_msg}[/dim]')
-                            buffer.append(status.init())
-                            buffer.append(
-                                status.update(f'[dim]{waiting_msg}[/dim]'))
-                elif req_status.status == requests_lib.RequestStatus.RUNNING:
-                    # Resumed: the request drives its own status again.
+                        buffer.extend(
+                            _waiting_status_chunks(waiting_msg, plain_logs))
+                else:
+                    # Any other status (resumed, queued again, finished): the
+                    # request drives its own status again, and a later park has
+                    # to be able to report the same reason afresh.
                     last_waiting_msg = None
                 if req_status.status > requests_lib.RequestStatus.RUNNING:
                     if (req_status.status ==

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -306,12 +306,18 @@ async def _tail_log_file(
                             # Padding forces browser rendering of the chunk.
                             buffer.append(waiting_msg + ' ' * 4096 + '\n')
                         else:
-                            # INIT, not UPDATE: parking ended the request's own
-                            # rich status (an EXIT reached this client), and an
-                            # exited status ignores updates.
+                            # INIT *and* UPDATE. Parking ended the request's own
+                            # rich status (an EXIT reached this client), so a
+                            # status has to be re-initialized -- but on a client
+                            # that still holds one, INIT reuses it without
+                            # applying the new text (see rich_utils.
+                            # client_status / _RevertibleStatus), so the UPDATE
+                            # is what actually changes what the user reads.
+                            status = rich_utils.EncodedStatusMessage(
+                                f'[dim]{waiting_msg}[/dim]')
+                            buffer.append(status.init())
                             buffer.append(
-                                rich_utils.EncodedStatusMessage(
-                                    f'[dim]{waiting_msg}[/dim]').init())
+                                status.update(f'[dim]{waiting_msg}[/dim]'))
                 elif req_status.status == requests_lib.RequestStatus.RUNNING:
                     # Resumed: the request drives its own status again.
                     last_waiting_msg = None

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -505,13 +505,19 @@ class LockAcquirableCondition:
         self._lock_id = lock_id
         self._poll_interval_seconds = poll_interval_seconds
 
-    def wait(self, *, is_cancelled: Callable[[], bool],
-             fallback_wait_seconds: float) -> bool:
+    def wait(self,
+             *,
+             is_cancelled: Callable[[], bool],
+             fallback_wait_seconds: float,
+             update_status_msg: Optional[Callable[[str], None]] = None) -> bool:
         """Block until the lock is acquirable; return False if cancelled."""
         # There is no better signal than the probe itself; on probe errors
         # (e.g. a database glitch) the exception propagates to the scheduler,
         # which falls back to a fixed ``fallback_wait_seconds`` backoff.
         del fallback_wait_seconds
+        # The reason cannot change while waiting -- the lock holder is the
+        # whole story -- so the message written at pause time stands.
+        del update_status_msg
         while True:
             if is_cancelled():
                 return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,8 @@ def test_api_stream_heartbeat(monkeypatch):
         async def mock_get_request(request_id, fields):
             return MockRequest()
 
-        async def mock_get_request_status(request_id):
+        async def mock_get_request_status(request_id, include_msg=False):
+            del include_msg  # The mock always reports the message.
             return requests_lib.StatusWithMsg(MockRequest().status,
                                               MockRequest().status_msg)
 
@@ -153,7 +154,8 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
         async def mock_get_request(request_id, fields):
             return MockRequest()
 
-        async def mock_get_request_status(request_id):
+        async def mock_get_request_status(request_id, include_msg=False):
+            del include_msg  # The mock always reports the message.
             return requests_lib.StatusWithMsg(MockRequest().status,
                                               MockRequest().status_msg)
 

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1695,3 +1695,73 @@ class TestCancelJobsByIdWorkspaceScoping:
         msg = jobs_utils.cancel_jobs_by_id([5], current_workspace='ws-a')
         assert 'not in the active workspace' in msg
         assert 'terminal' not in msg
+
+
+class TestParkedLaunchReason:
+    """The fallback explanation for a job whose launch parked.
+
+    A parked launch ends its rich status, so the provisioning headline relayed
+    into the controller log disappears and `sky jobs launch` is left saying only
+    "Waiting for task to start". The parked request still carries the reason.
+    """
+
+    def _patch(self,
+               monkeypatch,
+               *,
+               task_name='task',
+               requests=None,
+               raises=None):
+        monkeypatch.setattr(jobs_utils.managed_job_state, 'get_task_name',
+                            lambda job_id, task_id: task_name)
+
+        def get_request_tasks(req_filter):
+            if raises is not None:
+                raise raises
+            self.filter = req_filter
+            return requests or []
+
+        monkeypatch.setattr(jobs_utils.requests_lib, 'get_request_tasks',
+                            get_request_tasks)
+
+    def test_returns_the_parked_requests_message(self, monkeypatch):
+        parked = MagicMock()
+        parked.status_msg = ('Pending (Queue: q, Position: 0, needs memory) '
+                             '(waiting to resume)')
+        self._patch(monkeypatch, requests=[parked])
+
+        assert jobs_utils._parked_launch_reason(7, 0) == parked.status_msg
+        # Scoped to a parked launch of THIS job's cluster: a WAITING request of
+        # another kind, or another job's, must not be shown as this job's
+        # reason.
+        assert self.filter.status == [
+            jobs_utils.requests_lib.RequestStatus.WAITING
+        ]
+        assert self.filter.include_request_names == ['sky.launch']
+        assert self.filter.cluster_names == [
+            jobs_utils.generate_managed_job_cluster_name('task', 7)
+        ]
+
+    def test_no_parked_request_means_no_reason(self, monkeypatch):
+        self._patch(monkeypatch, requests=[])
+        assert jobs_utils._parked_launch_reason(7, 0) is None
+
+    def test_empty_message_is_not_reported(self, monkeypatch):
+        parked = MagicMock()
+        parked.status_msg = ''
+        self._patch(monkeypatch, requests=[parked])
+        assert jobs_utils._parked_launch_reason(7, 0) is None
+
+    def test_unknown_task_means_no_reason(self, monkeypatch):
+        self._patch(monkeypatch, task_name=None)
+        assert jobs_utils._parked_launch_reason(7, 0) is None
+
+    def test_lookup_failure_is_swallowed(self, monkeypatch):
+        """Log streaming must not break where the request DB is unreadable.
+
+        This runs wherever the log stream runs -- the API server under
+        consolidation, the controller host otherwise -- so an unavailable or
+        differently-shaped request store has to degrade to today's behavior
+        (no appended line), never to an error in the middle of following a job.
+        """
+        self._patch(monkeypatch, raises=RuntimeError('no requests db here'))
+        assert jobs_utils._parked_launch_reason(7, 0) is None

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1768,37 +1768,31 @@ class TestParkedLaunchReason:
 
 
 class TestWaitingLineFallback:
-    """The line `sky jobs launch` shows while the job has not started."""
-
-    def _render(self, headline, parked_reason):
-        """The waiting line as the follow loop composes it."""
-        provision_str = '' if headline is None else f'\n  {headline}'
-        if headline is None and parked_reason is not None:
-            provision_str = f'\n  {parked_reason}'
-        return jobs_utils._JOB_WAITING_STATUS_MESSAGE.format(
-            status_str=' (status: PENDING)',
-            provision_str=provision_str,
-            job_id=7)
+    """The detail line shown under "Waiting for task to start"."""
 
     def test_live_headline_wins(self):
         """A live provisioning headline is shown as before."""
-        line = self._render('Launching (Preparing SkyPilot runtime)',
-                            'Pending (Queue: q) (waiting to resume)')
-        assert 'Preparing SkyPilot runtime' in line
-        assert 'waiting to resume' not in line
+        assert jobs_utils._waiting_line_detail(
+            '[bold cyan]Preparing SkyPilot runtime[/]  hint',
+            'Pending (Queue: q) (waiting to resume)',
+        ) == 'Preparing SkyPilot runtime'
 
     def test_parked_reason_fills_the_gap(self):
-        """With no headline, the parked reason takes its place.
+        """With no live status, the parked reason takes its place.
 
-        The headline comes from rich-status payloads relayed into the
-        controller log, and parking ends that status -- so without this the
-        line degrades to "Waiting for task to start" with nothing after it.
+        The headline comes from rich-status payloads relayed into the controller
+        log, and parking ends that status -- so without this the line degrades
+        to "Waiting for task to start" with nothing after it.
         """
-        line = self._render(None, 'Pending (Queue: q, Position: 0)')
-        assert 'Pending (Queue: q, Position: 0)' in line
+        assert jobs_utils._waiting_line_detail(
+            None, 'Pending (Queue: q, Position: 0)'
+        ) == 'Pending (Queue: q, Position: 0)'
+
+    def test_a_headline_less_provision_message_still_falls_back(self):
+        """A relayed message with no [bold cyan] headline counts as none."""
+        assert jobs_utils._waiting_line_detail(
+            'no markup here', 'Pending (Queue: q)') == 'Pending (Queue: q)'
 
     def test_nothing_to_show(self):
         """Neither available renders the plain waiting line."""
-        line = self._render(None, None)
-        assert 'Waiting for task to start' in line
-        assert 'Pending (Queue' not in line
+        assert jobs_utils._waiting_line_detail(None, None) is None

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1765,3 +1765,40 @@ class TestParkedLaunchReason:
         """
         self._patch(monkeypatch, raises=RuntimeError('no requests db here'))
         assert jobs_utils._parked_launch_reason(7, 0) is None
+
+
+class TestWaitingLineFallback:
+    """The line `sky jobs launch` shows while the job has not started."""
+
+    def _render(self, headline, parked_reason):
+        """The waiting line as the follow loop composes it."""
+        provision_str = '' if headline is None else f'\n  {headline}'
+        if headline is None and parked_reason is not None:
+            provision_str = f'\n  {parked_reason}'
+        return jobs_utils._JOB_WAITING_STATUS_MESSAGE.format(
+            status_str=' (status: PENDING)',
+            provision_str=provision_str,
+            job_id=7)
+
+    def test_live_headline_wins(self):
+        """A live provisioning headline is shown as before."""
+        line = self._render('Launching (Preparing SkyPilot runtime)',
+                            'Pending (Queue: q) (waiting to resume)')
+        assert 'Preparing SkyPilot runtime' in line
+        assert 'waiting to resume' not in line
+
+    def test_parked_reason_fills_the_gap(self):
+        """With no headline, the parked reason takes its place.
+
+        The headline comes from rich-status payloads relayed into the
+        controller log, and parking ends that status -- so without this the
+        line degrades to "Waiting for task to start" with nothing after it.
+        """
+        line = self._render(None, 'Pending (Queue: q, Position: 0)')
+        assert 'Pending (Queue: q, Position: 0)' in line
+
+    def test_nothing_to_show(self):
+        """Neither available renders the plain waiting line."""
+        line = self._render(None, None)
+        assert 'Waiting for task to start' in line
+        assert 'Pending (Queue' not in line

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -797,7 +797,12 @@ class _RecordingCondition(continue_condition_lib.ContinueCondition):
         self._verdict = verdict
         self.calls = []
 
-    def wait(self, *, is_cancelled, fallback_wait_seconds) -> bool:
+    def wait(self,
+             *,
+             is_cancelled,
+             fallback_wait_seconds,
+             update_status_msg=None) -> bool:
+        del update_status_msg  # This condition reports no reason.
         self.calls.append({
             'is_cancelled': is_cancelled(),
             'fallback_wait_seconds': fallback_wait_seconds,
@@ -870,6 +875,144 @@ def test_pause_base_condition_dropped_if_cancelled_during_wait(
     assert pause_harness.queue_items == []
 
 
+class _ReportingCondition(continue_condition_lib.ContinueCondition):
+    """A condition that pushes fresh reasons while parked."""
+
+    def __init__(self, reasons, before_report=None):
+        self._reasons = reasons
+        self._before_report = before_report
+        self.got_updater = None
+
+    def wait(self,
+             *,
+             is_cancelled,
+             fallback_wait_seconds,
+             update_status_msg=None) -> bool:
+        del is_cancelled, fallback_wait_seconds
+        self.got_updater = update_status_msg
+        if self._before_report is not None:
+            self._before_report()
+        for reason in self._reasons:
+            assert update_status_msg is not None
+            update_status_msg(reason)
+        return True
+
+
+def test_pause_status_msg_refreshed_while_parked(pause_harness):
+    """A parked request's status message follows the condition's latest reason.
+
+    A pause can last hours (e.g. waiting on queue admission), so the message
+    the client is shown must not be frozen at the one written when the request
+    parked. The scheduler owns the formatting, so the refreshed message carries
+    the same suffix as the initial one.
+    """
+    condition = _ReportingCondition(
+        reasons=['Pending (Queue: q, Position: 4)', 'Pending (Queue: q)'])
+
+    pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert condition.got_updater is not None
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status_msg'])
+    # The last reason wins, formatted exactly like the initial message.
+    assert updated.status_msg == 'Pending (Queue: q) (waiting to resume)'
+
+
+def test_pause_status_msg_refresh_skipped_once_not_waiting(pause_harness):
+    """A late refresh must not resurrect a parked message.
+
+    The wait runs concurrently with cancellation (and with the resume that
+    follows it), so a reason arriving after the request left WAITING must be
+    dropped rather than overwrite the newer state's message.
+    """
+
+    def cancel():
+        with requests_lib.update_request(pause_harness.request_id) as request:
+            request.status = requests_lib.RequestStatus.CANCELLED
+            request.status_msg = 'cancelled by user'
+
+    condition = _ReportingCondition(reasons=['Pending (Queue: q, Position: 4)'],
+                                    before_report=cancel)
+
+    pause_harness.run(condition, retry_wait_seconds=30)
+
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status_msg'])
+    assert updated.status_msg == 'cancelled by user'
+
+
+def test_pause_status_msg_reason_truncated(pause_harness):
+    """A long reason is truncated but keeps the suffix readable."""
+    condition = _ReportingCondition(reasons=['x' * 500])
+
+    pause_harness.run(condition, retry_wait_seconds=30)
+
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status_msg'])
+    assert updated.status_msg.endswith('... (waiting to resume)')
+    assert len(updated.status_msg) < 250
+
+
+class _LegacyWaitCondition:
+    """A duck-typed condition whose wait() predates update_status_msg."""
+
+    def __init__(self):
+        self.calls = []
+
+    def wait(self, *, is_cancelled, fallback_wait_seconds) -> bool:
+        self.calls.append(fallback_wait_seconds)
+        del is_cancelled
+        return True
+
+
+class _KwargsWaitCondition:
+    """A duck-typed condition that absorbs unknown kwargs."""
+
+    def __init__(self):
+        self.kwargs = []
+
+    def wait(self, *, is_cancelled, fallback_wait_seconds, **kwargs) -> bool:
+        del is_cancelled, fallback_wait_seconds
+        self.kwargs.append(sorted(kwargs))
+        return True
+
+
+def test_pause_tolerates_condition_wait_without_the_new_kwarg(pause_harness):
+    """A condition from a separately versioned package still waits normally.
+
+    The continue-condition contract is duck-typed, so an implementation whose
+    wait() predates update_status_msg must keep parking the request rather than
+    failing the call and degrading to a fixed-backoff retry loop.
+    """
+    condition = _LegacyWaitCondition()
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert condition.calls == [30]
+    assert pause_harness.queue_items == [request_element]
+
+
+def test_pause_passes_the_new_kwarg_to_a_kwargs_absorbing_wait(pause_harness):
+    """A wait() with **kwargs is given the updater rather than skipped."""
+    condition = _KwargsWaitCondition()
+
+    pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert condition.kwargs == [['update_status_msg']]
+
+
+@pytest.mark.parametrize(('reason', 'suffix', 'expected'), [
+    ('Pending (Queue: q)', 'waiting to resume',
+     'Pending (Queue: q) (waiting to resume)'),
+    ('multi\nline   reason', 'retrying in 5s',
+     'multi line reason (retrying in 5s)'),
+    ('', 'waiting to resume', 'Waiting to resume'),
+])
+def test_waiting_status_msg_formatting(reason, suffix, expected):
+    """Whitespace is collapsed, and an empty reason leaves just the suffix."""
+    assert executor._waiting_status_msg(reason, suffix) == expected
+
+
 def test_pause_marks_executor_free_before_wait(pause_harness, monkeypatch):
     """The freed worker process is accounted for before the pause wait runs.
 
@@ -891,8 +1034,12 @@ def test_pause_marks_executor_free_before_wait(pause_harness, monkeypatch):
 
     class _GaugeWatchingCondition(continue_condition_lib.ContinueCondition):
 
-        def wait(self, *, is_cancelled, fallback_wait_seconds) -> bool:
-            del is_cancelled, fallback_wait_seconds
+        def wait(self,
+                 *,
+                 is_cancelled,
+                 fallback_wait_seconds,
+                 update_status_msg=None) -> bool:
+            del is_cancelled, fallback_wait_seconds, update_status_msg
             inc_count_at_wait.append(gauge.inc.call_count)
             return True
 

--- a/tests/unit_tests/test_sky/server/test_stream_utils.py
+++ b/tests/unit_tests/test_sky/server/test_stream_utils.py
@@ -1,0 +1,124 @@
+"""Tests for log streaming of a request that parks mid-execution."""
+import aiofiles
+import pytest
+
+from sky.server import stream_utils
+from sky.server.requests import requests as requests_lib
+from sky.utils import message_utils
+from sky.utils import rich_utils
+
+
+def _decoded_controls(chunks):
+    """(control, message) for every rich-status payload in the chunks."""
+    out = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            is_payload, decoded = message_utils.decode_payload(
+                line, raise_for_mismatch=False)
+            if not is_payload:
+                continue
+            control, msg = rich_utils.Control.decode(decoded)
+            if control is not None:
+                out.append((control, msg))
+    return out
+
+
+def _status_sequence(monkeypatch, sequence):
+    """Serve a fixed (status, status_msg) sequence to the tail loop."""
+    remaining = list(sequence)
+
+    async def get_request_status_async(request_id, include_msg=False):
+        del request_id, include_msg
+        status, msg = remaining.pop(0) if remaining else sequence[-1]
+        return requests_lib.StatusWithMsg(status, msg)
+
+    monkeypatch.setattr(requests_lib, 'get_request_status_async',
+                        get_request_status_async)
+
+
+async def _collect(log_path, plain_logs=False):
+    chunks = []
+    async with aiofiles.open(log_path, 'rb') as f:
+        async for chunk in stream_utils._tail_log_file(f,
+                                                       request_id='rid',
+                                                       plain_logs=plain_logs,
+                                                       follow=True,
+                                                       polling_interval=0):
+            chunks.append(chunk)
+    return chunks
+
+
+@pytest.mark.asyncio
+async def test_parked_request_status_is_pushed_to_an_attached_stream(
+        monkeypatch, tmp_path):
+    """A client attached before the park must not be left on a stale line.
+
+    A parked request stops writing to its log, so a client that is already
+    tailing it sees nothing more: before this it kept displaying whatever it had
+    streamed last, for as long as the wait lasted and no matter how the reason
+    changed. The parked message is pushed into the stream instead.
+    """
+    log_path = tmp_path / 'request.log'
+    log_path.write_text('provisioning...\n')
+    waiting = requests_lib.RequestStatus.WAITING
+    _status_sequence(monkeypatch, [
+        (waiting, 'Pending (Queue: q, Position: 1) (waiting to resume)'),
+        (waiting, 'Pending (Queue: q, Position: 1) (waiting to resume)'),
+        (waiting, 'Pending (Queue: q, Position: 0) (waiting to resume)'),
+        (requests_lib.RequestStatus.SUCCEEDED, None),
+    ])
+
+    controls = _decoded_controls(await _collect(log_path))
+
+    messages = [
+        msg for control, msg in controls if control is rich_utils.Control.INIT
+    ]
+    # Both distinct reasons reached the client, and the repeat did not.
+    assert messages == [
+        '[dim]Pending (Queue: q, Position: 1) (waiting to resume)[/dim]',
+        '[dim]Pending (Queue: q, Position: 0) (waiting to resume)[/dim]',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parked_request_status_is_pushed_as_plain_text(
+        monkeypatch, tmp_path):
+    """With plain logs the parked message is a line, not a control frame."""
+    log_path = tmp_path / 'request.log'
+    log_path.write_text('provisioning...\n')
+    _status_sequence(monkeypatch, [
+        (requests_lib.RequestStatus.WAITING, 'Pending (Queue: q)'),
+        (requests_lib.RequestStatus.SUCCEEDED, None),
+    ])
+
+    chunks = await _collect(log_path, plain_logs=True)
+
+    assert any('Pending (Queue: q)' in chunk for chunk in chunks)
+    assert not _decoded_controls(chunks)
+
+
+@pytest.mark.asyncio
+async def test_resume_lets_the_request_drive_its_own_status_again(
+        monkeypatch, tmp_path):
+    """After a resume, the same reason may be pushed again if it parks anew.
+
+    The parked message is de-duplicated only while the request stays parked;
+    a resumed request writes its own status, so the next park has to be able to
+    report the same reason rather than being silently suppressed.
+    """
+    log_path = tmp_path / 'request.log'
+    log_path.write_text('provisioning...\n')
+    waiting = requests_lib.RequestStatus.WAITING
+    running = requests_lib.RequestStatus.RUNNING
+    msg = 'Pending (Queue: q, Position: 0) (waiting to resume)'
+    _status_sequence(monkeypatch, [
+        (waiting, msg),
+        (running, None),
+        (waiting, msg),
+        (requests_lib.RequestStatus.SUCCEEDED, None),
+    ])
+
+    controls = _decoded_controls(await _collect(log_path))
+
+    inits = [m for c, m in controls if c is rich_utils.Control.INIT]
+    assert len(inits) == 2, inits

--- a/tests/unit_tests/test_sky/server/test_stream_utils.py
+++ b/tests/unit_tests/test_sky/server/test_stream_utils.py
@@ -70,14 +70,22 @@ async def test_parked_request_status_is_pushed_to_an_attached_stream(
 
     controls = _decoded_controls(await _collect(log_path))
 
-    messages = [
-        msg for control, msg in controls if control is rich_utils.Control.INIT
-    ]
     # Both distinct reasons reached the client, and the repeat did not.
-    assert messages == [
+    expected = [
         '[dim]Pending (Queue: q, Position: 1) (waiting to resume)[/dim]',
         '[dim]Pending (Queue: q, Position: 0) (waiting to resume)[/dim]',
     ]
+    inits = [
+        msg for control, msg in controls if control is rich_utils.Control.INIT
+    ]
+    assert inits == expected
+    # ...and each is applied, not merely initialized: a client that still holds
+    # a status reuses it on INIT without picking up the new text, so the UPDATE
+    # is what the user actually reads.
+    updates = [
+        msg for control, msg in controls if control is rich_utils.Control.UPDATE
+    ]
+    assert updates == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_sky/server/test_stream_utils.py
+++ b/tests/unit_tests/test_sky/server/test_stream_utils.py
@@ -79,6 +79,10 @@ async def test_parked_request_status_is_pushed_to_an_attached_stream(
         msg for control, msg in controls if control is rich_utils.Control.INIT
     ]
     assert inits == expected
+    # START is what paints it: an INIT alone leaves the client's Live stopped,
+    # so the message would be pushed and never drawn.
+    assert [control for control, _ in controls
+           ].count(rich_utils.Control.START) == len(expected)
     # ...and each is applied, not merely initialized: a client that still holds
     # a status reuses it on INIT without picking up the new text, so the UPDATE
     # is what the user actually reads.
@@ -130,3 +134,30 @@ async def test_resume_lets_the_request_drive_its_own_status_again(
 
     inits = [m for c, m in controls if c is rich_utils.Control.INIT]
     assert len(inits) == 2, inits
+
+
+@pytest.mark.asyncio
+async def test_parked_message_repeats_after_any_status_change(
+        monkeypatch, tmp_path):
+    """A reason may be reported again once the request has left WAITING.
+
+    The de-dup is per parked stretch. Resetting it only on RUNNING meant a
+    resume that went WAITING -> PENDING -> WAITING between two polls kept the
+    old message suppressed, leaving the client on whatever the request emitted
+    while it ran.
+    """
+    log_path = tmp_path / 'request.log'
+    log_path.write_text('provisioning...\n')
+    waiting = requests_lib.RequestStatus.WAITING
+    msg = 'Pending (Queue: q) (waiting to resume)'
+    _status_sequence(monkeypatch, [
+        (waiting, msg),
+        (requests_lib.RequestStatus.PENDING, None),
+        (waiting, msg),
+        (requests_lib.RequestStatus.SUCCEEDED, None),
+    ])
+
+    controls = _decoded_controls(await _collect(log_path))
+
+    inits = [m for c, m in controls if c is rich_utils.Control.INIT]
+    assert inits == [f'[dim]{msg}[/dim]'] * 2, inits


### PR DESCRIPTION
## Summary

A request that pauses mid-execution — waiting on queue admission, a cluster lock, anything a `ContinueCondition` can wait for — says why exactly once, when it parks, and then goes quiet for as long as the wait lasts. On a busy cluster that is hours. Three surfaces were left with nothing useful to show:

1. **The parked message never changes.** `ContinueCondition.wait()` now receives an `update_status_msg` callback, so a wait that learns more can re-write the request's status message. The scheduler owns the formatting (`_waiting_status_msg`), so a refresh reads exactly like the message written at pause time instead of drifting from it, and a refresh that arrives after the request left `WAITING` is dropped rather than resurrecting a stale message.

   The callback is passed only to a `wait()` that accepts it: the continue-condition contract is duck-typed and implementations live in separately versioned packages, so an older `wait()` must keep parking the request rather than failing the call and degrading into a fixed-backoff retry loop.

2. **A client already streaming the request froze.** A parked request stops writing to its log, and the tail loop only reacted to terminal statuses — so whatever line had been streamed last stayed on screen for the whole wait, and stale as soon as the reason changed. The parked message is now pushed into the stream as the live status, and again whenever it changes. (`INIT`, not `UPDATE`: parking ends the request's own rich status, and an exited status ignores updates.)

3. **`sky jobs launch` lost its explanation at the park.** The line under `Waiting for task to start` shows a headline relayed from the inner cluster launch's rich status; parking emits an `EXIT`, which clears it. It now falls back to the parked launch's own message, resolved on the status-check cadence (15s, not the 1s spinner poll) and best-effort — any failure renders exactly as before, which also covers a dedicated controller host whose request store this code cannot read.

Nothing here is queue-specific: a launch parked on a cluster lock reports its own reason through the same path.

## Test plan

```
pytest tests/unit_tests/test_sky/server/requests/test_executor.py \
       tests/unit_tests/test_sky/server/test_stream_utils.py \
       tests/unit_tests/test_sky/jobs/test_utils.py
```
153 passed. New coverage: refresh-on-change and its formatting, the drop of a late refresh, truncation, both duck-typed `wait()` shapes, the parked-status push (rich and plain-log), re-push after a resume, and the jobs-waiting-line fallback including its failure path.

Every new test was checked against a simulated revert of the code it guards — including swapping in the previous `_tail_log_file` — and fails there.

Coverage boundary worth stating: item 3, the `sky jobs launch` waiting line, is covered by these unit tests only. It is a rich status, so it never renders into captured stdout and a smoke test cannot grep it; the companion smoke coverage asserts the reason reaches the controller log instead, which is the same message through a different surface.

Manually, against a queue-gated launch on a live Kubernetes cluster with an admission controller:

- a parked `sky launch` reported the queue, position and reason instead of the queue name alone;
- while parked, the message followed the queue (position 2 → 1 after the workload ahead was admitted) and kept the scheduler's suffix;
- the request log and a re-attached `sky api logs` both carried it;
- releasing the queue resumed both parked requests, cleared their status messages, and the clusters came up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

### Review follow-ups (in `bb1d73e26`, `9f28b7273`)

- **The parked message was pushed but never painted.** The push emitted INIT and UPDATE without START: on the client INIT creates a status without entering its `Live`, so UPDATE only mutated a renderable nothing was drawing. Replaying the control sequence through the client's own decode path leaves `Live.is_started` False, and True once START is added. Fixed, and the two places in this file that show a waiting message now share `_waiting_status_chunks` so they cannot drift again. The test asserts the frame, not just the message.
- **The de-dup is now cleared on any status other than WAITING**, not only RUNNING: a resume that passed through PENDING between two polls used to keep a repeat of the same reason suppressed.
- Guard the status read for None; look the parked reason up lazily (a normally provisioning job has a live headline and never needs it); a test for the waiting-line branch itself.
- **On topology:** a review pass read the waiting-line fallback as a no-op off consolidation mode — the launch request in the API server's store, the reader on the controller host. It is not. On a dedicated controller this code runs *on the controller* (`ManagedJobCodeGen.stream_logs` + `run_on_head`) and the controller submits its launches to its own local API server: `recovery_strategy.ENV_VARS_TO_CLEAR` clears `SKY_API_SERVER_URL_ENV_VAR` for exactly that reason. Under consolidation the controller *is* the API server. So the request is co-located either way; `9f28b7273` records this in the docstring, since the two halves of the argument live far apart in the code.

### Review follow-ups (in `181a4316e`)

- The waiting loop re-stated the condition the detail helper already decides, once a second. Both sides now ask `_live_headline()`, so "the relayed status has a headline" has one definition. Pure refactor — the two fallback tests still fail when the fallback is removed.

