### PR TITLE
[Server] Move the chunked-upload rename and part scan off the event loop

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1694,6 +1694,44 @@ async def _prepare_client_mount_dir(user_hash: str,
     return client_file_mounts_dir
 
 
+def _publish_chunk(zip_file_path: pathlib.Path, final_path: pathlib.Path,
+                   chunk_dir: Optional[pathlib.Path],
+                   total_chunks: int) -> Set[str]:
+    """Publishes a received chunk and reports which chunks are still missing.
+
+    Call this in a worker thread: the rename and the directory listing are
+    both synchronous, and the upload directory can live on a shared
+    filesystem (NFS/EFS) where a single operation costs milliseconds to
+    seconds. On the event loop that blocks every other request served by the
+    same worker for as long as the filesystem takes.
+
+    Args:
+        zip_file_path: The writer-unique temporary file holding the chunk.
+        final_path: The name to publish the chunk under.
+        chunk_dir: Directory holding the parts of a multi-chunk upload, or
+            None for a single-chunk upload, which has nothing to wait for.
+        total_chunks: The total number of chunks of this upload.
+
+    Returns:
+        The names of the chunks that have not been published yet, empty if
+        the upload is complete.
+    """
+    os.rename(str(zip_file_path), str(final_path))
+    if chunk_dir is None:
+        return set()
+    # A single directory read gives the state of the whole upload. Skip tmp
+    # files (e.g. ``part0.tmp.<hex>``) that may belong to in-flight
+    # concurrent writers: only published ``part{N}`` names count toward
+    # completion.
+    existing = set()
+    with os.scandir(chunk_dir) as entries:
+        for entry in entries:
+            name = entry.name
+            if name.startswith('part') and name[len('part'):].isdigit():
+                existing.add(name)
+    return set(f'part{i}' for i in range(total_chunks)) - existing
+
+
 async def _receive_and_assemble_chunks(
     base_dir: pathlib.Path,
     zip_name: str,
@@ -1734,6 +1772,8 @@ async def _receive_and_assemble_chunks(
     # a same blob does not interleave with each other.
     if total_chunks == 1:
         await anyio.Path(base_dir).mkdir(parents=True, exist_ok=True)
+        # No parts directory: a single-chunk upload has nothing to wait for.
+        chunk_dir = None
         final_path = base_dir / f'{zip_name}.zip'
         zip_file_path = base_dir / f'{zip_name}.tmp.{uuid.uuid4().hex}.zip'
     else:
@@ -1748,41 +1788,30 @@ async def _receive_and_assemble_chunks(
                 await f.write(chunk)
     except starlette.requests.ClientDisconnect as e:
         # Client disconnected, remove the zip file.
-        zip_file_path.unlink(missing_ok=True)
+        await asyncio.to_thread(zip_file_path.unlink, missing_ok=True)
         raise fastapi.HTTPException(
             status_code=400,
             detail='Client disconnected, please try again.') from e
     except Exception as e:
         logger.error(f'Error uploading zip file: {zip_file_path}')
         # Client disconnected, remove the zip file.
-        zip_file_path.unlink(missing_ok=True)
+        await asyncio.to_thread(zip_file_path.unlink, missing_ok=True)
         raise fastapi.HTTPException(
             status_code=500,
             detail=('Error uploading zip file: '
                     f'{common_utils.format_exception(e)}'))
 
-    def get_missing_chunks(total_chunks: int) -> Set[str]:
-        existing = set()
-        for p in chunk_dir.glob('part*'):
-            # Filter out tmp files (e.g. ``part0.tmp.<hex>``) that may
-            # belong to in-flight concurrent writers.  Only renamed
-            # final names ``part{N}`` count toward completion.
-            name = p.name
-            suffix = name[len('part'):] if name.startswith('part') else ''
-            if suffix.isdigit():
-                existing.add(name)
-        return set(f'part{i}' for i in range(total_chunks)) - existing
-
-    # Rename the writer-unique tmp file to its final name.
-    os.rename(str(zip_file_path), str(final_path))
+    # Rename the writer-unique tmp file to its final name and find out
+    # whether that completed the upload.
+    missing_chunks = await asyncio.to_thread(_publish_chunk, zip_file_path,
+                                             final_path, chunk_dir,
+                                             total_chunks)
     zip_file_path = final_path
 
-    if total_chunks > 1:
-        missing_chunks = get_missing_chunks(total_chunks)
-        if missing_chunks:
-            return payloads.UploadZipFileResponse(
-                status=responses.UploadStatus.UPLOADING.value,
-                missing_chunks=missing_chunks)
+    if missing_chunks:
+        return payloads.UploadZipFileResponse(
+            status=responses.UploadStatus.UPLOADING.value,
+            missing_chunks=missing_chunks)
     logger.info(f'Uploaded chunk: {zip_file_path}')
     if assemble:
         await _finalize_chunked_upload(base_dir=base_dir,

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -14,6 +14,7 @@ import pytest
 import uvicorn
 
 from sky import models
+from sky.schemas.api import responses as api_responses
 from sky.server import common as server_common
 from sky.server import constants as server_constants
 from sky.server import server
@@ -1404,3 +1405,121 @@ def test_api_stream_log_path_admin_only(_request_authz_env, monkeypatch):
                       headers={
                           'user-agent': 'curl'
                       }).status_code == 404
+
+
+def _write_part(path: pathlib.Path) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b'data')
+    return path
+
+
+def test_publish_chunk_single_chunk_upload_has_nothing_to_wait_for(tmp_path):
+    tmp = _write_part(tmp_path / 'upload.tmp.deadbeef.zip')
+    final = tmp_path / 'upload.zip'
+
+    assert server._publish_chunk(tmp, final, None, 1) == set()
+    assert final.read_bytes() == b'data'
+    assert not tmp.exists()
+
+
+def test_publish_chunk_reports_chunks_not_published_yet(tmp_path):
+    chunk_dir = tmp_path / 'staging'
+    _write_part(chunk_dir / 'part0')
+    # A concurrent writer's in-flight tmp file must not count as published.
+    _write_part(chunk_dir / 'part2.tmp.deadbeef')
+    tmp = _write_part(chunk_dir / 'part1.tmp.cafe1234')
+
+    missing = server._publish_chunk(tmp, chunk_dir / 'part1', chunk_dir, 4)
+
+    assert missing == {'part2', 'part3'}
+    assert (chunk_dir / 'part1').read_bytes() == b'data'
+
+
+def test_publish_chunk_last_chunk_completes_the_upload(tmp_path):
+    chunk_dir = tmp_path / 'staging'
+    _write_part(chunk_dir / 'part0')
+    tmp = _write_part(chunk_dir / 'part1.tmp.cafe1234')
+
+    assert server._publish_chunk(tmp, chunk_dir / 'part1', chunk_dir,
+                                 2) == set()
+
+
+class _FakeUploadRequest:
+    """Minimal stand-in for the streaming request of an upload endpoint."""
+
+    def __init__(self, payload: bytes = b'chunk'):
+        self._payload = payload
+
+    async def stream(self):
+        yield self._payload
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_does_no_sync_fs_work_on_the_event_loop(
+        tmp_path, monkeypatch):
+    """The rename and the directory listing must not block the serving loop.
+
+    Both are synchronous calls that can take seconds on a shared filesystem,
+    and while either runs no other request on the same worker can proceed.
+    """
+    loop_thread = threading.get_ident()
+    calls = []
+
+    real_rename = os.rename
+    real_scandir = os.scandir
+
+    def tracking_rename(src, dst):
+        if str(tmp_path) in str(src):
+            calls.append(('rename', threading.get_ident()))
+        return real_rename(src, dst)
+
+    def tracking_scandir(path):
+        if str(tmp_path) in str(path):
+            calls.append(('scandir', threading.get_ident()))
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, 'rename', tracking_rename)
+    monkeypatch.setattr(os, 'scandir', tracking_scandir)
+
+    result = await server._receive_and_assemble_chunks(
+        base_dir=tmp_path,
+        zip_name='upload',
+        request=_FakeUploadRequest(),
+        chunk_index=0,
+        total_chunks=2,
+        extract=False,
+        assemble=False)
+
+    # Chunk 1 has not arrived, so the client is told to keep going.
+    assert result is not None
+    assert result.status == api_responses.UploadStatus.UPLOADING.value
+    assert {op for op, _ in calls} == {'rename', 'scandir'}
+    assert [ident for _, ident in calls if ident == loop_thread] == []
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_skips_the_directory_listing_for_one_chunk(
+        tmp_path, monkeypatch):
+    """A single-chunk upload has nothing to wait for, so it must not list."""
+    real_scandir = os.scandir
+    listed = []
+
+    def tracking_scandir(path):
+        if str(tmp_path) in str(path):
+            listed.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, 'scandir', tracking_scandir)
+
+    result = await server._receive_and_assemble_chunks(
+        base_dir=tmp_path,
+        zip_name='upload',
+        request=_FakeUploadRequest(),
+        chunk_index=0,
+        total_chunks=1,
+        extract=False,
+        assemble=False)
+
+    assert result is None
+    assert listed == []
+    assert (tmp_path / 'upload.zip').read_bytes() == b'chunk'


### PR DESCRIPTION
`_receive_and_assemble_chunks` streams each chunk asynchronously (`anyio.Path(...).mkdir`, `aiofiles.open`), then did two **synchronous** filesystem calls on the event loop right after: `os.rename` to publish the chunk under its final name, and `chunk_dir.glob('part*')` to check whether that completed the upload. While either is in flight, no other request served by the same worker can proceed.

That matters because the upload directory is often on a shared filesystem, where a single operation costs milliseconds to seconds rather than microseconds. A loop-stall watchdog on a busy API server attributed 27 stalls to these two calls over 48 h — 15 to the glob (worst 2.088 s) and 12 to the rename (worst 2.063 s), p50 1.035 s, spread over 6 worker processes, so not one pathological upload.

Both calls now happen in a single `asyncio.to_thread` hop, matching what the write path in the same function already does. The two cleanup `unlink`s on the error paths (client disconnect / write failure) go off the loop as well. The directory listing became a plain `os.scandir` — the same single directory read, but without constructing a `Path` and running `fnmatch` per entry — and it is skipped entirely for single-chunk uploads, which have no parts directory to wait on.

### One note on the completion check

The per-chunk listing is still O(parts) per request, i.e. O(parts²) directory entries over a whole upload. I looked at removing it and did not, because the measurement does not support it being the dominant cost: `pathlib.glob('part*')` issues exactly **one** `scandir`, not one `stat` per expected name (verified by counting `os.scandir` calls), so an upload costs O(parts) directory reads, and each read is a handful of round trips regardless of entry count. Consistently, the single-operation `os.rename` — which has no relation at all to the number of chunks — stalls the loop just as long as the glob (2.063 s vs 2.088 s worst case). Per-operation filesystem latency dominates, not entry count.

Making the check O(1) would need cross-process shared state, since the chunks of one upload are served by different workers and, with multiple replicas, different pods. Every filesystem-only way to do that (link-count tricks, a lock-guarded counter file) trades a cheap directory read for a new way to *miss* a completion and silently force a full re-upload. Not worth it for a term the data says is second-order.

For reference, on a 204-entry directory: `scandir` 155 µs, `glob` 246 µs, one `stat` per expected name 709 µs — so the alternative of stat-ing each `part{N}` would have been ~4.6× worse than what is there now.

## Tested

- Code formatting: `bash format.sh` (yapf 0.32.0, isort 5.12.0), `pylint` 10.00/10 on `sky/server/server.py`
- New unit tests in `tests/unit_tests/test_sky/server/test_server.py` (5 added; whole file 53 passed / 0 failed):
  - `test_receive_chunks_does_no_sync_fs_work_on_the_event_loop` is the regression test — it records the thread each `os.rename` / `os.scandir` runs on and asserts neither is the loop thread. Verified that it **fails on master** (`assert [8662494272, 8662494272] == []`, i.e. both calls on the loop thread) and passes with this change.
  - `test_receive_chunks_skips_the_directory_listing_for_one_chunk` asserts a single-chunk upload lists nothing.
  - Three tests for `_publish_chunk` semantics: single-chunk, partial upload (in-flight `part{N}.tmp.<hex>` files must not count as published), and the last chunk completing the upload.
