### PR TITLE
[API server] Run the requests GC daemon once an hour

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -72,6 +72,8 @@ COL_FILE_MOUNTS_BLOB_ID = 'file_mounts_blob_id'
 LEGACY_REQUEST_LOG_PATH_PREFIX = '~/sky_logs/api_server/requests'
 
 DEFAULT_REQUESTS_RETENTION_HOURS = 24  # 1 day
+# Interval between two runs of the requests GC daemon.
+_REQUESTS_GC_INTERVAL_SECONDS = 3600  # 1 hour
 
 # TODO(zhwu): For scalability, there are several TODOs:
 # [x] Have a way to queue requests.
@@ -1377,7 +1379,7 @@ async def requests_gc_daemon():
                          f'traceback: {traceback.format_exc()}')
         # Run the daemon at most once every hour to avoid too frequent
         # cleanup.
-        await asyncio.sleep(max(retention_seconds, 3600))
+        await asyncio.sleep(_REQUESTS_GC_INTERVAL_SECONDS)
 
 
 def _cleanup():


### PR DESCRIPTION
`requests_gc_daemon()` slept for `max(retention_seconds, 3600)` between runs. The comment says the daemon should run "at most once every hour", i.e. one hour is meant to be a *floor* on the interval — but `max()` makes the interval *equal to the retention period* whenever retention exceeds one hour. With the default `DEFAULT_REQUESTS_RETENTION_HOURS = 24` the daemon runs once a day instead of hourly.

Consequences:

- Finished requests accumulate for between 1x and 2x the retention period rather than being held at a steady retention window.
- All expired requests are then deleted in a single burst (batches of 1000 in `clean_finished_requests_with_retention`) instead of being trimmed gradually. On servers whose requests carry large `request_body` / `return_value` payloads, this concentrates a large amount of delete + TOAST churn, WAL and checkpoint work into one window once per retention period.
- A longer configured `api_server.requests_retention_hours` makes the daemon *less* frequent, which is the opposite of what an operator would expect.

This PR sleeps a fixed one hour between runs, via a new module-level `_REQUESTS_GC_INTERVAL_SECONDS`, matching the comment's intent.

The loop calls `skypilot_config.reload_config()` on each iteration, so this also means a config change that enables or disables GC (a negative retention disables it) now takes effect within an hour rather than within a retention period.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

No local verification beyond formatting — the change is a constant sleep interval and is covered by CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->