### PR TITLE
[Volume] Refresh a volume's size from the cloud, not only at creation

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -25,6 +25,8 @@ from sky.utils import common_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import decimal
+
     import kubernetes
     import urllib3
     import urllib3.exceptions
@@ -427,6 +429,18 @@ def watch(context: Optional[str] = None):
     w = kubernetes.watch.Watch()
     w._api_client = _get_api_client(context)  # pylint: disable=protected-access
     return w
+
+
+def parse_quantity(quantity: str) -> 'decimal.Decimal':
+    """Parses a Kubernetes resource quantity into a number of bytes.
+
+    Kubernetes' own grammar, which is not SkyPilot's: a bare number is bytes,
+    and both binary (`10Gi`) and decimal (`2G`) suffixes are legal, as is
+    exponent notation. Anything read off an object the cluster owns has to be
+    read with these rules -- a claim SkyPilot did not create is written
+    however its author wrote it.
+    """
+    return kubernetes.utils.parse_quantity(quantity)
 
 
 def api_exception():

--- a/sky/models.py
+++ b/sky/models.py
@@ -140,6 +140,25 @@ class KubernetesNodesInfo:
         )
 
 
+@dataclasses.dataclass
+class ObservedVolumeState:
+    """The fields of a volume that the cloud owns, as the cloud reports them.
+
+    ``VolumeConfig`` doubles as the request SkyPilot made and the state the
+    cloud is in, and only the request is known when the volume is created --
+    storage can be expanded, and a provisioner can round a request up. This
+    carries what a later look at the cloud found, so the recorded config can be
+    brought back in line with it.
+
+    A field left None means the cloud reported nothing for it, which must never
+    be read as "the recorded value is gone".
+    """
+    # The capacity the volume actually has, in the same units as
+    # ``VolumeConfig.size``.
+    size: Optional[str] = None
+    storage_class_name: Optional[str] = None
+
+
 class VolumeConfig(pydantic.BaseModel):
     """Configuration for creating a volume."""
     # If any fields changed, increment the version. For backward compatibility,

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -307,13 +307,16 @@ def map_all_volumes_usedby(
 
 
 @_route_to_cloud_impl
-def get_all_volumes_errors(
+def get_all_volumes_state(
     provider_name: str, configs: List[models.VolumeConfig]
-) -> Tuple[Dict[str, Optional[str]], Set[str]]:
-    """Get error messages for all volumes.
+) -> Tuple[Dict[str, Optional[str]], Dict[str, models.ObservedVolumeState],
+           Set[str]]:
+    """Get the cloud's view of all volumes.
 
     Checks if volumes have errors (e.g., pending state due to
-    misconfiguration) and returns appropriate error messages.
+    misconfiguration), and reports the fields the cloud owns rather than the
+    stored config -- a volume's size can change on the cloud side long after
+    it was created.
 
     Args:
         provider_name: Name of the provider.
@@ -322,18 +325,21 @@ def get_all_volumes_errors(
     Returns:
         errors: Dict mapping volume name to an error message, or to None
           when the volume is healthy.
+        observed: Dict mapping volume name to the cloud-owned fields the
+          cloud reported for it. A volume may be absent, and any field may be
+          None: both mean "no answer", never "the recorded value is gone".
         failed_volume_names: Set of volume names whose status could not be
           determined because the cloud could not be queried. A volume listed
           here must keep its recorded status; absence from ``errors`` alone
           does not mean healthy.
 
         An implementation should place every input config in exactly one of
-        the two. A volume in neither means this provider does not check
-        volume errors, as with the default below.
+        errors and failed_volume_names. A volume in neither means this
+        provider does not check volume errors, as with the default below.
     """
     # Default implementation reports no errors (no error checking)
     del provider_name, configs
-    return {}, set()
+    return {}, {}, set()
 
 
 @_route_to_cloud_impl

--- a/sky/provision/kubernetes/__init__.py
+++ b/sky/provision/kubernetes/__init__.py
@@ -14,7 +14,7 @@ from sky.provision.kubernetes.network import open_ports
 from sky.provision.kubernetes.network import query_ports
 from sky.provision.kubernetes.volume import apply_volume
 from sky.provision.kubernetes.volume import delete_volume
-from sky.provision.kubernetes.volume import get_all_volumes_errors
+from sky.provision.kubernetes.volume import get_all_volumes_state
 from sky.provision.kubernetes.volume import get_all_volumes_usedby
 from sky.provision.kubernetes.volume import get_volume_usedby
 from sky.provision.kubernetes.volume import map_all_volumes_usedby

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -706,25 +706,34 @@ def _get_pvc_error(context: Optional[str], namespace: str,
     return None
 
 
-def get_all_volumes_errors(
+def get_all_volumes_state(
     configs: List[models.VolumeConfig],
-) -> Tuple[Dict[str, Optional[str]], Set[str]]:
-    """Gets error messages for all Kubernetes PVC volumes.
+) -> Tuple[Dict[str, Optional[str]], Dict[str, models.ObservedVolumeState],
+           Set[str]]:
+    """Gets the cluster's view of all Kubernetes PVC volumes.
+
+    Both the error check and the cloud-owned fields come out of the same PVC
+    objects, so they are read in one pass: no volume can be judged against one
+    version of a PVC and described from another, and the listing is not paid
+    for twice.
 
     Args:
         configs: List of VolumeConfig objects.
 
     Returns:
-        A tuple of (errors, failed_volume_names):
+        A tuple of (errors, observed, failed_volume_names):
         - errors maps volume name to an error message, or to None when the
           volume is healthy.
+        - observed maps volume name to what the PVC reports about the fields
+          the cluster owns. Absent for a volume whose PVC could not be read.
         - failed_volume_names holds volumes whose status could not be
           determined because the cluster could not be queried. Callers must
           leave the recorded status of these volumes untouched rather than
           reading their absence from ``errors`` as "healthy".
 
-        Every input config lands in exactly one of the two, so a caller never
-        has to guess what an absent volume means.
+        Every input config lands in exactly one of errors and
+        failed_volume_names, so a caller never has to guess what an absent
+        volume means.
     """
     # Keyed by (context, namespace): the same PVC name may exist in several
     # namespaces, and resolving it against the wrong one would mismatch.
@@ -732,6 +741,7 @@ def get_all_volumes_errors(
                                                     models.VolumeConfig]] = {}
 
     volume_errors: Dict[str, Optional[str]] = {}
+    observed: Dict[str, models.ObservedVolumeState] = {}
     failed_volume_names: Set[str] = set()
 
     for config in configs:
