### PR TITLE
[k8s] Park a launch as WAITING while its pods are only slow to start

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1,12 +1,13 @@
 """Kubernetes instance provisioning."""
 import copy
 import datetime
+import functools
 import json
 import re
 import sys
 import time
-from typing import (Any, Callable, Dict, List, Mapping, NamedTuple, Optional,
-                    Set, Tuple, TYPE_CHECKING, Union)
+from typing import (Any, Callable, Dict, List, Mapping, NamedTuple, NoReturn,
+                    Optional, Set, Tuple, TYPE_CHECKING, Union)
 
 from sky import exceptions
 from sky import global_user_state
@@ -166,6 +167,24 @@ _STALL_EXEMPT_PENDING_REASONS = frozenset(
 # not going to resolve. Without this deadline such a pod hangs the launch
 # forever behind a 'Launching' spinner, with no error, ever.
 _POD_RUN_STALL_TIMEOUT_SECONDS = 600
+# How long a launch waits for its pods to run before parking the request (see
+# _park_for_slow_pods). Far longer than an ordinary container start: parking
+# ends the launch's rich status, so a launch that would have finished on its
+# own shortly should not pay for it.
+_POD_RUN_PARK_GRACE_SECONDS = 300
+# Poll policy for PodsProgressedCondition.wait(): jittered backoff between
+# these bounds.
+_PARK_POLL_INITIAL_SECONDS = 2
+_PARK_POLL_MAX_FACTOR = 15  # max poll interval = 2 * 15 = 30s
+# Consecutive poll errors tolerated before handing the launch back rather than
+# probing blind.
+_PARK_MAX_CONSECUTIVE_ERRORS = 5
+# Safety cap before handing the launch back to re-derive the pods' state. Not a
+# deadline: it re-runs and parks again if nothing has changed.
+_PARK_MAX_WAIT_SECONDS = 60 * 60
+# How often a parked request's status message is refreshed. Much slower than
+# the poll: the message only has to not go stale.
+_PARK_REASON_REFRESH_SECONDS = 60
 
 # How long to wait before first probing the volumes of a pod that is not up
 # yet, and how long between probes after that. A probe costs one GET per claim,
@@ -1339,6 +1358,196 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
             f'Error: {common_utils.format_exception(e)}') from None
 
 
