### PR TITLE
[Volume] Show a resize that has not landed yet

### DIFF
--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -160,6 +160,12 @@ class VolumeTable(abc.ABC):
             size = f'{size}Gi'
         else:
             size = '-'
+        # A volume reports the capacity it has now, so a resize that has not
+        # landed yet is invisible in the size alone. The message column says
+        # what it is waiting for, but only this says how big it is getting.
+        target = row.get('resize_target_size')
+        if row.get('resize_status') and _is_larger(target, row.get('size')):
+            size = f'{size} -> {target}Gi'
         usedby_str = '-'
         usedby_clusters = row.get('usedby_clusters')
         usedby_pods = row.get('usedby_pods')
@@ -203,14 +209,37 @@ class VolumeTable(abc.ABC):
         raise NotImplementedError
 
 
+def _is_larger(target: Optional[str], size: Optional[str]) -> bool:
+    """Whether a resize is heading somewhere the recorded size does not show.
+
+    Both are whole gibibytes, so a resize smaller than that -- or one whose new
+    space has landed while the state has not cleared -- reads as no resize.
+    """
+    try:
+        return (target is not None and size is not None and
+                int(target) > int(size))
+    except ValueError:
+        return False
+
+
+def _volume_message(row: responses.VolumeRecord) -> str:
+    """What the MESSAGE column says about a volume.
+
+    One cell, so a volume with both an error and a resize in flight shows the
+    error: it is the one that says the volume is unusable. The dashboard's
+    details column picks the same way.
+    """
+    return row.get('error_message') or row.get('resize_message') or ''
+
+
 class PVCVolumeTable(VolumeTable):
     """The PVC volume table."""
 
     def __init__(self,
                  volumes: List[responses.VolumeRecord],
                  show_all: bool = False):
-        # Check if any volume has an error before creating the table
-        self._has_errors = any(row.get('error_message') for row in volumes)
+        # Check if any volume has something to say before creating the table
+        self._has_messages = any(_volume_message(row) for row in volumes)
         super().__init__(volumes, show_all)
 
     def _create_table(self, show_all: bool = False) -> prettytable.PrettyTable:
@@ -234,7 +263,7 @@ class PVCVolumeTable(VolumeTable):
                 'ACCESS_MODE',
                 'MESSAGE',
             ]
-        elif self._has_errors:
+        elif self._has_messages:
             # Show MESSAGE column even without show_all if there are issues
             columns = columns + ['MESSAGE']
 
@@ -253,17 +282,17 @@ class PVCVolumeTable(VolumeTable):
                 table_row.append(
                     row.get('config', {}).get('storage_class_name', '-'))
                 table_row.append(row.get('config', {}).get('access_mode', ''))
-                # Add error message
-                error_msg = row.get('error_message', '')
-                table_row.append(error_msg if error_msg else '-')
-            elif self._has_errors:
-                # Show error message even without show_all if there are errors
-                error_msg = row.get('error_message', '')
-                # Truncate error message for display
-                if error_msg:
-                    error_msg = common_utils.truncate_long_string(
-                        error_msg, constants.ERROR_MESSAGE_TRUNC_LENGTH)
-                table_row.append(error_msg if error_msg else '-')
+                # Add the message
+                message = _volume_message(row)
+                table_row.append(message if message else '-')
+            elif self._has_messages:
+                # Show the message even without show_all if there is one
+                message = _volume_message(row)
+                # Truncate the message for display
+                if message:
+                    message = common_utils.truncate_long_string(
+                        message, constants.ERROR_MESSAGE_TRUNC_LENGTH)
+                table_row.append(message if message else '-')
 
             self.table.add_row(table_row)
 

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -247,7 +247,7 @@ class PVCVolumeTable(VolumeTable):
         #  If show_all is False, show the table with the columns:
         #   NAME, TYPE, INFRA, SIZE, USER, WORKSPACE,
         #   AGE, STATUS, LAST_USE, USED_BY, IS_EPHEMERAL
-        #   (+ MESSAGE if any volume is not ready)
+        #   (+ MESSAGE if any volume has something to say)
         #  If show_all is True, show the table with the columns:
         #   NAME, TYPE, INFRA, SIZE, USER, WORKSPACE,
         #   AGE, STATUS, LAST_USE, USED_BY, IS_EPHEMERAL, NAME_ON_CLOUD
@@ -264,7 +264,7 @@ class PVCVolumeTable(VolumeTable):
                 'MESSAGE',
             ]
         elif self._has_messages:
-            # Show MESSAGE column even without show_all if there are issues
+            # Show MESSAGE column even without show_all if there is one
             columns = columns + ['MESSAGE']
 
         table = log_utils.create_table(columns)

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -289,6 +289,13 @@ export function formatAutostop(autostop, toDown) {
   return autostopStr;
 }
 
