### PR TITLE
[Kubernetes] Let pod_config opt out of OCI RoCE host networking

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1014,19 +1014,22 @@ class Kubernetes(clouds.Cloud):
         #   1. The user sets spec.hostNetwork in pod_config. Resolved through
         #      the same helper combine_pod_config_fields() uses, so this
         #      agrees with the pod_config folded into the rendered YAML.
-        #   2. OCI OKE RoCE: the template forces `hostNetwork: true` from
-        #      k8s_enable_oci_roce (the user never sets it in pod_config, so
-        #      path 1 wouldn't catch it). Without the probe, the OCI RoCE
-        #      pod's sshd can't bind host:22 (the K8s node's own sshd owns
-        #      it) and inter-node Ray ports collide — so OCI RoCE is treated
-        #      as host-networked here too. Keep this in sync with the
-        #      `hostNetwork: true` gate in kubernetes-ray.yml.j2.
+        #   2. OCI OKE RoCE defaults to host networking. Without the probe,
+        #      the pod's sshd can't bind host:22 (the K8s node's own sshd owns
+        #      it) and inter-node Ray ports collide.
+        # An explicit pod_config value wins over the OCI RoCE default, so a
+        # cluster whose RDMA arrives through a device plugin rather than the
+        # host namespace can opt out with `hostNetwork: false`. This value is
+        # also what gates `hostNetwork` in kubernetes-ray.yml.j2, so the pod
+        # and the probe can no longer disagree about which mode it is in.
         oci_roce_enabled = (
             network_type == KubernetesHighPerformanceNetworkType.OCI_ROCE)
         merged_pod_config = kubernetes_utils.resolve_effective_pod_config(
             resources.cluster_config_overrides, self, context)
-        k8s_host_network = oci_roce_enabled or bool(
-            merged_pod_config.get('spec', {}).get('hostNetwork', False))
+        pod_config_host_network = merged_pod_config.get('spec',
+                                                        {}).get('hostNetwork')
+        k8s_host_network = (oci_roce_enabled if pod_config_host_network is None
+                            else bool(pod_config_host_network))
         if k8s_host_network:
             cluster_name_on_cloud = cluster_name.name_on_cloud
             k8s_env_vars['SKYPILOT_HOST_NETWORK'] = '1'
@@ -1162,10 +1165,10 @@ class Kubernetes(clouds.Cloud):
         deploy_vars['k8s_ipc_lock_capability'] = (
             network_type.requires_ipc_lock_capability())
 
-        # OCI OKE RoCE: requires hostNetwork, privileged containers, and a
-        # hostPath mount of /dev/infiniband (no device plugin on OCI). The
-        # hostNetwork part also feeds k8s_host_network above (see comment
-        # there), which is what activates the Ray-port probe machinery.
+        # OCI OKE RoCE: privileged containers plus a hostPath mount of
+        # /dev/infiniband, for shapes with no RDMA device plugin. hostNetwork
+        # is gated on k8s_host_network instead (see comment there), so it can
+        # be turned off from pod_config without losing the device access.
         deploy_vars['k8s_enable_oci_roce'] = oci_roce_enabled
 
         # User-specified APT mirror candidates for pod package installs.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -199,6 +199,11 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
                     'NCCL_SOCKET_IFNAME': 'eth0',
                     # GPU-to-CPU (C2C) GPUDirect over the Grace link.
                     'NCCL_NET_GDR_C2C': '1',
+                    # With NET_GDR_C2C on, NCCL's GDR cutoff is PATH_P2C, and
+                    # a GPU whose NIC sits one PCIe host bridge away falls
+                    # outside it -- GDR silently off. PHB widens the cutoff by
+                    # exactly that one level; nothing else changes.
+                    'NCCL_NET_GDR_LEVEL': 'PHB',
                     'NCCL_IB_GID_INDEX': '3',
                     'NCCL_IB_TC': '41',
                     'NCCL_IB_SL': '0',

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -397,24 +397,18 @@ available_node_types:
         {% if preemption_hook_timeout is defined and preemption_hook_timeout %}
         terminationGracePeriodSeconds: {{ preemption_hook_timeout }}
         {% endif %}
