### PR TITLE
[Agent] Add Slurm migration reference to the SkyPilot skill

### DIFF
--- a/agent/skills/skypilot/SKILL.md
+++ b/agent/skills/skypilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skypilot
-description: "Use when launching cloud VMs, Kubernetes pods, or Slurm jobs for GPU/TPU/CPU workloads, training or fine-tuning models on cloud GPUs, deploying inference servers (vllm, TGI, etc.) with autoscaling, writing or debugging SkyPilot task YAML files, using spot/preemptible instances for cost savings, comparing GPU prices across clouds, managing compute across 25+ clouds, Kubernetes, Slurm, and on-prem clusters with failover between them, troubleshooting resource availability or SkyPilot errors, or optimizing cost and GPU availability."
+description: "Use when launching cloud VMs, Kubernetes pods, or Slurm jobs for GPU/TPU/CPU workloads, training or fine-tuning models on cloud GPUs, deploying inference servers (vllm, TGI, etc.) with autoscaling, writing or debugging SkyPilot task YAML files, using spot/preemptible instances for cost savings, comparing GPU prices across clouds, managing compute across 25+ clouds, Kubernetes, Slurm, and on-prem clusters with failover between them, troubleshooting resource availability or SkyPilot errors, optimizing cost and GPU availability, or migrating an existing Slurm workload (converting sbatch scripts, salloc sessions, job arrays or srun invocations into SkyPilot task YAMLs, and mapping Slurm commands, directives and SLURM_* environment variables to their SkyPilot equivalents)."
 ---
 
 # SkyPilot Skill
