### PR TITLE
[Slurm] Support stopping/starting container clusters using fs snapshots

### DIFF
--- a/docs/source/reference/slurm/slurm-getting-started.rst
+++ b/docs/source/reference/slurm/slurm-getting-started.rst
@@ -427,6 +427,29 @@ limited to Docker Hub, AWS ECR, GCP Artifact Registry, and NVIDIA NGC.
     Container support requires the `Pyxis <https://github.com/NVIDIA/pyxis>`_
     SPANK plugin to be installed on your Slurm cluster.
 
+Stopping and restarting containers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Container clusters on Slurm support ``sky stop`` and ``sky start``. When a
+cluster stops, SkyPilot exports each node's container filesystem to shared
+storage and releases the Slurm allocation. Starting the cluster requests a new
+allocation and restores each node from its exported filesystem.
+
+Installed packages, files under ``/root``, and other changes to the container
+root filesystem are preserved. The user's home directory remains available
+through its existing shared-filesystem mount. Running processes and memory are
+not preserved, and ``/tmp`` and ``/run`` are recreated when the cluster starts.
+
+Snapshots are stored under
+``<workdir>/.sky_snapshots/<cluster-name-on-cloud>``. If ``workdir`` is not
+configured, SkyPilot uses the remote user's home directory. A snapshot uses
+approximately as much shared storage as the container root filesystem and
+continues to consume that storage while the cluster is stopped. ``sky down``
+deletes the snapshot.
+
+Stopping is available only when the cluster uses a container image and Pyxis
+is installed. Slurm clusters that run directly on the host cannot be stopped.
+
 Private registries
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/reference/slurm/slurm-getting-started.rst
+++ b/docs/source/reference/slurm/slurm-getting-started.rst
@@ -440,6 +440,13 @@ root filesystem are preserved. The user's home directory remains available
 through its existing shared-filesystem mount. Running processes and memory are
 not preserved, and ``/tmp`` and ``/run`` are recreated when the cluster starts.
 
+Before exporting the container filesystem, SkyPilot waits for the allocation's
+workload steps to exit. On clusters using ``proctrack/linuxproc``, a process
+that double-forks out of its Slurm step may remain alive after the step exits
+and cannot be detected by this drain. Workloads on these clusters should not
+detach processes from their Slurm steps before the cluster is stopped.
+``proctrack/cgroup`` tracks these descendants with the step.
+
 Snapshots are stored under
 ``<workdir>/.sky_snapshots/<cluster-name-on-cloud>``. If ``workdir`` is not
 configured, SkyPilot uses the remote user's home directory. A snapshot uses

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -26,6 +26,10 @@ _ALL_JOBS_INFO_CMD = (f'squeue -h --states=running,completing '
                       f'-o "%i{SEP}%j{SEP}%u{SEP}%N{SEP}%b"')
 _PARTITIONS_INFO_CMD = 'scontrol show partitions -o'
 _BATCH_OUTPUT_HEADER = 'SKYPILOT_SLURM_BATCH\n'
+_JOB_STEP_ID_REGEX = re.compile(r'(?:^|\s)StepId=(\S+)')
+_JOB_STEP_NAME_REGEX = re.compile(r'(?:^|\s)Name=(\S+)')
+_JOB_STEP_NOT_FOUND_REGEX = re.compile(
+    r'(?:Invalid job id|Job step .* not found)', re.IGNORECASE)
 
 # Regex pattern to extract partition names from scontrol output
 # Matches PartitionName=<name> and captures until the next field
@@ -83,6 +87,12 @@ class JobGresInfo(NamedTuple):
     # The job's per-node GRES request (squeue %b, TRES_PER_NODE), e.g.
     # 'gres/gpu:h100:4'.
     gres_str: str
+
+
+class JobStepInfo(NamedTuple):
+    """A Slurm job step returned by scontrol."""
+    step_id: str
+    name: str
 
 
 class SlurmInventorySnapshot(NamedTuple):
@@ -511,6 +521,65 @@ class SlurmClient:
                                            stderr=f'{stdout}\n{stderr}',
                                            stream_logs=False)
         logger.debug(f'Successfully cancelled job {job_name}: {stdout}')
+
+    def list_job_steps(self, job_id: str) -> List[JobStepInfo]:
+        """Lists the active steps in a Slurm job allocation."""
+        cmd = f'scontrol -o show step {shlex.quote(job_id)}'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        error_output = f'{stdout}\n{stderr}'
+        if rc != 0 and _JOB_STEP_NOT_FOUND_REGEX.search(error_output):
+            subprocess_utils.handle_returncode(
+                rc,
+                cmd,
+                f'Slurm allocation {job_id} disappeared during stop.',
+                stderr=error_output,
+                stream_logs=False)
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            f'Failed to query steps for Slurm job {job_id}.',
+            stderr=error_output,
+            stream_logs=False)
+        steps = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            step_id_match = _JOB_STEP_ID_REGEX.search(line)
+            name_match = _JOB_STEP_NAME_REGEX.search(line)
+            if step_id_match is None or name_match is None:
+                raise RuntimeError(
+                    f'Unexpected Slurm job step output: {line!r}.')
+            steps.append(
+                JobStepInfo(step_id=step_id_match.group(1),
+                            name=name_match.group(1)))
+        if not steps:
+            raise RuntimeError('Unexpected empty Slurm job step output for '
+                               f'allocation {job_id}.')
+        return steps
+
+    def signal_job_step(self, job_id: str, step_id: str, signal: str) -> None:
+        """Signals one step, tolerating its concurrent completion."""
+        if not step_id.startswith(f'{job_id}.'):
+            raise ValueError(f'Slurm step {step_id!r} does not belong to job '
+                             f'{job_id!r}.')
+        cmd = (f'scancel --signal {shlex.quote(signal)} '
+               f'{shlex.quote(step_id)}')
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            active_step_ids = {
+                step.step_id for step in self.list_job_steps(job_id)
+            }
+            if step_id not in active_step_ids:
+                logger.debug(f'Slurm step {step_id} exited before it could be '
+                             f'signalled.')
+                return
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            f'Failed to signal Slurm job step {step_id}.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
 
     def info(self) -> str:
         """Get Slurm cluster information.

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -36,8 +36,9 @@ class Slurm(clouds.Cloud):
     _CLOUD_UNSUPPORTED_FEATURES = {
         clouds.CloudImplementationFeatures.AUTOSTOP: 'Slurm does not '
                                                      'support autostop.',
-        clouds.CloudImplementationFeatures.STOP: 'Slurm does not support '
-                                                 'stopping instances.',
+        clouds.CloudImplementationFeatures.STOP:
+            'Stopping is supported only for container clusters on Slurm '
+            'clusters with Pyxis installed.',
         clouds.CloudImplementationFeatures.SPOT_INSTANCE: 'Spot instances are '
                                                           'not supported in '
                                                           'Slurm.',
@@ -67,6 +68,7 @@ class Slurm(clouds.Cloud):
     # Used for early exit in _unsupported_features_for_resources().
     _DYNAMICALLY_CHECKED_FEATURES = {
         clouds.CloudImplementationFeatures.DOCKER_IMAGE,
+        clouds.CloudImplementationFeatures.STOP,
         clouds.CloudImplementationFeatures.STORAGE_MOUNTING,
     }
     _MAX_CLUSTER_NAME_LEN_LIMIT = 120
@@ -116,12 +118,20 @@ class Slurm(clouds.Cloud):
             clusters = cls.existing_allowed_clusters()
         else:
             clusters = [cluster]
+        uses_container = resources.extract_docker_image() is not None
+        dynamically_checked_features = cls._DYNAMICALLY_CHECKED_FEATURES.copy()
+        if not uses_container:
+            dynamically_checked_features.remove(
+                clouds.CloudImplementationFeatures.STOP)
         for c in clusters:
             try:
                 # Docker image support requires the Pyxis SPANK plugin.
                 if slurm_utils.check_pyxis_enabled(c):
                     unsupported.pop(
                         clouds.CloudImplementationFeatures.DOCKER_IMAGE, None)
+                    if uses_container:
+                        unsupported.pop(clouds.CloudImplementationFeatures.STOP,
+                                        None)
                 # Storage mounting requires FUSE (/dev/fuse).
                 if slurm_utils.check_fuse_enabled(c):
                     unsupported.pop(
@@ -131,8 +141,7 @@ class Slurm(clouds.Cloud):
                 logger.debug(f'Failed to check cluster features on {c}: '
                              f'{common_utils.format_exception(e)}')
             # Stop early if all dynamically checked features are resolved.
-            if not any(f in unsupported
-                       for f in cls._DYNAMICALLY_CHECKED_FEATURES):
+            if not any(f in unsupported for f in dynamically_checked_features):
                 break
         return unsupported
 

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -639,6 +639,18 @@ class Slurm(clouds.Cloud):
         volume_mount_vars.extend(
             mount.to_yaml_config() for mount in volume_mounts or [])
 
+        client = slurm.SlurmClient(
+            ssh_config_dict['hostname'],
+            int(ssh_config_dict.get('port', 22)),
+            ssh_config_dict['user'],
+            slurm_utils.get_identity_file(ssh_config_dict),
+            ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
+            ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
+            identities_only=slurm_utils.get_identities_only(ssh_config_dict),
+            slurm_user=slurm_user,
+        )
+        sky_base_dir = slurm_utils.resolve_sky_base_dir(cluster, client)
+
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -649,6 +661,7 @@ class Slurm(clouds.Cloud):
             'slurm_cluster': cluster,
             'slurm_partition': partition,
             'provision_timeout': provision_timeout,
+            'sky_base_dir': sky_base_dir,
             # TODO(jwj): Pass SSH config in a smarter way
             'ssh_hostname': ssh_config_dict['hostname'],
             'ssh_port': str(ssh_config_dict.get('port', 22)),

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -554,22 +554,15 @@ def _make_login_node_runner(
 def _resolve_sky_base_dir(client: 'slurm.SlurmClient',
                           provider_config: Dict[str, Any]) -> str:
     """Resolve the shared base directory used for Slurm cluster state."""
+    sky_base_dir = provider_config.get('sky_base_dir')
+    if sky_base_dir is not None:
+        if not isinstance(sky_base_dir, str) or not os.path.isabs(sky_base_dir):
+            raise RuntimeError('Slurm sky_base_dir must be an absolute path, '
+                               f'got {sky_base_dir!r}.')
+        return sky_base_dir
+
     slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
-    workdir = skypilot_config.get_effective_region_config(cloud='slurm',
-                                                          region=slurm_cluster,
-                                                          keys=('workdir',),
-                                                          default_value=None)
-    if workdir is not None:
-        workdir = slurm_utils.expand_path_vars(workdir, client.get_env())
-        if not os.path.isabs(workdir):
-            raise RuntimeError('Resolved Slurm workdir must be absolute, got '
-                               f'{workdir!r}.')
-        return workdir
-    remote_home_dir = client.get_remote_home_dir()
-    if not os.path.isabs(remote_home_dir):
-        raise RuntimeError('Slurm remote home directory must be absolute, got '
-                           f'{remote_home_dir!r}.')
-    return remote_home_dir
+    return slurm_utils.resolve_sky_base_dir(slurm_cluster, client)
 
 
 def _wait_for_job_ready(
@@ -709,10 +702,6 @@ def _create_virtual_instance(
             rich_utils.force_update_status(status_msg)
             last_status_msg = status_msg
 
-    workdir = skypilot_config.get_effective_region_config(cloud='slurm',
-                                                          region=region,
-                                                          keys=('workdir',),
-                                                          default_value=None)
     tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
                                                          region=region,
                                                          keys=('tmpdir',),
@@ -774,20 +763,11 @@ def _create_virtual_instance(
     )
     remote_home_dir = login_node_runner.get_remote_home_dir()
 
-    # Resolve shell variables (e.g. $USER) in workdir/tmpdir using the
-    # remote host's environment.
-    if workdir is not None or tmpdir is not None:
-        remote_env = client.get_env()
-        if workdir is not None:
-            workdir = slurm_utils.expand_path_vars(workdir, remote_env)
-        if tmpdir is not None:
-            tmpdir = slurm_utils.expand_path_vars(tmpdir, remote_env)
-        logger.debug(f'Resolved workdir: {workdir}, tmpdir: {tmpdir}')
+    if tmpdir is not None:
+        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
+        logger.debug(f'Resolved tmpdir: {tmpdir}')
 
-    # Must be absolute — #SBATCH directives don't expand ~ or $HOME.
-    sky_base_dir = workdir if workdir is not None else remote_home_dir
-    assert os.path.isabs(sky_base_dir), (
-        f'sky_base_dir must be absolute, got: {sky_base_dir}')
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sbatch_log_base_dir = sky_base_dir
 
     provision_script_path = _sbatch_provision_script_path(
@@ -876,11 +856,9 @@ def _create_virtual_instance(
             # The host python symlink is invalid inside the container.
             f'{skypilot_runtime_dir}/.sky:{skypilot_runtime_dir}/.sky',
         ]
-        # When workdir differs from remote_home_dir (e.g. workdir is on
-        # NFS at /home/ubuntu while $HOME is /home_local/ubuntu), mount
-        # it so the container can access sky_cluster_home_dir.
-        if workdir is not None and workdir != remote_home_dir:
-            mount_paths.append(f'{workdir}:{workdir}')
+        # The cluster state directory may be outside the remote home directory.
+        if sky_base_dir != remote_home_dir:
+            mount_paths.append(f'{sky_base_dir}:{sky_base_dir}')
         for volume_mount in resources.get('volume_mounts', []) or []:
             dst_path = volume_mount['path']
             volume_config = volume_mount['volume_config']
@@ -2126,29 +2104,16 @@ def get_command_runners(
         identities_only=login_node_identities_only,
         slurm_user=slurm_user,
     )
-    remote_home_dir = client.get_remote_home_dir()
-
     slurm_cluster_name = provider_config.get('cluster')
-    workdir = skypilot_config.get_effective_region_config(
-        cloud='slurm',
-        region=slurm_cluster_name,
-        keys=('workdir',),
-        default_value=None)
     tmpdir = skypilot_config.get_effective_region_config(
         cloud='slurm',
         region=slurm_cluster_name,
         keys=('tmpdir',),
         default_value=None)
-    if workdir is not None or tmpdir is not None:
-        remote_env = client.get_env()
-        if workdir is not None:
-            workdir = slurm_utils.expand_path_vars(workdir, remote_env)
-        if tmpdir is not None:
-            tmpdir = slurm_utils.expand_path_vars(tmpdir, remote_env)
+    if tmpdir is not None:
+        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
 
-    sky_base_dir = workdir if workdir is not None else remote_home_dir
-    assert os.path.isabs(sky_base_dir), (
-        f'sky_base_dir must be absolute, got: {sky_base_dir}')
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
     container_marker = (

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -798,6 +798,7 @@ def _create_virtual_instance(
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
     snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+    snapshot_manifest_path = _snapshot_manifest_path(snapshot_dir)
     snapshot_manifest = _read_snapshot_manifest(login_node_runner,
                                                 snapshot_dir,
                                                 expected_num_nodes=num_nodes)
@@ -1125,7 +1126,15 @@ cleanup() {{
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
     srun --overlap --nodes={num_nodes} rm -rf {skypilot_runtime_dir}
-    rm -rf {sky_cluster_home_dir}
+    # A stop publishes the snapshot manifest before cancellation. Keep the
+    # logs referenced by the jobs database that start will restore.
+    if [ -f {shlex.quote(snapshot_manifest_path)} ]; then
+        find {shlex.quote(sky_cluster_home_dir)} -mindepth 1 -maxdepth 1 \\
+            ! -name sky_logs \\
+            -exec rm -rf -- {{}} +
+    else
+        rm -rf -- {shlex.quote(sky_cluster_home_dir)}
+    fi
     exit $saved_exit
 }}
 # Run cleanup on any exit, including container init failures.
@@ -1712,9 +1721,13 @@ enroot export -f -o {shlex.quote(staging_snapshot_path)} "$enroot_name"
         _remove_snapshot_paths_best_effort(
             login_node_runner, [previous_generation_dir],
             'previous Slurm snapshot generation')
-    cleanup = lambda: _cleanup_slurm_allocation(
-        client, login_node_runner, cluster_name_on_cloud, provider_config,
-        job_id, nodes)
+    cleanup = lambda: _cleanup_slurm_allocation(client,
+                                                login_node_runner,
+                                                cluster_name_on_cloud,
+                                                provider_config,
+                                                job_id,
+                                                nodes,
+                                                preserve_logs=True)
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster=False,
@@ -1754,6 +1767,7 @@ def _cleanup_slurm_allocation(
     provider_config: Dict[str, Any],
     job_id: str,
     nodes: List[str],
+    preserve_logs: bool = False,
 ) -> None:
     """Remove per-node state while the Slurm allocation is still active."""
     slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
@@ -1823,7 +1837,14 @@ rm -rf -- {shlex.quote(skypilot_runtime_dir)}
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
 
-    remove_shared_state_cmd = f'rm -rf -- {shlex.quote(sky_cluster_home_dir)}'
+    if preserve_logs:
+        remove_shared_state_cmd = (f'find {shlex.quote(sky_cluster_home_dir)} '
+                                   '-mindepth 1 -maxdepth 1 '
+                                   '! -name sky_logs '
+                                   '-exec rm -rf -- {} +')
+    else:
+        remove_shared_state_cmd = (
+            f'rm -rf -- {shlex.quote(sky_cluster_home_dir)}')
     rc, stdout, stderr = login_node_runner.run(remove_shared_state_cmd,
                                                require_outputs=True,
                                                stream_logs=False)

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1450,9 +1450,9 @@ def stop_instances(
         raise RuntimeError('Cannot stop Slurm cluster because its head node '
                            'command runner is unavailable.')
     cancel_jobs_code = job_lib.JobLibCodeGen.cancel_jobs(None, cancel_all=True)
-    rc, stdout, stderr = command_runners[0].run(cancel_jobs_code,
-                                                require_outputs=True,
-                                                stream_logs=False)
+    rc, stdout, stderr = command_runners[0].run_driver(cancel_jobs_code,
+                                                       require_outputs=True,
+                                                       stream_logs=False)
     subprocess_utils.handle_returncode(
         rc,
         cancel_jobs_code,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -309,11 +309,40 @@ def _snapshot_job_db_path(generation_dir: str) -> str:
     return f'{generation_dir}/{SNAPSHOT_JOB_DB_FILENAME}'
 
 
+def _run_on_login_node(
+        login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+        cmd: str,
+        failure_message: str,
+        tolerate_returncodes: Tuple[int, ...] = (),
+) -> Tuple[int, str]:
+    """Run a command on the login node and return (returncode, stdout).
+
+    Raises on failure unless the exit code is in `tolerate_returncodes`,
+    which is for commands that use dedicated exit codes to report state
+    (e.g. `test -f`).
+    """
+    rc, stdout, stderr = login_node_runner.run(cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    if rc not in tolerate_returncodes:
+        subprocess_utils.handle_returncode(rc,
+                                           cmd,
+                                           failure_message,
+                                           stderr=f'{stdout}\n{stderr}',
+                                           stream_logs=False)
+    return rc, stdout
+
+
 def _validate_snapshot_manifest(
         manifest: Any,
-        snapshot_dir: str,
         expected_num_nodes: Optional[int] = None) -> Dict[str, Any]:
-    """Validate and normalize a Slurm container snapshot manifest."""
+    """Validate a Slurm container snapshot manifest.
+
+    The manifest stores only facts about the snapshot. The paths of the
+    files it references are always derived from its generation (see
+    `_manifest_paths`), so no path read from shared storage is ever
+    trusted or embedded into a command.
+    """
     if not isinstance(manifest, dict):
         raise RuntimeError('Slurm container snapshot manifest must be a JSON '
                            'object.')
@@ -326,50 +355,22 @@ def _validate_snapshot_manifest(
             re.fullmatch(r'[0-9a-f]{32}', generation) is None):
         raise RuntimeError('Slurm container snapshot manifest has an invalid '
                            f'generation: {generation!r}.')
-    generation_dir = _snapshot_generation_dir(snapshot_dir, generation)
     image_id = manifest.get('image_id')
     if not isinstance(image_id, str) or not image_id:
         raise RuntimeError('Slurm container snapshot manifest has no image ID.')
-    num_nodes = manifest.get('num_nodes')
-    if (not isinstance(num_nodes, int) or isinstance(num_nodes, bool) or
-            num_nodes < 1):
+    nodes = manifest.get('nodes')
+    if (not isinstance(nodes, list) or not nodes or
+            not all(isinstance(node, str) and node for node in nodes)):
         raise RuntimeError('Slurm container snapshot manifest has an invalid '
-                           f'num_nodes value: {num_nodes!r}.')
-    if expected_num_nodes is not None and num_nodes != expected_num_nodes:
+                           f'source node list: {nodes!r}.')
+    if expected_num_nodes is not None and len(nodes) != expected_num_nodes:
         raise RuntimeError(
             'Slurm container snapshot node count does not match the cluster: '
-            f'manifest has {num_nodes}, cluster requires '
+            f'manifest has {len(nodes)}, cluster requires '
             f'{expected_num_nodes}.')
-    if 'job_db_path' not in manifest:
+    if not isinstance(manifest.get('has_job_db'), bool):
         raise RuntimeError('Slurm container snapshot manifest has no job '
                            'database entry.')
-    job_db_path = manifest['job_db_path']
-    expected_job_db_path = _snapshot_job_db_path(generation_dir)
-    if job_db_path is not None and job_db_path != expected_job_db_path:
-        raise RuntimeError('Slurm container snapshot job database path must be '
-                           f'{expected_job_db_path!r}, got {job_db_path!r}.')
-    snapshots = manifest.get('snapshots')
-    if not isinstance(snapshots, list) or len(snapshots) != num_nodes:
-        raise RuntimeError(
-            'Slurm container snapshot manifest does not contain exactly '
-            f'{num_nodes} rank snapshots.')
-    for rank, snapshot in enumerate(snapshots):
-        expected_path = _snapshot_rank_path(generation_dir, rank)
-        if not isinstance(snapshot, dict):
-            raise RuntimeError(
-                f'Slurm container snapshot entry for rank {rank} is invalid.')
-        if snapshot.get('rank') != rank:
-            raise RuntimeError(
-                f'Slurm container snapshot entry {rank} has invalid rank '
-                f'{snapshot.get("rank")!r}.')
-        if snapshot.get('path') != expected_path:
-            raise RuntimeError(
-                f'Slurm container snapshot path for rank {rank} must be '
-                f'{expected_path!r}, got {snapshot.get("path")!r}.')
-        if not isinstance(snapshot.get('node'), str) or not snapshot['node']:
-            raise RuntimeError(
-                f'Slurm container snapshot entry for rank {rank} has no '
-                'source node.')
     return manifest
 
 
@@ -382,35 +383,41 @@ def _read_snapshot_manifest(
     missing_exit_code = 44
     cmd = (f'test -f {shlex.quote(manifest_path)} || '
            f'exit {missing_exit_code}; cat {shlex.quote(manifest_path)}')
-    rc, stdout, stderr = login_node_runner.run(cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    if rc == missing_exit_code:
-        return None
-    subprocess_utils.handle_returncode(
-        rc,
+    rc, stdout = _run_on_login_node(
+        login_node_runner,
         cmd,
         'Failed to read Slurm container snapshot manifest.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+        tolerate_returncodes=(missing_exit_code,))
+    if rc == missing_exit_code:
+        return None
     try:
         manifest = json.loads(stdout)
     except json.JSONDecodeError as e:
         raise RuntimeError('Slurm container snapshot manifest is not valid '
                            f'JSON: {e}') from e
-    return _validate_snapshot_manifest(manifest, snapshot_dir,
-                                       expected_num_nodes)
+    return _validate_snapshot_manifest(manifest, expected_num_nodes)
 
 
-def _snapshot_paths(manifest: Dict[str, Any]) -> List[str]:
-    return [snapshot['path'] for snapshot in manifest['snapshots']]
+def _manifest_paths(
+        snapshot_dir: str,
+        manifest: Dict[str, Any]) -> Tuple[List[str], Optional[str]]:
+    """Derive the per-rank snapshot paths and job db path of a manifest."""
+    generation_dir = _snapshot_generation_dir(snapshot_dir,
+                                              manifest['generation'])
+    rank_paths = [
+        _snapshot_rank_path(generation_dir, rank)
+        for rank in range(len(manifest['nodes']))
+    ]
+    job_db_path = (_snapshot_job_db_path(generation_dir)
+                   if manifest['has_job_db'] else None)
+    return rank_paths, job_db_path
 
 
 def _write_snapshot_manifest(
         login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
         snapshot_dir: str, manifest: Dict[str, Any]) -> None:
     """Atomically write a validated snapshot manifest to shared storage."""
-    _validate_snapshot_manifest(manifest, snapshot_dir)
+    _validate_snapshot_manifest(manifest)
     manifest_path = _snapshot_manifest_path(snapshot_dir)
     remote_tmp_path = f'{manifest_path}.tmp'
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json') as f:
@@ -421,34 +428,21 @@ def _write_snapshot_manifest(
                                 remote_tmp_path,
                                 up=True,
                                 stream_logs=False)
-    cmd = f'mv -f {shlex.quote(remote_tmp_path)} {shlex.quote(manifest_path)}'
-    rc, stdout, stderr = login_node_runner.run(cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        cmd,
-        'Failed to publish Slurm container snapshot manifest.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+    _run_on_login_node(
+        login_node_runner,
+        f'mv -f {shlex.quote(remote_tmp_path)} {shlex.quote(manifest_path)}',
+        'Failed to publish Slurm container snapshot manifest.')
 
 
-def _remove_snapshot_paths_best_effort(
+def _remove_snapshot_path_best_effort(
     login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
-    paths: List[str],
+    path: str,
     description: str,
 ) -> None:
-    """Remove unreferenced snapshot paths without masking the main result."""
-    remove_cmd = 'rm -rf -- ' + ' '.join(shlex.quote(path) for path in paths)
+    """Remove an unreferenced snapshot path without masking the main result."""
     try:
-        rc, stdout, stderr = login_node_runner.run(remove_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        subprocess_utils.handle_returncode(rc,
-                                           remove_cmd,
-                                           f'Failed to remove {description}.',
-                                           stderr=f'{stdout}\n{stderr}',
-                                           stream_logs=False)
+        _run_on_login_node(login_node_runner, f'rm -rf -- {shlex.quote(path)}',
+                           f'Failed to remove {description}.')
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to remove {description}: '
                        f'{common_utils.format_exception(e, use_bracket=True)}')
@@ -457,41 +451,26 @@ def _remove_snapshot_paths_best_effort(
 
 def _validate_snapshot_files(
         login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
-        manifest: Dict[str, Any]) -> None:
-    """Raise if a rank snapshot referenced by a manifest is missing."""
+        snapshot_dir: str, manifest: Dict[str, Any]) -> None:
+    """Raise if a file referenced by a snapshot manifest is missing."""
+    rank_paths, job_db_path = _manifest_paths(snapshot_dir, manifest)
+    labeled_paths = [
+        (f'rank {rank}', path) for rank, path in enumerate(rank_paths)
+    ]
+    if job_db_path is not None:
+        labeled_paths.append(('job database', job_db_path))
     missing = []
-    for rank, path in enumerate(_snapshot_paths(manifest)):
-        cmd = f'test -f {shlex.quote(path)}'
-        rc, stdout, stderr = login_node_runner.run(cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
+    for label, path in labeled_paths:
+        rc, _ = _run_on_login_node(
+            login_node_runner,
+            f'test -f {shlex.quote(path)}',
+            f'Failed to inspect the Slurm container snapshot ({label}).',
+            tolerate_returncodes=(1,))
         if rc == 1:
-            missing.append(f'rank {rank}: {path}')
-        elif rc != 0:
-            subprocess_utils.handle_returncode(
-                rc,
-                cmd,
-                f'Failed to inspect Slurm container snapshot for rank {rank}.',
-                stderr=f'{stdout}\n{stderr}',
-                stream_logs=False)
+            missing.append(f'{label}: {path}')
     if missing:
         raise RuntimeError('Slurm container snapshot is incomplete; missing ' +
                            ', '.join(missing) + '.')
-    job_db_path = manifest['job_db_path']
-    if job_db_path is not None:
-        cmd = f'test -f {shlex.quote(job_db_path)}'
-        rc, stdout, stderr = login_node_runner.run(cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        if rc == 1:
-            raise RuntimeError('Slurm container snapshot is incomplete; '
-                               f'missing job database: {job_db_path}.')
-        subprocess_utils.handle_returncode(
-            rc,
-            cmd,
-            'Failed to inspect Slurm container snapshot job database.',
-            stderr=f'{stdout}\n{stderr}',
-            stream_logs=False)
 
 
 def _sbatch_provision_script_path(base_dir: str,
@@ -518,6 +497,13 @@ def _enroot_container_name_global_scope(cluster_name_on_cloud: str) -> str:
     # Added in commit:
     # https://github.com/NVIDIA/pyxis/commit/a35027cf2ffa45cf702b117d215b1240aa6de22e
     return f'pyxis_{slurm_utils.pyxis_container_name(cluster_name_on_cloud)}'
+
+
+def _enroot_container_name_job_scope(cluster_name_on_cloud: str,
+                                     job_id: str) -> str:
+    """Get enroot container name when container_scope=job (the default)."""
+    return (f'pyxis_{job_id}_'
+            f'{slurm_utils.pyxis_container_name(cluster_name_on_cloud)}')
 
 
 def _make_slurm_client(provider_config: Dict[str, Any]) -> 'slurm.SlurmClient':
@@ -565,6 +551,44 @@ def _resolve_sky_base_dir(client: 'slurm.SlurmClient',
     return slurm_utils.resolve_sky_base_dir(slurm_cluster, client)
 
 
+def _resolve_skypilot_runtime_dir(client: 'slurm.SlurmClient',
+                                  provider_config: Dict[str, Any],
+                                  cluster_name_on_cloud: str) -> str:
+    """Resolve the node-local SkyPilot runtime directory for a cluster."""
+    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
+    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
+                                                         region=slurm_cluster,
+                                                         keys=('tmpdir',),
+                                                         default_value=None)
+    if tmpdir is not None:
+        # Resolve shell variables (e.g. $USER) in tmpdir using the remote
+        # host's environment.
+        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
+        logger.debug(f'Resolved tmpdir: {tmpdir}')
+    return _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
+
+
+def _stop_skylet_script(skypilot_runtime_dir: str) -> str:
+    """Script that stops Skylet and keeps the keeper from restarting it."""
+    skylet_start_file = (
+        f'{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}')
+    skylet_pid_file = f'{skypilot_runtime_dir}/.sky/skylet_pid'
+    # Remove the start spec first so the keeper cannot restart Skylet.
+    return (
+        f'rm -f -- {shlex.quote(skylet_start_file)}; '
+        f'if [ -f {shlex.quote(skylet_pid_file)} ]; then '
+        f'skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"; '
+        'if kill -0 "$skylet_pid" 2>/dev/null; then kill "$skylet_pid"; fi; '
+        'fi')
+
+
+def _srun_on_node(job_id: str, node: str, script: str) -> str:
+    """Build an srun command that runs a script on one allocated node."""
+    return (f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+            f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
+            f'bash -c {shlex.quote(script)}')
+
+
 def _wait_for_job_ready(
     login_node_runner: 'command_runner.SSHCommandRunner',
     client: 'slurm.SlurmClient',
@@ -608,27 +632,8 @@ def _create_virtual_instance(
     job with sbatch, to mimic a cloud VM.
     """
     provider_config = config.provider_config