+def _check_init_containers(pod) -> Optional[_InitContainerProgress]:
+    """Check init containers for errors and return the one holding up pod
+    initialization.
+
+    Returns the first init container that is running, else the first one
+    the kubelet is still creating (pulling its image), else None -- no
+    init container accounts for the pod being uninitialized.
+    Raises KubernetesError if any init container failed.
+    """
+    init_statuses = pod.status.init_container_statuses
+    total = len(init_statuses)
+    running_info: Optional[_InitContainerProgress] = None
+    starting_info: Optional[_InitContainerProgress] = None
+    for idx, init_status in enumerate(init_statuses):
+        init_terminated = init_status.state.terminated
+        if init_terminated:
+            if init_terminated.exit_code != 0:
+                msg = init_terminated.message if (
+                    init_terminated.message) else str(init_terminated)
+                raise config_lib.KubernetesError(
+                    'Failed to run init container for pod '
+                    f'{pod.metadata.name}. Error details: {msg}.')
+            continue
+        if (init_status.state.running is not None and running_info is None):
+            running_info = _InitContainerProgress(init_status.name, idx + 1,
+                                                  total, True)
+        init_waiting = init_status.state.waiting
+        if init_waiting is not None:
+            if init_waiting.reason in ('ContainerCreating', 'PodInitializing'):
+                # The kubelet is creating it -- most often pulling its
+                # image, which is legitimately slow. Recorded so the
+                # no-progress deadline does not mistake it for a stall.
+                if starting_info is None:
+                    starting_info = _InitContainerProgress(
+                        init_status.name, idx + 1, total, False)
+            else:
+                # TODO(romilb): There may be more states to check for. Add
+                #  them as needed.
+                msg = init_waiting.message if (
+                    init_waiting.message) else str(init_waiting)
+                unmasked = _unmask_crashloopbackoff_reason(init_status)
+                reason_text = (unmasked if unmasked is not None else
+                               (init_waiting.reason or 'Unknown'))
+                raise config_lib.KubernetesError(
+                    f'Failed to create init container for pod '
+                    f'{pod.metadata.name}. Error details: '
+                    f'{reason_text}: {msg}.')
+    return running_info if running_info is not None else starting_info
+
+
+def _inspect_pod_status(pod, context: Optional[str], namespace: str,
+                        cluster_name: str) -> Tuple[bool, Optional[str]]:
+    """Whether ``pod`` is fully running, and the single reason it is not.
+
+    ``pending_reason`` is None when none could be derived. Raises
+    ``config_lib.KubernetesError`` for a pod that has failed outright, which
+    callers let propagate.
+
+    Module-level so the parked-launch continue condition classifies pods
+    exactly the way the wait loop does; the two must not drift.
+    """
+    # Check if pod is terminated/preempted/failed (unchanged).
+    if (pod.metadata.deletion_timestamp is not None or
+            pod.status.phase == 'Failed'):
+        # Get the reason and write to cluster events before
+        # the pod gets completely deleted from the API.
+        termination_reason = _get_pod_termination_reason(pod, cluster_name)
+        logger.warning(
+            f'Pod {pod.metadata.name} terminated: {termination_reason}')
+        condensed = _condensed_pod_reason(pod)
+        raise config_lib.KubernetesError(
+            f'Pod {pod.metadata.name} failed: {condensed}')
+
+    container_statuses = pod.status.container_statuses
+    # Happy path: pod Running and every container Running (unchanged).
+    if (pod.status.phase == 'Running' and container_statuses is not None and
+            all(container.state.running for container in container_statuses)):
+        return True, None
+
+    # Tier 1: container-status sweep. Computed once, consumed in both
+    # branches below.
+    container_reason = _get_pod_pending_reason_from_container_status(pod)
+
+    if pod.status.phase == 'Pending':
+        # Today's raise block -- control flow preserved, message enriched
+        # via _unmask_crashloopbackoff_reason when the waiting state is
+        # CrashLoopBackOff. msg body (waiting.message) is always preserved.
+        init_reason: Optional[str] = None
+        # Whether init_reason is an assumption about what the kubelet is
+        # doing rather than something it reported -- see below.
+        init_reason_is_assumed = False
+        if container_statuses is not None:
+            for container_status in container_statuses:
+                if not container_status.state:
+                    continue
+                waiting = container_status.state.waiting
+                if waiting is not None:
+                    if waiting.reason == 'PodInitializing':
+                        init_progress = _check_init_containers(pod)
+                        if init_progress is not None:
+                            verb = ('running'
+                                    if init_progress.running else 'starting')
+                            init_reason = (f'{_INIT_CONTAINER_REASON_PREFIX}'
+                                           f'{init_progress.name!r} {verb} '
+                                           f'({init_progress.position}/'
+                                           f'{init_progress.total})')
+                            init_reason_is_assumed = (not init_progress.running)
+                        else:
+                            # PodInitializing, yet no init container is
+                            # running or being created -- they have all
+                            # terminated successfully and the kubelet has
+                            # simply not moved on to the main containers.
+                            # Nothing here is legitimately slow, so unlike
+                            # the two branches above this reason is not
+                            # exempt from the no-progress deadline.
+                            init_reason = _POD_INITIALIZATION_REASON
+                    elif waiting.reason != 'ContainerCreating':
+                        msg = waiting.message if (
+                            waiting.message) else str(waiting)
+                        unmasked = _unmask_crashloopbackoff_reason(
+                            container_status)
+                        reason_text = (unmasked if unmasked is not None else
+                                       (waiting.reason or 'Unknown'))
+                        raise config_lib.KubernetesError(
+                            f'{reason_text}: {msg}')
+                terminated = container_status.state.terminated
+                if terminated is not None and terminated.exit_code != 0:
+                    reason_str = (terminated.reason if terminated.reason else
+                                  f'exit({terminated.exit_code})')
+                    raise config_lib.KubernetesError(
+                        f'Container in pod {pod.metadata.name} '
+                        f'terminated with error while pod is still '
+                        f'pending: {reason_str}. Run '
+                        f'`sky logs --provision {cluster_name}` '
+                        'for more details.')
+
+        # Init container reason wins over all event-based reasons,
+        # since events can retain stale "Pulling image" entries long
+        # after the pull completed.  Otherwise, Tier 1 (container
+        # status) wins; fall back to Tier 2/3 events.
+        reason: Optional[str] = init_reason or container_reason
+        event_message: Optional[str] = None
+        if reason is None:
+            pending_reason = _get_pod_pending_reason(context, namespace,
+                                                     pod.metadata.name)
+            if pending_reason is not None:
+                reason, event_message = pending_reason
+        elif init_reason_is_assumed:
+            # 'init container ... starting' says only that the kubelet has
+            # not started the container yet; that this is legitimately slow
+            # work (an image pull of its own) is an assumption, and it is
+            # the assumption that makes the reason stall-exempt. The same
+            # state is what a pod shows when the kubelet cannot get as far
+            # as starting the container at all -- a sandbox it cannot
+            # create, a volume it cannot mount -- which is reported only
+            # through events. So let a live Warning, one the pod has not
+            # already moved past, replace the assumption: it is both the
+            # truer reason and, unlike the init label, bounded by the
+            # no-progress deadline. An allow-listed Normal is not consulted
+            # -- it is exempt either way, and the init label names which
+            # container the pod is waiting on.
+            pending_reason = _get_pod_pending_reason(context,
+                                                     namespace,
+                                                     pod.metadata.name,
+                                                     warnings_only=True)
+            if pending_reason is not None:
+                reason, event_message = pending_reason
+        if reason is None and _pod_is_scheduled(pod):
+            # A freshly-bound pod that the kubelet has not picked up yet
+            # (and the uninformative 'ContainerCreating' state) has no
+            # container-status reason and no event yet. Default to
+            # 'container creation' so the launch spinner shows useful
+            # detail (e.g. 'Launching (1 pod(s) pending due to container
+            # creation)') instead of a bare 'Launching'. Gate on
+            # _pod_is_scheduled so an unbound pod still waiting for
+            # capacity is not mislabeled as creating a container.
+            reason = _CONTAINER_CREATION_REASON
+        if reason is not None:
+            log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
+            if event_message:
+                log_msg += f': {event_message}'
+            logger.debug(log_msg)
+        return False, reason
+
+    # phase == 'Running' but not all containers running (e.g. one is in
+    # CrashLoopBackOff). Surface tier-1's pending reason -- previously this
+    # returned (False, None) silently, masking OOMKilled etc.
+    return False, container_reason
+
+
 def _reason_is_exempt_from_stall(reason: Optional[str]) -> bool:
     """Whether a pending reason is allowed to persist indefinitely.
 
@@ -1365,6 +1574,222 @@ def _stall_timeout_seconds(reason: Optional[str]) -> int:
     return _POD_RUN_STALL_TIMEOUT_SECONDS
 
 
+def _pending_pod_wait_is_open_ended(
+        pod: Any, reason: Optional[str], context: Optional[str],
+        cluster_name: str) -> Tuple[bool, Optional[str]]:
+    """Whether a pod that has not started may be waited on without a deadline.
+
+    Returns ``(open_ended, fail_message)``. A registered ``PodStartPolicy``
+    decides first: ``WAIT`` makes the wait open-ended whatever the reason says
+    (suppressing the no-progress deadline), ``FAIL`` gives the message
+    provisioning must fail with. Absent an opinion, the built-in exemption
+    decides.
+
+    An open-ended wait is what the park exists for: nothing to do but wait it
+    out, so the request should not spend a worker on it.
+    """
+    verdict = plugin_extensions.PodStartPolicy.get(pod, reason, context,
+                                                   cluster_name)
+    if verdict is not None:
+        decision, message = verdict
+        if decision is plugin_extensions.PodStartVerdict.FAIL:
+            return False, (message or
+                           f'Pod {pod.metadata.name} will not start.')
+        return True, None
+    return _reason_is_exempt_from_stall(reason), None
+
+
+def _pending_reasons_summary(reasons: List[Optional[str]]) -> Optional[str]:
+    """E.g. ``'2 pod(s) pending due to Pulling, 1 pod(s) pending due to X'``.
+
+    None when no pod reported a reason. Shared by the launch spinner and by a
+    parked request's status message, so the two cannot drift.
+    """
+    counts: Dict[str, int] = {}
+    for reason in reasons:
+        if reason is not None:
+            counts[reason] = counts.get(reason, 0) + 1
+    if not counts:
+        return None
+    return ', '.join(f'{count} pod(s) pending due to {reason}'
+                     for reason, count in sorted(counts.items()))
+
+
+class PodsProgressedCondition:
+    """Resume a parked launch once its pods stop being merely slow to start.
+
+    Implements the ``wait()`` continue-condition contract for
+    ``exceptions.ExecutionPausedError`` (duck-typed via its
+    ``continue_condition`` field, like ``locks.LockAcquirableCondition``).
+    Instances are pickled onto the exception, so state stays picklable.
+
+    Resumes when the pods' wait stops being open-ended -- not when they run,
+    and not on any change to the reason. Two invariants rest on that:
+
+    * The park/resume cycle stays finite with no wall-clock deadline, because
+      every resume follows a real exit from the open-ended class. Resuming on
+      any change would not: a pod still pulling an image reads as 'Pulling'
+      until that event ages out of the event window and as 'container
+      creation' after, which is not progress. Progress within the class goes
+      to the status message instead.
+    * The no-progress deadline survives. A pod that goes from pulling an image
+      to failing to mount a volume hands the launch back and is timed as
+      usual; waiting here for it to *run* would suspend that deadline for the
+      length of the park, and it would never fail.
+    """
+
+    def __init__(self, namespace: str, context: Optional[str],
+                 cluster_name: str, cluster_name_on_cloud: str,
+                 pod_names: List[str], reason: Optional[str]) -> None:
+        self.namespace = namespace
+        self.context = context
+        self.cluster_name = cluster_name
+        self.cluster_name_on_cloud = cluster_name_on_cloud
+        self.pod_names = pod_names
+        # The reason the request parked with; refreshes report against it, so
+        # the first one only pushes if there is something new to say.
+        self.reason = reason
+
+    def _poll(self) -> Tuple[bool, Optional[str]]:
+        """Whether to resume, and the reason to report if not.
+
+        Resumes on anything the launch has to act on: a pod gone, a pod
+        failed, a pod whose wait has stopped being open-ended, or all pods
+        running. Goes through the same two functions the wait loop uses
+        (``_inspect_pod_status`` and ``_pending_pod_wait_is_open_ended``), so
+        the two cannot disagree about what a pod is doing.
+        """
+        pods = kubernetes.core_api(self.context).list_namespaced_pod(
+            self.namespace,
+            label_selector=(f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                            f'{self.cluster_name_on_cloud}'),
+            _request_timeout=_POD_POLL_REQUEST_TIMEOUT).items
+        by_name = {pod.metadata.name: pod for pod in pods}
+        if any(name not in by_name for name in self.pod_names):
+            # The set the launch was waiting on no longer exists. Let it
+            # re-run: its own missing-pod handling reports why.
+            return True, None
+        pending: List[Optional[str]] = []
+        for name in self.pod_names:
+            pod = by_name[name]
+            # A terminated pod is the launch's business. Checked before
+            # _inspect_pod_status, which would write the termination cluster
+            # event from the scheduler's monitor thread, and again on re-run.
+            if (pod.metadata.deletion_timestamp is not None or
+                    pod.status.phase == 'Failed'):
+                return True, None
+            try:
+                is_running, reason = _inspect_pod_status(
+                    pod, self.context, self.namespace, self.cluster_name)
+            except config_lib.KubernetesError:
+                # The pod cannot start at all. Same reasoning: let the launch
+                # raise it.
+                return True, None
+            if is_running:
+                continue
+            open_ended, fail_message = _pending_pod_wait_is_open_ended(
+                pod, reason, self.context, self.cluster_name)
+            if fail_message is not None:
+                # The policy's verdict turned while parked. Hand the launch
+                # back rather than raise in the monitor thread: it consults
+                # the same policy and reports through its own error path.
+                return True, None
+            if not open_ended:
+                return True, None
+            pending.append(reason)
+        if not pending:
+            return True, None
+        return False, _pending_reasons_summary(pending)
+
+    def wait(self,
+             *,
+             is_cancelled: Callable[[], bool],
+             fallback_wait_seconds: float,
+             update_status_msg: Optional[Callable[[str], None]] = None) -> bool:
+        """Poll until the pods progress, the cap elapses, or cancelled."""
+        deadline = time.time() + _PARK_MAX_WAIT_SECONDS
+        backoff = common_utils.Backoff(
+            initial_backoff=_PARK_POLL_INITIAL_SECONDS,
+            max_backoff_factor=_PARK_POLL_MAX_FACTOR)
+        consecutive_errors = 0
+        last_message = self.reason
+        last_refresh = time.monotonic()
+        while True:
+            if is_cancelled():
+                logger.info('Request cancelled while paused for pods '
+                            f'{self.pod_names} to start; not rescheduling.')
+                return False
+            try:
+                progressed, reason = self._poll()
+                consecutive_errors = 0
+            except Exception as e:  # pylint: disable=broad-except
+                consecutive_errors += 1
+                logger.warning(f'Error polling pods {self.pod_names} while '
+                               f'paused ({consecutive_errors}/'
+                               f'{_PARK_MAX_CONSECUTIVE_ERRORS}): {e}')
+                if consecutive_errors >= _PARK_MAX_CONSECUTIVE_ERRORS:
+                    # Hand the launch back rather than probe blind: it derives
+                    # the same state itself, and parks again if nothing moved.
+                    time.sleep(fallback_wait_seconds)
+                    return True
+                progressed, reason = False, None
+            if progressed:
+                logger.info(f'Pods {self.pod_names} are no longer waiting on a '
+                            'slow-but-expected step; resuming launch.')
+                return True
+            if time.time() >= deadline:
+                logger.info(f'Pods {self.pod_names} still starting after '
+                            f'{_PARK_MAX_WAIT_SECONDS}s; rescheduling to '
+                            're-evaluate.')
+                return True
+            now = time.monotonic()
+            if now - last_refresh >= _PARK_REASON_REFRESH_SECONDS:
+                last_refresh = now
+                if (reason is not None and reason != last_message and
+                        update_status_msg is not None):
+                    last_message = reason
+                    try:
+                        update_status_msg(reason)
+                    except Exception as e:  # pylint: disable=broad-except
+                        logger.debug(f'Failed to update status message: {e}')
+            time.sleep(backoff.current_backoff())
+
+
+def _park_for_slow_pods(*, namespace: str, context: Optional[str],
+                        cluster_name: str, cluster_name_on_cloud: str,
+                        pod_names: List[str],
+                        pending_reasons: List[Optional[str]]) -> NoReturn:
+    """Raise ExecutionPausedError to free the worker while pods start slowly.
+
+    Called once every pod the launch is still waiting on has an open-ended
+    wait ahead of it. Parking hands that wait to the scheduler, which frees
+    the worker and re-enqueues the request when ``PodsProgressedCondition``
+    says the pods have moved on.
+
+    The pods are kept: the pause is handled without teardown or failover (see
+    ``provisioner.bulk_provision`` and the failover loop in
+    ``cloud_vm_ray_backend``), and the resumed launch adopts them, since pod
+    creation skips pods that already exist. Unwinding this far also releases
+    the cluster status lock, so another operation on the cluster can proceed.
+    """
+    summary = _pending_reasons_summary(pending_reasons)
+    detail = f': {summary}' if summary is not None else ''
+    raise exceptions.ExecutionPausedError(
+        f'Waiting for pod(s) to start{detail}.',
+        hint=('Request will resume once the pods start running or report a '
+              'different reason; follow the wait with `sky api logs`, or drop '
+              'it with `sky api cancel`.'),
+        # Fallback wait used only if the condition's own wait() bails out.
+        retry_wait_seconds=30,
+        continue_condition=PodsProgressedCondition(
+            namespace=namespace,
+            context=context,
+            cluster_name=cluster_name,
+            cluster_name_on_cloud=cluster_name_on_cloud,
+            pod_names=pod_names,
+            reason=summary))
+
+
 @timeline.event
 def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     """Wait for pods and their containers to be ready.
