### PR TITLE
[Server] Account server and job controller process memory when sizing the executor pools

### DIFF
--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -13,6 +13,7 @@ from sky.skylet import constants
 from sky.skylet import runtime_utils
 from sky.utils import common_utils
 from sky.utils import config_utils
+from sky.utils import env_options
 from sky.utils import yaml_utils
 
 # Constants based on profiling the peak memory usage while serving various
@@ -29,8 +30,8 @@ from sky.utils import yaml_utils
 # TODO(luca): The future is now! ^^^
 LONG_WORKER_MEM_GB = 0.4
 SHORT_WORKER_MEM_GB = 0.3
-# A uvicorn server worker is a separate process holding its own copy of the
-# imported modules, so it costs about as much as a long worker.
+# A server worker is a separate process with its own copy of the imported
+# modules, so it costs about as much as a long worker.
 SERVER_WORKER_MEM_GB = 0.4
 # To control the number of long workers.
 _CPU_MULTIPLIER_FOR_LONG_WORKERS = 2
@@ -133,18 +134,13 @@ def compute_server_config(
         mem_size_gb -= (reserved_memory_mb / 1024)
     logger.debug(f'Memory size: {mem_size_gb}GB')
     num_server_workers = cpu_count if deploy else 1
-    # Server workers are permanent processes that live for the lifetime of the
-    # API server, so their memory is already committed by the time the executor
-    # pools are sized. Take it out of the budget before sizing the pools;
-    # otherwise the pools are sized against memory the server workers are
-    # already holding, and workers plus pools together overcommit the machine.
-    # In deployment mode the workers are children of a parent process that also
-    # stays resident (main event loop + gc daemons), so count one extra.
-    num_resident_server_procs = (num_server_workers +
-                                 1) if deploy else num_server_workers
-    mem_size_gb = max(
-        0.0, mem_size_gb - num_resident_server_procs * SERVER_WORKER_MEM_GB)
-    logger.debug(f'Memory size for executor pools: {mem_size_gb}GB')
+    if env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
+        # Server workers are resident for the lifetime of the API server; the
+        # pools only get what is left. In deployment mode the workers are
+        # children of a parent process that stays resident too.
+        resident = (num_server_workers + 1) if deploy else num_server_workers
+        mem_size_gb = max(0.0, mem_size_gb - resident * SERVER_WORKER_MEM_GB)
+        logger.debug(f'Memory size for executor pools: {mem_size_gb}GB')
     max_parallel_for_long = _max_long_worker_parallism(cpu_count,
                                                        mem_size_gb,
                                                        local=not deploy)

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -30,8 +30,6 @@ from sky.utils import yaml_utils
 # TODO(luca): The future is now! ^^^
 LONG_WORKER_MEM_GB = 0.4
 SHORT_WORKER_MEM_GB = 0.3
-# A server worker is a separate process with its own copy of the imported
-# modules, so it costs about as much as a long worker.
 SERVER_WORKER_MEM_GB = 0.4
 # To control the number of long workers.
 _CPU_MULTIPLIER_FOR_LONG_WORKERS = 2

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -29,6 +29,9 @@ from sky.utils import yaml_utils
 # TODO(luca): The future is now! ^^^
 LONG_WORKER_MEM_GB = 0.4
 SHORT_WORKER_MEM_GB = 0.3
+# A uvicorn server worker is a separate process holding its own copy of the
+# imported modules, so it costs about as much as a long worker.
+SERVER_WORKER_MEM_GB = 0.4
 # To control the number of long workers.
 _CPU_MULTIPLIER_FOR_LONG_WORKERS = 2
 # Limit the number of long workers of local API server, since local server is
@@ -129,6 +132,19 @@ def compute_server_config(
     if reserved_memory_mb is not None:
         mem_size_gb -= (reserved_memory_mb / 1024)
     logger.debug(f'Memory size: {mem_size_gb}GB')
+    num_server_workers = cpu_count if deploy else 1
+    # Server workers are permanent processes that live for the lifetime of the
+    # API server, so their memory is already committed by the time the executor
+    # pools are sized. Take it out of the budget before sizing the pools;
+    # otherwise the pools are sized against memory the server workers are
+    # already holding, and workers plus pools together overcommit the machine.
+    # In deployment mode the workers are children of a parent process that also
+    # stays resident (main event loop + gc daemons), so count one extra.
+    num_resident_server_procs = (num_server_workers +
+                                 1) if deploy else num_server_workers
+    mem_size_gb = max(
+        0.0, mem_size_gb - num_resident_server_procs * SERVER_WORKER_MEM_GB)
+    logger.debug(f'Memory size for executor pools: {mem_size_gb}GB')
     max_parallel_for_long = _max_long_worker_parallism(cpu_count,
                                                        mem_size_gb,
                                                        local=not deploy)
@@ -141,7 +157,6 @@ def compute_server_config(
     # to conserve the number of concurrent db connections.
     # This could lead to performance degradation.
     num_db_connections_per_worker = 0
-    num_server_workers = cpu_count
 
     # +1 for the event loop running the main process
     # and gc daemons in the '__main__' body of sky/server/server.py
@@ -151,7 +166,6 @@ def compute_server_config(
     if not deploy:
         # For local mode, use local queue backend since we only run 1 uvicorn
         # worker in local mode and no multiprocessing is needed.
-        num_server_workers = 1
         queue_backend = QueueBackend.LOCAL
         # Enable burstable workers for local API server.
         burstable_parallel_for_long = _BURSTABLE_WORKERS_FOR_LOCAL

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -133,11 +133,13 @@ def compute_server_config(
     logger.debug(f'Memory size: {mem_size_gb}GB')
     num_server_workers = cpu_count if deploy else 1
     if env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
-        # Server workers are resident for the lifetime of the API server; the
-        # pools only get what is left. In deployment mode the workers are
-        # children of a parent process that stays resident too.
+        # Server workers are resident for the lifetime of the API server. The
+        # pools already hold back _min_avail_mem_gb(), which is what covered
+        # them before, so only the excess comes off the top. In deployment mode
+        # the workers are children of a parent process that stays resident too.
         resident = (num_server_workers + 1) if deploy else num_server_workers
-        mem_size_gb = max(0.0, mem_size_gb - resident * SERVER_WORKER_MEM_GB)
+        excess = max(0.0, resident * SERVER_WORKER_MEM_GB - _min_avail_mem_gb())
+        mem_size_gb = max(0.0, mem_size_gb - excess)
         logger.debug(f'Memory size for executor pools: {mem_size_gb}GB')
     max_parallel_for_long = _max_long_worker_parallism(cpu_count,
                                                        mem_size_gb,
@@ -166,12 +168,7 @@ def compute_server_config(
         burstable_parallel_for_short = _BURSTABLE_WORKERS_FOR_LOCAL
         # Runs in low resource mode if the available memory is less than
         # server_constants.MIN_AVAIL_MEM_GB.
-        # pylint: disable=import-outside-toplevel
-        import sky.jobs.utils as job_utils
-        max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                      if job_utils.is_consolidation_mode() else
-                      server_constants.MIN_AVAIL_MEM_GB)
-        if not deploy and mem_size_gb < max_memory:
+        if not deploy and mem_size_gb < _min_avail_mem_gb():
             # Permanent worker process may have significant memory consumption
             # (~350MB per worker) after running commands like `sky check`, so we
             # don't start any permanent workers in low resource local mode. This
@@ -220,17 +217,21 @@ def compute_server_config(
     )
 
 
+def _min_avail_mem_gb() -> float:
+    """The memory SkyPilot tries not to use, to prevent OOM."""
+    # pylint: disable=import-outside-toplevel
+    import sky.jobs.utils as job_utils
+    return (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
+            if job_utils.is_consolidation_mode() else
+            server_constants.MIN_AVAIL_MEM_GB)
+
+
 def _max_long_worker_parallism(cpu_count: int,
                                mem_size_gb: float,
                                local=False) -> int:
     """Max parallelism for long workers."""
     # Reserve min available memory to avoid OOM.
-    # pylint: disable=import-outside-toplevel
-    import sky.jobs.utils as job_utils
-    max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                  if job_utils.is_consolidation_mode() else
-                  server_constants.MIN_AVAIL_MEM_GB)
-    available_mem = max(0, mem_size_gb - max_memory)
+    available_mem = max(0, mem_size_gb - _min_avail_mem_gb())
     cpu_based_max_parallel = cpu_count * _CPU_MULTIPLIER_FOR_LONG_WORKERS
     mem_based_max_parallel = int(available_mem * _MAX_MEM_PERCENT_FOR_BLOCKING /
                                  LONG_WORKER_MEM_GB)
@@ -254,12 +255,8 @@ def _max_short_worker_parallism(mem_size_gb: float,
                                 long_worker_parallism: int) -> int:
     """Max parallelism for short workers."""
     # Reserve memory for long workers and min available memory.
-    # pylint: disable=import-outside-toplevel
-    import sky.jobs.utils as job_utils
-    max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                  if job_utils.is_consolidation_mode() else
-                  server_constants.MIN_AVAIL_MEM_GB)
-    reserved_mem = max_memory + (long_worker_parallism * LONG_WORKER_MEM_GB)
+    reserved_mem = (_min_avail_mem_gb() +
+                    (long_worker_parallism * LONG_WORKER_MEM_GB))
     available_mem = max(0, mem_size_gb - reserved_mem)
     n = max(_get_min_short_workers(), int(available_mem / SHORT_WORKER_MEM_GB))
     return n

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4069,8 +4069,7 @@ if __name__ == '__main__':
     logger.info(f'Max db connections: {max_db_connections}')
 
     # Reserve memory for jobs and serve/pool controller in consolidation mode.
-    # setup_consolidation_mode_on_startup() above has already written the
-    # consolidation signal file, so the reservation reads the effective state.
+    # setup_consolidation_mode_on_startup() above has written the signal file.
     reserved_memory_mb = (
         controller_utils.compute_memory_reserved_for_controllers(
             # For jobs controller, we need to reserve for both jobs and

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4069,10 +4069,10 @@ if __name__ == '__main__':
     logger.info(f'Max db connections: {max_db_connections}')
 
     # Reserve memory for jobs and serve/pool controller in consolidation mode.
+    # setup_consolidation_mode_on_startup() above has already written the
+    # consolidation signal file, so the reservation reads the effective state.
     reserved_memory_mb = (
         controller_utils.compute_memory_reserved_for_controllers(
-            reserve_for_controllers=os.environ.get(
-                constants.OVERRIDE_CONSOLIDATION_MODE) is not None,
             # For jobs controller, we need to reserve for both jobs and
             # pool controller.
             reserve_extra_for_pool=not os.environ.get(

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -1413,11 +1413,13 @@ def compute_memory_reserved_for_controllers(
     sides of the split agree on one number. Returns 0 outside consolidation
     mode, where the controllers run on their own cluster.
     """
-    if not env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
-        # Only reserved inside a controller process.
-        if os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is None:
-            return 0.0
+    if os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is not None:
+        # A local API server started from a controller process, which inherits
+        # its env. _get_parallelism() sizes that machine assuming only the flat
+        # headroom was withheld, so withhold exactly that.
         return _controller_headroom_mb(reserve_extra_for_pool)
+    if not env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
+        return 0.0
     # Either kind of consolidation puts controller processes in the API
     # server's own memory.
     if not is_jobs_consolidation_mode() and not _is_consolidation_mode(

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -1378,37 +1378,72 @@ MAX_TOTAL_RUNNING_JOBS = 2000
 _CONSOLIDATION_WORKER_MEMORY_FRACTION = 0.7
 
 
+def _controller_headroom_mb(reserve_extra_for_pool: bool) -> float:
+    """Memory kept free on top of whatever the controllers themselves use."""
+    headroom = float(MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB)
+    if reserve_extra_for_pool:
+        headroom *= (1. + POOL_JOBS_RESOURCES_RATIO)
+    return headroom
+
+
+def _consolidation_worker_reserved_mb(reserve_extra_for_pool: bool) -> float:
+    """Memory withheld from worker sizing when controllers run in-process.
+
+    Headroom plus the share set aside for the controllers themselves. Scales
+    with system memory via _CONSOLIDATION_WORKER_MEMORY_FRACTION, so a machine
+    that can run more concurrent jobs also holds back more memory for their
+    controller processes instead of a flat constant.
+
+    In low-memory scenarios (total <= MIN_AVAIL_MB) the controller share is
+    skipped so workers get all available memory; otherwise workers are
+    guaranteed at least MIN_AVAIL_MB and capped at the fraction.
+    """
+    headroom = _controller_headroom_mb(reserve_extra_for_pool)
+    total_memory_mb = common_utils.get_mem_size_gb() * 1024 - headroom
+    min_avail_mb = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE * 1024)
+    controllers_reserved = min(
+        total_memory_mb * (1 - _CONSOLIDATION_WORKER_MEMORY_FRACTION),
+        max(0, total_memory_mb - min_avail_mb))
+    return headroom + controllers_reserved
+
+
 def compute_memory_reserved_for_controllers(
-        reserve_for_controllers: bool, reserve_extra_for_pool: bool) -> float:
-    reserved_memory_mb = 0.0
-    if reserve_for_controllers:
-        reserved_memory_mb = float(MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB)
-        if reserve_extra_for_pool:
-            reserved_memory_mb *= (1. + POOL_JOBS_RESOURCES_RATIO)
-    return reserved_memory_mb
+        reserve_extra_for_pool: bool) -> float:
+    """Memory (MB) to withhold from API server worker sizing.
+
+    In consolidation mode the jobs and serve/pool controllers run as processes
+    inside the API server, so the memory they will take has to be withheld
+    before the executor pools are sized. Returns the same quantity
+    _get_total_usable_memory_mb() assumes the workers left behind, so both
+    sides of the split agree on one number.
+
+    Returns 0 outside consolidation mode, where the controllers run on their
+    own cluster and cost the API server nothing.
+    """
+    # Either kind of consolidation puts controller processes in the API
+    # server's own memory. Jobs consolidation is the signal-file-backed source
+    # of truth (and is forced True inside a controller process); serve/pool
+    # consolidation is a plain config read.
+    if not is_jobs_consolidation_mode() and not _is_consolidation_mode(
+            pool=False):
+        return 0.0
+    return _consolidation_worker_reserved_mb(reserve_extra_for_pool)
 
 
 def _get_total_usable_memory_mb(pool: bool, consolidation_mode: bool) -> float:
-    controller_reserved = compute_memory_reserved_for_controllers(
-        reserve_for_controllers=True, reserve_extra_for_pool=pool)
-    total_memory_mb = (common_utils.get_mem_size_gb() * 1024 -
-                       controller_reserved)
+    headroom = _controller_headroom_mb(reserve_extra_for_pool=pool)
+    total_memory_mb = common_utils.get_mem_size_gb() * 1024 - headroom
     if not consolidation_mode:
         return total_memory_mb
-    # Cap the memory available for server workers so that both workers and
-    # services scale with system memory. Without this cap, short workers
-    # grow linearly with memory, consuming nearly all of it and leaving a
-    # roughly fixed amount for services regardless of system memory size.
-    # In low-memory scenarios (total_memory_mb <= MIN_AVAIL_MB), skip the
-    # service reservation so workers get all available memory; otherwise
-    # guarantee workers at least MIN_AVAIL_MB and cap them at the fraction.
-    min_avail_mb = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE * 1024)
-    service_reserved = min(
-        total_memory_mb * (1 - _CONSOLIDATION_WORKER_MEMORY_FRACTION),
-        max(0, total_memory_mb - min_avail_mb))
-    worker_reserved = controller_reserved + service_reserved
+    # Size the workers against the same reservation the API server itself uses,
+    # then hand the controllers whatever the workers did not take. Both sides
+    # must read from one number, otherwise each sizes itself against memory the
+    # other has already claimed.
     config = server_config.compute_server_config(
-        deploy=True, quiet=True, reserved_memory_mb=worker_reserved)
+        deploy=True,
+        quiet=True,
+        reserved_memory_mb=_consolidation_worker_reserved_mb(
+            reserve_extra_for_pool=pool))
     used = 0.0
     used += ((config.long_worker_config.garanteed_parallelism +
               config.long_worker_config.burstable_parallelism) *
@@ -1416,6 +1451,9 @@ def _get_total_usable_memory_mb(pool: bool, consolidation_mode: bool) -> float:
     used += ((config.short_worker_config.garanteed_parallelism +
               config.short_worker_config.burstable_parallelism) *
              server_config.SHORT_WORKER_MEM_GB * 1024)
+    # Server workers are resident too, and the parent process along with them.
+    used += ((config.num_server_workers + 1) *
+             server_config.SERVER_WORKER_MEM_GB * 1024)
     return total_memory_mb - used
 
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -1387,16 +1387,11 @@ def _controller_headroom_mb(reserve_extra_for_pool: bool) -> float:
 
 
 def _consolidation_worker_reserved_mb(reserve_extra_for_pool: bool) -> float:
-    """Memory withheld from worker sizing when controllers run in-process.
+    """Headroom plus the share set aside for the in-process controllers.
 
-    Headroom plus the share set aside for the controllers themselves. Scales
-    with system memory via _CONSOLIDATION_WORKER_MEMORY_FRACTION, so a machine
-    that can run more concurrent jobs also holds back more memory for their
-    controller processes instead of a flat constant.
-
-    In low-memory scenarios (total <= MIN_AVAIL_MB) the controller share is
-    skipped so workers get all available memory; otherwise workers are
-    guaranteed at least MIN_AVAIL_MB and capped at the fraction.
+    Scales with system memory, so a machine that can run more concurrent jobs
+    also holds back more memory for their controller processes. Below
+    MIN_AVAIL_MB the controller share is skipped so workers get everything.
     """
     headroom = _controller_headroom_mb(reserve_extra_for_pool)
     total_memory_mb = common_utils.get_mem_size_gb() * 1024 - headroom
@@ -1412,18 +1407,19 @@ def compute_memory_reserved_for_controllers(
     """Memory (MB) to withhold from API server worker sizing.
 
     In consolidation mode the jobs and serve/pool controllers run as processes
-    inside the API server, so the memory they will take has to be withheld
-    before the executor pools are sized. Returns the same quantity
+    inside the API server, so their memory has to be withheld before the
+    executor pools are sized. Returns the same quantity
     _get_total_usable_memory_mb() assumes the workers left behind, so both
-    sides of the split agree on one number.
-
-    Returns 0 outside consolidation mode, where the controllers run on their
-    own cluster and cost the API server nothing.
+    sides of the split agree on one number. Returns 0 outside consolidation
+    mode, where the controllers run on their own cluster.
     """
+    if not env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
+        # Only reserved inside a controller process.
+        if os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is None:
+            return 0.0
+        return _controller_headroom_mb(reserve_extra_for_pool)
     # Either kind of consolidation puts controller processes in the API
-    # server's own memory. Jobs consolidation is the signal-file-backed source
-    # of truth (and is forced True inside a controller process); serve/pool
-    # consolidation is a plain config read.
+    # server's own memory.
     if not is_jobs_consolidation_mode() and not _is_consolidation_mode(
             pool=False):
         return 0.0
@@ -1435,10 +1431,8 @@ def _get_total_usable_memory_mb(pool: bool, consolidation_mode: bool) -> float:
     total_memory_mb = common_utils.get_mem_size_gb() * 1024 - headroom
     if not consolidation_mode:
         return total_memory_mb
-    # Size the workers against the same reservation the API server itself uses,
-    # then hand the controllers whatever the workers did not take. Both sides
-    # must read from one number, otherwise each sizes itself against memory the
-    # other has already claimed.
+    # Size the workers against the same reservation the API server uses, then
+    # hand the controllers whatever the workers did not take.
     config = server_config.compute_server_config(
         deploy=True,
         quiet=True,
@@ -1451,9 +1445,10 @@ def _get_total_usable_memory_mb(pool: bool, consolidation_mode: bool) -> float:
     used += ((config.short_worker_config.garanteed_parallelism +
               config.short_worker_config.burstable_parallelism) *
              server_config.SHORT_WORKER_MEM_GB * 1024)
-    # Server workers are resident too, and the parent process along with them.
-    used += ((config.num_server_workers + 1) *
-             server_config.SERVER_WORKER_MEM_GB * 1024)
+    if env_options.Options.MEMORY_AWARE_WORKER_SIZING.get():
+        # Server workers are resident too, and the parent process with them.
+        used += ((config.num_server_workers + 1) *
+                 server_config.SERVER_WORKER_MEM_GB * 1024)
     return total_memory_mb - used
 
 

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -46,6 +46,11 @@ class Options(enum.Enum):
     # compute target via `allowed_contexts: 'all'`.
     ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER = (
         'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER', True)
+    # Subtract the memory of the server worker processes, and of the
+    # consolidation-mode controllers, before sizing the executor pools. Without
+    # it the pools are sized against total memory and the permanent processes
+    # can add up to more memory than the server has.
+    MEMORY_AWARE_WORKER_SIZING = ('SKYPILOT_MEMORY_AWARE_WORKER_SIZING', False)
 
     def __init__(self, env_var: str, default: bool) -> None:
         super().__init__()

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -50,7 +50,9 @@ class Options(enum.Enum):
     # consolidation-mode controllers, before sizing the executor pools. Without
     # it the pools are sized against total memory and the permanent processes
     # can add up to more memory than the server has.
-    MEMORY_AWARE_WORKER_SIZING = ('SKYPILOT_MEMORY_AWARE_WORKER_SIZING', False)
+    # TEMPORARY: defaulted on so test runs exercise the new sizing without
+    # setting the env var. Flip back to False before merging.
+    MEMORY_AWARE_WORKER_SIZING = ('SKYPILOT_MEMORY_AWARE_WORKER_SIZING', True)
 
     def __init__(self, env_var: str, default: bool) -> None:
         super().__init__()

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -50,9 +50,7 @@ class Options(enum.Enum):
     # consolidation-mode controllers, before sizing the executor pools. Without
     # it the pools are sized against total memory and the permanent processes
     # can add up to more memory than the server has.
-    # TEMPORARY: defaulted on so test runs exercise the new sizing without
-    # setting the env var. Flip back to False before merging.
-    MEMORY_AWARE_WORKER_SIZING = ('SKYPILOT_MEMORY_AWARE_WORKER_SIZING', True)
+    MEMORY_AWARE_WORKER_SIZING = ('SKYPILOT_MEMORY_AWARE_WORKER_SIZING', False)
 
     def __init__(self, env_var: str, default: bool) -> None:
         super().__init__()

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -8,19 +8,6 @@ import pytest
 from sky.server import config
 
 
-@pytest.fixture(autouse=True)
-def _gate_off_unless_asked():
-    """TEMPORARY: pin the sizing gate off, it is defaulted on for test runs.
-
-    Tests that want it on patch the same key to 'true' on top of this.
-    """
-    from sky.utils import env_options
-    with mock.patch.dict(
-            os.environ,
-        {env_options.Options.MEMORY_AWARE_WORKER_SIZING.env_key: 'false'}):
-        yield
-
-
 @mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=8)
 @mock.patch('sky.utils.common_utils.get_cpu_count', return_value=4)
 def test_compute_server_config_on_minimal_deployment(cpu_count, mem_size_gb):

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -14,9 +14,9 @@ def test_compute_server_config_on_minimal_deployment(cpu_count, mem_size_gb):
     # Test deployment mode
     c = config.compute_server_config(deploy=True)
     assert c.num_server_workers == 4
-    assert c.long_worker_config.garanteed_parallelism == 5
+    assert c.long_worker_config.garanteed_parallelism == 8
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 6
+    assert c.short_worker_config.garanteed_parallelism == 9
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -29,7 +29,7 @@ def test_compute_server_config_on_large_deployment(cpu_count, mem_size_gb):
     assert c.num_server_workers == 196
     assert c.long_worker_config.garanteed_parallelism == 392
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 1821
+    assert c.short_worker_config.garanteed_parallelism == 2084
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -42,7 +42,7 @@ def test_compute_server_config(cpu_count, mem_size_gb):
     assert c.num_server_workers == 4
     assert c.long_worker_config.garanteed_parallelism == 8
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 29
+    assert c.short_worker_config.garanteed_parallelism == 36
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -51,7 +51,7 @@ def test_compute_server_config(cpu_count, mem_size_gb):
     assert c.num_server_workers == 1
     assert c.long_worker_config.garanteed_parallelism == 4
     assert c.long_worker_config.burstable_parallelism == 1024
-    assert c.short_worker_config.garanteed_parallelism == 40
+    assert c.short_worker_config.garanteed_parallelism == 41
     assert c.short_worker_config.burstable_parallelism == 1024
     assert c.queue_backend == config.QueueBackend.LOCAL
 
@@ -93,7 +93,7 @@ def test_compute_server_config_pool(cpu_count, mem_size_gb, buildkite_mock):
     assert c.num_server_workers == 12
     assert c.long_worker_config.garanteed_parallelism == 24
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 97
+    assert c.short_worker_config.garanteed_parallelism == 114
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -101,18 +101,45 @@ def test_compute_server_config_pool(cpu_count, mem_size_gb, buildkite_mock):
     assert controller_utils._get_request_parallelism(pool=True) == 40
 
 
+def _memory_aware_sizing():
+    """Enable SKYPILOT_MEMORY_AWARE_WORKER_SIZING."""
+    from sky.utils import env_options
+    return mock.patch.dict(
+        os.environ,
+        {env_options.Options.MEMORY_AWARE_WORKER_SIZING.env_key: 'true'})
+
+
+def _permanent_worker_memory_gb(c: 'config.ServerConfig') -> float:
+    """Memory the permanent processes of a ServerConfig are budgeted to use."""
+    # +1 for the parent process running the main event loop.
+    return (
+        (c.num_server_workers + 1) * config.SERVER_WORKER_MEM_GB +
+        c.long_worker_config.garanteed_parallelism * config.LONG_WORKER_MEM_GB +
+        c.short_worker_config.garanteed_parallelism *
+        config.SHORT_WORKER_MEM_GB)
+
+
 @mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
 @mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
-def test_compute_server_config_consolidation_mode(cpu_count, mem_size_gb):
-    """In consolidation mode the controllers' memory is withheld up front.
+def test_memory_aware_sizing_reserves_server_workers(cpu_count, mem_size_gb):
+    """Server worker memory comes out of the budget before the pools."""
+    with _memory_aware_sizing():
+        c = config.compute_server_config(deploy=True, quiet=True)
+    # 13 resident server processes at 0.4GB, so 42.8GB is left for the pools.
+    assert c.num_server_workers == 12
+    assert c.long_worker_config.garanteed_parallelism == 24
+    assert c.short_worker_config.garanteed_parallelism == 103
+    assert _permanent_worker_memory_gb(c) <= 48
 
-    The jobs and serve/pool controllers run as processes inside the API server,
-    so the executor pools have to be sized against what is left after their
-    share rather than against the whole machine.
-    """
+
+@mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
+@mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
+def test_memory_aware_sizing_consolidation_mode(cpu_count, mem_size_gb):
+    """In consolidation mode the in-process controllers are reserved for."""
     from sky.utils import controller_utils
 
-    with mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
+    with _memory_aware_sizing(), \
+         mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
                            return_value=True), \
          mock.patch.object(controller_utils, '_is_consolidation_mode',
                            return_value=True), \
@@ -124,20 +151,28 @@ def test_compute_server_config_consolidation_mode(cpu_count, mem_size_gb):
                                          quiet=True,
                                          reserved_memory_mb=reserved_memory_mb)
 
-    # 2GB of headroom, doubled for the pool controller, plus 30% of what is
-    # left for the controller processes themselves.
+    # 2GB of headroom, doubled for the pool controller, plus 30% of the rest.
     assert reserved_memory_mb == pytest.approx(4096 + 0.3 * (48 * 1024 - 4096))
     assert c.num_server_workers == 12
     assert c.long_worker_config.garanteed_parallelism == 24
-    # 12.0GB left for short workers at 0.3GB each; int() truncation of the
-    # binary representation of 40.0 lands on 39.
+    # 12.0GB left at 0.3GB each; int() of the binary 40.0 truncates to 39.
     assert c.short_worker_config.garanteed_parallelism == 39
-    assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
-
-    # Everything the server permanently holds -- server workers, both executor
-    # pools and the controller reservation -- has to fit in its memory.
-    committed_gb = (_permanent_worker_memory_gb(c) + reserved_memory_mb / 1024)
+    committed_gb = _permanent_worker_memory_gb(c) + reserved_memory_mb / 1024
     assert committed_gb <= 48
+
+
+@mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
+@mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
+def test_memory_aware_sizing_off_by_default(cpu_count, mem_size_gb):
+    """Without the env var, consolidation mode reserves nothing."""
+    from sky.utils import controller_utils
+
+    with mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
+                           return_value=True), \
+         mock.patch.object(controller_utils, '_is_consolidation_mode',
+                           return_value=True):
+        assert controller_utils.compute_memory_reserved_for_controllers(
+            reserve_extra_for_pool=True) == 0.0
 
 
 @mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
@@ -147,22 +182,13 @@ def test_no_controller_reservation_outside_consolidation(
     """Outside consolidation mode the controllers cost the API server nothing."""
     from sky.utils import controller_utils
 
-    with mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
+    with _memory_aware_sizing(), \
+         mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
                            return_value=False), \
          mock.patch.object(controller_utils, '_is_consolidation_mode',
                            return_value=False):
         assert controller_utils.compute_memory_reserved_for_controllers(
             reserve_extra_for_pool=True) == 0.0
-
-
-def _permanent_worker_memory_gb(c: 'config.ServerConfig') -> float:
-    """Memory the permanent processes of a ServerConfig are budgeted to use."""
-    # +1 server process for the parent running the main event loop.
-    return (
-        (c.num_server_workers + 1) * config.SERVER_WORKER_MEM_GB +
-        c.long_worker_config.garanteed_parallelism * config.LONG_WORKER_MEM_GB +
-        c.short_worker_config.garanteed_parallelism *
-        config.SHORT_WORKER_MEM_GB)
 
 
 # Shapes big enough that the _MIN_LONG_WORKERS / _get_min_short_workers
@@ -172,7 +198,8 @@ def _permanent_worker_memory_gb(c: 'config.ServerConfig') -> float:
                                                    (64, 128), (196, 784)])
 def test_permanent_processes_fit_in_memory(cpu_count, mem_size_gb):
     """Server workers plus both executor pools must fit in the server memory."""
-    with mock.patch('sky.utils.common_utils.get_cpu_count',
+    with _memory_aware_sizing(), \
+         mock.patch('sky.utils.common_utils.get_cpu_count',
                     return_value=cpu_count), \
          mock.patch('sky.utils.common_utils.get_mem_size_gb',
                     return_value=mem_size_gb), \

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -8,6 +8,19 @@ import pytest
 from sky.server import config
 
 
+@pytest.fixture(autouse=True)
+def _gate_off_unless_asked():
+    """TEMPORARY: pin the sizing gate off, it is defaulted on for test runs.
+
+    Tests that want it on patch the same key to 'true' on top of this.
+    """
+    from sky.utils import env_options
+    with mock.patch.dict(
+            os.environ,
+        {env_options.Options.MEMORY_AWARE_WORKER_SIZING.env_key: 'false'}):
+        yield
+
+
 @mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=8)
 @mock.patch('sky.utils.common_utils.get_cpu_count', return_value=4)
 def test_compute_server_config_on_minimal_deployment(cpu_count, mem_size_gb):

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -14,9 +14,9 @@ def test_compute_server_config_on_minimal_deployment(cpu_count, mem_size_gb):
     # Test deployment mode
     c = config.compute_server_config(deploy=True)
     assert c.num_server_workers == 4
-    assert c.long_worker_config.garanteed_parallelism == 8
+    assert c.long_worker_config.garanteed_parallelism == 5
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 9
+    assert c.short_worker_config.garanteed_parallelism == 6
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -29,7 +29,7 @@ def test_compute_server_config_on_large_deployment(cpu_count, mem_size_gb):
     assert c.num_server_workers == 196
     assert c.long_worker_config.garanteed_parallelism == 392
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 2084
+    assert c.short_worker_config.garanteed_parallelism == 1821
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -42,7 +42,7 @@ def test_compute_server_config(cpu_count, mem_size_gb):
     assert c.num_server_workers == 4
     assert c.long_worker_config.garanteed_parallelism == 8
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 36
+    assert c.short_worker_config.garanteed_parallelism == 29
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -51,7 +51,7 @@ def test_compute_server_config(cpu_count, mem_size_gb):
     assert c.num_server_workers == 1
     assert c.long_worker_config.garanteed_parallelism == 4
     assert c.long_worker_config.burstable_parallelism == 1024
-    assert c.short_worker_config.garanteed_parallelism == 41
+    assert c.short_worker_config.garanteed_parallelism == 40
     assert c.short_worker_config.burstable_parallelism == 1024
     assert c.queue_backend == config.QueueBackend.LOCAL
 
@@ -93,12 +93,92 @@ def test_compute_server_config_pool(cpu_count, mem_size_gb, buildkite_mock):
     assert c.num_server_workers == 12
     assert c.long_worker_config.garanteed_parallelism == 24
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 114
+    assert c.short_worker_config.garanteed_parallelism == 97
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
     assert controller_utils._get_number_of_services(pool=True) == 5
     assert controller_utils._get_request_parallelism(pool=True) == 40
+
+
+@mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
+@mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
+def test_compute_server_config_consolidation_mode(cpu_count, mem_size_gb):
+    """In consolidation mode the controllers' memory is withheld up front.
+
+    The jobs and serve/pool controllers run as processes inside the API server,
+    so the executor pools have to be sized against what is left after their
+    share rather than against the whole machine.
+    """
+    from sky.utils import controller_utils
+
+    with mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
+                           return_value=True), \
+         mock.patch.object(controller_utils, '_is_consolidation_mode',
+                           return_value=True), \
+         mock.patch('sky.jobs.utils.is_consolidation_mode', return_value=True):
+        reserved_memory_mb = (
+            controller_utils.compute_memory_reserved_for_controllers(
+                reserve_extra_for_pool=True))
+        c = config.compute_server_config(deploy=True,
+                                         quiet=True,
+                                         reserved_memory_mb=reserved_memory_mb)
+
+    # 2GB of headroom, doubled for the pool controller, plus 30% of what is
+    # left for the controller processes themselves.
+    assert reserved_memory_mb == pytest.approx(4096 + 0.3 * (48 * 1024 - 4096))
+    assert c.num_server_workers == 12
+    assert c.long_worker_config.garanteed_parallelism == 24
+    # 12.0GB left for short workers at 0.3GB each; int() truncation of the
+    # binary representation of 40.0 lands on 39.
+    assert c.short_worker_config.garanteed_parallelism == 39
+    assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
+
+    # Everything the server permanently holds -- server workers, both executor
+    # pools and the controller reservation -- has to fit in its memory.
+    committed_gb = (_permanent_worker_memory_gb(c) + reserved_memory_mb / 1024)
+    assert committed_gb <= 48
+
+
+@mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
+@mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
+def test_no_controller_reservation_outside_consolidation(
+        cpu_count, mem_size_gb):
+    """Outside consolidation mode the controllers cost the API server nothing."""
+    from sky.utils import controller_utils
+
+    with mock.patch.object(controller_utils, 'is_jobs_consolidation_mode',
+                           return_value=False), \
+         mock.patch.object(controller_utils, '_is_consolidation_mode',
+                           return_value=False):
+        assert controller_utils.compute_memory_reserved_for_controllers(
+            reserve_extra_for_pool=True) == 0.0
+
+
+def _permanent_worker_memory_gb(c: 'config.ServerConfig') -> float:
+    """Memory the permanent processes of a ServerConfig are budgeted to use."""
+    # +1 server process for the parent running the main event loop.
+    return (
+        (c.num_server_workers + 1) * config.SERVER_WORKER_MEM_GB +
+        c.long_worker_config.garanteed_parallelism * config.LONG_WORKER_MEM_GB +
+        c.short_worker_config.garanteed_parallelism *
+        config.SHORT_WORKER_MEM_GB)
+
+
+# Shapes big enough that the _MIN_LONG_WORKERS / _get_min_short_workers
+# responsiveness floors do not override the memory budget.
+@pytest.mark.parametrize('cpu_count,mem_size_gb', [(4, 8), (4, 16), (8, 32),
+                                                   (12, 48), (24, 96),
+                                                   (64, 128), (196, 784)])
+def test_permanent_processes_fit_in_memory(cpu_count, mem_size_gb):
+    """Server workers plus both executor pools must fit in the server memory."""
+    with mock.patch('sky.utils.common_utils.get_cpu_count',
+                    return_value=cpu_count), \
+         mock.patch('sky.utils.common_utils.get_mem_size_gb',
+                    return_value=mem_size_gb), \
+         mock.patch('sky.jobs.utils.is_consolidation_mode', return_value=False):
+        c = config.compute_server_config(deploy=True, quiet=True)
+    assert _permanent_worker_memory_gb(c) <= mem_size_gb
 
 
 def test_parallel_size_long():

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -125,10 +125,11 @@ def test_memory_aware_sizing_reserves_server_workers(cpu_count, mem_size_gb):
     """Server worker memory comes out of the budget before the pools."""
     with _memory_aware_sizing():
         c = config.compute_server_config(deploy=True, quiet=True)
-    # 13 resident server processes at 0.4GB, so 42.8GB is left for the pools.
+    # 13 resident server processes at 0.4GB = 5.2GB, of which the 2GB min-avail
+    # reserve already covered part, so 3.2GB comes off the top.
     assert c.num_server_workers == 12
     assert c.long_worker_config.garanteed_parallelism == 24
-    assert c.short_worker_config.garanteed_parallelism == 103
+    assert c.short_worker_config.garanteed_parallelism == 110
     assert _permanent_worker_memory_gb(c) <= 48
 
 
@@ -155,8 +156,7 @@ def test_memory_aware_sizing_consolidation_mode(cpu_count, mem_size_gb):
     assert reserved_memory_mb == pytest.approx(4096 + 0.3 * (48 * 1024 - 4096))
     assert c.num_server_workers == 12
     assert c.long_worker_config.garanteed_parallelism == 24
-    # 12.0GB left at 0.3GB each; int() of the binary 40.0 truncates to 39.
-    assert c.short_worker_config.garanteed_parallelism == 39
+    assert c.short_worker_config.garanteed_parallelism == 53
     committed_gb = _permanent_worker_memory_gb(c) + reserved_memory_mb / 1024
     assert committed_gb <= 48
 
@@ -173,6 +173,31 @@ def test_memory_aware_sizing_off_by_default(cpu_count, mem_size_gb):
                            return_value=True):
         assert controller_utils.compute_memory_reserved_for_controllers(
             reserve_extra_for_pool=True) == 0.0
+
+
+@pytest.mark.parametrize('gate_on', [False, True])
+@mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)
+@mock.patch('sky.utils.common_utils.get_cpu_count', return_value=12)
+def test_controller_process_reserves_flat_headroom(cpu_count, mem_size_gb,
+                                                   gate_on):
+    """A local API server under a controller process keeps the flat headroom.
+
+    _get_parallelism() sizes that machine assuming only the headroom was
+    withheld, so the gate must not switch it to the scaling reservation.
+    """
+    from sky.skylet import constants as skylet_constants
+    from sky.utils import controller_utils
+
+    env = {skylet_constants.OVERRIDE_CONSOLIDATION_MODE: 'true'}
+    if gate_on:
+        from sky.utils import env_options
+        env[env_options.Options.MEMORY_AWARE_WORKER_SIZING.env_key] = 'true'
+    with mock.patch.dict(os.environ, env):
+        reserved = controller_utils.compute_memory_reserved_for_controllers(
+            reserve_extra_for_pool=True)
+    assert reserved == float(
+        controller_utils.MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB) * (
+            1 + controller_utils.POOL_JOBS_RESOURCES_RATIO)
 
 
 @mock.patch('sky.utils.common_utils.get_mem_size_gb', return_value=48)


### PR DESCRIPTION
The API server sizes its long and short executor pools against total memory, but two sets of permanent processes are never charged against that budget:

- the server (uvicorn) worker processes — `num_server_workers` of them, each a separate process with its own copy of the imported modules;
- in consolidation mode, the jobs and serve/pool controllers that run inside the API server. They were covered only by a flat 2GB (x2 for pool) reserve, and that reserve was gated on `IS_SKYPILOT_JOB_CONTROLLER` — an env var only ever set *inside* a controller process, so on an API server it evaluated to 0.

So the pools are sized as if they had the whole machine and the unbudgeted processes take memory on top. Every shape from 8 CPUs up commits more memory than it has before serving a request. What absorbs the overcommit is the page cache: the cgroup sits at its hard limit and every allocation drives direct reclaim of the server's own code pages.

This PR makes the budget cover what the server actually starts:

- withhold `max(MIN_AVAIL_MEM_GB, server worker memory)` before sizing the executor pools. `MIN_AVAIL_MEM_GB` is the memory the server keeps free for itself and is what covered the server workers before they were budgeted, so the two are not charged twice;
- derive the consolidation reservation from the same scaling rule the controller side already applies (`_CONSOLIDATION_WORKER_MEMORY_FRACTION`), so the memory withheld tracks the number of controllers the scheduler will admit instead of a flat constant;
- gate that reservation on the effective consolidation state rather than on the controller-process env var. A local API server started from a controller process still gets the flat headroom, since `_get_parallelism()` sizes that machine assuming only the headroom was withheld;
- have both sides of the split read one number, so neither sizes itself against memory the other has already claimed.

Behind `SKYPILOT_MEMORY_AWARE_WORKER_SIZING`, off by default. With the env var unset, sizing is byte-identical to today.

### Worker counts, env var off / on

`committed` is server workers + parent + both pools + the controller reservation, as a percentage of machine memory; anything above 100% is oversubscription. In the off column of the consolidation table the reservation is 0, so the controllers' memory is not counted at all — the real figure is higher than shown.

#### consolidation mode OFF

| CPU / mem | server | long (off / on) | short (off / on) | committed (off / on) |
| --- | --- | --- | --- | --- |
| 4 / 16GB | 4 | 8 / 8 | 36 / 36 | 100% / 100% |
| 8 / 16GB | 8 | 16 / 16 | 25 / 20 | 109% / 100% |
| 8 / 32GB | 8 | 16 / 16 | 78 / 73 | 104% / 100% |
| 12 / 24GB | 12 | 24 / 24 | 41 / 30 | 113% / 99% |
| 12 / 48GB | 12 | 24 / 24 | 121 / 110 | 106% / 100% |
| 12 / 96GB | 12 | 24 / 24 | 281 / 270 | 103% / 100% |
| 32 / 64GB | 32 | 64 / 64 | 121 / 83 | 117% / 100% |
| 32 / 128GB | 32 | 64 / 64 | 334 / 297 | 109% / 100% |
| 64 / 128GB | 64 | 128 / 128 | 249 / 169 | 119% / 100% |
| 64 / 256GB | 64 | 128 / 128 | 676 / 596 | 109% / 100% |
| 196 / 784GB | 196 | 392 / 392 | 2084 / 1828 | 110% / 100% |

#### consolidation mode ON

| CPU / mem | server | long (off / on) | short (off / on) | committed (off / on) |
| --- | --- | --- | --- | --- |
| 4 / 16GB | 4 | 8 / 6 | 29 / 6 | 87% / 86% |
| 8 / 16GB | 8 | 16 / 6 | 18 / 6 | 96% / 96% |
| 8 / 32GB | 8 | 16 / 16 | 72 / 30 | 99% / 98% |
| 12 / 24GB | 12 | 24 / 13 | 34 / 12 | 104% / 100% |
| 12 / 48GB | 12 | 24 / 24 | 114 / 53 | 102% / 100% |
| 12 / 96GB | 12 | 24 / 24 | 274 / 165 | 101% / 100% |
| 32 / 64GB | 32 | 64 / 43 | 114 / 38 | 114% / 100% |
| 32 / 128GB | 32 | 64 / 64 | 328 / 159 | 107% / 100% |
| 64 / 128GB | 64 | 128 / 91 | 242 / 81 | 117% / 100% |
| 64 / 256GB | 64 | 128 / 128 | 669 / 330 | 109% / 100% |
| 196 / 784GB | 196 | 392 / 392 | 2077 / 1034 | 110% / 100% |

The concurrent managed-job controller limit is unchanged (22 at 12 CPU / 48GB). This trades apparent capacity for honest capacity: a deployment whose pool was only reachable by overcommitting will now queue requests instead. Memory-tight shapes lose the most, since server workers and long workers both scale with CPU while memory does not.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_sky/server/test_config.py` cover the server-worker reservation, the consolidation reservation, the controller-process case, the gate being off by default, and a parametrized check that the permanent processes fit in memory across 8 CPU/memory shapes — every one of which overcommitted before this change. The pre-existing sizing assertions are unchanged, which is the check that the gate-off path is a no-op.