@@ -768,6 +778,7 @@ def get_all_volumes_errors(
             seen_pvc_names.add(pvc.metadata.name)
             volume_errors[vol_config.name] = _get_pvc_error(
                 context, namespace, pvc)
+            observed[vol_config.name] = _observed_volume_state(pvc)
 
         # A registered PVC missing from the labelled listing is either a
         # use_existing volume (adopted as-is, so it never got the skypilot
@@ -802,8 +813,9 @@ def get_all_volumes_errors(
                 continue
             volume_errors[vol_config.name] = _get_pvc_error(
                 context, namespace, pvc)
+            observed[vol_config.name] = _observed_volume_state(pvc)
 
-    return volume_errors, failed_volume_names
+    return volume_errors, observed, failed_volume_names
 
 
 def _check_storage_class_volume_binding_mode(context: Optional[str],
@@ -891,6 +903,65 @@ def _check_pvc_access_mode_error(context: Optional[str],
             f'kubectl describe pvc {pvc_name} -n {namespace}')
 
 
+def _pvc_capacity(pvc_obj: Any) -> Optional[str]:
+    """Returns the capacity the PVC's bound volume actually has, if any.
+
+    ``status.capacity`` is the real size of the underlying volume, while
+    ``spec.resources.requests`` is only what was asked for: a request can be
+    rounded up by the provisioner, expanded later, or not yet fulfilled. A
+    claim that is not bound reports nothing here.
+    """
+    capacity = getattr(getattr(pvc_obj, 'status', None), 'capacity', None)
+    if isinstance(capacity, dict):
+        return capacity.get('storage')
+    return None
+
+
+def _parse_pvc_size(size_quantity: Optional[str],
+                    pvc_name: str) -> Optional[str]:
+    """Normalizes a Kubernetes storage quantity to a volume size, or None.
+
+    Shared by the create and refresh paths so the two cannot record the same
+    PVC differently.
+    """
+    if not size_quantity:
+        return None
+    try:
+        # Normalize to GB string (e.g., '20')
+        size = resources_utils.parse_memory_resource(size_quantity,
+                                                     'size',
+                                                     allow_rounding=True)
+    except ValueError as e:
+        # Just log the error since it is not critical.
+        logger.warning(f'Failed to parse PVC size {size_quantity!r} '
+                       f'for PVC {pvc_name}: {e}')
+        return None
+    if size == '0':
+        # Rounded down from a sub-Gi quantity. Volume creation rejects '0' as a
+        # size, so recording it here would put a value in the database that the
+        # same volume could not have been created with.
+        logger.warning(f'Ignoring PVC size {size_quantity!r} for PVC '
+                       f'{pvc_name}: rounds to less than 1Gi.')
+        return None
+    return size
+
+
+def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
+    """Reads the fields of a PVC that the cluster, not our config, owns.
+
+    Only reports what the PVC actually says, so that a caller merging this into
+    a recorded config never clears a value it cannot see.
+    """
+    pvc_name = pvc_obj.metadata.name
+    return models.ObservedVolumeState(
+        size=_parse_pvc_size(_pvc_capacity(pvc_obj), pvc_name),
+        # An empty storageClassName is the Kubernetes way of opting out of
+        # dynamic provisioning, not a class name to record.
+        storage_class_name=(getattr(pvc_obj.spec, 'storage_class_name', None) or
+                            None),
+    )
+
+
 def _populate_config_from_pvc(config: models.VolumeConfig,
                               pvc_obj: Any) -> None:
     """Populate missing fields in config from a PVC object.
@@ -923,28 +994,14 @@ def _populate_config_from_pvc(config: models.VolumeConfig,
             config.config['access_mode'] = pvc_access_mode
 
     # Populate size if not set (prefer bound capacity, fallback to requested)
-    pvc_size = None
-    size_quantity = None
-    # Try status.capacity (dict) - actual bound size
-    capacity = getattr(getattr(pvc_obj, 'status', None), 'capacity', None)
-    if isinstance(capacity, dict) and 'storage' in capacity:
-        size_quantity = capacity['storage']
+    size_quantity = _pvc_capacity(pvc_obj)
     # Fallback to spec.resources.requests (dict) - requested size
     if size_quantity is None:
         requests = getattr(getattr(pvc_obj.spec, 'resources', None), 'requests',
                            None)
         if isinstance(requests, dict):
             size_quantity = requests.get('storage')
-    # Parse and normalize the size if found
-    if size_quantity:
-        try:
-            # Normalize to GB string (e.g., '20')
-            pvc_size = resources_utils.parse_memory_resource(
-                size_quantity, 'size', allow_rounding=True)
-        except ValueError as e:
-            # Just log the error since it is not critical.
-            logger.warning(f'Failed to parse PVC size {size_quantity!r} '
-                           f'for PVC {pvc_name}: {e}')
+    pvc_size = _parse_pvc_size(size_quantity, pvc_name)
     if pvc_size is not None:
         if config.size is not None and config.size != pvc_size:
             logger.warning(f'PVC {pvc_name} has size {pvc_size} but config '

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -1,4 +1,5 @@
 """Kubernetes volume provisioning (PVC and hostPath)."""
+import decimal
 import enum
 import re
 import time as time_module
@@ -12,10 +13,13 @@ from sky.provision import constants
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
-from sky.utils import resources_utils
 from sky.utils import volume as volume_lib
 
 logger = sky_logging.init_logger(__name__)
+
+# A volume's size is recorded in gibibytes, which is also the unit the PVC
+# spec is written in.
+_BYTES_PER_GIB = 1024**3
 
 PVC_FAILING_EVENT_REASONS = ('ProvisioningFailed',)
 WARNING_EVENT_TYPE = 'Warning'
@@ -919,31 +923,43 @@ def _pvc_capacity(pvc_obj: Any) -> Optional[str]:
 
 def _parse_pvc_size(size_quantity: Optional[str],
                     pvc_name: str) -> Optional[str]:
-    """Normalizes a Kubernetes storage quantity to a volume size, or None.
+    """Normalizes a Kubernetes storage quantity to a volume size in GiB.
 
     Shared by the create and refresh paths so the two cannot record the same
     PVC differently.
+
+    Parsed by the Kubernetes client rather than `resources_utils`, which reads
+    a quantity by SkyPilot's rules rather than Kubernetes': a bare number is
+    bytes to Kubernetes and gigabytes to SkyPilot, and the decimal suffixes a
+    claim can perfectly well be written with (`2G`, `500M`) are not units it
+    knows at all. A claim SkyPilot did not create -- which is every
+    `use_existing` volume -- is written however its author wrote it.
+
+    Rounds to the nearest GiB, since that is the only unit a volume's size is
+    recorded in: a claim written `2G` is 1.86GiB, and reporting 1Gi for it
+    would look like half the volume went missing.
     """
     if not size_quantity:
         return None
     try:
-        # Normalize to GB string (e.g., '20')
-        size = resources_utils.parse_memory_resource(size_quantity,
-                                                     'size',
-                                                     allow_rounding=True)
-    except ValueError as e:
-        # Just log the error since it is not critical.
+        size_bytes = kubernetes.parse_quantity(size_quantity)
+        size = int(
+            decimal.Decimal(size_bytes / _BYTES_PER_GIB).quantize(
+                decimal.Decimal('1'), rounding=decimal.ROUND_HALF_UP))
+    except Exception as e:  # pylint: disable=broad-except
+        # Just log the error since it is not critical: a volume whose size
+        # cannot be read keeps the one already recorded.
         logger.warning(f'Failed to parse PVC size {size_quantity!r} '
                        f'for PVC {pvc_name}: {e}')
         return None
-    if size == '0':
-        # Rounded down from a sub-Gi quantity. Volume creation rejects '0' as a
-        # size, so recording it here would put a value in the database that the
-        # same volume could not have been created with.
+    if size <= 0:
+        # Under half a gibibyte. Volume creation rejects '0' as a size, so
+        # recording it here would put a value in the database that the same
+        # volume could not have been created with.
         logger.warning(f'Ignoring PVC size {size_quantity!r} for PVC '
                        f'{pvc_name}: rounds to less than 1Gi.')
         return None
-    return size
+    return str(size)
 
 
 def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -29,6 +29,37 @@ VOLUME_LOCK_PATH = os.path.expanduser('~/.sky/.{volume_name}.lock')
 VOLUME_LOCK_TIMEOUT_SECONDS = 20
 
 
+def _apply_observed_state(
+        config: models.VolumeConfig,
+        observed: Optional[models.ObservedVolumeState]) -> bool:
+    """Brings a volume config in line with what the cloud reports.
+
+    Returns whether anything changed, so a config that already matches is not
+    re-pickled and re-written on every refresh.
+
+    Only fields the cloud owns are touched, and only when it reported one: a
+    missing value means the cloud had no answer, never that the recorded value
+    should be dropped.
+    """
+    if observed is None:
+        return False
+    changed = False
+    if observed.size is not None and observed.size != config.size:
+        logger.info(f'Volume {config.name} size changed from '
+                    f'{config.size} to {observed.size}.')
+        config.size = observed.size
+        changed = True
+    # Back-fill only. A storage class is fixed once the backing resource has
+    # one, so a recorded value is not something the cloud can contradict --
+    # but volumes created before SkyPilot read it back, or before the cluster
+    # had a default class to assign, have nothing recorded at all.
+    if (observed.storage_class_name is not None and
+            config.config.get('storage_class_name') is None):
+        config.config['storage_class_name'] = observed.storage_class_name
+        changed = True
+    return changed
+
+
 def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
     """Refreshes volume status by querying cloud APIs.
 
@@ -72,22 +103,26 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
         cloud_to_volume_names.setdefault(cloud, set()).add(volume.get('name'))
         volume_name_to_config[volume.get('name')] = config
 
-    # Check for volume errors (e.g., misconfiguration)
+    # Check for volume errors (e.g., misconfiguration), and read back the
+    # fields the cloud owns rather than the config.
     cloud_to_volume_errors: Dict[str, Dict[str, Optional[str]]] = {}
+    cloud_to_observed: Dict[str, Dict[str, models.ObservedVolumeState]] = {}
     cloud_to_error_failed_names: Dict[str, Set[str]] = {}
     for cloud, configs in cloud_to_configs.items():
         try:
-            # A cloud with no error check of its own returns both empty, which
+            # A cloud with no error check of its own returns all empty, which
             # leaves its volumes eligible for a status update driven by their
             # usedby info alone.
-            volume_errors, error_failed_names = (
-                provision.get_all_volumes_errors(cloud, configs))
+            volume_errors, observed, error_failed_names = (
+                provision.get_all_volumes_state(cloud, configs))
             cloud_to_volume_errors[cloud] = volume_errors
+            cloud_to_observed[cloud] = observed
             cloud_to_error_failed_names[cloud] = error_failed_names
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(
                 f'Failed to get volume errors for volumes on {cloud}: {e}')
             cloud_to_volume_errors[cloud] = {}
+            cloud_to_observed[cloud] = {}
             # Do not let an unreadable cloud silently clear every volume's
             # error and mark them all healthy -- keep their current status.
             cloud_to_error_failed_names[cloud] = cloud_to_volume_names.get(
@@ -197,6 +232,13 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             # the region to the in-cluster context name for these volumes.
             need_refresh, volume_config = provision.refresh_volume_config(
                 volume_config.cloud, volume_config)
+            # The observed state was read before the lock, so it is merged into
+            # the handle just re-read under it, not into the copy it was fetched
+            # with.
+            if _apply_observed_state(
+                    volume_config,
+                    cloud_to_observed.get(cloud, {}).get(volume_name)):
+                need_refresh = True
             if need_refresh:
                 global_user_state.update_volume_config(volume_name,
                                                        volume_config)
@@ -379,8 +421,8 @@ def _initial_volume_status(
     optimistic behavior everywhere else on this path.
     """
     try:
-        volume_errors, failed_volume_names = provision.get_all_volumes_errors(
-            cloud, [config])
+        volume_errors, _, failed_volume_names = (
+            provision.get_all_volumes_state(cloud, [config]))
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Failed to check the initial status of volume '
                      f'{config.name}: {e}')

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -24,7 +24,7 @@ import pathlib
 import shlex
 import tempfile
 import textwrap
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import jinja2
 import pytest
@@ -2607,6 +2607,105 @@ def test_volume_mix_on_kubernetes():
             timeout=25 * 60,
         )
         smoke_tests_utils.run_one_test(test)
+
+
+# ---------- A volume's recorded size follows its actual capacity ----------
+@pytest.mark.kubernetes
+# Creates and recreates the PVC with the agent's own kubectl, which a remote
+# server's agent does not have.
+@pytest.mark.no_remote_server
+def test_volume_size_resync_on_kubernetes():
+    """The recorded size has to follow the storage, not the original request.
+
+    A volume's size is written once, when it is created or registered, so a
+    volume whose backing storage changed afterwards kept advertising its
+    original size forever -- in `sky volumes ls` and on the dashboard, which
+    reads the same record.
+
+    Expansion is how that happens in the wild, but it needs a StorageClass whose
+    provisioner runs a resizer sidecar, which the CI clusters do not have: the
+    request is accepted and then never carried out. Recreating the claim at a
+    different size under the same name moves the same field (the PVC's
+    status.capacity) and is read back by the same code, and it is a real
+    scenario for a `use_existing` volume, whose PVC lifecycle SkyPilot does not
+    own.
+    """
+    storage_class = smoke_tests_utils.rwx_storage_class_name()
+    if storage_class is None:
+        pytest.skip(
+            'Needs a StorageClass that binds without a consumer. The default '
+            'local-path class is WaitForFirstConsumer, so its claims stay '
+            'Pending -- and a Pending claim reports no capacity to read back.')
+    name = smoke_tests_utils.get_cluster_name()
+    # `--use-existing` finds the PVC by the volume's own name.
+    pvc = name
+
+    def create_pvc(size: str) -> str:
+        return (f'kubectl delete pvc {pvc} --ignore-not-found --wait=true && '
+                f'kubectl create -f - <<EOF\n'
+                f'apiVersion: v1\n'
+                f'kind: PersistentVolumeClaim\n'
+                f'metadata:\n'
+                f'  name: {pvc}\n'
+                f'spec:\n'
+                f'  accessModes:\n'
+                f'    - ReadWriteMany\n'
+                f'  storageClassName: {storage_class}\n'
+                f'  resources:\n'
+                f'    requests:\n'
+                f'      storage: {size}\n'
+                f'EOF')
+
+    def wait_for_capacity(size: str) -> str:
+        # The size is only readable once the claim is bound; until then the
+        # capacity field does not exist.
+        return (f'start=$SECONDS; '
+                f'while true; do '
+                f'  cap=$(kubectl get pvc {pvc} '
+                f'-o jsonpath="{{.status.capacity.storage}}" || true); '
+                f'  echo "PVC capacity: $cap"; '
+                f'  [ "$cap" = "{size}" ] && break; '
+                f'  if (( $SECONDS - $start > 120 )); then '
+                f'    echo "Timeout waiting for PVC {pvc} to report {size}"; '
+                f'    kubectl describe pvc {pvc}; exit 1; '
+                f'  fi; '
+                f'  sleep 5; '
+                f'done')
+
+    def size_is(size: str, was: Optional[str] = None) -> str:
+        # -w so the size cannot be matched by another column of the same row.
+        cmd = (f'vols=$(sky volumes ls) && echo "$vols" && '
+               f'echo "$vols" | grep {name} | grep -w "{size}"')
+        if was is not None:
+            # The old size has to be gone, not merely accompanied.
+            cmd += f' && ! echo "$vols" | grep {name} | grep -qw "{was}"'
+        return cmd
+
+    test = smoke_tests_utils.Test(
+        'volume_size_resync_on_kubernetes',
+        [
+            f'echo "StorageClass under test: {storage_class}"',
+            create_pvc('2Gi'),
+            wait_for_capacity('2Gi'),
+            # No --size: the recorded size has to come from the claim, so that
+            # the check below cannot pass on what the command line said.
+            f'sky volumes apply -y -n {name} --type k8s-pvc '
+            f'{smoke_tests_utils.AGENT_K8S_INFRA} --use-existing',
+            size_is('2Gi'),
+            # The storage changes behind SkyPilot's back.
+            create_pvc('5Gi'),
+            wait_for_capacity('5Gi'),
+            # `ls --refresh` runs the same refresh the background daemon runs,
+            # without waiting out its interval.
+            f'sky volumes ls --refresh > /dev/null',
+            size_is('5Gi', was='2Gi'),
+        ],
+        smoke_tests_utils.chain_teardown(
+            f'sky volumes delete {name} -y || true',
+            f'kubectl delete pvc {pvc} --ignore-not-found'),
+        timeout=10 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
 
 
 # ---------- Container logs from task on Kubernetes ----------

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -23,8 +23,8 @@ def mock_no_volume_errors(monkeypatch):
     the cloud, so a test that asserts on the refresh outcome has to say what
     the check found.
     """
-    monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                        mock.MagicMock(return_value=({}, set())))
+    monkeypatch.setattr(provision, 'get_all_volumes_state',
+                        mock.MagicMock(return_value=({}, {}, set())))
 
 
 class TestVolumeCore:
@@ -1205,10 +1205,9 @@ class TestVolumeCore:
         monkeypatch.setattr(provision, 'get_all_volumes_usedby',
                             mock_get_all_usedby)
 
-        # Mock get_all_volumes_errors
+        # Mock get_all_volumes_state
         mock_get_errors = mock.MagicMock(return_value={})
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            mock_get_errors)
+        monkeypatch.setattr(provision, 'get_all_volumes_state', mock_get_errors)
 
         # Mock filelock
         mock_filelock = mock.MagicMock()
@@ -1496,13 +1495,12 @@ class TestVolumeCore:
         mock_get_volumes = mock.MagicMock(return_value=mock_volumes)
         monkeypatch.setattr(global_user_state, 'get_volumes', mock_get_volumes)
 
-        # Mock get_all_volumes_errors to return an error
+        # Mock get_all_volumes_state to return an error
         error_msg = 'PVC access mode mismatch: PVC requests ReadWriteOnce'
         mock_get_errors = mock.MagicMock(return_value=({
             'test-volume': error_msg
-        }, set()))
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            mock_get_errors)
+        }, {}, set()))
+        monkeypatch.setattr(provision, 'get_all_volumes_state', mock_get_errors)
 
         mock_get_all_usedby = mock.MagicMock(return_value=({}, {}, set()))
         monkeypatch.setattr(provision, 'get_all_volumes_usedby',
@@ -1872,10 +1870,10 @@ class TestInitialVolumeStatus:
 
     def test_bound_volume_is_ready(self, monkeypatch):
         config = _make_volume_config()
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            lambda cloud, configs: ({
-                                'test-vol': None
-                            }, set()))
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_state', lambda cloud, configs: ({
+                'test-vol': None
+            }, {}, set()))
 
         status, error = core._initial_volume_status('Kubernetes', config)
 
@@ -1887,9 +1885,9 @@ class TestInitialVolumeStatus:
         just-created volume must not be advertised as usable."""
         config = _make_volume_config()
         monkeypatch.setattr(
-            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+            provision, 'get_all_volumes_state', lambda cloud, configs: ({
                 'test-vol': 'PVC is pending.'
-            }, set()))
+            }, {}, set()))
 
         status, error = core._initial_volume_status('Kubernetes', config)
 