@@ -1377,188 +1802,6 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
 
     # Create a set of pod names we're waiting for
     expected_pod_names = {pod.metadata.name for pod in new_pods}
-
-    def _check_init_containers(pod) -> Optional[_InitContainerProgress]:
-        """Check init containers for errors and return the one holding up pod
-        initialization.
-
-        Returns the first init container that is running, else the first one
-        the kubelet is still creating (pulling its image), else None -- no
-        init container accounts for the pod being uninitialized.
-        Raises KubernetesError if any init container failed.
-        """
-        init_statuses = pod.status.init_container_statuses
-        total = len(init_statuses)
-        running_info: Optional[_InitContainerProgress] = None
-        starting_info: Optional[_InitContainerProgress] = None
-        for idx, init_status in enumerate(init_statuses):
-            init_terminated = init_status.state.terminated
-            if init_terminated:
-                if init_terminated.exit_code != 0:
-                    msg = init_terminated.message if (
-                        init_terminated.message) else str(init_terminated)
-                    raise config_lib.KubernetesError(
-                        'Failed to run init container for pod '
-                        f'{pod.metadata.name}. Error details: {msg}.')
-                continue
-            if (init_status.state.running is not None and running_info is None):
-                running_info = _InitContainerProgress(init_status.name, idx + 1,
-                                                      total, True)
-            init_waiting = init_status.state.waiting
-            if init_waiting is not None:
-                if init_waiting.reason in ('ContainerCreating',
-                                           'PodInitializing'):
-                    # The kubelet is creating it -- most often pulling its
-                    # image, which is legitimately slow. Recorded so the
-                    # no-progress deadline does not mistake it for a stall.
-                    if starting_info is None:
-                        starting_info = _InitContainerProgress(
-                            init_status.name, idx + 1, total, False)
-                else:
-                    # TODO(romilb): There may be more states to check for. Add
-                    #  them as needed.
-                    msg = init_waiting.message if (
-                        init_waiting.message) else str(init_waiting)
-                    unmasked = _unmask_crashloopbackoff_reason(init_status)
-                    reason_text = (unmasked if unmasked is not None else
-                                   (init_waiting.reason or 'Unknown'))
-                    raise config_lib.KubernetesError(
-                        f'Failed to create init container for pod '
-                        f'{pod.metadata.name}. Error details: '
-                        f'{reason_text}: {msg}.')
-        return running_info if running_info is not None else starting_info
-
-    def _inspect_pod_status(pod):
-        # Check if pod is terminated/preempted/failed (unchanged).
-        if (pod.metadata.deletion_timestamp is not None or
-                pod.status.phase == 'Failed'):
-            # Get the reason and write to cluster events before
-            # the pod gets completely deleted from the API.
-            termination_reason = _get_pod_termination_reason(pod, cluster_name)
-            logger.warning(
-                f'Pod {pod.metadata.name} terminated: {termination_reason}')
-            condensed = _condensed_pod_reason(pod)
-            raise config_lib.KubernetesError(
-                f'Pod {pod.metadata.name} failed: {condensed}')
-
-        container_statuses = pod.status.container_statuses
-        # Happy path: pod Running and every container Running (unchanged).
-        if (pod.status.phase == 'Running' and container_statuses is not None and
-                all(container.state.running
-                    for container in container_statuses)):
-            return True, None
-
-        # Tier 1: container-status sweep. Computed once, consumed in both
-        # branches below.
-        container_reason = _get_pod_pending_reason_from_container_status(pod)
-
-        if pod.status.phase == 'Pending':
-            # Today's raise block -- control flow preserved, message enriched
-            # via _unmask_crashloopbackoff_reason when the waiting state is
-            # CrashLoopBackOff. msg body (waiting.message) is always preserved.
-            init_reason: Optional[str] = None
-            # Whether init_reason is an assumption about what the kubelet is
-            # doing rather than something it reported -- see below.
-            init_reason_is_assumed = False
-            if container_statuses is not None:
-                for container_status in container_statuses:
-                    if not container_status.state:
-                        continue
-                    waiting = container_status.state.waiting
-                    if waiting is not None:
-                        if waiting.reason == 'PodInitializing':
-                            init_progress = _check_init_containers(pod)
-                            if init_progress is not None:
-                                verb = ('running' if init_progress.running else
-                                        'starting')
-                                init_reason = (
-                                    f'{_INIT_CONTAINER_REASON_PREFIX}'
-                                    f'{init_progress.name!r} {verb} '
-                                    f'({init_progress.position}/'
-                                    f'{init_progress.total})')
-                                init_reason_is_assumed = (
-                                    not init_progress.running)
-                            else:
-                                # PodInitializing, yet no init container is
-                                # running or being created -- they have all
-                                # terminated successfully and the kubelet has
-                                # simply not moved on to the main containers.
-                                # Nothing here is legitimately slow, so unlike
-                                # the two branches above this reason is not
-                                # exempt from the no-progress deadline.
-                                init_reason = _POD_INITIALIZATION_REASON
-                        elif waiting.reason != 'ContainerCreating':
-                            msg = waiting.message if (
-                                waiting.message) else str(waiting)
-                            unmasked = _unmask_crashloopbackoff_reason(
-                                container_status)
-                            reason_text = (unmasked if unmasked is not None else
-                                           (waiting.reason or 'Unknown'))
-                            raise config_lib.KubernetesError(
-                                f'{reason_text}: {msg}')
-                    terminated = container_status.state.terminated
-                    if terminated is not None and terminated.exit_code != 0:
-                        reason_str = (terminated.reason if terminated.reason
-                                      else f'exit({terminated.exit_code})')
-                        raise config_lib.KubernetesError(
-                            f'Container in pod {pod.metadata.name} '
-                            f'terminated with error while pod is still '
-                            f'pending: {reason_str}. Run '
-                            f'`sky logs --provision {cluster_name}` '
-                            'for more details.')
-
-            # Init container reason wins over all event-based reasons,
-            # since events can retain stale "Pulling image" entries long
-            # after the pull completed.  Otherwise, Tier 1 (container
-            # status) wins; fall back to Tier 2/3 events.
-            reason: Optional[str] = init_reason or container_reason
-            event_message: Optional[str] = None
-            if reason is None:
-                pending_reason = _get_pod_pending_reason(
-                    context, namespace, pod.metadata.name)
-                if pending_reason is not None:
-                    reason, event_message = pending_reason
-            elif init_reason_is_assumed:
-                # 'init container ... starting' says only that the kubelet has
-                # not started the container yet; that this is legitimately slow
-                # work (an image pull of its own) is an assumption, and it is
-                # the assumption that makes the reason stall-exempt. The same
-                # state is what a pod shows when the kubelet cannot get as far
-                # as starting the container at all -- a sandbox it cannot
-                # create, a volume it cannot mount -- which is reported only
-                # through events. So let a live Warning, one the pod has not
-                # already moved past, replace the assumption: it is both the
-                # truer reason and, unlike the init label, bounded by the
-                # no-progress deadline. An allow-listed Normal is not consulted
-                # -- it is exempt either way, and the init label names which
-                # container the pod is waiting on.
-                pending_reason = _get_pod_pending_reason(context,
-                                                         namespace,
-                                                         pod.metadata.name,
-                                                         warnings_only=True)
-                if pending_reason is not None:
-                    reason, event_message = pending_reason
-            if reason is None and _pod_is_scheduled(pod):
-                # A freshly-bound pod that the kubelet has not picked up yet
-                # (and the uninformative 'ContainerCreating' state) has no
-                # container-status reason and no event yet. Default to
-                # 'container creation' so the launch spinner shows useful
-                # detail (e.g. 'Launching (1 pod(s) pending due to container
-                # creation)') instead of a bare 'Launching'. Gate on
-                # _pod_is_scheduled so an unbound pod still waiting for
-                # capacity is not mislabeled as creating a container.
-                reason = _CONTAINER_CREATION_REASON
-            if reason is not None:
-                log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
-                if event_message:
-                    log_msg += f': {event_message}'
-                logger.debug(log_msg)
-            return False, reason
-
-        # phase == 'Running' but not all containers running (e.g. one is in
-        # CrashLoopBackOff). Surface tier-1's pending reason -- previously this
-        # returned (False, None) silently, masking OOMKilled etc.
-        return False, container_reason
 
     # The pending reason each pod is currently being timed against, and when
     # that reason was first seen, keyed by pod name. Reset whenever the reason