+// Sizes come from the API as a number of GiB.
+export const formatSize = (size) => {
+  if (size == null) return '-';
+  if (size >= 1024) return `${+(size / 1024).toFixed(1)}Ti`;
+  return `${size}Gi`;
+};
+
 // Format duration from seconds to a readable format
 export function formatDuration(durationInSeconds) {
   if (!durationInSeconds && durationInSeconds !== 0) return '-';

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -46,6 +46,7 @@ import {
   TimestampWithTooltip,
   LastUpdatedTimestamp,
   NonCapitalizedTooltip as Tooltip,
+  formatSize,
 } from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import {
@@ -70,13 +71,6 @@ const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 
 const VOLUMES_PAGE_SIZE_OPTIONS = [10, 30, 50, 100, 200];
 const VOLUMES_PAGE_SIZE_STORAGE_KEY = 'skypilot-volumes-page-size';
-
-// Sizes come from the API as a number of GiB.
-export const formatSize = (size) => {
-  if (size == null) return '-';
-  if (size >= 1024) return `${+(size / 1024).toFixed(1)}Ti`;
-  return `${size}Gi`;
-};
 
 // The filterable properties, declared once. `key` is the URL parameter and the
 // `valueList` key for the typeahead; `label` is what lands in
@@ -711,6 +705,13 @@ export function VolumesTable({
     if (!volume.resize_status || volume.resize_target_size == null) {
       return size;
     }
+    // Both sizes are whole GiB, so a resize smaller than that -- or one whose
+    // new space has landed while the state has not cleared -- would render an
+    // arrow pointing at the size it already shows. The reason still reaches
+    // the user through the details column.
+    if (Number(volume.resize_target_size) <= Number(volume.size)) {
+      return size;
+    }
     const target = formatSize(volume.resize_target_size);
     return (
       <Tooltip content={volume.resize_message}>
@@ -739,6 +740,10 @@ export function VolumesTable({
   // Volumes are usable most of the time, so a column of dashes would be noise.
   // Judge over the whole dataset, not the current page or filter, so the column
   // does not come and go while paging.
+  //
+  // One cell, so a volume with both an error and a resize shows the error: it
+  // is the one that says the volume is unusable. The volume's own page has
+  // room and shows both -- deliberately, not by oversight.
   const volumeDetails = (volume) =>
     volume.error_message || volume.resize_message || null;
 

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -972,9 +972,9 @@ export function VolumesTable({
                     </TableRow>
                     {/* A volume can become ready while its reason is
                         expanded, taking the column with it. */}
-                    {expandedRowId === volume.name && volume.error_message && (
+                    {expandedRowId === volume.name && volumeDetails(volume) && (
                       <ExpandedDetailsRow
-                        text={volume.error_message}
+                        text={volumeDetails(volume)}
                         colSpan={totalColSpan}
                         innerRef={expandedRowRef}
                       />

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -67,6 +67,13 @@ const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 const VOLUMES_PAGE_SIZE_OPTIONS = [10, 30, 50, 100, 200];
 const VOLUMES_PAGE_SIZE_STORAGE_KEY = 'skypilot-volumes-page-size';
 
+// Sizes come from the API as a number of GiB.
+export const formatSize = (size) => {
+  if (size == null) return '-';
+  if (size >= 1024) return `${+(size / 1024).toFixed(1)}Ti`;
+  return `${size}Gi`;
+};
+
 // The filterable properties, declared once. `key` is the URL parameter and the
 // `valueList` key for the typeahead; `label` is what lands in
 // `filter.property`, which `evaluateCondition` lowercases to look up the field
@@ -691,10 +698,35 @@ export function VolumesTable({
     setCurrentPage(1); // Reset to first page when changing page size
   };
 
-  const formatSize = (size) => {
-    if (size == null) return '-';
-    if (size >= 1024) return `${+(size / 1024).toFixed(1)}Ti`;
-    return `${size}Gi`;
+  // A volume reports the capacity it actually has, so a resize that has not
+  // landed yet is invisible in the size alone. Show where it is heading, and
+  // say what the volume is waiting for -- `needs_restart` in particular never
+  // clears on its own.
+  const resizeHint = (status, target) => {
+    switch (status) {
+      case 'needs_restart':
+        return `Resizing to ${target}: the space is allocated, but the filesystem only grows when the volume is next mounted. Restart the cluster or pod using it.`;
+      case 'in_progress':
+        return `Resizing to ${target}.`;
+      case 'failed':
+        return `Resize to ${target} failed. Check the volume's events on the cluster.`;
+      default:
+        return `Resizing to ${target}.`;
+    }
+  };
+
+  const renderSize = (volume) => {
+    const size = formatSize(volume.size);
+    if (!volume.resize_status || volume.resize_target_size == null) {
+      return size;
+    }
+    const target = formatSize(volume.resize_target_size);
+    return (
+      <span title={resizeHint(volume.resize_status, target)}>
+        {size}
+        <span className="text-gray-500"> &rarr; {target}</span>
+      </span>
+    );
   };
 
   const formatTimestamp = (timestamp) => {
@@ -766,7 +798,7 @@ export function VolumesTable({
       id: 'size',
       order: 30,
       renderHeader: () => sortableHeader('Size', 'size'),
-      renderCell: (volume) => <TableCell>{formatSize(volume.size)}</TableCell>,
+      renderCell: (volume) => <TableCell>{renderSize(volume)}</TableCell>,
     },
     {
       id: 'user_name',

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -42,7 +42,11 @@ import {
 import { ErrorDisplay } from '@/components/elements/ErrorDisplay';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { TimestampWithTooltip, LastUpdatedTimestamp } from '@/components/utils';
+import {
+  TimestampWithTooltip,
+  LastUpdatedTimestamp,
+  NonCapitalizedTooltip as Tooltip,
+} from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import {
   TruncatedDetails,
@@ -699,22 +703,9 @@ export function VolumesTable({
   };
 
   // A volume reports the capacity it actually has, so a resize that has not
-  // landed yet is invisible in the size alone. Show where it is heading, and
-  // say what the volume is waiting for -- `needs_restart` in particular never
-  // clears on its own.
-  const resizeHint = (status, target) => {
-    switch (status) {
-      case 'needs_restart':
-        return `Resizing to ${target}: the space is allocated, but the filesystem only grows when the volume is next mounted. Restart the cluster or pod using it.`;
-      case 'in_progress':
-        return `Resizing to ${target}.`;
-      case 'failed':
-        return `Resize to ${target} failed. Check the volume's events on the cluster.`;
-      default:
-        return `Resizing to ${target}.`;
-    }
-  };
-
+  // landed yet is invisible in the size alone. Show where it is heading, with
+  // the server's explanation of what it is waiting for -- the same text the
+  // details column shows, when that one is free.
   const renderSize = (volume) => {
     const size = formatSize(volume.size);
     if (!volume.resize_status || volume.resize_target_size == null) {
@@ -722,10 +713,14 @@ export function VolumesTable({
     }
     const target = formatSize(volume.resize_target_size);
     return (
-      <span title={resizeHint(volume.resize_status, target)}>
-        {size}
-        <span className="text-gray-500"> &rarr; {target}</span>
-      </span>
+      <Tooltip content={volume.resize_message}>
+        {/* nowrap: the column is narrow, and a size broken across three lines
+            reads worse than a wider column. */}
+        <span className="whitespace-nowrap">
+          {size}
+          <span className="text-gray-500"> &rarr; {target}</span>
+        </span>
+      </Tooltip>
     );
   };
 
@@ -744,8 +739,11 @@ export function VolumesTable({
   // Volumes are usable most of the time, so a column of dashes would be noise.
   // Judge over the whole dataset, not the current page or filter, so the column
   // does not come and go while paging.
+  const volumeDetails = (volume) =>
+    volume.error_message || volume.resize_message || null;
+
   const anyVolumeHasDetails = useMemo(
-    () => data.some((volume) => volume.error_message),
+    () => data.some((volume) => volumeDetails(volume)),
     [data]
   );
 
@@ -847,9 +845,9 @@ export function VolumesTable({
             renderHeader: () => <TableHead>Details</TableHead>,
             renderCell: (volume) => (
               <TableCell>
-                {volume.error_message ? (
+                {volumeDetails(volume) ? (
                   <TruncatedDetails
-                    text={volume.error_message}
+                    text={volumeDetails(volume)}
                     rowId={volume.name}
                     expandedRowId={expandedRowId}
                     setExpandedRowId={setExpandedRowId}

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -232,6 +232,19 @@ describe('VolumesTable size column while a resize is pending', () => {
     expect(details.textContent).not.toContain('Restart the cluster');
   });
 
+  it('expands a resize explanation, not only an error', async () => {
+    // The expanded row used to be gated on the error message, so "show more"
+    // flipped to "show less" with nothing revealed.
+    const long = `Waiting for user to (re-)start a pod to finish file system resize of volume on node. Restart the cluster or job using this volume to finish the resize.`;
+    const { container } = await renderTable([resizing('needs_restart', long)]);
+
+    fireEvent.click(screen.getByText('... show more'));
+
+    const expanded = container.querySelector('tr.expanded-details');
+    expect(expanded).toBeTruthy();
+    expect(expanded.textContent).toContain('finish the resize.');
+  });
+
   it('ignores a status from a server that reports no target size', async () => {
     // An older server sends none of these fields; a half-populated row must
     // not render a dangling arrow.

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -176,3 +176,57 @@ describe('VolumesTable details column', () => {
     expect(cellsInColumn).toContain('-');
   });
 });
+
+describe('VolumesTable size column while a resize is pending', () => {
+  // The recorded size is the capacity the volume has now, so a resize that
+  // has not landed is invisible in it. `needs_restart` in particular never
+  // clears on its own -- the user has to restart what is using the volume.
+  const resizing = (status) => ({
+    ...volume('vol-resizing'),
+    size: 1,
+    resize_status: status,
+    resize_target_size: 2,
+  });
+
+  it('shows only the current size when nothing is resizing', async () => {
+    const { container } = await renderTable([volume('vol-steady')]);
+
+    const row = container.querySelector('table tbody tr');
+    expect(row.textContent).toContain('1Gi');
+    expect(row.textContent).not.toContain('→');
+  });
+
+  it('shows where the size is heading while a resize is pending', async () => {
+    const { container } = await renderTable([resizing('needs_restart')]);
+
+    const row = container.querySelector('table tbody tr');
+    expect(row.textContent).toContain('1Gi');
+    expect(row.textContent).toContain('2Gi');
+  });
+
+  it('says a pending resize is waiting on a restart', async () => {
+    const { container } = await renderTable([resizing('needs_restart')]);
+
+    const hint = container.querySelector('[title*="Resizing to 2Gi"]');
+    expect(hint).toBeTruthy();
+    expect(hint.getAttribute('title')).toContain('Restart');
+  });
+
+  it('says a failed resize failed', async () => {
+    const { container } = await renderTable([resizing('failed')]);
+
+    const hint = container.querySelector('[title*="2Gi"]');
+    expect(hint.getAttribute('title')).toContain('failed');
+  });
+
+  it('ignores a status from a server that reports no target size', async () => {
+    // An older server sends neither field; a half-populated row must not
+    // render a dangling arrow.
+    const { container } = await renderTable([
+      { ...volume('vol-half'), resize_status: 'in_progress' },
+    ]);
+
+    const row = container.querySelector('table tbody tr');
+    expect(row.textContent).not.toContain('→');
+  });
+});

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -179,9 +179,9 @@ describe('VolumesTable details column', () => {
 
 describe('VolumesTable size column while a resize is pending', () => {
   // The recorded size is the capacity the volume has now, so a resize that
-  // has not landed is invisible in it. `needs_restart` in particular never
-  // clears on its own -- the user has to restart what is using the volume.
-  // The message is composed by the server, so the table just renders it.
+  // has not landed is invisible in it, and one waiting on the node can stay
+  // that way indefinitely. What it is waiting for is composed by the server,
+  // so the table just renders it.
   const resizing = (
     status,
     message = 'Resizing to 2Gi. Restart the cluster.'
@@ -202,7 +202,7 @@ describe('VolumesTable size column while a resize is pending', () => {
   });
 
   it('shows where the size is heading while a resize is pending', async () => {
-    const { container } = await renderTable([resizing('needs_restart')]);
+    const { container } = await renderTable([resizing('pending_on_node')]);
 
     const row = container.querySelector('table tbody tr');
     expect(row.textContent).toContain('1Gi');
@@ -210,7 +210,7 @@ describe('VolumesTable size column while a resize is pending', () => {
   });
 
   it("shows the server's explanation without hovering, in details", async () => {
-    const { container } = await renderTable([resizing('needs_restart')]);
+    const { container } = await renderTable([resizing('pending_on_node')]);
 
     expect(container.textContent).toContain('Restart the cluster');
   });
@@ -219,7 +219,7 @@ describe('VolumesTable size column while a resize is pending', () => {
     // An error means the volume is unusable, which outranks a resize that has
     // not landed; the resize keeps its tooltip on the size cell.
     const withBoth = {
-      ...resizing('needs_restart'),
+      ...resizing('pending_on_node'),
       status: 'NOT_READY',
       error_message: 'PVC is pending. ProvisioningFailed: no capacity',
     };
@@ -236,7 +236,9 @@ describe('VolumesTable size column while a resize is pending', () => {
     // The expanded row used to be gated on the error message, so "show more"
     // flipped to "show less" with nothing revealed.
     const long = `Waiting for user to (re-)start a pod to finish file system resize of volume on node. Restart the cluster or job using this volume to finish the resize.`;
-    const { container } = await renderTable([resizing('needs_restart', long)]);
+    const { container } = await renderTable([
+      resizing('pending_on_node', long),
+    ]);
 
     fireEvent.click(screen.getByText('... show more'));
 

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -181,11 +181,16 @@ describe('VolumesTable size column while a resize is pending', () => {
   // The recorded size is the capacity the volume has now, so a resize that
   // has not landed is invisible in it. `needs_restart` in particular never
   // clears on its own -- the user has to restart what is using the volume.
-  const resizing = (status) => ({
+  // The message is composed by the server, so the table just renders it.
+  const resizing = (
+    status,
+    message = 'Resizing to 2Gi. Restart the cluster.'
+  ) => ({
     ...volume('vol-resizing'),
     size: 1,
     resize_status: status,
     resize_target_size: 2,
+    resize_message: message,
   });
 
   it('shows only the current size when nothing is resizing', async () => {
@@ -204,24 +209,32 @@ describe('VolumesTable size column while a resize is pending', () => {
     expect(row.textContent).toContain('2Gi');
   });
 
-  it('says a pending resize is waiting on a restart', async () => {
+  it("shows the server's explanation without hovering, in details", async () => {
     const { container } = await renderTable([resizing('needs_restart')]);
 
-    const hint = container.querySelector('[title*="Resizing to 2Gi"]');
-    expect(hint).toBeTruthy();
-    expect(hint.getAttribute('title')).toContain('Restart');
+    expect(container.textContent).toContain('Restart the cluster');
   });
 
-  it('says a failed resize failed', async () => {
-    const { container } = await renderTable([resizing('failed')]);
+  it('leaves the details column to an error when there is one', async () => {
+    // An error means the volume is unusable, which outranks a resize that has
+    // not landed; the resize keeps its tooltip on the size cell.
+    const withBoth = {
+      ...resizing('needs_restart'),
+      status: 'NOT_READY',
+      error_message: 'PVC is pending. ProvisioningFailed: no capacity',
+    };
+    const { container } = await renderTable([withBoth]);
 
-    const hint = container.querySelector('[title*="2Gi"]');
-    expect(hint.getAttribute('title')).toContain('failed');
+    const details =
+      container.querySelector('table tbody tr').lastElementChild
+        .previousElementSibling;
+    expect(details.textContent).toContain('ProvisioningFailed');
+    expect(details.textContent).not.toContain('Restart the cluster');
   });
 
   it('ignores a status from a server that reports no target size', async () => {
-    // An older server sends neither field; a half-populated row must not
-    // render a dangling arrow.
+    // An older server sends none of these fields; a half-populated row must
+    // not render a dangling arrow.
     const { container } = await renderTable([
       { ...volume('vol-half'), resize_status: 'in_progress' },
     ]);

--- a/sky/dashboard/src/components/volumes.test.jsx
+++ b/sky/dashboard/src/components/volumes.test.jsx
@@ -247,6 +247,20 @@ describe('VolumesTable size column while a resize is pending', () => {
     expect(expanded.textContent).toContain('finish the resize.');
   });
 
+  it('ignores a target that rounds to the size already shown', async () => {
+    // Sizes are whole GiB on both sides, so a resize smaller than that -- or
+    // one whose space has landed while the state has not cleared -- would
+    // render an arrow pointing at the size next to it.
+    const { container } = await renderTable([
+      { ...resizing('pending_on_node'), resize_target_size: 1 },
+    ]);
+
+    const row = container.querySelector('table tbody tr');
+    expect(row.textContent).not.toContain('→');
+    // The reason still reaches the user through the details column.
+    expect(container.textContent).toContain('Restart the cluster');
+  });
+
   it('ignores a status from a server that reports no target size', async () => {
     // An older server sends none of these fields; a half-populated row must
     // not render a dangling arrow.

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -50,6 +50,7 @@ export async function getVolumes() {
           // resize lands. Servers older than these fields report nothing.
           resize_status: volume.resize_status || null,
           resize_target_size: volume.resize_target_size ?? null,
+          resize_message: volume.resize_message || null,
         };
       }) || [];
 

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -45,6 +45,11 @@ export async function getVolumes() {
           // from "cannot tell".
           error_may_resolve: volume.error_may_resolve,
           creation_yaml: volume.creation_yaml || null,
+          // Only set while the volume is being resized: `size` above is the
+          // capacity it has now, which is not what was asked for until the
+          // resize lands. Servers older than these fields report nothing.
+          resize_status: volume.resize_status || null,
+          resize_target_size: volume.resize_target_size ?? null,
         };
       }) || [];
 

--- a/sky/dashboard/src/pages/volumes/[volume].js
+++ b/sky/dashboard/src/pages/volumes/[volume].js
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { getVolumes } from '@/data/connectors/volumes';
-import { formatSize } from '@/components/volumes';
 import dashboardCache from '@/lib/cache';
 import {
   RotateCwIcon,
@@ -17,6 +16,7 @@ import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
   formatFullTimestamp,
+  formatSize,
 } from '@/components/utils';
 import { useMobile } from '@/hooks/useMobile';
 import Head from 'next/head';

--- a/sky/dashboard/src/pages/volumes/[volume].js
+++ b/sky/dashboard/src/pages/volumes/[volume].js
@@ -300,16 +300,9 @@ function VolumeDetailCard({ volumeData }) {
                 </div>
                 {/* The size above is the capacity the volume has now; a
                     resize only shows up there once it has landed. */}
-                {volumeData.resize_status === 'needs_restart' && (
+                {volumeData.resize_message && (
                   <div className="text-sm mt-1 text-gray-500">
-                    Waiting to grow the filesystem: restart the cluster or pod
-                    using this volume.
-                  </div>
-                )}
-                {volumeData.resize_status === 'failed' && (
-                  <div className="text-sm mt-1 text-gray-500">
-                    The resize did not complete. Check the volume&apos;s events
-                    on the cluster.
+                    {volumeData.resize_message}
                   </div>
                 )}
               </div>

--- a/sky/dashboard/src/pages/volumes/[volume].js
+++ b/sky/dashboard/src/pages/volumes/[volume].js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { getVolumes } from '@/data/connectors/volumes';
+import { formatSize } from '@/components/volumes';
 import dashboardCache from '@/lib/cache';
 import {
   RotateCwIcon,
@@ -285,7 +286,32 @@ function VolumeDetailCard({ volumeData }) {
               </div>
               <div>
                 <div className="text-gray-600 font-medium text-base">Size</div>
-                <div className="text-base mt-1">{volumeData.size || 'N/A'}</div>
+                <div className="text-base mt-1">
+                  {volumeData.size != null
+                    ? formatSize(volumeData.size)
+                    : 'N/A'}
+                  {volumeData.resize_status &&
+                    volumeData.resize_target_size != null && (
+                      <span className="text-gray-500">
+                        {' '}
+                        &rarr; {formatSize(volumeData.resize_target_size)}
+                      </span>
+                    )}
+                </div>
+                {/* The size above is the capacity the volume has now; a
+                    resize only shows up there once it has landed. */}
+                {volumeData.resize_status === 'needs_restart' && (
+                  <div className="text-sm mt-1 text-gray-500">
+                    Waiting to grow the filesystem: restart the cluster or pod
+                    using this volume.
+                  </div>
+                )}
+                {volumeData.resize_status === 'failed' && (
+                  <div className="text-sm mt-1 text-gray-500">
+                    The resize did not complete. Check the volume&apos;s events
+                    on the cluster.
+                  </div>
+                )}
               </div>
               <div>
                 <div className="text-gray-600 font-medium text-base">User</div>

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -177,6 +177,9 @@ volume_table = sqlalchemy.Table(
     sqlalchemy.Column('resize_target_size',
                       sqlalchemy.Text,
                       server_default=None),
+    # What the cloud said about the resize, in its own words. What is shown to
+    # the user is built from this in volume_list, not stored.
+    sqlalchemy.Column('resize_message', sqlalchemy.Text, server_default=None),
 )
 
 # Table for Cluster History
@@ -3004,6 +3007,7 @@ def _volume_record_from_row(row: Any) -> Dict[str, Any]:
         'creation_yaml': row.creation_yaml,
         'resize_status': row.resize_status,
         'resize_target_size': row.resize_target_size,
+        'resize_message': row.resize_message,
     }
 
 
@@ -3152,7 +3156,8 @@ def update_volume_status(name: str,
                          usedby_clusters: Optional[List[str]] = None,
                          resize_status: Optional[
                              models.VolumeResizeStatus] = None,
-                         resize_target_size: Optional[str] = None) -> None:
+                         resize_target_size: Optional[str] = None,
+                         resize_message: Optional[str] = None) -> None:
     """Update volume status and related fields.
 
     Args:
@@ -3165,6 +3170,7 @@ def update_volume_status(name: str,
             which is what a finished resize looks like).
         resize_target_size: The size that resize is heading for (None clears
             it).
+        resize_message: What the cloud said about the resize (None clears it).
     """
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
@@ -3178,6 +3184,7 @@ def update_volume_status(name: str,
         update_dict[volume_table.c.resize_status] = (
             resize_status.value if resize_status is not None else None)
         update_dict[volume_table.c.resize_target_size] = resize_target_size
+        update_dict[volume_table.c.resize_message] = resize_message
         # Update usedby fields if provided (encode as JSON)
         if usedby_pods is not None:
             update_dict[volume_table.c.usedby_pods] = json.dumps(usedby_pods)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -170,6 +170,13 @@ volume_table = sqlalchemy.Table(
     sqlalchemy.Column('usedby_pods', sqlalchemy.Text, server_default=None),
     sqlalchemy.Column('usedby_clusters', sqlalchemy.Text, server_default=None),
     sqlalchemy.Column('creation_yaml', sqlalchemy.Text, server_default=None),
+    # Set only while the volume is being resized to a size it does not have
+    # yet; `handle`'s size stays the capacity that exists. See
+    # models.VolumeResizeStatus.
+    sqlalchemy.Column('resize_status', sqlalchemy.Text, server_default=None),
+    sqlalchemy.Column('resize_target_size',
+                      sqlalchemy.Text,
+                      server_default=None),
 )
 
 # Table for Cluster History
@@ -2995,6 +3002,8 @@ def _volume_record_from_row(row: Any) -> Dict[str, Any]:
         'usedby_clusters':
             (json.loads(row.usedby_clusters) if row.usedby_clusters else []),
         'creation_yaml': row.creation_yaml,
+        'resize_status': row.resize_status,
+        'resize_target_size': row.resize_target_size,
     }
 
 
@@ -3140,7 +3149,10 @@ def update_volume_status(name: str,
                          status: status_lib.VolumeStatus,
                          error_message: Optional[str] = None,
                          usedby_pods: Optional[List[str]] = None,
-                         usedby_clusters: Optional[List[str]] = None) -> None:
+                         usedby_clusters: Optional[List[str]] = None,
+                         resize_status: Optional[
+                             models.VolumeResizeStatus] = None,
+                         resize_target_size: Optional[str] = None) -> None:
     """Update volume status and related fields.
 
     Args:
@@ -3149,6 +3161,10 @@ def update_volume_status(name: str,
         error_message: Error message (None clears it).
         usedby_pods: List of pods using the volume (None keeps existing value).
         usedby_clusters: List of clusters using the volume (None keeps it).
+        resize_status: How far a resize of the volume has got (None clears it,
+            which is what a finished resize looks like).
+        resize_target_size: The size that resize is heading for (None clears
+            it).
     """
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
@@ -3157,6 +3173,11 @@ def update_volume_status(name: str,
         }
         # Always update error_message (None clears it)
         update_dict[volume_table.c.error_message] = error_message
+        # Same for the resize fields: a resize that finished stops being
+        # reported, and that absence is the signal it is done.
+        update_dict[volume_table.c.resize_status] = (
+            resize_status.value if resize_status is not None else None)
+        update_dict[volume_table.c.resize_target_size] = resize_target_size
         # Update usedby fields if provided (encode as JSON)
         if usedby_pods is not None:
             update_dict[volume_table.c.usedby_pods] = json.dumps(usedby_pods)

--- a/sky/models.py
+++ b/sky/models.py
@@ -141,20 +141,24 @@ class KubernetesNodesInfo:
 
 
 class VolumeResizeStatus(enum.Enum):
-    """How far along a resize is, in terms of what the user can do about it.
+    """Where a resize has got to, in terms of what stands between it and done.
 
-    Deliberately not the cloud's own vocabulary: Kubernetes reports one set of
-    values on clusters new enough for `allocatedResourceStatuses` and another
-    (its resize conditions) on older ones, and another cloud would report
-    something else again. Callers care about the three cases that differ in
-    what happens next.
+    Deliberately not the cloud's own vocabulary, which is both wordier and
+    version-specific: Kubernetes alone names these differently on its
+    conditions and on `allocatedResourceStatuses`, and another cloud would name
+    them differently again.
+
+    What the user should *do* is not part of the state: for the middle one it
+    depends on whether anything is using the volume, which the state itself
+    cannot say. See `volume.resize_display_message`.
     """
     # The storage backend is working on it; waiting is all that is needed.
     IN_PROGRESS = 'in_progress'
     # The new capacity is allocated, but the filesystem is grown by the node
-    # when it next mounts the volume -- so it stays at the old size until the
-    # workload using it restarts. Can sit here indefinitely.
-    NEEDS_RESTART = 'needs_restart'
+    # that mounts the volume, so the volume keeps its old size until that
+    # happens. For a volume in use it happens on its own, without restarting
+    # anything; for one nothing is using, it waits indefinitely.
+    PENDING_ON_NODE = 'pending_on_node'
     # The resize stopped short. The recorded size is still the real one.
     FAILED = 'failed'
 

--- a/sky/models.py
+++ b/sky/models.py
@@ -182,6 +182,9 @@ class ObservedVolumeState:
     # has to do -- looks indistinguishable from one that was never resized.
     resize_status: Optional[VolumeResizeStatus] = None
     resize_target_size: Optional[str] = None
+    # How the cloud explains the state, in its own words. None when it offers
+    # none, which is the usual case for everything but Kubernetes conditions.
+    resize_message: Optional[str] = None
 
 
 class VolumeConfig(pydantic.BaseModel):

--- a/sky/models.py
+++ b/sky/models.py
@@ -140,6 +140,25 @@ class KubernetesNodesInfo:
         )
 
 
+class VolumeResizeStatus(enum.Enum):
+    """How far along a resize is, in terms of what the user can do about it.
+
+    Deliberately not the cloud's own vocabulary: Kubernetes reports one set of
+    values on clusters new enough for `allocatedResourceStatuses` and another
+    (its resize conditions) on older ones, and another cloud would report
+    something else again. Callers care about the three cases that differ in
+    what happens next.
+    """
+    # The storage backend is working on it; waiting is all that is needed.
+    IN_PROGRESS = 'in_progress'
+    # The new capacity is allocated, but the filesystem is grown by the node
+    # when it next mounts the volume -- so it stays at the old size until the
+    # workload using it restarts. Can sit here indefinitely.
+    NEEDS_RESTART = 'needs_restart'
+    # The resize stopped short. The recorded size is still the real one.
+    FAILED = 'failed'
+
+
 @dataclasses.dataclass
 class ObservedVolumeState:
     """The fields of a volume that the cloud owns, as the cloud reports them.
@@ -157,6 +176,12 @@ class ObservedVolumeState:
     # ``VolumeConfig.size``.
     size: Optional[str] = None
     storage_class_name: Optional[str] = None
+    # Set while the volume is being resized to a size it does not have yet.
+    # `size` stays the capacity that exists, so without these two a volume
+    # whose expansion is in flight -- or stuck waiting on something the user
+    # has to do -- looks indistinguishable from one that was never resized.
+    resize_status: Optional[VolumeResizeStatus] = None
+    resize_target_size: Optional[str] = None
 
 
 class VolumeConfig(pydantic.BaseModel):

--- a/sky/models.py
+++ b/sky/models.py
@@ -156,10 +156,13 @@ class VolumeResizeStatus(enum.Enum):
     IN_PROGRESS = 'in_progress'
     # The new capacity is allocated, but the filesystem is grown by the node
     # that mounts the volume, so the volume keeps its old size until that
-    # happens. For a volume in use it happens on its own, without restarting
-    # anything; for one nothing is using, it waits indefinitely.
+    # happens. For a volume in use it usually happens on its own, without
+    # restarting anything; for one nothing is using, it waits indefinitely.
     PENDING_ON_NODE = 'pending_on_node'
     # The resize stopped short. The recorded size is still the real one.
+    #
+    # Only clusters that report a failed resize can produce this: where they
+    # do not, a resize that can never succeed keeps reporting IN_PROGRESS.
     FAILED = 'failed'
 
 

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -60,6 +60,25 @@ _TERMINAL_GRPC_CODES = ('InvalidArgument', 'AlreadyExists', 'OutOfRange',
 _IN_PROGRESS_GRPC_CODES = ('Canceled', 'DeadlineExceeded', 'Unavailable',
                            'Aborted')
 
+# Every state `status.allocatedResourceStatuses` can report for a claim being
+# resized, mapped to what the user can do about it. NodeResizePending is the
+# one that does not clear on its own: the filesystem is grown by the node the
+# next time it mounts the volume, so the workload has to restart.
+_RESIZE_STATUSES = {
+    'ControllerResizeInProgress': models.VolumeResizeStatus.IN_PROGRESS,
+    'NodeResizeInProgress': models.VolumeResizeStatus.IN_PROGRESS,
+    'NodeResizePending': models.VolumeResizeStatus.NEEDS_RESTART,
+    'ControllerResizeFailed': models.VolumeResizeStatus.FAILED,
+    'NodeResizeFailed': models.VolumeResizeStatus.FAILED,
+}
+# What a cluster too old for allocatedResourceStatuses reports instead: the
+# same two live states, as claim conditions. There is no failed condition --
+# a failure only shows up as the resize never finishing.
+_RESIZE_CONDITIONS = {
+    'Resizing': models.VolumeResizeStatus.IN_PROGRESS,
+    'FileSystemResizePending': models.VolumeResizeStatus.NEEDS_RESTART,
+}
+
 
 class PvcFailure(enum.Enum):
     """What a failure reported on a PVC says about waiting any longer."""
@@ -962,6 +981,52 @@ def _parse_pvc_size(size_quantity: Optional[str],
     return str(size)
 
 
+def _pvc_resize_state(
+        pvc_obj: Any, pvc_name: str
+) -> Tuple[Optional[models.VolumeResizeStatus], Optional[str]]:
+    """Returns how far a resize of this claim has got, and its target size.
+
+    Both are None when no resize is in flight, which is the normal case.
+
+    A claim's capacity only moves once the new space exists, so an expansion
+    that is still running -- or that is waiting for the workload to restart
+    before the filesystem can grow -- looks like nothing happened at all.
+    """
+    status = getattr(pvc_obj, 'status', None)
+    resize_status = None
+    statuses = getattr(status, 'allocated_resource_statuses', None)
+    if isinstance(statuses, dict):
+        storage_status = statuses.get('storage')
+        if storage_status is not None:
+            resize_status = _RESIZE_STATUSES.get(storage_status)
+    if resize_status is None:
+        # Clusters older than allocatedResourceStatuses report a resize only
+        # through the claim's conditions.
+        conditions = getattr(status, 'conditions', None)
+        for condition in conditions if isinstance(conditions, list) else []:
+            if getattr(condition, 'status', None) != 'True':
+                continue
+            condition_type = getattr(condition, 'type', None)
+            mapped = (_RESIZE_CONDITIONS.get(condition_type)
+                      if condition_type is not None else None)
+            if mapped is not None:
+                resize_status = mapped
+                break
+    if resize_status is None:
+        return None, None
+
+    # What the resize is heading for: the capacity being allocated, or, before
+    # the backend has acknowledged anything, the request itself.
+    allocated = getattr(status, 'allocated_resources', None)
+    target = allocated.get('storage') if isinstance(allocated, dict) else None
+    if target is None:
+        requests = getattr(getattr(pvc_obj.spec, 'resources', None), 'requests',
+                           None)
+        if isinstance(requests, dict):
+            target = requests.get('storage')
+    return resize_status, _parse_pvc_size(target, pvc_name)
+
+
 def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
     """Reads the fields of a PVC that the cluster, not our config, owns.
 
@@ -969,12 +1034,15 @@ def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
     a recorded config never clears a value it cannot see.
     """
     pvc_name = pvc_obj.metadata.name
+    resize_status, resize_target_size = _pvc_resize_state(pvc_obj, pvc_name)
     return models.ObservedVolumeState(
         size=_parse_pvc_size(_pvc_capacity(pvc_obj), pvc_name),
         # An empty storageClassName is the Kubernetes way of opting out of
         # dynamic provisioning, not a class name to record.
         storage_class_name=(getattr(pvc_obj.spec, 'storage_class_name', None) or
                             None),
+        resize_status=resize_status,
+        resize_target_size=resize_target_size,
     )
 
 

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -60,29 +60,18 @@ _TERMINAL_GRPC_CODES = ('InvalidArgument', 'AlreadyExists', 'OutOfRange',
 _IN_PROGRESS_GRPC_CODES = ('Canceled', 'DeadlineExceeded', 'Unavailable',
                            'Aborted')
 
-# Every state `status.allocatedResourceStatuses` can report for a claim being
-# resized, mapped to what the user can do about it. NodeResizePending is the
-# one that does not clear on its own: the filesystem is grown by the node the
-# next time it mounts the volume, so the workload has to restart.
-_RESIZE_STATUSES = {
-    'ControllerResizeInProgress': models.VolumeResizeStatus.IN_PROGRESS,
-    'NodeResizeInProgress': models.VolumeResizeStatus.IN_PROGRESS,
-    'NodeResizePending': models.VolumeResizeStatus.NEEDS_RESTART,
-    'ControllerResizeFailed': models.VolumeResizeStatus.FAILED,
-    'NodeResizeFailed': models.VolumeResizeStatus.FAILED,
-}
-# The same states as claim conditions, which is all a cluster too old for
-# allocatedResourceStatuses reports -- and, on any cluster, the only place the
-# claim explains itself in words.
+# Every resize state a claim reports on its conditions, and what each means
+# for the volume. This is the only place the claim explains itself in words,
+# so it is also where the state is read from -- see `_pvc_resize_state`.
 #
-# Ordered, because a claim carries several at once: one parked waiting for a
-# restart is still `Resizing` too. Reading them in list order would report the
-# wrong one, so they are read in the order of what the user has to do about
-# them: fix a failure, restart something, or just wait.
+# Ordered, because a claim holds several at once: one waiting to be mounted is
+# still `Resizing` too. Reading them in list order would report the wrong one,
+# so they are read worst-first: a failure to look at, then work that cannot
+# proceed, then work that is proceeding.
 _RESIZE_CONDITIONS = (
     ('ControllerResizeError', models.VolumeResizeStatus.FAILED),
     ('NodeResizeError', models.VolumeResizeStatus.FAILED),
-    ('FileSystemResizePending', models.VolumeResizeStatus.NEEDS_RESTART),
+    ('FileSystemResizePending', models.VolumeResizeStatus.PENDING_ON_NODE),
     ('Resizing', models.VolumeResizeStatus.IN_PROGRESS),
 )
 
@@ -1010,34 +999,27 @@ def _pvc_resize_state(
     All three are None when no resize is in flight, which is the normal case.
 
     A claim's capacity only moves once the new space exists, so an expansion
-    that is still running -- or that is waiting for the workload to restart
-    before the filesystem can grow -- looks like nothing happened at all.
+    that is still running -- or that is waiting to be mounted before the
+    filesystem can grow -- looks like nothing happened at all.
+
+    Read from the conditions rather than `status.allocatedResourceStatuses`,
+    even though the latter is the purpose-built field: the state and the words
+    describing it then come from the same place and cannot disagree, and every
+    cluster has conditions while only recent ones have that field. What it
+    would add -- telling a controller-stage resize from a node-stage one -- is
+    collapsed by VolumeResizeStatus anyway.
     """
     status = getattr(pvc_obj, 'status', None)
     conditions = _true_resize_conditions(status)
     resize_status = None
-    statuses = getattr(status, 'allocated_resource_statuses', None)
-    if isinstance(statuses, dict):
-        storage_status = statuses.get('storage')
-        if storage_status is not None:
-            resize_status = _RESIZE_STATUSES.get(storage_status)
-    if resize_status is None:
-        # All a cluster older than allocatedResourceStatuses reports.
-        for condition_type, mapped in _RESIZE_CONDITIONS:
-            if condition_type in conditions:
-                resize_status = mapped
-                break
-    if resize_status is None:
-        return None, None, None
-
-    # The claim's own account of the state settled on above -- Kubernetes says
-    # it better than a message reconstructed from the state name, and only the
-    # conditions carry one at all.
     message = None
     for condition_type, mapped in _RESIZE_CONDITIONS:
-        if mapped == resize_status and conditions.get(condition_type):
+        if condition_type in conditions:
+            resize_status = mapped
             message = conditions[condition_type]
             break
+    if resize_status is None:
+        return None, None, None
 
     # What the resize is heading for: the capacity being allocated, or, before
     # the backend has acknowledged anything, the request itself.

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -71,13 +71,20 @@ _RESIZE_STATUSES = {
     'ControllerResizeFailed': models.VolumeResizeStatus.FAILED,
     'NodeResizeFailed': models.VolumeResizeStatus.FAILED,
 }
-# What a cluster too old for allocatedResourceStatuses reports instead: the
-# same two live states, as claim conditions. There is no failed condition --
-# a failure only shows up as the resize never finishing.
-_RESIZE_CONDITIONS = {
-    'Resizing': models.VolumeResizeStatus.IN_PROGRESS,
-    'FileSystemResizePending': models.VolumeResizeStatus.NEEDS_RESTART,
-}
+# The same states as claim conditions, which is all a cluster too old for
+# allocatedResourceStatuses reports -- and, on any cluster, the only place the
+# claim explains itself in words.
+#
+# Ordered, because a claim carries several at once: one parked waiting for a
+# restart is still `Resizing` too. Reading them in list order would report the
+# wrong one, so they are read in the order of what the user has to do about
+# them: fix a failure, restart something, or just wait.
+_RESIZE_CONDITIONS = (
+    ('ControllerResizeError', models.VolumeResizeStatus.FAILED),
+    ('NodeResizeError', models.VolumeResizeStatus.FAILED),
+    ('FileSystemResizePending', models.VolumeResizeStatus.NEEDS_RESTART),
+    ('Resizing', models.VolumeResizeStatus.IN_PROGRESS),
+)
 
 
 class PvcFailure(enum.Enum):
@@ -981,18 +988,33 @@ def _parse_pvc_size(size_quantity: Optional[str],
     return str(size)
 
 
-def _pvc_resize_state(
-        pvc_obj: Any, pvc_name: str
-) -> Tuple[Optional[models.VolumeResizeStatus], Optional[str]]:
-    """Returns how far a resize of this claim has got, and its target size.
+def _true_resize_conditions(status: Any) -> Dict[str, Optional[str]]:
+    """The claim's resize conditions that currently hold, and what they say."""
+    conditions = getattr(status, 'conditions', None)
+    held: Dict[str, Optional[str]] = {}
+    for condition in conditions if isinstance(conditions, list) else []:
+        if getattr(condition, 'status', None) != 'True':
+            continue
+        condition_type = getattr(condition, 'type', None)
+        if condition_type is not None:
+            held[condition_type] = getattr(condition, 'message', None)
+    return held
 
-    Both are None when no resize is in flight, which is the normal case.
+
+def _pvc_resize_state(
+    pvc_obj: Any, pvc_name: str
+) -> Tuple[Optional[models.VolumeResizeStatus], Optional[str], Optional[str]]:
+    """Returns how far a resize of this claim has got, what it is heading for,
+    and how the claim explains itself.
+
+    All three are None when no resize is in flight, which is the normal case.
 
     A claim's capacity only moves once the new space exists, so an expansion
     that is still running -- or that is waiting for the workload to restart
     before the filesystem can grow -- looks like nothing happened at all.
     """
     status = getattr(pvc_obj, 'status', None)
+    conditions = _true_resize_conditions(status)
     resize_status = None
     statuses = getattr(status, 'allocated_resource_statuses', None)
     if isinstance(statuses, dict):
@@ -1000,20 +1022,22 @@ def _pvc_resize_state(
         if storage_status is not None:
             resize_status = _RESIZE_STATUSES.get(storage_status)
     if resize_status is None:
-        # Clusters older than allocatedResourceStatuses report a resize only
-        # through the claim's conditions.
-        conditions = getattr(status, 'conditions', None)
-        for condition in conditions if isinstance(conditions, list) else []:
-            if getattr(condition, 'status', None) != 'True':
-                continue
-            condition_type = getattr(condition, 'type', None)
-            mapped = (_RESIZE_CONDITIONS.get(condition_type)
-                      if condition_type is not None else None)
-            if mapped is not None:
+        # All a cluster older than allocatedResourceStatuses reports.
+        for condition_type, mapped in _RESIZE_CONDITIONS:
+            if condition_type in conditions:
                 resize_status = mapped
                 break
     if resize_status is None:
-        return None, None
+        return None, None, None
+
+    # The claim's own account of the state settled on above -- Kubernetes says
+    # it better than a message reconstructed from the state name, and only the
+    # conditions carry one at all.
+    message = None
+    for condition_type, mapped in _RESIZE_CONDITIONS:
+        if mapped == resize_status and conditions.get(condition_type):
+            message = conditions[condition_type]
+            break
 
     # What the resize is heading for: the capacity being allocated, or, before
     # the backend has acknowledged anything, the request itself.
@@ -1024,7 +1048,7 @@ def _pvc_resize_state(
                            None)
         if isinstance(requests, dict):
             target = requests.get('storage')
-    return resize_status, _parse_pvc_size(target, pvc_name)
+    return resize_status, _parse_pvc_size(target, pvc_name), message
 
 
 def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
@@ -1034,7 +1058,8 @@ def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
     a recorded config never clears a value it cannot see.
     """
     pvc_name = pvc_obj.metadata.name
-    resize_status, resize_target_size = _pvc_resize_state(pvc_obj, pvc_name)
+    resize_status, resize_target_size, resize_message = _pvc_resize_state(
+        pvc_obj, pvc_name)
     return models.ObservedVolumeState(
         size=_parse_pvc_size(_pvc_capacity(pvc_obj), pvc_name),
         # An empty storageClassName is the Kubernetes way of opting out of
@@ -1043,6 +1068,7 @@ def _observed_volume_state(pvc_obj: Any) -> models.ObservedVolumeState:
                             None),
         resize_status=resize_status,
         resize_target_size=resize_target_size,
+        resize_message=resize_message,
     )
 
 

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -303,3 +303,6 @@ class VolumeRecord(ResponseBaseModel):
     # models.VolumeResizeStatus's values.
     resize_status: Optional[str] = None
     resize_target_size: Optional[str] = None
+    # What to show about the resize: the cloud's own account of it where there
+    # is one, plus what the user has to do next.
+    resize_message: Optional[str] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -297,3 +297,9 @@ class VolumeRecord(ResponseBaseModel):
     error_may_resolve: bool = False
     # YAML configuration used to create the volume
     creation_yaml: Optional[str] = None
+    # Set only while the volume is being resized: `size` is the capacity it has
+    # now, and a resize can be in progress, or waiting for the workload using
+    # the volume to restart, for a long time. One of
+    # models.VolumeResizeStatus's values.
+    resize_status: Optional[str] = None
+    resize_target_size: Optional[str] = None

--- a/sky/schemas/db/global_user_state/022_volume_resize_fields.py
+++ b/sky/schemas/db/global_user_state/022_volume_resize_fields.py
@@ -21,7 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade():
-    """Add resize_status and resize_target_size columns to volumes table.
+    """Add the resize_status, resize_target_size and resize_message columns.
 
     A volume's recorded size is the capacity it actually has, so an expansion
     that has not finished -- or that is waiting on the workload to restart
@@ -34,6 +34,10 @@ def upgrade():
                                              server_default=None)
         db_utils.add_column_to_table_alembic('volumes',
                                              'resize_target_size',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('volumes',
+                                             'resize_message',
                                              sa.Text(),
                                              server_default=None)
 

--- a/sky/schemas/db/global_user_state/022_volume_resize_fields.py
+++ b/sky/schemas/db/global_user_state/022_volume_resize_fields.py
@@ -1,0 +1,43 @@
+"""Add resize columns to volumes table.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-08-25
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '022'
+down_revision: Union[str, Sequence[str], None] = '021'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add resize_status and resize_target_size columns to volumes table.
+
+    A volume's recorded size is the capacity it actually has, so an expansion
+    that has not finished -- or that is waiting on the workload to restart
+    before the filesystem can grow -- is invisible without these.
+    """
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('volumes',
+                                             'resize_status',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('volumes',
+                                             'resize_target_size',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '021'  # add leader_leases table
+GLOBAL_USER_STATE_VERSION = '022'  # add volume resize fields
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -142,8 +142,14 @@ _RESIZE_STATE_MESSAGES = {
 # mounted by something else -- `get_all_volumes_usedby` only counts pods
 # SkyPilot created -- so that side says what will finish the resize rather
 # than asserting nothing is using it.
-_RESIZE_PENDING_IN_USE = ('A cluster or job is using it, so the node grows the '
-                          'filesystem without anything being restarted.')
+#
+# Growing a mounted volume needs the storage driver to support it, which
+# SkyPilot does not ask about, so the in-use side promises no more than
+# "usually" and leaves the way out in the sentence rather than sending
+# everyone down it.
+_RESIZE_PENDING_IN_USE = ('A cluster or job is using it, so the node usually '
+                          'grows the filesystem without a restart. If it stays '
+                          'this way, restart the cluster or job using it.')
 _RESIZE_PENDING_UNUSED = ('The node grows the filesystem the next time '
                           'something mounts the volume; start or restart a '
                           'cluster or job that uses it.')
@@ -183,8 +189,8 @@ def resize_display_message(resize_status: Optional[str],
             action = _RESIZE_PENDING_IN_USE
             # The one place the cloud's own words are dropped. Kubernetes sets
             # the same "(re-)start a pod" message whether or not the volume is
-            # mounted, so on a volume that is, it contradicts the sentence
-            # after it -- and it is the half that is wrong.
+            # mounted, so on a volume that is, it leads with the instruction
+            # the sentence after it says to try only if waiting does not work.
             why = None
         else:
             action = _RESIZE_PENDING_UNUSED

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -117,6 +117,52 @@ def is_read_write_many_pvc(volume_config: models.VolumeConfig) -> bool:
 PVC_PROVISIONING_MESSAGE = ('PVC is pending: the PersistentVolume is still '
                             'being provisioned.')
 
+# What each resize state means, for a cloud that reports the state but not a
+# word about it. Kubernetes puts it better on the claim's conditions, so these
+# are only the fallback.
+_RESIZE_STATE_MESSAGES = {
+    models.VolumeResizeStatus.IN_PROGRESS: ('The storage backend is resizing '
+                                            'this volume.'),
+    models.VolumeResizeStatus.NEEDS_RESTART:
+        ('The new space is allocated, but the filesystem only grows when the '
+         'volume is next mounted.'),
+    models.VolumeResizeStatus.FAILED: 'The resize did not complete.',
+}
+
+# What to do about it, in SkyPilot's terms. Kubernetes explains the pending
+# case as "(re-)start a pod ... on node", which is accurate and is not how a
+# SkyPilot user reaches the volume -- so its own account of why is kept, and
+# this says what to do next.
+_RESIZE_STATE_ACTIONS = {
+    models.VolumeResizeStatus.NEEDS_RESTART:
+        ('Restart the cluster or job using this volume to finish the '
+         'resize.'),
+    models.VolumeResizeStatus.FAILED: 'The volume still has its previous size.',
+}
+
+
+def resize_display_message(resize_status: Optional[str],
+                           cloud_message: Optional[str]) -> Optional[str]:
+    """The one sentence to show about a resize, or None if none is in flight.
+
+    Built here rather than stored so that every surface -- the volumes table,
+    the volume's own page, any client -- says the same thing, and so that the
+    wording can change without rewriting what is in the database.
+
+    An unrecognized status comes from a newer writer than this reader, which
+    happens while a deployment is half upgraded: report what it said rather
+    than nothing.
+    """
+    if not resize_status:
+        return None
+    try:
+        status = models.VolumeResizeStatus(resize_status)
+    except ValueError:
+        return cloud_message or f'Resize state: {resize_status}.'
+    parts = [cloud_message or _RESIZE_STATE_MESSAGES.get(status)]
+    parts.append(_RESIZE_STATE_ACTIONS.get(status))
+    return ' '.join(part for part in parts if part) or None
+
 
 def volume_error_may_resolve(error_message: Optional[str]) -> bool:
     """Whether a not-ready volume may still become usable without a change.

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -123,31 +123,48 @@ PVC_PROVISIONING_MESSAGE = ('PVC is pending: the PersistentVolume is still '
 _RESIZE_STATE_MESSAGES = {
     models.VolumeResizeStatus.IN_PROGRESS: ('The storage backend is resizing '
                                             'this volume.'),
-    models.VolumeResizeStatus.NEEDS_RESTART:
+    models.VolumeResizeStatus.PENDING_ON_NODE:
         ('The new space is allocated, but the filesystem only grows when the '
-         'volume is next mounted.'),
+         'volume is mounted.'),
     models.VolumeResizeStatus.FAILED: 'The resize did not complete.',
 }
 
-# What to do about it, in SkyPilot's terms. Kubernetes explains the pending
-# case as "(re-)start a pod ... on node", which is accurate and is not how a
-# SkyPilot user reaches the volume -- so its own account of why is kept, and
-# this says what to do next.
-_RESIZE_STATE_ACTIONS = {
-    models.VolumeResizeStatus.NEEDS_RESTART:
-        ('Restart the cluster or job using this volume to finish the '
-         'resize.'),
-    models.VolumeResizeStatus.FAILED: 'The volume still has its previous size.',
-}
+# What to do about it, in SkyPilot's terms rather than Kubernetes'.
+#
+# A volume waiting on the node is the case that needs telling apart, and the
+# state alone cannot: Kubernetes grows the filesystem of a volume that is in
+# use without anything being restarted, and leaves one that nothing is using
+# waiting indefinitely. Its own words for both are "(re-)start a pod", which
+# would send someone to restart a job that is about to finish on its own.
+#
+# The two are worded around what SkyPilot can actually know. A volume it sees
+# a cluster on is certainly mounted; one it sees nothing on may still be
+# mounted by something else -- `get_all_volumes_usedby` only counts pods
+# SkyPilot created -- so that side says what will finish the resize rather
+# than asserting nothing is using it.
+_RESIZE_PENDING_IN_USE = ('A cluster or job is using it, so the node grows the '
+                          'filesystem without anything being restarted.')
+_RESIZE_PENDING_UNUSED = ('The node grows the filesystem the next time '
+                          'something mounts the volume; start or restart a '
+                          'cluster or job that uses it.')
+_RESIZE_FAILED_ACTION = 'The volume still has its previous size.'
 
 
 def resize_display_message(resize_status: Optional[str],
-                           cloud_message: Optional[str]) -> Optional[str]:
+                           cloud_message: Optional[str],
+                           known_in_use: bool = False) -> Optional[str]:
     """The one sentence to show about a resize, or None if none is in flight.
 
     Built here rather than stored so that every surface -- the volumes table,
     the volume's own page, any client -- says the same thing, and so that the
     wording can change without rewriting what is in the database.
+
+    Args:
+        resize_status: a `models.VolumeResizeStatus` value.
+        cloud_message: the cloud's own account of the state, if it gave one.
+        known_in_use: whether SkyPilot can see a cluster or job holding the
+            volume. Positive only: nothing to see does not mean nothing has it
+            mounted, since only pods SkyPilot created are counted.
 
     An unrecognized status comes from a newer writer than this reader, which
     happens while a deployment is half upgraded: report what it said rather
@@ -159,8 +176,21 @@ def resize_display_message(resize_status: Optional[str],
         status = models.VolumeResizeStatus(resize_status)
     except ValueError:
         return cloud_message or f'Resize state: {resize_status}.'
-    parts = [cloud_message or _RESIZE_STATE_MESSAGES.get(status)]
-    parts.append(_RESIZE_STATE_ACTIONS.get(status))
+    action = None
+    why = cloud_message
+    if status == models.VolumeResizeStatus.PENDING_ON_NODE:
+        if known_in_use:
+            action = _RESIZE_PENDING_IN_USE
+            # The one place the cloud's own words are dropped. Kubernetes sets
+            # the same "(re-)start a pod" message whether or not the volume is
+            # mounted, so on a volume that is, it contradicts the sentence
+            # after it -- and it is the half that is wrong.
+            why = None
+        else:
+            action = _RESIZE_PENDING_UNUSED
+    elif status == models.VolumeResizeStatus.FAILED:
+        action = _RESIZE_FAILED_ACTION
+    parts = [why or _RESIZE_STATE_MESSAGES.get(status), action]
     return ' '.join(part for part in parts if part) or None
 
 

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -360,7 +360,14 @@ def volume_list(
                 'resize_target_size': volume.get('resize_target_size'),
                 # Built here, not stored, so every surface says the same thing.
                 'resize_message': volume_utils.resize_display_message(
-                    volume.get('resize_status'), volume.get('resize_message')),
+                    volume.get('resize_status'),
+                    volume.get('resize_message'),
+                    # Seeing a cluster on the volume means it is certainly
+                    # mounted, which is what decides the advice for a resize
+                    # waiting on the node.
+                    known_in_use=bool(
+                        volume.get('usedby_pods') or
+                        volume.get('usedby_clusters'))),
                 'type': config.type,
                 'cloud': config.cloud,
                 'region': config.region,

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -191,6 +191,13 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             current_error = latest_volume.get('error_message')
             current_usedby_pods = latest_volume.get('usedby_pods', [])
             current_usedby_clusters = latest_volume.get('usedby_clusters', [])
+            current_resize_status = latest_volume.get('resize_status')
+            current_resize_target = latest_volume.get('resize_target_size')
+            observed = cloud_to_observed.get(cloud, {}).get(volume_name)
+            new_resize_status = (observed.resize_status
+                                 if observed is not None else None)
+            new_resize_target = (observed.resize_target_size
+                                 if observed is not None else None)
 
             # Determine new status and error_message
             if volume_error:
@@ -209,8 +216,13 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             usedby_changed = (
                 set(current_usedby_pods) != set(usedby_pods) or
                 set(current_usedby_clusters) != set(usedby_clusters))
+            resize_changed = (
+                current_resize_status !=
+                (new_resize_status.value if new_resize_status else None) or
+                current_resize_target != new_resize_target)
 
-            if status_changed or error_changed or usedby_changed:
+            if (status_changed or error_changed or usedby_changed or
+                    resize_changed):
                 logger.info(f'Update volume {volume_name} status to '
                             f'{new_status.value}'
                             f'{", error: " + new_error if new_error else ""}')
@@ -219,7 +231,9 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
                     status=new_status,
                     error_message=new_error,
                     usedby_pods=usedby_pods,
-                    usedby_clusters=usedby_clusters)
+                    usedby_clusters=usedby_clusters,
+                    resize_status=new_resize_status,
+                    resize_target_size=new_resize_target)
             volume_config = latest_volume.get('handle')
             if volume_config is None:
                 continue
@@ -235,9 +249,7 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             # The observed state was read before the lock, so it is merged into
             # the handle just re-read under it, not into the copy it was fetched
             # with.
-            if _apply_observed_state(
-                    volume_config,
-                    cloud_to_observed.get(cloud, {}).get(volume_name)):
+            if _apply_observed_state(volume_config, observed):
                 need_refresh = True
             if need_refresh:
                 global_user_state.update_volume_config(volume_name,
@@ -336,6 +348,11 @@ def volume_list(
                 'error_may_resolve':
                     volume_utils.volume_error_may_resolve(error_message),
                 'creation_yaml': volume.get('creation_yaml'),
+                # Only set while a resize is in flight: the size above is the
+                # capacity the volume has now, which is not what was asked for
+                # until the resize lands.
+                'resize_status': volume.get('resize_status'),
+                'resize_target_size': volume.get('resize_target_size'),
                 'type': config.type,
                 'cloud': config.cloud,
                 'region': config.region,

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -193,11 +193,14 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             current_usedby_clusters = latest_volume.get('usedby_clusters', [])
             current_resize_status = latest_volume.get('resize_status')
             current_resize_target = latest_volume.get('resize_target_size')
+            current_resize_message = latest_volume.get('resize_message')
             observed = cloud_to_observed.get(cloud, {}).get(volume_name)
             new_resize_status = (observed.resize_status
                                  if observed is not None else None)
             new_resize_target = (observed.resize_target_size
                                  if observed is not None else None)
+            new_resize_message = (observed.resize_message
+                                  if observed is not None else None)
 
             # Determine new status and error_message
             if volume_error:
@@ -219,7 +222,8 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
             resize_changed = (
                 current_resize_status !=
                 (new_resize_status.value if new_resize_status else None) or
-                current_resize_target != new_resize_target)
+                current_resize_target != new_resize_target or
+                current_resize_message != new_resize_message)
 
             if (status_changed or error_changed or usedby_changed or
                     resize_changed):
@@ -233,7 +237,8 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
                     usedby_pods=usedby_pods,
                     usedby_clusters=usedby_clusters,
                     resize_status=new_resize_status,
-                    resize_target_size=new_resize_target)
+                    resize_target_size=new_resize_target,
+                    resize_message=new_resize_message)
             volume_config = latest_volume.get('handle')
             if volume_config is None:
                 continue
@@ -353,6 +358,9 @@ def volume_list(
                 # until the resize lands.
                 'resize_status': volume.get('resize_status'),
                 'resize_target_size': volume.get('resize_target_size'),
+                # Built here, not stored, so every surface says the same thing.
+                'resize_message': volume_utils.resize_display_message(
+                    volume.get('resize_status'), volume.get('resize_message')),
                 'type': config.type,
                 'cloud': config.cloud,
                 'region': config.region,

--- a/tests/unit_tests/test_sky/test_cli_volumes.py
+++ b/tests/unit_tests/test_sky/test_cli_volumes.py
@@ -1239,3 +1239,81 @@ class TestRunPodVolumeTable:
         assert 'Kubernetes PVCs:' in out
         assert 'RunPod Network Volumes:' in out
         assert '\n\n' in out
+
+
+class TestVolumeTableResize:
+    """What `sky volumes ls` says about a resize that has not landed yet.
+
+    The size column is the capacity the volume has, so an expansion in flight
+    is invisible there, and the message column only appears when something has
+    something to say.
+    """
+
+    def _volume(self, **overrides):
+        volume = {
+            'name': 'test-volume',
+            'type': 'k8s-pvc',
+            'region': 'context-1',
+            'config': {},
+            'size': '10',
+            'user_hash': 'user123',
+            'workspace': 'default',
+            'launched_at': 1234567890,
+            'last_attached_at': None,
+            'status': 'READY',
+            'last_use': 'sky volumes apply',
+        }
+        volume.update(overrides)
+        return volume
+
+    def test_a_resize_in_flight_shows_where_the_size_is_heading(self):
+        table = table_utils.PVCVolumeTable([
+            self._volume(resize_status='pending_on_node',
+                         resize_target_size='25',
+                         resize_message='Waiting to be mounted.')
+        ])
+
+        result = table.format()
+
+        assert '10Gi -> 25Gi' in result
+        # The message column is the one that says what it is waiting for.
+        assert 'MESSAGE' in result
+        assert 'Waiting to be mounted.' in result
+
+    def test_a_volume_that_is_not_resizing_gets_neither(self):
+        table = table_utils.PVCVolumeTable([self._volume()])
+
+        result = table.format()
+
+        assert '10Gi' in result
+        assert '->' not in result
+        assert 'MESSAGE' not in result
+
+    def test_an_error_wins_the_one_message_cell(self):
+        """It is the one that says the volume cannot be used at all."""
+        table = table_utils.PVCVolumeTable([
+            self._volume(status='FAILED',
+                         error_message='PVC is pending.',
+                         resize_status='in_progress',
+                         resize_target_size='25',
+                         resize_message='Resizing.')
+        ])
+
+        result = table.format()
+
+        assert 'PVC is pending.' in result
+        assert 'Resizing.' not in result
+
+    def test_a_target_that_rounds_to_the_current_size_is_not_shown(self):
+        """Both are whole gibibytes, so such an arrow would point at itself."""
+        table = table_utils.PVCVolumeTable([
+            self._volume(resize_status='pending_on_node',
+                         resize_target_size='10',
+                         resize_message='Waiting to be mounted.')
+        ])
+
+        result = table.format()
+
+        assert '->' not in result
+        # The reason still reaches the user.
+        assert 'Waiting to be mounted.' in result

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -852,24 +852,51 @@ class TestResizeDisplayMessage:
 
     def test_the_clouds_own_words_are_kept(self):
         message = volume.resize_display_message(
-            'needs_restart',
+            'pending_on_node',
             'Waiting for user to (re-)start a pod to finish file system '
             'resize of volume on node.')
 
         assert message.startswith('Waiting for user to (re-)start a pod')
 
     def test_and_what_to_do_about_it_is_added(self):
-        message = volume.resize_display_message('needs_restart', 'k8s says so')
+        message = volume.resize_display_message('pending_on_node',
+                                                'k8s says so')
 
         # The cloud says why; this says what to do in SkyPilot's terms.
         assert 'k8s says so' in message
-        assert 'Restart the cluster' in message
+        assert 'mounts the volume' in message
 
     def test_a_cloud_with_nothing_to_say_still_gets_a_sentence(self):
-        message = volume.resize_display_message('needs_restart', None)
+        message = volume.resize_display_message('pending_on_node', None)
 
         assert 'filesystem' in message
-        assert 'Restart the cluster' in message
+
+    def test_a_volume_in_use_is_not_told_to_restart_anything(self):
+        """Kubernetes grows the filesystem of a mounted volume by itself.
+
+        Its own words say "(re-)start a pod" either way, which would send
+        someone to restart a job that is about to finish on its own.
+        """
+        message = volume.resize_display_message(
+            'pending_on_node',
+            'Waiting for user to (re-)start a pod to finish file system '
+            'resize of volume on node.',
+            known_in_use=True)
+
+        assert 'without anything being restarted' in message
+        # Kubernetes sets that message whether or not the volume is mounted,
+        # so keeping it here would contradict the sentence after it.
+        assert '(re-)start a pod' not in message
+        # Not an instruction to restart anything.
+        assert 'Restart' not in message
+        assert 'start or restart' not in message
+
+    def test_a_volume_nothing_is_using_is_told_what_will_finish_it(self):
+        message = volume.resize_display_message('pending_on_node',
+                                                None,
+                                                known_in_use=False)
+
+        assert 'next time something mounts the volume' in message
 
     def test_a_resize_in_progress_asks_for_nothing(self):
         message = volume.resize_display_message('in_progress', None)

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -837,3 +837,55 @@ class TestAutoMountScope:
         assert volume.AutoMountScope.supported_scopes() == [
             'personal', 'workspace', 'global'
         ]
+
+
+class TestResizeDisplayMessage:
+    """The one sentence shown about a resize, built in one place.
+
+    Kubernetes explains the state better than a message reconstructed from the
+    state name, but it explains it in its own terms -- a pod on a node, not a
+    SkyPilot cluster -- and it does not always say anything at all.
+    """
+
+    def test_no_resize_says_nothing(self):
+        assert volume.resize_display_message(None, None) is None
+
+    def test_the_clouds_own_words_are_kept(self):
+        message = volume.resize_display_message(
+            'needs_restart',
+            'Waiting for user to (re-)start a pod to finish file system '
+            'resize of volume on node.')
+
+        assert message.startswith('Waiting for user to (re-)start a pod')
+
+    def test_and_what_to_do_about_it_is_added(self):
+        message = volume.resize_display_message('needs_restart', 'k8s says so')
+
+        # The cloud says why; this says what to do in SkyPilot's terms.
+        assert 'k8s says so' in message
+        assert 'Restart the cluster' in message
+
+    def test_a_cloud_with_nothing_to_say_still_gets_a_sentence(self):
+        message = volume.resize_display_message('needs_restart', None)
+
+        assert 'filesystem' in message
+        assert 'Restart the cluster' in message
+
+    def test_a_resize_in_progress_asks_for_nothing(self):
+        message = volume.resize_display_message('in_progress', None)
+
+        assert 'resizing' in message.lower()
+        assert 'Restart' not in message
+
+    def test_a_failed_resize_says_the_size_did_not_change(self):
+        message = volume.resize_display_message('failed', 'disk full')
+
+        assert 'disk full' in message
+        assert 'previous size' in message
+
+    def test_a_status_this_reader_does_not_know_is_still_reported(self):
+        """A half-upgraded deployment can have a newer writer than reader."""
+        assert volume.resize_display_message(
+            'from_the_future', 'the cloud said this') == 'the cloud said this'
+        assert 'from_the_future' in volume.resize_display_message(
+            'from_the_future', None)

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -871,11 +871,13 @@ class TestResizeDisplayMessage:
 
         assert 'filesystem' in message
 
-    def test_a_volume_in_use_is_not_told_to_restart_anything(self):
-        """Kubernetes grows the filesystem of a mounted volume by itself.
+    def test_a_volume_in_use_is_not_sent_to_restart_first(self):
+        """Kubernetes usually grows the filesystem of a mounted volume itself.
 
         Its own words say "(re-)start a pod" either way, which would send
-        someone to restart a job that is about to finish on its own.
+        someone to restart a job that is about to finish on its own. Restarting
+        is the fallback, since growing a mounted volume needs a driver that
+        supports it -- so it is offered, not led with.
         """
         message = volume.resize_display_message(
             'pending_on_node',
@@ -883,13 +885,12 @@ class TestResizeDisplayMessage:
             'resize of volume on node.',
             known_in_use=True)
 
-        assert 'without anything being restarted' in message
-        # Kubernetes sets that message whether or not the volume is mounted,
-        # so keeping it here would contradict the sentence after it.
+        assert 'usually grows the filesystem without a restart' in message
+        # Kubernetes sets that message whether or not the volume is mounted, so
+        # keeping it would lead with the fallback.
         assert '(re-)start a pod' not in message
-        # Not an instruction to restart anything.
-        assert 'Restart' not in message
-        assert 'start or restart' not in message
+        # And the fallback is still reachable, conditioned on waiting failing.
+        assert 'If it stays this way, restart' in message
 
     def test_a_volume_nothing_is_using_is_told_what_will_finish_it(self):
         message = volume.resize_display_message('pending_on_node',

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2483,20 +2483,20 @@ class TestVolumeRefreshResizeState:
             monkeypatch, volume, {
                 'checkpoints': models.ObservedVolumeState(
                     size='1',
-                    resize_status=models.VolumeResizeStatus.NEEDS_RESTART,
+                    resize_status=models.VolumeResizeStatus.PENDING_ON_NODE,
                     resize_target_size='2')
             })
 
         update_status.assert_called_once()
         kwargs = update_status.call_args.kwargs
         assert kwargs['resize_status'] == (
-            models.VolumeResizeStatus.NEEDS_RESTART)
+            models.VolumeResizeStatus.PENDING_ON_NODE)
         assert kwargs['resize_target_size'] == '2'
 
     def test_a_finished_resize_clears_what_was_recorded(self, monkeypatch):
         """The cloud stops reporting a resize once it lands; so must we."""
         volume = self._volume(self._config(size='2'),
-                              resize_status='needs_restart',
+                              resize_status='pending_on_node',
                               resize_target_size='2')
 
         update_status = self._refresh(
@@ -2512,23 +2512,40 @@ class TestVolumeRefreshResizeState:
         """A resize can sit pending for hours; that must not cost a write a
         minute."""
         volume = self._volume(self._config(size='1'),
-                              resize_status='needs_restart',
+                              resize_status='pending_on_node',
                               resize_target_size='2')
 
         update_status = self._refresh(
             monkeypatch, volume, {
                 'checkpoints': models.ObservedVolumeState(
                     size='1',
-                    resize_status=models.VolumeResizeStatus.NEEDS_RESTART,
+                    resize_status=models.VolumeResizeStatus.PENDING_ON_NODE,
                     resize_target_size='2')
             })
 
         update_status.assert_not_called()
 
+    def test_a_volume_in_use_gets_the_advice_for_one(self, monkeypatch):
+        """Whether anything holds the volume decides what the user is told,
+        and volume_list is where the two meet."""
+        volume = self._volume(self._config(size='1'),
+                              resize_status='pending_on_node',
+                              resize_target_size='2')
+        volume['usedby_clusters'] = ['some-cluster']
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=[volume]))
+        monkeypatch.setattr(global_user_state, 'get_all_users',
+                            mock.MagicMock(return_value=[]))
+
+        records = core.volume_list()
+
+        assert ('without anything being restarted'
+                in records[0]['resize_message'])
+
     def test_the_fields_survive_the_response_model(self, monkeypatch):
         """volume_list has to carry them through to the client."""
         volume = self._volume(self._config(size='1'),
-                              resize_status='needs_restart',
+                              resize_status='pending_on_node',
                               resize_target_size='2')
         monkeypatch.setattr(global_user_state, 'get_volumes',
                             mock.MagicMock(return_value=[volume]))
@@ -2537,5 +2554,5 @@ class TestVolumeRefreshResizeState:
 
         records = core.volume_list()
 
-        assert records[0]['resize_status'] == 'needs_restart'
+        assert records[0]['resize_status'] == 'pending_on_node'
         assert records[0]['resize_target_size'] == '2'

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2539,7 +2539,7 @@ class TestVolumeRefreshResizeState:
 
         records = core.volume_list()
 
-        assert ('without anything being restarted'
+        assert ('usually grows the filesystem without a restart'
                 in records[0]['resize_message'])
 
     def test_the_fields_survive_the_response_model(self, monkeypatch):

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -119,14 +119,16 @@ class TestVolumeCore:
                       usedby_pods=[],
                       usedby_clusters=[],
                       resize_status=None,
-                      resize_target_size=None),
+                      resize_target_size=None,
+                      resize_message=None),
             mock.call('test-volume-2',
                       status=status_lib.VolumeStatus.READY,
                       error_message=None,
                       usedby_pods=[],
                       usedby_clusters=[],
                       resize_status=None,
-                      resize_target_size=None)
+                      resize_target_size=None,
+                      resize_message=None)
         ]
         mock_update_status.assert_has_calls(expected_calls, any_order=True)
 
@@ -225,14 +227,16 @@ class TestVolumeCore:
                       usedby_pods=['pod1', 'pod2'],
                       usedby_clusters=['cluster1', 'cluster2'],
                       resize_status=None,
-                      resize_target_size=None),
+                      resize_target_size=None,
+                      resize_message=None),
             mock.call('test-volume-2',
                       status=status_lib.VolumeStatus.IN_USE,
                       error_message=None,
                       usedby_pods=['pod1', 'pod2'],
                       usedby_clusters=['cluster1', 'cluster2'],
                       resize_status=None,
-                      resize_target_size=None)
+                      resize_target_size=None,
+                      resize_message=None)
         ]
         mock_update_status.assert_has_calls(expected_calls, any_order=True)
 

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -117,12 +117,16 @@ class TestVolumeCore:
                       status=status_lib.VolumeStatus.READY,
                       error_message=None,
                       usedby_pods=[],
-                      usedby_clusters=[]),
+                      usedby_clusters=[],
+                      resize_status=None,
+                      resize_target_size=None),
             mock.call('test-volume-2',
                       status=status_lib.VolumeStatus.READY,
                       error_message=None,
                       usedby_pods=[],
-                      usedby_clusters=[])
+                      usedby_clusters=[],
+                      resize_status=None,
+                      resize_target_size=None)
         ]
         mock_update_status.assert_has_calls(expected_calls, any_order=True)
 
@@ -219,12 +223,16 @@ class TestVolumeCore:
                       status=status_lib.VolumeStatus.IN_USE,
                       error_message=None,
                       usedby_pods=['pod1', 'pod2'],
-                      usedby_clusters=['cluster1', 'cluster2']),
+                      usedby_clusters=['cluster1', 'cluster2'],
+                      resize_status=None,
+                      resize_target_size=None),
             mock.call('test-volume-2',
                       status=status_lib.VolumeStatus.IN_USE,
                       error_message=None,
                       usedby_pods=['pod1', 'pod2'],
-                      usedby_clusters=['cluster1', 'cluster2'])
+                      usedby_clusters=['cluster1', 'cluster2'],
+                      resize_status=None,
+                      resize_target_size=None)
         ]
         mock_update_status.assert_has_calls(expected_calls, any_order=True)
 
@@ -2395,3 +2403,135 @@ class TestVolumeRefreshObservedState:
 
         update_config.assert_not_called()
         assert handle.config['storage_class_name'] == 'standard-rwo'
+
+
+class TestVolumeRefreshResizeState:
+    """A resize that has not landed yet has to be visible while it lasts.
+
+    The recorded size is the capacity the volume has, so an expansion that is
+    still running -- or parked until the workload restarts -- otherwise looks
+    exactly like nothing happening.
+    """
+
+    def _config(self, size='1'):
+        return models.VolumeConfig(
+            _version=1,
+            name='checkpoints',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='checkpoints-abc123',
+            size=size,
+            config={'namespace': 'my-namespace'},
+        )
+
+    def _volume(self, handle, resize_status=None, resize_target_size=None):
+        return {
+            'name': 'checkpoints',
+            'launched_at': 1234567890,
+            'user_hash': 'user123',
+            'workspace': 'default',
+            'last_attached_at': None,
+            'last_use': None,
+            'handle': handle,
+            'status': status_lib.VolumeStatus.READY,
+            'is_ephemeral': False,
+            'usedby_pods': [],
+            'usedby_clusters': [],
+            'error_message': None,
+            'resize_status': resize_status,
+            'resize_target_size': resize_target_size,
+        }
+
+    def _refresh(self, monkeypatch, volume, observed):
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=[volume]))
+        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                            mock.MagicMock(return_value=volume))
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_state',
+            mock.MagicMock(return_value=({
+                'checkpoints': None
+            }, observed, set())))
+        monkeypatch.setattr(provision, 'get_all_volumes_usedby',
+                            mock.MagicMock(return_value=({}, {}, set())))
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock.MagicMock(return_value=([], [])))
+        monkeypatch.setattr(
+            provision, 'refresh_volume_config',
+            mock.MagicMock(side_effect=lambda cloud, c: (False, c)))
+        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                            mock.MagicMock())
+        monkeypatch.setattr(global_user_state, 'update_volume_config',
+                            mock.MagicMock())
+        update_status = mock.MagicMock()
+        monkeypatch.setattr(global_user_state, 'update_volume_status',
+                            update_status)
+
+        core.volume_refresh()
+        return update_status
+
+    def test_a_resize_in_flight_is_recorded(self, monkeypatch):
+        volume = self._volume(self._config(size='1'))
+
+        update_status = self._refresh(
+            monkeypatch, volume, {
+                'checkpoints': models.ObservedVolumeState(
+                    size='1',
+                    resize_status=models.VolumeResizeStatus.NEEDS_RESTART,
+                    resize_target_size='2')
+            })
+
+        update_status.assert_called_once()
+        kwargs = update_status.call_args.kwargs
+        assert kwargs['resize_status'] == (
+            models.VolumeResizeStatus.NEEDS_RESTART)
+        assert kwargs['resize_target_size'] == '2'
+
+    def test_a_finished_resize_clears_what_was_recorded(self, monkeypatch):
+        """The cloud stops reporting a resize once it lands; so must we."""
+        volume = self._volume(self._config(size='2'),
+                              resize_status='needs_restart',
+                              resize_target_size='2')
+
+        update_status = self._refresh(
+            monkeypatch, volume,
+            {'checkpoints': models.ObservedVolumeState(size='2')})
+
+        update_status.assert_called_once()
+        kwargs = update_status.call_args.kwargs
+        assert kwargs['resize_status'] is None
+        assert kwargs['resize_target_size'] is None
+
+    def test_an_unchanged_resize_is_not_rewritten(self, monkeypatch):
+        """A resize can sit pending for hours; that must not cost a write a
+        minute."""
+        volume = self._volume(self._config(size='1'),
+                              resize_status='needs_restart',
+                              resize_target_size='2')
+
+        update_status = self._refresh(
+            monkeypatch, volume, {
+                'checkpoints': models.ObservedVolumeState(
+                    size='1',
+                    resize_status=models.VolumeResizeStatus.NEEDS_RESTART,
+                    resize_target_size='2')
+            })
+
+        update_status.assert_not_called()
+
+    def test_the_fields_survive_the_response_model(self, monkeypatch):
+        """volume_list has to carry them through to the client."""
+        volume = self._volume(self._config(size='1'),
+                              resize_status='needs_restart',
+                              resize_target_size='2')
+        monkeypatch.setattr(global_user_state, 'get_volumes',
+                            mock.MagicMock(return_value=[volume]))
+        monkeypatch.setattr(global_user_state, 'get_all_users',
+                            mock.MagicMock(return_value=[]))
+
+        records = core.volume_list()
+
+        assert records[0]['resize_status'] == 'needs_restart'
+        assert records[0]['resize_target_size'] == '2'

--- a/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
+++ b/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
@@ -5,6 +5,7 @@ that is necessary for PostgreSQL compatibility. See issue #8178 and PR #8179.
 """
 
 import pickle
+import sqlite3
 from unittest import mock
 
 import pytest
@@ -331,6 +332,8 @@ class TestVolumeResizeColumnsRoundTrip:
         # it.
         assert record['handle'].size == '10'
 
+    @pytest.mark.skipif(sqlite3.sqlite_version_info < (3, 35),
+                        reason='ALTER TABLE ... DROP COLUMN needs SQLite 3.35+')
     def test_a_database_that_predates_the_columns_is_upgraded_into_them(
             self, fresh_db):
         """The pinned target revision has to reach the migration that adds them.

--- a/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
+++ b/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
@@ -8,10 +8,14 @@ import pickle
 from unittest import mock
 
 import pytest
+import sqlalchemy
+import sqlalchemy.orm
 
 from sky import global_user_state
 from sky import models
+from sky.skylet import constants
 from sky.utils import status_lib
+from sky.utils.db import db_utils
 
 
 class TestVolumeIsEphemeralHandling:
@@ -262,3 +266,112 @@ class TestVolumeIsEphemeralHandling:
                                 'status'] == expected_status.value
                             # Verify last_attached_at is set
                             assert call_kwargs['last_attached_at'] == 1234567890
+
+
+class TestVolumeResizeColumnsRoundTrip:
+    """The resize fields against a real database, not a mocked session.
+
+    Every other test here mocks the SQLAlchemy session, so nothing proves the
+    three columns exist: they arrive with a migration, and the target revision
+    is pinned rather than resolved to the newest one, so a migration that is
+    written but not pinned leaves the code writing columns the database does
+    not have. That is a runtime failure a mocked session cannot see.
+    """
+
+    @pytest.fixture
+    def fresh_db(self, tmp_path, monkeypatch):
+        """A state database built the way production builds it."""
+        monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+        monkeypatch.setattr(
+            global_user_state,
+            '_db_manager',
+            db_utils.DatabaseManager(
+                'state',
+                global_user_state.create_table,
+                post_init_fn=lambda _: global_user_state.
+                _sqlite_supports_returning(),
+            ),
+        )
+        monkeypatch.setattr(global_user_state.common_utils, 'get_current_user',
+                            lambda: models.User(id='user123', name='user'))
+        monkeypatch.setattr(global_user_state.skypilot_config,
+                            'get_active_workspace', lambda: 'default')
+
+    def _add_volume(self, name='test-volume'):
+        global_user_state.add_volume(
+            name=name,
+            config=models.VolumeConfig(
+                name=name,
+                type='k8s-pvc',
+                cloud='kubernetes',
+                region='my-context',
+                zone=None,
+                size='10',
+                config={},
+                name_on_cloud='test-pvc',
+            ),
+            status=status_lib.VolumeStatus.READY,
+        )
+
+    def test_a_resize_in_flight_survives_the_database(self, fresh_db):
+        self._add_volume()
+
+        global_user_state.update_volume_status(
+            'test-volume',
+            status_lib.VolumeStatus.READY,
+            resize_status=models.VolumeResizeStatus.PENDING_ON_NODE,
+            resize_target_size='25',
+            resize_message='Waiting for a pod.')
+
+        record = global_user_state.get_volume_by_name('test-volume')
+        assert record['resize_status'] == 'pending_on_node'
+        assert record['resize_target_size'] == '25'
+        assert record['resize_message'] == 'Waiting for a pod.'
+        # The size is the capacity the volume has, and a resize does not move
+        # it.
+        assert record['handle'].size == '10'
+
+    def test_a_database_that_predates_the_columns_is_upgraded_into_them(
+            self, fresh_db):
+        """The pinned target revision has to reach the migration that adds them.
+
+        A database created from scratch gets every column from the ORM
+        metadata whatever revision is pinned, so only an upgrade runs the
+        migration -- and the target is pinned rather than resolved to the
+        newest revision, so one that is written but not pinned never runs.
+        """
+        engine = global_user_state._db_manager.get_engine()
+        columns = ('resize_status', 'resize_target_size', 'resize_message')
+        with sqlalchemy.orm.Session(engine) as session:
+            for column in columns:
+                session.execute(
+                    sqlalchemy.text(
+                        f'ALTER TABLE volumes DROP COLUMN {column}'))
+            session.execute(
+                sqlalchemy.text('UPDATE alembic_version_state_db '
+                                "SET version_num = '021'"))
+            session.commit()
+
+        global_user_state.create_table(engine)
+
+        with sqlalchemy.orm.Session(engine) as session:
+            present = session.execute(
+                sqlalchemy.text('SELECT * FROM volumes')).keys()
+        assert set(columns) <= set(present)
+
+    def test_a_finished_resize_clears_what_was_recorded(self, fresh_db):
+        self._add_volume()
+        global_user_state.update_volume_status(
+            'test-volume',
+            status_lib.VolumeStatus.READY,
+            resize_status=models.VolumeResizeStatus.IN_PROGRESS,
+            resize_target_size='25',
+            resize_message='Resizing.')
+
+        global_user_state.update_volume_status('test-volume',
+                                               status_lib.VolumeStatus.READY)
+
+        record = global_user_state.get_volume_by_name('test-volume')
+        assert record['resize_status'] is None
+        assert record['resize_target_size'] is None
+        assert record['resize_message'] is None

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -3054,3 +3054,136 @@ class TestObservedResizeState:
         observed = self._observe(mock_core_api, pvc)
 
         assert observed.resize_status is None
+
+
+class TestResizeConditionsAndMessage:
+    """Which condition decides the state, and whose words describe it.
+
+    A resizing claim holds several conditions at once -- one parked waiting for
+    a restart is still `Resizing` too -- so the order they are read in is the
+    difference between telling the user to wait and telling them to restart
+    something.
+    """
+
+    def _config(self):
+        return models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='1',
+            config={'namespace': 'my-namespace'},
+        )
+
+    def _observe(self, mock_core_api, pvc):
+        pvc_list = Mock()
+        pvc_list.items = [pvc]
+        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
+         return_value) = pvc_list
+        _, observed, _ = k8s_volume.get_all_volumes_state([self._config()])
+        return observed['test-vol']
+
+    def _condition(self, condition_type, message=None, status='True'):
+        condition = Mock()
+        condition.type = condition_type
+        condition.status = status
+        condition.message = message
+        return condition
+
+    def _pvc(self, conditions, allocated_status=None):
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+        pvc.status.capacity = {'storage': '1Gi'}
+        pvc.status.allocated_resources = {'storage': '2Gi'}
+        pvc.status.allocated_resource_statuses = ({
+            'storage': allocated_status
+        } if allocated_status else None)
+        pvc.status.conditions = conditions
+        return pvc
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_restart_outranks_a_resize_in_progress(self, mock_core_api,
+                                                     mock_get_context):
+        """Both hold at once, and `Resizing` is listed first."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([
+            self._condition('Resizing'),
+            self._condition('FileSystemResizePending', message='k8s says so'),
+        ])
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_message == 'k8s says so'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_failure_outranks_everything(self, mock_core_api,
+                                           mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([
+            self._condition('Resizing'),
+            self._condition('FileSystemResizePending'),
+            self._condition('NodeResizeError', message='quota exceeded'),
+        ])
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.FAILED
+        assert observed.resize_message == 'quota exceeded'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_the_message_describes_the_state_that_was_settled_on(
+            self, mock_core_api, mock_get_context):
+        """The state comes from allocatedResourceStatuses; the words have to
+        come from the condition that matches it, not from whichever holds."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc(
+            [
+                self._condition('Resizing', message='about the wrong state'),
+                self._condition('FileSystemResizePending',
+                                message='waiting for a restart'),
+            ],
+            allocated_status='NodeResizePending',
+        )
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_message == 'waiting for a restart'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_condition_without_words_reports_none(self, mock_core_api,
+                                                    mock_get_context):
+        """Nothing is invented here; the caller supplies the fallback."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([self._condition('FileSystemResizePending')],
+                        allocated_status='NodeResizePending')
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_message is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_condition_that_no_longer_holds_is_not_read(
+            self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([
+            self._condition('FileSystemResizePending',
+                            message='stale',
+                            status='False'),
+            self._condition('Resizing', message='current'),
+        ])
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.IN_PROGRESS
+        assert observed.resize_message == 'current'

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -38,6 +38,12 @@ class MockPVC:
 
         self.status = Mock()
         self.status.capacity = {'storage': size}
+        # A claim that is not being resized reports neither, and the real
+        # client gives None rather than a Mock -- which a bare Mock() would
+        # make truthy and iterable-looking.
+        self.status.allocated_resource_statuses = None
+        self.status.allocated_resources = None
+        self.status.conditions = None
 
 
 class MockPod:
@@ -2916,3 +2922,135 @@ class TestPvcSizeQuantities:
         assert k8s_volume._parse_pvc_size('2Gi', 'test-pvc') == '2'
         assert k8s_volume._parse_pvc_size('2000G', 'test-pvc') == '1863'
         assert k8s_volume._parse_pvc_size('2000Gi', 'test-pvc') == '2000'
+
+
+class TestObservedResizeState:
+    """What `get_all_volumes_state` reports about a resize in flight.
+
+    A claim's capacity only moves once the new space exists, so an expansion
+    that is still running -- or parked waiting for the workload to restart --
+    is indistinguishable from no expansion at all unless it is reported
+    separately.
+    """
+
+    def _config(self):
+        return models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size='1',
+            config={'namespace': 'my-namespace'},
+        )
+
+    def _observe(self, mock_core_api, pvc):
+        pvc_list = Mock()
+        pvc_list.items = [pvc]
+        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
+         return_value) = pvc_list
+        _, observed, _ = k8s_volume.get_all_volumes_state([self._config()])
+        return observed['test-vol']
+
+    def _resizing_pvc(self, status: str, allocated: str = '2Gi'):
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+        pvc.status.capacity = {'storage': '1Gi'}
+        pvc.spec.resources.requests = {'storage': allocated}
+        pvc.status.allocated_resources = {'storage': allocated}
+        pvc.status.allocated_resource_statuses = {'storage': status}
+        return pvc
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_resize_waiting_on_the_node_needs_a_restart(
+            self, mock_core_api, mock_get_context):
+        """The one state that never clears on its own."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        observed = self._observe(mock_core_api,
+                                 self._resizing_pvc('NodeResizePending'))
+
+        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_target_size == '2'
+        # The size is still what the volume actually has.
+        assert observed.size == '1'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    @pytest.mark.parametrize(
+        'status', ['ControllerResizeInProgress', 'NodeResizeInProgress'])
+    def test_a_running_resize_is_in_progress(self, mock_core_api,
+                                             mock_get_context, status):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        observed = self._observe(mock_core_api, self._resizing_pvc(status))
+
+        assert observed.resize_status == models.VolumeResizeStatus.IN_PROGRESS
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    @pytest.mark.parametrize('status',
+                             ['ControllerResizeFailed', 'NodeResizeFailed'])
+    def test_a_stopped_resize_is_failed(self, mock_core_api, mock_get_context,
+                                        status):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        observed = self._observe(mock_core_api, self._resizing_pvc(status))
+
+        assert observed.resize_status == models.VolumeResizeStatus.FAILED
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_volume_that_is_not_being_resized_reports_nothing(
+            self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status is None
+        assert observed.resize_target_size is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_an_older_cluster_reports_the_resize_as_a_condition(
+            self, mock_core_api, mock_get_context):
+        """Clusters without allocatedResourceStatuses only set conditions."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+        pvc.status.capacity = {'storage': '1Gi'}
+        pvc.status.allocated_resource_statuses = None
+        pvc.status.allocated_resources = None
+        pvc.spec.resources.requests = {'storage': '2Gi'}
+        condition = Mock()
+        condition.type = 'FileSystemResizePending'
+        condition.status = 'True'
+        pvc.status.conditions = [condition]
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        # No allocatedResources on such a cluster: fall back to the request.
+        assert observed.resize_target_size == '2'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_condition_that_is_not_true_is_not_a_resize(
+            self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+        pvc.status.allocated_resource_statuses = None
+        condition = Mock()
+        condition.type = 'Resizing'
+        condition.status = 'False'
+        pvc.status.conditions = [condition]
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status is None

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -2927,142 +2927,10 @@ class TestPvcSizeQuantities:
 class TestObservedResizeState:
     """What `get_all_volumes_state` reports about a resize in flight.
 
-    A claim's capacity only moves once the new space exists, so an expansion
-    that is still running -- or parked waiting for the workload to restart --
-    is indistinguishable from no expansion at all unless it is reported
-    separately.
-    """
-
-    def _config(self):
-        return models.VolumeConfig(
-            _version=1,
-            name='test-vol',
-            type='k8s-pvc',
-            cloud='kubernetes',
-            region='my-context',
-            zone=None,
-            name_on_cloud='test-pvc',
-            size='1',
-            config={'namespace': 'my-namespace'},
-        )
-
-    def _observe(self, mock_core_api, pvc):
-        pvc_list = Mock()
-        pvc_list.items = [pvc]
-        (mock_core_api.return_value.list_namespaced_persistent_volume_claim.
-         return_value) = pvc_list
-        _, observed, _ = k8s_volume.get_all_volumes_state([self._config()])
-        return observed['test-vol']
-
-    def _resizing_pvc(self, status: str, allocated: str = '2Gi'):
-        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
-        pvc.status.phase = 'Bound'
-        pvc.status.capacity = {'storage': '1Gi'}
-        pvc.spec.resources.requests = {'storage': allocated}
-        pvc.status.allocated_resources = {'storage': allocated}
-        pvc.status.allocated_resource_statuses = {'storage': status}
-        return pvc
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    def test_a_resize_waiting_on_the_node_needs_a_restart(
-            self, mock_core_api, mock_get_context):
-        """The one state that never clears on its own."""
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-
-        observed = self._observe(mock_core_api,
-                                 self._resizing_pvc('NodeResizePending'))
-
-        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
-        assert observed.resize_target_size == '2'
-        # The size is still what the volume actually has.
-        assert observed.size == '1'
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    @pytest.mark.parametrize(
-        'status', ['ControllerResizeInProgress', 'NodeResizeInProgress'])
-    def test_a_running_resize_is_in_progress(self, mock_core_api,
-                                             mock_get_context, status):
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-
-        observed = self._observe(mock_core_api, self._resizing_pvc(status))
-
-        assert observed.resize_status == models.VolumeResizeStatus.IN_PROGRESS
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    @pytest.mark.parametrize('status',
-                             ['ControllerResizeFailed', 'NodeResizeFailed'])
-    def test_a_stopped_resize_is_failed(self, mock_core_api, mock_get_context,
-                                        status):
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-
-        observed = self._observe(mock_core_api, self._resizing_pvc(status))
-
-        assert observed.resize_status == models.VolumeResizeStatus.FAILED
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    def test_a_volume_that_is_not_being_resized_reports_nothing(
-            self, mock_core_api, mock_get_context):
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
-        pvc.status.phase = 'Bound'
-
-        observed = self._observe(mock_core_api, pvc)
-
-        assert observed.resize_status is None
-        assert observed.resize_target_size is None
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    def test_an_older_cluster_reports_the_resize_as_a_condition(
-            self, mock_core_api, mock_get_context):
-        """Clusters without allocatedResourceStatuses only set conditions."""
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
-        pvc.status.phase = 'Bound'
-        pvc.status.capacity = {'storage': '1Gi'}
-        pvc.status.allocated_resource_statuses = None
-        pvc.status.allocated_resources = None
-        pvc.spec.resources.requests = {'storage': '2Gi'}
-        condition = Mock()
-        condition.type = 'FileSystemResizePending'
-        condition.status = 'True'
-        pvc.status.conditions = [condition]
-
-        observed = self._observe(mock_core_api, pvc)
-
-        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
-        # No allocatedResources on such a cluster: fall back to the request.
-        assert observed.resize_target_size == '2'
-
-    @patch('sky.provision.kubernetes.volume._get_context_namespace')
-    @patch('sky.adaptors.kubernetes.core_api')
-    def test_a_condition_that_is_not_true_is_not_a_resize(
-            self, mock_core_api, mock_get_context):
-        mock_get_context.return_value = ('my-context', 'my-namespace')
-        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
-        pvc.status.phase = 'Bound'
-        pvc.status.allocated_resource_statuses = None
-        condition = Mock()
-        condition.type = 'Resizing'
-        condition.status = 'False'
-        pvc.status.conditions = [condition]
-
-        observed = self._observe(mock_core_api, pvc)
-
-        assert observed.resize_status is None
-
-
-class TestResizeConditionsAndMessage:
-    """Which condition decides the state, and whose words describe it.
-
-    A resizing claim holds several conditions at once -- one parked waiting for
-    a restart is still `Resizing` too -- so the order they are read in is the
-    difference between telling the user to wait and telling them to restart
-    something.
+    A claim's capacity only moves once the new space exists, so a resize that
+    is still running -- or that is waiting to be mounted -- is invisible in the
+    size alone. It is read from the claim's conditions, which is also the only
+    place the claim says anything about it in words.
     """
 
     def _config(self):
@@ -3093,11 +2961,18 @@ class TestResizeConditionsAndMessage:
         condition.message = message
         return condition
 
-    def _pvc(self, conditions, allocated_status=None):
+    def _pvc(self,
+             conditions,
+             allocated='2Gi',
+             requested='2Gi',
+             allocated_status=None):
         pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
         pvc.status.phase = 'Bound'
         pvc.status.capacity = {'storage': '1Gi'}
-        pvc.status.allocated_resources = {'storage': '2Gi'}
+        pvc.spec.resources.requests = {'storage': requested}
+        pvc.status.allocated_resources = ({
+            'storage': allocated
+        } if allocated else None)
         pvc.status.allocated_resource_statuses = ({
             'storage': allocated_status
         } if allocated_status else None)
@@ -3106,9 +2981,30 @@ class TestResizeConditionsAndMessage:
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
     @patch('sky.adaptors.kubernetes.core_api')
-    def test_a_restart_outranks_a_resize_in_progress(self, mock_core_api,
-                                                     mock_get_context):
-        """Both hold at once, and `Resizing` is listed first."""
+    @pytest.mark.parametrize('condition_type,expected', [
+        ('Resizing', models.VolumeResizeStatus.IN_PROGRESS),
+        ('FileSystemResizePending', models.VolumeResizeStatus.PENDING_ON_NODE),
+        ('ControllerResizeError', models.VolumeResizeStatus.FAILED),
+        ('NodeResizeError', models.VolumeResizeStatus.FAILED),
+    ])
+    def test_each_condition_reports_its_state(self, mock_core_api,
+                                              mock_get_context, condition_type,
+                                              expected):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+
+        observed = self._observe(mock_core_api,
+                                 self._pvc([self._condition(condition_type)]))
+
+        assert observed.resize_status == expected
+        assert observed.resize_target_size == '2'
+        # The size stays the capacity the volume actually has.
+        assert observed.size == '1'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_waiting_on_the_node_outranks_resizing(self, mock_core_api,
+                                                   mock_get_context):
+        """Both hold at once on a real claim, and `Resizing` is listed first."""
         mock_get_context.return_value = ('my-context', 'my-namespace')
         pvc = self._pvc([
             self._condition('Resizing'),
@@ -3117,7 +3013,8 @@ class TestResizeConditionsAndMessage:
 
         observed = self._observe(mock_core_api, pvc)
 
-        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_status == (
+            models.VolumeResizeStatus.PENDING_ON_NODE)
         assert observed.resize_message == 'k8s says so'
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
@@ -3138,24 +3035,19 @@ class TestResizeConditionsAndMessage:
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
     @patch('sky.adaptors.kubernetes.core_api')
-    def test_the_message_describes_the_state_that_was_settled_on(
+    def test_the_words_come_from_the_condition_that_decided_the_state(
             self, mock_core_api, mock_get_context):
-        """The state comes from allocatedResourceStatuses; the words have to
-        come from the condition that matches it, not from whichever holds."""
+        """Otherwise a message about one stage describes another."""
         mock_get_context.return_value = ('my-context', 'my-namespace')
-        pvc = self._pvc(
-            [
-                self._condition('Resizing', message='about the wrong state'),
-                self._condition('FileSystemResizePending',
-                                message='waiting for a restart'),
-            ],
-            allocated_status='NodeResizePending',
-        )
+        pvc = self._pvc([
+            self._condition('Resizing', message='about the wrong state'),
+            self._condition('FileSystemResizePending',
+                            message='waiting to be mounted'),
+        ])
 
         observed = self._observe(mock_core_api, pvc)
 
-        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
-        assert observed.resize_message == 'waiting for a restart'
+        assert observed.resize_message == 'waiting to be mounted'
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
     @patch('sky.adaptors.kubernetes.core_api')
@@ -3163,12 +3055,12 @@ class TestResizeConditionsAndMessage:
                                                     mock_get_context):
         """Nothing is invented here; the caller supplies the fallback."""
         mock_get_context.return_value = ('my-context', 'my-namespace')
-        pvc = self._pvc([self._condition('FileSystemResizePending')],
-                        allocated_status='NodeResizePending')
+        pvc = self._pvc([self._condition('FileSystemResizePending')])
 
         observed = self._observe(mock_core_api, pvc)
 
-        assert observed.resize_status == models.VolumeResizeStatus.NEEDS_RESTART
+        assert observed.resize_status == (
+            models.VolumeResizeStatus.PENDING_ON_NODE)
         assert observed.resize_message is None
 
     @patch('sky.provision.kubernetes.volume._get_context_namespace')
@@ -3187,3 +3079,51 @@ class TestResizeConditionsAndMessage:
 
         assert observed.resize_status == models.VolumeResizeStatus.IN_PROGRESS
         assert observed.resize_message == 'current'
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_allocated_resource_statuses_alone_reports_nothing(
+            self, mock_core_api, mock_get_context):
+        """Deliberate: the conditions are the single source.
+
+        Reading the state from allocatedResourceStatuses and the words from a
+        condition lets the two describe different stages of the same resize --
+        and every cluster has conditions, while only recent ones have that
+        field.
+        """
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([], allocated_status='NodeResizePending')
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status is None
+        assert observed.resize_target_size is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_a_volume_that_is_not_being_resized_reports_nothing(
+            self, mock_core_api, mock_get_context):
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = MockPVC('test-pvc', 'my-namespace', size='1Gi')
+        pvc.status.phase = 'Bound'
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_status is None
+        assert observed.resize_target_size is None
+        assert observed.resize_message is None
+
+    @patch('sky.provision.kubernetes.volume._get_context_namespace')
+    @patch('sky.adaptors.kubernetes.core_api')
+    def test_the_target_falls_back_to_the_request(self, mock_core_api,
+                                                  mock_get_context):
+        """A cluster that does not report allocatedResources still asked for
+        something."""
+        mock_get_context.return_value = ('my-context', 'my-namespace')
+        pvc = self._pvc([self._condition('FileSystemResizePending')],
+                        allocated=None,
+                        requested='5Gi')
+
+        observed = self._observe(mock_core_api, pvc)
+
+        assert observed.resize_target_size == '5'


### PR DESCRIPTION
## Summary

A volume's recorded size is the capacity it actually has, so an expansion that has not landed looks exactly like nothing happening: the claim reports the old size, the dashboard shows the old size, and nothing says the new space is on its way — or that the user has to do something to get it.

Kubernetes parks an expansion once the space is allocated but the filesystem has not grown: the node grows it when it next mounts the volume, so a volume nothing is mounting stays that way indefinitely. It looks like this, and can look like this forever:

```yaml
status:
  capacity: {storage: 10Gi}                  # what the volume has
  allocatedResources: {storage: 25Gi}        # what it is getting
  conditions:
  - type: FileSystemResizePending
    status: "True"
    message: Waiting for user to (re-)start a pod to finish file system resize...
```

- Read the resize state off the claim's conditions, in the same pass that reads the capacity — no extra API calls. Conditions rather than `status.allocatedResourceStatuses`, which is the purpose-built field: the state and the words describing it then come from the same place and cannot disagree, and every cluster has conditions while only recent ones have that field. A claim holds several at once — one parked on the node is still `Resizing` too — so they are read worst-first.
- The cloud's vocabulary does not cross the boundary. It maps to the three cases that differ in what happens next — wait, get the volume mounted, or look at a failure — so the dashboard does not have to know Kubernetes' names, and a second Kubernetes version (or another cloud) does not become a second vocabulary.
- **The size itself is untouched.** Reporting the target as if it existed would advertise space the volume does not have; `status.allocatedResources` is documented as possibly larger than the real capacity for exactly this window.
- The fields clear when the resize lands, mirroring how the cloud reports it: the absence is the signal that it is done.

What to *do* about a parked resize is not part of the state, because the state cannot say it: Kubernetes' own message is "(re-)start a pod" whether or not anything has the volume mounted, which would send someone to restart a job that is about to finish on its own. So the advice is composed from what SkyPilot can see — a volume it can see a cluster or job on is certainly mounted — and, since growing a mounted volume needs a storage driver that supports it, restarting is offered as the fallback rather than led with.

Recorded as columns next to the status and error message they belong with, rather than in the pickled handle — the handle is the volume's config, not a place for something this transient. Migration `022` adds them; no API version bump (additive optional response fields, like `error_may_resolve` in #10486).

The dashboard shows the current size first, then where it is heading, and says what it is waiting for. `sky volumes ls` does the same, with the reason in the MESSAGE column it already grows when a volume has something to say:

```
NAME    TYPE     INFRA        SIZE          ...  MESSAGE
okvol   k8s-pvc  /my-context  10Gi -> 25Gi  ...  The new space is allocated, but the filesystem only grows when the...
steady  k8s-pvc  /my-context  100Gi         ...  -
```

## Test plan

**Unit** — `pytest tests/unit_tests/test_sky/volumes tests/unit_tests/test_sky/utils/test_volume_utils.py tests/unit_tests/test_sky/test_cli_volumes.py tests/unit_tests/test_sky/provision tests/unit_tests/test_sky/db` (863 passed; the two `test_volumes_apply_*` failures on my machine reproduce on `master` — they need a local API server). New:

- **extraction**: each resize condition maps to the right state; the worst-first order matters, since a claim parked on the node is `Resizing` too; a condition whose status is not `True` is not a resize; the target falls back to the request when nothing is allocated yet. The recorded size stays the real capacity throughout.
- **refresh**: a resize in flight is recorded; a finished one **clears** what was recorded; an unchanged one is not rewritten (a resize can sit pending for hours, and must not cost a database write a minute); the fields survive `volume_list` into the response.
- **wording**: what each state says, and that a volume something is using is not led with a restart.
- **database** — against a real SQLite database, not a mocked session: the three columns round-trip, clear on `None`, and **a database that predates them is upgraded into having them**. That last one is the one worth having: a database created from scratch gets every column from the ORM metadata whatever revision is pinned, so only an upgrade runs the migration — and the target revision is pinned rather than resolved to the newest one. Reverting the pin to `021` fails exactly that test and nothing else.
- **CLI**: the arrow and the message appear while a resize is in flight, neither appears otherwise, an error wins the single message cell, and a target that rounds to the size already shown is not rendered as an arrow pointing at itself.

  The migration test is skipped where SQLite predates `ALTER TABLE ... DROP COLUMN` (3.35), which it uses to put the database back before the migration.

**Dashboard** — `npx jest` (196 passed), 6 for the size cell: no arrow when nothing is resizing, the target when there is one, the right hint for pending and for failed, no dangling arrow when a server reports a status without a target size, and no arrow when the target rounds to the current size. Reverting the cell fails exactly the tests that assert the new rendering.

**Live, on a real cluster (GKE v1.35.6)** — parked a real expansion (bind a `premium-rwo` claim, delete the pod holding it, patch the request), then read that claim back through this code at this commit:

```
claim:  allocatedResourceStatuses: {storage: NodeResizePending}
        conditions: Resizing=True (no message)
                    FileSystemResizePending=True
                      message='Waiting for user to (re-)start a pod to finish
                               file system resize of volume on node.'

code:   _pvc_resize_state -> PENDING_ON_NODE, target='25', message=<the above>
        the recorded size stays '10'
        shown, volume in use:  The new space is allocated, but the filesystem only
          grows when the volume is mounted. A cluster or job is using it, so the
          node usually grows the filesystem without a restart. If it stays this
          way, restart the cluster or job using it.
        shown, nothing seen using it:  Waiting for user to (re-)start a pod to
          finish file system resize of volume on node. The node grows the
          filesystem the next time something mounts the volume; start or restart
          a cluster or job that uses it.
```

This is the check that the conditions-based read is not just plausible but current: a modern cluster still sets `FileSystemResizePending` alongside `allocatedResourceStatuses`, and sets `Resizing` at the same time, which is why the conditions are read worst-first.

**End to end, same cluster, this commit** — a volume created through SkyPilot, expanded by patching the claim, watched through every state it passes:

| what was done | what SkyPilot said |
| --- | --- |
| `sky volumes apply` a 10Gi claim | `10Gi`, no arrow, no message column |
| patch to 25Gi with a pod holding it | parked briefly, then landed on its own: `25Gi`, resize fields cleared |
| patch to 50Gi, this time with the pod labelled so SkyPilot counts it | caught in the pending window: `25Gi -> 50Gi` and *"A cluster or job is using it, so the node usually grows the filesystem without a restart. If it stays this way, restart the cluster or job using it."* — the node then grew it unaided, which is why waiting leads |
| delete the pod, patch to 75Gi | parks indefinitely: `50Gi -> 75Gi` with Kubernetes' own sentence plus what will finish it |
| recreate the pod | `75Gi`, no arrow, message column gone |

Nothing above passed `--refresh`; the refresh daemon picked each change up on its own. In the parked state:

```
$ sky volumes ls
NAME             TYPE     INFRA  SIZE          ...  MESSAGE
dan-6784-expand  k8s-pvc  ...    50Gi -> 75Gi  ...  Waiting for user to (re-)start a pod to finish file system resize of...
```

and the dashboard showed the same on the table (with the reason expanding in place) and on the volume's own page.