@@ -1898,8 +1896,8 @@ class TestInitialVolumeStatus:
 
     def test_unqueryable_volume_is_ready(self, monkeypatch):
         config = _make_volume_config()
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            lambda cloud, configs: ({}, {'test-vol'}))
+        monkeypatch.setattr(provision, 'get_all_volumes_state',
+                            lambda cloud, configs: ({}, {}, {'test-vol'}))
 
         status, error = core._initial_volume_status('Kubernetes', config)
 
@@ -1913,7 +1911,7 @@ class TestInitialVolumeStatus:
             raise RuntimeError('kube API unreachable')
 
         config = _make_volume_config()
-        monkeypatch.setattr(provision, 'get_all_volumes_errors', _raise)
+        monkeypatch.setattr(provision, 'get_all_volumes_state', _raise)
 
         status, error = core._initial_volume_status('Kubernetes', config)
 
@@ -1974,7 +1972,7 @@ class TestVolumeRefreshErrorFetchFailure:
         def _raise(cloud, configs):
             raise RuntimeError('kube API unreachable')
 
-        monkeypatch.setattr(provision, 'get_all_volumes_errors', _raise)
+        monkeypatch.setattr(provision, 'get_all_volumes_state', _raise)
 
         core.volume_refresh()
 
@@ -1985,8 +1983,8 @@ class TestVolumeRefreshErrorFetchFailure:
         volumes must not get frozen by the failed-fetch guard."""
         mock_update_status = self._setup(monkeypatch,
                                          status_lib.VolumeStatus.READY, None)
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            lambda cloud, configs: ({}, set()))
+        monkeypatch.setattr(provision, 'get_all_volumes_state',
+                            lambda cloud, configs: ({}, {}, set()))
         monkeypatch.setattr(provision, 'map_all_volumes_usedby',
                             mock.MagicMock(return_value=(['pod-a'], [])))
 
@@ -2001,9 +1999,9 @@ class TestVolumeRefreshErrorFetchFailure:
         mock_update_status = self._setup(monkeypatch,
                                          status_lib.VolumeStatus.READY, None)
         monkeypatch.setattr(
-            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+            provision, 'get_all_volumes_state', lambda cloud, configs: ({
                 'test-volume': 'PVC is pending.'
-            }, set()))
+            }, {}, set()))
 
         core.volume_refresh()
 
@@ -2041,9 +2039,9 @@ class TestVolumeApplyRecordsInitialStatus:
     def test_unbound_volume_is_recorded_not_ready(self, monkeypatch):
         mock_add_volume = self._setup(monkeypatch)
         monkeypatch.setattr(
-            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+            provision, 'get_all_volumes_state', lambda cloud, configs: ({
                 'test-vol': 'PVC is pending.'
-            }, set()))
+            }, {}, set()))
 
         core.volume_apply(name='test-vol',
                           volume_type='k8s-pvc',
@@ -2061,10 +2059,10 @@ class TestVolumeApplyRecordsInitialStatus:
 
     def test_bound_volume_is_recorded_ready(self, monkeypatch):
         mock_add_volume = self._setup(monkeypatch)
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            lambda cloud, configs: ({
-                                'test-vol': None
-                            }, set()))
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_state', lambda cloud, configs: ({
+                'test-vol': None
+            }, {}, set()))
 
         core.volume_apply(name='test-vol',
                           volume_type='k8s-pvc',
@@ -2100,9 +2098,8 @@ class TestEphemeralVolumeSkipsStatusProbe:
         monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
                             mock.MagicMock())
         monkeypatch.setattr(global_user_state, 'add_volume', mock.MagicMock())
-        mock_get_errors = mock.MagicMock(return_value=({}, set()))
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            mock_get_errors)
+        mock_get_errors = mock.MagicMock(return_value=({}, {}, set()))
+        monkeypatch.setattr(provision, 'get_all_volumes_state', mock_get_errors)
 
         core.volume_apply(name='eph-vol',
                           volume_type='k8s-pvc',
@@ -2146,8 +2143,8 @@ class TestVolumeRefreshScopedToNames:
         }
 
     def _patch_common(self, monkeypatch, wanted):
-        monkeypatch.setattr(provision, 'get_all_volumes_errors',
-                            mock.MagicMock(return_value=({}, set())))
+        monkeypatch.setattr(provision, 'get_all_volumes_state',
+                            mock.MagicMock(return_value=({}, {}, set())))
         monkeypatch.setattr(provision, 'get_all_volumes_usedby',
                             mock.MagicMock(return_value=({}, {}, set())))
         monkeypatch.setattr(provision, 'map_all_volumes_usedby',
@@ -2254,3 +2251,146 @@ class TestVolumeListReportsWhetherTheErrorMayResolve:
                                 volume_utils.PVC_PROVISIONING_MESSAGE)
 
         assert 'error_may_resolve' in record.model_dump()
+
+
+class TestVolumeRefreshObservedState:
+    """The refresh has to bring cloud-owned fields back in line.
+
+    A volume's size is recorded when it is created, so a volume whose storage
+    was expanded afterwards keeps advertising the size it started with -- on
+    the dashboard, in `sky volumes ls`, and to anyone planning capacity.
+    """
+
+    def _config(self, size='10240', config=None):
+        return models.VolumeConfig(
+            _version=1,
+            name='checkpoints',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='checkpoints-abc123',
+            size=size,
+            config=config
+            if config is not None else {'namespace': 'my-namespace'},
+        )
+
+    def _volume(self, handle):
+        return {
+            'name': 'checkpoints',
+            'launched_at': 1234567890,
+            'user_hash': 'user123',
+            'workspace': 'default',
+            'last_attached_at': None,
+            'last_use': None,
+            'handle': handle,
+            'status': status_lib.VolumeStatus.READY,
+            'is_ephemeral': False,
+            'usedby_pods': [],
+            'usedby_clusters': [],
+            'error_message': None,
+        }
+
+    def _refresh(self, monkeypatch, handle, observed, errors=None, failed=None):
+        """Runs volume_refresh over one volume and returns the config writes."""
+        volume = self._volume(handle)
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=[volume]))
+        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                            mock.MagicMock(return_value=volume))
+        monkeypatch.setattr(global_user_state, 'update_volume_status',
+                            mock.MagicMock())
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_state',
+            mock.MagicMock(return_value=(errors if errors is not None else {
+                'checkpoints': None
+            }, observed, failed if failed is not None else set())))
+        monkeypatch.setattr(provision, 'get_all_volumes_usedby',
+                            mock.MagicMock(return_value=({}, {}, set())))
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock.MagicMock(return_value=([], [])))
+        monkeypatch.setattr(
+            provision, 'refresh_volume_config',
+            mock.MagicMock(side_effect=lambda cloud, c: (False, c)))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        update_config = mock.MagicMock()
+        monkeypatch.setattr(global_user_state, 'update_volume_config',
+                            update_config)
+
+        core.volume_refresh()
+        return update_config
+
+    def test_an_expanded_volume_is_recorded_at_its_new_size(self, monkeypatch):
+        handle = self._config(size='10240')
+
+        update_config = self._refresh(
+            monkeypatch, handle,
+            {'checkpoints': models.ObservedVolumeState(size='25600')})
+
+        update_config.assert_called_once()
+        assert update_config.call_args[0][1].size == '25600'
+
+    def test_a_volume_that_still_matches_is_not_rewritten(self, monkeypatch):
+        """The daemon runs every minute; an unchanged volume must not cost a
+        pickle and a database write each time."""
+        handle = self._config(size='25600')
+
+        update_config = self._refresh(
+            monkeypatch, handle,
+            {'checkpoints': models.ObservedVolumeState(size='25600')})
+
+        update_config.assert_not_called()
+
+    def test_a_cloud_with_no_answer_leaves_the_size_alone(self, monkeypatch):
+        handle = self._config(size='10240')
+
+        update_config = self._refresh(
+            monkeypatch, handle,
+            {'checkpoints': models.ObservedVolumeState(size=None)})
+
+        update_config.assert_not_called()
+        assert handle.size == '10240'
+
+    def test_an_unreadable_cloud_leaves_the_size_alone(self, monkeypatch):
+        """A volume whose PVC could not be read must keep what it has, rather
+        than be described from an answer nobody got."""
+        handle = self._config(size='10240')
+
+        update_config = self._refresh(monkeypatch,
+                                      handle, {},
+                                      errors={},
+                                      failed={'checkpoints'})
+
+        update_config.assert_not_called()
+        assert handle.size == '10240'
+
+    def test_a_missing_storage_class_is_filled_in(self, monkeypatch):
+        """Volumes created before SkyPilot read the class back have none
+        recorded, even though their PVC has one."""
+        handle = self._config(config={'namespace': 'my-namespace'})
+
+        update_config = self._refresh(
+            monkeypatch, handle, {
+                'checkpoints':
+                    models.ObservedVolumeState(storage_class_name='premium-rwo')
+            })
+
+        update_config.assert_called_once()
+        assert update_config.call_args[0][1].config[
+            'storage_class_name'] == 'premium-rwo'
+
+    def test_a_recorded_storage_class_is_not_overwritten(self, monkeypatch):
+        handle = self._config(config={
+            'namespace': 'my-namespace',
+            'storage_class_name': 'standard-rwo',
+        })
+
+        update_config = self._refresh(
+            monkeypatch, handle, {
+                'checkpoints':
+                    models.ObservedVolumeState(storage_class_name='premium-rwo')
+            })
+
+        update_config.assert_not_called()
+        assert handle.config['storage_class_name'] == 'standard-rwo'

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -1205,8 +1205,9 @@ class TestVolumeCore:
         monkeypatch.setattr(provision, 'get_all_volumes_usedby',
                             mock_get_all_usedby)
 
-        # Mock get_all_volumes_state
-        mock_get_errors = mock.MagicMock(return_value={})
+        # Reports the volume healthy, so that it reaches the usedby check this
+        # test is about instead of being skipped by the error-fetch guard.
+        mock_get_errors = mock.MagicMock(return_value=({}, {}, set()))
         monkeypatch.setattr(provision, 'get_all_volumes_state', mock_get_errors)
 
         # Mock filelock

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -2499,6 +2499,9 @@ class TestCreatePVCWithUseExisting:
     @patch('sky.provision.kubernetes.volume.kubernetes')
     def test_use_existing_populates_config(self, mock_k8s, mock_find_pvc):
         """Test use_existing populates config from found PVC."""
+        # Sizes are read with Kubernetes' quantity grammar, so the mocked
+        # adaptor has to keep that one real for the size to be read at all.
+        mock_k8s.parse_quantity = kubernetes.parse_quantity
         mock_pvc = MockPVC('myvolume-abc123',
                            'my-namespace',
                            storage_class='fast-ssd',
@@ -2870,3 +2873,46 @@ class TestObservedVolumeState:
         assert errors == {'host-vol': None}
         assert observed == {}
         assert not failed
+
+
+class TestPvcSizeQuantities:
+    """Sizes are read with Kubernetes' quantity grammar, not SkyPilot's.
+
+    A claim SkyPilot did not create -- which is every `use_existing` volume --
+    is written however its author wrote it, and the two grammars disagree on
+    the two things most likely to appear: a bare number is bytes to Kubernetes
+    and gibibytes to SkyPilot, and `2G` is a legal claim size that SkyPilot's
+    parser does not recognise at all.
+    """
+
+    @pytest.mark.parametrize('quantity,expected', [
+        ('10Gi', '10'),
+        ('1Ti', '1024'),
+        ('25Ti', '25600'),
+        ('100Mi', None),
+        ('2G', '2'),
+        ('1G', '1'),
+        ('500M', None),
+        ('2T', '1863'),
+        ('1e9', '1'),
+        ('1000', None),
+        ('512', None),
+        ('1.5Gi', '2'),
+        (None, None),
+        ('', None),
+        ('garbage', None),
+    ])
+    def test_a_quantity_reads_as_kubernetes_means_it(self, quantity, expected):
+        assert k8s_volume._parse_pvc_size(quantity, 'test-pvc') == expected
+
+    def test_a_bare_number_is_bytes_not_gibibytes(self):
+        """The reading that would overstate a volume a billionfold."""
+        assert k8s_volume._parse_pvc_size('10240', 'test-pvc') is None
+
+    def test_a_decimal_suffix_is_read_rather_than_dropped(self):
+        """`2G` is 2e9 bytes, which is 1.86GiB -- recorded as the nearest GiB
+        rather than discarded, and not confused with 2Gi."""
+        assert k8s_volume._parse_pvc_size('2G', 'test-pvc') == '2'
+        assert k8s_volume._parse_pvc_size('2Gi', 'test-pvc') == '2'
+        assert k8s_volume._parse_pvc_size('2000G', 'test-pvc') == '1863'
+        assert k8s_volume._parse_pvc_size('2000Gi', 'test-pvc') == '2000'

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1728,8 +1728,8 @@ class TestRefreshVolumeConfig:
         assert config.region == 'existing-context'
 
 
-class TestGetAllVolumesErrors:
-    """Tests for get_all_volumes_errors function."""
+class TestGetAllVolumesState:
+    """Tests for get_all_volumes_state function."""
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
     @patch('sky.adaptors.kubernetes.core_api')
@@ -1757,7 +1757,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         assert errors.get('test-vol') is None
 
@@ -1800,7 +1800,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         assert 'test-vol' in errors
         assert errors['test-vol'] is not None
@@ -1852,7 +1852,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         assert 'test-vol' in errors
         assert 'access mode mismatch' in errors['test-vol'].lower()
@@ -1900,7 +1900,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         # Should be None for WaitForFirstConsumer
         assert errors.get('test-vol') is None
@@ -1944,7 +1944,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         # Should be None when storage class read fails
         assert errors.get('test-vol') is None
@@ -1983,7 +1983,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         # Should be None when storage class read fails
         assert errors.get('test-vol') is None
@@ -2014,7 +2014,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         assert 'test-vol' in errors
         assert 'Lost' in errors['test-vol']
@@ -2044,7 +2044,7 @@ class TestGetAllVolumesErrors:
 
         # Should not raise. The volume must be reported as failed rather than
         # simply omitted -- an omitted volume reads as healthy to the caller.
-        errors, failed = k8s_volume.get_all_volumes_errors([config])
+        errors, _, failed = k8s_volume.get_all_volumes_state([config])
         assert errors == {}
         assert failed == {'test-vol'}
 
@@ -2063,7 +2063,7 @@ class TestGetAllVolumesErrors:
             config={'host_path': '/mnt/data'},
         )
 
-        errors, failed = k8s_volume.get_all_volumes_errors([config])
+        errors, _, failed = k8s_volume.get_all_volumes_state([config])
 
         assert errors == {'test-vol': None}
         assert failed == set()
@@ -2094,7 +2094,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, failed = k8s_volume.get_all_volumes_errors([config])
+        errors, _, failed = k8s_volume.get_all_volumes_state([config])
 
         assert 'test-vol' not in failed
         assert errors['test-vol'] is not None
@@ -2131,7 +2131,7 @@ class TestGetAllVolumesErrors:
             },
         )
 
-        errors, failed = k8s_volume.get_all_volumes_errors([config])
+        errors, _, failed = k8s_volume.get_all_volumes_state([config])
 
         assert failed == set()
         assert errors['test-vol'] is None
@@ -2182,7 +2182,7 @@ class TestGetAllVolumesErrors:
             config={'namespace': 'my-namespace'},
         )
 
-        errors, _ = k8s_volume.get_all_volumes_errors([config])
+        errors, _, _ = k8s_volume.get_all_volumes_state([config])
 
         assert 'ProvisioningFailed' in errors['test-vol']
         assert 'below the 1Ti minimum' in errors['test-vol']
@@ -2223,7 +2223,7 @@ class TestGetAllVolumesErrors:
                 config={},
             )
 
-        errors, failed = k8s_volume.get_all_volumes_errors(
+        errors, _, failed = k8s_volume.get_all_volumes_state(
             [_config('vol-a'), _config('vol-b')])
 
         assert failed == set()
@@ -2259,7 +2259,7 @@ class TestGetAllVolumesErrors:
                 config={'namespace': 'my-namespace'},
             )
 
-        errors, _ = k8s_volume.get_all_volumes_errors(
+        errors, _, _ = k8s_volume.get_all_volumes_state(
             [_config('good-vol', 'good-pvc'),
              _config('bad-vol', 'bad-pvc')])
 
@@ -2683,3 +2683,190 @@ class TestFirstPvcFailureEvent:
             self, monkeypatch):
         assert 'instance.tier' in self._first(monkeypatch, _DEADLINE_MESSAGE,
                                               _TERMINAL_MESSAGE)
+
+
+class TestObservedVolumeState:
+    """What `get_all_volumes_state` reports about the cluster-owned fields.
+
+    A volume's size is recorded when it is created, but the cluster can change
+    it afterwards -- storage gets expanded, and a provisioner can round a
+    request up -- so the refresh has to read it back from the PVC.
+    """
+
+    def _config(self, name_on_cloud='test-pvc', size='10', config=None):
+        return models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud=name_on_cloud,
+            size=size,
+            config=config
+            if config is not None else {'namespace': 'my-namespace'},
+        )
+
+    def _observe(self, mock_core_api, pvc, config=None):
+        pvc_list = Mock()
+        pvc_list.items = [pvc] if pvc is not None else []
+        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
+         return_value) = pvc_list
+        _, observed, _ = k8s_volume.get_all_volumes_state(
+            [config if config is not None else self._config()])
+        return observed
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_expanded_volume_reports_its_new_capacity(self, mock_core_api,
+                                                      mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='10Ti')
+        pvc.status.phase = 'Bound'
+        # An expansion moves the request first; status.capacity follows once
+        # the volume has actually grown, and that is the size that exists.
+        pvc.spec.resources.requests = {'storage': '25Ti'}
+        pvc.status.capacity = {'storage': '25Ti'}
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].size == '25600'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_request_that_is_not_yet_fulfilled_is_not_a_capacity(
+            self, mock_core_api, mock_get_context):
+        """A pending expansion must not be reported as the size on disk."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='10Gi')
+        pvc.status.phase = 'Bound'
+        pvc.spec.resources.requests = {'storage': '20Gi'}
+        pvc.status.capacity = {'storage': '10Gi'}
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].size == '10'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_an_unbound_claim_reports_no_capacity(self, mock_core_api,
+                                                  mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace')
+        pvc.status.phase = 'Pending'
+        pvc.status.capacity = None
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].size is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_an_unreadable_capacity_reports_none(self, mock_core_api,
+                                                 mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace')
+        pvc.status.phase = 'Bound'
+        pvc.status.capacity = {'storage': 'not-a-quantity'}
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].size is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_sub_gi_capacity_reports_none(self, mock_core_api,
+                                            mock_get_context):
+        """Rounding to '0' is not a size a volume could be created with."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace')
+        pvc.status.phase = 'Bound'
+        pvc.status.capacity = {'storage': '100Mi'}
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].size is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_storage_class_is_reported(self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', storage_class='premium-rwo')
+        pvc.status.phase = 'Bound'
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].storage_class_name == 'premium-rwo'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_no_storage_class_is_not_a_class_name(self, mock_core_api,
+                                                  mock_get_context):
+        """'' opts out of dynamic provisioning; it is not a class to record."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', storage_class='')
+        pvc.status.phase = 'Bound'
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed['test-vol'].storage_class_name is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_use_existing_pvc_is_observed_too(self, mock_core_api,
+                                                mock_get_context):
+        """An adopted PVC carries no skypilot label, so it is read by name in
+        the other branch -- which has to observe it all the same."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('adopted-pvc', 'my-namespace', size='25Ti')
+        pvc.status.phase = 'Bound'
+        pvc.metadata.labels = {}
+
+        empty = Mock()
+        empty.items = []
+        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
+         return_value) = empty
+        (mock_core_api.return_value.read_namespaced_persistent_volume_claim.
+         return_value) = pvc
+
+        _, observed, _ = k8s_volume.get_all_volumes_state([
+            self._config(name_on_cloud='adopted-pvc',
+                         config={
+                             'namespace': 'my-namespace',
+                             'use_existing': True
+                         })
+        ])
+
+        assert observed['test-vol'].size == '25600'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_an_unreadable_namespace_observes_nothing(self, mock_core_api,
+                                                      mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
+         side_effect) = Exception('apiserver down')
+
+        _, observed, failed = k8s_volume.get_all_volumes_state([self._config()])
+
+        assert observed == {}
+        assert failed == {'test-vol'}
+
+    def test_a_hostpath_volume_has_nothing_to_observe(self):
+        config = models.VolumeConfig(
+            _version=1,
+            name='host-vol',
+            type='k8s-hostpath',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='host-vol',
+            size=None,
+            config={'host_path': '/mnt/data'},
+        )
+
+        errors, observed, failed = k8s_volume.get_all_volumes_state([config])
+
+        assert errors == {'host-vol': None}
+        assert observed == {}
+        assert not failed


### PR DESCRIPTION
## Summary

A volume's size is recorded once, when it is created or registered, and the refresh daemon only ever updated status, error message and usedby info. So a volume whose backing storage was expanded afterwards keeps advertising its original size forever — in `sky volumes ls` and on the dashboard, which reads the same record. It also goes wrong with no expansion at all: at creation the claim is usually still `Pending`, so what gets recorded is the *requested* size, and a provisioner that rounds the request up (a network filesystem with a minimum tier) is never reflected.

- Read the fields the cluster owns back out of the PVC objects the error check already lists — **no extra API calls** — and merge them into the handle re-read under the volume lock, writing only when something actually changed.
- `size` comes from `status.capacity`, the capacity the volume actually has. The request in `spec.resources` may never have been fulfilled, so it is not an answer; an unbound claim reports nothing and is left alone.
- `storage_class_name` is back-filled only where nothing is recorded (volumes created before it was read back, or a class assigned retroactively). A recorded class is never overwritten.
- `get_all_volumes_errors` becomes `get_all_volumes_state`, so the one pass that reads a PVC reports everything it saw and a volume can never be judged against one version of a claim and described from another.

No API or schema change, and no behavior change: after creation the recorded size is display-only (it builds the PVC spec at create time and is read for ephemeral volumes at provision time, nowhere else), so this only makes a displayed number true.

### Why `access_mode` is deliberately not refreshed

It looks like it should drift — a user who sets no `access_mode` gets a `ReadWriteOnce` default — but it does not:

- a volume SkyPilot creates gets a PV with exactly the modes the claim asked for, so there is no hidden `ReadWriteMany` to discover;
- registering an existing claim already overwrites that default with the claim's own `spec.accessModes`;
- a claim's access modes are immutable thereafter.

The one residual case is a claim requesting `ReadWriteOnce` bound to a static PV that advertises `ReadWriteMany`. Adopting the bound volume's wider modes would *widen* what SkyPilot allows for that volume, and would have to move the launch-time single-consumer guard (`check_pvc_usage_for_pod`, which reads the claim's spec) in the same change, or the record would promise a mount that the launch then refuses. Left alone.

## Test plan

**Unit** — `pytest tests/unit_tests/test_sky/volumes tests/unit_tests/test_sky/provision` (703 passed), including 16 new tests:

- extraction (`test_k8s_volume.py`): expanded capacity is reported; a request that is not yet fulfilled is not reported as capacity; an unbound claim reports none; unparseable and sub-1Gi quantities report none; storage class reported, `""` is not a class name; an adopted (unlabelled) PVC is observed through the read-by-name branch; an unreadable namespace observes nothing; a hostPath volume has nothing to observe.
- merge (`test_core.py`): an expanded volume is recorded at its new size; a volume that still matches is **not** rewritten; a cloud with no answer and an unreadable cloud both leave the size alone; a missing storage class is filled in; a recorded one is not overwritten.

Reverting the merge fails exactly the two behavioural tests (size adopted, class back-filled) and leaves the four guard tests green.

**Smoke** — new `test_volume_size_resync_on_kubernetes`. No storage class available in CI provides a working expansion path (the request is accepted and then never carried out without a `csi-resizer` sidecar), so the test moves the same field the other way it can move: it registers an existing 2Gi claim with `--use-existing` and no `--size` (so the recorded size can only have come from the claim), recreates the claim at 5Gi under the same name — a real scenario for a `use_existing` volume, whose PVC lifecycle SkyPilot does not own — and asserts the record reports 5Gi and no longer 2Gi. Skips where the cluster has no `ReadWriteMany` class, since the default `local-path` class binds `WaitForFirstConsumer` and a `Pending` claim reports no capacity at all.

**Manual, on a real cluster (GKE, `premium-rwo`, `allowVolumeExpansion: true`)** — the reported scenario end to end:

```bash
sky volumes apply -y -n vtest --type k8s-pvc --size 10 --infra k8s   # records 10Gi
# mount it once: premium-rwo binds WaitForFirstConsumer, and PD-CSI needs a
# node to grow the filesystem before status.capacity moves
kubectl apply -f consumer-pod.yaml
kubectl patch pvc <name_on_cloud> -p \
  '{"spec":{"resources":{"requests":{"storage":"25Gi"}}}}'
kubectl get pvc <name_on_cloud>          # wait for CAPACITY 25Gi
sky volumes ls                           # 25Gi, with no --refresh and no user action
```

Observed: the record followed within the daemon's interval, the dashboard's own `GET /volumes` payload reported `size: 25`, and the daemon logged `size changed from 10 to 25` exactly once across four refresh cycles — i.e. an unchanged volume costs no pickle and no database write per minute.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->