@@ -392,6 +392,32 @@ sky logs exp-vm-01 $job_id --status && sky logs exp-vm-01 $job_id --tail 50
 sky queue exp-vm-01 -o json
 ```
 
+### Converting a Slurm Workload
+
+When the user has an existing `sbatch` script, `salloc` workflow, or asks how a
+Slurm command maps to SkyPilot, **read
+[Migrating from Slurm](references/migrating-from-slurm.md) before writing any
+YAML.** The mapping has non-obvious parts that are easy to get wrong:
+
+- `--time` does **not** map to `autostop` — autostop is unsupported on Slurm.
+  Use `config.slurm.sbatch_options.time`.
+- A bare `srun <cmd>` should usually be **dropped**, not translated: `run`
+  already executes on every node. Only MPI/PMIx launchers keep `srun`, and
+  then they need `--overlap` and a rank-0 guard.
+- `--account` / `--qos` / `--exclusive` and other unmodeled directives go
+  through `config.slurm.sbatch_options`, which passes them to `sbatch`
+  verbatim.
+- `sbatch --array` maps to `sky jobs launch --num-jobs` with
+  `$SKYPILOT_JOB_RANK`, not to a shell loop.
+
+Validate the result with `sky launch --dryrun <yaml>` — note there is no
+`--dryrun` on `sky jobs launch`, so dry-run via `sky launch` even when the
+final command will be `sky jobs launch`.
+
+Do not assume the user wants to leave Slurm. SkyPilot submits to an existing
+Slurm cluster through its login node; migrating *to Kubernetes* is a separate
+question, and the constraints differ.
+
 ## Agent Feedback Loop
 
 When using SkyPilot programmatically, follow this loop:
@@ -444,5 +470,6 @@ For detailed reference documentation:
 - [YAML Specification](references/yaml-spec.md) — Complete task YAML schema, file mounts, environment variables
 - [Python SDK](references/python-sdk.md) — Programmatic API and SDK usage
 - [Advanced Patterns](references/advanced-patterns.md) — Multi-cloud, distributed training, production patterns
+- [Migrating from Slurm](references/migrating-from-slurm.md) — Converting `sbatch` scripts to task YAMLs, Slurm command/env-var mapping, Slurm-specific constraints
 - [Troubleshooting](references/troubleshooting.md) — Error diagnosis and solutions
 - [Examples](references/examples.md) — Copy-paste task YAML examples

--- a/agent/skills/skypilot/evals/evals.json
+++ b/agent/skills/skypilot/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "skypilot",
-  "description": "Evaluates the 'Before You Start (Agent Bootstrap)' section behavior",
+  "description": "Evaluates the 'Before You Start (Agent Bootstrap)' and 'Converting a Slurm Workload' section behavior",
   "evals": [
     {
       "id": 1,
@@ -75,6 +75,58 @@
         {
           "text": "Agent re-runs `sky api status` after connecting to confirm it's reachable",
           "type": "required_action"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "slurm-sbatch-time-not-autostop",
+      "prompt": "Convert this to SkyPilot for our Slurm cluster:\n#!/bin/bash\n#SBATCH --nodes=2\n#SBATCH --gpus-per-node=8\n#SBATCH --time=24:00:00\n#SBATCH --account=ai-research\nsrun python train.py",
+      "expected_output": "Agent produces a task YAML with num_nodes: 2, resources.accelerators: H100:8 (or asks for the GRES name), and puts both --time and --account under config.slurm.sbatch_options. The bare `srun` is dropped because `run` already executes on every node. Agent recommends `sky jobs launch` for this batch script.",
+      "assertions": [
+        {
+          "text": "Agent maps --time to config.slurm.sbatch_options.time",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent does NOT map --time to autostop, which is unsupported on Slurm",
+          "type": "negative"
+        },
+        {
+          "text": "Agent maps --account to config.slurm.sbatch_options.account",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent puts num_nodes at task level, not under resources",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent does NOT wrap the run command in `srun` again",
+          "type": "negative"
+        },
+        {
+          "text": "Agent recommends `sky jobs launch` (not `sky launch`) for this batch script",
+          "type": "required_action"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "slurm-job-array-to-num-jobs",
+      "prompt": "On Slurm I run `sbatch --array=0-99 shard.sh` and the script reads $SLURM_ARRAY_TASK_ID to pick its shard. What's the SkyPilot equivalent?",
+      "expected_output": "Agent answers `sky jobs launch --num-jobs 100` and maps $SLURM_ARRAY_TASK_ID to $SKYPILOT_JOB_RANK (with $SKYPILOT_NUM_JOBS for the count). May also mention pools for reusing workers across submissions.",
+      "assertions": [
+        {
+          "text": "Agent uses `sky jobs launch --num-jobs 100`",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent maps $SLURM_ARRAY_TASK_ID to $SKYPILOT_JOB_RANK",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent does NOT propose a shell for-loop as the primary answer",
+          "type": "negative"
         }
       ]
     }

--- a/agent/skills/skypilot/references/migrating-from-slurm.md
+++ b/agent/skills/skypilot/references/migrating-from-slurm.md
@@ -1,0 +1,417 @@
+# Migrating from Slurm Reference
+
+This reference is for converting existing Slurm workloads into SkyPilot task
+YAMLs, and for answering "how do I do X, which I used to do with Slurm?".
+
+Two distinct situations, which need different answers:
+
+- **SkyPilot on the user's existing Slurm cluster.** SkyPilot submits to it
+  through the login node via `sbatch`. The cluster is unchanged. Most users
+  start here — do not assume they want to leave Slurm.
+- **SkyPilot on Kubernetes or a cloud.** The workload moves off Slurm. The
+  YAML is the same; the constraints are different (see section 8).
+
+Ask which one applies if it is not obvious. The conversion is nearly identical;
+the difference shows up in lifecycle (section 7) and what is unsupported
+(section 8).
+
+---
+
+## 1. Conversion Procedure
+
+Follow this order. Do not skip step 5.
+
+1. **Read the whole `sbatch` script**, not just the `#SBATCH` block. The
+   `srun` invocations and `module load` lines carry as much information as the
+   directives.
+2. **Map the `#SBATCH` directives** to `resources` / `num_nodes` (section 2).
+3. **Map the body**: `module load` → `setup`, environment activation → `setup`,
+   the actual work → `run` (section 6).
+4. **Translate `srun`** — this is the step most likely to be done wrong
+   (section 5).
+5. **Validate**: `sky launch --dryrun <yaml>`. This resolves resources and
+   runs the optimizer without provisioning anything. Note there is **no**
+   `--dryrun` on `sky jobs launch`, so dry-run against `sky launch` even when
+   the final command will be `sky jobs launch`.
+6. **Tell the user which submit command to use**: `sky jobs launch` for batch
+   work (an `sbatch` script), `sky launch` for an interactive allocation (an
+   `salloc` session).
+
+### 1.1 Choosing the submit command
+
+| The user's script is | Use | Why |
+|---|---|---|
+| `sbatch` batch job | `sky jobs launch` | Allocation released when the job ends, and the job is recovered if the node fails |
+| `salloc` / `srun --pty` session | `sky launch` + `ssh <cluster>` | Long-lived allocation to work in |
+| `sbatch --array` | `sky jobs launch --num-jobs N` | Section 7.1 |
+| A chain with `--dependency` | One managed pipeline | Section 7.2 |
+
+---
+
+## 2. `#SBATCH` Directive Mapping
+
+| `#SBATCH` directive | SkyPilot YAML | Notes |
+|---|---|---|
+| `--nodes=2` | `num_nodes: 2` | Task-level field, **not** under `resources` |
+| `--gpus-per-node=8`, `--gres=gpu:h100:8` | `resources.accelerators: H100:8` | Emitted as `--gres=gpu:<type>:<count>`. The name must match the cluster's GRES config |
+| `--cpus-per-task=32` | `resources.cpus: 32+` | `+` means "at least". Emitted as `--cpus-per-task` |
+| `--mem=256G` | `resources.memory: 256+` | In GB. Emitted as `--mem` |
+| `--partition=gpu` | `resources.infra: slurm/<cluster>/gpu` | Omit to let the optimizer choose a partition |
+| `--time=24:00:00` | `config.slurm.sbatch_options.time: "24:00:00"` | Defaults to the partition's `MaxTime` if unset. **Not** `autostop` — see section 8 |
+| `--job-name=train` | `name: train` | |
+| `--output=`, `--error=` | *(nothing)* | SkyPilot manages job logs; see section 7.4 |
+| `--account`, `--qos`, `--reservation`, `--exclusive`, `--constraint`, ... | `config.slurm.sbatch_options.<key>` | Section 3 |
+
+### 2.1 Worked example
+
+Input:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=train
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=256G
+#SBATCH --partition=gpu
+#SBATCH --time=24:00:00
+#SBATCH --account=ai-research
+
+module load cuda/12.1
+source ~/venv/bin/activate
+
+srun python train.py --epochs 100
+```
+
+Output:
+
+```yaml
+# train.yaml
+name: train
+
+num_nodes: 2
+
+resources:
+  infra: slurm/mycluster/gpu
+  accelerators: H100:8
+  cpus: 32+
+  memory: 256+
+
+config:
+  slurm:
+    sbatch_options:
+      time: "24:00:00"
+      account: ai-research
+
+setup: |
+  pip install -r requirements.txt
+
+run: |
+  python train.py --epochs 100
+```
+
+Submit with `sky jobs launch -n train train.yaml`.
+
+Note what happened to the `srun`: it disappeared. `run` already executes on
+every node of the allocation, so wrapping the command in `srun` again would
+nest a job step inside SkyPilot's own. See section 5.
+
+---
+
+## 3. Directives SkyPilot Does Not Model
+
+Anything without a `resources` equivalent goes through
+`slurm.sbatch_options`, which is emitted verbatim as `#SBATCH` lines. Keys are
+`sbatch` long option names; underscores become hyphens; `true` emits a bare
+flag; `null` / `false` omit the line.
+
+```yaml
+config:
+  slurm:
+    sbatch_options:
+      account: ai-research
+      qos: high
+      time: "24:00:00"
+      exclusive: true
+      constraint: ib
+```
+
+The same block works in `~/.sky/config.yaml` under a top-level `slurm:` key to
+apply fleet-wide, and can be scoped per cluster or per partition under
+`slurm.cluster_configs`.
+
+**Do not put these in `sbatch_options`** — SkyPilot manages them and will drop
+them with a warning:
+
+```
+job-name  output  error  nodes  wait-all-nodes
+no-requeue  cpus-per-task  mem  gres  partition
+```
+
+If a user asks for one of those, set it through `resources` / `name` instead.
+
+---
+
+## 4. Environment Variable Mapping
+
+| Slurm | SkyPilot | Notes |
+|---|---|---|
+| `$SLURM_JOB_NODELIST` | `$SKYPILOT_NODE_IPS` | Newline-separated IPs, **not** a Slurm hostlist expression. `$(echo "$SKYPILOT_NODE_IPS" \| head -n1)` is the head node |
+| `$SLURM_NNODES` | `$SKYPILOT_NUM_NODES` | |
+| `$SLURM_NODEID`, `$SLURM_PROCID` | `$SKYPILOT_NODE_RANK` | `0` to `num_nodes-1` |
+| `$SLURM_GPUS_PER_NODE` | `$SKYPILOT_NUM_GPUS_PER_NODE` | |
+| `$SLURM_JOB_ID` | `$SKYPILOT_TASK_ID` | |
+| `$SLURM_ARRAY_TASK_ID` | `$SKYPILOT_JOB_RANK` | Only set under `--num-jobs`; section 7.1 |
+| `$SLURM_ARRAY_TASK_COUNT` | `$SKYPILOT_NUM_JOBS` | |
+
+**On Slurm specifically**, the *job-scoped* `SLURM_*` variables of the
+underlying allocation are still present inside `run` — `SLURM_JOB_ID`,
+`SLURM_JOB_NODELIST`, `SLURM_GPUS_ON_NODE`, etc. Scripts that read them keep
+working. The *step-scoped* variables from SkyPilot's own job step
+(`SLURM_CPUS_PER_TASK`, `SLURM_CPU_BIND*`, `SLURM_STEP_*`, `SLURM_PROCID`, ...)
+are deliberately unset before the user script runs, so a nested `srun` targets
+the full allocation instead of inheriting SkyPilot's step shape.
+
+Prefer the `SKYPILOT_*` variables in generated YAML — they are what makes the
+same task portable to Kubernetes and clouds. Use the `SLURM_*` ones only when
+translating a script that must keep working unchanged.
+
+---
+
+## 5. Translating `srun`
+
+Three cases. Pick by what the `srun` was *for*.
+
+### 5.1 `srun <program>` launching one process per node
+
+Drop the `srun`. `run` already runs on every node.
+
+```bash
+# Slurm
+srun python preprocess.py
+```
+
+```yaml
+run: |
+  python preprocess.py
+```
+
+### 5.2 `srun` launching distributed training ranks
+
+Use the rank variables and the framework's own launcher. This is the portable
+form and should be the default for training workloads.
+
+```yaml
+num_nodes: 2
+
+resources:
+  accelerators: H100:8
+
+run: |
+  MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  torchrun \
+    --nnodes=$SKYPILOT_NUM_NODES \
+    --nproc_per_node=$SKYPILOT_NUM_GPUS_PER_NODE \
+    --node_rank=$SKYPILOT_NODE_RANK \
+    --master_addr=$MASTER_ADDR \
+    --master_port=8008 \
+    train.py
+```
+
+### 5.3 `srun` launching an MPI/PMIx program
+
+Some binaries must be launched by Slurm's own PMI (NCCL tests, anything
+MPI-linked, `--mpi=pmix`). Keep `srun`, but:
+
+- **Gate it on rank 0**, or every node will launch the whole job.
+- **Pass `--overlap`**, so the step can share the allocation with SkyPilot's
+  own step.
+
+```yaml
+num_nodes: 2
+
+resources:
+  infra: slurm
+  accelerators: H100:8
+
+run: |
+  if [ "$SKYPILOT_NODE_RANK" == "0" ]; then
+    srun --overlap --mpi=pmix \
+      --ntasks-per-node=$SKYPILOT_NUM_GPUS_PER_NODE \
+      ./my_mpi_program
+  fi
+```
+
+This form is Slurm-only by construction — it will not run on Kubernetes or a
+cloud. Say so when generating it.
+
+---
+
+## 6. Replacing the Module System
+
+`module load` reads a cluster-wide tree shared by all jobs. SkyPilot gives
+each job its own environment. In increasing order of isolation:
+
+```yaml
+# 1. setup commands — runs once per cluster, before the job
+setup: |
+  pip install -r requirements.txt
+```
+
+```yaml
+# 2. a container image — the closest thing to a reproducible module set.
+#    On Slurm this needs the Pyxis SPANK plugin on the cluster.
+resources:
+  image_id: docker:pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime
+```
+
+```yaml
+# 3. conda on the shared filesystem, if the user wants to keep their layout
+setup: |
+  conda create -n myenv python=3.10 -y
+  conda activate myenv
+  conda install pytorch pytorch-cuda=12.1 -c pytorch -c nvidia -y
+
+run: |
+  conda activate myenv
+  python train.py
+```
+
+`module load` itself still works inside `setup` / `run` on a Slurm cluster,
+as long as the task is not running in a container. Keeping it is a legitimate
+first migration step — it just does not port to Kubernetes or clouds.
+
+---
+
+## 7. Patterns Without a One-to-One Field
+
+### 7.1 Job arrays → `--num-jobs`
+
+`sbatch --array=0-99` becomes:
+
+```bash
+sky jobs launch --num-jobs 100 -y -d task.yaml
+```
+
+Each job gets `$SKYPILOT_JOB_RANK` (the index) and `$SKYPILOT_NUM_JOBS`:
+
+```yaml
+run: |
+  python train.py --shard $SKYPILOT_JOB_RANK --num-shards $SKYPILOT_NUM_JOBS
+```
+
+Each job provisions its own allocation. To reuse workers across submissions
+instead — closer to how a long-lived Slurm allocation behaves, and much
+cheaper when `setup` is expensive — submit to a pool:
+
+```bash
+sky jobs pool apply -p mypool pool.yaml
+sky jobs launch -p mypool --num-jobs 100 task.yaml
+```
+
+For sweeps over *named* parameters rather than an index, loop with `--env`:
+
+```bash
+for lr in 0.001 0.01 0.1; do
+  sky jobs launch --env LR=$lr -y -d task.yaml
+done
+```
+
+### 7.2 Job dependencies → a managed pipeline
+
+`sbatch --dependency=afterok:<jobid>` becomes a sequence of tasks in one
+managed job, separated by `---`. Each task can request different resources.
+
+```yaml
+name: train-then-eval
+
+---
+
+name: train
+resources:
+  accelerators: H100:8
+run: python train.py
+
+---
+
+name: eval
+resources:
+  accelerators: L4:1
+run: python eval.py
+```
+
+For tasks that should run *in parallel* rather than in sequence, use a job
+group instead of a pipeline.
+
+### 7.3 Login node workflow
+
+There is no login node in the SkyPilot workflow. Submit from the user's laptop
+or CI; SkyPilot makes the SSH hop to the login node itself. Sync code with
+`workdir` (a local path or a git URL) rather than editing on NFS. For
+interactive work, `ssh <cluster>` lands on the *allocated compute node*, not a
+shared login node.
+
+### 7.4 Job output files
+
+Slurm writes `slurm-<jobid>.out`. SkyPilot streams logs instead:
+
+```bash
+sky jobs logs <job_id>       # managed job
+sky logs <cluster>           # latest job on a cluster
+sky logs <cluster> 2         # a specific job
+```
+
+Do not translate `--output` / `--error` into anything. If the script writes
+its own result files, point them at the shared filesystem or a bucket.
+
+---
+
+## 8. Constraints When Running on Slurm
+
+Do not generate YAML that uses these on a Slurm target — they will fail or be
+rejected:
+
+| Feature | Status on Slurm | What to do instead |
+|---|---|---|
+| `autostop` / `sky stop` | Unsupported | `sky down` explicitly; bound wall-clock with `sbatch_options.time` |
+| `ports:` / `sky serve` | Unsupported | Run serving on Kubernetes or a cloud |
+| `use_spot: true` | Unsupported | Omit; there is no spot tier |
+| Jobs/serve controllers | Not hosted on Slurm | With a remote API server, consolidation mode runs the controller inside the API server, so `sky jobs launch` works against a Slurm-only fleet. With a local API server the controller needs Kubernetes or a cloud |
+| `image_id: docker:...` | Needs Pyxis on the cluster | Fall back to `setup` commands |
+| Bucket mounting (`mode: MOUNT`) | Needs FUSE on compute nodes | Use the shared filesystem, or `mode: COPY` |
+
+Because autostop does not exist on Slurm, an idle `sky launch` cluster holds
+its allocation until `sky down`. Prefer `sky jobs launch` for anything
+batch-like so the allocation is released automatically.
+
+### 8.1 If the target is Kubernetes instead
+
+The assumption that breaks first is shared storage: Kubernetes does not mount
+home directories. A Slurm script that reads `~/data` or writes `~/checkpoints`
+needs one of:
+
+- an NFS mount via `config.kubernetes.pod_config` (if the nodes can reach the
+  existing NFS server),
+- a `ReadWriteMany` PVC through SkyPilot volumes,
+- a bucket under `file_mounts` with `mode: MOUNT`,
+- `workdir` for code only.
+
+Partitions map to Kubernetes contexts (`infra: kubernetes/<context>`), and
+Slurm's fairshare/QoS has no built-in equivalent — that is Kueue or priority
+classes.
+
+---
+
+## 9. Validation Checklist
+
+Before handing a converted YAML to the user:
+
+- [ ] `sky launch --dryrun <yaml>` resolves without error.
+- [ ] `num_nodes` is at task level, not under `resources`.
+- [ ] No `autostop` / `ports` / `use_spot` if the target is Slurm.
+- [ ] Every `srun` is accounted for by section 5 — dropped, replaced with
+      rank variables, or kept with `--overlap` and gated on rank 0.
+- [ ] GPU name matches the cluster's GRES names (check `sky gpus list --infra
+      slurm`).
+- [ ] Protected `sbatch` options are not in `sbatch_options` (section 3).
+- [ ] The user is told whether to run `sky launch` or `sky jobs launch`.

--- a/agent/skills/skypilot/references/migrating-from-slurm.md
+++ b/agent/skills/skypilot/references/migrating-from-slurm.md
@@ -57,7 +57,7 @@ Follow this order. Do not skip step 5.
 | `--cpus-per-task=32` | `resources.cpus: 32+` | `+` means "at least". Emitted as `--cpus-per-task` |
 | `--mem=256G` | `resources.memory: 256+` | In GB. Emitted as `--mem` |
 | `--partition=gpu` | `resources.infra: slurm/<cluster>/gpu` | Omit to let the optimizer choose a partition |
-| `--time=24:00:00` | `config.slurm.sbatch_options.time: "24:00:00"` | Defaults to the partition's `MaxTime` if unset. **Not** `autostop` — see section 8 |
+| `--time=24:00:00` | `config.slurm.sbatch_options.time: "24:00:00"` | Defaults to the partition's `MaxTime` (or `DefaultTime` when `MaxTime` is `UNLIMITED`) if unset. **Not** `autostop` — see section 8 |
 | `--job-name=train` | `name: train` | |
 | `--output=`, `--error=` | *(nothing)* | SkyPilot manages job logs; see section 7.4 |
 | `--account`, `--qos`, `--reservation`, `--exclusive`, `--constraint`, ... | `config.slurm.sbatch_options.<key>` | Section 3 |
@@ -137,8 +137,9 @@ config:
 ```
 
 The same block works in `~/.sky/config.yaml` under a top-level `slurm:` key to
