### PR TITLE
[Test] Fix the inline-env queue assertion matching a log line instead of the queue row

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1837,12 +1837,20 @@ def test_managed_jobs_inline_env(generic_cloud: str):
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.SUCCEEDED],
                 timeout=55),
-            f'JOB_ROW=$(sky jobs queue -v | grep {name} | head -n1) && '
-            f'echo "$JOB_ROW" && echo "$JOB_ROW" | grep -E "DONE|ALIVE" | grep "SUCCEEDED" && '
+            # Dump the queue before matching in it: when the row is
+            # missing, the grep alone leaves no evidence of what the queue
+            # actually returned.
+            'QUEUE=$(sky jobs queue -v) && echo "$QUEUE" && '
+            f'JOB_ROW=$(echo "$QUEUE" | grep {name} | head -n1) && '
+            f'echo "JOB_ROW=$JOB_ROW" && echo "$JOB_ROW" | grep -E "DONE|ALIVE" | grep "SUCCEEDED" && '
             f'JOB_ID=$(echo "$JOB_ROW" | awk \'{{print $1}}\') && '
             f'echo "JOB_ID=$JOB_ID" && '
             # Test that logs are still available after the job finishes.
-            'unset SKYPILOT_DEBUG; s=$(sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && '
+            # Scope SKYPILOT_DEBUG to this command: `unset SKYPILOT_DEBUG;`
+            # sat outside the && chain, so an earlier failure skipped the
+            # unset and the head -n2 assertion below then failed on debug
+            # lines rather than reporting the real failure.
+            's=$(SKYPILOT_DEBUG=0 sky jobs logs $JOB_ID --refresh) && echo "$s" && echo "$s" | grep "hello world" && '
             # Make sure we skip the unnecessary logs.
             'echo "$s" | head -n2 | grep "Waiting for"',
         ],

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1841,7 +1841,12 @@ def test_managed_jobs_inline_env(generic_cloud: str):
             # missing, the grep alone leaves no evidence of what the queue
             # actually returned.
             'QUEUE=$(sky jobs queue -v) && echo "$QUEUE" && '
-            f'JOB_ROW=$(echo "$QUEUE" | grep {name} | head -n1) && '
+            # Anchor on a table row (starts with the job id). The captured
+            # output also carries the request's log, streamed from the server,
+            # and a log line that happens to mention the job name would
+            # otherwise win the `head -n1` -- which is how this assertion fails
+            # on a server whose plugins log about the job.
+            f'JOB_ROW=$(echo "$QUEUE" | grep -E "^[0-9]+[[:space:]].*{name}" | head -n1) && '
             f'echo "JOB_ROW=$JOB_ROW" && echo "$JOB_ROW" | grep -E "DONE|ALIVE" | grep "SUCCEEDED" && '
             f'JOB_ID=$(echo "$JOB_ROW" | awk \'{{print $1}}\') && '
             f'echo "JOB_ID=$JOB_ID" && '


### PR DESCRIPTION
## Summary

`test_managed_jobs_inline_env` picks the job's row out of `sky jobs queue -v` with `grep <job-name> | head -n1`. The captured output is not only the table: the request's log is streamed from the server into the same stdout, so the first line naming the job wins — and on a server whose plugins log about the job, that is a log line, not the row. The row-shape check (`grep -E "DONE|ALIVE" | grep SUCCEEDED`) then fails against text that was never a row.

Reproduced on a Kubernetes lane with the enterprise plugin set loaded, three runs out of three, while every plugin-free lane passed:

```
JOB_ROW=D ... backend_utils.py:3165] Failed to fetch Kueue workload
              t-jobs-inline-env-aeca-1-2c9f9ac6 in context kind-skypilot
```

Two lines above it, the table held exactly what the case wanted:

```
ID  TASK  WORKSPACE  NAME                    ...  STATUS     ...  SCHED. STATE
1   -     default    t-jobs-inline-env-aeca  ...  SUCCEEDED  ...  ALIVE
```

This PR makes the case match a table row (a line starting with the job id) and, so a future failure is legible, dumps the queue output before matching in it. Suppressing debug output client-side would not fix it: those lines come from the server's request log — their PID is a server worker, not the CLI.

It also drops a second hazard in the same command. The chain ended with `... && unset SKYPILOT_DEBUG; s=$(sky jobs logs ...)`. Everything after the `;` sits outside the `&&` chain, so when an earlier link fails the `unset` is skipped and the remaining assertions still run — against a `$s` that now starts with debug lines. The result then depends on the ambient environment: with `SKYPILOT_DEBUG` set the case fails at the final `head -n2 | grep "Waiting for"`, blaming the wrong assertion (this is what the failure above looked like); with it unset the case **passes** having asserted nothing. Scoping the variable to the one command that needs it is the pattern the rest of this file already uses (e.g. `test_managed_jobs_logs_sync_down`).

## Test plan

Replayed both greps over the real captured output from the failing run:

| grep | selects | shape check |
|---|---|---|
| `grep <name>` (before) | the Kueue debug line | **fails** |
| `grep -E "^[0-9]+[[:space:]].*<name>"` (after) | the table row | passes |

And the `;` hazard, with a stubbed `sky` on `PATH` and `SKYPILOT_DEBUG=1` in the environment:

| queue row | new chain | old chain |
|---|---|---|
| present | exit 0 | exit 0 |
| missing | exit 1, last output is the queue dump | **exit 0** — passes having asserted nothing |

On CI, the queue-dump commit alone (before the anchor fix) already passed both plugin-free lanes, which is why this had never shown up there:

- `/smoke-test --jobs-consolidation --kubernetes -k test_managed_jobs_inline_env` — [build 12587](https://buildkite.com/skypilot-1/smoke-tests/builds/12587), passed
- `/smoke-test --kubernetes -k test_managed_jobs_inline_env` — [build 12588](https://buildkite.com/skypilot-1/smoke-tests/builds/12588), passed

Both to re-run with the anchor fix, plus the plugin-loaded lane that reproduces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)