-    ssh_config_dict = provider_config['ssh']
-    ssh_host = ssh_config_dict['hostname']
-    ssh_port = int(ssh_config_dict['port'])
-    ssh_user = ssh_config_dict['user']
-    ssh_key = ssh_config_dict.get('private_key', None)
-    ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
-    ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
-    identities_only = ssh_config_dict.get('identities_only', False)
     partition = slurm_utils.get_partition_from_config(provider_config)
-
-    slurm_user = provider_config.get('slurm_user')
-    client = slurm.SlurmClient(
-        ssh_host,
-        ssh_port,
-        ssh_user,
-        ssh_key,
-        ssh_proxy_command=ssh_proxy_command,
-        ssh_proxy_jump=ssh_proxy_jump,
-        identities_only=identities_only,
-        slurm_user=slurm_user,
-    )
+    client = _make_slurm_client(provider_config)
 
     slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
 
@@ -702,10 +707,6 @@ def _create_virtual_instance(
             rich_utils.force_update_status(status_msg)
             last_status_msg = status_msg
 
-    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
-                                                         region=region,
-                                                         keys=('tmpdir',),
-                                                         default_value=None)
     if existing_jobs:
         assert len(existing_jobs) == 1, (
             f'Multiple jobs found with name {cluster_name_on_cloud}: '
@@ -751,21 +752,8 @@ def _create_virtual_instance(
 
     # To bootstrap things, we need to do it with SSHCommandRunner first.
     # SlurmCommandRunner is for after the virtual instances are created.
-    login_node_runner = command_runner.SlurmLoginNodeCommandRunner(
-        (ssh_host, ssh_port),
-        ssh_user,
-        ssh_key,
-        ssh_proxy_command=ssh_proxy_command,
-        ssh_proxy_jump=ssh_proxy_jump,
-        enable_interactive_auth=True,
-        disable_identities_only=not identities_only,
-        slurm_user=slurm_user,
-    )
+    login_node_runner = _make_login_node_runner(provider_config)
     remote_home_dir = login_node_runner.get_remote_home_dir()
-
-    if tmpdir is not None:
-        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
-        logger.debug(f'Resolved tmpdir: {tmpdir}')
 
     sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sbatch_log_base_dir = sky_base_dir
@@ -774,7 +762,8 @@ def _create_virtual_instance(
         sky_base_dir, cluster_name_on_cloud)
     provision_scripts_dir = os.path.dirname(provision_script_path)
 
-    skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
+    skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
+        client, provider_config, cluster_name_on_cloud)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
     snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
@@ -783,7 +772,8 @@ def _create_virtual_instance(
                                                 snapshot_dir,
                                                 expected_num_nodes=num_nodes)
     if snapshot_manifest is not None:
-        _validate_snapshot_files(login_node_runner, snapshot_manifest)
+        _validate_snapshot_files(login_node_runner, snapshot_dir,
+                                 snapshot_manifest)
     ready_signal = f'{sky_cluster_home_dir}/.sky_sbatch_ready'
 
     # For non-Docker Hub registries, pyxis/enroot requires '#' separator
@@ -916,6 +906,8 @@ while IFS= read -r candidate; do
     fi
 done < <(enroot list)
 """
+            snapshot_rank_paths, snapshot_job_db_path = _manifest_paths(
+                snapshot_dir, snapshot_manifest)
             restore_lines = [
                 'mapfile -t SKY_NODES < <(scontrol show hostnames '
                 '"$SLURM_JOB_NODELIST")',
@@ -925,7 +917,6 @@ done < <(enroot list)
                 '  exit 1',
                 'fi',
             ]
-            snapshot_job_db_path = snapshot_manifest['job_db_path']
             if snapshot_job_db_path is not None:
                 restored_job_db_path = (f'{skypilot_runtime_dir}/.sky/jobs.db')
                 restored_job_db_dir = os.path.dirname(restored_job_db_path)
@@ -943,8 +934,7 @@ done < <(enroot list)
                 f'{shlex.quote(remove_stale_container_script)}',
                 'CONTAINER_PIDS=()',
             ])
-            for rank, snapshot_path in enumerate(
-                    _snapshot_paths(snapshot_manifest)):
+            for rank, snapshot_path in enumerate(snapshot_rank_paths):
                 container_cmd = shlex.quote(
                     f'touch {container_init_done_dir}/{rank} && '
                     'sleep infinity')
@@ -1230,25 +1220,7 @@ def query_instances(
     del cluster_name, retry_if_missing  # Unused for Slurm
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
 
-    ssh_config_dict = provider_config['ssh']
-    ssh_host = ssh_config_dict['hostname']
-    ssh_port = int(ssh_config_dict['port'])
-    ssh_user = ssh_config_dict['user']
-    ssh_key = ssh_config_dict.get('private_key', None)
-    ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
-    ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
-    identities_only = ssh_config_dict.get('identities_only', False)
-
-    client = slurm.SlurmClient(
-        ssh_host,
-        ssh_port,
-        ssh_user,
-        ssh_key,
-        ssh_proxy_command=ssh_proxy_command,
-        ssh_proxy_jump=ssh_proxy_jump,
-        identities_only=identities_only,
-        slurm_user=provider_config.get('slurm_user'),
-    )
+    client = _make_slurm_client(provider_config)
 
     # Map Slurm job states to SkyPilot ClusterStatus
     # Slurm states:
@@ -1314,7 +1286,7 @@ def query_instances(
     if manifest is not None:
         return {
             f'snapshot-rank-{rank}': (status_lib.ClusterStatus.STOPPED, None)
-            for rank in range(manifest['num_nodes'])
+            for rank in range(len(manifest['nodes']))
         }
 
     return statuses
@@ -1452,10 +1424,11 @@ def stop_instances(
                                                  cluster_name_on_cloud)
     container_marker = (
         f'{sky_cluster_home_dir}/{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
-    read_image_cmd = f'cat {shlex.quote(container_marker)}'
-    rc, stdout, stderr = login_node_runner.run(read_image_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
+    rc, stdout = _run_on_login_node(
+        login_node_runner,
+        f'cat {shlex.quote(container_marker)}',
+        'Failed to read the Slurm container marker.',
+        tolerate_returncodes=(1,))
     if rc != 0:
         raise exceptions.NotSupportedError(
             'Stopping Slurm clusters is supported only for containers '
@@ -1486,41 +1459,18 @@ def stop_instances(
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
 
-    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
-    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
-                                                         region=slurm_cluster,
-                                                         keys=('tmpdir',),
-                                                         default_value=None)
-    if tmpdir is not None:
-        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
-    skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
-    skylet_start_file = (
-        f'{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}')
-    skylet_pid_file = f'{skypilot_runtime_dir}/.sky/skylet_pid'
-    # Remove the start spec first so the keeper cannot restart Skylet.
-    stop_skylet_script = (
-        f'rm -f -- {shlex.quote(skylet_start_file)}; '
-        f'if [ -f {shlex.quote(skylet_pid_file)} ]; then '
-        f'skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"; '
-        'if kill -0 "$skylet_pid" 2>/dev/null; then kill "$skylet_pid"; fi; '
-        'fi')
-    stop_skylet_cmd = (
-        f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-        f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
-        f'bash -c {shlex.quote(stop_skylet_script)}')
-    rc, stdout, stderr = login_node_runner.run(stop_skylet_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        stop_skylet_cmd,
-        'Failed to stop Skylet before snapshotting the Slurm container.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+    skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
+        client, provider_config, cluster_name_on_cloud)
+    _run_on_login_node(
+        login_node_runner,
+        _srun_on_node(job_id, nodes[0],
+                      _stop_skylet_script(skypilot_runtime_dir)),
+        'Failed to stop Skylet before snapshotting the Slurm container.')
 
-    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
-    global_enroot_name = f'pyxis_{pyxis_name}'
-    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
+    global_enroot_name = _enroot_container_name_global_scope(
+        cluster_name_on_cloud)
+    job_enroot_name = _enroot_container_name_job_scope(cluster_name_on_cloud,
+                                                       job_id)
 
     def _find_enroot_container_script(node: str) -> str:
         return f"""\
@@ -1542,46 +1492,30 @@ fi
 
     def _check_node_container(node: str) -> None:
         check_script = 'set -e\n' + _find_enroot_container_script(node)
-        check_cmd = (
-            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-            f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
-            f'bash -c {shlex.quote(check_script)}')
-        check_rc, check_stdout, check_stderr = login_node_runner.run(
-            check_cmd, require_outputs=True, stream_logs=False)
-        subprocess_utils.handle_returncode(
-            check_rc,
-            check_cmd,
+        _run_on_login_node(
+            login_node_runner, _srun_on_node(job_id, node, check_script),
             f'Failed to verify the Slurm container on node {node} before '
-            'preparing its snapshot.',
-            stderr=f'{check_stdout}\n{check_stderr}',
-            stream_logs=False)
+            'preparing its snapshot.')
 
     subprocess_utils.run_in_parallel(_check_node_container, nodes)
 
     generation = uuid.uuid4().hex
-    generations_dir = (f'{snapshot_dir}/{SNAPSHOT_GENERATIONS_DIRECTORY_NAME}')
     generation_dir = _snapshot_generation_dir(snapshot_dir, generation)
     staging_dir = f'{snapshot_dir}/.staging-{generation}'
-    prepare_snapshot_cmd = (f'mkdir -p {shlex.quote(generations_dir)} && '
-                            f'mkdir {shlex.quote(staging_dir)}')
-    rc, stdout, stderr = login_node_runner.run(prepare_snapshot_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        prepare_snapshot_cmd,
-        'Failed to prepare Slurm container snapshot directory.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+    _run_on_login_node(
+        login_node_runner,
+        (f'mkdir -p {shlex.quote(os.path.dirname(generation_dir))} && '
+         f'mkdir {shlex.quote(staging_dir)}'),
+        'Failed to prepare Slurm container snapshot directory.')
 
-    generation_committed = False
-    manifest_publish_started = False
+    # The directory to delete if the snapshot fails partway. Cleared before
+    # publishing starts: the manifest rename may complete remotely even if
+    # SSH loses its acknowledgement, so from that point the generation must
+    # be kept for any manifest that now references it.
+    cleanup_dir_on_failure: Optional[str] = staging_dir
     try:
-        skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir,
-                                                     cluster_name_on_cloud)
         runtime_job_db_path = f'{skypilot_runtime_dir}/.sky/jobs.db'
         staging_job_db_path = _snapshot_job_db_path(staging_dir)
-        generation_job_db_path = _snapshot_job_db_path(generation_dir)
         backup_job_db_code = (
             'import sqlite3, sys; '
             'source = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", '
@@ -1597,122 +1531,75 @@ fi
             f'{shlex.quote(backup_job_db_code)} '
             f'{shlex.quote(runtime_job_db_path)} '
             f'{shlex.quote(staging_job_db_path)}; fi')