-apply fleet-wide, and can be scoped per cluster or per partition under
-`slurm.cluster_configs`.
+apply fleet-wide, and can be scoped per cluster or per partition:
+`slurm.cluster_configs.<cluster>.sbatch_options` and
+`slurm.cluster_configs.<cluster>.partition_configs.<partition>.sbatch_options`.
 
 **Do not put these in `sbatch_options`** — SkyPilot manages them and will drop
 them with a warning:
@@ -302,7 +303,8 @@ run: |
 
 Each job provisions its own allocation. To reuse workers across submissions
 instead — closer to how a long-lived Slurm allocation behaves, and much
-cheaper when `setup` is expensive — submit to a pool:
+cheaper when `setup` is expensive — submit to a pool (note `pool.yaml` is a
+pool spec: it needs a `pool:` section, not a bare task YAML):
 
 ```bash
 sky jobs pool apply -p mypool pool.yaml
@@ -341,7 +343,28 @@ run: python eval.py
 ```
 
 For tasks that should run *in parallel* rather than in sequence, use a job
-group instead of a pipeline.
+group instead of a pipeline. A job group is the same multi-document layout,
+but the header must set `execution: parallel` — without it the file is a
+*serial* pipeline:
+
+```yaml
+name: train-and-eval
+execution: parallel
+
+---
+
+name: train
+resources:
+  accelerators: H100:8
+run: python train.py
+
+---
+
+name: eval
+resources:
+  accelerators: L4:1
+run: python eval.py
+```
 
 ### 7.3 Login node workflow
 

