### PR TITLE
[Core] Report an inaccessible workspace as an access-filter result

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -415,11 +415,27 @@ def check_capabilities(
     if workspace is not None:
         # Check only the specified workspace
         if workspace not in available_workspaces:
+            # `available_workspaces` is this caller's access-filtered set, not
+            # the server's configured workspace set, so a miss here means
+            # either "no such workspace" or "this identity has no grant on
+            # it". Reporting it as "not found in SkyPilot configuration"
+            # points debugging at the config even when the workspace is
+            # present and correct, and when the filtered set is empty the old
+            # message rendered as `Available workspaces: `, which reads as
+            # "this server has none configured".
+            user = common_utils.get_current_user()
+            identity = repr(user.name) if user.name else f'id {user.id!r}'
+            if available_workspaces:
+                accessible = ('Accessible workspaces: '
+                              f'{", ".join(available_workspaces)}.')
+            else:
+                accessible = 'No workspaces are accessible to this identity.'
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Workspace {workspace!r} not found in SkyPilot '
-                    'configuration. '
-                    f'Available workspaces: {", ".join(available_workspaces)}')
+                    f'Workspace {workspace!r} is not accessible to user '
+                    f'{identity}. {accessible} A workspace is inaccessible '
+                    'when it is absent from the SkyPilot configuration or '
+                    'when the caller has no grant on it.')
 
         # Always show details for single specified check (if verbose)
         hide_per_cloud_details_flag = False

--- a/tests/unit_tests/test_sky/test_check.py
+++ b/tests/unit_tests/test_sky/test_check.py
@@ -611,3 +611,37 @@ class TestCheckWorkspacePermission:
     def test_skips_check_when_workspace_is_none(self, mock_check, _):
         sky_check.check(workspace=None)
         mock_check.assert_not_called()
+
+
+class TestCheckCapabilitiesInaccessibleWorkspace:
+    """A workspace miss is an access-filter result, not a config lookup."""
+
+    @staticmethod
+    def _message_for(monkeypatch, accessible):
+        # Signature-agnostic on purpose: this helper only cares about the
+        # returned set, not about how the caller narrows it.
+        monkeypatch.setattr(
+            'sky.workspaces.core.get_accessible_workspace_names',
+            lambda *args, **kwargs: set(accessible))
+        monkeypatch.setattr('sky.check.common_utils.get_current_user',
+                            lambda: models.User(id='u-1', name='alice'))
+        with pytest.raises(ValueError) as exc_info:
+            sky_check.check_capabilities(quiet=True, workspace='team-ws')
+        return str(exc_info.value)
+
+    def test_names_the_identity_and_the_accessible_set(self, monkeypatch):
+        message = self._message_for(monkeypatch, ['default'])
+        assert "Workspace 'team-ws' is not accessible to user 'alice'" in (
+            message)
+        assert 'Accessible workspaces: default.' in message
+        # The old wording blamed the server configuration unconditionally,
+        # which sent debugging at the config file instead of at the grants.
+        assert 'not found in SkyPilot configuration' not in message
+
+    def test_empty_filtered_set_is_not_an_empty_configuration(
+            self, monkeypatch):
+        message = self._message_for(monkeypatch, [])
+        assert 'No workspaces are accessible to this identity.' in message
+        # `Available workspaces: ` with nothing after it read as "this server
+        # has no workspaces configured at all".
+        assert 'Available workspaces:' not in message


### PR DESCRIPTION
Fixes #10507.

## Problem

`check_capabilities()` (`sky/check.py`) validates the requested workspace against
`available_workspaces`:

```python
available_workspaces = list(core.get_accessible_workspace_names(...))
...
if workspace not in available_workspaces:
    raise ValueError(
        f'Workspace {workspace!r} not found in SkyPilot configuration. '
        f'Available workspaces: {", ".join(available_workspaces)}')
```

`available_workspaces` is the **caller's access-filtered set**, not the server's
configured workspace set. So a workspace that exists and is configured correctly
produces exactly the same message as one that does not exist at all — the only
difference is whether this identity holds a grant on it.

Two concrete failure modes:

1. The message blames the SkyPilot configuration for what is an RBAC outcome, so
   debugging starts at the config file and the workspaces YAML, both of which are
   fine.
2. When the filtered set is empty, `", ".join([])` renders the message as
   `Available workspaces: ` with nothing after it — which reads as *"this server
   has no workspaces configured at all"*.

As reported in #10507, this came up while investigating #10506, where the
workspace was real and correctly configured but the identity used for the check
had an empty grant list. The message gave no indication that access filtering was
the cause.

## Change

Describe what was actually checked, and stop asserting a cause the code cannot
distinguish:

```
Workspace 'team-ws' is not accessible to user 'alice'. Accessible workspaces:
default, team-a. A workspace is inaccessible when it is absent from the SkyPilot
configuration or when the caller has no grant on it.
```

and when nothing is accessible:

```
Workspace 'team-ws' is not accessible to user 'alice'. No workspaces are
accessible to this identity. A workspace is inaccessible when it is absent from
the SkyPilot configuration or when the caller has no grant on it.
```

Service accounts and other users with no display name degrade to the id, which is
the identifier an operator can actually grep for in the grants:

```
Workspace 'team-ws' is not accessible to user id 'sa-9'. ...
```

### What this deliberately does *not* do

It does **not** consult the unfiltered configured-workspace set to report
"exists but you cannot see it". That would confirm the existence of a private
workspace to an identity with no grant on it, which is an information-disclosure
change and a separate decision from fixing a misleading message. The new wording
names both possibilities without revealing which one applies.

This is a diagnostics-only change; it does not address the underlying defects in
#10506 (`/validate` not resolving the caller's workspace, and a cloud-cache
refresh reaching an RBAC-gated check). As the reporter notes, a better message
would not have prevented that bug — it would have made it diagnosable in minutes.

## Tested

- `pytest -c /dev/null tests/unit_tests/test_sky/test_check.py tests/unit_tests/test_sky/test_check_persistence.py`
  → **23 passed** (15 pre-existing in `test_check.py`, +2 new, +6 persistence).
- The two new tests were confirmed **red** against unmodified `sky/check.py`
  (`2 failed, 15 passed`) and green with the change, so they exercise the new
  branch rather than passing vacuously.
- `yapf==0.32.0` (the pinned `.pre-commit-config.yaml` version, `based_on_style
  = google`) reports no diff on either changed file.

The new tests mock `sky.workspaces.core.get_accessible_workspace_names` with
`lambda *args, **kwargs:` on purpose — the assertion is about the returned set,
not about how the caller narrows it, so the test does not re-pin that signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->