### PR TITLE
[Server] Give the retention daemons a fixed cadence and a startup jitter

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -31,6 +31,7 @@ from sky import skypilot_config
 from sky.metrics import utils as metrics_lib
 from sky.skylet import constants
 from sky.utils import annotations
+from sky.utils import asyncio_utils
 from sky.utils import common_utils
 from sky.utils import context_utils
 from sky.utils import registry
@@ -54,7 +55,11 @@ _ALLOWED_CLOUDS_KEY_PREFIX = 'allowed_clouds_'
 DEFAULT_CLUSTER_EVENT_RETENTION_HOURS = 30 * 24.0
 DEBUG_CLUSTER_EVENT_RETENTION_HOURS = 30 * 24.0
 TERMINAL_CLUSTER_EVENT_RETENTION_HOURS = 30 * 24.0
-MIN_CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS = 3600
+# How often the cluster-event retention daemon wakes up. Fixed, and
+# deliberately independent of the retention windows above: events become
+# eligible for deletion continuously, so the interval decides how much
+# work accumulates between passes, not how long events are kept.
+CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS = 3600
 
 _UNIQUE_CONSTRAINT_FAILED_ERROR_MSGS = [
     # sqlite
@@ -1261,6 +1266,7 @@ def cleanup_cluster_events_with_retention(retention_hours: float,
 
 async def cluster_event_retention_daemon():
     """Garbage collect cluster events periodically."""
+    await asyncio_utils.sleep_startup_jitter('cluster event retention daemon')
     while True:
         logger.info('Running cluster event retention daemon...')
         # Use the latest config.
@@ -1302,11 +1308,7 @@ async def cluster_event_retention_daemon():
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'Error running cluster event retention daemon: {e}')
 
-        # Run daemon at most once every hour to avoid too frequent cleanup.
-        sleep_amount = max(
-            min(retention_hours * 3600, debug_retention_hours * 3600),
-            MIN_CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS)
-        await asyncio.sleep(sleep_amount)
+        await asyncio.sleep(CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS)
 
 
 @typing.overload

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -26,6 +26,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.dag import DagExecution
 from sky.skylet import constants
+from sky.utils import asyncio_utils
 from sky.utils import common_utils
 from sky.utils.db import db_utils
 from sky.utils.db import migration_utils
@@ -4164,6 +4165,7 @@ async def cleanup_job_events_with_retention_async(
 
 async def job_event_retention_daemon():
     """Garbage collect job events periodically."""
+    await asyncio_utils.sleep_startup_jitter('job event retention daemon')
     while True:
         logger.info('Running job event retention daemon...')
         try:

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1360,6 +1360,7 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
 
 async def requests_gc_daemon():
     """Garbage collect finished requests periodically."""
+    await asyncio_utils.sleep_startup_jitter('requests GC daemon')
     while True:
         logger.info('Running requests GC daemon...')
         # Use the latest config.
@@ -1377,8 +1378,9 @@ async def requests_gc_daemon():
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'Error running requests GC daemon: {e}'
                          f'traceback: {traceback.format_exc()}')
-        # Run the daemon at most once every hour to avoid too frequent
-        # cleanup.
+        # Fixed, and deliberately independent of the retention window: the
+        # interval controls how much accumulates between passes, not how long
+        # anything is kept.
         await asyncio.sleep(_REQUESTS_GC_INTERVAL_SECONDS)
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -99,6 +99,7 @@ from sky.users import rbac
 from sky.users import server as users_rest
 from sky.users import token_service
 from sky.utils import admin_policy_utils
+from sky.utils import asyncio_utils
 from sky.utils import command_runner
 from sky.utils import common as common_lib
 from sky.utils import common_utils
@@ -911,6 +912,7 @@ def _prune_sky_logs(cutoff: float) -> int:
 
 async def cleanup_sky_logs():
     """Hourly GC of expired per-operation ~/sky_logs artifacts."""
+    await asyncio_utils.sleep_startup_jitter('sky_logs cleanup daemon')
     while True:
         try:
             skypilot_config.reload_config()

--- a/sky/utils/asyncio_utils.py
+++ b/sky/utils/asyncio_utils.py
@@ -2,9 +2,51 @@
 
 import asyncio
 import functools
+import random
 from typing import Set
 
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
 _background_tasks: Set[asyncio.Task] = set()
+
+# Upper bound on the random delay applied before a periodic housekeeping
+# daemon runs its first pass. See sleep_startup_jitter().
+DEFAULT_STARTUP_JITTER_SECONDS = 1800
+
+
+async def sleep_startup_jitter(
+        name: str, max_seconds: float = DEFAULT_STARTUP_JITTER_SECONDS) -> None:
+    """Sleep a random offset before a periodic daemon's first pass.
+
+    Periodic housekeeping daemons are written as::
+
+        while True:
+            do_the_pass()
+            await asyncio.sleep(interval)
+
+    so the first pass runs at t=0 of the process. That is fine for a single
+    server, but it means every API server that boots at the same moment also
+    starts its housekeeping at the same moment, and the passes stay aligned
+    from then on: a fleet that is restarted together (a rolling upgrade, a
+    node drain, an eviction) has its daily retention sweeps permanently
+    phase-locked, so they all land on the shared database at once.
+
+    Sleeping a random offset in [0, max_seconds) before entering the loop
+    spreads those first passes out, and because the interval is unchanged the
+    offset persists for the lifetime of the process.
+
+    Only safe for work that is pure housekeeping -- nothing whose result is
+    needed for the server to start serving correctly.
+    """
+    if max_seconds <= 0:
+        return
+    delay = random.uniform(0, max_seconds)
+    logger.debug(
+        '%s: delaying first pass by %.0fs to avoid a synchronized '
+        'startup burst across servers', name, delay)
+    await asyncio.sleep(delay)
 
 
 def shield(func):

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -34,15 +34,19 @@ def test_enabled_clouds_empty():
 @pytest.mark.asyncio
 async def test_cluster_event_retention_daemon():
     """Test the cluster event retention daemon runs correctly."""
+    interval = sky.global_user_state.CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS
     with mock.patch('sky.global_user_state.skypilot_config') as mock_config:
         with mock.patch(
                 'sky.global_user_state.cleanup_cluster_events_with_retention'
         ) as mock_clean:
-            with mock.patch('asyncio.sleep') as mock_sleep:
+            # The daemon jitters before its first pass; patch that out so the
+            # sleep call counts below refer only to the loop's own interval.
+            with mock.patch('sky.utils.asyncio_utils.sleep_startup_jitter'
+                           ), mock.patch('asyncio.sleep') as mock_sleep:
                 # Configure negative retention (disabled)
                 mock_config.get_nested.return_value = -1
 
-                mock_sleep.side_effect = [None, asyncio.CancelledError()]
+                mock_sleep.side_effect = [asyncio.CancelledError()]
 
                 # Run the daemon
                 with pytest.raises(asyncio.CancelledError):
@@ -51,13 +55,12 @@ async def test_cluster_event_retention_daemon():
                 # Verify cleanup was NOT called due to negative retention
                 mock_clean.assert_not_called()
 
-                # Verify sleep was called with max(-1, 3600) = 3600
-                assert mock_sleep.call_count == 2
-                mock_sleep.assert_any_call(3600)
+                assert mock_sleep.call_count == 1
+                mock_sleep.assert_any_call(interval)
 
                 # Now test when we run retention with a positive value.
                 mock_config.get_nested.return_value = 2  # every 2 hours.
-                mock_sleep.side_effect = [None, None, asyncio.CancelledError()]
+                mock_sleep.side_effect = [None, asyncio.CancelledError()]
 
                 with pytest.raises(asyncio.CancelledError):
                     await sky.global_user_state.cluster_event_retention_daemon()
@@ -68,9 +71,14 @@ async def test_cluster_event_retention_daemon():
                 mock_clean.assert_any_call(
                     2, sky.global_user_state.ClusterEventType.DEBUG)
 
-                # Verify sleep was called with max(2 * 3600, 3600) = 7200
-                assert mock_sleep.call_count == 5
-                mock_sleep.assert_any_call(7200)
+                # The retention window still governs *what* is deleted (asserted
+                # above), but no longer how often the daemon wakes. It used to
+                # sleep max(min(retention, debug_retention), 3600), so a 2-hour
+                # retention meant waking every 2 hours and accumulating two
+                # hours of eligible events per pass.
+                assert mock_sleep.call_count == 3
+                mock_sleep.assert_any_call(interval)
+                assert mock.call(7200) not in mock_sleep.call_args_list
 
 
 def test_add_or_update_cluster_update_only(_mock_db_conn):

--- a/tests/unit_tests/test_housekeeping_daemon_cadence.py
+++ b/tests/unit_tests/test_housekeeping_daemon_cadence.py
@@ -1,0 +1,151 @@
+"""Tests for housekeeping daemon wake intervals and startup jitter."""
+import asyncio
+from unittest import mock
+
+import pytest
+
+from sky import global_user_state
+from sky import skypilot_config
+from sky.server.requests import requests as requests_lib
+from sky.utils import asyncio_utils
+
+
+class _StopLoop(Exception):
+    """Raised from the patched sleep to break the daemon's `while True`."""
+
+
+def _sleep_recorder(recorded):
+
+    async def fake_sleep(secs):
+        recorded.append(secs)
+        raise _StopLoop
+
+    return fake_sleep
+
+
+@pytest.mark.asyncio
+async def test_requests_gc_interval_is_independent_of_retention():
+    """The wake interval must not scale with the retention window.
+
+    A long retention window means rows are kept longer, not that eligible
+    rows should be left to accumulate between passes.
+    """
+    slept = []
+    # 30 days of retention: if the interval tracked retention, the daemon
+    # would sleep for 30 days and each pass would have a month of rows.
+    with mock.patch.object(skypilot_config, 'reload_config'), \
+         mock.patch.object(skypilot_config, 'get_nested',
+                           return_value=24 * 30), \
+         mock.patch.object(requests_lib,
+                           'clean_finished_requests_with_retention',
+                           mock.AsyncMock()), \
+         mock.patch.object(asyncio_utils, 'sleep_startup_jitter',
+                           mock.AsyncMock()), \
+         mock.patch.object(asyncio, 'sleep', _sleep_recorder(slept)):
+        with pytest.raises(_StopLoop):
+            await requests_lib.requests_gc_daemon()
+
+    assert slept == [requests_lib._REQUESTS_GC_INTERVAL_SECONDS]
+    assert requests_lib._REQUESTS_GC_INTERVAL_SECONDS == 3600
+
+
+@pytest.mark.asyncio
+async def test_requests_gc_interval_same_for_short_retention():
+    """A short retention window does not shorten the interval either."""
+    slept = []
+    with mock.patch.object(skypilot_config, 'reload_config'), \
+         mock.patch.object(skypilot_config, 'get_nested', return_value=1), \
+         mock.patch.object(requests_lib,
+                           'clean_finished_requests_with_retention',
+                           mock.AsyncMock()), \
+         mock.patch.object(asyncio_utils, 'sleep_startup_jitter',
+                           mock.AsyncMock()), \
+         mock.patch.object(asyncio, 'sleep', _sleep_recorder(slept)):
+        with pytest.raises(_StopLoop):
+            await requests_lib.requests_gc_daemon()
+
+    assert slept == [requests_lib._REQUESTS_GC_INTERVAL_SECONDS]
+
+
+@pytest.mark.asyncio
+async def test_cluster_event_interval_is_independent_of_retention():
+    """Same for the cluster-event retention daemon.
+
+    Its default retention is 30 days, so an interval derived from retention
+    left it waking roughly once a month.
+    """
+    slept = []
+    with mock.patch.object(skypilot_config, 'reload_config'), \
+         mock.patch.object(skypilot_config, 'get_nested',
+                           return_value=24 * 30), \
+         mock.patch.object(global_user_state,
+                           'cleanup_cluster_events_with_retention'), \
+         mock.patch.object(asyncio_utils, 'sleep_startup_jitter',
+                           mock.AsyncMock()), \
+         mock.patch.object(asyncio, 'sleep', _sleep_recorder(slept)):
+        with pytest.raises(_StopLoop):
+            await global_user_state.cluster_event_retention_daemon()
+
+    assert slept == [global_user_state.CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS]
+    assert global_user_state.CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS == 3600
+
+
+@pytest.mark.asyncio
+async def test_startup_jitter_bounded_and_random():
+    """sleep_startup_jitter sleeps within [0, max) and varies between calls."""
+    slept = []
+
+    async def fake_sleep(secs):
+        slept.append(secs)
+
+    with mock.patch.object(asyncio, 'sleep', fake_sleep):
+        for _ in range(50):
+            await asyncio_utils.sleep_startup_jitter('t', max_seconds=100)
+
+    assert len(slept) == 50
+    assert all(0 <= s < 100 for s in slept), slept
+    # Identical values across 50 draws would mean it is not random.
+    assert len(set(slept)) > 40, 'delays are not spread out'
+
+
+@pytest.mark.asyncio
+async def test_startup_jitter_disabled_does_not_sleep():
+    slept = []
+
+    async def fake_sleep(secs):
+        slept.append(secs)
+
+    with mock.patch.object(asyncio, 'sleep', fake_sleep):
+        await asyncio_utils.sleep_startup_jitter('t', max_seconds=0)
+        await asyncio_utils.sleep_startup_jitter('t', max_seconds=-1)
+
+    assert not slept
+
+
+@pytest.mark.asyncio
+async def test_gc_daemon_jitters_before_first_pass():
+    """The jitter runs before the loop, not between passes."""
+    order = []
+
+    async def fake_jitter(*_args, **_kwargs):
+        order.append('jitter')
+
+    async def fake_clean(*_args, **_kwargs):
+        order.append('pass')
+
+    async def fake_sleep(_secs):
+        order.append('interval')
+        raise _StopLoop
+
+    with mock.patch.object(skypilot_config, 'reload_config'), \
+         mock.patch.object(skypilot_config, 'get_nested', return_value=24), \
+         mock.patch.object(requests_lib,
+                           'clean_finished_requests_with_retention',
+                           fake_clean), \
+         mock.patch.object(asyncio_utils, 'sleep_startup_jitter',
+                           fake_jitter), \
+         mock.patch.object(asyncio, 'sleep', fake_sleep):
+        with pytest.raises(_StopLoop):
+            await requests_lib.requests_gc_daemon()
+
+    assert order == ['jitter', 'pass', 'interval'], order


### PR DESCRIPTION
## Problem

Follows #10555, which gave `requests_gc_daemon` a fixed hourly interval. Two things that change did not cover.

**1. `cluster_event_retention_daemon` has the same bug, and worse.**

```python
sleep_amount = max(min(retention_hours * 3600, debug_retention_hours * 3600),
                   MIN_CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS)
```

The `3600` is only a floor, and at the default 30-day retention it is never reached, so the daemon wakes every 30 days and each pass deletes a month of accumulated events at once. Events become eligible for deletion continuously, so the interval controls **how much work accumulates between passes**, not how long anything is kept.

Sleeping 30 days has a second effect: with any regular restart cadence the daemon only ever runs its startup pass and never reaches its own schedule at all.

**2. All four of these daemons run their first pass at t=0.**

They are written as `while True: do_pass(); await sleep(interval)`. Servers that boot together therefore start housekeeping together, and because the interval never varies they stay aligned from then on.

## Fix

**A fixed wake interval for `cluster_event_retention_daemon`**, from a module constant — the same shape `job_event_retention_daemon` (`JOB_EVENT_DAEMON_INTERVAL_SECONDS`) already uses, and now `requests_gc_daemon` too.

**`asyncio_utils.sleep_startup_jitter()`**, applied to the four daemons that run a pass at t=0: `requests_gc_daemon`, `cluster_event_retention_daemon`, `job_event_retention_daemon`, `cleanup_sky_logs`. One random offset in `[0, 30min)` per process, drawn before the loop.

Not applied to `cleanup_unreferenced_file_mounts` or `cleanup_clients_tmp` — both already `await asyncio.sleep(3600)` before their first pass. Not applied to the `InternalRequestDaemon` events either: refreshing cluster status shortly after a restart is useful, not just housekeeping.

## Why the cadence matters

Measured A/B on a dedicated Postgres 17 instance. 6,000 rows with a realistic serialized `return_value` averaging 925 KiB on disk, giving 5.6 GB of table against 3.8 GB of RAM — about 19% of buffer accesses served from disk. One arm deletes the whole backlog in a single pass, as an interval equal to the retention window does; the other spreads the identical row set over 24 passes.

| | one pass | 24 passes | |
|---|---|---|---|
| **longest single pass** | **99.9 s** | **10.6 s** | **9.4x shorter** |
| total time | 99.9 s | 104.1 s | +4.2% |
| total WAL | 6,577 MiB | 6,687 MiB | +1.7% |
| buffer-miss rate | 19.19% | 18.89% | comparable |

Total work is unchanged, which is the point — the same rows get deleted either way. What collapses is how long any one pass occupies the database's write path. Per-batch cost was 16.7 s per 1000-row batch at that payload size.

Two notes on WAL. With the table fully cached the same delete costs ~43 KiB of WAL per row; against a cold table it costs **1,123 KiB per row**. The difference is `full_page_writes`, on by default: the first modification to a page after a checkpoint writes a full-page image, so on a table larger than cache nearly every page the delete touches contributes its whole image.

The absolute seconds are specific to this instance size; the ratio is the transferable part.

## What this deliberately does not include

An earlier revision added a partial index on `finished_at` for the GC's eligibility query, reasoning that nothing indexes it (`status_name_idx` is partial on the *active* statuses, so it excludes exactly these rows).

Measurement did not support it, so it is out:

- The eligibility scan reads only the **heap** — never the TOAST that holds ~95% of the bytes. Measured heap density is **51 rows per 8 KB page**, so 2,000 rows occupy 39 pages / 0.3 MiB. Scanning that 24 times a day is not worth an index.
- The index did cut that scan from 39 pages to 2, but only from 1.99 ms to 1.55 ms.
- Meanwhile it made every `DELETE` maintain a sixth index: the 24-pass arm went from 104.1 s to **132.2 s**, **+27%**.

## Tests

`tests/unit_tests/test_housekeeping_daemon_cadence.py`, 6 cases:

- both daemons sleep their fixed constant with a 30-day retention configured (the previous code would have slept 30 days)
- the requests-GC interval is also unchanged by a 1-hour retention
- jitter stays within `[0, max)` and is spread across 50 draws
- jitter is skipped at `max_seconds <= 0`
- the jitter runs before the loop, not between passes (asserts `jitter → pass → interval`)

`tests/test_global_user_state.py::test_cluster_event_retention_daemon` is updated to the new contract: it now asserts the fixed interval and that `sleep(7200)` is *not* called, with `sleep_startup_jitter` patched out so the call counts are honest rather than coincidental.

## Compatibility

No API, schema or config change. `MIN_CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS` is renamed to `CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS` since it is no longer a floor; it had no other references.

One behaviour change worth naming: a cluster event previously became eligible at the retention boundary but could wait up to another full interval for the next pass, so effective lifetime was 30–60 days at the default. It is now 30 days plus at most an hour — closer to what the setting reads as, but a tightening for anyone relying on the longer tail.