-        backup_job_db_cmd = (
-            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-            f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
-            f'bash -c {shlex.quote(backup_job_db_script)}')
-        rc, stdout, stderr = login_node_runner.run(backup_job_db_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        subprocess_utils.handle_returncode(
-            rc,
-            backup_job_db_cmd,
-            'Failed to snapshot the Slurm cluster job database.',
-            stderr=f'{stdout}\n{stderr}',
-            stream_logs=False)
-        job_db_exists_cmd = f'test -f {shlex.quote(staging_job_db_path)}'
-        rc, stdout, stderr = login_node_runner.run(job_db_exists_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        if rc == 0:
-            manifest_job_db_path: Optional[str] = generation_job_db_path
-        elif rc == 1:
-            manifest_job_db_path = None
-        else:
-            subprocess_utils.handle_returncode(
-                rc,
-                job_db_exists_cmd,
-                'Failed to inspect the Slurm cluster job database snapshot.',
-                stderr=f'{stdout}\n{stderr}',
-                stream_logs=False)
-            raise AssertionError('unreachable')
+        _run_on_login_node(
+            login_node_runner,
+            _srun_on_node(job_id, nodes[0], backup_job_db_script),
+            'Failed to snapshot the Slurm cluster job database.')
+        rc, _ = _run_on_login_node(
+            login_node_runner,
+            f'test -f {shlex.quote(staging_job_db_path)}',
+            'Failed to inspect the Slurm cluster job database snapshot.',
+            tolerate_returncodes=(1,))
+        has_job_db = rc == 0
 
-        def _export_node(rank_and_node: Tuple[int, str]) -> Dict[str, Any]:
+        def _export_node(rank_and_node: Tuple[int, str]) -> None:
             rank, node = rank_and_node
             staging_snapshot_path = _snapshot_rank_path(staging_dir, rank)
-            snapshot_path = _snapshot_rank_path(generation_dir, rank)
             export_script = f"""\
 set -e
 {_find_enroot_container_script(node)}\
 sync
 enroot export -f -o {shlex.quote(staging_snapshot_path)} "$enroot_name"
 """
-            export_cmd = (
-                f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-                f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
-                f'bash -c {shlex.quote(export_script)}')
-            export_rc, export_stdout, export_stderr = login_node_runner.run(
-                export_cmd, require_outputs=True, stream_logs=False)
-            subprocess_utils.handle_returncode(
-                export_rc,
-                export_cmd,
+            _run_on_login_node(
+                login_node_runner, _srun_on_node(job_id, node, export_script),
                 f'Failed to snapshot Slurm container rank {rank} on node '
-                f'{node}.',
-                stderr=f'{export_stdout}\n{export_stderr}',
-                stream_logs=False)
-            return {
-                'rank': rank,
-                'node': node,
-                'path': snapshot_path,
-            }
+                f'{node}.')
 
-        snapshots = subprocess_utils.run_in_parallel(_export_node,
-                                                     list(enumerate(nodes)))
+        subprocess_utils.run_in_parallel(_export_node, list(enumerate(nodes)))
         manifest = {
             'version': SNAPSHOT_MANIFEST_VERSION,
             'generation': generation,
             'image_id': image_id,
-            'num_nodes': len(nodes),
             'created_at': time.time(),
-            'job_db_path': manifest_job_db_path,
-            'snapshots': snapshots,
+            'has_job_db': has_job_db,
+            'nodes': nodes,
         }
-        commit_generation_cmd = (f'test ! -e {shlex.quote(generation_dir)} && '
-                                 f'mv -- {shlex.quote(staging_dir)} '
-                                 f'{shlex.quote(generation_dir)}')
-        rc, stdout, stderr = login_node_runner.run(commit_generation_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        subprocess_utils.handle_returncode(
-            rc,
-            commit_generation_cmd,
-            'Failed to commit the Slurm container snapshot generation.',
-            stderr=f'{stdout}\n{stderr}',
-            stream_logs=False)
-        generation_committed = True
-        _validate_snapshot_files(login_node_runner, manifest)
+        _run_on_login_node(
+            login_node_runner,
+            (f'test ! -e {shlex.quote(generation_dir)} && '
+             f'mv -- {shlex.quote(staging_dir)} {shlex.quote(generation_dir)}'),
+            'Failed to commit the Slurm container snapshot generation.')
+        cleanup_dir_on_failure = generation_dir
+        _validate_snapshot_files(login_node_runner, snapshot_dir, manifest)
         # Keep the previous generation reachable until its replacement is
         # complete and the manifest can switch to it atomically.
-        manifest_publish_started = True
+        cleanup_dir_on_failure = None
         _write_snapshot_manifest(login_node_runner, snapshot_dir, manifest)
     except Exception:
-        # A manifest rename may complete even if SSH loses its acknowledgement.
-        # Keep committed data so any manifest published remotely stays usable.
-        if not (generation_committed and manifest_publish_started):
-            incomplete_path = (generation_dir
-                               if generation_committed else staging_dir)
-            _remove_snapshot_paths_best_effort(
-                login_node_runner, [incomplete_path],
+        if cleanup_dir_on_failure is not None:
+            _remove_snapshot_path_best_effort(
+                login_node_runner, cleanup_dir_on_failure,
                 'incomplete Slurm snapshot generation')
         raise
 
     if previous_manifest is not None:
-        previous_generation_dir = _snapshot_generation_dir(
-            snapshot_dir, previous_manifest['generation'])
-        _remove_snapshot_paths_best_effort(
-            login_node_runner, [previous_generation_dir],
+        _remove_snapshot_path_best_effort(
+            login_node_runner,
+            _snapshot_generation_dir(snapshot_dir,
+                                     previous_manifest['generation']),
             'previous Slurm snapshot generation')
-    cleanup = lambda: _cleanup_slurm_allocation(client,
-                                                login_node_runner,
-                                                cluster_name_on_cloud,
-                                                provider_config,
-                                                job_id,
-                                                nodes,
-                                                preserve_logs=True)
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster=False,
-                      pre_batch_cancel=cleanup)
+                      pre_batch_cancel=_make_pre_batch_cancel_cleanup(
+                          client,
+                          login_node_runner,
+                          cluster_name_on_cloud,
+                          provider_config,
+                          job_id,
+                          nodes,
+                          preserve_logs=True))
 
 
 def _wait_for_job_states(client: 'slurm.SlurmClient', job_name: str,
@@ -1751,29 +1638,18 @@ def _cleanup_slurm_allocation(
     preserve_logs: bool = False,
 ) -> None:
     """Remove per-node state while the Slurm allocation is still active."""
-    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
-    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
-                                                         region=slurm_cluster,
-                                                         keys=('tmpdir',),
-                                                         default_value=None)
-    if tmpdir is not None:
-        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
-    skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
+    skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
+        client, provider_config, cluster_name_on_cloud)
     sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
-    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
-    global_enroot_name = f'pyxis_{pyxis_name}'
-    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
-    skylet_pid_file = f'{skypilot_runtime_dir}/.sky/skylet_pid'
+    global_enroot_name = _enroot_container_name_global_scope(
+        cluster_name_on_cloud)
+    job_enroot_name = _enroot_container_name_job_scope(cluster_name_on_cloud,
+                                                       job_id)
     cleanup_node_script = f"""\
 set -e
-if [ -f {shlex.quote(skylet_pid_file)} ]; then
-    skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"
-    if kill -0 "$skylet_pid" 2>/dev/null; then
-        kill "$skylet_pid"
-    fi
-fi
+{_stop_skylet_script(skypilot_runtime_dir)}
 if command -v enroot > /dev/null; then
     container_exists() {{
         while IFS= read -r existing; do
@@ -1808,17 +1684,13 @@ rm -rf -- {shlex.quote(skypilot_runtime_dir)}
         f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
         f'--nodes={len(nodes)} --ntasks-per-node=1 '
         f'bash -c {shlex.quote(cleanup_node_script)}')
-    rc, stdout, stderr = login_node_runner.run(cleanup_node_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        cleanup_node_cmd,
-        'Failed to clean up the Slurm allocation before cancellation.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+    _run_on_login_node(
+        login_node_runner, cleanup_node_cmd,
+        'Failed to clean up the Slurm allocation before cancellation.')
 
     if preserve_logs:
+        # A stop keeps the logs referenced by the jobs database that start
+        # will restore.
         remove_shared_state_cmd = (f'find {shlex.quote(sky_cluster_home_dir)} '
                                    '-mindepth 1 -maxdepth 1 '
                                    '! -name sky_logs '
@@ -1826,15 +1698,44 @@ rm -rf -- {shlex.quote(skypilot_runtime_dir)}
     else:
         remove_shared_state_cmd = (
             f'rm -rf -- {shlex.quote(sky_cluster_home_dir)}')
-    rc, stdout, stderr = login_node_runner.run(remove_shared_state_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        remove_shared_state_cmd,
-        'Failed to clean up shared Slurm cluster state before cancellation.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+    _run_on_login_node(
+        login_node_runner, remove_shared_state_cmd,
+        'Failed to clean up shared Slurm cluster state before cancellation.')
+
+
+def _make_pre_batch_cancel_cleanup(
+    client: 'slurm.SlurmClient',
+    login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    job_id: str,
+    nodes: List[str],
+    preserve_logs: bool = False,
+) -> Callable[[], None]:
+    """Best-effort node cleanup to run between step and batch cancellation.
+
+    Cleanup failures must not abort the cancellation: the batch script's
+    exit trap re-runs the same cleanup, and the allocation must come down
+    regardless.
+    """
+
+    def _cleanup() -> None:
+        try:
+            _cleanup_slurm_allocation(client,
+                                      login_node_runner,
+                                      cluster_name_on_cloud,
+                                      provider_config,
+                                      job_id,
+                                      nodes,
+                                      preserve_logs=preserve_logs)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'Failed to clean up the Slurm allocation before '
+                'cancellation; proceeding with cancellation. Details: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
+            logger.debug('Full exception details:', exc_info=True)
+
+    return _cleanup
 
 
 def _cancel_slurm_job(
@@ -1946,25 +1847,7 @@ def terminate_instances(
         logger.debug('Running inside a Slurm cluster, using local execution')
         client = slurm.SlurmClient(is_inside_slurm_cluster=True)
     else:
-        ssh_config_dict = provider_config['ssh']
-        ssh_host = ssh_config_dict['hostname']
-        ssh_port = int(ssh_config_dict['port'])
-        ssh_user = ssh_config_dict['user']
-        ssh_private_key = ssh_config_dict.get('private_key', None)
-        ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
-        ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
-        identities_only = ssh_config_dict.get('identities_only', False)
-
-        client = slurm.SlurmClient(
-            ssh_host,
-            ssh_port,
-            ssh_user,
-            ssh_private_key,
-            ssh_proxy_command=ssh_proxy_command,
-            ssh_proxy_jump=ssh_proxy_jump,
-            identities_only=identities_only,
-            slurm_user=provider_config.get('slurm_user'),
-        )
+        client = _make_slurm_client(provider_config)
     pre_batch_cancel = None
     if not inside_slurm_cluster:
         running_jobs = client.query_jobs(cluster_name_on_cloud,
@@ -1975,21 +1858,9 @@ def terminate_instances(
         if len(running_jobs) == 1:
             job_id = running_jobs[0]
             nodes, _ = client.get_job_nodes(job_id)
-            login_node_runner = _make_login_node_runner(provider_config)
-
-            def cleanup_before_terminate() -> None:
-                try:
-                    _cleanup_slurm_allocation(client, login_node_runner,
-                                              cluster_name_on_cloud,
-                                              provider_config, job_id, nodes)
-                except Exception as e:  # pylint: disable=broad-except
-                    logger.warning(
-                        'Failed to clean up the Slurm allocation before '
-                        'termination; proceeding with cancellation. Details: '
-                        f'{common_utils.format_exception(e, use_bracket=True)}')
-                    logger.debug('Full exception details:', exc_info=True)
-
-            pre_batch_cancel = cleanup_before_terminate
+            pre_batch_cancel = _make_pre_batch_cancel_cleanup(
+                client, _make_login_node_runner(provider_config),
+                cluster_name_on_cloud, provider_config, job_id, nodes)
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster,
@@ -2000,17 +1871,9 @@ def terminate_instances(
         if os.path.exists(snapshot_dir):
             shutil.rmtree(snapshot_dir)
     else:
-        login_node_runner = _make_login_node_runner(provider_config)
-        remove_snapshot_cmd = f'rm -rf -- {shlex.quote(snapshot_dir)}'
-        rc, stdout, stderr = login_node_runner.run(remove_snapshot_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
-        subprocess_utils.handle_returncode(
-            rc,
-            remove_snapshot_cmd,
-            'Failed to remove Slurm container snapshot.',
-            stderr=f'{stdout}\n{stderr}',
-            stream_logs=False)
+        _run_on_login_node(_make_login_node_runner(provider_config),
+                           f'rm -rf -- {shlex.quote(snapshot_dir)}',
+                           'Failed to remove Slurm container snapshot.')
 
 
 def open_ports(
@@ -2104,15 +1967,8 @@ def get_command_runners(
         identities_only=login_node_identities_only,
         slurm_user=slurm_user,
     )
-    slurm_cluster_name = provider_config.get('cluster')
-    tmpdir = skypilot_config.get_effective_region_config(
-        cloud='slurm',
-        region=slurm_cluster_name,
-        keys=('tmpdir',),
-        default_value=None)
-    if tmpdir is not None:
-        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
-
+    skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
+        client, provider_config, cluster_name_on_cloud)
     sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
@@ -2130,8 +1986,7 @@ def get_command_runners(
             login_node_ssh_user,
             login_node_ssh_private_key,
             sky_dir=sky_cluster_home_dir,
-            skypilot_runtime_dir=_skypilot_runtime_dir(tmpdir,
-                                                       cluster_name_on_cloud),
+            skypilot_runtime_dir=skypilot_runtime_dir,
             job_id=instance_info.tags['job_id'],
             slurm_node=instance_info.tags['node'],
             ssh_proxy_jump=login_node_ssh_proxy_jump,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -299,6 +299,8 @@ def _sky_cluster_home_dir(base_dir: str, cluster_name_on_cloud: str) -> str:
 
 def _snapshot_dir(base_dir: str, cluster_name_on_cloud: str) -> str:
     """Returns the shared directory for a Slurm container snapshot."""
+    # TODO(kevin): Verify that base_dir is on a shared filesystem (e.g., NFS)
+    # visible to every allocated node before using it for snapshots.
     return f'{base_dir}/{SNAPSHOT_DIRECTORY_NAME}/{cluster_name_on_cloud}'
 
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -40,6 +40,8 @@ SNAPSHOT_MANIFEST_FILENAME = 'manifest.json'
 SNAPSHOT_JOB_DB_FILENAME = 'jobs.db'
 SNAPSHOT_GENERATIONS_DIRECTORY_NAME = 'generations'
 SNAPSHOT_MANIFEST_VERSION = 1
+_CONTAINER_KEEPER_STEP_NAME = 'sky-container-keeper'
+_SKYLET_KEEPER_STEP_NAME = 'sky-skylet-keeper'
 
 
 def _sbatch_log_path(base_dir: str, job_id: str) -> str:
@@ -53,6 +55,14 @@ _JOB_TERMINATION_TIMEOUT_SECONDS = 60
 # before escalating to a plain scancel. Matches Slurm's default KillWait,
 # the grace Slurm itself gives between SIGTERM and SIGKILL.
 _TERMINATION_GRACE_PERIOD_SECONDS = 30
+# Workloads get longer than Slurm's default 30-second KillWait to finish their
+# TERM handlers before the stop path escalates individual steps to KILL.
+_WORKLOAD_STEP_TERM_GRACE_PERIOD_SECONDS = 40
+_WORKLOAD_STEP_DRAIN_TIMEOUT_SECONDS = 120
+_WORKLOAD_KEEPER_STEP_NAMES = frozenset({
+    _CONTAINER_KEEPER_STEP_NAME,
+    _SKYLET_KEEPER_STEP_NAME,
+})
 
 # Terminal states where scancel is not needed or will fail.
 _TERMINAL_JOB_STATES = {
@@ -893,6 +903,7 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
             container_launch_block = (
                 f'CONTAINER_PIDS=()\n'
                 f'srun --overlap '
+                f'--job-name={_CONTAINER_KEEPER_STEP_NAME} '
                 f'{"--label " if num_nodes > 1 else ""}--unbuffered '
                 f'--nodes={num_nodes} --ntasks-per-node=1 '
                 f'--container-image={shlex.quote(container_image)} '
@@ -941,7 +952,9 @@ done < <(enroot list)
                 restore_lines.extend([
                     f'echo "[container] Restoring rank {rank} on '
                     f'${{SKY_NODES[{rank}]}}"',
-                    f'srun --overlap --unbuffered --nodes=1 --ntasks=1 '
+                    f'srun --overlap '
+                    f'--job-name={_CONTAINER_KEEPER_STEP_NAME} '
+                    f'--unbuffered --nodes=1 --ntasks=1 '
                     f'-w "${{SKY_NODES[{rank}]}}" '
                     f'--container-image={shlex.quote(snapshot_path)} '
                     f'{pyxis_args} bash -c {container_cmd} &',
@@ -1041,6 +1054,7 @@ exit 1
         '| head -n1)\n'
         f'( while true; do '
         f'srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 '
+        f'--job-name={_SKYLET_KEEPER_STEP_NAME} '
         f'--nodelist=$SKY_HEAD_NODE '
         f'bash -c {shlex.quote(keeper_loop)}; '
         f'sleep 5; done ) &')
@@ -1458,6 +1472,7 @@ def stop_instances(
         'Failed to cancel jobs before snapshotting the Slurm container.',
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
+    _drain_slurm_workload_steps(client, job_id)
 
     skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
         client, provider_config, cluster_name_on_cloud)
@@ -1600,6 +1615,51 @@ enroot export -f -o {shlex.quote(staging_snapshot_path)} "$enroot_name"
                           job_id,
                           nodes,
                           preserve_logs=True))
+
+
+def _drain_slurm_workload_steps(client: 'slurm.SlurmClient',
+                                job_id: str) -> None:
+    """Stop every non-infrastructure step before snapshotting an allocation."""
+    deadline = time.monotonic() + _WORKLOAD_STEP_DRAIN_TIMEOUT_SECONDS
+    term_sent_at: Dict[str, float] = {}
+    kill_sent: Set[str] = set()
+    infrastructure_step_ids = {f'{job_id}.batch', f'{job_id}.extern'}
+
+    while True:
+        active_steps = client.list_job_steps(job_id)
+        workload_steps = [
+            step for step in active_steps
+            if step.step_id not in infrastructure_step_ids and
+            step.name not in _WORKLOAD_KEEPER_STEP_NAMES
+        ]
+        if not workload_steps:
+            return
+
+        now = time.monotonic()
+        for step in workload_steps:
+            if step.step_id not in term_sent_at:
+                logger.debug(f'Signalling Slurm workload step {step.step_id} '
+                             f'({step.name}) with TERM before snapshotting.')
+                client.signal_job_step(job_id, step.step_id, 'TERM')
+                term_sent_at[step.step_id] = now
+            elif (step.step_id not in kill_sent and
+                  now - term_sent_at[step.step_id] >=
+                  _WORKLOAD_STEP_TERM_GRACE_PERIOD_SECONDS):
+                logger.warning(f'Slurm workload step {step.step_id} '
+                               f'({step.name}) did not exit after TERM; '
+                               'escalating to KILL.')
+                client.signal_job_step(job_id, step.step_id, 'KILL')
+                kill_sent.add(step.step_id)
+
+        if now >= deadline:
+            remaining = ', '.join(
+                f'{step.step_id} ({step.name})' for step in workload_steps)
+            raise RuntimeError(
+                'Cannot snapshot the Slurm cluster because workload steps '
+                f'are still running after '
+                f'{_WORKLOAD_STEP_DRAIN_TIMEOUT_SECONDS}s: {remaining}')
+        time.sleep(
+            min(POLL_INTERVAL_SECONDS, max(0, deadline - time.monotonic())))
 
 
 def _wait_for_job_states(client: 'slurm.SlurmClient', job_name: str,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1005,10 +1005,8 @@ echo "[container] ERROR: Container is not running as $global_target or $job_targ
 exit 1
 """
         assert original_container_image is not None
-        container_ready_failure = ''
         snapshot_restore_complete_block = ''
         if snapshot_manifest is not None:
-            container_ready_failure = ' || exit 1'
             snapshot_restore_complete_block = (
                 f'if ! rm -rf -- {shlex.quote(snapshot_dir)}; then\n'
                 '  echo "[container] ERROR: Failed to consume snapshot." '
@@ -1042,7 +1040,7 @@ exit 1
             f'srun --overlap --unbuffered --nodes={num_nodes} '
             f'--ntasks-per-node=1 bash -c '
             f'{shlex.quote(container_ready_script)}'
-            f'{container_ready_failure}\n'
+            f' || exit 1\n'
             f'echo "[container] Ready in $((SECONDS - CONTAINER_START))s"\n'
             f'printf \'%s\\n\' {shlex.quote(original_container_image)} > '
             f'{container_marker_file}\n'

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -968,7 +968,6 @@ done < <(enroot list)
             for rank, snapshot_path in enumerate(
                     _snapshot_paths(snapshot_manifest)):
                 container_cmd = shlex.quote(
-                    f'{container_init_script}'
                     f'touch {container_init_done_dir}/{rank} && '
                     'sleep infinity')
                 restore_lines.extend([
@@ -1479,12 +1478,18 @@ def stop_instances(
     rc, stdout, stderr = login_node_runner.run(read_image_cmd,
                                                require_outputs=True,
                                                stream_logs=False)
-    if rc != 0 or not stdout.strip():
+    if rc != 0:
         raise exceptions.NotSupportedError(
             'Stopping Slurm clusters is supported only for containers '
             'launched with Pyxis. The running cluster has no container '
             'snapshot metadata.')
     image_id = stdout.strip()
+    # An empty marker identifies a Pyxis cluster without the image metadata
+    # required to create a restorable snapshot.
+    if not image_id:
+        raise exceptions.NotSupportedError(
+            'The running Slurm cluster has no container snapshot metadata. '
+            'Relaunch the cluster before stopping it.')
     previous_manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
 
     cluster_info = get_cluster_info('', cluster_name_on_cloud, provider_config)

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1132,7 +1132,7 @@ touch {sky_cluster_home_dir}/.hushlogin
 {f'touch {ready_signal}' if container_image is None else ''}
 # Host-side keeper step that starts skylet and restarts it if it dies.
 {skylet_keeper_block}
-{'sleep infinity' if container_image is None else 'wait "$CONTAINER_PID"'}
+{'sleep infinity' if container_image is None else 'wait -n "${CONTAINER_PIDS[@]}"'}
 """
     # fmt: on
     # pylint: enable=line-too-long

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+import uuid
 
 import colorama
 
@@ -37,6 +38,7 @@ PROVISION_SCRIPTS_DIRECTORY_NAME = '.sky_provision'
 SNAPSHOT_DIRECTORY_NAME = '.sky_snapshots'
 SNAPSHOT_MANIFEST_FILENAME = 'manifest.json'
 SNAPSHOT_JOB_DB_FILENAME = 'jobs.db'
+SNAPSHOT_GENERATIONS_DIRECTORY_NAME = 'generations'
 SNAPSHOT_MANIFEST_VERSION = 1
 
 
@@ -294,12 +296,17 @@ def _snapshot_manifest_path(snapshot_dir: str) -> str:
     return f'{snapshot_dir}/{SNAPSHOT_MANIFEST_FILENAME}'
 
 
-def _snapshot_rank_path(snapshot_dir: str, rank: int) -> str:
-    return f'{snapshot_dir}/rank{rank}.sqsh'
+def _snapshot_generation_dir(snapshot_dir: str, generation: str) -> str:
+    return (f'{snapshot_dir}/{SNAPSHOT_GENERATIONS_DIRECTORY_NAME}/'
+            f'{generation}')
 
 
-def _snapshot_job_db_path(snapshot_dir: str) -> str:
-    return f'{snapshot_dir}/{SNAPSHOT_JOB_DB_FILENAME}'
+def _snapshot_rank_path(generation_dir: str, rank: int) -> str:
+    return f'{generation_dir}/rank{rank}.sqsh'
+
+
+def _snapshot_job_db_path(generation_dir: str) -> str:
+    return f'{generation_dir}/{SNAPSHOT_JOB_DB_FILENAME}'
 
 
 def _validate_snapshot_manifest(
@@ -314,6 +321,12 @@ def _validate_snapshot_manifest(
         raise RuntimeError(
             'Unsupported Slurm container snapshot manifest version: '
             f'{manifest.get("version")!r}.')
+    generation = manifest.get('generation')
+    if (not isinstance(generation, str) or
+            re.fullmatch(r'[0-9a-f]{32}', generation) is None):
+        raise RuntimeError('Slurm container snapshot manifest has an invalid '
+                           f'generation: {generation!r}.')
+    generation_dir = _snapshot_generation_dir(snapshot_dir, generation)
     image_id = manifest.get('image_id')
     if not isinstance(image_id, str) or not image_id:
         raise RuntimeError('Slurm container snapshot manifest has no image ID.')
@@ -331,7 +344,7 @@ def _validate_snapshot_manifest(
         raise RuntimeError('Slurm container snapshot manifest has no job '
                            'database entry.')
     job_db_path = manifest['job_db_path']
-    expected_job_db_path = _snapshot_job_db_path(snapshot_dir)
+    expected_job_db_path = _snapshot_job_db_path(generation_dir)
     if job_db_path is not None and job_db_path != expected_job_db_path:
         raise RuntimeError('Slurm container snapshot job database path must be '
                            f'{expected_job_db_path!r}, got {job_db_path!r}.')
@@ -341,7 +354,7 @@ def _validate_snapshot_manifest(
             'Slurm container snapshot manifest does not contain exactly '
             f'{num_nodes} rank snapshots.')
     for rank, snapshot in enumerate(snapshots):
-        expected_path = _snapshot_rank_path(snapshot_dir, rank)
+        expected_path = _snapshot_rank_path(generation_dir, rank)
         if not isinstance(snapshot, dict):
             raise RuntimeError(
                 f'Slurm container snapshot entry for rank {rank} is invalid.')
@@ -418,6 +431,28 @@ def _write_snapshot_manifest(
         'Failed to publish Slurm container snapshot manifest.',
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
+
+
+def _remove_snapshot_paths_best_effort(
+    login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+    paths: List[str],
+    description: str,
+) -> None:
+    """Remove unreferenced snapshot paths without masking the main result."""
+    remove_cmd = 'rm -rf -- ' + ' '.join(shlex.quote(path) for path in paths)
+    try:
+        rc, stdout, stderr = login_node_runner.run(remove_cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        subprocess_utils.handle_returncode(rc,
+                                           remove_cmd,
+                                           f'Failed to remove {description}.',
+                                           stderr=f'{stdout}\n{stderr}',
+                                           stream_logs=False)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to remove {description}: '
+                       f'{common_utils.format_exception(e, use_bracket=True)}')
+        logger.debug('Full exception details:', exc_info=True)
 
 
 def _validate_snapshot_files(
@@ -1443,6 +1478,7 @@ def stop_instances(
             'launched with Pyxis. The running cluster has no container '
             'snapshot metadata.')
     image_id = stdout.strip()
+    previous_manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
 
     cluster_info = get_cluster_info('', cluster_name_on_cloud, provider_config)
     command_runners = get_command_runners(cluster_info)
@@ -1532,8 +1568,12 @@ fi
 
     subprocess_utils.run_in_parallel(_check_node_container, nodes)
 
-    prepare_snapshot_cmd = (f'rm -rf -- {shlex.quote(snapshot_dir)}; '
-                            f'mkdir -p {shlex.quote(snapshot_dir)}')
+    generation = uuid.uuid4().hex
+    generations_dir = (f'{snapshot_dir}/{SNAPSHOT_GENERATIONS_DIRECTORY_NAME}')
+    generation_dir = _snapshot_generation_dir(snapshot_dir, generation)
+    staging_dir = f'{snapshot_dir}/.staging-{generation}'
+    prepare_snapshot_cmd = (f'mkdir -p {shlex.quote(generations_dir)} && '
+                            f'mkdir {shlex.quote(staging_dir)}')
     rc, stdout, stderr = login_node_runner.run(prepare_snapshot_cmd,
                                                require_outputs=True,
                                                stream_logs=False)
@@ -1544,88 +1584,134 @@ fi
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
 
-    runtime_job_db_path = (
-        f'{_skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)}/.sky/jobs.db')
-    snapshot_job_db_path = _snapshot_job_db_path(snapshot_dir)
-    backup_job_db_code = (
-        'import sqlite3, sys; '
-        'source = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True); '
-        'destination = sqlite3.connect(sys.argv[2]); '
-        'source.backup(destination); '
-        'destination.close(); source.close()')
-    backup_job_db_script = (
-        f'if [ -f {shlex.quote(runtime_job_db_path)} ]; then '
-        f'/usr/bin/python3 -c {shlex.quote(backup_job_db_code)} '
-        f'{shlex.quote(runtime_job_db_path)} '
-        f'{shlex.quote(snapshot_job_db_path)}; fi')
-    backup_job_db_cmd = (
-        f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-        f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
-        f'bash -c {shlex.quote(backup_job_db_script)}')
-    rc, stdout, stderr = login_node_runner.run(backup_job_db_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        backup_job_db_cmd,
-        'Failed to snapshot the Slurm cluster job database.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
-    job_db_exists_cmd = f'test -f {shlex.quote(snapshot_job_db_path)}'
-    rc, stdout, stderr = login_node_runner.run(job_db_exists_cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
-    if rc == 0:
-        manifest_job_db_path: Optional[str] = snapshot_job_db_path
-    elif rc == 1:
-        manifest_job_db_path = None
-    else:
+    generation_committed = False
+    manifest_publish_started = False
+    try:
+        skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir,
+                                                     cluster_name_on_cloud)
+        runtime_job_db_path = f'{skypilot_runtime_dir}/.sky/jobs.db'
+        staging_job_db_path = _snapshot_job_db_path(staging_dir)
+        generation_job_db_path = _snapshot_job_db_path(generation_dir)
+        backup_job_db_code = (
+            'import sqlite3, sys; '
+            'source = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", '
+            'uri=True); '
+            'destination = sqlite3.connect(sys.argv[2]); '
+            'source.backup(destination); '
+            'destination.close(); source.close()')
+        backup_job_db_script = (
+            f'export {skylet_constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
+            f'{shlex.quote(skypilot_runtime_dir)} && '
+            f'if [ -f {shlex.quote(runtime_job_db_path)} ]; then '
+            f'{skylet_constants.SKY_SLURM_PYTHON_CMD} -c '
+            f'{shlex.quote(backup_job_db_code)} '
+            f'{shlex.quote(runtime_job_db_path)} '
+            f'{shlex.quote(staging_job_db_path)}; fi')
+        backup_job_db_cmd = (
+            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+            f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
+            f'bash -c {shlex.quote(backup_job_db_script)}')
+        rc, stdout, stderr = login_node_runner.run(backup_job_db_cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
         subprocess_utils.handle_returncode(
             rc,
-            job_db_exists_cmd,
-            'Failed to inspect the Slurm cluster job database snapshot.',
+            backup_job_db_cmd,
+            'Failed to snapshot the Slurm cluster job database.',
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
-        raise AssertionError('unreachable')
+        job_db_exists_cmd = f'test -f {shlex.quote(staging_job_db_path)}'
+        rc, stdout, stderr = login_node_runner.run(job_db_exists_cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        if rc == 0:
+            manifest_job_db_path: Optional[str] = generation_job_db_path
+        elif rc == 1:
+            manifest_job_db_path = None
+        else:
+            subprocess_utils.handle_returncode(
+                rc,
+                job_db_exists_cmd,
+                'Failed to inspect the Slurm cluster job database snapshot.',
+                stderr=f'{stdout}\n{stderr}',
+                stream_logs=False)
+            raise AssertionError('unreachable')
 
-    def _export_node(rank_and_node: Tuple[int, str]) -> Dict[str, Any]:
-        rank, node = rank_and_node
-        snapshot_path = _snapshot_rank_path(snapshot_dir, rank)
-        export_script = f"""\
+        def _export_node(rank_and_node: Tuple[int, str]) -> Dict[str, Any]:
+            rank, node = rank_and_node
+            staging_snapshot_path = _snapshot_rank_path(staging_dir, rank)
+            snapshot_path = _snapshot_rank_path(generation_dir, rank)
+            export_script = f"""\
 set -e
 {_find_enroot_container_script(node)}\
 sync
-enroot export -f -o {shlex.quote(snapshot_path)} "$enroot_name"
+enroot export -f -o {shlex.quote(staging_snapshot_path)} "$enroot_name"
 """
-        export_cmd = (
-            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
-            f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
-            f'bash -c {shlex.quote(export_script)}')
-        export_rc, export_stdout, export_stderr = login_node_runner.run(
-            export_cmd, require_outputs=True, stream_logs=False)
-        subprocess_utils.handle_returncode(
-            export_rc,
-            export_cmd,
-            f'Failed to snapshot Slurm container rank {rank} on node {node}.',
-            stderr=f'{export_stdout}\n{export_stderr}',
-            stream_logs=False)
-        return {
-            'rank': rank,
-            'node': node,
-            'path': snapshot_path,
-        }
+            export_cmd = (
+                f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+                f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
+                f'bash -c {shlex.quote(export_script)}')
+            export_rc, export_stdout, export_stderr = login_node_runner.run(
+                export_cmd, require_outputs=True, stream_logs=False)
+            subprocess_utils.handle_returncode(
+                export_rc,
+                export_cmd,
+                f'Failed to snapshot Slurm container rank {rank} on node '
+                f'{node}.',
+                stderr=f'{export_stdout}\n{export_stderr}',
+                stream_logs=False)
+            return {
+                'rank': rank,
+                'node': node,
+                'path': snapshot_path,
+            }
 
-    snapshots = subprocess_utils.run_in_parallel(_export_node,
-                                                 list(enumerate(nodes)))
-    manifest = {
-        'version': SNAPSHOT_MANIFEST_VERSION,
-        'image_id': image_id,
-        'num_nodes': len(nodes),
-        'created_at': time.time(),
-        'job_db_path': manifest_job_db_path,
-        'snapshots': snapshots,
-    }
-    _write_snapshot_manifest(login_node_runner, snapshot_dir, manifest)
+        snapshots = subprocess_utils.run_in_parallel(_export_node,
+                                                     list(enumerate(nodes)))
+        manifest = {
+            'version': SNAPSHOT_MANIFEST_VERSION,
+            'generation': generation,
+            'image_id': image_id,
+            'num_nodes': len(nodes),
+            'created_at': time.time(),
+            'job_db_path': manifest_job_db_path,
+            'snapshots': snapshots,
+        }
+        commit_generation_cmd = (f'test ! -e {shlex.quote(generation_dir)} && '
+                                 f'mv -- {shlex.quote(staging_dir)} '
+                                 f'{shlex.quote(generation_dir)}')
+        rc, stdout, stderr = login_node_runner.run(commit_generation_cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        subprocess_utils.handle_returncode(
+            rc,
+            commit_generation_cmd,
+            'Failed to commit the Slurm container snapshot generation.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+        generation_committed = True
+        _validate_snapshot_files(login_node_runner, manifest)
+        # Keep the previous generation reachable until its replacement is
+        # complete and the manifest can switch to it atomically.
+        manifest_publish_started = True
+        _write_snapshot_manifest(login_node_runner, snapshot_dir, manifest)
+    except Exception:
+        # A manifest rename may complete even if SSH loses its acknowledgement.
+        # Keep committed data so any manifest published remotely stays usable.
+        if not (generation_committed and manifest_publish_started):
+            incomplete_path = (generation_dir
+                               if generation_committed else staging_dir)
+            _remove_snapshot_paths_best_effort(
+                login_node_runner, [incomplete_path],
+                'incomplete Slurm snapshot generation')
+        raise
+
+    if previous_manifest is not None:
+        previous_generation_dir = _snapshot_generation_dir(
+            snapshot_dir, previous_manifest['generation'])
+        _remove_snapshot_paths_best_effort(
+            login_node_runner, [previous_generation_dir],
+            'previous Slurm snapshot generation')
     cleanup = lambda: _cleanup_slurm_allocation(
         client, login_node_runner, cluster_name_on_cloud, provider_config,
         job_id, nodes)

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1607,7 +1607,7 @@ enroot export -f -o {shlex.quote(staging_snapshot_path)} "$enroot_name"
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster=False,
-                      pre_batch_cancel=_make_pre_batch_cancel_cleanup(
+                      pre_batch_cancel=lambda: _cleanup_slurm_allocation(
                           client,
                           login_node_runner,
                           cluster_name_on_cloud,
@@ -1763,41 +1763,6 @@ rm -rf -- {shlex.quote(skypilot_runtime_dir)}
         'Failed to clean up shared Slurm cluster state before cancellation.')
 
 
-def _make_pre_batch_cancel_cleanup(
-    client: 'slurm.SlurmClient',
-    login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
-    cluster_name_on_cloud: str,
-    provider_config: Dict[str, Any],
-    job_id: str,
-    nodes: List[str],
-    preserve_logs: bool = False,
-) -> Callable[[], None]:
-    """Best-effort node cleanup to run between step and batch cancellation.
-
-    Cleanup failures must not abort the cancellation: the batch script's
-    exit trap re-runs the same cleanup, and the allocation must come down
-    regardless.
-    """
-
-    def _cleanup() -> None:
-        try:
-            _cleanup_slurm_allocation(client,
-                                      login_node_runner,
-                                      cluster_name_on_cloud,
-                                      provider_config,
-                                      job_id,
-                                      nodes,
-                                      preserve_logs=preserve_logs)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(
-                'Failed to clean up the Slurm allocation before '
-                'cancellation; proceeding with cancellation. Details: '
-                f'{common_utils.format_exception(e, use_bracket=True)}')
-            logger.debug('Full exception details:', exc_info=True)
-
-    return _cleanup
-
-
 def _cancel_slurm_job(
     client: 'slurm.SlurmClient',
     cluster_name_on_cloud: str,
@@ -1850,7 +1815,14 @@ def _cancel_slurm_job(
         # batch script and its child processes.
         client.cancel_jobs_by_name(cluster_name_on_cloud, signal='TERM')
         if pre_batch_cancel is not None:
-            pre_batch_cancel()
+            try:
+                pre_batch_cancel()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    'Failed to clean up the Slurm allocation before '
+                    'cancellation; proceeding with cancellation. Details: '
+                    f'{common_utils.format_exception(e, use_bracket=True)}')
+                logger.debug('Full exception details:', exc_info=True)
         client.cancel_jobs_by_name(cluster_name_on_cloud,
                                    signal='TERM',
                                    full=True)
@@ -1918,9 +1890,10 @@ def terminate_instances(
         if len(running_jobs) == 1:
             job_id = running_jobs[0]
             nodes, _ = client.get_job_nodes(job_id)
-            pre_batch_cancel = _make_pre_batch_cancel_cleanup(
-                client, _make_login_node_runner(provider_config),
-                cluster_name_on_cloud, provider_config, job_id, nodes)
+            login_node_runner = _make_login_node_runner(provider_config)
+            pre_batch_cancel = lambda: _cleanup_slurm_allocation(
+                client, login_node_runner, cluster_name_on_cloud,
+                provider_config, job_id, nodes)
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1467,9 +1467,13 @@ def stop_instances(
                                                          default_value=None)
     if tmpdir is not None:
         tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
-    skylet_pid_file = (f'{_skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)}'
-                       '/.sky/skylet_pid')
+    skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
+    skylet_start_file = (
+        f'{skypilot_runtime_dir}/{skylet_constants.SKYLET_START_FILE}')
+    skylet_pid_file = f'{skypilot_runtime_dir}/.sky/skylet_pid'
+    # Remove the start spec first so the keeper cannot restart Skylet.
     stop_skylet_script = (
+        f'rm -f -- {shlex.quote(skylet_start_file)}; '
         f'if [ -f {shlex.quote(skylet_pid_file)} ]; then '
         f'skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"; '
         'if kill -0 "$skylet_pid" 2>/dev/null; then kill "$skylet_pid"; fi; '
@@ -1487,6 +1491,46 @@ def stop_instances(
         'Failed to stop Skylet before snapshotting the Slurm container.',
         stderr=f'{stdout}\n{stderr}',
         stream_logs=False)
+
+    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
+    global_enroot_name = f'pyxis_{pyxis_name}'
+    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
+
+    def _find_enroot_container_script(node: str) -> str:
+        return f"""\
+enroot_name=''
+while IFS= read -r candidate; do
+    if [ "$candidate" = {shlex.quote(global_enroot_name)} ] || [ "$candidate" = {shlex.quote(job_enroot_name)} ]; then
+        if [ -n "$enroot_name" ]; then
+            echo "Multiple matching Pyxis containers found" >&2
+            exit 1
+        fi
+        enroot_name="$candidate"
+    fi
+done < <(enroot list)
+if [ -z "$enroot_name" ]; then
+    echo "Pyxis container not found on node {node}" >&2
+    exit 1
+fi
+"""
+
+    def _check_node_container(node: str) -> None:
+        check_script = 'set -e\n' + _find_enroot_container_script(node)
+        check_cmd = (
+            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+            f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
+            f'bash -c {shlex.quote(check_script)}')
+        check_rc, check_stdout, check_stderr = login_node_runner.run(
+            check_cmd, require_outputs=True, stream_logs=False)
+        subprocess_utils.handle_returncode(
+            check_rc,
+            check_cmd,
+            f'Failed to verify the Slurm container on node {node} before '
+            'preparing its snapshot.',
+            stderr=f'{check_stdout}\n{check_stderr}',
+            stream_logs=False)
+
+    subprocess_utils.run_in_parallel(_check_node_container, nodes)
 
     prepare_snapshot_cmd = (f'rm -rf -- {shlex.quote(snapshot_dir)}; '
                             f'mkdir -p {shlex.quote(snapshot_dir)}')
@@ -1544,29 +1588,12 @@ def stop_instances(
             stream_logs=False)
         raise AssertionError('unreachable')
 
-    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
-    global_enroot_name = f'pyxis_{pyxis_name}'
-    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
-
     def _export_node(rank_and_node: Tuple[int, str]) -> Dict[str, Any]:
         rank, node = rank_and_node
         snapshot_path = _snapshot_rank_path(snapshot_dir, rank)
         export_script = f"""\
 set -e
-enroot_name=''
-while IFS= read -r candidate; do
-    if [ "$candidate" = {shlex.quote(global_enroot_name)} ] || [ "$candidate" = {shlex.quote(job_enroot_name)} ]; then
-        if [ -n "$enroot_name" ]; then
-            echo "Multiple matching Pyxis containers found" >&2
-            exit 1
-        fi
-        enroot_name="$candidate"
-    fi
-done < <(enroot list)
-if [ -z "$enroot_name" ]; then
-    echo "Pyxis container not found on node {node}" >&2
-    exit 1
-fi
+{_find_enroot_container_script(node)}\
 sync
 enroot export -f -o {shlex.quote(snapshot_path)} "$enroot_name"
 """
@@ -1861,9 +1888,20 @@ def terminate_instances(
             job_id = running_jobs[0]
             nodes, _ = client.get_job_nodes(job_id)
             login_node_runner = _make_login_node_runner(provider_config)
-            pre_batch_cancel = lambda: _cleanup_slurm_allocation(
-                client, login_node_runner, cluster_name_on_cloud,
-                provider_config, job_id, nodes)
+
+            def cleanup_before_terminate() -> None:
+                try:
+                    _cleanup_slurm_allocation(client, login_node_runner,
+                                              cluster_name_on_cloud,
+                                              provider_config, job_id, nodes)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning(
+                        'Failed to clean up the Slurm allocation before '
+                        'termination; proceeding with cancellation. Details: '
+                        f'{common_utils.format_exception(e, use_bracket=True)}')
+                    logger.debug('Full exception details:', exc_info=True)
+
+            pre_batch_cancel = cleanup_before_terminate
     _cancel_slurm_job(client,
                       cluster_name_on_cloud,
                       inside_slurm_cluster,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -969,6 +969,16 @@ echo "[container] ERROR: Container is not running as $global_target or $job_targ
 exit 1
 """
         assert original_container_image is not None
+        container_ready_failure = ''
+        snapshot_restore_complete_block = ''
+        if snapshot_manifest is not None:
+            container_ready_failure = ' || exit 1'
+            snapshot_restore_complete_block = (
+                f'if ! rm -rf -- {shlex.quote(snapshot_dir)}; then\n'
+                '  echo "[container] ERROR: Failed to consume snapshot." '
+                '>&2\n'
+                '  exit 1\n'
+                'fi\n')
         container_block = (
             f'srun --nodes={num_nodes} mkdir -p {host_ccache_dir}\n'
             f'CONTAINER_START=$SECONDS\n'
@@ -995,10 +1005,12 @@ exit 1
             f'done\n'
             f'srun --overlap --unbuffered --nodes={num_nodes} '
             f'--ntasks-per-node=1 bash -c '
-            f'{shlex.quote(container_ready_script)}\n'
+            f'{shlex.quote(container_ready_script)}'
+            f'{container_ready_failure}\n'
             f'echo "[container] Ready in $((SECONDS - CONTAINER_START))s"\n'
             f'printf \'%s\\n\' {shlex.quote(original_container_image)} > '
             f'{container_marker_file}\n'
+            f'{snapshot_restore_complete_block}'
             f'touch {ready_signal}')
 
     # sbatch batch script ── lives as long as the allocation

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1,9 +1,11 @@
 """Slurm instance provisioning."""
 
+import json
 import math
 import os
 import re
 import shlex
+import shutil
 import tempfile
 import threading
 import time
@@ -19,6 +21,7 @@ from sky.provision import common
 from sky.provision import constants
 from sky.provision.slurm import utils as slurm_utils
 from sky.skylet import constants as skylet_constants
+from sky.skylet import job_lib
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import env_options
@@ -31,6 +34,10 @@ from sky.utils import ux_utils
 logger = sky_logging.init_logger(__name__)
 
 PROVISION_SCRIPTS_DIRECTORY_NAME = '.sky_provision'
+SNAPSHOT_DIRECTORY_NAME = '.sky_snapshots'
+SNAPSHOT_MANIFEST_FILENAME = 'manifest.json'
+SNAPSHOT_JOB_DB_FILENAME = 'jobs.db'
+SNAPSHOT_MANIFEST_VERSION = 1
 
 
 def _sbatch_log_path(base_dir: str, job_id: str) -> str:
@@ -278,6 +285,180 @@ def _sky_cluster_home_dir(base_dir: str, cluster_name_on_cloud: str) -> str:
     return f'{base_dir}/.sky_clusters/{cluster_name_on_cloud}'
 
 
+def _snapshot_dir(base_dir: str, cluster_name_on_cloud: str) -> str:
+    """Returns the shared directory for a Slurm container snapshot."""
+    return f'{base_dir}/{SNAPSHOT_DIRECTORY_NAME}/{cluster_name_on_cloud}'
+
+
+def _snapshot_manifest_path(snapshot_dir: str) -> str:
+    return f'{snapshot_dir}/{SNAPSHOT_MANIFEST_FILENAME}'
+
+
+def _snapshot_rank_path(snapshot_dir: str, rank: int) -> str:
+    return f'{snapshot_dir}/rank{rank}.sqsh'
+
+
+def _snapshot_job_db_path(snapshot_dir: str) -> str:
+    return f'{snapshot_dir}/{SNAPSHOT_JOB_DB_FILENAME}'
+
+
+def _validate_snapshot_manifest(
+        manifest: Any,
+        snapshot_dir: str,
+        expected_num_nodes: Optional[int] = None) -> Dict[str, Any]:
+    """Validate and normalize a Slurm container snapshot manifest."""
+    if not isinstance(manifest, dict):
+        raise RuntimeError('Slurm container snapshot manifest must be a JSON '
+                           'object.')
+    if manifest.get('version') != SNAPSHOT_MANIFEST_VERSION:
+        raise RuntimeError(
+            'Unsupported Slurm container snapshot manifest version: '
+            f'{manifest.get("version")!r}.')
+    image_id = manifest.get('image_id')
+    if not isinstance(image_id, str) or not image_id:
+        raise RuntimeError('Slurm container snapshot manifest has no image ID.')
+    num_nodes = manifest.get('num_nodes')
+    if (not isinstance(num_nodes, int) or isinstance(num_nodes, bool) or
+            num_nodes < 1):
+        raise RuntimeError('Slurm container snapshot manifest has an invalid '
+                           f'num_nodes value: {num_nodes!r}.')
+    if expected_num_nodes is not None and num_nodes != expected_num_nodes:
+        raise RuntimeError(
+            'Slurm container snapshot node count does not match the cluster: '
+            f'manifest has {num_nodes}, cluster requires '
+            f'{expected_num_nodes}.')
+    if 'job_db_path' not in manifest:
+        raise RuntimeError('Slurm container snapshot manifest has no job '
+                           'database entry.')
+    job_db_path = manifest['job_db_path']
+    expected_job_db_path = _snapshot_job_db_path(snapshot_dir)
+    if job_db_path is not None and job_db_path != expected_job_db_path:
+        raise RuntimeError('Slurm container snapshot job database path must be '
+                           f'{expected_job_db_path!r}, got {job_db_path!r}.')
+    snapshots = manifest.get('snapshots')
+    if not isinstance(snapshots, list) or len(snapshots) != num_nodes:
+        raise RuntimeError(
+            'Slurm container snapshot manifest does not contain exactly '
+            f'{num_nodes} rank snapshots.')
+    for rank, snapshot in enumerate(snapshots):
+        expected_path = _snapshot_rank_path(snapshot_dir, rank)
+        if not isinstance(snapshot, dict):
+            raise RuntimeError(
+                f'Slurm container snapshot entry for rank {rank} is invalid.')
+        if snapshot.get('rank') != rank:
+            raise RuntimeError(
+                f'Slurm container snapshot entry {rank} has invalid rank '
+                f'{snapshot.get("rank")!r}.')
+        if snapshot.get('path') != expected_path:
+            raise RuntimeError(
+                f'Slurm container snapshot path for rank {rank} must be '
+                f'{expected_path!r}, got {snapshot.get("path")!r}.')
+        if not isinstance(snapshot.get('node'), str) or not snapshot['node']:
+            raise RuntimeError(
+                f'Slurm container snapshot entry for rank {rank} has no '
+                'source node.')
+    return manifest
+
+
+def _read_snapshot_manifest(
+        login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+        snapshot_dir: str,
+        expected_num_nodes: Optional[int] = None) -> Optional[Dict[str, Any]]:
+    """Read a snapshot manifest from the Slurm cluster's shared storage."""
+    manifest_path = _snapshot_manifest_path(snapshot_dir)
+    missing_exit_code = 44
+    cmd = (f'test -f {shlex.quote(manifest_path)} || '
+           f'exit {missing_exit_code}; cat {shlex.quote(manifest_path)}')
+    rc, stdout, stderr = login_node_runner.run(cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    if rc == missing_exit_code:
+        return None
+    subprocess_utils.handle_returncode(
+        rc,
+        cmd,
+        'Failed to read Slurm container snapshot manifest.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+    try:
+        manifest = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError('Slurm container snapshot manifest is not valid '
+                           f'JSON: {e}') from e
+    return _validate_snapshot_manifest(manifest, snapshot_dir,
+                                       expected_num_nodes)
+
+
+def _snapshot_paths(manifest: Dict[str, Any]) -> List[str]:
+    return [snapshot['path'] for snapshot in manifest['snapshots']]
+
+
+def _write_snapshot_manifest(
+        login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+        snapshot_dir: str, manifest: Dict[str, Any]) -> None:
+    """Atomically write a validated snapshot manifest to shared storage."""
+    _validate_snapshot_manifest(manifest, snapshot_dir)
+    manifest_path = _snapshot_manifest_path(snapshot_dir)
+    remote_tmp_path = f'{manifest_path}.tmp'
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json') as f:
+        json.dump(manifest, f, sort_keys=True)
+        f.write('\n')
+        f.flush()
+        login_node_runner.rsync(f.name,
+                                remote_tmp_path,
+                                up=True,
+                                stream_logs=False)
+    cmd = f'mv -f {shlex.quote(remote_tmp_path)} {shlex.quote(manifest_path)}'
+    rc, stdout, stderr = login_node_runner.run(cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        cmd,
+        'Failed to publish Slurm container snapshot manifest.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+
+def _validate_snapshot_files(
+        login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+        manifest: Dict[str, Any]) -> None:
+    """Raise if a rank snapshot referenced by a manifest is missing."""
+    missing = []
+    for rank, path in enumerate(_snapshot_paths(manifest)):
+        cmd = f'test -f {shlex.quote(path)}'
+        rc, stdout, stderr = login_node_runner.run(cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        if rc == 1:
+            missing.append(f'rank {rank}: {path}')
+        elif rc != 0:
+            subprocess_utils.handle_returncode(
+                rc,
+                cmd,
+                f'Failed to inspect Slurm container snapshot for rank {rank}.',
+                stderr=f'{stdout}\n{stderr}',
+                stream_logs=False)
+    if missing:
+        raise RuntimeError('Slurm container snapshot is incomplete; missing ' +
+                           ', '.join(missing) + '.')
+    job_db_path = manifest['job_db_path']
+    if job_db_path is not None:
+        cmd = f'test -f {shlex.quote(job_db_path)}'
+        rc, stdout, stderr = login_node_runner.run(cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        if rc == 1:
+            raise RuntimeError('Slurm container snapshot is incomplete; '
+                               f'missing job database: {job_db_path}.')
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            'Failed to inspect Slurm container snapshot job database.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+
+
 def _sbatch_provision_script_path(base_dir: str,
                                   cluster_name_on_cloud: str) -> str:
     """Returns the path to the sbatch provision script on the login node."""
@@ -302,6 +483,58 @@ def _enroot_container_name_global_scope(cluster_name_on_cloud: str) -> str:
     # Added in commit:
     # https://github.com/NVIDIA/pyxis/commit/a35027cf2ffa45cf702b117d215b1240aa6de22e
     return f'pyxis_{slurm_utils.pyxis_container_name(cluster_name_on_cloud)}'
+
+
+def _make_slurm_client(provider_config: Dict[str, Any]) -> 'slurm.SlurmClient':
+    ssh_config = provider_config['ssh']
+    return slurm.SlurmClient(
+        ssh_config['hostname'],
+        int(ssh_config['port']),
+        ssh_config['user'],
+        ssh_config.get('private_key'),
+        ssh_proxy_command=ssh_config.get('proxycommand'),
+        ssh_proxy_jump=ssh_config.get('proxyjump'),
+        identities_only=ssh_config.get('identities_only', False),
+        slurm_user=provider_config.get('slurm_user'),
+    )
+
+
+def _make_login_node_runner(
+    provider_config: Dict[str,
+                          Any]) -> command_runner.SlurmLoginNodeCommandRunner:
+    ssh_config = provider_config['ssh']
+    identities_only = ssh_config.get('identities_only', False)
+    return command_runner.SlurmLoginNodeCommandRunner(
+        (ssh_config['hostname'], int(ssh_config['port'])),
+        ssh_config['user'],
+        ssh_config.get('private_key'),
+        ssh_proxy_command=ssh_config.get('proxycommand'),
+        ssh_proxy_jump=ssh_config.get('proxyjump'),
+        enable_interactive_auth=True,
+        disable_identities_only=not identities_only,
+        slurm_user=provider_config.get('slurm_user'),
+    )
+
+
+def _resolve_sky_base_dir(client: 'slurm.SlurmClient',
+                          provider_config: Dict[str, Any]) -> str:
+    """Resolve the shared base directory used for Slurm cluster state."""
+    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
+    workdir = skypilot_config.get_effective_region_config(cloud='slurm',
+                                                          region=slurm_cluster,
+                                                          keys=('workdir',),
+                                                          default_value=None)
+    if workdir is not None:
+        workdir = slurm_utils.expand_path_vars(workdir, client.get_env())
+        if not os.path.isabs(workdir):
+            raise RuntimeError('Resolved Slurm workdir must be absolute, got '
+                               f'{workdir!r}.')
+        return workdir
+    remote_home_dir = client.get_remote_home_dir()
+    if not os.path.isabs(remote_home_dir):
+        raise RuntimeError('Slurm remote home directory must be absolute, got '
+                           f'{remote_home_dir!r}.')
+    return remote_home_dir
 
 
 def _wait_for_job_ready(
@@ -529,12 +762,29 @@ def _create_virtual_instance(
     skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
+    snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+    snapshot_manifest = _read_snapshot_manifest(login_node_runner,
+                                                snapshot_dir,
+                                                expected_num_nodes=num_nodes)
+    if snapshot_manifest is not None:
+        _validate_snapshot_files(login_node_runner, snapshot_manifest)
     ready_signal = f'{sky_cluster_home_dir}/.sky_sbatch_ready'
 
     # For non-Docker Hub registries, pyxis/enroot requires '#' separator
     # between registry and path. See:
     # https://github.com/NVIDIA/pyxis/wiki/Usage#registry-syntax
     container_image = resources.get('image_id')
+    original_container_image = container_image
+    if snapshot_manifest is not None:
+        if container_image is None:
+            raise RuntimeError('A Slurm container snapshot exists for this '
+                               'cluster, but its cluster record has no '
+                               'container image.')
+        if snapshot_manifest['image_id'] != container_image:
+            raise RuntimeError(
+                'Slurm container snapshot image does not match the cluster '
+                f'record: manifest has {snapshot_manifest["image_id"]!r}, '
+                f'cluster has {container_image!r}.')
     if container_image is not None:
         if container_image.endswith('.sqsh'):
             # Local .sqsh file, use path directly.
@@ -624,45 +874,132 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
                                  f'{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
         container_init_done_dir = (
             f'{sky_cluster_home_dir}/.sky_container_init_done')
-        # Run container init, touch per-node "done" marker, then sleep infinity
-        # to keep container running. Use --overlap so subsequent sruns can share
-        # the allocation. Background with & so sbatch continues.
-        container_cmd = shlex.quote(
-            f'{container_init_script}'
-            f'touch {container_init_done_dir}/$SLURM_PROCID && sleep infinity')
+        pyxis_args = (f'--container-name={shlex.quote(container_name)}:create '
+                      f'--container-mounts="{container_mounts}" '
+                      f'--container-remap-root '
+                      f'--no-container-mount-home '
+                      f'--container-writable')
+        global_enroot_name = _enroot_container_name_global_scope(
+            cluster_name_on_cloud)
+        if snapshot_manifest is None:
+            container_cmd = shlex.quote(
+                f'{container_init_script}'
+                f'touch {container_init_done_dir}/$SLURM_PROCID && '
+                'sleep infinity')
+            container_launch_block = (
+                f'CONTAINER_PIDS=()\n'
+                f'srun --overlap '
+                f'{"--label " if num_nodes > 1 else ""}--unbuffered '
+                f'--nodes={num_nodes} --ntasks-per-node=1 '
+                f'--container-image={shlex.quote(container_image)} '
+                f'{pyxis_args} bash -c {container_cmd} &\n'
+                f'CONTAINER_PIDS+=("$!")')
+        else:
+            remove_stale_container_script = f"""\
+while IFS= read -r candidate; do
+    if [ "$candidate" = {shlex.quote(global_enroot_name)} ]; then
+        enroot remove -f "$candidate"
+    fi
+done < <(enroot list)
+"""
+            restore_lines = [
+                'mapfile -t SKY_NODES < <(scontrol show hostnames '
+                '"$SLURM_JOB_NODELIST")',
+                f'if [ "${{#SKY_NODES[@]}}" -ne "{num_nodes}" ]; then',
+                '  echo "[container] ERROR: Allocation node count does not '
+                'match snapshot."',
+                '  exit 1',
+                'fi',
+            ]
+            snapshot_job_db_path = snapshot_manifest['job_db_path']
+            if snapshot_job_db_path is not None:
+                restored_job_db_path = (f'{skypilot_runtime_dir}/.sky/jobs.db')
+                restored_job_db_dir = os.path.dirname(restored_job_db_path)
+                restore_job_db_script = (
+                    f'mkdir -p {shlex.quote(restored_job_db_dir)}; '
+                    f'cp -f {shlex.quote(snapshot_job_db_path)} '
+                    f'{shlex.quote(restored_job_db_path)}')
+                restore_lines.append(
+                    'srun --overlap --unbuffered --nodes=1 --ntasks=1 '
+                    '-w "${SKY_NODES[0]}" bash -c '
+                    f'{shlex.quote(restore_job_db_script)}')
+            restore_lines.extend([
+                f'srun --overlap --unbuffered --nodes={num_nodes} '
+                f'--ntasks-per-node=1 bash -c '
+                f'{shlex.quote(remove_stale_container_script)}',
+                'CONTAINER_PIDS=()',
+            ])
+            for rank, snapshot_path in enumerate(
+                    _snapshot_paths(snapshot_manifest)):
+                container_cmd = shlex.quote(
+                    f'{container_init_script}'
+                    f'touch {container_init_done_dir}/{rank} && '
+                    'sleep infinity')
+                restore_lines.extend([
+                    f'echo "[container] Restoring rank {rank} on '
+                    f'${{SKY_NODES[{rank}]}}"',
+                    f'srun --overlap --unbuffered --nodes=1 --ntasks=1 '
+                    f'-w "${{SKY_NODES[{rank}]}}" '
+                    f'--container-image={shlex.quote(snapshot_path)} '
+                    f'{pyxis_args} bash -c {container_cmd} &',
+                    'CONTAINER_PIDS+=("$!")',
+                ])
+            container_launch_block = '\n'.join(restore_lines)
+        container_ready_script = f"""\
+global_target={shlex.quote(global_enroot_name)}
+job_target="pyxis_${{SLURM_JOB_ID}}_"{shlex.quote(container_name)}
+for ((attempt = 1; attempt <= 30; attempt++)); do
+    container_pid=
+    while read -r name pid rest; do
+        if [ "$name" = "$global_target" ] || [ "$name" = "$job_target" ]; then
+            container_pid=$pid
+        fi
+    done < <(enroot list -f)
+    case "$container_pid" in
+        ''|*[!0-9]*) ;;
+        *)
+            if kill -0 "$container_pid" 2>/dev/null; then
+                exit 0
+            fi
+            ;;
+    esac
+    sleep 1
+done
+echo "[container] ERROR: Container is not running as $global_target or $job_target." >&2
+exit 1
+"""
+        assert original_container_image is not None
         container_block = (
             f'srun --nodes={num_nodes} mkdir -p {host_ccache_dir}\n'
             f'CONTAINER_START=$SECONDS\n'
             f'echo "[container] Initializing {container_name} on all nodes"\n'
             f'rm -rf {container_init_done_dir}\n'
             f'mkdir -p {container_init_done_dir}\n'
-            f'srun --overlap {"--label " if num_nodes > 1 else ""}--unbuffered '
-            f'--nodes={num_nodes} --ntasks-per-node=1 '
-            f'--container-image={shlex.quote(container_image)} '
-            f'--container-name={shlex.quote(container_name)}:create '
-            f'--container-mounts="{container_mounts}" '
-            f'--container-remap-root '
-            f'--no-container-mount-home '
-            f'--container-writable '
-            f'bash -c {container_cmd} &\n'
-            f'CONTAINER_PID=$!\n'
+            f'{container_launch_block}\n'
             f'while true; do\n'
-            f'  num_ready=$(ls -1 {container_init_done_dir} 2>/dev/null | '
-            f'wc -l)\n'
-            f'  if [ "$num_ready" -ge "{num_nodes}" ]; then\n'
-            f'    break\n'
-            f'  fi\n'
-            f'  if ! kill -0 $CONTAINER_PID 2>/dev/null; then\n'
-            f'    echo "[container] ERROR: Container initialization failed."\n'
-            f'    echo "[container] Only $num_ready of {num_nodes}'
-            f' node(s) completed initialization."\n'
-            f'    wait $CONTAINER_PID\n'
-            f'    exit $?\n'
-            f'  fi\n'
+            f'  for container_pid in "${{CONTAINER_PIDS[@]}}"; do\n'
+            f'    if ! kill -0 "$container_pid" 2>/dev/null; then\n'
+            f'      wait "$container_pid"\n'
+            f'      container_rc=$?\n'
+            f'      if [ "$container_rc" -eq 0 ]; then container_rc=1; fi\n'
+            f'      echo "[container] ERROR: Container initialization '
+            f'failed with exit code $container_rc."\n'
+            f'      exit "$container_rc"\n'
+            f'    fi\n'
+            f'  done\n'
+            f'  shopt -s nullglob\n'
+            f'  ready_markers=({container_init_done_dir}/*)\n'
+            f'  num_ready=${{#ready_markers[@]}}\n'
+            f'  if [ "$num_ready" -ge "{num_nodes}" ]; then break; fi\n'
             f'  sleep 1\n'
             f'done\n'
+            f'srun --overlap --unbuffered --nodes={num_nodes} '
+            f'--ntasks-per-node=1 bash -c '
+            f'{shlex.quote(container_ready_script)}\n'
             f'echo "[container] Ready in $((SECONDS - CONTAINER_START))s"\n'
-            f'touch {container_marker_file} {ready_signal}')
+            f'printf \'%s\\n\' {shlex.quote(original_container_image)} > '
+            f'{container_marker_file}\n'
+            f'touch {ready_signal}')
 
     # sbatch batch script ── lives as long as the allocation
     #   └─ keeper srun client (host side, never enters the container)
@@ -932,6 +1269,23 @@ def query_instances(
         # MinJobAge seconds (default 300s). Or could be earlier if it
         # reaches MaxJobCount first (default 10_000).
 
+    non_terminated_statuses = {
+        instance_id: status_and_reason
+        for instance_id, status_and_reason in statuses.items()
+        if status_and_reason[0] is not None
+    }
+    if non_terminated_statuses:
+        return non_terminated_statuses
+    login_node_runner = _make_login_node_runner(provider_config)
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
+    snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+    manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
+    if manifest is not None:
+        return {
+            f'snapshot-rank-{rank}': (status_lib.ClusterStatus.STOPPED, None)
+            for rank in range(manifest['num_nodes'])
+        }
+
     return statuses
 
 
@@ -1033,8 +1387,213 @@ def stop_instances(
     provider_config: Optional[Dict[str, Any]] = None,
     worker_only: bool = False,
 ) -> None:
-    """Keep the Slurm virtual instances running."""
-    raise NotImplementedError()
+    """Snapshot and stop a container-backed Slurm virtual instance."""
+    assert provider_config is not None, cluster_name_on_cloud
+    if worker_only:
+        logger.warning(
+            'worker_only=True is not supported for Slurm, this is a no-op.')
+        return
+
+    client = _make_slurm_client(provider_config)
+    login_node_runner = _make_login_node_runner(provider_config)
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
+    snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+
+    running_jobs = client.query_jobs(cluster_name_on_cloud,
+                                     ['running', 'suspended'])
+    if not running_jobs:
+        manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
+        if manifest is not None:
+            logger.debug(f'Cluster {cluster_name_on_cloud} is already stopped.')
+            return
+        states = client.get_jobs_state_by_name(cluster_name_on_cloud)
+        state_text = ', '.join(state.strip() for state in states) or 'missing'
+        raise RuntimeError(
+            f'Cannot stop Slurm cluster {cluster_name_on_cloud!r}: expected '
+            f'one running allocation, found state {state_text}.')
+    if len(running_jobs) != 1:
+        raise RuntimeError(f'Multiple running jobs found for cluster '
+                           f'{cluster_name_on_cloud}: {running_jobs}')
+    job_id = running_jobs[0]
+    nodes, _ = client.get_job_nodes(job_id)
+
+    sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
+                                                 cluster_name_on_cloud)
+    container_marker = (
+        f'{sky_cluster_home_dir}/{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
+    read_image_cmd = f'cat {shlex.quote(container_marker)}'
+    rc, stdout, stderr = login_node_runner.run(read_image_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    if rc != 0 or not stdout.strip():
+        raise exceptions.NotSupportedError(
+            'Stopping Slurm clusters is supported only for containers '
+            'launched with Pyxis. The running cluster has no container '
+            'snapshot metadata.')
+    image_id = stdout.strip()
+
+    cluster_info = get_cluster_info('', cluster_name_on_cloud, provider_config)
+    command_runners = get_command_runners(cluster_info)
+    if not command_runners:
+        raise RuntimeError('Cannot stop Slurm cluster because its head node '
+                           'command runner is unavailable.')
+    cancel_jobs_code = job_lib.JobLibCodeGen.cancel_jobs(None, cancel_all=True)
+    rc, stdout, stderr = command_runners[0].run(cancel_jobs_code,
+                                                require_outputs=True,
+                                                stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        cancel_jobs_code,
+        'Failed to cancel jobs before snapshotting the Slurm container.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
+    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
+                                                         region=slurm_cluster,
+                                                         keys=('tmpdir',),
+                                                         default_value=None)
+    if tmpdir is not None:
+        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
+    skylet_pid_file = (f'{_skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)}'
+                       '/.sky/skylet_pid')
+    stop_skylet_script = (
+        f'if [ -f {shlex.quote(skylet_pid_file)} ]; then '
+        f'skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"; '
+        'if kill -0 "$skylet_pid" 2>/dev/null; then kill "$skylet_pid"; fi; '
+        'fi')
+    stop_skylet_cmd = (
+        f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+        f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
+        f'bash -c {shlex.quote(stop_skylet_script)}')
+    rc, stdout, stderr = login_node_runner.run(stop_skylet_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        stop_skylet_cmd,
+        'Failed to stop Skylet before snapshotting the Slurm container.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+    prepare_snapshot_cmd = (f'rm -rf -- {shlex.quote(snapshot_dir)}; '
+                            f'mkdir -p {shlex.quote(snapshot_dir)}')
+    rc, stdout, stderr = login_node_runner.run(prepare_snapshot_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        prepare_snapshot_cmd,
+        'Failed to prepare Slurm container snapshot directory.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+    runtime_job_db_path = (
+        f'{_skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)}/.sky/jobs.db')
+    snapshot_job_db_path = _snapshot_job_db_path(snapshot_dir)
+    backup_job_db_code = (
+        'import sqlite3, sys; '
+        'source = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True); '
+        'destination = sqlite3.connect(sys.argv[2]); '
+        'source.backup(destination); '
+        'destination.close(); source.close()')
+    backup_job_db_script = (
+        f'if [ -f {shlex.quote(runtime_job_db_path)} ]; then '
+        f'/usr/bin/python3 -c {shlex.quote(backup_job_db_code)} '
+        f'{shlex.quote(runtime_job_db_path)} '
+        f'{shlex.quote(snapshot_job_db_path)}; fi')
+    backup_job_db_cmd = (
+        f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+        f'--nodelist={shlex.quote(nodes[0])} --nodes=1 --ntasks=1 '
+        f'bash -c {shlex.quote(backup_job_db_script)}')
+    rc, stdout, stderr = login_node_runner.run(backup_job_db_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        backup_job_db_cmd,
+        'Failed to snapshot the Slurm cluster job database.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+    job_db_exists_cmd = f'test -f {shlex.quote(snapshot_job_db_path)}'
+    rc, stdout, stderr = login_node_runner.run(job_db_exists_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    if rc == 0:
+        manifest_job_db_path: Optional[str] = snapshot_job_db_path
+    elif rc == 1:
+        manifest_job_db_path = None
+    else:
+        subprocess_utils.handle_returncode(
+            rc,
+            job_db_exists_cmd,
+            'Failed to inspect the Slurm cluster job database snapshot.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
+        raise AssertionError('unreachable')
+
+    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
+    global_enroot_name = f'pyxis_{pyxis_name}'
+    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
+
+    def _export_node(rank_and_node: Tuple[int, str]) -> Dict[str, Any]:
+        rank, node = rank_and_node
+        snapshot_path = _snapshot_rank_path(snapshot_dir, rank)
+        export_script = f"""\
+set -e
+enroot_name=''
+while IFS= read -r candidate; do
+    if [ "$candidate" = {shlex.quote(global_enroot_name)} ] || [ "$candidate" = {shlex.quote(job_enroot_name)} ]; then
+        if [ -n "$enroot_name" ]; then
+            echo "Multiple matching Pyxis containers found" >&2
+            exit 1
+        fi
+        enroot_name="$candidate"
+    fi
+done < <(enroot list)
+if [ -z "$enroot_name" ]; then
+    echo "Pyxis container not found on node {node}" >&2
+    exit 1
+fi
+sync
+enroot export -f -o {shlex.quote(snapshot_path)} "$enroot_name"
+"""
+        export_cmd = (
+            f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+            f'--nodelist={shlex.quote(node)} --nodes=1 --ntasks=1 '
+            f'bash -c {shlex.quote(export_script)}')
+        export_rc, export_stdout, export_stderr = login_node_runner.run(
+            export_cmd, require_outputs=True, stream_logs=False)
+        subprocess_utils.handle_returncode(
+            export_rc,
+            export_cmd,
+            f'Failed to snapshot Slurm container rank {rank} on node {node}.',
+            stderr=f'{export_stdout}\n{export_stderr}',
+            stream_logs=False)
+        return {
+            'rank': rank,
+            'node': node,
+            'path': snapshot_path,
+        }
+
+    snapshots = subprocess_utils.run_in_parallel(_export_node,
+                                                 list(enumerate(nodes)))
+    manifest = {
+        'version': SNAPSHOT_MANIFEST_VERSION,
+        'image_id': image_id,
+        'num_nodes': len(nodes),
+        'created_at': time.time(),
+        'job_db_path': manifest_job_db_path,
+        'snapshots': snapshots,
+    }
+    _write_snapshot_manifest(login_node_runner, snapshot_dir, manifest)
+    cleanup = lambda: _cleanup_slurm_allocation(
+        client, login_node_runner, cluster_name_on_cloud, provider_config,
+        job_id, nodes)
+    _cancel_slurm_job(client,
+                      cluster_name_on_cloud,
+                      inside_slurm_cluster=False,
+                      pre_batch_cancel=cleanup)
 
 
 def _wait_for_job_states(client: 'slurm.SlurmClient', job_name: str,
@@ -1061,6 +1620,180 @@ def _wait_for_job_states(client: 'slurm.SlurmClient', job_name: str,
         if time.time() >= deadline:
             return False
         time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def _cleanup_slurm_allocation(
+    client: 'slurm.SlurmClient',
+    login_node_runner: 'command_runner.SlurmLoginNodeCommandRunner',
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    job_id: str,
+    nodes: List[str],
+) -> None:
+    """Remove per-node state while the Slurm allocation is still active."""
+    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
+    tmpdir = skypilot_config.get_effective_region_config(cloud='slurm',
+                                                         region=slurm_cluster,
+                                                         keys=('tmpdir',),
+                                                         default_value=None)
+    if tmpdir is not None:
+        tmpdir = slurm_utils.expand_path_vars(tmpdir, client.get_env())
+    skypilot_runtime_dir = _skypilot_runtime_dir(tmpdir, cluster_name_on_cloud)
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
+    sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
+                                                 cluster_name_on_cloud)
+    pyxis_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
+    global_enroot_name = f'pyxis_{pyxis_name}'
+    job_enroot_name = f'pyxis_{job_id}_{pyxis_name}'
+    skylet_pid_file = f'{skypilot_runtime_dir}/.sky/skylet_pid'
+    cleanup_node_script = f"""\
+set -e
+if [ -f {shlex.quote(skylet_pid_file)} ]; then
+    skylet_pid="$(cat {shlex.quote(skylet_pid_file)})"
+    if kill -0 "$skylet_pid" 2>/dev/null; then
+        kill "$skylet_pid"
+    fi
+fi
+if command -v enroot > /dev/null; then
+    container_exists() {{
+        while IFS= read -r existing; do
+            if [ "$existing" = "$1" ]; then
+                return 0
+            fi
+        done < <(enroot list)
+        return 1
+    }}
+    for enroot_name in {shlex.quote(global_enroot_name)} {shlex.quote(job_enroot_name)}; do
+        removed=false
+        for ((attempt = 1; attempt <= 30; attempt++)); do
+            if ! container_exists "$enroot_name"; then
+                removed=true
+                break
+            fi
+            if enroot remove -f "$enroot_name" && ! container_exists "$enroot_name"; then
+                removed=true
+                break
+            fi
+            sleep 1
+        done
+        if [ "$removed" != true ]; then
+            echo "Failed to remove Enroot container $enroot_name" >&2
+            exit 1
+        fi
+    done
+fi
+rm -rf -- {shlex.quote(skypilot_runtime_dir)}
+"""
+    cleanup_node_cmd = (
+        f'srun --unbuffered --overlap --jobid={shlex.quote(job_id)} '
+        f'--nodes={len(nodes)} --ntasks-per-node=1 '
+        f'bash -c {shlex.quote(cleanup_node_script)}')
+    rc, stdout, stderr = login_node_runner.run(cleanup_node_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        cleanup_node_cmd,
+        'Failed to clean up the Slurm allocation before cancellation.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+    remove_shared_state_cmd = f'rm -rf -- {shlex.quote(sky_cluster_home_dir)}'
+    rc, stdout, stderr = login_node_runner.run(remove_shared_state_cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        remove_shared_state_cmd,
+        'Failed to clean up shared Slurm cluster state before cancellation.',
+        stderr=f'{stdout}\n{stderr}',
+        stream_logs=False)
+
+
+def _cancel_slurm_job(
+    client: 'slurm.SlurmClient',
+    cluster_name_on_cloud: str,
+    inside_slurm_cluster: bool,
+    pre_batch_cancel: Optional[Callable[[], None]] = None,
+) -> None:
+    """Cancel a Slurm virtual-instance allocation and verify it exits."""
+    jobs_state = client.get_jobs_state_by_name(cluster_name_on_cloud)
+    if not jobs_state:
+        logger.debug(f'Job for cluster {cluster_name_on_cloud} not found, '
+                     'it may have been terminated.')
+        return
+    assert len(jobs_state) == 1, (
+        f'Multiple jobs found for cluster {cluster_name_on_cloud}: {jobs_state}'
+    )
+
+    job_state = jobs_state[0].strip()
+    if job_state in _TERMINAL_JOB_STATES:
+        logger.debug(
+            f'Job for cluster {cluster_name_on_cloud} is already in a terminal '
+            f'state {job_state}. No action needed.')
+        return
+
+    if job_state in ('PENDING', 'CONFIGURING'):
+        # For pending/configuring jobs, cancel without signal to avoid hangs.
+        client.cancel_jobs_by_name(cluster_name_on_cloud, signal=None)
+    elif job_state == 'COMPLETING':
+        # Job is already being terminated. No action needed.
+        logger.debug(
+            f'Job for cluster {cluster_name_on_cloud} is already completing. '
+            'No action needed.')
+    elif job_state not in _ESCALATION_JOB_STATES or inside_slurm_cluster:
+        # Transient states (e.g. STAGING_OUT, SIGNALING): the job is not
+        # holding a steady allocation; a graceful signal is sufficient.
+        # Autodown (running inside the cluster): the Skylet performing this
+        # teardown lives inside a job step's cgroup, so the step-level TERM
+        # below would kill the terminating process itself; and autodown only
+        # fires on idle clusters, which have no task steps that could block
+        # the batch script's cleanup.
+        client.cancel_jobs_by_name(cluster_name_on_cloud,
+                                   signal='TERM',
+                                   full=True)
+    else:
+        # For RUNNING/SUSPENDED jobs, TERM all job steps first. This stops
+        # processes that hold the container rootfs busy while preserving the
+        # allocation for the node cleanup. Signal the batch script only after
+        # that cleanup finishes.
+        # Both scancel invocations are needed: without --full, scancel signals
+        # all job steps but not the batch script; with --full, it signals the
+        # batch script and its child processes.
+        client.cancel_jobs_by_name(cluster_name_on_cloud, signal='TERM')
+        if pre_batch_cancel is not None:
+            pre_batch_cancel()
+        client.cancel_jobs_by_name(cluster_name_on_cloud,
+                                   signal='TERM',
+                                   full=True)
+        # Graceful termination is not guaranteed to bring the job down: if
+        # any step survives the TERM, it keeps the allocation busy, which
+        # blocks the batch script's cleanup srun from starting a step and
+        # leaves the job RUNNING indefinitely. Verify the job exits within
+        # a grace period, and escalate to a plain scancel (Slurm's own
+        # TERM -> KillWait -> KILL sequence) if it does not.
+        if _wait_for_job_states(client, cluster_name_on_cloud,
+                                _EXITING_JOB_STATES,
+                                _TERMINATION_GRACE_PERIOD_SECONDS):
+            return
+        logger.warning(
+            f'Job for cluster {cluster_name_on_cloud} did not exit within '
+            f'{_TERMINATION_GRACE_PERIOD_SECONDS}s of the termination '
+            'signal. Escalating to a full cancellation.')
+        client.cancel_jobs_by_name(cluster_name_on_cloud)
+        # The plain scancel moves the job to COMPLETING while Slurm runs
+        # its TERM -> KillWait -> KILL sequence, so here require the job to
+        # actually leave the queue: a job wedged in COMPLETING (typically
+        # non-killable processes) still holds the allocation and must be
+        # reported, not treated as success.
+        if not _wait_for_job_states(client, cluster_name_on_cloud,
+                                    _TERMINAL_JOB_STATES,
+                                    _JOB_TERMINATION_TIMEOUT_SECONDS):
+            raise RuntimeError(
+                f'Slurm job for cluster {cluster_name_on_cloud} is still '
+                f'running {_JOB_TERMINATION_TIMEOUT_SECONDS}s after scancel. '
+                'The allocation may be leaked; check squeue and cancel the '
+                'job manually if needed.')
 
 
 def terminate_instances(
@@ -1105,85 +1838,41 @@ def terminate_instances(
             identities_only=identities_only,
             slurm_user=provider_config.get('slurm_user'),
         )
-    jobs_state = client.get_jobs_state_by_name(cluster_name_on_cloud)
-    if not jobs_state:
-        logger.debug(f'Job for cluster {cluster_name_on_cloud} not found, '
-                     'it may have been terminated.')
-        return
-    assert len(jobs_state) == 1, (
-        f'Multiple jobs found for cluster {cluster_name_on_cloud}: {jobs_state}'
-    )
-
-    job_state = jobs_state[0].strip()
-    if job_state in _TERMINAL_JOB_STATES:
-        logger.debug(
-            f'Job for cluster {cluster_name_on_cloud} is already in a terminal '
-            f'state {job_state}. No action needed.')
-        return
-
-    if job_state in ('PENDING', 'CONFIGURING'):
-        # For pending/configuring jobs, cancel without signal to avoid hangs.
-        client.cancel_jobs_by_name(cluster_name_on_cloud, signal=None)
-    elif job_state == 'COMPLETING':
-        # Job is already being terminated. No action needed.
-        logger.debug(
-            f'Job for cluster {cluster_name_on_cloud} is already completing. '
-            'No action needed.')
-    elif job_state not in _ESCALATION_JOB_STATES or inside_slurm_cluster:
-        # Transient states (e.g. STAGING_OUT, SIGNALING): the job is not
-        # holding a steady allocation; a graceful signal is sufficient.
-        # Autodown (running inside the cluster): the Skylet performing this
-        # teardown lives inside a job step's cgroup, so the step-level TERM
-        # below would kill the terminating process itself; and autodown only
-        # fires on idle clusters, which have no task steps that could block
-        # the batch script's cleanup.
-        client.cancel_jobs_by_name(cluster_name_on_cloud,
-                                   signal='TERM',
-                                   full=True)
+    pre_batch_cancel = None
+    if not inside_slurm_cluster:
+        running_jobs = client.query_jobs(cluster_name_on_cloud,
+                                         ['running', 'suspended'])
+        if len(running_jobs) > 1:
+            raise RuntimeError(f'Multiple running jobs found for cluster '
+                               f'{cluster_name_on_cloud}: {running_jobs}')
+        if len(running_jobs) == 1:
+            job_id = running_jobs[0]
+            nodes, _ = client.get_job_nodes(job_id)
+            login_node_runner = _make_login_node_runner(provider_config)
+            pre_batch_cancel = lambda: _cleanup_slurm_allocation(
+                client, login_node_runner, cluster_name_on_cloud,
+                provider_config, job_id, nodes)
+    _cancel_slurm_job(client,
+                      cluster_name_on_cloud,
+                      inside_slurm_cluster,
+                      pre_batch_cancel=pre_batch_cancel)
+    sky_base_dir = _resolve_sky_base_dir(client, provider_config)
+    snapshot_dir = _snapshot_dir(sky_base_dir, cluster_name_on_cloud)
+    if inside_slurm_cluster:
+        if os.path.exists(snapshot_dir):
+            shutil.rmtree(snapshot_dir)
     else:
-        # For RUNNING/SUSPENDED jobs, attempt a graceful termination first:
-        # TERM all job steps (the running task processes) and the batch
-        # script, whose TERM trap cleans up the cluster's runtime
-        # directories before exiting.
-        # Both scancel invocations are needed: without --full, scancel
-        # signals all job steps but not the batch script; with --full, it
-        # signals the batch script and its child processes, which does not
-        # reach steps launched from outside the batch script's process tree
-        # (e.g. task steps launched by the Skylet).
-        client.cancel_jobs_by_name(cluster_name_on_cloud, signal='TERM')
-        client.cancel_jobs_by_name(cluster_name_on_cloud,
-                                   signal='TERM',
-                                   full=True)
-        # Graceful termination is not guaranteed to bring the job down: if
-        # any step survives the TERM, it keeps the allocation busy, which
-        # blocks the batch script's cleanup srun from starting a step and
-        # leaves the job RUNNING indefinitely. Verify the job exits within
-        # a grace period, and escalate to a plain scancel (Slurm's own
-        # TERM -> KillWait -> KILL sequence) if it does not.
-        if _wait_for_job_states(client, cluster_name_on_cloud,
-                                _EXITING_JOB_STATES,
-                                _TERMINATION_GRACE_PERIOD_SECONDS):
-            return
-        logger.warning(
-            f'Job for cluster {cluster_name_on_cloud} did not exit within '
-            f'{_TERMINATION_GRACE_PERIOD_SECONDS}s of the termination '
-            'signal. Escalating to a full cancellation; the cleanup in the '
-            'batch script may be cut short, which can leave SkyPilot runtime '
-            'directories behind on the nodes.')
-        client.cancel_jobs_by_name(cluster_name_on_cloud)
-        # The plain scancel moves the job to COMPLETING while Slurm runs
-        # its TERM -> KillWait -> KILL sequence, so here require the job to
-        # actually leave the queue: a job wedged in COMPLETING (typically
-        # non-killable processes) still holds the allocation and must be
-        # reported, not treated as success.
-        if not _wait_for_job_states(client, cluster_name_on_cloud,
-                                    _TERMINAL_JOB_STATES,
-                                    _JOB_TERMINATION_TIMEOUT_SECONDS):
-            raise RuntimeError(
-                f'Slurm job for cluster {cluster_name_on_cloud} is still '
-                f'running {_JOB_TERMINATION_TIMEOUT_SECONDS}s after scancel. '
-                'The allocation may be leaked; check squeue and cancel the '
-                'job manually if needed.')
+        login_node_runner = _make_login_node_runner(provider_config)
+        remove_snapshot_cmd = f'rm -rf -- {shlex.quote(snapshot_dir)}'
+        rc, stdout, stderr = login_node_runner.run(remove_snapshot_cmd,
+                                                   require_outputs=True,
+                                                   stream_logs=False)
+        subprocess_utils.handle_returncode(
+            rc,
+            remove_snapshot_cmd,
+            'Failed to remove Slurm container snapshot.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
 
 
 def open_ports(

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -82,6 +82,26 @@ def expand_path_vars(path: str, env: Dict[str, str]) -> str:
     return _VAR_PATTERN.sub(_repl, path)
 
 
+def resolve_sky_base_dir(cluster: str, client: 'slurm.SlurmClient') -> str:
+    """Resolve the absolute shared directory used for Slurm cluster state."""
+    workdir = skypilot_config.get_effective_region_config(cloud='slurm',
+                                                          region=cluster,
+                                                          keys=('workdir',),
+                                                          default_value=None)
+    if workdir is not None:
+        workdir = expand_path_vars(workdir, client.get_env())
+        if not os.path.isabs(workdir):
+            raise RuntimeError('Resolved Slurm workdir must be absolute, got '
+                               f'{workdir!r}.')
+        return workdir
+
+    remote_home_dir = client.get_remote_home_dir()
+    if not os.path.isabs(remote_home_dir):
+        raise RuntimeError('Slurm remote home directory must be absolute, got '
+                           f'{remote_home_dir!r}.')
+    return remote_home_dir
+
+
 def get_gpu_type_and_count(gres_str: str) -> Tuple[Optional[str], int]:
     """Parses GPU type and count from a GRES string.
 

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -15,6 +15,7 @@ provider:
   cluster: "{{slurm_cluster}}"
   partition: "{{slurm_partition}}"
   provision_timeout: {{provision_timeout}}
+  sky_base_dir: {{sky_base_dir | tojson}}
 {% if slurm_user is defined and slurm_user is not none %}
   slurm_user: {{slurm_user | tojson}}
 {% endif %}

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -699,6 +699,86 @@ def test_docker_preinstalled_package_slurm_sqsh(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.slurm
+def test_slurm_container_stop_start(generic_cloud: str):
+    """A Slurm container keeps its root filesystem across two stop cycles."""
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'slurm_container_stop_start',
+        [
+            f'sky launch -y -c {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            '--image-id docker:ubuntu:24.04 -- '
+            "'echo generation-1 > /snapshot_marker; "
+            "apt-get update; apt-get install -y tree'",
+            f'sky logs {name} 1 --status',
+            f'sky stop -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=smoke_tests_utils.get_timeout('slurm')),
+            f'sky start -y {name}',
+            f'sky exec {name} -- '
+            "'test \"$(cat /snapshot_marker)\" = generation-1; "
+            "dpkg -s tree'",
+            f'sky logs {name} 2 --status',
+            f'ssh {name} \'test "$(cat /snapshot_marker)" = generation-1\'',
+            f'queue="$(sky queue {name})"; printf "%s\\n" "$queue"; '
+            '[[ "$queue" == *"1"*"SUCCEEDED"* ]]',
+            f'sky exec {name} -- '
+            "'echo generation-2 >> /snapshot_marker'",
+            f'sky logs {name} 3 --status',
+            f'sky stop -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=smoke_tests_utils.get_timeout('slurm')),
+            f'sky start -y {name}',
+            f'sky exec {name} -- '
+            "'mapfile -t generations < /snapshot_marker; "
+            "test \"${generations[0]}\" = generation-1; "
+            "test \"${generations[1]}\" = generation-2; "
+            "test \"${#generations[@]}\" -eq 2; dpkg -s tree'",
+            f'sky logs {name} 4 --status',
+            f'sky down -y {name}',
+        ],
+        f'sky down -y {name} || true',
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.slurm
+def test_slurm_container_stop_start_multi_node(generic_cloud: str):
+    """Each Slurm node restores the snapshot from its previous rank."""
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'slurm_container_stop_start_multi_node',
+        [
+            f'sky launch -y -c {name} --infra {generic_cloud} '
+            f'--num-nodes 2 {smoke_tests_utils.LOW_RESOURCE_ARG} '
+            '--image-id docker:ubuntu:24.04 -- '
+            "'echo rank-$SKYPILOT_NODE_RANK > /snapshot_rank_marker'",
+            f'sky logs {name} 1 --status',
+            f'sky stop -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=smoke_tests_utils.get_timeout('slurm')),
+            f'sky start -y {name}',
+            f'sky exec {name} --num-nodes 2 -- '
+            "'test \"$(cat /snapshot_rank_marker)\" = "
+            "\"rank-$SKYPILOT_NODE_RANK\"'",
+            f'sky logs {name} 2 --status',
+            f'ssh {name} '
+            '\'test "$(cat /snapshot_rank_marker)" = rank-0\'',
+        ],
+        f'sky down -y {name} || true',
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Submitting multiple tasks to the same cluster. ----------
 @pytest.mark.no_vast  # Vast has low availability of T4 GPUs
 @pytest.mark.no_shadeform  # Shadeform does not have T4 GPUs

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -701,7 +701,7 @@ def test_docker_preinstalled_package_slurm_sqsh(generic_cloud: str):
 
 @pytest.mark.slurm
 def test_slurm_container_stop_start(generic_cloud: str):
-    """A Slurm container keeps its root filesystem across two stop cycles."""
+    """A Slurm container keeps its state, job queue, and logs after restart."""
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(
         'slurm_container_stop_start',
@@ -709,37 +709,46 @@ def test_slurm_container_stop_start(generic_cloud: str):
             f'sky launch -y -c {name} --infra {generic_cloud} '
             f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
             '--image-id docker:ubuntu:24.04 -- '
-            "'echo generation-1 > /snapshot_marker; "
+            "'echo pre-stop-job-1; echo generation-1 > /snapshot_marker; "
             "apt-get update; apt-get install -y tree'",
             f'sky logs {name} 1 --status',
-            f'sky stop -y {name}',
+            f'sky exec {name} -- echo pre-stop-job-2',
+            f'sky logs {name} 2 --status',
+            # Shared-FS cleanup can transiently return stale handles; Slurm
+            # stop is idempotent, so retry once.
+            f'sky stop -y {name} || sky stop -y {name}',
             smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
                 cluster_name=name,
                 cluster_status=[sky.ClusterStatus.STOPPED],
                 timeout=smoke_tests_utils.get_timeout('slurm')),
             f'sky start -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.UP],
+                timeout=smoke_tests_utils.get_timeout('slurm')),
+            smoke_tests_utils.
+            get_cmd_wait_until_job_status_contains_matching_job_id(
+                cluster_name=name,
+                job_id='1',
+                job_status=[sky.JobStatus.SUCCEEDED],
+                timeout=60),
+            smoke_tests_utils.
+            get_cmd_wait_until_job_status_contains_matching_job_id(
+                cluster_name=name,
+                job_id='2',
+                job_status=[sky.JobStatus.SUCCEEDED],
+                timeout=60),
+            f'logs="$(sky logs {name} 1 --no-follow)"; '
+            'printf "%s\\n" "$logs"; '
+            '[[ "$logs" == *pre-stop-job-1* ]]',
+            f'logs="$(sky logs {name} 2 --no-follow)"; '
+            'printf "%s\\n" "$logs"; '
+            '[[ "$logs" == *pre-stop-job-2* ]]',
             f'sky exec {name} -- '
             "'test \"$(cat /snapshot_marker)\" = generation-1; "
             "dpkg -s tree'",
-            f'sky logs {name} 2 --status',
-            f'ssh {name} \'test "$(cat /snapshot_marker)" = generation-1\'',
-            f'queue="$(sky queue {name})"; printf "%s\\n" "$queue"; '
-            '[[ "$queue" == *"1"*"SUCCEEDED"* ]]',
-            f'sky exec {name} -- '
-            "'echo generation-2 >> /snapshot_marker'",
             f'sky logs {name} 3 --status',
-            f'sky stop -y {name}',
-            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
-                cluster_name=name,
-                cluster_status=[sky.ClusterStatus.STOPPED],
-                timeout=smoke_tests_utils.get_timeout('slurm')),
-            f'sky start -y {name}',
-            f'sky exec {name} -- '
-            "'mapfile -t generations < /snapshot_marker; "
-            "test \"${generations[0]}\" = generation-1; "
-            "test \"${generations[1]}\" = generation-2; "
-            "test \"${#generations[@]}\" -eq 2; dpkg -s tree'",
-            f'sky logs {name} 4 --status',
+            f'ssh {name} \'test "$(cat /snapshot_marker)" = generation-1\'',
             f'sky down -y {name}',
         ],
         f'sky down -y {name} || true',
@@ -758,20 +767,39 @@ def test_slurm_container_stop_start_multi_node(generic_cloud: str):
             f'sky launch -y -c {name} --infra {generic_cloud} '
             f'--num-nodes 2 {smoke_tests_utils.LOW_RESOURCE_ARG} '
             '--image-id docker:ubuntu:24.04 -- '
-            "'echo rank-$SKYPILOT_NODE_RANK > /snapshot_rank_marker'",
+            "'echo pre-stop-rank-$SKYPILOT_NODE_RANK; "
+            "echo rank-$SKYPILOT_NODE_RANK > /snapshot_rank_marker'",
             f'sky logs {name} 1 --status',
-            f'sky stop -y {name}',
+            # Shared-FS cleanup can transiently return stale handles; Slurm
+            # stop is idempotent, so retry once.
+            f'sky stop -y {name} || sky stop -y {name}',
             smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
                 cluster_name=name,
                 cluster_status=[sky.ClusterStatus.STOPPED],
                 timeout=smoke_tests_utils.get_timeout('slurm')),
             f'sky start -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.UP],
+                timeout=smoke_tests_utils.get_timeout('slurm')),
+            smoke_tests_utils.
+            get_cmd_wait_until_job_status_contains_matching_job_id(
+                cluster_name=name,
+                job_id='1',
+                job_status=[sky.JobStatus.SUCCEEDED],
+                timeout=60),
+            f'logs="$(sky logs {name} 1 --no-follow)"; '
+            'printf "%s\\n" "$logs"; '
+            '[[ "$logs" == *pre-stop-rank-0* ]]; '
+            '[[ "$logs" == *pre-stop-rank-1* ]]',
             f'sky exec {name} --num-nodes 2 -- '
             "'test \"$(cat /snapshot_rank_marker)\" = "
-            "\"rank-$SKYPILOT_NODE_RANK\"'",
+            "\"rank-$SKYPILOT_NODE_RANK\"; "
+            "echo restored-rank-$SKYPILOT_NODE_RANK'",
             f'sky logs {name} 2 --status',
             f'ssh {name} '
             '\'test "$(cat /snapshot_rank_marker)" = rank-0\'',
+            f'sky down -y {name}',
         ],
         f'sky down -y {name} || true',
         timeout=30 * 60,

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -189,6 +189,95 @@ class TestRunCommand:
         assert mock_run.call_args.kwargs['timeout'] == 9
 
 
+class TestJobSteps:
+    """Tests for querying and signalling Slurm job steps."""
+
+    @staticmethod
+    def _client():
+        return slurm.SlurmClient(ssh_host='localhost',
+                                 ssh_port=22,
+                                 ssh_user='root',
+                                 ssh_key=None)
+
+    def test_list_job_steps(self):
+        client = self._client()
+        with mock.patch.object(client, '_run_slurm_cmd') as mock_run:
+            mock_run.return_value = (
+                0, 'StepId=123.batch State=RUNNING Name=batch TRES=(null)\n'
+                'StepId=123.0 State=RUNNING Name=sky-container-keeper '
+                'TRES=cpu=1\n'
+                'StepId=123.1 State=RUNNING Name=bash TRES=cpu=1\n', '')
+
+            assert client.list_job_steps('123') == [
+                slurm.JobStepInfo('123.batch', 'batch'),
+                slurm.JobStepInfo('123.0', 'sky-container-keeper'),
+                slurm.JobStepInfo('123.1', 'bash'),
+            ]
+
+        mock_run.assert_called_once_with('scontrol -o show step 123')
+
+    def test_rejects_malformed_job_step_output(self):
+        client = self._client()
+        with mock.patch.object(client,
+                               '_run_slurm_cmd',
+                               return_value=(0, 'StepId=123.0 State=RUNNING\n',
+                                             '')):
+            with pytest.raises(RuntimeError, match='Unexpected.*step'):
+                client.list_job_steps('123')
+
+    def test_rejects_empty_job_step_output(self):
+        client = self._client()
+        with mock.patch.object(client,
+                               '_run_slurm_cmd',
+                               return_value=(0, '', '')):
+            with pytest.raises(RuntimeError, match='Unexpected empty'):
+                client.list_job_steps('123')
+
+    @pytest.mark.parametrize(
+        'error', ['Invalid job id specified', 'Job step 123. not found'])
+    def test_list_job_steps_reports_disappeared_allocation(self, error):
+        client = self._client()
+        with mock.patch.object(client,
+                               '_run_slurm_cmd',
+                               return_value=(1, '', error)):
+            with pytest.raises(exceptions.CommandError,
+                               match='allocation 123 disappeared during stop'):
+                client.list_job_steps('123')
+
+    def test_signal_job_step(self):
+        client = self._client()
+        with mock.patch.object(client,
+                               '_run_slurm_cmd',
+                               return_value=(0, '', '')) as mock_run:
+            client.signal_job_step('123', '123.4', 'TERM')
+
+        mock_run.assert_called_once_with('scancel --signal TERM 123.4')
+
+    def test_signal_tolerates_step_exiting_concurrently(self):
+        client = self._client()
+        with mock.patch.object(client, '_run_slurm_cmd') as mock_run:
+            mock_run.side_effect = [
+                (1, '', 'Invalid job id'),
+                (0, 'StepId=123.batch State=RUNNING Name=batch\n', ''),
+            ]
+            client.signal_job_step('123', '123.4', 'TERM')
+
+        assert mock_run.call_args_list == [
+            mock.call('scancel --signal TERM 123.4'),
+            mock.call('scontrol -o show step 123'),
+        ]
+
+    def test_signal_failure_for_active_step_is_reported(self):
+        client = self._client()
+        with mock.patch.object(client, '_run_slurm_cmd') as mock_run:
+            mock_run.side_effect = [(1, '', 'Permission denied'),
+                                    (0, 'StepId=123.4 State=RUNNING '
+                                     'Name=bash\n', '')]
+            with pytest.raises(exceptions.CommandError,
+                               match='Failed to signal'):
+                client.signal_job_step('123', '123.4', 'TERM')
+
+
 class TestGetPartitions:
     """Test SlurmClient.get_partitions()."""
 

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1869,7 +1869,8 @@ class TestCreateVirtualInstance:
         keeper_idx = script.index(
             '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
             '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
-        anchor_idx = script.rindex('\nwait "$CONTAINER_PID"\n')
+        anchor_idx = script.rindex(
+            '\nwait -n "${CONTAINER_PIDS[@]}"\n')
         assert keeper_idx < anchor_idx
         keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]
         # The keeper never attaches the container: Slurm CLIs are host-only.

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -218,7 +218,10 @@ class TestSubmitUserDeployVariables:
              patch('sky.clouds.slurm.skypilot_config.get_nested',
                    side_effect=_get_nested), \
              patch('sky.clouds.slurm.skypilot_config.'
-                   'get_effective_region_config', return_value=None):
+                   'get_effective_region_config', return_value=None), \
+             patch('sky.clouds.slurm.slurm.SlurmClient'), \
+             patch('sky.clouds.slurm.slurm_utils.resolve_sky_base_dir',
+                   return_value='/home/testuser'):
             return cloud.make_deploy_resources_variables(
                 resources=resources,
                 cluster_name=mock.MagicMock(),
@@ -231,6 +234,11 @@ class TestSubmitUserDeployVariables:
         deploy_vars = self._make_deploy_variables('alice')
 
         assert deploy_vars['slurm_user'] == 'alice'
+
+    def test_sky_base_dir_persisted(self):
+        deploy_vars = self._make_deploy_variables('alice')
+
+        assert deploy_vars['sky_base_dir'] == '/home/testuser'
 
     def test_disabled_keeps_default(self):
         deploy_vars = self._make_deploy_variables(None, ssh_user='ubuntu')
@@ -368,6 +376,7 @@ class TestSubmitUserTemplate:
                 'slurm_cluster': 'my-cluster',
                 'slurm_partition': 'gpu',
                 'provision_timeout': 120,
+                'sky_base_dir': '/fsx/alice',
                 'ssh_hostname': 'login.example.com',
                 'ssh_port': 22,
                 'slurm_private_key': '/root/.ssh/key',
@@ -415,6 +424,7 @@ class TestSubmitUserTemplate:
         else:
             assert config['provider']['slurm_user'] == slurm_user
         assert config['provider']['ssh']['user'] == transport_user
+        assert config['provider']['sky_base_dir'] == '/fsx/alice'
         assert config['auth']['ssh_user'] == expected_ssh_user
         assert config['available_node_types']['ray_head_default'][
             'node_config']['volume_mounts'][0]['path'] == '/data'
@@ -1035,7 +1045,11 @@ class TestSbatchOptionsPrecedence:
                     return_value=['gpu', 'cpu']), \
                  patch(
                     'sky.clouds.slurm.slurm_utils.resolve_gres_gpu_type',
-                    side_effect=lambda cluster, t, count=1, partition=None: t):
+                    side_effect=lambda cluster, t, count=1, partition=None: t), \
+                 patch('sky.clouds.slurm.slurm.SlurmClient'), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.resolve_sky_base_dir',
+                    return_value='/home/slurm'):
                 deploy_vars = cloud.make_deploy_resources_variables(
                     resources=mock_resources,
                     cluster_name=mock.MagicMock(),
@@ -1250,7 +1264,10 @@ class TestSlurmProvisionTimeout:
              patch('sky.clouds.slurm.slurm_utils.get_submit_user',
                    return_value=None), \
              patch('sky.clouds.slurm.slurm_utils.resolve_gres_gpu_type',
-                   side_effect=lambda cluster, t, count=1, partition=None: t):
+                   side_effect=lambda cluster, t, count=1, partition=None: t), \
+             patch('sky.clouds.slurm.slurm.SlurmClient'), \
+             patch('sky.clouds.slurm.slurm_utils.resolve_sky_base_dir',
+                   return_value='/home/slurm'):
             deploy_vars = cloud.make_deploy_resources_variables(
                 resources=mock_resources,
                 cluster_name=mock.MagicMock(),
@@ -1329,6 +1346,7 @@ class TestProvisionTimeoutPassthrough:
                 'cluster': 'test-slurm',
                 'partition': 'gpu',
                 'provision_timeout': 120,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1402,6 +1420,7 @@ class TestProvisionTimeoutPassthrough:
                 'cluster': 'test-slurm',
                 'partition': 'gpu',
                 'provision_timeout': 120,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1499,6 +1518,7 @@ class TestCreateVirtualInstance:
                 'partition': 'cpus',
                 'provision_timeout': 300,
                 'slurm_user': 'alice',
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1540,6 +1560,7 @@ class TestCreateVirtualInstance:
                 'cluster': 'test-slurm',
                 'partition': 'gpu',
                 'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1647,6 +1668,7 @@ class TestCreateVirtualInstance:
                 'cluster': 'test-slurm',
                 'partition': 'gpu',
                 'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1828,6 +1850,7 @@ class TestCreateVirtualInstance:
                 'cluster': 'test-slurm',
                 'partition': 'gpu',
                 'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -1896,6 +1919,7 @@ class TestCreateVirtualInstance:
                 'cluster': 'test-slurm',
                 'partition': 'cpus',
                 'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
             },
             authentication_config={},
             docker_config={},
@@ -2079,3 +2103,36 @@ class TestExpandPathVars:
         result = slurm_utils.expand_path_vars('/home/; rm -rf /',
                                               self.REMOTE_ENV)
         assert result == '/home/; rm -rf /'
+
+
+class TestResolveSkyBaseDir:
+    """Tests initial Slurm cluster state directory resolution."""
+
+    @patch('sky.provision.slurm.utils.skypilot_config.'
+           'get_effective_region_config',
+           return_value='/fsx/$USER')
+    def test_resolves_configured_workdir(self, mock_get_config):
+        client = mock.MagicMock(spec=slurm.SlurmClient)
+        client.get_env.return_value = {'USER': 'alice'}
+
+        result = slurm_utils.resolve_sky_base_dir('my-cluster', client)
+
+        assert result == '/fsx/alice'
+        mock_get_config.assert_called_once_with(cloud='slurm',
+                                                region='my-cluster',
+                                                keys=('workdir',),
+                                                default_value=None)
+        client.get_remote_home_dir.assert_not_called()
+
+    @patch('sky.provision.slurm.utils.skypilot_config.'
+           'get_effective_region_config',
+           return_value=None)
+    def test_uses_remote_home_without_workdir(self, mock_get_config):
+        client = mock.MagicMock(spec=slurm.SlurmClient)
+        client.get_remote_home_dir.return_value = '/home/alice'
+
+        result = slurm_utils.resolve_sky_base_dir('my-cluster', client)
+
+        assert result == '/home/alice'
+        mock_get_config.assert_called_once()
+        client.get_env.assert_not_called()

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1869,8 +1869,7 @@ class TestCreateVirtualInstance:
         keeper_idx = script.index(
             '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
             '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
-        anchor_idx = script.rindex(
-            '\nwait -n "${CONTAINER_PIDS[@]}"\n')
+        anchor_idx = script.rindex('\nwait -n "${CONTAINER_PIDS[@]}"\n')
         assert keeper_idx < anchor_idx
         keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]
         # The keeper never attaches the container: Slurm CLIs are host-only.

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1669,6 +1669,8 @@ class TestCreateVirtualInstance:
         assert '-w "${SKY_NODES[1]}"' in script
         assert f'--container-image={snapshot_dir}/rank0.sqsh' in script
         assert f'--container-image={snapshot_dir}/rank1.sqsh' in script
+        assert 'apt-get update' not in script
+        assert 'echo \'alias sudo=""\' >> ~/.bashrc' not in script
         stale_cleanup = 'enroot remove -f "$candidate"'
         assert stale_cleanup in script
         assert script.index(stale_cleanup) < script.index(

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1690,6 +1690,7 @@ class TestCreateVirtualInstance:
         assert '-w "${SKY_NODES[1]}"' in script
         assert f'--container-image={generation_dir}/rank0.sqsh' in script
         assert f'--container-image={generation_dir}/rank1.sqsh' in script
+        assert script.count('--job-name=sky-container-keeper') == 2
         assert 'apt-get update' not in script
         assert 'echo \'alias sudo=""\' >> ~/.bashrc' not in script
         stale_cleanup = 'enroot remove -f "$candidate"'
@@ -1798,7 +1799,8 @@ class TestCreateVirtualInstance:
 
         keeper_idx = script.index(
             '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
-            '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
+            '--nodes=1 --ntasks=1 --job-name=sky-skylet-keeper '
+            '--nodelist=$SKY_HEAD_NODE')
         anchor_idx = script.rindex('sleep infinity\n')
         # The keeper is backgrounded before the allocation-lifetime anchor.
         assert keeper_idx < anchor_idx
@@ -1867,7 +1869,8 @@ class TestCreateVirtualInstance:
 
         keeper_idx = script.index(
             '( while true; do srun --overlap --jobid=$SLURM_JOB_ID '
-            '--nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE')
+            '--nodes=1 --ntasks=1 --job-name=sky-skylet-keeper '
+            '--nodelist=$SKY_HEAD_NODE')
         anchor_idx = script.rindex('\nwait -n "${CONTAINER_PIDS[@]}"\n')
         assert keeper_idx < anchor_idx
         keeper_line = script[keeper_idx:script.index('\n', keeper_idx)]

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -8,12 +8,41 @@ import unittest.mock as mock
 
 import pytest
 
+from sky import clouds
 from sky import resources as resources_lib
 from sky.adaptors import slurm
 from sky.clouds import slurm as slurm_cloud
 from sky.provision.slurm import instance as slurm_instance
 from sky.provision.slurm import utils as slurm_utils
 from sky.skylet import constants
+
+
+class TestStopFeatureSupport:
+    """Tests dynamic stop support for Slurm resources."""
+
+    @pytest.mark.parametrize(
+        'image_id,pyxis_enabled,stop_supported',
+        [
+            ('ubuntu:24.04', True, True),
+            ('ubuntu:24.04', False, False),
+            (None, True, False),
+        ],
+    )
+    def test_requires_container_and_pyxis(self, image_id, pyxis_enabled,
+                                          stop_supported):
+        resources = mock.MagicMock()
+        resources.region = 'my-cluster'
+        resources.extract_docker_image.return_value = image_id
+
+        with patch('sky.clouds.slurm.slurm_utils.check_pyxis_enabled',
+                   return_value=pyxis_enabled), \
+             patch('sky.clouds.slurm.slurm_utils.check_fuse_enabled',
+                   return_value=False):
+            unsupported = slurm_cloud.Slurm._unsupported_features_for_resources(
+                resources)
+
+        assert ((clouds.CloudImplementationFeatures.STOP
+                 not in unsupported) == stop_supported)
 
 
 class TestGetSubmitUser:
@@ -1282,7 +1311,10 @@ class TestProvisionTimeoutPassthrough:
         mock_slurm_client.return_value = mock_client
 
         mock_runner = mock.MagicMock()
-        mock_runner.run.return_value = (0, '', '')
+        mock_runner.run.side_effect = lambda cmd, **kwargs: (
+            (44, '', '')
+            if slurm_instance.SNAPSHOT_MANIFEST_FILENAME in cmd else
+            (0, '', ''))
         mock_runner.get_remote_home_dir.return_value = '/home/testuser'
         mock_ssh_runner.return_value = mock_runner
 
@@ -1352,7 +1384,10 @@ class TestProvisionTimeoutPassthrough:
         mock_slurm_client.return_value = mock_client
 
         mock_runner = mock.MagicMock()
-        mock_runner.run.return_value = (0, '', '')
+        mock_runner.run.side_effect = lambda cmd, **kwargs: (
+            (44, '', '')
+            if slurm_instance.SNAPSHOT_MANIFEST_FILENAME in cmd else
+            (0, '', ''))
         mock_runner.get_remote_home_dir.return_value = '/home/testuser'
         mock_ssh_runner.return_value = mock_runner
 
@@ -1416,11 +1451,14 @@ class TestCreateVirtualInstance:
         mock_slurm_client.return_value = mock_client
 
         mock_runner = mock.MagicMock()
-        mock_runner.run.return_value = (0, '', '')
+        mock_runner.run.side_effect = lambda cmd, **kwargs: (
+            (44, '', '')
+            if slurm_instance.SNAPSHOT_MANIFEST_FILENAME in cmd else
+            (0, '', ''))
         mock_runner.get_remote_home_dir.return_value = '/home/testuser'
         mock_ssh_runner.return_value = mock_runner
 
-    def _run_and_capture_script(self, cluster_name, config):
+    def _run_and_capture_script(self, cluster_name, config) -> str:
         """Run _create_virtual_instance and capture the generated script."""
         written_script = None
 
@@ -1442,6 +1480,7 @@ class TestCreateVirtualInstance:
             )
 
         assert written_script is not None, 'Script was not written'
+        assert isinstance(written_script, str)
         return written_script
 
     @staticmethod
@@ -1562,6 +1601,92 @@ class TestCreateVirtualInstance:
                 '/tmp/test-cluster-mounted/.sky:/tmp/test-cluster-mounted/.sky,'
                 '/host/data:/data:ro,/nvme/$SLURM_JOB_ID:/scratch,'
                 '/host/models:/models:ro"' in mounted_script)
+
+    @patch('sky.provision.slurm.instance._validate_snapshot_files')
+    @patch('sky.provision.slurm.instance._read_snapshot_manifest')
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_multi_node_snapshot_restore_script(
+            self, mock_ssh_runner, mock_slurm_client, mock_get_partition_info,
+            mock_get_proctrack_type, mock_wait_for_job_nodes,
+            mock_read_manifest, mock_validate_files):
+        from sky.provision import common
+
+        del mock_wait_for_job_nodes
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'gpu')
+        mock_get_proctrack_type.return_value = 'cgroup'
+        cluster_name = 'test-cluster-restore'
+        snapshot_dir = (
+            f'/home/testuser/{slurm_instance.SNAPSHOT_DIRECTORY_NAME}'
+            f'/{cluster_name}')
+        mock_read_manifest.return_value = {
+            'version': slurm_instance.SNAPSHOT_MANIFEST_VERSION,
+            'image_id': 'ubuntu:24.04',
+            'num_nodes': 2,
+            'created_at': 1234.5,
+            'job_db_path': f'{snapshot_dir}/jobs.db',
+            'snapshots': [{
+                'rank': rank,
+                'node': f'old-node-{rank}',
+                'path': slurm_instance._snapshot_rank_path(snapshot_dir, rank),
+            } for rank in range(2)],
+        }
+        config = common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'testuser',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'gpu',
+                'provision_timeout': 300,
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': 4,
+                'memory': 16,
+                'image_id': 'ubuntu:24.04',
+            },
+            count=2,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        script = self._run_and_capture_script(cluster_name, config)
+
+        mock_validate_files.assert_called_once()
+        assert 'mapfile -t SKY_NODES' in script
+        assert '-w "${SKY_NODES[0]}"' in script
+        assert '-w "${SKY_NODES[1]}"' in script
+        assert f'--container-image={snapshot_dir}/rank0.sqsh' in script
+        assert f'--container-image={snapshot_dir}/rank1.sqsh' in script
+        stale_cleanup = 'enroot remove -f "$candidate"'
+        assert stale_cleanup in script
+        assert script.index(stale_cleanup) < script.index(
+            f'--container-image={snapshot_dir}/rank0.sqsh')
+        restore_job_db = f'cp -f {snapshot_dir}/jobs.db'
+        assert restore_job_db in script
+        assert script.index(restore_job_db) < script.index(
+            f'--container-image={snapshot_dir}/rank0.sqsh')
+        assert script.count('CONTAINER_PIDS+=("$!")') == 2
+        readiness_check = 'done < <(enroot list -f)'
+        assert readiness_check in script
+        assert ('job_target="pyxis_${SLURM_JOB_ID}_"'
+                'test-cluster-restore' in script)
+        assert script.index(readiness_check) > script.index(
+            f'--container-image={snapshot_dir}/rank1.sqsh')
+        assert script.index(readiness_check) < script.index(
+            'touch /home/testuser/.sky_clusters/'
+            'test-cluster-restore/.sky_sbatch_ready')
 
     @pytest.mark.parametrize('path', [
         '/host/data,other',

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1687,6 +1687,12 @@ class TestCreateVirtualInstance:
         assert script.index(readiness_check) < script.index(
             'touch /home/testuser/.sky_clusters/'
             'test-cluster-restore/.sky_sbatch_ready')
+        consume_snapshot = ('rm -rf -- /home/testuser/.sky_snapshots/'
+                            'test-cluster-restore')
+        ready_signal = ('touch /home/testuser/.sky_clusters/'
+                        'test-cluster-restore/.sky_sbatch_ready')
+        assert script.index(readiness_check) < script.index(consume_snapshot)
+        assert script.index(consume_snapshot) < script.index(ready_signal)
 
     @pytest.mark.parametrize('path', [
         '/host/data,other',

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1645,17 +1645,16 @@ class TestCreateVirtualInstance:
         snapshot_dir = (
             f'/home/testuser/{slurm_instance.SNAPSHOT_DIRECTORY_NAME}'
             f'/{cluster_name}')
+        generation = '0123456789abcdef0123456789abcdef'
+        generation_dir = slurm_instance._snapshot_generation_dir(
+            snapshot_dir, generation)
         mock_read_manifest.return_value = {
             'version': slurm_instance.SNAPSHOT_MANIFEST_VERSION,
+            'generation': generation,
             'image_id': 'ubuntu:24.04',
-            'num_nodes': 2,
             'created_at': 1234.5,
-            'job_db_path': f'{snapshot_dir}/jobs.db',
-            'snapshots': [{
-                'rank': rank,
-                'node': f'old-node-{rank}',
-                'path': slurm_instance._snapshot_rank_path(snapshot_dir, rank),
-            } for rank in range(2)],
+            'has_job_db': True,
+            'nodes': ['old-node-0', 'old-node-1'],
         }
         config = common.ProvisionConfig(
             provider_config={
@@ -1689,25 +1688,25 @@ class TestCreateVirtualInstance:
         assert 'mapfile -t SKY_NODES' in script
         assert '-w "${SKY_NODES[0]}"' in script
         assert '-w "${SKY_NODES[1]}"' in script
-        assert f'--container-image={snapshot_dir}/rank0.sqsh' in script
-        assert f'--container-image={snapshot_dir}/rank1.sqsh' in script
+        assert f'--container-image={generation_dir}/rank0.sqsh' in script
+        assert f'--container-image={generation_dir}/rank1.sqsh' in script
         assert 'apt-get update' not in script
         assert 'echo \'alias sudo=""\' >> ~/.bashrc' not in script
         stale_cleanup = 'enroot remove -f "$candidate"'
         assert stale_cleanup in script
         assert script.index(stale_cleanup) < script.index(
-            f'--container-image={snapshot_dir}/rank0.sqsh')
-        restore_job_db = f'cp -f {snapshot_dir}/jobs.db'
+            f'--container-image={generation_dir}/rank0.sqsh')
+        restore_job_db = f'cp -f {generation_dir}/jobs.db'
         assert restore_job_db in script
         assert script.index(restore_job_db) < script.index(
-            f'--container-image={snapshot_dir}/rank0.sqsh')
+            f'--container-image={generation_dir}/rank0.sqsh')
         assert script.count('CONTAINER_PIDS+=("$!")') == 2
         readiness_check = 'done < <(enroot list -f)'
         assert readiness_check in script
         assert ('job_target="pyxis_${SLURM_JOB_ID}_"'
                 'test-cluster-restore' in script)
         assert script.index(readiness_check) > script.index(
-            f'--container-image={snapshot_dir}/rank1.sqsh')
+            f'--container-image={generation_dir}/rank1.sqsh')
         assert script.index(readiness_check) < script.index(
             'touch /home/testuser/.sky_clusters/'
             'test-cluster-restore/.sky_sbatch_ready')

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -63,5 +63,5 @@ touch /home/testuser/.sky_clusters/test-cluster-no-container/.hushlogin
 touch /home/testuser/.sky_clusters/test-cluster-no-container/.sky_sbatch_ready
 # Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
-( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster-no-container/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster-no-container bash /tmp/test-cluster-no-container/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
+( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --job-name=sky-skylet-keeper --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster-no-container/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster-no-container bash /tmp/test-cluster-no-container/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
 sleep infinity

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -32,7 +32,15 @@ cleanup() {
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
     srun --overlap --nodes=1 rm -rf /tmp/test-cluster-no-container
-    rm -rf /home/testuser/.sky_clusters/test-cluster-no-container
+    # A stop publishes the snapshot manifest before cancellation. Keep the
+    # logs referenced by the jobs database that start will restore.
+    if [ -f /home/testuser/.sky_snapshots/test-cluster-no-container/manifest.json ]; then
+        find /home/testuser/.sky_clusters/test-cluster-no-container -mindepth 1 -maxdepth 1 \
+            ! -name sky_logs \
+            -exec rm -rf -- {} +
+    else
+        rm -rf -- /home/testuser/.sky_clusters/test-cluster-no-container
+    fi
     exit $saved_exit
 }
 # Run cleanup on any exit, including container init failures.

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -65,7 +65,7 @@ echo "[container] Initializing test-cluster on all nodes"
 rm -rf /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
 mkdir -p /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
 CONTAINER_PIDS=()
-srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster/.sky:/tmp/test-cluster/.sky" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
+srun --overlap --job-name=sky-container-keeper --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster/.sky:/tmp/test-cluster/.sky" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
 echo "[container-init] Starting..."
 INIT_START=$SECONDS
 apt-get update
@@ -118,5 +118,5 @@ touch /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 
 # Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
-( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster bash /tmp/test-cluster/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
+( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --job-name=sky-skylet-keeper --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster bash /tmp/test-cluster/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
 wait -n "${CONTAINER_PIDS[@]}"

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -111,7 +111,7 @@ for ((attempt = 1; attempt <= 30; attempt++)); do
 done
 echo "[container] ERROR: Container is not running as $global_target or $job_target." >&2
 exit 1
-'
+' || exit 1
 echo "[container] Ready in $((SECONDS - CONTAINER_START))s"
 printf '%s\n' nvcr.io/nvidia/pytorch:24.01-py3 > /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container
 touch /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -32,7 +32,15 @@ cleanup() {
     # that this srun will run on the same subset of nodes as the srun
     # that created the sky directories.
     srun --overlap --nodes=1 rm -rf /tmp/test-cluster
-    rm -rf /home/testuser/.sky_clusters/test-cluster
+    # A stop publishes the snapshot manifest before cancellation. Keep the
+    # logs referenced by the jobs database that start will restore.
+    if [ -f /home/testuser/.sky_snapshots/test-cluster/manifest.json ]; then
+        find /home/testuser/.sky_clusters/test-cluster -mindepth 1 -maxdepth 1 \
+            ! -name sky_logs \
+            -exec rm -rf -- {} +
+    else
+        rm -rf -- /home/testuser/.sky_clusters/test-cluster
+    fi
     exit $saved_exit
 }
 # Run cleanup on any exit, including container init failures.

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -56,6 +56,7 @@ CONTAINER_START=$SECONDS
 echo "[container] Initializing test-cluster on all nodes"
 rm -rf /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
 mkdir -p /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done
+CONTAINER_PIDS=()
 srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 --container-image='nvcr.io#nvidia/pytorch:24.01-py3' --container-name=test-cluster:create --container-mounts="/home/testuser:/home/testuser,/tmp/ccache_$(id -u):/var/cache/ccache,/tmp/test-cluster/.sky:/tmp/test-cluster/.sky" --container-remap-root --no-container-mount-home --container-writable bash -c 'set -e
 echo "[container-init] Starting..."
 INIT_START=$SECONDS
@@ -64,22 +65,48 @@ apt-get install -y ca-certificates rsync curl git wget fuse
 echo '"'"'alias sudo=""'"'"' >> ~/.bashrc
 echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 touch /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done/$SLURM_PROCID && sleep infinity' &
-CONTAINER_PID=$!
+CONTAINER_PIDS+=("$!")
 while true; do
-  num_ready=$(ls -1 /home/testuser/.sky_clusters/test-cluster/.sky_container_init_done 2>/dev/null | wc -l)
-  if [ "$num_ready" -ge "1" ]; then
-    break
-  fi
-  if ! kill -0 $CONTAINER_PID 2>/dev/null; then
-    echo "[container] ERROR: Container initialization failed."
-    echo "[container] Only $num_ready of 1 node(s) completed initialization."
-    wait $CONTAINER_PID
-    exit $?
-  fi
+  for container_pid in "${CONTAINER_PIDS[@]}"; do
+    if ! kill -0 "$container_pid" 2>/dev/null; then
+      wait "$container_pid"
+      container_rc=$?
+      if [ "$container_rc" -eq 0 ]; then container_rc=1; fi
+      echo "[container] ERROR: Container initialization failed with exit code $container_rc."
+      exit "$container_rc"
+    fi
+  done
+  shopt -s nullglob
+  ready_markers=(/home/testuser/.sky_clusters/test-cluster/.sky_container_init_done/*)
+  num_ready=${#ready_markers[@]}
+  if [ "$num_ready" -ge "1" ]; then break; fi
   sleep 1
 done
+srun --overlap --unbuffered --nodes=1 --ntasks-per-node=1 bash -c 'global_target=pyxis_test-cluster
+job_target="pyxis_${SLURM_JOB_ID}_"test-cluster
+for ((attempt = 1; attempt <= 30; attempt++)); do
+    container_pid=
+    while read -r name pid rest; do
+        if [ "$name" = "$global_target" ] || [ "$name" = "$job_target" ]; then
+            container_pid=$pid
+        fi
+    done < <(enroot list -f)
+    case "$container_pid" in
+        '"'"''"'"'|*[!0-9]*) ;;
+        *)
+            if kill -0 "$container_pid" 2>/dev/null; then
+                exit 0
+            fi
+            ;;
+    esac
+    sleep 1
+done
+echo "[container] ERROR: Container is not running as $global_target or $job_target." >&2
+exit 1
+'
 echo "[container] Ready in $((SECONDS - CONTAINER_START))s"
-touch /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
+printf '%s\n' nvcr.io/nvidia/pytorch:24.01-py3 > /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container
+touch /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 
 # Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -119,4 +119,4 @@ touch /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 # Host-side keeper step that starts skylet and restarts it if it dies.
 SKY_HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
 ( while true; do srun --overlap --jobid=$SLURM_JOB_ID --nodes=1 --ntasks=1 --nodelist=$SKY_HEAD_NODE bash -c 'while true; do if [ -f /tmp/test-cluster/.sky/skylet_start ]; then HOME=/home/testuser/.sky_clusters/test-cluster bash /tmp/test-cluster/.sky/skylet_start; fi; sleep 5; done'; sleep 5; done ) &
-wait "$CONTAINER_PID"
+wait -n "${CONTAINER_PIDS[@]}"

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1,4 +1,5 @@
 """Unit tests for sky.provision.slurm.instance."""
+import json
 from unittest import mock
 
 import pytest
@@ -17,6 +18,83 @@ _PROVIDER_CONFIG = {
 }
 
 
+def _snapshot_manifest(snapshot_dir='/home/test/.sky_snapshots/test-cluster',
+                       num_nodes=2):
+    return {
+        'version': instance.SNAPSHOT_MANIFEST_VERSION,
+        'image_id': 'ubuntu:24.04',
+        'num_nodes': num_nodes,
+        'created_at': 1234.5,
+        'job_db_path': None,
+        'snapshots': [{
+            'rank': rank,
+            'node': f'node-{rank}',
+            'path': instance._snapshot_rank_path(snapshot_dir, rank),
+        } for rank in range(num_nodes)],
+    }
+
+
+class TestSnapshotManifest:
+    """Tests snapshot manifest parsing and validation."""
+
+    def test_valid_manifest(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest(snapshot_dir)
+        assert instance._validate_snapshot_manifest(
+            manifest, snapshot_dir, expected_num_nodes=2) is manifest
+
+    def test_num_nodes_mismatch(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        with pytest.raises(RuntimeError, match='node count does not match'):
+            instance._validate_snapshot_manifest(
+                _snapshot_manifest(snapshot_dir),
+                snapshot_dir,
+                expected_num_nodes=1)
+
+    def test_rank_path_mismatch(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest(snapshot_dir)
+        manifest['snapshots'][1]['path'] = '/other/rank1.sqsh'
+        with pytest.raises(RuntimeError, match='path for rank 1'):
+            instance._validate_snapshot_manifest(manifest, snapshot_dir)
+
+    def test_missing_manifest(self):
+        runner = mock.MagicMock()
+        runner.run.return_value = (44, '', '')
+        assert instance._read_snapshot_manifest(
+            runner, '/home/test/.sky_snapshots/test-cluster') is None
+
+    def test_read_valid_manifest(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest(snapshot_dir)
+        runner = mock.MagicMock()
+        runner.run.return_value = (0, json.dumps(manifest), '')
+        assert instance._read_snapshot_manifest(runner,
+                                                snapshot_dir) == manifest
+
+    def test_read_corrupt_manifest(self):
+        runner = mock.MagicMock()
+        runner.run.return_value = (0, '{', '')
+        with pytest.raises(RuntimeError, match='not valid JSON'):
+            instance._read_snapshot_manifest(
+                runner, '/home/test/.sky_snapshots/test-cluster')
+
+    def test_missing_rank_snapshot(self):
+        runner = mock.MagicMock()
+        runner.run.side_effect = [(0, '', ''), (1, '', '')]
+        with pytest.raises(RuntimeError, match='rank 1'):
+            instance._validate_snapshot_files(runner, _snapshot_manifest())
+
+    def test_missing_job_db_snapshot(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest(snapshot_dir)
+        manifest['job_db_path'] = instance._snapshot_job_db_path(snapshot_dir)
+        runner = mock.MagicMock()
+        runner.run.side_effect = [(0, '', ''), (0, '', ''), (1, '', '')]
+        with pytest.raises(RuntimeError, match='missing job database'):
+            instance._validate_snapshot_files(runner, manifest)
+
+
 @pytest.fixture
 def mock_client(monkeypatch):
     """Mock SlurmClient for terminate_instances tests (SSH path)."""
@@ -25,6 +103,13 @@ def mock_client(monkeypatch):
                         mock.MagicMock(return_value=client))
     monkeypatch.setattr(instance.slurm_utils, 'is_inside_slurm_cluster',
                         mock.MagicMock(return_value=False))
+    login_runner = mock.MagicMock()
+    login_runner.run.return_value = (0, '', '')
+    monkeypatch.setattr(instance, '_make_login_node_runner',
+                        mock.MagicMock(return_value=login_runner))
+    monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                        mock.MagicMock(return_value='/home/test'))
+    client.test_login_runner = login_runner
     # Make waits resolve quickly in tests that exercise timeouts.
     monkeypatch.setattr(instance, '_TERMINATION_GRACE_PERIOD_SECONDS', 0.05)
     monkeypatch.setattr(instance, '_JOB_TERMINATION_TIMEOUT_SECONDS', 0.05)
@@ -55,6 +140,12 @@ class TestTerminateInstances:
         mock_client.get_jobs_state_by_name.return_value = []
         instance.terminate_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
         mock_client.cancel_jobs_by_name.assert_not_called()
+        remove_commands = [
+            call.args[0]
+            for call in mock_client.test_login_runner.run.call_args_list
+        ]
+        assert any('.sky_snapshots/test-cluster' in command
+                   for command in remove_commands)
 
     @pytest.mark.parametrize('job_state', ['PENDING', 'CONFIGURING'])
     def test_pending_cancels_without_signal(self, mock_client, job_state):
@@ -98,6 +189,28 @@ class TestTerminateInstances:
             mock.call(_CLUSTER, signal='TERM'),
             mock.call(_CLUSTER, signal='TERM', full=True),
         ]
+
+    def test_pre_batch_cleanup_runs_between_step_and_batch_term(
+            self, monkeypatch):
+        client = mock.MagicMock()
+        client.get_jobs_state_by_name.return_value = ['RUNNING']
+        monkeypatch.setattr(instance, '_wait_for_job_states',
+                            mock.MagicMock(return_value=True))
+        events = []
+
+        def cancel(job_name, signal=None, full=False):
+            assert job_name == _CLUSTER
+            events.append((signal, full))
+
+        client.cancel_jobs_by_name.side_effect = cancel
+
+        instance._cancel_slurm_job(
+            client,
+            _CLUSTER,
+            inside_slurm_cluster=False,
+            pre_batch_cancel=lambda: events.append('cleanup'))
+
+        assert events == [('TERM', False), 'cleanup', ('TERM', True)]
 
     def test_graceful_wait_tolerates_transient_query_failure(self, mock_client):
         # One failed poll inside the wait must not fail the teardown.
@@ -193,3 +306,181 @@ class TestWaitForJobStates:
             255, 'squeue', 'ssh dropped', None)
         assert not instance._wait_for_job_states(
             client, 'job', instance._EXITING_JOB_STATES, timeout=0)
+
+
+class TestStopInstances:
+    """Tests Slurm container export and stop ordering."""
+
+    @staticmethod
+    def _setup(monkeypatch, nodes):
+        client = mock.MagicMock()
+        client.query_jobs.return_value = ['123']
+        client.get_job_nodes.return_value = (nodes, [
+            f'10.0.0.{i + 1}' for i in range(len(nodes))
+        ])
+        login_runner = mock.MagicMock()
+
+        def run(command, **kwargs):
+            del kwargs
+            if command.startswith('cat '):
+                return 0, 'ubuntu:24.04\n', ''
+            return 0, '', ''
+
+        login_runner.run.side_effect = run
+        head_runner = mock.MagicMock()
+        head_runner.run.return_value = (0, '', '')
+        monkeypatch.setattr(instance, '_make_slurm_client',
+                            mock.MagicMock(return_value=client))
+        monkeypatch.setattr(instance, '_make_login_node_runner',
+                            mock.MagicMock(return_value=login_runner))
+        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                            mock.MagicMock(return_value='/home/test'))
+        monkeypatch.setattr(instance, 'get_cluster_info', mock.MagicMock())
+        monkeypatch.setattr(instance, 'get_command_runners',
+                            mock.MagicMock(return_value=[head_runner]))
+        write_manifest = mock.MagicMock()
+        cancel_slurm_job = mock.MagicMock()
+        monkeypatch.setattr(instance, '_write_snapshot_manifest',
+                            write_manifest)
+        monkeypatch.setattr(instance, '_cancel_slurm_job', cancel_slurm_job)
+        monkeypatch.setattr(instance.slurm_utils,
+                            'get_slurm_cluster_from_config',
+                            mock.MagicMock(return_value='test-slurm'))
+        return (client, login_runner, head_runner, write_manifest,
+                cancel_slurm_job)
+
+    def test_exports_all_nodes_then_publishes_manifest(self, monkeypatch):
+        nodes = ['node-a', 'node-b']
+        _, login_runner, head_runner, write_manifest, cancel_slurm_job = (
+            self._setup(monkeypatch, nodes))
+
+        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        head_runner.run.assert_called_once()
+        assert 'cancel_jobs_encoded_results' in head_runner.run.call_args.args[
+            0]
+        manifest = write_manifest.call_args.args[2]
+        assert manifest['num_nodes'] == 2
+        assert manifest['job_db_path'] == (
+            '/home/test/.sky_snapshots/test-cluster/jobs.db')
+        assert [entry['node'] for entry in manifest['snapshots']] == nodes
+        assert [entry['rank'] for entry in manifest['snapshots']] == [0, 1]
+        export_commands = [
+            call.args[0]
+            for call in login_runner.run.call_args_list
+            if 'enroot export' in call.args[0]
+        ]
+        assert len(export_commands) == 2
+        assert all('enroot export -f' in command for command in export_commands)
+        assert any(
+            '--nodelist=node-a' in command for command in export_commands)
+        assert any(
+            '--nodelist=node-b' in command for command in export_commands)
+        cancel_slurm_job.assert_called_once()
+
+    def test_cleanup_allocation_runs_on_every_node(self, monkeypatch):
+        client = mock.MagicMock()
+        login_runner = mock.MagicMock()
+        login_runner.run.return_value = (0, '', '')
+        monkeypatch.setattr(instance.skypilot_config,
+                            'get_effective_region_config',
+                            mock.MagicMock(return_value=None))
+        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                            mock.MagicMock(return_value='/home/test'))
+        monkeypatch.setattr(instance.slurm_utils,
+                            'get_slurm_cluster_from_config',
+                            mock.MagicMock(return_value='test-slurm'))
+
+        instance._cleanup_slurm_allocation(client, login_runner, _CLUSTER,
+                                           _PROVIDER_CONFIG, '123',
+                                           ['node-a', 'node-b'])
+
+        node_cleanup = login_runner.run.call_args_list[0].args[0]
+        assert '--jobid=123' in node_cleanup
+        assert '--nodes=2 --ntasks-per-node=1' in node_cleanup
+        assert 'pyxis_test-cluster' in node_cleanup
+        assert 'pyxis_123_test-cluster' in node_cleanup
+        assert ('for ((attempt = 1; attempt <= 30; attempt++)); do\n'
+                '            if ! container_exists "$enroot_name"; then'
+                in node_cleanup)
+        assert 'rm -rf -- /tmp/test-cluster' in node_cleanup
+        shared_cleanup = login_runner.run.call_args_list[1].args[0]
+        assert shared_cleanup == (
+            'rm -rf -- /home/test/.sky_clusters/test-cluster')
+
+    def test_export_failure_keeps_allocation_running(self, monkeypatch):
+        _, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
+            monkeypatch, ['node-a', 'node-b'])
+        original_run = login_runner.run.side_effect
+
+        def fail_rank_one(command, **kwargs):
+            if 'enroot export' in command and 'rank1.sqsh' in command:
+                return 7, '', 'export failed'
+            return original_run(command, **kwargs)
+
+        login_runner.run.side_effect = fail_rank_one
+
+        with pytest.raises(exceptions.CommandError, match='rank 1'):
+            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        write_manifest.assert_not_called()
+        cancel_slurm_job.assert_not_called()
+
+
+class TestQueryInstances:
+    """Tests manifest-backed Slurm stopped status."""
+
+    def test_manifest_reports_each_rank_stopped(self, monkeypatch):
+        client = mock.MagicMock()
+        client.query_jobs.return_value = []
+        monkeypatch.setattr(instance.slurm, 'SlurmClient',
+                            mock.MagicMock(return_value=client))
+        monkeypatch.setattr(instance, '_make_login_node_runner',
+                            mock.MagicMock(return_value=mock.MagicMock()))
+        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                            mock.MagicMock(return_value='/home/test'))
+        manifest = _snapshot_manifest('/home/test/.sky_snapshots/test-cluster',
+                                      num_nodes=2)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest',
+                            mock.MagicMock(return_value=manifest))
+
+        statuses = instance.query_instances('test-cluster',
+                                            _CLUSTER,
+                                            provider_config=_PROVIDER_CONFIG)
+
+        assert statuses == {
+            'snapshot-rank-0':
+                (instance.status_lib.ClusterStatus.STOPPED, None),
+            'snapshot-rank-1':
+                (instance.status_lib.ClusterStatus.STOPPED, None),
+        }
+
+    def test_running_job_ignores_recent_terminal_allocation(self, monkeypatch):
+        client = mock.MagicMock()
+
+        def query_jobs(job_name, states):
+            del job_name
+            if states == ['running']:
+                return ['new-job']
+            if states == ['completed']:
+                return ['old-job']
+            return []
+
+        client.query_jobs.side_effect = query_jobs
+        client.get_job_nodes.return_value = (['node-a'], ['10.0.0.1'])
+        client.get_job_reason.return_value = 'None'
+        monkeypatch.setattr(instance.slurm, 'SlurmClient',
+                            mock.MagicMock(return_value=client))
+        read_manifest = mock.MagicMock()
+        monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+
+        statuses = instance.query_instances('test-cluster',
+                                            _CLUSTER,
+                                            provider_config=_PROVIDER_CONFIG,
+                                            non_terminated_only=False)
+
+        assert statuses == {
+            instance.slurm_utils.instance_id('new-job', 'node-a'):
+                (instance.status_lib.ClusterStatus.UP, None)
+        }
+        read_manifest.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1,6 +1,7 @@
 """Unit tests for sky.provision.slurm.instance."""
 import json
 import shlex
+import subprocess
 from unittest import mock
 
 import pytest
@@ -476,6 +477,64 @@ class TestStopInstances:
         shared_cleanup = login_runner.run.call_args_list[1].args[0]
         assert shared_cleanup == (
             'rm -rf -- /home/test/.sky_clusters/test-cluster')
+
+    def test_cleanup_allocation_preserves_logs(self, monkeypatch, tmp_path):
+        client = mock.MagicMock()
+        login_runner = mock.MagicMock()
+
+        def run(command, **kwargs):
+            del kwargs
+            if command.startswith('srun '):
+                return 0, '', ''
+            result = subprocess.run(['/bin/bash', '-c', command],
+                                    check=False,
+                                    capture_output=True,
+                                    text=True)
+            return result.returncode, result.stdout, result.stderr
+
+        login_runner.run.side_effect = run
+        monkeypatch.setattr(instance.skypilot_config,
+                            'get_effective_region_config',
+                            mock.MagicMock(return_value=None))
+        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                            mock.MagicMock(return_value=str(tmp_path)))
+        monkeypatch.setattr(instance.slurm_utils,
+                            'get_slurm_cluster_from_config',
+                            mock.MagicMock(return_value='test-slurm'))
+        cluster_home = tmp_path / '.sky_clusters' / _CLUSTER
+        log_file = cluster_home / 'sky_logs' / '1-job' / 'run.log'
+        log_file.parent.mkdir(parents=True)
+        log_file.write_text('job output')
+        stale_state = cluster_home / '.sky' / 'state'
+        stale_state.parent.mkdir()
+        stale_state.write_text('state')
+        workdir = cluster_home / 'sky_workdir'
+        workdir.mkdir()
+
+        instance._cleanup_slurm_allocation(client,
+                                           login_runner,
+                                           _CLUSTER,
+                                           _PROVIDER_CONFIG,
+                                           '123', ['node-a'],
+                                           preserve_logs=True)
+
+        assert log_file.read_text() == 'job output'
+        assert not stale_state.parent.exists()
+        assert not workdir.exists()
+
+    def test_stop_cleanup_preserves_logs(self, monkeypatch):
+        _, _, _, _, cancel_slurm_job = self._setup(monkeypatch, ['node-a'])
+        cleanup_slurm_allocation = mock.MagicMock()
+        monkeypatch.setattr(instance, '_cleanup_slurm_allocation',
+                            cleanup_slurm_allocation)
+
+        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        cleanup = cancel_slurm_job.call_args.kwargs['pre_batch_cancel']
+        cleanup()
+
+        assert cleanup_slurm_allocation.call_args.kwargs == {
+            'preserve_logs': True,
+        }
 
     def test_export_failure_preserves_previous_snapshot(self, monkeypatch):
         client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -536,6 +536,19 @@ class TestStopInstances:
             'preserve_logs': True,
         }
 
+    def test_empty_container_marker_requires_relaunch(self, monkeypatch):
+        _, login_runner, head_runner, write_manifest, cancel_slurm_job = (
+            self._setup(monkeypatch, ['node-a']))
+        login_runner.run.side_effect = lambda command, **kwargs: (0, '', '')
+
+        with pytest.raises(exceptions.NotSupportedError,
+                           match='Relaunch the cluster before stopping it'):
+            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        head_runner.run_driver.assert_not_called()
+        write_manifest.assert_not_called()
+        cancel_slurm_job.assert_not_called()
+
     def test_export_failure_preserves_previous_snapshot(self, monkeypatch):
         client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
             monkeypatch, ['node-a', 'node-b'])

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -212,6 +212,26 @@ class TestTerminateInstances:
 
         assert events == [('TERM', False), 'cleanup', ('TERM', True)]
 
+    def test_cleanup_failure_still_cancels_allocation(self, mock_client,
+                                                      monkeypatch):
+        mock_client.query_jobs.return_value = ['123']
+        mock_client.get_job_nodes.return_value = (['node-a'], ['10.0.0.1'])
+        mock_client.get_jobs_state_by_name.side_effect = [['RUNNING'], []]
+        cleanup = mock.MagicMock(side_effect=RuntimeError('cleanup failed'))
+        monkeypatch.setattr(instance, '_cleanup_slurm_allocation', cleanup)
+        warning = mock.MagicMock()
+        monkeypatch.setattr(instance.logger, 'warning', warning)
+
+        instance.terminate_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        cleanup.assert_called_once()
+        assert mock_client.cancel_jobs_by_name.call_args_list == [
+            mock.call(_CLUSTER, signal='TERM'),
+            mock.call(_CLUSTER, signal='TERM', full=True),
+        ]
+        warning.assert_called_once()
+        assert 'cleanup failed' in warning.call_args.args[0]
+
     def test_graceful_wait_tolerates_transient_query_failure(self, mock_client):
         # One failed poll inside the wait must not fail the teardown.
         mock_client.get_jobs_state_by_name.side_effect = [
@@ -360,6 +380,16 @@ class TestStopInstances:
         head_runner.run.assert_not_called()
         assert ('cancel_jobs_encoded_results'
                 in head_runner.run_driver.call_args.args[0])
+        stop_skylet_commands = [
+            call.args[0]
+            for call in login_runner.run.call_args_list
+            if 'skylet_pid' in call.args[0]
+        ]
+        assert len(stop_skylet_commands) == 1
+        stop_skylet_command = stop_skylet_commands[0]
+        assert 'rm -f --' in stop_skylet_command
+        assert (stop_skylet_command.index('.sky/skylet_start') <
+                stop_skylet_command.index('.sky/skylet_pid'))
         manifest = write_manifest.call_args.args[2]
         assert manifest['num_nodes'] == 2
         assert manifest['job_db_path'] == (
@@ -424,6 +454,30 @@ class TestStopInstances:
         with pytest.raises(exceptions.CommandError, match='rank 1'):
             instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
 
+        write_manifest.assert_not_called()
+        cancel_slurm_job.assert_not_called()
+
+    def test_missing_container_preserves_existing_snapshot(self, monkeypatch):
+        _, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
+            monkeypatch, ['node-a', 'node-b'])
+        original_run = login_runner.run.side_effect
+
+        def fail_node_preflight(command, **kwargs):
+            if ('enroot list' in command and 'enroot export' not in command and
+                    '--nodelist=node-b' in command):
+                return 1, '', 'Pyxis container not found on node node-b'
+            return original_run(command, **kwargs)
+
+        login_runner.run.side_effect = fail_node_preflight
+
+        with pytest.raises(exceptions.CommandError, match='node node-b'):
+            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        commands = [call.args[0] for call in login_runner.run.call_args_list]
+        assert not any(
+            command.startswith(
+                'rm -rf -- /home/test/.sky_snapshots/test-cluster')
+            for command in commands)
         write_manifest.assert_not_called()
         cancel_slurm_job.assert_not_called()
 

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -678,6 +678,44 @@ class TestStopInstances:
             'preserve_logs': True,
         }
 
+    def test_stop_cleanup_failure_still_cancels_after_manifest(
+            self, monkeypatch):
+        cancel_slurm_job = instance._cancel_slurm_job
+        client, _, _, write_manifest, _ = self._setup(monkeypatch, ['node-a'])
+        monkeypatch.setattr(instance, '_cancel_slurm_job', cancel_slurm_job)
+        client.get_jobs_state_by_name.side_effect = [['RUNNING'], []]
+        events = []
+        write_manifest.side_effect = lambda *args: events.append('manifest')
+
+        def fail_cleanup(*args, **kwargs):
+            del args, kwargs
+            events.append('cleanup')
+            raise RuntimeError('cleanup failed')
+
+        cleanup = mock.MagicMock(side_effect=fail_cleanup)
+        monkeypatch.setattr(instance, '_cleanup_slurm_allocation', cleanup)
+
+        def cancel(job_name, signal=None, full=False):
+            assert job_name == _CLUSTER
+            events.append(('cancel', signal, full))
+
+        client.cancel_jobs_by_name.side_effect = cancel
+        warning = mock.MagicMock()
+        monkeypatch.setattr(instance.logger, 'warning', warning)
+
+        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        write_manifest.assert_called_once()
+        cleanup.assert_called_once()
+        assert events == [
+            'manifest',
+            ('cancel', 'TERM', False),
+            'cleanup',
+            ('cancel', 'TERM', True),
+        ]
+        warning.assert_called_once()
+        assert 'cleanup failed' in warning.call_args.args[0]
+
     def test_empty_container_marker_requires_relaunch(self, monkeypatch):
         _, login_runner, head_runner, write_manifest, cancel_slurm_job = (
             self._setup(monkeypatch, ['node-a']))

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -380,6 +380,94 @@ class TestWaitForJobStates:
             client, 'job', instance._EXITING_JOB_STATES, timeout=0)
 
 
+class TestDrainSlurmWorkloadSteps:
+    """Tests the pre-snapshot Slurm step drain."""
+
+    @staticmethod
+    def _patch_clock(monkeypatch):
+        clock = mock.MagicMock()
+        elapsed = [0.0]
+        clock.monotonic.side_effect = lambda: elapsed[0]
+
+        def sleep(seconds):
+            elapsed[0] += seconds
+
+        clock.sleep.side_effect = sleep
+        monkeypatch.setattr(instance.time, 'monotonic', clock.monotonic)
+        monkeypatch.setattr(instance.time, 'sleep', clock.sleep)
+        monkeypatch.setattr(instance, 'POLL_INTERVAL_SECONDS', 1)
+        monkeypatch.setattr(instance,
+                            '_WORKLOAD_STEP_TERM_GRACE_PERIOD_SECONDS', 1)
+        monkeypatch.setattr(instance, '_WORKLOAD_STEP_DRAIN_TIMEOUT_SECONDS', 3)
+        return clock
+
+    def test_preserves_only_infrastructure_steps(self):
+        client = mock.MagicMock()
+        client.list_job_steps.return_value = [
+            instance.slurm.JobStepInfo('123.batch', 'batch'),
+            instance.slurm.JobStepInfo('123.extern', 'extern'),
+            instance.slurm.JobStepInfo('123.0', 'sky-container-keeper'),
+            instance.slurm.JobStepInfo('123.1', 'sky-skylet-keeper'),
+        ]
+
+        instance._drain_slurm_workload_steps(client, '123')
+
+        client.signal_job_step.assert_not_called()
+
+    def test_terms_task_and_ssh_steps_then_waits_for_exit(self, monkeypatch):
+        self._patch_clock(monkeypatch)
+        client = mock.MagicMock()
+        workload_steps = [
+            instance.slurm.JobStepInfo('123.2', 'sky-1'),
+            instance.slurm.JobStepInfo('123.3', 'bash'),
+        ]
+        client.list_job_steps.side_effect = [workload_steps, []]
+
+        instance._drain_slurm_workload_steps(client, '123')
+
+        assert client.signal_job_step.call_args_list == [
+            mock.call('123', '123.2', 'TERM'),
+            mock.call('123', '123.3', 'TERM'),
+        ]
+
+    def test_escalates_surviving_step_to_kill(self, monkeypatch):
+        self._patch_clock(monkeypatch)
+        client = mock.MagicMock()
+        workload_step = instance.slurm.JobStepInfo('123.2', 'sky-1')
+        killed = [False]
+        client.list_job_steps.side_effect = lambda job_id: ([] if killed[0] else
+                                                            [workload_step])
+
+        def signal(job_id, step_id, signal_name):
+            del job_id, step_id
+            if signal_name == 'KILL':
+                killed[0] = True
+
+        client.signal_job_step.side_effect = signal
+
+        instance._drain_slurm_workload_steps(client, '123')
+
+        assert client.signal_job_step.call_args_list == [
+            mock.call('123', '123.2', 'TERM'),
+            mock.call('123', '123.2', 'KILL'),
+        ]
+
+    def test_fails_if_step_survives_kill(self, monkeypatch):
+        self._patch_clock(monkeypatch)
+        client = mock.MagicMock()
+        client.list_job_steps.return_value = [
+            instance.slurm.JobStepInfo('123.2', 'bash')
+        ]
+
+        with pytest.raises(RuntimeError, match=r'123\.2 \(bash\)'):
+            instance._drain_slurm_workload_steps(client, '123')
+
+        assert client.signal_job_step.call_args_list == [
+            mock.call('123', '123.2', 'TERM'),
+            mock.call('123', '123.2', 'KILL'),
+        ]
+
+
 class TestStopInstances:
     """Tests Slurm container export and stop ordering."""
 
@@ -390,6 +478,7 @@ class TestStopInstances:
         client.get_job_nodes.return_value = (nodes, [
             f'10.0.0.{i + 1}' for i in range(len(nodes))
         ])
+        client.list_job_steps.return_value = []
         login_runner = mock.MagicMock()
 
         def run(command, **kwargs):
@@ -427,6 +516,28 @@ class TestStopInstances:
         client.test_read_manifest = read_manifest
         return (client, login_runner, head_runner, write_manifest,
                 cancel_slurm_job)
+
+    def test_drains_steps_before_snapshotting_job_database(self, monkeypatch):
+        client, login_runner, head_runner, _, _ = self._setup(
+            monkeypatch, ['node-a'])
+        events = []
+        head_runner.run_driver.side_effect = lambda *args, **kwargs: (
+            events.append('cancel jobs') or (0, '', ''))
+        client.list_job_steps.side_effect = lambda job_id: (events.append(
+            'drain steps') or [])
+        original_run = login_runner.run.side_effect
+
+        def run(command, **kwargs):
+            if 'sqlite3.connect' in command:
+                events.append('backup jobs db')
+            return original_run(command, **kwargs)
+
+        login_runner.run.side_effect = run
+
+        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        assert events.index('cancel jobs') < events.index('drain steps')
+        assert events.index('drain steps') < events.index('backup jobs db')
 
     def test_exports_all_nodes_then_publishes_manifest(self, monkeypatch):
         nodes = ['node-a', 'node-b']

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -23,22 +23,14 @@ _SNAPSHOT_GENERATION = '0123456789abcdef0123456789abcdef'
 _NEW_SNAPSHOT_GENERATION = 'fedcba9876543210fedcba9876543210'
 
 
-def _snapshot_manifest(snapshot_dir='/home/test/.sky_snapshots/test-cluster',
-                       num_nodes=2,
-                       generation=_SNAPSHOT_GENERATION):
-    generation_dir = instance._snapshot_generation_dir(snapshot_dir, generation)
+def _snapshot_manifest(num_nodes=2, generation=_SNAPSHOT_GENERATION):
     return {
         'version': instance.SNAPSHOT_MANIFEST_VERSION,
         'generation': generation,
         'image_id': 'ubuntu:24.04',
-        'num_nodes': num_nodes,
         'created_at': 1234.5,
-        'job_db_path': None,
-        'snapshots': [{
-            'rank': rank,
-            'node': f'node-{rank}',
-            'path': instance._snapshot_rank_path(generation_dir, rank),
-        } for rank in range(num_nodes)],
+        'has_job_db': False,
+        'nodes': [f'node-{rank}' for rank in range(num_nodes)],
     }
 
 
@@ -46,32 +38,26 @@ class TestSnapshotManifest:
     """Tests snapshot manifest parsing and validation."""
 
     def test_valid_manifest(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
-        manifest = _snapshot_manifest(snapshot_dir)
+        manifest = _snapshot_manifest()
         assert instance._validate_snapshot_manifest(
-            manifest, snapshot_dir, expected_num_nodes=2) is manifest
+            manifest, expected_num_nodes=2) is manifest
 
     def test_num_nodes_mismatch(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
         with pytest.raises(RuntimeError, match='node count does not match'):
-            instance._validate_snapshot_manifest(
-                _snapshot_manifest(snapshot_dir),
-                snapshot_dir,
-                expected_num_nodes=1)
+            instance._validate_snapshot_manifest(_snapshot_manifest(),
+                                                 expected_num_nodes=1)
 
-    def test_rank_path_mismatch(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
-        manifest = _snapshot_manifest(snapshot_dir)
-        manifest['snapshots'][1]['path'] = '/other/rank1.sqsh'
-        with pytest.raises(RuntimeError, match='path for rank 1'):
-            instance._validate_snapshot_manifest(manifest, snapshot_dir)
+    def test_invalid_source_nodes(self):
+        manifest = _snapshot_manifest()
+        manifest['nodes'][1] = ''
+        with pytest.raises(RuntimeError, match='source node list'):
+            instance._validate_snapshot_manifest(manifest)
 
     def test_invalid_generation(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
-        manifest = _snapshot_manifest(snapshot_dir)
+        manifest = _snapshot_manifest()
         manifest['generation'] = '../other'
         with pytest.raises(RuntimeError, match='invalid generation'):
-            instance._validate_snapshot_manifest(manifest, snapshot_dir)
+            instance._validate_snapshot_manifest(manifest)
 
     def test_missing_manifest(self):
         runner = mock.MagicMock()
@@ -80,12 +66,11 @@ class TestSnapshotManifest:
             runner, '/home/test/.sky_snapshots/test-cluster') is None
 
     def test_read_valid_manifest(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
-        manifest = _snapshot_manifest(snapshot_dir)
+        manifest = _snapshot_manifest()
         runner = mock.MagicMock()
         runner.run.return_value = (0, json.dumps(manifest), '')
-        assert instance._read_snapshot_manifest(runner,
-                                                snapshot_dir) == manifest
+        assert instance._read_snapshot_manifest(
+            runner, '/home/test/.sky_snapshots/test-cluster') == manifest
 
     def test_read_corrupt_manifest(self):
         runner = mock.MagicMock()
@@ -94,22 +79,35 @@ class TestSnapshotManifest:
             instance._read_snapshot_manifest(
                 runner, '/home/test/.sky_snapshots/test-cluster')
 
+    def test_manifest_paths_derived_from_generation(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest()
+        manifest['has_job_db'] = True
+        generation_dir = (f'{snapshot_dir}/generations/{_SNAPSHOT_GENERATION}')
+        rank_paths, job_db_path = instance._manifest_paths(
+            snapshot_dir, manifest)
+        assert rank_paths == [
+            f'{generation_dir}/rank0.sqsh',
+            f'{generation_dir}/rank1.sqsh',
+        ]
+        assert job_db_path == f'{generation_dir}/jobs.db'
+
     def test_missing_rank_snapshot(self):
         runner = mock.MagicMock()
         runner.run.side_effect = [(0, '', ''), (1, '', '')]
         with pytest.raises(RuntimeError, match='rank 1'):
-            instance._validate_snapshot_files(runner, _snapshot_manifest())
+            instance._validate_snapshot_files(
+                runner, '/home/test/.sky_snapshots/test-cluster',
+                _snapshot_manifest())
 
     def test_missing_job_db_snapshot(self):
-        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
-        manifest = _snapshot_manifest(snapshot_dir)
-        generation_dir = instance._snapshot_generation_dir(
-            snapshot_dir, manifest['generation'])
-        manifest['job_db_path'] = instance._snapshot_job_db_path(generation_dir)
+        manifest = _snapshot_manifest()
+        manifest['has_job_db'] = True
         runner = mock.MagicMock()
         runner.run.side_effect = [(0, '', ''), (0, '', ''), (1, '', '')]
         with pytest.raises(RuntimeError, match='missing job database'):
-            instance._validate_snapshot_files(runner, manifest)
+            instance._validate_snapshot_files(
+                runner, '/home/test/.sky_snapshots/test-cluster', manifest)
 
 
 class TestResolveSkyBaseDir:
@@ -453,12 +451,8 @@ class TestStopInstances:
                 stop_skylet_command.index('.sky/skylet_pid'))
         manifest = write_manifest.call_args.args[2]
         assert manifest['generation'] == _NEW_SNAPSHOT_GENERATION
-        assert manifest['num_nodes'] == 2
-        assert manifest['job_db_path'] == (
-            '/home/test/.sky_snapshots/test-cluster/generations/'
-            f'{_NEW_SNAPSHOT_GENERATION}/jobs.db')
-        assert [entry['node'] for entry in manifest['snapshots']] == nodes
-        assert [entry['rank'] for entry in manifest['snapshots']] == [0, 1]
+        assert manifest['nodes'] == nodes
+        assert manifest['has_job_db'] is True
         export_commands = [
             call.args[0]
             for call in login_runner.run.call_args_list
@@ -709,8 +703,7 @@ class TestQueryInstances:
             side_effect=AssertionError('global config must not be read'))
         monkeypatch.setattr(instance.skypilot_config,
                             'get_effective_region_config', get_config)
-        manifest = _snapshot_manifest('/home/test/.sky_snapshots/test-cluster',
-                                      num_nodes=2)
+        manifest = _snapshot_manifest(num_nodes=2)
         read_manifest = mock.MagicMock(return_value=manifest)
         monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
         provider_config = {

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -112,6 +112,43 @@ class TestSnapshotManifest:
             instance._validate_snapshot_files(runner, manifest)
 
 
+class TestResolveSkyBaseDir:
+    """Tests persisted Slurm cluster state directory lookup."""
+
+    def test_uses_persisted_provider_value(self, monkeypatch):
+        client = mock.MagicMock()
+        get_config = mock.MagicMock(
+            side_effect=AssertionError('global config must not be read'))
+        monkeypatch.setattr(instance.skypilot_config,
+                            'get_effective_region_config', get_config)
+        provider_config = {
+            **_PROVIDER_CONFIG,
+            'sky_base_dir': '/old/shared/path',
+        }
+
+        result = instance._resolve_sky_base_dir(client, provider_config)
+
+        assert result == '/old/shared/path'
+        get_config.assert_not_called()
+        client.get_env.assert_not_called()
+        client.get_remote_home_dir.assert_not_called()
+
+    def test_provider_without_value_resolves_current_config(self, monkeypatch):
+        client = mock.MagicMock()
+        resolve = mock.MagicMock(return_value='/current/shared/path')
+        monkeypatch.setattr(instance.slurm_utils, 'resolve_sky_base_dir',
+                            resolve)
+        provider_config = {
+            **_PROVIDER_CONFIG,
+            'cluster': 'test-slurm',
+        }
+
+        result = instance._resolve_sky_base_dir(client, provider_config)
+
+        assert result == '/current/shared/path'
+        resolve.assert_called_once_with('test-slurm', client)
+
+
 @pytest.fixture
 def mock_client(monkeypatch):
     """Mock SlurmClient for terminate_instances tests (SSH path)."""
@@ -665,18 +702,25 @@ class TestQueryInstances:
         client.query_jobs.return_value = []
         monkeypatch.setattr(instance.slurm, 'SlurmClient',
                             mock.MagicMock(return_value=client))
+        login_runner = mock.MagicMock()
         monkeypatch.setattr(instance, '_make_login_node_runner',
-                            mock.MagicMock(return_value=mock.MagicMock()))
-        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
-                            mock.MagicMock(return_value='/home/test'))
+                            mock.MagicMock(return_value=login_runner))
+        get_config = mock.MagicMock(
+            side_effect=AssertionError('global config must not be read'))
+        monkeypatch.setattr(instance.skypilot_config,
+                            'get_effective_region_config', get_config)
         manifest = _snapshot_manifest('/home/test/.sky_snapshots/test-cluster',
                                       num_nodes=2)
-        monkeypatch.setattr(instance, '_read_snapshot_manifest',
-                            mock.MagicMock(return_value=manifest))
+        read_manifest = mock.MagicMock(return_value=manifest)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+        provider_config = {
+            **_PROVIDER_CONFIG,
+            'sky_base_dir': '/home/test',
+        }
 
         statuses = instance.query_instances('test-cluster',
                                             _CLUSTER,
-                                            provider_config=_PROVIDER_CONFIG)
+                                            provider_config=provider_config)
 
         assert statuses == {
             'snapshot-rank-0':
@@ -684,6 +728,9 @@ class TestQueryInstances:
             'snapshot-rank-1':
                 (instance.status_lib.ClusterStatus.STOPPED, None),
         }
+        read_manifest.assert_called_once_with(
+            login_runner, '/home/test/.sky_snapshots/test-cluster')
+        get_config.assert_not_called()
 
     def test_running_job_ignores_recent_terminal_allocation(self, monkeypatch):
         client = mock.MagicMock()

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1,11 +1,13 @@
 """Unit tests for sky.provision.slurm.instance."""
 import json
+import shlex
 from unittest import mock
 
 import pytest
 
 from sky import exceptions
 from sky.provision.slurm import instance
+from sky.skylet import constants as skylet_constants
 
 _CLUSTER = 'test-cluster'
 _PROVIDER_CONFIG = {
@@ -16,12 +18,17 @@ _PROVIDER_CONFIG = {
         'private_key': '/path/to/key',
     }
 }
+_SNAPSHOT_GENERATION = '0123456789abcdef0123456789abcdef'
+_NEW_SNAPSHOT_GENERATION = 'fedcba9876543210fedcba9876543210'
 
 
 def _snapshot_manifest(snapshot_dir='/home/test/.sky_snapshots/test-cluster',
-                       num_nodes=2):
+                       num_nodes=2,
+                       generation=_SNAPSHOT_GENERATION):
+    generation_dir = instance._snapshot_generation_dir(snapshot_dir, generation)
     return {
         'version': instance.SNAPSHOT_MANIFEST_VERSION,
+        'generation': generation,
         'image_id': 'ubuntu:24.04',
         'num_nodes': num_nodes,
         'created_at': 1234.5,
@@ -29,7 +36,7 @@ def _snapshot_manifest(snapshot_dir='/home/test/.sky_snapshots/test-cluster',
         'snapshots': [{
             'rank': rank,
             'node': f'node-{rank}',
-            'path': instance._snapshot_rank_path(snapshot_dir, rank),
+            'path': instance._snapshot_rank_path(generation_dir, rank),
         } for rank in range(num_nodes)],
     }
 
@@ -56,6 +63,13 @@ class TestSnapshotManifest:
         manifest = _snapshot_manifest(snapshot_dir)
         manifest['snapshots'][1]['path'] = '/other/rank1.sqsh'
         with pytest.raises(RuntimeError, match='path for rank 1'):
+            instance._validate_snapshot_manifest(manifest, snapshot_dir)
+
+    def test_invalid_generation(self):
+        snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
+        manifest = _snapshot_manifest(snapshot_dir)
+        manifest['generation'] = '../other'
+        with pytest.raises(RuntimeError, match='invalid generation'):
             instance._validate_snapshot_manifest(manifest, snapshot_dir)
 
     def test_missing_manifest(self):
@@ -88,7 +102,9 @@ class TestSnapshotManifest:
     def test_missing_job_db_snapshot(self):
         snapshot_dir = '/home/test/.sky_snapshots/test-cluster'
         manifest = _snapshot_manifest(snapshot_dir)
-        manifest['job_db_path'] = instance._snapshot_job_db_path(snapshot_dir)
+        generation_dir = instance._snapshot_generation_dir(
+            snapshot_dir, manifest['generation'])
+        manifest['job_db_path'] = instance._snapshot_job_db_path(generation_dir)
         runner = mock.MagicMock()
         runner.run.side_effect = [(0, '', ''), (0, '', ''), (1, '', '')]
         with pytest.raises(RuntimeError, match='missing job database'):
@@ -355,6 +371,12 @@ class TestStopInstances:
                             mock.MagicMock(return_value=login_runner))
         monkeypatch.setattr(instance, '_resolve_sky_base_dir',
                             mock.MagicMock(return_value='/home/test'))
+        read_manifest = mock.MagicMock(return_value=None)
+        monkeypatch.setattr(instance, '_read_snapshot_manifest', read_manifest)
+        new_uuid = mock.MagicMock()
+        new_uuid.hex = _NEW_SNAPSHOT_GENERATION
+        monkeypatch.setattr(instance.uuid, 'uuid4',
+                            mock.MagicMock(return_value=new_uuid))
         monkeypatch.setattr(instance, 'get_cluster_info', mock.MagicMock())
         monkeypatch.setattr(instance, 'get_command_runners',
                             mock.MagicMock(return_value=[head_runner]))
@@ -366,6 +388,7 @@ class TestStopInstances:
         monkeypatch.setattr(instance.slurm_utils,
                             'get_slurm_cluster_from_config',
                             mock.MagicMock(return_value='test-slurm'))
+        client.test_read_manifest = read_manifest
         return (client, login_runner, head_runner, write_manifest,
                 cancel_slurm_job)
 
@@ -391,9 +414,11 @@ class TestStopInstances:
         assert (stop_skylet_command.index('.sky/skylet_start') <
                 stop_skylet_command.index('.sky/skylet_pid'))
         manifest = write_manifest.call_args.args[2]
+        assert manifest['generation'] == _NEW_SNAPSHOT_GENERATION
         assert manifest['num_nodes'] == 2
         assert manifest['job_db_path'] == (
-            '/home/test/.sky_snapshots/test-cluster/jobs.db')
+            '/home/test/.sky_snapshots/test-cluster/generations/'
+            f'{_NEW_SNAPSHOT_GENERATION}/jobs.db')
         assert [entry['node'] for entry in manifest['snapshots']] == nodes
         assert [entry['rank'] for entry in manifest['snapshots']] == [0, 1]
         export_commands = [
@@ -403,10 +428,23 @@ class TestStopInstances:
         ]
         assert len(export_commands) == 2
         assert all('enroot export -f' in command for command in export_commands)
+        assert all(f'.staging-{_NEW_SNAPSHOT_GENERATION}' in command
+                   for command in export_commands)
         assert any(
             '--nodelist=node-a' in command for command in export_commands)
         assert any(
             '--nodelist=node-b' in command for command in export_commands)
+        backup_job_db_commands = [
+            call.args[0]
+            for call in login_runner.run.call_args_list
+            if 'sqlite3.connect' in call.args[0]
+        ]
+        assert len(backup_job_db_commands) == 1
+        backup_job_db_script = shlex.split(backup_job_db_commands[0])[-1]
+        assert backup_job_db_script.startswith(
+            'export SKY_RUNTIME_DIR=/tmp/test-cluster && ')
+        assert skylet_constants.SKY_SLURM_PYTHON_CMD in backup_job_db_script
+        assert '/usr/bin/python3 -c' not in backup_job_db_script
         cancel_slurm_job.assert_called_once()
 
     def test_cleanup_allocation_runs_on_every_node(self, monkeypatch):
@@ -439,9 +477,11 @@ class TestStopInstances:
         assert shared_cleanup == (
             'rm -rf -- /home/test/.sky_clusters/test-cluster')
 
-    def test_export_failure_keeps_allocation_running(self, monkeypatch):
-        _, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
+    def test_export_failure_preserves_previous_snapshot(self, monkeypatch):
+        client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
             monkeypatch, ['node-a', 'node-b'])
+        previous_manifest = _snapshot_manifest()
+        client.test_read_manifest.return_value = previous_manifest
         original_run = login_runner.run.side_effect
 
         def fail_rank_one(command, **kwargs):
@@ -456,10 +496,73 @@ class TestStopInstances:
 
         write_manifest.assert_not_called()
         cancel_slurm_job.assert_not_called()
+        previous_generation_dir = instance._snapshot_generation_dir(
+            '/home/test/.sky_snapshots/test-cluster',
+            previous_manifest['generation'])
+        commands = [call.args[0] for call in login_runner.run.call_args_list]
+        assert not any(
+            previous_generation_dir in command for command in commands)
+
+    def test_previous_generation_removed_after_manifest_publish(
+            self, monkeypatch):
+        client, login_runner, _, write_manifest, _ = self._setup(
+            monkeypatch, ['node-a'])
+        previous_manifest = _snapshot_manifest(num_nodes=1)
+        client.test_read_manifest.return_value = previous_manifest
+        previous_generation_dir = instance._snapshot_generation_dir(
+            '/home/test/.sky_snapshots/test-cluster',
+            previous_manifest['generation'])
+        original_run = login_runner.run.side_effect
+        events = []
+
+        def record_snapshot_events(command, **kwargs):
+            if command.startswith('test ! -e ') and 'mv --' in command:
+                events.append('commit generation')
+            if command == f'rm -rf -- {previous_generation_dir}':
+                events.append('remove previous generation')
+            return original_run(command, **kwargs)
+
+        login_runner.run.side_effect = record_snapshot_events
+        write_manifest.side_effect = lambda *args: events.append(
+            'publish manifest')
+
+        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        assert events == [
+            'commit generation',
+            'publish manifest',
+            'remove previous generation',
+        ]
+
+    def test_manifest_publish_failure_preserves_generations(self, monkeypatch):
+        client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
+            monkeypatch, ['node-a'])
+        previous_manifest = _snapshot_manifest(num_nodes=1)
+        client.test_read_manifest.return_value = previous_manifest
+        write_manifest.side_effect = RuntimeError('publish failed')
+
+        with pytest.raises(RuntimeError, match='publish failed'):
+            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+
+        previous_generation_dir = instance._snapshot_generation_dir(
+            '/home/test/.sky_snapshots/test-cluster',
+            previous_manifest['generation'])
+        new_generation_dir = instance._snapshot_generation_dir(
+            '/home/test/.sky_snapshots/test-cluster', _NEW_SNAPSHOT_GENERATION)
+        commands = [call.args[0] for call in login_runner.run.call_args_list]
+        remove_commands = [
+            command for command in commands if command.startswith('rm -rf -- ')
+        ]
+        assert not any(
+            previous_generation_dir in command for command in remove_commands)
+        assert not any(
+            new_generation_dir in command for command in remove_commands)
+        cancel_slurm_job.assert_not_called()
 
     def test_missing_container_preserves_existing_snapshot(self, monkeypatch):
-        _, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
+        client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
             monkeypatch, ['node-a', 'node-b'])
+        client.test_read_manifest.return_value = _snapshot_manifest()
         original_run = login_runner.run.side_effect
 
         def fail_node_preflight(command, **kwargs):

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -328,7 +328,7 @@ class TestStopInstances:
 
         login_runner.run.side_effect = run
         head_runner = mock.MagicMock()
-        head_runner.run.return_value = (0, '', '')
+        head_runner.run_driver.return_value = (0, '', '')
         monkeypatch.setattr(instance, '_make_slurm_client',
                             mock.MagicMock(return_value=client))
         monkeypatch.setattr(instance, '_make_login_node_runner',
@@ -356,9 +356,10 @@ class TestStopInstances:
 
         instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
 
-        head_runner.run.assert_called_once()
-        assert 'cancel_jobs_encoded_results' in head_runner.run.call_args.args[
-            0]
+        head_runner.run_driver.assert_called_once()
+        head_runner.run.assert_not_called()
+        assert ('cancel_jobs_encoded_results'
+                in head_runner.run_driver.call_args.args[0])
         manifest = write_manifest.call_args.args[2]
         assert manifest['num_nodes'] == 2
         assert manifest['job_db_path'] == (


### PR DESCRIPTION
Add `sky stop` and `sky start` support for Slurm container clusters backed by Pyxis.

Slurm clusters use live `sbatch` allocations as their instance lifecycle. Cancelling an allocation removes the writable Enroot filesystem and the cluster's jobs database, so the container cannot otherwise be reconstructed. This change exports each rank's filesystem and snapshots the jobs database before cancellation, then validates and restores both into a new allocation on `sky start`.

- Enable stop dynamically for Pyxis-backed container resources. Autostop remains unsupported.
- Store per-rank Enroot images, a manifest, and the jobs database on shared storage.
- Report `STOPPED` from a valid snapshot and restore each filesystem to its previous rank.
- Clean up allocation-local Enroot and runtime state during stop and down.
- Document the behavior and add single-node and multi-node smoke coverage.

### How it works

```text
RUNNING Slurm allocation
  rank 0 container rootfs -------+
  rank 1 container rootfs -------+--> sky stop
  rank 0 host runtime jobs.db ---+
                                  |
                                  | cancel tasks and stop Skylet
                                  | back up the host jobs.db
                                  | export each container rootfs by rank
                                  v
Shared storage: .sky_snapshots/<cluster>/
  manifest.json  jobs.db  rank0.sqsh  rank1.sqsh
                                  |
                                  | clean node-local state
                                  | cancel the sbatch allocation
                                  v
STOPPED (no Slurm allocation)
                                  |
                                  | sky start
                                  | validate all snapshot files
                                  | request a new allocation
                                  | restore jobs.db on the new rank 0 host
                                  | rankN.sqsh -> new node at rank N
                                  v
RUNNING
  Container files, packages, and job history restored
  /tmp and /run recreated empty
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh --files sky/clouds/slurm.py sky/provision/slurm/instance.py`
- [x] Any manual or new tests for this PR:
  - `pytest -n0 tests/unit_tests/test_sky/provision/slurm/test_instance.py tests/unit_tests/test_sky/clouds/test_slurm.py` (`181 passed`)
  - Ran a one-node container through launch, filesystem mutation, stop, start, `sky exec`, SSH, queue-history validation, and down on a real Slurm cluster.
  - Confirmed the writable root filesystem and installed package survived restart while `/tmp` and `/run` remained ephemeral.
  - Confirmed down removed the allocation, snapshot, Enroot state, runtime directory, and cluster record.
  - Ran two stop/start generations and exercised two-node rank-specific restoration. The final cleanup-race fix was re-tested with fresh one-node clusters.
- [ ] All smoke tests: `/smoke-test`
- [ ] Relevant individual smoke tests: `/smoke-test --slurm -k 'slurm_container_stop_start'`
- [ ] Backward compatibility: `/quicktest-core`

The available Slurm controllers both use `proctrack/cgroup`; `proctrack/linuxproc` was not available for manual testing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
