### PR TITLE
[Docs] Fix three errors in the Slurm migration guide

### DIFF
--- a/docs/source/reference/slurm-migration.rst
+++ b/docs/source/reference/slurm-migration.rst
@@ -187,7 +187,7 @@ Here's a side-by-side comparison of a typical Slurm script and its SkyPilot equi
 Key differences:
 
 - **No module system**: Use ``setup:`` for environment configuration (pip, conda) or Docker images
-- **Time limits are optional**: SkyPilot uses :ref:`autostop <auto-stop>` for auto-termination. Can be configured to terminate on idleness or wall-clock time.
+- **Time limits work differently**: on Kubernetes and clouds, SkyPilot uses :ref:`autostop <auto-stop>` to terminate a cluster after an idle period. On Slurm, autostop is not supported; set a wall-clock limit with ``slurm.sbatch_options.time`` instead, or rely on the partition's ``MaxTime`` (which SkyPilot submits by default).
 - **Simpler syntax**: Resource requirements are declarative YAML fields
 - **Native container support**: Easily use :ref:`containers <docker-containers>` by setting ``image_id``.
 
@@ -211,8 +211,11 @@ Resource requests
      - ``accelerators: H100:8``
      - GPU type and count
    * - ``--time=24:00:00``
-     - ``autostop: 60m``
-     - Idle-based timeout
+     - ``config.slurm.sbatch_options.time`` (Slurm);
+       ``autostop: 60m`` (Kubernetes/clouds)
+     - On Slurm, passed through as ``#SBATCH --time``; defaults to the
+       partition's ``MaxTime``. Elsewhere, ``autostop`` is an *idle* timeout,
+       not a wall-clock limit
 
 Example with resource constraints:
 
@@ -291,27 +294,27 @@ Job arrays and parameter sweeps
 
 Slurm job arrays (``sbatch --array=1-100``) allow running many similar jobs with different parameters.
 
-In SkyPilot, use :ref:`managed jobs <managed-jobs>` with environment variables:
+The direct equivalent is ``sky jobs launch --num-jobs``, which submits N
+:ref:`managed jobs <managed-jobs>` from one task YAML:
 
 .. code-block:: bash
 
-   # Launch 100 jobs with different TASK_ID values
-   for i in $(seq 1 100); do
-     sky jobs launch --env TASK_ID=$i -y -d task.yaml
-   done
+   # Launch 100 jobs
+   sky jobs launch --num-jobs 100 -y -d task.yaml
 
-Your task YAML can use ``TASK_ID`` to vary behavior:
+Each job gets ``$SKYPILOT_JOB_RANK`` (the array index, ``0`` to ``N-1``, like
+``$SLURM_ARRAY_TASK_ID``) and ``$SKYPILOT_NUM_JOBS``:
 
 .. code-block:: yaml
 
-   envs:
-     TASK_ID: null  # Required, passed via --env
-
    run: |
-     echo "Running task $TASK_ID"
-     python train.py --seed $TASK_ID
+     echo "Shard $SKYPILOT_JOB_RANK of $SKYPILOT_NUM_JOBS"
+     python train.py --shard $SKYPILOT_JOB_RANK --num-shards $SKYPILOT_NUM_JOBS
 
-For hyperparameter sweeps, you can also pass multiple environment variables:
+To reuse workers across submissions instead of provisioning per job, submit to
+a :ref:`pool <pool>`: ``sky jobs launch -p mypool --num-jobs 100 task.yaml``.
+
+For sweeps over *named* parameters, pass environment variables per job:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Summary

Three corrections to `docs/source/reference/slurm-migration.rst`. Each was verified against the code, not assumed.

- **`--time` was mapped to `autostop`.** Autostop is unsupported on Slurm — `CloudImplementationFeatures.AUTOSTOP` is in Slurm's `_CLOUD_UNSUPPORTED_FEATURES` (`sky/clouds/slurm.py`). The mapping pointed Slurm users at the one lifecycle feature that doesn't work there. Now maps to `slurm.sbatch_options.time`, and notes the partition-`MaxTime` default that `_compute_time_directive()` emits.
- **"terminate on idleness or wall-clock time"** — there is no wall-clock termination. `_AUTOSTOP_SCHEMA` is idle-only.
- **Job arrays were a bash `for` loop.** `sky jobs launch --num-jobs` with `$SKYPILOT_JOB_RANK` / `$SKYPILOT_NUM_JOBS` is a direct `--array` / `$SLURM_ARRAY_TASK_ID` analogue. The loop is kept for sweeps over *named* parameters, which is what it's actually good for.

Scoped deliberately to correctness — no reflowing or rewording of the surrounding prose, so the diff is 3 hunks.

Refs SKY-4263. The broader structural gaps in this guide (how SkyPilot integrates with an existing Slurm cluster; native Slurm vs. SkyPilot on Slurm) are being handled in the agent skill instead — see SKY-6539.

## Test plan

- `cd docs && make html` — build succeeded with **0 warnings/errors** (the docs build treats any warning as a failure).
- Confirmed `--num-jobs` sets both env vars with no pool involved: `SKYPILOT_NUM_JOBS` in `sky/jobs/server/core.py`, `SKYPILOT_JOB_RANK` in `sky/jobs/controller.py`.
- Confirmed `slurm.sbatch_options` is settable from a task YAML via `OVERRIDEABLE_CONFIG_KEYS_IN_TASK` (`sky/skylet/constants.py`), and validated the snippet against `schemas.get_task_schema()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VMJWsy5ckfumTKKAqR4Mw
