### PR TITLE
[k8s] Recommend set_pod_resource_limits when an OOM'd pod had no memory limit

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3210,7 +3210,9 @@ def _update_cluster_status(
             hint = kubernetes_utils.match_kubernetes_failure_hint_text(
                 log_message)
             if hint:
-                log_message += f' {hint}'
+                # Own line: the remedy reads as a separate statement from the
+                # diagnosis, both in the terminal and in the dashboard event.
+                log_message += f'\n{hint}'
         # Do not add event if the cluster is already in INIT status.
         if status != status_lib.ClusterStatus.INIT:
             global_user_state.add_cluster_event(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3213,8 +3213,22 @@ def _update_cluster_status(
                 # Own line: the remedy reads as a separate statement from the
                 # diagnosis, both in the terminal and in the dashboard event.
                 log_message += f'\n{hint}'
-        # Do not add event if the cluster is already in INIT status.
-        if status != status_lib.ClusterStatus.INIT:
+        # A node that stops heartbeating leaves its pods' status stale -- the
+        # pod still reads 'Running', so a refresh during the outage can only
+        # record a generic reason ('ray cluster is unhealthy'). Once the node
+        # is back, a later refresh names the real cause, but by then the
+        # cluster is INIT and the guard below would drop it, leaving the
+        # useless message as the last word forever. Let a refresh that finally
+        # identified the cause supersede it. add_cluster_event() drops an
+        # identical reason, so a stable cause is recorded once, not per poll.
+        identified_cause = False
+        if isinstance(launched_resources.cloud, clouds.Kubernetes):
+            identified_cause = any(
+                k8s_instance.pod_reason_identifies_cause(pod_reason)
+                for _, pod_reason in node_statuses.values())
+        # Do not add event if the cluster is already in INIT status, unless
+        # this refresh is the one that explained why.
+        if (status != status_lib.ClusterStatus.INIT or identified_cause):
             global_user_state.add_cluster_event(
                 cluster_name,
                 status_lib.ClusterStatus.INIT,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3216,8 +3216,10 @@ def _update_cluster_status(
             hint = kubernetes_utils.match_kubernetes_failure_hint_text(
                 log_message)
             if hint:
-                # Own line: the remedy reads as a separate statement from the
-                # diagnosis, both in the terminal and in the dashboard event.
+                # Own line, so the remedy reads as a separate statement from
+                # the diagnosis. Despite the variable name this string is not
+                # logged: it is only stored as the cluster event, which the
+                # dashboard renders. No CLI command reads it.
                 log_message += f'\n{hint}'
         # A node that stops heartbeating leaves its pods' status stale -- the
         # pod still reads 'Running', so a refresh during the outage can only

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3015,6 +3015,7 @@ def _update_cluster_status(
         #   once the container is running again, so a snapshot that raced the
         #   restart misses it -> re-read the pods' current+previous states.
         # Bounded: only on an abnormal k8s cluster with no status reason.
+        recovered_cause = False
         if not status_reason and isinstance(launched_resources.cloud,
                                             clouds.Kubernetes):
             try:
@@ -3027,6 +3028,11 @@ def _update_cluster_status(
                             ray_config['provider'], pod_names) or
                         k8s_instance.get_cluster_failure_reason_from_pods(
                             ray_config['provider'], pod_names) or '')
+                    # These extractors only ever return a specific cause, and
+                    # the result lands in status_reason rather than in
+                    # node_statuses -- so the supersede check below cannot see
+                    # it unless we record it here.
+                    recovered_cause = bool(status_reason)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Failed to get pod failure reason for '
                              f'{cluster_name!r}: {e}')
@@ -3223,7 +3229,11 @@ def _update_cluster_status(
         # identical reason, so a stable cause is recorded once, not per poll.
         identified_cause = False
         if isinstance(launched_resources.cloud, clouds.Kubernetes):
-            identified_cause = any(
+            # A cause can arrive by either route: named in a pod's live status,
+            # or recovered from kubelet events / a container's previous state
+            # when the live status had nothing (the latter never reaches
+            # node_statuses, hence the separate flag).
+            identified_cause = recovered_cause or any(
                 k8s_instance.pod_reason_identifies_cause(pod_reason)
                 for _, pod_reason in node_statuses.values())
         # Do not add event if the cluster is already in INIT status, unless

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3028,10 +3028,8 @@ def _update_cluster_status(
                             ray_config['provider'], pod_names) or
                         k8s_instance.get_cluster_failure_reason_from_pods(
                             ray_config['provider'], pod_names) or '')
-                    # These extractors only ever return a specific cause, and
-                    # the result lands in status_reason rather than in
-                    # node_statuses -- so the supersede check below cannot see
-                    # it unless we record it here.
+                    # Lands in status_reason, not node_statuses, so the
+                    # supersede check below cannot see it otherwise.
                     recovered_cause = bool(status_reason)
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Failed to get pod failure reason for '
@@ -3216,30 +3214,17 @@ def _update_cluster_status(
             hint = kubernetes_utils.match_kubernetes_failure_hint_text(
                 log_message)
             if hint:
-                # Own line, so the remedy reads as a separate statement from
-                # the diagnosis. Despite the variable name this string is not
-                # logged: it is only stored as the cluster event, which the
-                # dashboard renders. No CLI command reads it.
+                # Own line so the remedy reads separately from the cause.
                 log_message += f'\n{hint}'
-        # A node that stops heartbeating leaves its pods' status stale -- the
-        # pod still reads 'Running', so a refresh during the outage can only
-        # record a generic reason ('ray cluster is unhealthy'). Once the node
-        # is back, a later refresh names the real cause, but by then the
-        # cluster is INIT and the guard below would drop it, leaving the
-        # useless message as the last word forever. Let a refresh that finally
-        # identified the cause supersede it. add_cluster_event() drops an
-        # identical reason, so a stable cause is recorded once, not per poll.
+        # A refresh during a node outage sees stale pod status and can only
+        # record a generic reason; the guard below would then freeze that in.
+        # add_cluster_event() dedups, so a stable cause is recorded once.
         identified_cause = False
         if isinstance(launched_resources.cloud, clouds.Kubernetes):
-            # A cause can arrive by either route: named in a pod's live status,
-            # or recovered from kubelet events / a container's previous state
-            # when the live status had nothing (the latter never reaches
-            # node_statuses, hence the separate flag).
             identified_cause = recovered_cause or any(
                 k8s_instance.pod_reason_identifies_cause(pod_reason)
                 for _, pod_reason in node_statuses.values())
-        # Do not add event if the cluster is already in INIT status, unless
-        # this refresh is the one that explained why.
+        # Skip if already INIT, unless this refresh explained why.
         if (status != status_lib.ClusterStatus.INIT or identified_cause):
             global_user_state.add_cluster_event(
                 cluster_name,

--- a/sky/dashboard/src/components/elements/LinkifiedText.jsx
+++ b/sky/dashboard/src/components/elements/LinkifiedText.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React from 'react';
+
+// Matches a bare http(s) URL. The final character class excludes trailing
+// sentence punctuation so a URL that ends a sentence -- "... See
+// https://docs.skypilot.co/...#anchor." -- does not pull the period into the
+// href. No `g` flag: String.split does not need it, and a stateful regex
+// shared across renders is a footgun.
+const URL_REGEX = /(https?:\/\/[^\s<>"']*[^\s<>"'.,;:!?)\]}])/;
+
+/**
+ * Renders `text` with any bare http(s) URL turned into a real link.
+ *
+ * Remediation hints (e.g. the Kubernetes OOM hints) carry a docs URL with a
+ * section anchor. Rendered as plain text that anchor cannot be followed, which
+ * defeats the point of pointing at a specific section.
+ */
+export function LinkifiedText({ text, className }) {
+  const safeText = text == null ? '' : String(text);
+  if (!safeText) {
+    return null;
+  }
+  // String.split with a capturing group interleaves the captures at the odd
+  // indices, so parity tells us which parts are URLs.
+  const parts = safeText.split(URL_REGEX);
+  return (
+    <span className={className}>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? (
+          <a
+            key={i}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            {part}
+          </a>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
+}

--- a/sky/dashboard/src/components/elements/LinkifiedText.jsx
+++ b/sky/dashboard/src/components/elements/LinkifiedText.jsx
@@ -9,12 +9,32 @@ import React from 'react';
 // shared across renders is a footgun.
 const URL_REGEX = /(https?:\/\/[^\s<>"']*[^\s<>"'.,;:!?)\]}])/;
 
+// Long docs URLs dominate a line of prose. Show host + fragment, which is the
+// part that carries meaning, and keep the full URL in the href.
+const MAX_VISIBLE_URL = 48;
+
+function displayUrl(url) {
+  if (url.length <= MAX_VISIBLE_URL) {
+    return url;
+  }
+  try {
+    const u = new URL(url);
+    return `${u.host}${u.hash}`;
+  } catch {
+    return `${url.slice(0, MAX_VISIBLE_URL - 1)}…`;
+  }
+}
+
 /**
  * Renders `text` with any bare http(s) URL turned into a real link.
  *
  * Remediation hints (e.g. the Kubernetes OOM hints) carry a docs URL with a
  * section anchor. Rendered as plain text that anchor cannot be followed, which
  * defeats the point of pointing at a specific section.
+ *
+ * Newlines are preserved: these messages are composed server-side with line
+ * breaks separating the diagnosis from the remedy, and collapsing them turns
+ * the whole thing into one unreadable paragraph.
  */
 export function LinkifiedText({ text, className }) {
   const safeText = text == null ? '' : String(text);
@@ -25,17 +45,18 @@ export function LinkifiedText({ text, className }) {
   // indices, so parity tells us which parts are URLs.
   const parts = safeText.split(URL_REGEX);
   return (
-    <span className={className}>
+    <span className={className} style={{ whiteSpace: 'pre-wrap' }}>
       {parts.map((part, i) =>
         i % 2 === 1 ? (
           <a
             key={i}
             href={part}
+            title={part}
             target="_blank"
             rel="noopener noreferrer"
             className="text-blue-600 hover:text-blue-800 underline"
           >
-            {part}
+            {displayUrl(part)}
           </a>
         ) : (
           part

--- a/sky/dashboard/src/components/elements/TruncatedDetails.jsx
+++ b/sky/dashboard/src/components/elements/TruncatedDetails.jsx
@@ -2,6 +2,7 @@
 
 import React, { useRef } from 'react';
 import { TableRow, TableCell } from '@/components/ui/table';
+import { LinkifiedText } from '@/components/elements/LinkifiedText';
 
 const TOGGLE_SELECTOR = '[data-button-type="show-more-less"]';
 
@@ -27,7 +28,9 @@ export function ExpandedDetailsRow({ text, colSpan, innerRef }) {
                 className="mt-1 text-sm text-gray-700"
                 style={{ whiteSpace: 'pre-wrap' }}
               >
-                {text}
+                {/* Details can carry a remediation hint with a docs URL; make
+                    it followable now that the full text is on screen. */}
+                <LinkifiedText text={text} />
               </p>
             </div>
           </div>

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -9,6 +9,7 @@ import { CircularProgress } from '@mui/material';
 import { ClusterJobs } from '@/components/jobs';
 import { useRouter } from 'next/router';
 import { Layout } from '@/components/elements/layout';
+import { LinkifiedText } from '@/components/elements/LinkifiedText';
 import Link from 'next/link';
 import { Status2Actions } from '@/components/clusters';
 import { StatusBadge } from '@/components/elements/StatusBadge';
@@ -574,7 +575,7 @@ function ActiveTab({
                         content={clusterData.last_event || '-'}
                         className="text-sm text-muted-foreground"
                       >
-                        <span>{clusterData.last_event || '-'}</span>
+                        <LinkifiedText text={clusterData.last_event || '-'} />
                       </NonCapitalizedTooltip>
                     }
                   />

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -3292,7 +3292,12 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
                 if reason is None:
                     # just in-case reason is None, have default for debugging
                     reason = f'exit({exit_code})'
-                container_reasons.append(reason)
+                # An OOM kill on a container with no memory limit is a
+                # node-level OOM, not the container overrunning its own cap.
+                # Tag it so the hint lookup can recommend the right fix.
+                container_reasons.append(
+                    kubernetes_utils.annotate_oom_reason(
+                        reason, pod, container_status.name))
                 if terminated.finished_at is not None:
                     latest_timestamp = max(latest_timestamp,
                                            terminated.finished_at)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2973,6 +2973,40 @@ class NodeHealthInfo:
         self.pods = pods
 
 
+# Lead-ins that the reason builders below emit before they know *why* a pod is
+# unhealthy. `_get_pod_health_issues` always starts with the not-ready prefix
+# and appends container detail only if it found any;
+# `_get_pod_termination_reason` starts with the termination fallback and adds a
+# "Container errors:" section only if it found any.
+# pod_reason_identifies_cause() reads the formats these
+# two functions write, so it lives beside them and must stay in sync.
+_POD_NOT_READY_PREFIX = 'pod not ready ('
+_TERMINATION_FALLBACK = 'Terminated unexpectedly'
+_CONTAINER_ERRORS_MARKER = 'Container errors:'
+
+
+def pod_reason_identifies_cause(reason: Optional[str]) -> bool:
+    """Whether a per-pod reason names an actual cause, or only that it is sick.
+
+    A node that stops heartbeating leaves its pods' status stale -- kubelet
+    never gets to record the OOM kill -- so a refresh during the outage sees a
+    pod that still looks fine and can only report "not ready". Once the node is
+    back the very same code produces the real cause. Callers use this to tell
+    the two apart, and so to know when a later refresh is worth recording.
+    """
+    if not reason:
+        return False
+    if reason.startswith(_POD_NOT_READY_PREFIX):
+        # '<prefix>(<condition>)' alone; container detail is appended after
+        # '; ' when the container statuses explained anything.
+        return '; ' in reason
+    if reason.startswith(_TERMINATION_FALLBACK):
+        return _CONTAINER_ERRORS_MARKER in reason
+    # Anything else (Evicted, Preempted by Kueue, a kubelet pod-status reason)
+    # already names the cause.
+    return True
+
+
 def _get_pod_health_issues(pod: Any) -> Optional[str]:
     """Check a Running pod for health issues.
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2973,13 +2973,9 @@ class NodeHealthInfo:
         self.pods = pods
 
 
-# Lead-ins that the reason builders below emit before they know *why* a pod is
-# unhealthy. `_get_pod_health_issues` always starts with the not-ready prefix
-# and appends container detail only if it found any;
-# `_get_pod_termination_reason` starts with the termination fallback and adds a
-# "Container errors:" section only if it found any.
-# pod_reason_identifies_cause() reads the formats these
-# two functions write, so it lives beside them and must stay in sync.
+# Lead-ins the reason builders below emit before they know *why* a pod is
+# unhealthy. pod_reason_identifies_cause() parses what those two functions
+# write, so it lives beside them and must stay in sync.
 _POD_NOT_READY_PREFIX = 'pod not ready ('
 _TERMINATION_FALLBACK = 'Terminated unexpectedly'
 _CONTAINER_ERRORS_MARKER = 'Container errors:'
@@ -2988,22 +2984,18 @@ _CONTAINER_ERRORS_MARKER = 'Container errors:'
 def pod_reason_identifies_cause(reason: Optional[str]) -> bool:
     """Whether a per-pod reason names an actual cause, or only that it is sick.
 
-    A node that stops heartbeating leaves its pods' status stale -- kubelet
-    never gets to record the OOM kill -- so a refresh during the outage sees a
-    pod that still looks fine and can only report "not ready". Once the node is
-    back the very same code produces the real cause. Callers use this to tell
-    the two apart, and so to know when a later refresh is worth recording.
+    A node that stops heartbeating leaves its pod status stale, so a refresh
+    during the outage can only report "not ready"; once it is back the same
+    code names the real cause. Callers use this to tell the two apart.
     """
     if not reason:
         return False
     if reason.startswith(_POD_NOT_READY_PREFIX):
-        # '<prefix>(<condition>)' alone; container detail is appended after
-        # '; ' when the container statuses explained anything.
+        # Container detail, when found, is appended after '; '.
         return '; ' in reason
     if reason.startswith(_TERMINATION_FALLBACK):
         return _CONTAINER_ERRORS_MARKER in reason
-    # Anything else (Evicted, Preempted by Kueue, a kubelet pod-status reason)
-    # already names the cause.
+    # Evicted, Preempted by Kueue, etc. already name the cause.
     return True
 
 
@@ -3326,9 +3318,8 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
                 if reason is None:
                     # just in-case reason is None, have default for debugging
                     reason = f'exit({exit_code})'
-                # An OOM kill on a container with no memory limit is a
-                # node-level OOM, not the container overrunning its own cap.
-                # Tag it so the hint lookup can recommend the right fix.
+                # An OOM with no memory limit is a node-level OOM, not the
+                # container overrunning its own cap; the hints differ.
                 container_reasons.append(
                     kubernetes_utils.annotate_oom_reason(
                         reason, pod, container_status.name))

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2053,6 +2053,73 @@ def _iter_terminated_states(cs):
             yield term
 
 
+# Docs section for the config that caps a pod's memory at its request.
+SET_POD_RESOURCE_LIMITS_DOC_URL = (
+    'https://docs.skypilot.co/en/latest/reference/config.html'
+    '#kubernetes-set-pod-resource-limits')
+
+# Appended to an OOMKilled reason when the killed container declared no memory
+# limit. Produced by the reason builders here and in
+# sky/provision/kubernetes/instance.py, and matched by KUBERNETES_FAILURE_HINTS
+# below. The marker is the only channel those two ends share: the hint lookup
+# only ever sees a reason string, never the pod (e.g. the managed-jobs details
+# column formats a reason read back from the jobs database), so the
+# distinction has to travel in the text.
+NO_MEMORY_LIMIT_MARKER = 'no memory limit set'
+
+
+def _find_container(pod: 'kubernetes_models.V1Pod',
+                    container_name: Optional[str]) -> Optional[Any]:
+    """The named container from the pod *spec*, or None if it is not there."""
+    spec = getattr(pod, 'spec', None)
+    for container in (getattr(spec, 'containers', None) or []):
+        if getattr(container, 'name', None) == container_name:
+            return container
+    return None
+
+
+def _container_memory_limit(container: Any) -> Optional[str]:
+    """The memory limit `container` declares, or None if it declares none.
+
+    Reads the pod *spec*, not its status: a container with no
+    ``resources.limits.memory`` is unbounded, so its own cgroup can never
+    OOM-kill it.
+    """
+    resources = getattr(container, 'resources', None)
+    limits = getattr(resources, 'limits', None) or {}
+    return limits.get('memory')
+
+
+def is_unbounded_oom(reason: Optional[str], pod: 'kubernetes_models.V1Pod',
+                     container_name: Optional[str]) -> bool:
+    """Whether an OOM kill hit a container that had no memory limit.
+
+    A container that OOMs *with* a limit exceeded a cap it asked for, and the
+    fix is to ask for more. One that OOMs *without* a limit was never capped:
+    it grew until the node ran out of memory and the kernel reclaimed it, which
+    can take other pods on that node down too. Same `OOMKilled` reason, two
+    different failures, two different fixes -- hence the distinction.
+
+    False when the container is not in the pod spec: we cannot confirm it was
+    unbounded, and a confidently wrong node-level hint is worse than the
+    generic OOM one.
+    """
+    if reason != 'OOMKilled':
+        return False
+    container = _find_container(pod, container_name)
+    if container is None:
+        return False
+    return _container_memory_limit(container) is None
+
+
+def annotate_oom_reason(reason: Optional[str], pod: 'kubernetes_models.V1Pod',
+                        container_name: Optional[str]) -> str:
+    """Tag `reason` with NO_MEMORY_LIMIT_MARKER if it is an unbounded OOM."""
+    if not is_unbounded_oom(reason, pod, container_name):
+        return reason or ''
+    return f'{reason} ({NO_MEMORY_LIMIT_MARKER})'
+
+
 def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
     """Condense a pod failure into a single-line user-facing summary.
 
@@ -2105,7 +2172,10 @@ def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
             for term in _iter_terminated_states(cs):
                 if term.exit_code != 0:
                     if term.reason:
-                        return f'{term.reason} (exit code {term.exit_code})'
+                        detail = f'exit code {term.exit_code}'
+                        if is_unbounded_oom(term.reason, pod, cs.name):
+                            detail += f', {NO_MEMORY_LIMIT_MARKER}'
+                        return f'{term.reason} ({detail})'
                     return f'Terminated with exit code {term.exit_code}'
 
     return 'Terminated unexpectedly'
@@ -2142,6 +2212,15 @@ KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     (['ImagePullBackOff', 'ErrImagePull'],
      'To fix: Verify the image tag exists and registry credentials are configured.'
     ),
+    # NO_MEMORY_LIMIT_MARKER must precede 'OOMKilled': an unbounded-OOM reason
+    # contains both, and the first match wins.
+    ([NO_MEMORY_LIMIT_MARKER],
+     'The container had no memory limit, so nothing capped it before the node '
+     'itself ran out of memory -- a node-level OOM kill, which can also '
+     'disrupt other pods on that node. To fix: set `kubernetes.'
+     'set_pod_resource_limits` to cap every pod at its memory request, and/or '
+     'increase `resources.memory` in your task YAML. See '
+     f'{SET_POD_RESOURCE_LIMITS_DOC_URL}'),
     (['OOMKilled'],
      'The container ran out of memory. To fix: Increase the memory request with '
      '`resources.memory` in your task YAML; if `kubernetes.'

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2215,11 +2215,9 @@ KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     # NO_MEMORY_LIMIT_MARKER must precede 'OOMKilled': an unbounded-OOM reason
     # contains both, and the first match wins.
     ([NO_MEMORY_LIMIT_MARKER],
-     'The container had no memory limit, so nothing capped it before the node '
-     'itself ran out of memory -- a node-level OOM kill, which can also '
-     'disrupt other pods on that node. To fix: set `kubernetes.'
-     'set_pod_resource_limits` to cap every pod at its memory request, and/or '
-     'increase `resources.memory` in your task YAML. See '
+     'The container had no memory limit, so the node ran out of memory '
+     'instead -- a node-level OOM that can kill other pods too. To fix: set '
+     '`kubernetes.set_pod_resource_limits`: '
      f'{SET_POD_RESOURCE_LIMITS_DOC_URL}'),
     (['OOMKilled'],
      'The container ran out of memory. To fix: Increase the memory request with '

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2215,9 +2215,8 @@ KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     # NO_MEMORY_LIMIT_MARKER must precede 'OOMKilled': an unbounded-OOM reason
     # contains both, and the first match wins.
     ([NO_MEMORY_LIMIT_MARKER],
-     'The container had no memory limit, so the node ran out of memory '
-     'instead -- a node-level OOM that can kill other pods too. To fix: set '
-     '`kubernetes.set_pod_resource_limits`: '
+     'The container had no memory limit and the node ran out of memory. '
+     'To fix: set `kubernetes.set_pod_resource_limits`: '
      f'{SET_POD_RESOURCE_LIMITS_DOC_URL}'),
     (['OOMKilled'],
      'The container ran out of memory. To fix: Increase the memory request with '

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5650,3 +5650,91 @@ class TestGetNodeAffinity:
             'requiredDuringSchedulingIgnoredDuringExecution',
             'preferredDuringSchedulingIgnoredDuringExecution',
         }
+
+
+def _make_pod_with_spec(*,
+                        container_name='c',
+                        memory_limit=None,
+                        container_statuses=None,
+                        phase='Failed'):
+    """A pod whose spec declares `container_name`, optionally with a limit."""
+    limits = {'memory': memory_limit} if memory_limit is not None else None
+    container = kubernetes.client.V1Container(
+        name=container_name,
+        resources=kubernetes.client.V1ResourceRequirements(
+            requests={'memory': '2Gi'}, limits=limits))
+    return kubernetes.client.V1Pod(
+        spec=kubernetes.client.V1PodSpec(containers=[container]),
+        status=kubernetes.client.V1PodStatus(
+            phase=phase, container_statuses=container_statuses))
+
+
+def test_is_unbounded_oom_only_when_limit_absent():
+    unbounded = _make_pod_with_spec()
+    bounded = _make_pod_with_spec(memory_limit='4Gi')
+    assert utils.is_unbounded_oom('OOMKilled', unbounded, 'c')
+    # A container that OOMed against its own limit is not a node-level OOM.
+    assert not utils.is_unbounded_oom('OOMKilled', bounded, 'c')
+    # Only OOM kills are classified.
+    assert not utils.is_unbounded_oom('Error', unbounded, 'c')
+
+
+def test_is_unbounded_oom_false_when_container_not_in_spec():
+    # We cannot confirm the container was unbounded, so we must not claim it
+    # was: a confidently wrong node-level hint is worse than the generic one.
+    pod = _make_pod_with_spec(container_name='other')
+    assert not utils.is_unbounded_oom('OOMKilled', pod, 'c')
+    assert utils.annotate_oom_reason('OOMKilled', pod, 'c') == 'OOMKilled'
+
+
+def test_annotate_oom_reason_tags_only_unbounded():
+    assert utils.annotate_oom_reason(
+        'OOMKilled', _make_pod_with_spec(),
+        'c') == f'OOMKilled ({utils.NO_MEMORY_LIMIT_MARKER})'
+    assert utils.annotate_oom_reason('OOMKilled',
+                                     _make_pod_with_spec(memory_limit='4Gi'),
+                                     'c') == 'OOMKilled'
+    assert utils.annotate_oom_reason('Evicted', _make_pod_with_spec(),
+                                     'c') == 'Evicted'
+
+
+def test_get_condensed_pod_reason_marks_unbounded_oom():
+    pod = _make_pod_with_spec(container_statuses=[
+        _make_container_status(terminated_reason='OOMKilled',
+                               terminated_exit_code=137)
+    ])
+    assert utils.get_condensed_pod_reason(pod) == (
+        f'OOMKilled (exit code 137, {utils.NO_MEMORY_LIMIT_MARKER})')
+
+
+def test_get_condensed_pod_reason_bounded_oom_unchanged():
+    # With a limit set the message must stay exactly as it was.
+    pod = _make_pod_with_spec(memory_limit='4Gi',
+                              container_statuses=[
+                                  _make_container_status(
+                                      terminated_reason='OOMKilled',
+                                      terminated_exit_code=137)
+                              ])
+    assert utils.get_condensed_pod_reason(pod) == 'OOMKilled (exit code 137)'
+
+
+def test_unbounded_oom_hint_recommends_set_pod_resource_limits():
+    hint = utils.match_kubernetes_failure_hint(
+        f'OOMKilled (exit code 137, {utils.NO_MEMORY_LIMIT_MARKER})')
+    assert hint is not None
+    assert 'set_pod_resource_limits' in hint
+    # The hint must link the docs section, not just name the config.
+    assert utils.SET_POD_RESOURCE_LIMITS_DOC_URL in hint
+    assert '#kubernetes-set-pod-resource-limits' in (
+        utils.SET_POD_RESOURCE_LIMITS_DOC_URL)
+
+
+def test_unbounded_oom_hint_precedes_plain_oomkilled():
+    # The unbounded reason contains 'OOMKilled' too, so ordering decides which
+    # hint wins; the node-level one is the specific (and correct) advice.
+    unbounded = utils.match_kubernetes_failure_hint(
+        f'OOMKilled (exit code 137, {utils.NO_MEMORY_LIMIT_MARKER})')
+    bounded = utils.match_kubernetes_failure_hint('OOMKilled (exit code 137)')
+    assert unbounded != bounded
+    assert 'no memory limit' in unbounded
+    assert bounded.startswith('The container ran out of memory.')

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -598,3 +598,41 @@ class TestGetClusterFailureReasonFromPods:
         result = k8s_instance.get_cluster_failure_reason_from_pods(
             {}, ['pod-0', 'pod-1'])
         assert result == 'pod-1 is not ready (OOMKilled)'
+
+
+class TestPodReasonIdentifiesCause:
+    """A per-pod reason either names the cause, or only says "it is sick".
+
+    The distinction matters because a node that stops heartbeating leaves its
+    pods' status stale: a refresh during the outage can only say "not ready",
+    while a refresh after recovery names the real failure. Only the latter is
+    worth superseding an already-recorded reason with.
+    """
+
+    def test_bare_not_ready_does_not_identify_a_cause(self):
+        # kubelet never updated the pod, so the containers explain nothing.
+        assert not k8s_instance.pod_reason_identifies_cause(
+            'pod not ready (Unknown)')
+
+    def test_not_ready_with_container_detail_identifies_a_cause(self):
+        assert k8s_instance.pod_reason_identifies_cause(
+            'pod not ready (PodFailed); OOMKilled (exit code 137)')
+
+    def test_bare_termination_fallback_does_not_identify_a_cause(self):
+        assert not k8s_instance.pod_reason_identifies_cause(
+            'Terminated unexpectedly.\nLast known state: PodFailed.')
+
+    def test_termination_with_container_errors_identifies_a_cause(self):
+        # The fallback is only a *prefix* here -- the cause follows it, so a
+        # naive substring test on the fallback would get this backwards.
+        assert k8s_instance.pod_reason_identifies_cause(
+            'Terminated unexpectedly.\nLast known state: PodFailed.\n'
+            'Container errors: OOMKilled (no memory limit set)')
+
+    def test_kubelet_pod_status_reason_identifies_a_cause(self):
+        assert k8s_instance.pod_reason_identifies_cause(
+            'Evicted: The node was low on resource: memory')
+
+    def test_absent_reason_identifies_nothing(self):
+        assert not k8s_instance.pod_reason_identifies_cause(None)
+        assert not k8s_instance.pod_reason_identifies_cause('')


### PR DESCRIPTION
## Problem

On the cluster-status path, every reason containing `OOMKilled` gets one and
the same hint:

> The container ran out of memory. To fix: Increase the memory request with `resources.memory` …

There is exactly one `OOMKilled` entry in the hint table, and the reason string
is byte-identical whether the container hit its own limit or the node ran out —
so the advice cannot tell the two apart. It is only correct for the first.

SkyPilot sets a memory **request** and no **limit** unless
`kubernetes.set_pod_resource_limits` is on (it defaults to `false`). An
unbounded container therefore grows until the **node** runs out of memory and
the kernel kills it, often taking other pods on that node with it. Telling that
user to raise the request is wrong: the request was never a cap.

## What a user actually sees

A node-level OOM reaches the dashboard in one of three shapes. Only the middle
row is what the original hint change addresses; the last row is the common one.

| | reason SkyPilot records | on master | with this PR |
|---|---|---|---|
| **A** — container OOM, memory limit set | `OOMKilled` | correct hint: raise `resources.memory` | **unchanged** (verified, 3/3) |
| **B** — node OOM, no limit | `OOMKilled` | **wrong hint** — tells you to raise a request that was never a cap | **right hint** — `set_pod_resource_limits` |
| **C** — node OOM, reason lost | `ray cluster is unhealthy (0/1 ready)`, `pod not ready (Unknown)` | **no hint at all** — the OOM is never surfaced | **becomes B** once the node returns |

Case C is common: **40% of node-level OOMs** in the measurement below. The
node stops heartbeating, so the pod object is stale and still reads `Running`.
SkyPilot records a generic reason, and the `if status != INIT` guard then
freezes it -- the correct diagnosis, available a minute later, is discarded.

### Measured on the k3s cluster described under Evidence

25 node-level OOMs on master, stratified across worker sizes. `B` = the event
named the OOM; `C` = generic reason, nothing actionable.

| worker | B | C | case C |
|---|---|---|---|
| 2 GB | 3 | 4 | 57% |
| 4 GB | 5 | 4 | 44% |
| 8 GB | 7 | 2 | 22% |
| **all** | **15** | **10** | **40%** |

Two things worth taking from this. Case C is frequent enough to matter, but it
is *not* the majority -- both outcomes are common, which is what "race" should
lead you to expect. And smaller nodes lose the reason more often (57% vs 22%):
less headroom means the node wedges harder and stays unreadable longer. The
per-node samples are 7-9 trials each, so treat the gradient as a direction, not
a precise rate.

## B and C are the same failure -- a race

They are not two bugs. Both are one node-level OOM; which one you see depends
on timing.

When the node runs out of memory it stops heartbeating, so kubelet cannot
update the pod object -- it still reads `Running` even though the container is
already dead. The status refresh then races the node's recovery:

- refresh lands **after** the node returns → it reads the real container
  status → `OOMKilled` → **case B**
- refresh lands **during** the outage → the pod looks healthy, so nothing
  pod-level explains the failure → generic reason → **case C**

Neither side is rare: the refresh that notices the problem is often the one
that cannot yet see the cause, which is why case C lands 40% of the time
(measured above) rather than occasionally.

What makes it *permanent* is the guard on the event write, `if status != INIT`.
Once the cluster is INIT no further STATUS_CHANGE is recorded, so the later
refresh -- the one that can read `OOMKilled` -- has nowhere to put it. SkyPilot
computes the correct diagnosis and throws it away.

So case C is case B with the answer arriving a minute late and being discarded.

### How this PR fixes it

`pod_reason_identifies_cause()` lets a refresh tell "I named the cause" apart
from "I only know the pod is unhealthy". The guard becomes *already INIT,
**unless** this refresh finally identified the cause*, so the late diagnosis
supersedes the generic reason instead of being dropped.

It appends rather than overwrites: `cluster_events` is an audit trail and the
dashboard reads the latest status change anyway. `add_cluster_event()` already
drops an identical reason, so a stable cause is recorded once, not once per
poll, and the upgrade only ever runs generic → specific.

The race still happens. It just stops deciding what the user sees -- both sides
converge on B.

## Why the limit decides which hint

Both failures report an identical `OOMKilled` + `exitCode 137`. The only thing
that separates them is whether the container declares a memory limit:

| | Limit **is** set | Limit **not** set (default) |
|---|---|---|
| What happened | container exceeded **its own cap** | nothing capped it; it ate the **node** |
| Who else is hurt | nobody — the cgroup killed just this container | other pods on that node can be killed too |
| Correct fix | raise `resources.memory` | set `set_pod_resource_limits` |
| Wrong advice | "set `set_pod_resource_limits`" — it already is | "raise the request" — it was never a cap, so nothing changes |

There is no other signal to go on: kubelet emits no `SystemOOM` event for
either case.

## Change

- Tag an OOM on a limitless container with `no memory limit set`, and add a
  hint recommending `set_pod_resource_limits` with a link to its docs section.
  Ordered before the existing `OOMKilled` entry, since the node-level reason
  contains both substrings and the first match wins.
- Container-level OOMs keep today's hint, unchanged.
- If the container is absent from the pod spec we cannot confirm it was
  unbounded, so the generic hint is kept rather than asserting the wrong one.
- Dashboard: linkify URLs and preserve newlines in the cluster "Last Event" and
  in expanded job details — the hint was rendering as one unreadable paragraph
  with a dead URL.

## Before / after

Cluster detail → **Last Event**, same node-level OOM.

**Before**

<!-- screenshot: dashboard BEFORE -->

case B -> `refresh lands after the node returns → it reads the real container status → OOMKilled → case B`

<img width="3018" height="1670" alt="image" src="https://github.com/user-attachments/assets/dc8bf753-bae1-4175-be1f-579b20d078f1" />

case C -> `refresh lands **during** the outage → the pod looks healthy, so nothing
  pod-level explains the failure → generic reason`

<img width="3020" height="1620" alt="image" src="https://github.com/user-attachments/assets/cf1e7e57-cad2-44b3-b819-a2981d71e80f" />



**After**

<img width="3010" height="1562" alt="image" src="https://github.com/user-attachments/assets/c7ba9d99-bed1-4ba8-8c81-2fb532f884fa" />


<!-- screenshot: dashboard AFTER -->

No CLI change is observable for this failure mode: during a node OOM the
worker's kubelet is unreachable, so `sky exec` — the only CLI path that prints
these hints — cannot run, and the cluster flips to `INIT` moments later. The
dashboard event is the only surface that reaches the user.

## Evidence

Throwaway AWS k3s cluster (kernel 6.8, cgroup v2, containerd 2.3.2): tainted
control plane plus 2/4/8 GB workers, raw pods to isolate CRI behaviour.

| case | runs | result |
|---|---|---|
| node-level OOM, no limits anywhere | 9 | 7 `OOMKilled`, 2 `Error`; `exitCode 137` and empty `limits` in all 9 |
| container-level OOM, real `limits.memory` | 3 | 3 `OOMKilled`, limit present |

End-to-end through SkyPilot with **no overrides** (`cpus: 1, memory: 1` plus a
workload that runs healthily before growing): cluster reaches `UP`, the node
then OOMs, cluster transitions to `UNHEALTHY` carrying the new hint.

## Known limitation

Some node-level OOMs report `reason: Error` rather than `OOMKilled` (2 of 60
abnormal-INIT events observed across this work) — the global OOM killer fires without
the kill being attributed to the container's cgroup. The hint does not fire for
those; they fall back to today's behaviour.

Keying on `exitCode == 137` would catch them, but 137 is just SIGKILL and is
already overloaded in this repo: `CANCELLED_RETURN_CODE = 137`
(`task_codegen.py`), and SkyPilot's own multi-node cleanup exits 137. Hinting at
`set_pod_resource_limits` when a user simply cancelled a job is the same class
of wrong advice this PR removes. Closing the gap needs a positive OOM signal
(kernel log or a real node event) — a separate change.

## Tests

8 new unit tests: limit present vs. absent, container missing from the spec,
reason tagging, the condensed reason both ways, the hint content and its docs
anchor, and the ordering that makes the node-level hint win. Existing suites
pass — 283 and 77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ke7pjsJo1ckRhwFkU7qgH