-        {% if k8s_enable_oci_roce %}
-        # OCI OKE bare-metal GPU shapes expose RoCE NICs only on the host
-        # network namespace; pods must share host networking to reach the
-        # RDMA fabric. This is the only path that sets hostNetwork from the
-        # template — the pod_config path injects it via
-        # combine_pod_config_fields(). k8s_enable_oci_roce also implies
-        # k8s_host_network on the Python side, so the dnsPolicy below and the
-        # Ray-port probe machinery apply here too.
+        {% if k8s_host_network %}
+        # k8s_host_network is the single source of truth for "this pod runs on
+        # the host network": true when pod_config asks for it, and true by
+        # default on OCI OKE bare-metal GPU shapes, which expose RoCE NICs
+        # only in the host network namespace. An explicit pod_config
+        # `hostNetwork` overrides the OCI default either way, so a cluster
+        # whose RDMA arrives through a device plugin can opt out.
         # Refer to https://github.com/oracle-quickstart/oci-hpc-oke/blob/main/docs/running-pytorch-jobs-on-oke-using-hostnetwork-with-rdma.md for more details.
         hostNetwork: true
-        {% endif %}
-        {% if k8s_host_network %}
         # Under hostNetwork the default dnsPolicy silently falls back to
         # the host's resolv.conf — Service DNS like ${head}.svc.cluster.local
         # won't resolve, and the worker probe gets stuck dialing the head.
-        # k8s_host_network is the single source of truth for "this pod runs
-        # on the host network" (set for both the pod_config and OCI RoCE
-        # paths), so this covers OCI RoCE too.
         dnsPolicy: ClusterFirstWithHostNet
         {% endif %}
         {% if volume_mounts %}

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5510,6 +5510,43 @@ class TestOCINetworkEnvVars:
         assert env['NCCL_DMABUF_ENABLE'] == '1'
         assert env['NCCL_IB_TIMEOUT'] == '22'
 
+    def test_gb300_widens_gdr_level(self):
+        """GB300 sets NCCL_NET_GDR_LEVEL=PHB, and only GB300.
+
+        With NET_GDR_C2C on, NCCL's GDR cutoff is PATH_P2C; a GPU whose NIC is
+        one PCIe host bridge away lands outside it and loses GDR silently. PHB
+        widens the cutoff by that one level. Scoped to GB300: the GB200 and
+        RoCEv2 profiles mirror OCI's published sets, which omit it.
+        """
+        assert self._NET.get_network_env_vars(
+            'GB300')['NCCL_NET_GDR_LEVEL'] == 'PHB'
+        assert 'NCCL_NET_GDR_LEVEL' not in self._NET.get_network_env_vars(
+            'GB200')
+        assert 'NCCL_NET_GDR_LEVEL' not in self._NET.get_network_env_vars(
+            'H100')
+
+    def test_gb300_still_mirrors_oci_published_values(self):
+        """The rest of the GB300 profile must stay OCI's published set.
+
+        Guards against widening the GDR level turning into a general licence
+        to deviate: these are the values OCI ships for BM.GPU.GB300.4, and the
+        two a customer was observed overriding (IB_SL=1, IB_TIMEOUT=19) are
+        deliberately *not* adopted -- 19 is a tightening, and defaults should
+        fail lenient.
+        """
+        env = self._NET.get_network_env_vars('GB300')
+        assert env['NCCL_IB_SL'] == '0'
+        assert env['NCCL_IB_TIMEOUT'] == '22'
+        assert env['NCCL_BUFFSIZE'] == '16777216'
+        assert env['NCCL_IB_SPLIT_DATA_ON_QPS'] == '0'
+        # Workload/framework knobs must never be injected:
+        # CUDA_DEVICE_MAX_CONNECTIONS=32 suits FSDP/expert-parallel overlap and
+        # is actively wrong for Megatron tensor-parallel overlap, which needs 1.
+        for absent in ('CUDA_DEVICE_MAX_CONNECTIONS',
+                       'TORCH_NCCL_HIGH_PRIORITY',
+                       'TORCH_NCCL_AVOID_RECORD_STREAMS', 'NCCL_SHM_DISABLE'):
+            assert absent not in env, absent
+
     def test_gb200_and_gb300_are_distinct(self):
         """The two GB profiles must not be identical (NET_PLUGIN differs)."""
         gb200 = self._NET.get_network_env_vars('GB200')

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4521,6 +4521,179 @@ class TestKubernetesEfaSameAzAffinity(unittest.TestCase):
         self.assertNotIn('skypilot-cluster-name', rendered)
 
 