--- a/agent/test/eval_set.json
+++ b/agent/test/eval_set.json
@@ -78,5 +78,13 @@
   {
     "query": "I need to set up Weights & Biases experiment tracking for my training runs. Can you help me integrate wandb into my training script and configure the project dashboard?",
     "should_trigger": false
+  },
+  {
+    "query": "I have a bunch of sbatch scripts we use on our university cluster — 2 nodes, 8 gpus each, srun python train.py at the bottom. can you convert one of them into whatever format skypilot wants so I can submit the same job?",
+    "should_trigger": true
+  },
+  {
+    "query": "our slurmctld keeps dropping nodes into drain state after every reboot and scontrol update doesn't stick. how do I stop slurm from draining them on boot?",
+    "should_trigger": false
   }
 ]


### PR DESCRIPTION
## Summary

Customers arriving from Slurm port their `sbatch` scripts by hand today, and the skill offers no help: Slurm appears only as a launch *target*, with no directive mapping, no `srun` translation, and no indication of which SkyPilot features don't exist on Slurm.

Adds `references/migrating-from-slurm.md` — a conversion-oriented reference (procedure, `#SBATCH` and `SLURM_*` mapping tables, `sbatch_options` pass-through, `srun` translation, Slurm-specific constraints, validation checklist) — plus a routing section in `SKILL.md` targeting the four mistakes an agent is most likely to make unprompted:

- **`--time` → `autostop`.** Autostop is unsupported on Slurm (`AUTOSTOP` is in Slurm's `_CLOUD_UNSUPPORTED_FEATURES`). Correct target is `config.slurm.sbatch_options.time`.
- **Translating a bare `srun` instead of dropping it.** `run` already executes on every node, so re-wrapping nests a job step inside SkyPilot's own. Only MPI/PMIx launchers keep `srun`, and then they need `--overlap` plus a rank-0 guard.
- **Dropping unmodeled directives.** `--account`, `--qos`, `--exclusive` etc. pass through `config.slurm.sbatch_options` verbatim. The reference also lists the protected options SkyPilot manages and will discard with a warning.
- **`sbatch --array` → a shell loop.** `--num-jobs` with `$SKYPILOT_JOB_RANK` is the direct analogue.

**Hand-maintained, not generated.** `_rst_to_markdown()` in `generate_references.py` skips `list-table` directives along with the other unhandled ones — `yaml-spec.rst` has none, so this was never exercised. Since the mapping tables *are* the substance here, deriving this file from the docs page would have required teaching the converter about tables first. Kept out of the generator for now; happy to invert that if you'd rather have one source of truth.

Relates to SKY-6539 (Slurm slice only — Kubernetes manifests and Modal are still open there, and Modal should follow whatever packaging SKY-6215 lands on).

## Test plan

- `python agent/scripts/generate_references.py` → **no diff** under `agent/skills/skypilot/references/`, confirming the new hand-written file doesn't collide with the generated ones.
- `SKILL.md` frontmatter parses as YAML (description 778 chars); every relative `references/*.md` link resolves.
- `evals.json` and `eval_set.json` parse. Two behavior evals added (`--time`/`srun` mapping; array → `--num-jobs`), and the trigger set stays balanced at **11 positive / 11 negative** — the new negative is a pure `slurmctld` admin question, which should *not* trigger the skill.
- Claims checked against code rather than assumed: `_SBATCH_PROTECTED_OPTIONS` and `_compute_time_directive` (`sky/provision/slurm/instance.py`), `UNSET_STEP_SCOPED_SLURM_ENV` (`sky/skylet/executor/slurm.py`), `_CLOUD_UNSUPPORTED_FEATURES` (`sky/clouds/slurm.py`), and that `sky launch --dryrun` exists while `sky jobs launch` has none (`sky/client/cli/command.py:5740` still carries the `TODO(zhwu)`).

## Note: the staleness guard has broken path filters

Not included here — pushing `.github/workflows/**` needs a token scope I don't have. `skill-references-reviewable.yaml` still triggers on the pre-`#9017` layout:

```yaml
- 'skills/skypilot/scripts/generate_references.py'      # actual: agent/scripts/...
- 'skills/skypilot/skills/skypilot/references/**'       # actual: agent/skills/skypilot/references/**
```

`#9017` moved the tree and updated the workflow's `run:` step but not its triggers, so editing the generator — or hand-editing a generated reference — does not fire the check today. Worth a separate two-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VMJWsy5ckfumTKKAqR4Mw

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->