@@ -1592,6 +1835,11 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     missing_pods_retry = 0
     transport_error_since: Optional[float] = None
     last_status_msg: Optional[str] = None
+    # When this attempt first saw a pod that was not running yet; measures the
+    # park grace window. Attempt-scoped on purpose: a resumed launch only gets
+    # here after its pods left the open-ended state, so it is timing a new wait
+    # that deserves its own grace.
+    run_wait_started: Optional[float] = None
     while True:
         # Get all pods in a single API call
         cluster_name_on_cloud = new_pods[0].metadata.labels[
@@ -1669,20 +1917,37 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             pod for pod in all_pods if pod.metadata.name in expected_pod_names
         ]
         num_threads = max(1, min(_NUM_THREADS, len(pods_to_check)))
-        pod_statuses = subprocess_utils.run_in_parallel(_inspect_pod_status,
-                                                        pods_to_check,
-                                                        num_threads)
+        pod_statuses = subprocess_utils.run_in_parallel(
+            functools.partial(_inspect_pod_status,
+                              context=context,
+                              namespace=namespace,
+                              cluster_name=cluster_name), pods_to_check,
+            num_threads)
 
         all_pods_running = True
-        pending_reasons_count: Dict[str, int] = {}
+        # Reasons of the pods not running yet; a running pod never reports
+        # one, so this is every reason there is to report.
+        pending_reasons: List[Optional[str]] = []
+        # Not-running pods, and how many of those have an open-ended wait; the
+        # park below needs every one of them to.
+        not_running = 0
+        open_ended_pending = 0
         now = time.time()
         for pod, (is_running, pending_reason) in zip(pods_to_check,
                                                      pod_statuses):
-            if not is_running:
-                all_pods_running = False
-            if pending_reason is not None:
-                pending_reasons_count[pending_reason] = (
-                    pending_reasons_count.get(pending_reason, 0) + 1)
+            pod_name = pod.metadata.name
+            if is_running:
+                stalled_since.pop(pod_name, None)
+                continue
+            all_pods_running = False
+            not_running += 1
+            pending_reasons.append(pending_reason)
+            open_ended, fail_message = _pending_pod_wait_is_open_ended(
+                pod, pending_reason, context, cluster_name)
+            if fail_message is not None:
+                # The policy knows this pod will never start: fail now rather
+                # than wait out a deadline, or a reason that has none.
+                raise config_lib.KubernetesError(fail_message)
             # Escalate a pod that keeps reporting the same condition to a
             # provisioning error. Some kubelet-level failures raise from
             # _inspect_pod_status as soon as they are seen, but the ones that
@@ -1695,8 +1960,8 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             # progress", which holds only because _get_pod_pending_reason will
             # not keep reporting a Warning the pod has already moved past; see
             # its docstring.
-            pod_name = pod.metadata.name
-            if is_running or _reason_is_exempt_from_stall(pending_reason):
+            if open_ended:
+                open_ended_pending += 1
                 stalled_since.pop(pod_name, None)
             else:
                 previous = stalled_since.get(pod_name)
@@ -1709,19 +1974,45 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
         if all_pods_running:
             break
 
-        if pending_reasons_count:
-            msg = ', '.join([
-                f'{count} pod(s) pending due to {reason}'
-                for reason, count in sorted(pending_reasons_count.items())
-            ])
-            status_text = f'Launching ({msg})'
+        if run_wait_started is None:
+            run_wait_started = now
+
+        # Nothing left to do but wait the pods out: park instead of spending
+        # an executor worker on it (see _park_for_slow_pods).
+        #
+        # *Every* not-running pod must be open-ended. Parking while one is
+        # being timed against the no-progress deadline would suspend it --
+        # that deadline is measured within a single attempt -- and the pod
+        # would stop being on its way to failing.
+        #
+        # is_in_request_context() is the sole gate, as for the cluster-lock
+        # park in cloud_vm_ray_backend: an in-process caller has no scheduler
+        # to hand the pause to, and keeps blocking here.
+        if (open_ended_pending == not_running and
+                now - run_wait_started >= _POD_RUN_PARK_GRACE_SECONDS and
+                common_utils.is_in_request_context()):
+            logger.info(
+                f'Pods {sorted(expected_pod_names)} have not started after '
+                f'{now - run_wait_started:.0f}s and are only waiting on '
+                'slow-but-expected steps; releasing the executor worker until '
+                'they progress.')
+            _park_for_slow_pods(namespace=namespace,
+                                context=context,
+                                cluster_name=cluster_name,
+                                cluster_name_on_cloud=cluster_name_on_cloud,
+                                pod_names=sorted(expected_pod_names),
+                                pending_reasons=pending_reasons)
+
+        reasons_summary = _pending_reasons_summary(pending_reasons)
+        if reasons_summary is not None:
+            status_text = f'Launching ({reasons_summary})'
         else:
             status_text = 'Launching'
         new_status_msg = ux_utils.spinner_message(status_text,
                                                   cluster_name=cluster_name)
         if new_status_msg != last_status_msg:
             rich_utils.force_update_status(new_status_msg)
-            if pending_reasons_count:
+            if reasons_summary is not None:
                 # Skip the bare 'Launching' status_text — it duplicates
                 # the badge label and would produce a useless tooltip.
                 # The cluster row is written by add_or_update_cluster