+class TestKubernetesOciRoceHostNetworkOptOut(unittest.TestCase):
+    """An explicit pod_config `hostNetwork` must win over the OCI RoCE default.
+
+    OCI RoCE turns host networking on by default, but OCI also documents an
+    SR-IOV deployment where pods keep their own netns. Before the fix the two
+    halves disagreed: pod_config switched the pod off host networking while
+    SkyPilot still wired up the Ray-port probe for a host-networked pod. The
+    opt-out must not disturb the device access (privileged + /dev/infiniband),
+    which that deployment still needs.
+    """
+
+    def _deploy_vars(self, network_type, pod_config=None):
+        gpu_resources = mock.MagicMock()
+        gpu_resources.instance_type = '8CPU--32GB--GB300:4'
+        gpu_resources.accelerators = {'GB300': 4}
+        gpu_resources.use_spot = False
+        gpu_resources.region = 'oci-context'
+        gpu_resources.zone = None
+        gpu_resources.cluster_config_overrides = {}
+        gpu_resources.image_id = None
+        setattr(gpu_resources, 'assert_launchable', lambda: gpu_resources)
+        gpu_resources.network_tier = resources_utils.NetworkTier.BEST
+
+        region_config = {
+            ('kubernetes', 'remote_identity'): 'SERVICE_ACCOUNT',
+            ('kubernetes', 'provision_timeout'): 10,
+            ('kubernetes', 'high_availability', 'storage_class_name'): None,
+            ('kubernetes', 'pod_config'): pod_config or {},
+        }
+
+        with patch('sky.provision.kubernetes.utils.get_kubernetes_nodes'), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_current_kube_config_context_name',
+                   return_value='oci-context'), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_kube_config_context_namespace',
+                   return_value='default'), \
+             patch('sky.provision.kubernetes.utils.get_accelerator_label_keys',
+                   return_value=[]), \
+             patch('sky.provision.kubernetes.utils.'
+                   'get_accelerator_label_key_values',
+                   return_value=('accelerator', ['GB300'], None, None)), \
+             patch('sky.provision.kubernetes.utils.get_gpu_resource_key',
+                   return_value='nvidia.com/gpu'), \
+             patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth',
+                   return_value=(False, None)), \
+             patch('sky.skypilot_config.get_workspace_cloud') as mock_ws, \
+             patch('sky.skypilot_config.get_effective_region_config',
+                   side_effect=lambda cloud, keys, region, default_value=None,
+                   override_configs=None: region_config.get(
+                       (cloud,) + keys, default_value)), \
+             patch('sky.provision.kubernetes.network_utils.get_port_mode'
+                  ) as mock_pm, \
+             patch('sky.catalog.get_image_id_from_tag',
+                   return_value='img:latest'), \
+             patch('sky.clouds.kubernetes.Kubernetes._detect_network_type',
+                   return_value=(network_type, None)):
+            mock_ws.return_value.get.return_value = None
+            mock_pm.return_value.value = 'portforward'
+            k8s_cloud = kubernetes.Kubernetes()
+            return k8s_cloud.make_deploy_resources_variables(
+                resources=gpu_resources,
+                cluster_name=resources_utils.ClusterName(display_name='c',
+                                                         name_on_cloud='c'),
+                region=mock.MagicMock(name='oci-context'),
+                zones=None,
+                num_nodes=2,
+                dryrun=False)
+
+    def test_oci_roce_defaults_to_host_network(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        deploy_vars = self._deploy_vars(N.OCI_ROCE)
+        self.assertTrue(deploy_vars['k8s_host_network'])
+        self.assertIn('SKYPILOT_HOST_NETWORK', deploy_vars['k8s_env_vars'])
+
+    def test_explicit_false_opts_out_but_keeps_device_access(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        deploy_vars = self._deploy_vars(
+            N.OCI_ROCE, pod_config={'spec': {
+                'hostNetwork': False
+            }})
+        # The fix: the probe machinery must follow the pod, not the cloud.
+        self.assertFalse(deploy_vars['k8s_host_network'])
+        self.assertNotIn('SKYPILOT_HOST_NETWORK', deploy_vars['k8s_env_vars'])
+        # Scoped: privileged + /dev/infiniband are still needed on OCI RoCE
+        # shapes without an RDMA device plugin, so they must be untouched.
+        self.assertTrue(deploy_vars['k8s_enable_oci_roce'])
+        self.assertTrue(deploy_vars['k8s_ipc_lock_capability'])
+
+    def test_pod_config_true_on_non_oci_still_host_networked(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        deploy_vars = self._deploy_vars(
+            N.NONE, pod_config={'spec': {
+                'hostNetwork': True
+            }})
+        self.assertTrue(deploy_vars['k8s_host_network'])
+
+    def test_non_oci_without_pod_config_is_not_host_networked(self):
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType as N)
+        deploy_vars = self._deploy_vars(N.NONE)
+        self.assertFalse(deploy_vars['k8s_host_network'])
+
+    def _render_host_network_block(self, **variables):
+        """Render the hostNetwork block from the live template, so the gate
+        itself is asserted -- not only the deploy var."""
+        import jinja2
+
+        import sky
+        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
+                                     'kubernetes-ray.yml.j2')
+        with open(template_path, 'r', encoding='utf-8') as fin:
+            full = fin.read()
+        begin = full.index('{% if k8s_host_network %}')
+        end = full.index('{% endif %}', begin) + len('{% endif %}')
+        return jinja2.Template(full[begin:end]).render(**variables)
+
+    def _render_block(self, marker, **variables):
+        """Render one `{% if %}`-delimited block from the live template."""
+        import jinja2
+
+        import sky
+        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
+                                     'kubernetes-ray.yml.j2')
+        with open(template_path, 'r', encoding='utf-8') as fin:
+            full = fin.read()
+        begin = full.index(marker)
+        end = full.index('{% endif %}', begin) + len('{% endif %}')
+        return jinja2.Template(full[begin:end]).render(**variables)
+
+    def test_opting_out_restores_container_ports(self):
+        """Locks the port list to k8s_host_network, not to the network type.
+
+        Characterization test, not a regression test: it passes before and
+        after the fix, because this gate was always correct -- what was wrong
+        was the value fed to it. It is here to make the blast radius explicit.
+        k8s_host_network gates six sites beyond hostNetwork itself (one-pod-
+        per-node antiAffinity, the Downward-API pod name, the worker's Ray-port
+        handling, and this port list), so an OCI RoCE pod that opted out used
+        to lose its containerPorts while not being host-networked. Fails if
+        anyone re-gates this on k8s_enable_oci_roce.
+        """
+        opted_out = self._render_block('{% if not k8s_host_network %}',
+                                       k8s_host_network=False,
+                                       ray_port=6379,
+                                       ray_dashboard_port=8265)
+        self.assertIn('containerPort: 22', opted_out)
+
+        host_networked = self._render_block('{% if not k8s_host_network %}',
+                                            k8s_host_network=True,
+                                            ray_port=6379,
+                                            ray_dashboard_port=8265)
+        self.assertNotIn('containerPort', host_networked)
+
+    def test_template_gate_follows_host_network_not_oci_roce(self):
+        # The whole point of the fix: OCI RoCE alone must no longer force
+        # hostNetwork onto the pod when the user opted out.
+        opted_out = self._render_host_network_block(k8s_host_network=False,
+                                                    k8s_enable_oci_roce=True)
+        self.assertNotIn('hostNetwork: true', opted_out)
+        self.assertNotIn('ClusterFirstWithHostNet', opted_out)
+
+        default_on = self._render_host_network_block(k8s_host_network=True,
+                                                     k8s_enable_oci_roce=True)
+        self.assertIn('hostNetwork: true', default_on)
+        # dnsPolicy must stay paired with it: under hostNetwork the default
+        # policy cannot resolve in-cluster Service DNS.
+        self.assertIn('dnsPolicy: ClusterFirstWithHostNet', default_on)
+
+
 class TestKubernetesSpotLabelContext(unittest.TestCase):
     """Regression test for TICKET-034.
 

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/everything_on_multinode_ha.json
@@ -331,6 +331,7 @@
             }
           ],
           "dnsPolicy": "ClusterFirstWithHostNet",
+          "hostNetwork": true,
           "restartPolicy": "Always",
           "serviceAccountName": "skypilot-service-account",
           "terminationGracePeriodSeconds": 300,

--- a/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
+++ b/tests/unit_tests/test_sky/clouds/testdata/kubernetes_ray_template/host_network.json
@@ -132,6 +132,7 @@
             }
           ],
           "dnsPolicy": "ClusterFirstWithHostNet",
+          "hostNetwork": true,
           "restartPolicy": "Never",
           "serviceAccountName": "skypilot-service-account",
           "volumes": [


### PR DESCRIPTION
## Summary

Two independent Kubernetes fixes for OCI OKE RDMA clusters. They touch disjoint
files and can be split if preferred; the second is 5 lines.

**1. Let `pod_config` opt out of OCI RoCE host networking**

`network_tier: best` on an OCI RDMA cluster turned host networking on
unconditionally, and the two halves of that decision disagreed when a user
overrode it. The template rendered `hostNetwork: true` from
`k8s_enable_oci_roce`, while the Python side computed:

```python
k8s_host_network = oci_roce_enabled or bool(
    merged_pod_config.get('spec', {}).get('hostNetwork', False))
```

Because of the `or`, a `pod_config` `hostNetwork: false` produced a pod that was
*not* host-networked but was still treated as one everywhere else —
`k8s_host_network` gates seven template sites:

| Site | Effect on an opted-out pod (before) |
|---|---|
| `hostNetwork` / `dnsPolicy` | pod correctly not host-networked (pod_config merge won) |
| `SKYPILOT_HOST_NETWORK` + Ray-ports ConfigMap | wired up for a pod that isn't host-networked |
| one-pod-per-node `podAntiAffinity` | applied needlessly, blocking pod packing |
| `SKYPILOT_POD_NAME` via Downward API | set to work around a hostname quirk that doesn't apply |
| worker Ray-port handling | delegated to the probe instead of exporting a static port |
| `containerPort` list | silently omitted |

Now an explicit `pod_config` value wins over the OCI default and the template
gate reads that same resolved value, so all seven agree with the pod.

This matters beyond a single deployment: Oracle documents two RDMA models for
OKE, and the SR-IOV one explicitly does not use host networking —
"Each pod gets its own VF interfaces, so `hostNetwork: true` and
`dnsPolicy: ClusterFirstWithHostNet` are not needed"
([docs](https://github.com/oracle-quickstart/oci-hpc-oke/blob/main/docs/using-rdma-network-interfaces-in-manifests.md)).
Opting out is a supported configuration, not a corner case.

`k8s_host_network` only changes value when `pod_config` sets `hostNetwork`
explicitly — every other configuration renders bit-identically, so this is a
no-op for anyone who has not already opted out.

Scoped deliberately: `privileged` and the `/dev/infiniband` hostPath stay gated
on the network type, because Oracle's SR-IOV model still requires both.

**2. Widen the GDR level on the OCI GB300 NCCL profile**

With `NCCL_NET_GDR_C2C` on, NCCL's GPUDirect RDMA cutoff is `PATH_P2C`, so a
GPU-to-NIC path NCCL classifies as `PATH_PHB` falls outside it and loses GDR
with no warning. On a GB300 node each GPU reaches its two local NICs across PCIe
host bridges rather than a direct C2C hop, which is the shape that lands on PHB.
`NCCL_NET_GDR_LEVEL=PHB` widens the cutoff by exactly that one level: paths
already inside are unaffected, cross-NUMA paths stay excluded, and only the PHB
case flips off → on.

Caveat stated in the commit message too: the topology was read with
`nvidia-smi topo -m`, which reports `NODE` and has no `P2C` class of its own, so
the mapping onto NCCL's PHB is inferred rather than confirmed against an NCCL
debug log. Oracle's published per-shape parameters omit this variable, so it is
the first thing to revert if anyone measures a slowdown. Scoped to GB300 — the
GB200 and RoCEv2 profiles keep mirroring Oracle's published sets.

## Tested

Unit tests, 9 new cases:

- `TestKubernetesOciRoceHostNetworkOptOut` (7) — OCI RoCE still defaults to host
  networking; an explicit `false` clears `k8s_host_network` *and* the probe env
  while leaving `k8s_enable_oci_roce` / `k8s_ipc_lock_capability` set; a non-OCI
  cluster setting `true` in `pod_config` still gets it; plus two that render the
  relevant blocks out of the live template file so the gates themselves are
  asserted, not just the deploy var.
- `TestOCINetworkEnvVars` (2) — GB300 carries `NCCL_NET_GDR_LEVEL=PHB` and
  GB200/H100 do not; the rest of the GB300 profile still matches Oracle's
  published values, and workload-level knobs are never injected.

```console
$ pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py -k OciRoceHostNetwork
$ pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py -k TestOCINetworkEnvVars
```

Revert-checked: with the fix backed out, `test_explicit_false_opts_out_but_keeps_device_access`,
`test_template_gate_follows_host_network_not_oci_roce` and
`test_gb300_widens_gdr_level` all fail. The remainder are regression guards that
pass either way by design, and one is labelled in its docstring as a
characterization test rather than a regression test.

Pre-existing failures in `tests/unit_tests/test_sky/clouds/test_kubernetes.py`
(`TestKubernetesExistingAllowedContexts`, `test_remote_identity_with_cluster_overrides`)
reproduce identically on unmodified `master` in my environment and are unrelated.

## Manual verification plan

Not yet run on hardware — no OCI GB300 access from here. On a cluster with the
`oci.oraclecloud.com/rdma.*` node labels:

1. `sky launch --num-nodes 2` with `network_tier: best` → head pod has
   `hostNetwork: true`, no `containerPort` entries, `SKYPILOT_HOST_NETWORK=1`.
2. Same plus `pod_config.spec.hostNetwork: false` → no `hostNetwork`,
   `containerPort: 22` present, no `SKYPILOT_HOST_NETWORK`, and
   `/dev/infiniband` + `IPC_LOCK` still present.
3. Multi-node NCCL run to confirm the fabric still comes up in mode 1.

Step 2's `containerPort` assertion is the one that fails on unpatched code, so
it doubles as a check that the cluster is running the patched build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->