--- a/sky/utils/plugin_extensions/__init__.py
+++ b/sky/utils/plugin_extensions/__init__.py
@@ -10,6 +10,8 @@ from sky.utils.plugin_extensions.external_failure_source import (
 from sky.utils.plugin_extensions.log_delivery_source import LogDeliverySource
 from sky.utils.plugin_extensions.node_info_source import NodeInfoSource
 from sky.utils.plugin_extensions.pod_info_source import PodInfoSource
+from sky.utils.plugin_extensions.pod_start_policy import PodStartPolicy
+from sky.utils.plugin_extensions.pod_start_policy import PodStartVerdict
 from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
 
 __all__ = [
@@ -18,5 +20,7 @@ __all__ = [
     'LogDeliverySource',
     'NodeInfoSource',
     'PodInfoSource',
+    'PodStartPolicy',
+    'PodStartVerdict',
     'RecipeValidator',
 ]

--- a/sky/utils/plugin_extensions/pod_start_policy.py
+++ b/sky/utils/plugin_extensions/pod_start_policy.py
@@ -1,0 +1,149 @@
+"""Deployment-specific policy for a pod that has not started yet.
+
+SkyPilot recognises a fixed set of pending reasons that can legitimately
+persist for a long time (pulling a large image, an external volume
+provisioner, a running init container) and waits them out; everything else is
+failed once it has held the same reason for long enough. That set is
+necessarily incomplete: a deployment with its own CSI driver, admission
+controller or image registry knows about slow steps SkyPilot does not, and can
+often tell that a wait will never succeed long before any deadline expires.
+
+A registered policy says so per pod, with ``WAIT`` (legitimately open-ended:
+the no-progress deadline is suppressed and the launch may park, releasing its
+executor worker) or ``FAIL`` (provisioning fails now, with the policy's
+message). None means no opinion, leaving the built-in classification in
+charge.
+
+Example usage in a plugin:
+    from sky.utils.plugin_extensions import PodStartPolicy
+    from sky.utils.plugin_extensions import PodStartVerdict
+
+    def my_policy(pod, reason, context, cluster_name):
+        if reason == 'MyProvisionerWorking':
+            return PodStartVerdict.WAIT, None
+        if my_probe_says_hopeless(pod, context):
+            return PodStartVerdict.FAIL, 'Storage class X is not available'
+        return None
+
+    PodStartPolicy.register(my_policy)
+
+Example usage in core SkyPilot:
+    verdict = PodStartPolicy.get(pod, reason, context, cluster_name)
+
+Two properties a policy must have:
+
+  * **Cheap, or self-throttled.** It is consulted for every pod that is not
+    running yet, on every poll -- as often as once a second. Probe on a timer
+    of your own rather than on every call.
+  * **Park-transparent.** A launch that parks re-runs from the beginning when
+    it resumes, so a ``FAIL`` verdict has to be reachable again on that
+    re-run: derive it from cluster state, not from a timer living in the
+    process that first saw it.
+"""
+import enum
+from typing import Any, Optional, Protocol, Tuple
+
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
+
+class PodStartVerdict(enum.Enum):
+    """What a policy says about a pod that has not started yet."""
+    # Legitimately open-ended: wait it out, and park rather than hold a worker.
+    WAIT = 'wait'
+    # Will never succeed: fail provisioning now instead of waiting.
+    FAIL = 'fail'
+
+
+class PodStartPolicyFunc(Protocol):
+    """Protocol for a pod-start policy function.
+
+    Returns a ``(verdict, message)`` pair, or None for no opinion. ``message``
+    is the provisioning error for ``FAIL``; it is ignored for ``WAIT``.
+    """
+
+    def __call__(
+        self,
+        pod: Any,
+        reason: Optional[str],
+        context: Optional[str],
+        cluster_name: str,
+    ) -> Optional[Tuple[PodStartVerdict, Optional[str]]]:
+        ...
+
+
+class PodStartPolicy:
+    """Singleton class for the pod-start policy extension point.
+
+    Plugins register their policy during their install() phase; core SkyPilot
+    consults it through get(), which returns None whenever there is no policy
+    or the policy has no opinion.
+    """
+
+    _provider_func: Optional[PodStartPolicyFunc] = None
+
+    @classmethod
+    def register(cls, provider: PodStartPolicyFunc) -> None:
+        """Register a pod-start policy function.
+
+        Only one policy can be registered at a time.
+
+        Args:
+            provider: Function returning a ``(PodStartVerdict, message)`` pair
+                for a pod that has not started yet, or None for no opinion.
+        """
+        cls._provider_func = provider
+        logger.debug('Registered pod-start policy')
+
+    @classmethod
+    def is_registered(cls) -> bool:
+        """Check if a pod-start policy is registered."""
+        return cls._provider_func is not None
+
+    @classmethod
+    def get(
+        cls,
+        pod: Any,
+        reason: Optional[str],
+        context: Optional[str],
+        cluster_name: str,
+    ) -> Optional[Tuple[PodStartVerdict, Optional[str]]]:
+        """Ask the registered policy about a pod that has not started yet.
+
+        Args:
+            pod: The pod, as returned by the Kubernetes API.
+            reason: The pending reason SkyPilot derived, or None if it could
+                not derive one.
+            context: Kubernetes context the pod lives in.
+            cluster_name: SkyPilot cluster the pod belongs to.
+
+        Returns:
+            The policy's ``(verdict, message)``, or None when no policy is
+            registered, it has no opinion, or it failed.
+
+        A policy that raises or answers malformedly is treated as having no
+        opinion rather than failing the launch: this runs inside the
+        provisioning wait, where an escaping exception would abort a launch
+        that is merely slow.
+        """
+        if cls._provider_func is None:
+            return None
+        try:
+            # pylint: disable=not-callable
+            verdict = cls._provider_func(pod, reason, context, cluster_name)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Pod-start policy failed: {e}')
+            return None
+        if verdict is None:
+            return None
+        if not isinstance(verdict, tuple) or len(verdict) != 2:
+            logger.debug(f'Pod-start policy returned {verdict!r}, expected a '
+                         '(PodStartVerdict, message) pair; ignoring.')
+            return None
+        decision, message = verdict
+        if not isinstance(decision, PodStartVerdict):
+            logger.debug(f'Pod-start policy returned verdict {decision!r}, '
+                         'expected a PodStartVerdict; ignoring.')
+            return None
+        return decision, message

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -18,6 +18,7 @@ from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import instance
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.instance import logger
+from sky.utils import plugin_extensions
 from sky.utils import subprocess_utils
 
 
@@ -4901,3 +4902,767 @@ class TestGetMissingNodeReason:
 
     def test_unexpected_error_is_swallowed(self):
         assert self._reason({'node-1': RuntimeError('boom')}) is None
+
+
+def _make_run_wait_pod(name, *, running=False):
+    """A node-bound pod for the _wait_for_pods_to_run loop.
+
+    Pending with a plain 'ContainerCreating' container, so the reason it
+    reports comes from _get_pod_pending_reason (stubbed by the harnesses
+    below) or, when that has nothing, from the 'container creation' fallback.
+    """
+    from sky.provision import constants as prov_constants
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod.metadata.deletion_timestamp = None
+    pod.metadata.labels = {
+        prov_constants.TAG_SKYPILOT_CLUSTER_NAME: 'cn-on-cloud',
+    }
+    cs = mock.MagicMock()
+    cs.state.terminated = None
+    cs.last_state.terminated = None
+    if running:
+        pod.status.phase = 'Running'
+        cs.state.waiting = None
+        cs.state.running = mock.MagicMock()
+    else:
+        pod.status.phase = 'Pending'
+        cs.state.waiting = mock.MagicMock(reason='ContainerCreating',
+                                          message=None)
+        cs.state.running = None
+    pod.status.container_statuses = [cs]
+    pod.status.init_container_statuses = []
+    return pod
+
+
+class TestPendingReasonsSummary:
+    """The one phrasing shared by the launch spinner and a parked request."""
+
+    def test_counts_and_orders_reasons(self):
+        assert instance._pending_reasons_summary(
+            ['Pulling', 'Pulling',
+             'Provisioning']) == ('1 pod(s) pending due to Provisioning, '
+                                  '2 pod(s) pending due to Pulling')
+
+    def test_pods_without_a_reason_are_not_counted(self):
+        # A pod that cannot say why it is pending contributes nothing to
+        # report -- but it must not be counted as a reason of its own either.
+        assert instance._pending_reasons_summary(['Pulling',
+                                                  None]) == ('1 pod(s) pending '
+                                                             'due to Pulling')
+
+    @pytest.mark.parametrize('reasons', [[], [None], [None, None]])
+    def test_nothing_to_report(self, reasons):
+        assert instance._pending_reasons_summary(reasons) is None
+
+
+class TestWaitForPodsToRunPark:
+    """_wait_for_pods_to_run parks the request while its pods are only slow.
+
+    The reasons exempt from the no-progress deadline have no deadline at all,
+    so a launch behind one would hold its executor worker for as long as the
+    work takes. Inside a request context the wait goes to the scheduler
+    instead; outside one there is no scheduler to hand it to.
+    """
+
+    def _run_wait(self,
+                  monkeypatch,
+                  *,
+                  reasons_by_pod,
+                  in_request_context=True,
+                  clock_step=301.0,
+                  running_after=None,
+                  policy=None,
+                  max_iterations=200):
+        """Drive _wait_for_pods_to_run over the pods named in reasons_by_pod.
+
+        Each value is that pod's event-derived pending reason (None -> the
+        'container creation' fallback). The fake clock advances by
+        `clock_step` per iteration; `running_after` makes every pod Running
+        from that iteration on, so a test asserting the wait does *not* park
+        terminates instead of hanging.
+        """
+        names = list(reasons_by_pod)
+        pending = [_make_run_wait_pod(n) for n in names]
+        running = [_make_run_wait_pod(n, running=True) for n in names]
+        iteration = {'n': -1}
+
+        core_api = mock.MagicMock()
+
+        def _list_pods(*args, **kwargs):
+            del args, kwargs  # unused
+            iteration['n'] += 1
+            if iteration['n'] > max_iterations:
+                raise AssertionError(
+                    '_wait_for_pods_to_run did not terminate within '
+                    f'{max_iterations} iterations')
+            if running_after is not None and iteration['n'] >= running_after:
+                return mock.MagicMock(items=running)
+            return mock.MagicMock(items=pending)
+
+        core_api.list_namespaced_pod.side_effect = _list_pods
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        def _pending_reason(context, namespace, pod_name, warnings_only=False):
+            del context, namespace  # unused
+            reason = reasons_by_pod[pod_name]
+            if reason is None:
+                return None
+            if (warnings_only and
+                    reason in instance._PENDING_REASON_NORMAL_EVENT_ALLOWLIST):
+                return None
+            return reason, 'event detail'
+
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            _pending_reason)
+
+        clock = {'t': 1000.0}
+        monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
+
+        def _sleep(seconds):
+            del seconds  # unused
+            clock['t'] += clock_step
+
+        monkeypatch.setattr(instance.time, 'sleep', _sleep)
+        monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                            lambda fn, items, n: [fn(p) for p in items])
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+        monkeypatch.setattr('sky.utils.common_utils.is_in_request_context',
+                            lambda: in_request_context)
+        # Set the singleton's slot directly so monkeypatch restores it: a
+        # policy leaking into another test would be invisible and confusing.
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            policy)
+
+        instance._wait_for_pods_to_run(namespace='ns',
+                                       context='ctx',
+                                       cluster_name='cn',
+                                       new_pods=pending)
+
+    def test_parks_once_every_pod_is_only_slow(self, monkeypatch):
+        with pytest.raises(sky_exceptions.ExecutionPausedError) as exc_info:
+            self._run_wait(monkeypatch, reasons_by_pod={'pod-0': 'Pulling'})
+        err = exc_info.value
+        assert '1 pod(s) pending due to Pulling' in str(err)
+        condition = err.continue_condition
+        assert isinstance(condition, instance.PodsProgressedCondition)
+        assert condition.pod_names == ['pod-0']
+        assert condition.cluster_name_on_cloud == 'cn-on-cloud'
+        # The reason carried into the wait is the one the request parked with,
+        # so the first refresh only pushes if there is something new to say.
+        assert condition.reason == '1 pod(s) pending due to Pulling'
+
+    def test_parks_on_the_no_event_container_creation_fallback(
+            self, monkeypatch):
+        # 'container creation' is what a pod reports before the kubelet says
+        # anything, and also what one still pulling an image reports once its
+        # 'Pulling' event has aged out of the event window. It is the most
+        # common park trigger, so it must work with no event at all.
+        with pytest.raises(sky_exceptions.ExecutionPausedError) as exc_info:
+            self._run_wait(monkeypatch, reasons_by_pod={'pod-0': None})
+        assert instance._CONTAINER_CREATION_REASON in str(exc_info.value)
+
+    def test_no_park_before_the_grace_window(self, monkeypatch):
+        # An ordinary container start must not pay for a park: five iterations
+        # of 10s is 50s, well inside the grace window.
+        self._run_wait(monkeypatch,
+                       reasons_by_pod={'pod-0': 'Pulling'},
+                       clock_step=10.0,
+                       running_after=5)
+
+    def test_no_park_outside_a_request_context(self, monkeypatch):
+        # An in-process caller has no scheduler to hand the pause to. 150
+        # iterations at 301s is over 12 simulated hours of image pull.
+        self._run_wait(monkeypatch,
+                       reasons_by_pod={'pod-0': 'Pulling'},
+                       in_request_context=False,
+                       running_after=150)
+
+    def test_no_park_while_any_pod_is_non_exempt(self, monkeypatch):
+        """The park must not suspend the no-progress deadline.
+
+        It is measured within a single attempt, so a park resets it: a launch
+        with one legitimately-slow pod and one on its way to failing must stay
+        here and let the second fail.
+        """
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            self._run_wait(monkeypatch,
+                           reasons_by_pod={
+                               'pod-0': 'Pulling',
+                               'pod-1': 'FailedCreatePodSandBox',
+                           })
+        msg = str(exc_info.value)
+        assert 'FailedCreatePodSandBox' in msg
+        assert 'pod-1' in msg
+
+    def test_parks_a_multi_node_launch_once_all_of_it_is_slow(
+            self, monkeypatch):
+        with pytest.raises(sky_exceptions.ExecutionPausedError) as exc_info:
+            self._run_wait(monkeypatch,
+                           reasons_by_pod={
+                               'pod-0': 'Pulling',
+                               'pod-1': 'Provisioning',
+                           })
+        err = exc_info.value
+        assert ('1 pod(s) pending due to Provisioning, '
+                '1 pod(s) pending due to Pulling') in str(err)
+        assert err.continue_condition.pod_names == ['pod-0', 'pod-1']
+
+    def test_a_running_pod_does_not_hold_up_the_park(self, monkeypatch):
+        # Only the pods still being waited on are considered: a launch whose
+        # head pod is already up must still park for the worker that is not.
+        names = ['pod-0', 'pod-1']
+        pods = [
+            _make_run_wait_pod('pod-0', running=True),
+            _make_run_wait_pod('pod-1'),
+        ]
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.return_value = mock.MagicMock(items=pods)
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: ('Pulling', 'event detail'))
+        clock = {'t': 1000.0}
+        monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
+        monkeypatch.setattr(instance.time, 'sleep',
+                            lambda _s: clock.update(t=clock['t'] + 301.0))
+        monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                            lambda fn, items, n: [fn(p) for p in items])
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+        monkeypatch.setattr('sky.utils.common_utils.is_in_request_context',
+                            lambda: True)
+        with pytest.raises(sky_exceptions.ExecutionPausedError) as exc_info:
+            instance._wait_for_pods_to_run(namespace='ns',
+                                           context='ctx',
+                                           cluster_name='cn',
+                                           new_pods=pods)
+        err = exc_info.value
+        assert str(err).count('pod(s) pending') == 1
+        assert '1 pod(s) pending due to Pulling' in str(err)
+        # The condition still watches the whole set, so it can tell when the
+        # launch has nothing left to wait for.
+        assert err.continue_condition.pod_names == names
+
+
+class TestPodsProgressedCondition:
+    """The wait a launch parked by _wait_for_pods_to_run resumes on."""
+
+    @staticmethod
+    def _condition(
+            pod_names=('pod-0',), reason='1 pod(s) pending due to '
+        'Pulling'):
+        return instance.PodsProgressedCondition(
+            namespace='ns',
+            context='ctx',
+            cluster_name='cn',
+            cluster_name_on_cloud='cn-on-cloud',
+            pod_names=list(pod_names),
+            reason=reason)
+
+    def _run(self,
+             monkeypatch,
+             *,
+             polls,
+             pods_present=('pod-0',),
+             pod_names=('pod-0',),
+             cancelled_after=None,
+             list_raises=None,
+             update_status_msg=None,
+             monotonic_step=0.0,
+             clock_step=1.0,
+             terminated=(),
+             policy=None,
+             max_polls=60):
+        """Drive wait() with a scripted _inspect_pod_status per poll.
+
+        `polls` is a list of {pod_name: (is_running, reason)} or
+        {pod_name: exception}; the last entry repeats. `list_raises` makes the
+        pod LIST fail on every poll instead. Pods named in `terminated` are
+        listed as phase Failed. Returns (result, poll_count).
+        """
+        present = []
+        for name in pods_present:
+            pod = mock.MagicMock()
+            pod.metadata.name = name
+            # Not deleted, and not Failed unless the test says so: the
+            # condition checks both before it classifies a pod, and an
+            # auto-created MagicMock attribute would read as truthy.
+            pod.metadata.deletion_timestamp = None
+            pod.status.phase = ('Failed' if name in terminated else 'Pending')
+            present.append(pod)
+        state = {'i': -1}
+
+        core_api = mock.MagicMock()
+
+        def _list(*args, **kwargs):
+            del args, kwargs  # unused
+            state['i'] += 1
+            if state['i'] > max_polls:
+                raise AssertionError(
+                    f'wait() did not terminate within {max_polls} polls')
+            if list_raises is not None:
+                raise list_raises
+            return mock.MagicMock(items=present)
+
+        core_api.list_namespaced_pod.side_effect = _list
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        def _inspect(pod, context, namespace, cluster_name):
+            del context, namespace, cluster_name  # unused
+            entry = polls[min(state['i'], len(polls) - 1)]
+            value = entry[pod.metadata.name]
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        monkeypatch.setattr(instance, '_inspect_pod_status', _inspect)
+
+        clock = {'t': 1000.0, 'm': 500.0}
+        monkeypatch.setattr(instance.time, 'time', lambda: clock['t'])
+        monkeypatch.setattr(instance.time, 'monotonic', lambda: clock['m'])
+
+        def _sleep(seconds):
+            del seconds  # unused
+            clock['t'] += clock_step
+            clock['m'] += monotonic_step
+
+        monkeypatch.setattr(instance.time, 'sleep', _sleep)
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            policy)
+
+        result = self._condition(pod_names=pod_names).wait(
+            is_cancelled=lambda:
+            (cancelled_after is not None and state['i'] >= cancelled_after),
+            fallback_wait_seconds=0,
+            update_status_msg=update_status_msg)
+        return result, state['i'] + 1
+
+    def test_resumes_once_all_pods_run(self, monkeypatch):
+        result, polls = self._run(monkeypatch, polls=[{'pod-0': (True, None)}])
+        assert result is True
+        assert polls == 1
+
+    def test_resumes_when_a_pod_leaves_the_exempt_set(self, monkeypatch):
+        """The regression this design exists to prevent.
+
+        Pulling an image -> failing to mount a volume moves the pod from a
+        reason with no deadline to one with a ten-minute deadline. The launch
+        must be handed back so that deadline runs; waiting here for the pod to
+        *run* would mean it never failed.
+        """
+        result, polls = self._run(monkeypatch,
+                                  polls=[{
+                                      'pod-0': (False, 'Pulling')
+                                  }, {
+                                      'pod-0': (False, 'FailedMount')
+                                  }])
+        assert result is True
+        assert polls == 2
+
+    def test_keeps_waiting_while_the_reason_stays_exempt(self, monkeypatch):
+        """A change *within* the exempt set is not a reason to resume.
+
+        A pod still pulling an image reads as 'Pulling' until that event ages
+        out and as 'container creation' after. Resuming on that would re-run
+        the launch for a change that is not one.
+        """
+        result, polls = self._run(
+            monkeypatch,
+            polls=[{
+                'pod-0': (False, 'Pulling')
+            }, {
+                'pod-0': (False, instance._CONTAINER_CREATION_REASON)
+            }, {
+                'pod-0': (False, 'Pulling')
+            }] + [{
+                'pod-0': (False, instance._CONTAINER_CREATION_REASON)
+            }] * 20 + [{
+                'pod-0': (True, None)
+            }])
+        assert result is True
+        assert polls == 24
+
+    def test_resumes_when_a_pod_is_missing(self, monkeypatch):
+        # The set the launch was waiting on is gone (e.g. evicted): hand it
+        # back so its own missing-pod handling reports why.
+        result, polls = self._run(monkeypatch,
+                                  polls=[{
+                                      'pod-0': (False, 'Pulling')
+                                  }],
+                                  pods_present=())
+        assert result is True
+        assert polls == 1
+
+    def test_resumes_on_a_terminated_pod_without_inspecting_it(
+            self, monkeypatch):
+        """A terminated pod is the launch's business.
+
+        _inspect_pod_status writes the termination reason to the cluster events
+        as a side effect, so calling it here would emit that event from the
+        monitor thread and again from the re-run. The stub raises if reached.
+        """
+
+        def _must_not_run(*args, **kwargs):
+            del args, kwargs  # unused
+            raise AssertionError('_inspect_pod_status must not be called for '
+                                 'a terminated pod')
+
+        monkeypatch.setattr(instance, '_inspect_pod_status', _must_not_run)
+        # _run patches _inspect_pod_status too, so undo that afterwards by
+        # driving wait() directly against a Failed pod.
+        pod = mock.MagicMock()
+        pod.metadata.name = 'pod-0'
+        pod.metadata.deletion_timestamp = None
+        pod.status.phase = 'Failed'
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.return_value = mock.MagicMock(items=[pod])
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+        assert self._condition().wait(is_cancelled=lambda: False,
+                                      fallback_wait_seconds=0) is True
+
+    def test_resumes_when_a_pod_cannot_start(self, monkeypatch):
+        # _inspect_pod_status raises for a pod that cannot start at all (a
+        # failed init container, an image it cannot pull). The launch owns
+        # teardown and failover for that, so resume rather than raise here, in
+        # the scheduler's monitor thread.
+        result, polls = self._run(
+            monkeypatch,
+            polls=[{
+                'pod-0': config_lib.KubernetesError('pod-0 failed')
+            }])
+        assert result is True
+        assert polls == 1
+
+    def test_waits_for_every_pod_of_a_multi_node_launch(self, monkeypatch):
+        result, polls = self._run(monkeypatch,
+                                  pods_present=('pod-0', 'pod-1'),
+                                  pod_names=('pod-0', 'pod-1'),
+                                  polls=[{
+                                      'pod-0': (True, None),
+                                      'pod-1': (False, 'Pulling'),
+                                  }, {
+                                      'pod-0': (True, None),
+                                      'pod-1': (True, None),
+                                  }])
+        assert result is True
+        assert polls == 2
+
+    def test_cancelled_while_parked_is_not_rescheduled(self, monkeypatch):
+        result, _ = self._run(monkeypatch,
+                              polls=[{
+                                  'pod-0': (False, 'Pulling')
+                              }],
+                              cancelled_after=1)
+        assert result is False
+
+    def test_refreshes_the_status_message_when_the_reason_changes(
+            self, monkeypatch):
+        pushed = []
+        # One refresh interval per poll, so every change is eligible to push.
+        result, _ = self._run(
+            monkeypatch,
+            polls=[{
+                'pod-0': (False, 'Pulling')
+            }, {
+                'pod-0': (False, 'Provisioning')
+            }, {
+                'pod-0': (True, None)
+            }],
+            monotonic_step=instance._PARK_REASON_REFRESH_SECONDS,
+            update_status_msg=pushed.append)
+        assert result is True
+        # 'Pulling' is what the request parked with, so only the change to
+        # 'Provisioning' is worth pushing.
+        assert pushed == ['1 pod(s) pending due to Provisioning']
+
+    def test_hands_the_launch_back_after_repeated_poll_errors(
+            self, monkeypatch):
+        # Probing blind is worse than letting the launch re-derive the state
+        # itself: it parks again if the pods are still only slow.
+        result, polls = self._run(monkeypatch,
+                                  polls=[{
+                                      'pod-0': (False, 'Pulling')
+                                  }],
+                                  list_raises=RuntimeError('api down'))
+        assert result is True
+        assert polls == instance._PARK_MAX_CONSECUTIVE_ERRORS
+
+    def test_reschedules_at_the_safety_cap(self, monkeypatch):
+        # Not a deadline: the launch re-runs, re-derives the same state and
+        # parks again. It exists so a condition that is silently wrong cannot
+        # hold a request forever.
+        result, polls = self._run(monkeypatch,
+                                  polls=[{
+                                      'pod-0': (False, 'Pulling')
+                                  }],
+                                  clock_step=instance._PARK_MAX_WAIT_SECONDS,
+                                  max_polls=5)
+        assert result is True
+        assert polls == 2
+
+    def test_is_picklable(self):
+        # The condition rides on the pausing exception across the
+        # worker/scheduler process boundary.
+        import pickle
+        condition = self._condition(pod_names=('pod-0', 'pod-1'))
+        restored = pickle.loads(pickle.dumps(condition))
+        assert restored.pod_names == ['pod-0', 'pod-1']
+        assert restored.cluster_name_on_cloud == 'cn-on-cloud'
+        assert restored.reason == condition.reason
+
+    def test_the_pausing_exception_round_trips(self):
+        import pickle
+        with pytest.raises(sky_exceptions.ExecutionPausedError) as exc_info:
+            instance._park_for_slow_pods(namespace='ns',
+                                         context='ctx',
+                                         cluster_name='cn',
+                                         cluster_name_on_cloud='cn-on-cloud',
+                                         pod_names=['pod-0'],
+                                         pending_reasons=['Pulling'])
+        restored = pickle.loads(pickle.dumps(exc_info.value))
+        assert '1 pod(s) pending due to Pulling' in str(restored)
+        assert isinstance(restored.continue_condition,
+                          instance.PodsProgressedCondition)
+        assert restored.continue_condition.pod_names == ['pod-0']
+
+
+class TestPodStartPolicyExtensionPoint:
+    """The registry itself: a policy is advice, never a way to break a launch."""
+
+    def test_no_policy_registered_has_no_opinion(self, monkeypatch):
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            None)
+        assert plugin_extensions.PodStartPolicy.is_registered() is False
+        assert plugin_extensions.PodStartPolicy.get(mock.MagicMock(), 'Pulling',
+                                                    'ctx', 'cn') is None
+
+    def test_verdict_is_passed_through(self, monkeypatch):
+        seen = {}
+
+        def _policy(pod, reason, context, cluster_name):
+            seen.update(reason=reason,
+                        context=context,
+                        cluster_name=cluster_name,
+                        pod=pod)
+            return plugin_extensions.PodStartVerdict.FAIL, 'no such class'
+
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            _policy)
+        pod = mock.MagicMock()
+        assert plugin_extensions.PodStartPolicy.is_registered() is True
+        assert plugin_extensions.PodStartPolicy.get(
+            pod, 'FailedMount', 'ctx',
+            'cn') == (plugin_extensions.PodStartVerdict.FAIL, 'no such class')
+        assert seen == {
+            'reason': 'FailedMount',
+            'context': 'ctx',
+            'cluster_name': 'cn',
+            'pod': pod,
+        }
+
+    def test_a_raising_policy_is_treated_as_no_opinion(self, monkeypatch):
+        """An escaping exception would abort a launch that is merely slow."""
+
+        def _policy(pod, reason, context, cluster_name):
+            del pod, reason, context, cluster_name  # unused
+            raise RuntimeError('policy is broken')
+
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            _policy)
+        assert plugin_extensions.PodStartPolicy.get(mock.MagicMock(), 'Pulling',
+                                                    'ctx', 'cn') is None
+
+    @pytest.mark.parametrize('returned', [
+        pytest.param('fail', id='bare-string'),
+        pytest.param(('fail', 'msg'), id='string-instead-of-verdict'),
+        pytest.param((None,), id='wrong-arity'),
+    ])
+    def test_a_malformed_verdict_is_ignored(self, monkeypatch, returned):
+        monkeypatch.setattr(plugin_extensions.PodStartPolicy, '_provider_func',
+                            lambda *a, **kw: returned)
+        assert plugin_extensions.PodStartPolicy.get(mock.MagicMock(), 'Pulling',
+                                                    'ctx', 'cn') is None
+
+
+class TestPodStartPolicyInTheRunWait:
+    """A registered policy decides before the built-in exemption does.
+
+    WAIT makes a wait open-ended whatever the reason says, suppressing the
+    no-progress deadline and allowing the park; FAIL fails provisioning
+    without waiting for any deadline.
+    """
+
+    @staticmethod
+    def _verdict_for(reason_to_verdict):
+
+        def _policy(pod, reason, context, cluster_name):
+            del pod, context, cluster_name  # unused
+            return reason_to_verdict.get(reason)
+
+        return _policy
+
+    def test_wait_suppresses_the_no_progress_deadline_and_parks(
+            self, monkeypatch):
+        """The 'add an exempt scenario' case.
+
+        'FailedCreatePodSandBox' is not exempt built-in, so without a policy
+        this pod fails at the no-progress deadline. A policy that calls it
+        legitimately slow must get it parked instead.
+        """
+        with pytest.raises(sky_exceptions.ExecutionPausedError):
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={'pod-0': 'FailedCreatePodSandBox'},
+                policy=self._verdict_for({
+                    'FailedCreatePodSandBox':
+                        (plugin_extensions.PodStartVerdict.WAIT, None),
+                }))
+
+    def test_fail_stops_the_wait_without_parking(self, monkeypatch):
+        """The 'this will never succeed' case.
+
+        'Pulling' is exempt built-in, so without a policy this pod is parked
+        and waited on forever. A policy that knows better must fail
+        provisioning, with its own message.
+        """
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={'pod-0': 'Pulling'},
+                policy=self._verdict_for({
+                    'Pulling': (plugin_extensions.PodStartVerdict.FAIL,
+                                'registry mirror is decommissioned'),
+                }))
+        assert 'registry mirror is decommissioned' in str(exc_info.value)
+
+    def test_fail_without_a_message_still_names_the_pod(self, monkeypatch):
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={'pod-0': 'Pulling'},
+                policy=self._verdict_for({
+                    'Pulling': (plugin_extensions.PodStartVerdict.FAIL, None),
+                }))
+        assert 'pod-0' in str(exc_info.value)
+
+    def test_one_failed_verdict_fails_a_launch_whose_others_are_slow(
+            self, monkeypatch):
+        """FAIL is per pod and is not diluted by the park's "every pod" rule.
+
+        The park needs every not-running pod to be open-ended; a FAIL verdict
+        needs only one pod, and is checked inside the per-pod loop, so it is
+        reached whatever the other pods are doing.
+        """
+        with pytest.raises(config_lib.KubernetesError) as exc_info:
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={
+                    'pod-0': 'Pulling',
+                    'pod-1': 'Provisioning',
+                },
+                policy=self._verdict_for({
+                    'Provisioning': (plugin_extensions.PodStartVerdict.FAIL,
+                                     'volume backend is gone'),
+                }))
+        assert 'volume backend is gone' in str(exc_info.value)
+
+    def test_wait_suppresses_the_deadline_with_the_park_disabled(
+            self, monkeypatch):
+        """Suppression, established directly rather than inferred.
+
+        The park firing does not by itself show the deadline was suppressed --
+        it fires one iteration earlier than the deadline would. Outside a
+        request context there is no park, so 150 iterations of 301s (over 12
+        simulated hours against a 10-minute deadline) can only complete if the
+        deadline never ran.
+        """
+        TestWaitForPodsToRunPark()._run_wait(
+            monkeypatch,
+            reasons_by_pod={'pod-0': 'FailedCreatePodSandBox'},
+            in_request_context=False,
+            running_after=150,
+            policy=self._verdict_for({
+                'FailedCreatePodSandBox':
+                    (plugin_extensions.PodStartVerdict.WAIT, None),
+            }))
+
+    def test_no_opinion_leaves_the_built_in_behaviour(self, monkeypatch):
+        # A policy that answers None for everything must be
+        # indistinguishable from no policy at all.
+        with pytest.raises(sky_exceptions.ExecutionPausedError):
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={'pod-0': 'Pulling'},
+                policy=self._verdict_for({}))
+
+    def test_a_raising_policy_leaves_the_built_in_behaviour(self, monkeypatch):
+
+        def _policy(pod, reason, context, cluster_name):
+            del pod, reason, context, cluster_name  # unused
+            raise RuntimeError('policy is broken')
+
+        with pytest.raises(sky_exceptions.ExecutionPausedError):
+            TestWaitForPodsToRunPark()._run_wait(
+                monkeypatch,
+                reasons_by_pod={'pod-0': 'Pulling'},
+                policy=_policy)
+
+
+class TestPodStartPolicyWhileParked:
+    """The verdict is re-asked on every poll of the parked wait."""
+
+    @staticmethod
+    def _verdict_for(reason_to_verdict):
+
+        def _policy(pod, reason, context, cluster_name):
+            del pod, context, cluster_name  # unused
+            return reason_to_verdict.get(reason)
+
+        return _policy
+
+    def test_wait_keeps_a_non_exempt_pod_parked(self, monkeypatch):
+        """Without the policy, 'FailedMount' would resume on the first poll.
+
+        Three polls of it before the pod runs proves the parked wait consults
+        the verdict, not the built-in exemption.
+        """
+        result, polls = TestPodsProgressedCondition()._run(
+            monkeypatch,
+            polls=[{
+                'pod-0': (False, 'FailedMount')
+            }] * 3 + [{
+                'pod-0': (True, None)
+            }],
+            policy=self._verdict_for({
+                'FailedMount': (plugin_extensions.PodStartVerdict.WAIT, None),
+            }))
+        assert result is True
+        assert polls == 4
+
+    def test_fail_turning_while_parked_hands_the_launch_back(self, monkeypatch):
+        """The case this extension point exists for.
+
+        The policy learns mid-park that the wait is hopeless. The condition
+        must resume, not raise in the monitor thread, so the launch re-runs,
+        consults the same policy and reports through its own error path.
+        """
+        result, polls = TestPodsProgressedCondition()._run(
+            monkeypatch,
+            polls=[{
+                'pod-0': (False, 'Pulling')
+            }],
+            policy=self._verdict_for({
+                'Pulling': (plugin_extensions.PodStartVerdict.FAIL,
+                            'image was deleted from the registry'),
+            }))
+        assert result is True
+        assert polls == 1


### PR DESCRIPTION
The pending reasons that `_wait_for_pods_to_run` exempts from the no-progress deadline have no deadline by design. A launch behind one of them therefore held its request executor worker for as long as the underlying work took, with nothing to do but wait, starving the pool for launches that could otherwise proceed.

This PR park the request in these cases to release the executor pool

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
