### PR TITLE
[Jobs] Make the consolidation-mode recovery sweep targeted and rate-limited

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1575,6 +1575,29 @@ def get_cluster_workspace(cluster_name: str) -> Optional[str]:
 
 
 @metrics_lib.time_me
+def filter_existing_cluster_names(cluster_names: Set[str]) -> Set[str]:
+    """Of ``cluster_names``, the ones that have a row in the cluster table.
+
+    Existence-only check: unlike ``get_handles_from_cluster_names`` this does
+    not read or unpickle the handle, so it stays cheap for callers that only
+    need to know whether a cluster is still around (e.g. deciding whether
+    there is anything left to tear down).
+    """
+    result: Set[str] = set()
+    if not cluster_names:
+        return result
+    engine = _db_manager.get_engine()
+    names_list = list(cluster_names)
+    with orm.Session(engine) as session:
+        for offset in range(0, len(names_list), _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = names_list[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            rows = session.query(cluster_table.c.name).filter(
+                cluster_table.c.name.in_(batch)).all()
+            result.update(row.name for row in rows)
+    return result
+
+
+@metrics_lib.time_me
 def get_handles_from_cluster_names(
         cluster_names: Set[str]
 ) -> Dict[str, Optional['backends.ResourceHandle']]:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -3756,6 +3756,192 @@ def set_job_info(job_id: int,
         session.commit()
 
 
+# Chunk size for ``spot_job_id IN (...)`` lists in the recovery sweep. Keeps
+# the parameter count under SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999
+# before 3.32) and keeps each statement's share of a pooled connection short,
+# so a sweep over many jobs does not hold one connection for its whole
+# duration.
+_RECOVERY_CHUNK_SIZE = 200
+
+
+def _chunked(job_ids: List[int]) -> List[List[int]]:
+    return [
+        job_ids[i:i + _RECOVERY_CHUNK_SIZE]
+        for i in range(0, len(job_ids), _RECOVERY_CHUNK_SIZE)
+    ]
+
+
+# Schedule states that need no recovery: DONE is finished, and WAITING /
+# INACTIVE have no controller to recover (INACTIVE may be mid-submission, so
+# moving it to WAITING would race the submitting request).
+_NO_RECOVERY_SCHEDULE_STATES = [
+    ManagedJobScheduleState.DONE.value,
+    ManagedJobScheduleState.WAITING.value,
+    ManagedJobScheduleState.INACTIVE.value,
+]
+
+
+def _needs_recovery_condition() -> 'sqlalchemy.ColumnElement':
+    """Rows whose schedule_state says a controller should be running.
+
+    NULL is included: jobs submitted before schedule_state existed have no
+    state to interpret, and the sweep has always treated them as candidates.
+    """
+    return sqlalchemy.or_(
+        job_info_table.c.schedule_state.is_(None),
+        sqlalchemy.not_(
+            job_info_table.c.schedule_state.in_(_NO_RECOVERY_SCHEDULE_STATES)),
+    )
+
+
+def get_jobs_needing_recovery_check() -> List[Dict[str, Any]]:
+    """Jobs the consolidation-mode recovery sweep has to look at.
+
+    Returns one row per job (not per task) with just the columns the sweep
+    needs: the job id, the recorded controller pid, and the schedule state.
+
+    This deliberately reads ``job_info`` alone and filters on the indexed
+    ``schedule_state`` column, so its cost tracks the number of jobs that
+    could still have a controller rather than the size of the whole jobs
+    history. Do not widen it into a join against ``spot``: the sweep runs on
+    every leader election, and every extra row such a join contributes is by
+    definition a job that needs no recovery.
+    """
+    engine = _db_manager.get_engine()
+    query = sqlalchemy.select(
+        job_info_table.c.spot_job_id,
+        job_info_table.c.controller_pid,
+        job_info_table.c.controller_pid_started_at,
+        job_info_table.c.schedule_state,
+    ).where(_needs_recovery_condition()).order_by(
+        job_info_table.c.spot_job_id.asc())
+    with orm.Session(engine) as session:
+        rows = session.execute(query).fetchall()
+    return [{
+        'job_id': row[0],
+        'controller_pid': row[1],
+        'controller_pid_started_at': row[2],
+        'schedule_state':
+            (ManagedJobScheduleState(row[3]) if row[3] is not None else None),
+    } for row in rows]
+
+
+def get_job_ids_with_all_tasks_cancelled(job_ids: List[int]) -> Set[int]:
+    """Of ``job_ids``, those whose every task row is already CANCELLED.
+
+    Such a job has nothing left for a controller to do. CANCELLED
+    specifically -- rather than any terminal status -- because it is the one
+    terminal status a controller only ever writes *after* its cleanup
+    succeeded: ``set_cancelled`` transitions CANCELLING -> CANCELLED, and the
+    controller reaches that transition after cluster teardown and ephemeral
+    storage teardown have returned (a cleanup failure leaves the task
+    FAILED_CONTROLLER instead). The other route to CANCELLED is a job
+    cancelled while still PENDING, which never provisioned anything. Either
+    way there is nothing outstanding for a controller to clean up, which is
+    what makes skipping the controller safe.
+
+    A job with no task rows at all is *not* returned: it exists in
+    ``job_info`` but its tasks are not recorded yet (mid-submission), which is
+    the opposite of finished.
+    """
+    if not job_ids:
+        return set()
+    engine = _db_manager.get_engine()
+    not_cancelled = sqlalchemy.case(
+        (spot_table.c.status == ManagedJobStatus.CANCELLED.value, 0),
+        else_=1,
+    )
+    all_cancelled: Set[int] = set()
+    with orm.Session(engine) as session:
+        for chunk in _chunked(job_ids):
+            query = sqlalchemy.select(spot_table.c.spot_job_id).where(
+                spot_table.c.spot_job_id.in_(chunk)).group_by(
+                    spot_table.c.spot_job_id).having(
+                        sqlalchemy.func.sum(not_cancelled) == 0)
+            all_cancelled.update(row[0] for row in session.execute(query))
+    return all_cancelled
+
+
+def get_non_pool_task_names(job_ids: List[int]) -> List[Tuple[int, str]]:
+    """(job_id, task name) for tasks of ``job_ids`` that ran outside a pool.
+
+    The caller turns these into managed-job cluster names to check whether a
+    finished job still has a cluster to tear down. Pool tasks are excluded:
+    they run on a cluster owned by the pool, which managed-job cleanup never
+    terminates.
+    """
+    if not job_ids:
+        return []
+    engine = _db_manager.get_engine()
+    names: List[Tuple[int, str]] = []
+    with orm.Session(engine) as session:
+        for chunk in _chunked(job_ids):
+            query = sqlalchemy.select(
+                spot_table.c.spot_job_id,
+                spot_table.c.task_name,
+            ).select_from(
+                spot_table.outerjoin(
+                    job_info_table, spot_table.c.spot_job_id ==
+                    job_info_table.c.spot_job_id)).where(
+                        sqlalchemy.and_(
+                            spot_table.c.spot_job_id.in_(chunk),
+                            job_info_table.c.pool.is_(None),
+                            spot_table.c.task_name.is_not(None),
+                        ))
+            names.extend((row[0], row[1]) for row in session.execute(query))
+    return names
+
+
+def reset_jobs_for_recovery_batch(job_ids: List[int]) -> int:
+    """Reset a batch of jobs to WAITING, dropping their controller pids.
+
+    Rows that no longer need recovery are skipped rather than overwritten, so
+    a job that reached DONE (or was already picked up and moved to WAITING)
+    between the sweep's read and this write keeps its newer state.
+
+    Returns the number of rows updated.
+    """
+    return _update_jobs_schedule_state_batch(
+        job_ids, ManagedJobScheduleState.WAITING.value)
+
+
+def set_jobs_done_batch(job_ids: List[int]) -> int:
+    """Mark a batch of already-finished jobs DONE, dropping controller pids.
+
+    For jobs whose tasks are all terminal and which have no cluster left to
+    clean up, DONE is the state a controller would reach anyway. Guarded by
+    the same predicate as :func:`reset_jobs_for_recovery_batch` so a
+    concurrent transition wins.
+
+    Returns the number of rows updated.
+    """
+    return _update_jobs_schedule_state_batch(job_ids,
+                                             ManagedJobScheduleState.DONE.value)
+
+
+def _update_jobs_schedule_state_batch(job_ids: List[int],
+                                      schedule_state: str) -> int:
+    if not job_ids:
+        return 0
+    engine = _db_manager.get_engine()
+    updated = 0
+    with orm.Session(engine) as session:
+        for chunk in _chunked(job_ids):
+            result = session.execute(
+                sqlalchemy.update(job_info_table).where(
+                    sqlalchemy.and_(
+                        job_info_table.c.spot_job_id.in_(chunk),
+                        _needs_recovery_condition(),
+                    )).values({
+                        job_info_table.c.controller_pid: None,
+                        job_info_table.c.controller_pid_started_at: None,
+                        job_info_table.c.schedule_state: schedule_state,
+                    }))
+            updated += result.rowcount
+        session.commit()
+    return updated
+
+
 def reset_jobs_for_recovery() -> None:
     """Remove controller PIDs for live jobs, allowing them to be recovered."""
     engine = _db_manager.get_engine()
@@ -3775,20 +3961,6 @@ def reset_jobs_for_recovery() -> None:
             job_info_table.c.schedule_state:
                 (ManagedJobScheduleState.WAITING.value)
         })
-        session.commit()
-
-
-def reset_job_for_recovery(job_id: int) -> None:
-    """Set a job to WAITING and remove PID, allowing it to be recovered."""
-    engine = _db_manager.get_engine()
-    with orm.Session(engine) as session:
-        session.query(job_info_table).filter(
-            job_info_table.c.spot_job_id == job_id).update({
-                job_info_table.c.controller_pid: None,
-                job_info_table.c.controller_pid_started_at: None,
-                job_info_table.c.schedule_state:
-                    ManagedJobScheduleState.WAITING.value,
-            })
         session.commit()
 
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -23,8 +23,8 @@ import threading
 import time
 import traceback
 import typing
-from typing import (Any, Dict, Iterable, List, Literal, Optional, Set, Tuple,
-                    Union)
+from typing import (Any, Dict, Iterable, Iterator, List, Literal, Optional, Set,
+                    TextIO, Tuple, Union)
 
 import colorama
 import filelock
@@ -144,6 +144,22 @@ _FINAL_JOB_STATUS_WAIT_TIMEOUT_SECONDS = 120
 
 # Content written to the jobs cancel signal file.
 _JOBS_GRACEFUL_CANCEL_SIGNAL = 'graceful'
+
+# How many jobs the consolidation-mode recovery sweep settles before pausing.
+# Small enough that one batch's DB work is a short burst rather than a long
+# hold on a pooled connection, large enough that the fixed per-batch queries
+# (a few) stay negligible next to the per-job work they replace.
+_RECOVERY_SWEEP_BATCH_SIZE = 100
+
+# Multiple of a batch's own duration to pause for before the next batch. 1.0
+# caps the sweep at half the DB throughput it could take; see
+# _throttle_recovery_sweep.
+_RECOVERY_SWEEP_PAUSE_RATIO = 1.0
+
+# Ceiling on one inter-batch pause. Without it, a single pathologically slow
+# batch (e.g. one that sat in a connection queue) would stall the rest of the
+# sweep for just as long, and recovery gates controller startup.
+_RECOVERY_SWEEP_MAX_PAUSE_SECONDS = 5.0
 
 # The response fields for managed jobs that require cluster handle
 _CLUSTER_HANDLE_FIELDS = [
@@ -393,60 +409,148 @@ def ha_recovery_for_consolidation_mode() -> None:
               encoding='utf-8') as f:
         start = time.time()
         f.write(f'Starting HA recovery at {datetime.now()}\n')
-        jobs, _ = managed_job_state.get_managed_jobs_with_filters(fields=[
-            'job_id', 'controller_pid', 'controller_pid_started_at',
-            'schedule_state', 'status'
-        ])
-        for job in jobs:
-            job_id = job['job_id']
-            controller_pid = job['controller_pid']
-            controller_pid_started_at = job.get('controller_pid_started_at')
 
-            # In consolidation mode, it is possible that only the API server
-            # process is restarted, and the controller process is not. In such
-            # case, we don't need to do anything and the controller process will
-            # just keep running. However, in most cases, the controller process
-            # will also be stopped - either by a pod restart in k8s API server,
-            # or by `sky api stop`, which will stop controllers.
-            # TODO(cooperc): Make sure we cannot have a controller process
-            # running across API server restarts for consistency.
-            if controller_pid is not None:
-                try:
-                    # Note: We provide the legacy job id to the
-                    # controller_process_alive just in case, but we shouldn't
-                    # have a running legacy job controller process at this point
-                    if controller_process_alive(
-                            managed_job_state.ControllerPidRecord(
-                                pid=controller_pid,
-                                started_at=controller_pid_started_at), job_id):
-                        message = (f'Controller pid {controller_pid} for '
-                                   f'job {job_id} is still running. '
-                                   'Skipping recovery.\n')
-                        logger.debug(message)
-                        f.write(message)
-                        continue
-                except Exception:  # pylint: disable=broad-except
-                    # _controller_process_alive may raise if psutil fails; we
-                    # should not crash the recovery logic because of this.
-                    message = ('Error checking controller pid '
-                               f'{controller_pid} for job {job_id}\n')
-                    logger.warning(message, exc_info=True)
-                    f.write(message)
+        # Only jobs whose schedule_state says a controller should be running
+        # can need recovery, so ask the DB for exactly those instead of
+        # reading the whole jobs history and filtering in Python.
+        candidates = managed_job_state.get_jobs_needing_recovery_check()
+        orphaned = [
+            job['job_id']
+            for job in candidates
+            if not _controller_still_running(job, f)
+        ]
+        f.write(f'{len(candidates)} job(s) to check, '
+                f'{len(orphaned)} without a live controller\n')
 
-            # Controller process is not set or not alive.
-            if job['schedule_state'] not in [
-                    managed_job_state.ManagedJobScheduleState.DONE,
-                    managed_job_state.ManagedJobScheduleState.WAITING,
-                    # INACTIVE job may be mid-submission, don't set to WAITING.
-                    managed_job_state.ManagedJobScheduleState.INACTIVE,
-            ]:
-                managed_job_state.reset_job_for_recovery(job_id)
-                message = (f'Job {job_id} completed recovery at '
-                           f'{datetime.now()}\n')
-                logger.info(message)
-                f.write(message)
+        finished = 0
+        recovered = 0
+        batch_seconds = 0.0
+        batches = _batched(orphaned, _RECOVERY_SWEEP_BATCH_SIZE)
+        for batch_index, batch in enumerate(batches):
+            if batch_index > 0:
+                # Pause between batches, not after the last one: recovery
+                # gates controller startup, so the final pause would be pure
+                # added latency with no batch left to protect.
+                _throttle_recovery_sweep(batch_seconds, f)
+            batch_start = time.time()
+            # Jobs that are already finished need no controller at all;
+            # sending them through the normal path would have a controller
+            # read the job's DAG just to observe that there is nothing left
+            # to run. Settle them directly.
+            done = _jobs_needing_no_controller(batch)
+            done_ids = sorted(done)
+            reset_ids = [job_id for job_id in batch if job_id not in done]
+            finished += managed_job_state.set_jobs_done_batch(done_ids)
+            recovered += managed_job_state.reset_jobs_for_recovery_batch(
+                reset_ids)
+            if done_ids:
+                f.write(f'Settled already-finished job(s) {done_ids}\n')
+            if reset_ids:
+                f.write(f'Reset job(s) {reset_ids} for recovery\n')
+            # Flush per batch: this file is how an operator watches a sweep
+            # that is still in progress, and a sweep that pauses between
+            # batches can be in progress for a while.
+            f.flush()
+            batch_seconds = time.time() - batch_start
+
+        message = (f'Recovered {recovered} job(s), settled {finished} '
+                   f'already-finished job(s)')
+        logger.info(message)
+        f.write(f'{message}\n')
         f.write(f'HA recovery completed at {datetime.now()}\n')
         f.write(f'Total recovery time: {time.time() - start} seconds\n')
+
+
+def _controller_still_running(job: Dict[str, Any], log_file: TextIO) -> bool:
+    """Whether the job's recorded controller process is still alive here.
+
+    In consolidation mode it is possible that only the API server process was
+    restarted and the controller process was not; then there is nothing to do
+    and the controller keeps running. In most cases the controller process is
+    also stopped -- either by a pod restart in the k8s API server, or by
+    `sky api stop`, which stops controllers.
+
+    TODO(cooperc): Make sure we cannot have a controller process running
+    across API server restarts for consistency.
+    """
+    job_id = job['job_id']
+    controller_pid = job['controller_pid']
+    if controller_pid is None:
+        return False
+    try:
+        # Note: We provide the legacy job id to the controller_process_alive
+        # just in case, but we shouldn't have a running legacy job controller
+        # process at this point.
+        if controller_process_alive(
+                managed_job_state.ControllerPidRecord(
+                    pid=controller_pid,
+                    started_at=job.get('controller_pid_started_at')), job_id):
+            message = (f'Controller pid {controller_pid} for job {job_id} is '
+                       'still running. Skipping recovery.\n')
+            logger.debug(message)
+            log_file.write(message)
+            return True
+    except Exception:  # pylint: disable=broad-except
+        # controller_process_alive may raise if psutil fails; we should not
+        # crash the recovery logic because of this.
+        message = (f'Error checking controller pid {controller_pid} for job '
+                   f'{job_id}\n')
+        logger.warning(message, exc_info=True)
+        log_file.write(message)
+    return False
+
+
+def _jobs_needing_no_controller(job_ids: List[int]) -> Set[int]:
+    """Subset of ``job_ids`` that recovery can settle without a controller.
+
+    A job qualifies when all its tasks are CANCELLED -- which, per
+    ``get_job_ids_with_all_tasks_cancelled``, means its cleanup already
+    completed -- and none of its clusters is still in the cluster table, so
+    there is provably nothing left for controller cleanup to tear down. The
+    cluster check is belt and braces for a job that reached CANCELLED by some
+    path that skipped teardown; such a job goes through the normal
+    reset-to-WAITING route and a controller cleans up after it.
+    """
+    cancelled = managed_job_state.get_job_ids_with_all_tasks_cancelled(job_ids)
+    if not cancelled:
+        return set()
+    cluster_name_to_job: Dict[str, int] = {}
+    for job_id, task_name in managed_job_state.get_non_pool_task_names(
+            sorted(cancelled)):
+        cluster_name_to_job.setdefault(
+            generate_managed_job_cluster_name(task_name, job_id), job_id)
+    still_around = global_user_state.filter_existing_cluster_names(
+        set(cluster_name_to_job))
+    return cancelled - {cluster_name_to_job[name] for name in still_around}
+
+
+def _throttle_recovery_sweep(batch_seconds: float, log_file: TextIO) -> None:
+    """Pause between recovery batches, in proportion to the last batch's cost.
+
+    The sweep shares its DB with the heartbeats and lease renewals that decide
+    whether this replica keeps the leader role. Pushing a large sweep through
+    at full speed can starve those, cost the lease, and hand the sweep to
+    another replica that starts it over -- so the sweep must leave headroom.
+
+    How much headroom is needed depends on how loaded the DB already is, and
+    the time a batch just took is the cheapest available measure of that: it
+    is the end-to-end cost of this sweep's own statements, connection wait
+    included, so it rises exactly when the DB is the contended resource. Wait
+    that long again (capped) before the next batch, which holds the sweep to
+    at most half of the throughput it could take and makes it back off further
+    the slower the DB gets, without a separate probe to interpret.
+    """
+    pause = min(batch_seconds * _RECOVERY_SWEEP_PAUSE_RATIO,
+                _RECOVERY_SWEEP_MAX_PAUSE_SECONDS)
+    if pause <= 0:
+        return
+    log_file.write(f'Batch took {batch_seconds:.2f}s; pausing {pause:.2f}s\n')
+    time.sleep(pause)
+
+
+def _batched(items: List[int], size: int) -> Iterator[List[int]]:
+    for i in range(0, len(items), size):
+        yield items[i:i + size]
 
 
 class JobStatusLogger:

--- a/tests/unit_tests/test_sky/jobs/test_ha_recovery_sweep.py
+++ b/tests/unit_tests/test_sky/jobs/test_ha_recovery_sweep.py
@@ -1,0 +1,451 @@
+"""Unit tests for the consolidation-mode HA recovery sweep.
+
+Covers the state-layer queries the sweep is built on (against a real SQLite
+state DB) and then the sweep itself, which decides per job whether to hand it
+back to a controller or settle it directly.
+"""
+import contextlib
+from unittest import mock
+
+import filelock
+import pytest
+import sqlalchemy
+from sqlalchemy import create_engine
+from sqlalchemy import orm
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sky.jobs import state
+from sky.jobs import utils as managed_job_utils
+
+ScheduleState = state.ManagedJobScheduleState
+Status = state.ManagedJobStatus
+
+
+@pytest.fixture
+def jobs_db(tmp_path, monkeypatch):
+    """A throwaway SQLite managed-jobs state DB."""
+    db_path = tmp_path / 'managed_jobs.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(section: str):
+        with filelock.FileLock(str(tmp_path / f'.{section}.lock'), timeout=10):
+            yield
+
+    monkeypatch.setattr(state.migration_utils, 'db_lock', _tmp_db_lock)
+    monkeypatch.setattr(state._db_manager, '_engine', engine)
+    monkeypatch.setattr(state._db_manager, '_engine_async', async_engine)
+    state.create_table(engine)
+    yield engine
+
+
+def _add_job(engine,
+             job_id: int,
+             schedule_state,
+             *,
+             task_statuses=(),
+             controller_pid=None,
+             controller_pid_started_at=None,
+             pool=None,
+             task_name='task'):
+    """Insert one job_info row plus one spot row per entry in task_statuses.
+
+    Writes the tables directly rather than going through the state-transition
+    helpers: these tests are about how the sweep's queries read state, so the
+    state under test has to be stated exactly, including combinations the
+    normal transitions would not produce in this order.
+    """
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.insert(state.job_info_table).values({
+                'spot_job_id': job_id,
+                'name': f'job-{job_id}',
+                'schedule_state': (
+                    schedule_state.value if schedule_state is not None else None
+                ),
+                'controller_pid': controller_pid,
+                'controller_pid_started_at': controller_pid_started_at,
+                'pool': pool,
+            }))
+        for task_id, status in enumerate(task_statuses):
+            session.execute(
+                sqlalchemy.insert(state.spot_table).values({
+                    'spot_job_id': job_id,
+                    'task_id': task_id,
+                    'task_name': f'{task_name}{task_id}',
+                    'job_name': f'job-{job_id}',
+                    'status': status.value,
+                    'run_timestamp': f'ts-{job_id}-{task_id}',
+                }))
+        session.commit()
+
+
+def _schedule_states(engine, job_ids):
+    with orm.Session(engine) as session:
+        rows = session.execute(
+            sqlalchemy.select(
+                state.job_info_table.c.spot_job_id,
+                state.job_info_table.c.schedule_state,
+                state.job_info_table.c.controller_pid,
+            ).where(
+                state.job_info_table.c.spot_job_id.in_(job_ids))).fetchall()
+    return {row[0]: (row[1], row[2]) for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# get_jobs_needing_recovery_check
+# ---------------------------------------------------------------------------
+
+
+def test_needing_recovery_check_skips_states_with_no_controller(jobs_db):
+    """DONE / WAITING / INACTIVE jobs are not candidates for recovery."""
+    _add_job(jobs_db, 1, ScheduleState.DONE)
+    _add_job(jobs_db, 2, ScheduleState.WAITING)
+    _add_job(jobs_db, 3, ScheduleState.INACTIVE)
+    _add_job(jobs_db, 4, ScheduleState.LAUNCHING)
+    _add_job(jobs_db, 5, ScheduleState.ALIVE)
+    _add_job(jobs_db, 6, ScheduleState.ALIVE_BACKOFF)
+
+    candidates = state.get_jobs_needing_recovery_check()
+
+    assert [job['job_id'] for job in candidates] == [4, 5, 6]
+
+
+def test_needing_recovery_check_includes_null_schedule_state(jobs_db):
+    """Jobs predating schedule_state have no state to interpret; still check."""
+    _add_job(jobs_db, 1, None)
+
+    candidates = state.get_jobs_needing_recovery_check()
+
+    assert [job['job_id'] for job in candidates] == [1]
+    assert candidates[0]['schedule_state'] is None
+
+
+def test_needing_recovery_check_returns_one_row_per_job(jobs_db):
+    """A multi-task job appears once, not once per task."""
+    _add_job(jobs_db,
+             1,
+             ScheduleState.ALIVE,
+             task_statuses=(Status.SUCCEEDED, Status.RUNNING, Status.PENDING),
+             controller_pid=4242,
+             controller_pid_started_at=99.5)
+
+    candidates = state.get_jobs_needing_recovery_check()
+
+    assert candidates == [{
+        'job_id': 1,
+        'controller_pid': 4242,
+        'controller_pid_started_at': 99.5,
+        'schedule_state': ScheduleState.ALIVE,
+    }]
+
+
+# ---------------------------------------------------------------------------
+# get_job_ids_with_all_tasks_cancelled
+# ---------------------------------------------------------------------------
+
+
+def test_all_tasks_cancelled_partitions_jobs(jobs_db):
+    _add_job(jobs_db,
+             1,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED,))
+    _add_job(jobs_db,
+             2,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED, Status.CANCELLED))
+    # One task not cancelled: the job is not finished.
+    _add_job(jobs_db,
+             3,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED, Status.RUNNING))
+    # Terminal but not CANCELLED: cleanup may not have run, so not eligible.
+    _add_job(jobs_db,
+             4,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.SUCCEEDED,))
+    _add_job(jobs_db,
+             5,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.FAILED_CONTROLLER,))
+
+    assert state.get_job_ids_with_all_tasks_cancelled([1, 2, 3, 4, 5]) == {1, 2}
+
+
+def test_all_tasks_cancelled_excludes_job_without_tasks(jobs_db):
+    """A job_info row with no spot rows is mid-submission, not finished."""
+    _add_job(jobs_db, 1, ScheduleState.LAUNCHING)
+
+    assert state.get_job_ids_with_all_tasks_cancelled([1]) == set()
+
+
+def test_all_tasks_cancelled_handles_more_ids_than_one_chunk(jobs_db):
+    job_ids = list(range(1, state._RECOVERY_CHUNK_SIZE * 2 + 5))
+    for job_id in job_ids:
+        _add_job(jobs_db,
+                 job_id,
+                 ScheduleState.LAUNCHING,
+                 task_statuses=(Status.CANCELLED,))
+
+    assert state.get_job_ids_with_all_tasks_cancelled(job_ids) == set(job_ids)
+
+
+def test_all_tasks_cancelled_empty_input(jobs_db):
+    assert state.get_job_ids_with_all_tasks_cancelled([]) == set()
+
+
+# ---------------------------------------------------------------------------
+# get_non_pool_task_names
+# ---------------------------------------------------------------------------
+
+
+def test_non_pool_task_names_excludes_pool_jobs(jobs_db):
+    _add_job(jobs_db,
+             1,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED, Status.CANCELLED),
+             task_name='solo')
+    _add_job(jobs_db,
+             2,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED,),
+             pool='my-pool',
+             task_name='pooled')
+
+    assert sorted(state.get_non_pool_task_names([1, 2])) == [(1, 'solo0'),
+                                                             (1, 'solo1')]
+
+
+# ---------------------------------------------------------------------------
+# batched writes
+# ---------------------------------------------------------------------------
+
+
+def test_reset_batch_sets_waiting_and_clears_pid(jobs_db):
+    _add_job(jobs_db, 1, ScheduleState.LAUNCHING, controller_pid=11)
+    _add_job(jobs_db, 2, ScheduleState.ALIVE, controller_pid=22)
+
+    assert state.reset_jobs_for_recovery_batch([1, 2]) == 2
+
+    assert _schedule_states(jobs_db, [1, 2]) == {
+        1: (ScheduleState.WAITING.value, None),
+        2: (ScheduleState.WAITING.value, None),
+    }
+
+
+def test_reset_batch_leaves_jobs_that_no_longer_need_recovery(jobs_db):
+    """A job that reached DONE after the sweep read it keeps its newer state."""
+    _add_job(jobs_db, 1, ScheduleState.DONE, controller_pid=11)
+    _add_job(jobs_db, 2, ScheduleState.LAUNCHING, controller_pid=22)
+
+    assert state.reset_jobs_for_recovery_batch([1, 2]) == 1
+
+    assert _schedule_states(jobs_db, [1, 2]) == {
+        1: (ScheduleState.DONE.value, 11),
+        2: (ScheduleState.WAITING.value, None),
+    }
+
+
+def test_set_done_batch(jobs_db):
+    _add_job(jobs_db, 1, ScheduleState.LAUNCHING, controller_pid=11)
+    _add_job(jobs_db, 2, ScheduleState.WAITING, controller_pid=22)
+
+    # Job 2 is WAITING, which needs no recovery, so it is left alone.
+    assert state.set_jobs_done_batch([1, 2]) == 1
+
+    assert _schedule_states(jobs_db, [1, 2]) == {
+        1: (ScheduleState.DONE.value, None),
+        2: (ScheduleState.WAITING.value, 22),
+    }
+
+
+def test_batched_writes_handle_more_ids_than_one_chunk(jobs_db):
+    job_ids = list(range(1, state._RECOVERY_CHUNK_SIZE * 2 + 5))
+    for job_id in job_ids:
+        _add_job(jobs_db,
+                 job_id,
+                 ScheduleState.LAUNCHING,
+                 controller_pid=job_id)
+
+    assert state.reset_jobs_for_recovery_batch(job_ids) == len(job_ids)
+
+    states = _schedule_states(jobs_db, job_ids)
+    assert all(states[job_id] == (ScheduleState.WAITING.value, None)
+               for job_id in job_ids)
+
+
+def test_batched_writes_empty_input(jobs_db):
+    assert state.reset_jobs_for_recovery_batch([]) == 0
+    assert state.set_jobs_done_batch([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# ha_recovery_for_consolidation_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sweep_env(jobs_db, tmp_path, monkeypatch):
+    """Run the sweep against ``jobs_db`` with its side effects stubbed out."""
+    monkeypatch.setattr(managed_job_utils.constants,
+                        'HA_PERSISTENT_RECOVERY_LOG_PATH',
+                        str(tmp_path / '{}recovery.log'))
+    monkeypatch.setattr(managed_job_utils.scheduler, 'maybe_start_controllers',
+                        mock.Mock())
+    # No cluster rows exist unless a test says otherwise.
+    existing = mock.Mock(return_value=set())
+    monkeypatch.setattr(managed_job_utils.global_user_state,
+                        'filter_existing_cluster_names', existing)
+    throttle = mock.Mock()
+    monkeypatch.setattr(managed_job_utils, '_throttle_recovery_sweep', throttle)
+    yield mock.Mock(engine=jobs_db,
+                    existing_clusters=existing,
+                    throttle=throttle)
+
+
+def test_sweep_settles_cancelled_jobs_and_recovers_the_rest(sweep_env):
+    """All-cancelled jobs go straight to DONE; live jobs go back to WAITING."""
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED,))
+    _add_job(sweep_env.engine,
+             2,
+             ScheduleState.ALIVE,
+             task_statuses=(Status.RUNNING,))
+    _add_job(sweep_env.engine,
+             3,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.SUCCEEDED,))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    assert _schedule_states(sweep_env.engine, [1, 2, 3]) == {
+        1: (ScheduleState.DONE.value, None),
+        2: (ScheduleState.WAITING.value, None),
+        3: (ScheduleState.WAITING.value, None),
+    }
+
+
+def test_sweep_recovers_cancelled_job_whose_cluster_survives(sweep_env):
+    """A leftover cluster means cleanup must run, so use a controller."""
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.CANCELLED,),
+             task_name='leaky')
+    cluster_name = managed_job_utils.generate_managed_job_cluster_name(
+        'leaky0', 1)
+    sweep_env.existing_clusters.return_value = {cluster_name}
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    assert _schedule_states(sweep_env.engine, [1]) == {
+        1: (ScheduleState.WAITING.value, None)
+    }
+
+
+def test_sweep_skips_job_with_a_live_controller(sweep_env, monkeypatch):
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.ALIVE,
+             task_statuses=(Status.RUNNING,),
+             controller_pid=1234,
+             controller_pid_started_at=7.0)
+    monkeypatch.setattr(managed_job_utils, 'controller_process_alive',
+                        mock.Mock(return_value=True))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    assert _schedule_states(sweep_env.engine, [1]) == {
+        1: (ScheduleState.ALIVE.value, 1234)
+    }
+
+
+def test_sweep_recovers_job_when_liveness_check_raises(sweep_env, monkeypatch):
+    """A psutil failure must not skip recovery, nor crash the sweep."""
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.ALIVE,
+             task_statuses=(Status.RUNNING,),
+             controller_pid=1234)
+    monkeypatch.setattr(managed_job_utils, 'controller_process_alive',
+                        mock.Mock(side_effect=RuntimeError('psutil boom')))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    assert _schedule_states(sweep_env.engine, [1]) == {
+        1: (ScheduleState.WAITING.value, None)
+    }
+
+
+def test_sweep_processes_every_batch_and_pauses_between_them(
+        sweep_env, monkeypatch):
+    monkeypatch.setattr(managed_job_utils, '_RECOVERY_SWEEP_BATCH_SIZE', 2)
+    job_ids = [1, 2, 3, 4, 5]
+    for job_id in job_ids:
+        _add_job(sweep_env.engine,
+                 job_id,
+                 ScheduleState.LAUNCHING,
+                 task_statuses=(Status.RUNNING,))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    states = _schedule_states(sweep_env.engine, job_ids)
+    assert all(states[job_id] == (ScheduleState.WAITING.value, None)
+               for job_id in job_ids)
+    # 3 batches of 2/2/1 -> a pause before batches 2 and 3, none after the last.
+    assert sweep_env.throttle.call_count == 2
+
+
+def test_sweep_does_not_pause_for_a_single_batch(sweep_env):
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.LAUNCHING,
+             task_statuses=(Status.RUNNING,))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    sweep_env.throttle.assert_not_called()
+
+
+def test_sweep_does_nothing_when_no_job_needs_recovery(sweep_env):
+    _add_job(sweep_env.engine,
+             1,
+             ScheduleState.DONE,
+             task_statuses=(Status.SUCCEEDED,))
+    _add_job(sweep_env.engine,
+             2,
+             ScheduleState.WAITING,
+             task_statuses=(Status.PENDING,))
+
+    managed_job_utils.ha_recovery_for_consolidation_mode()
+
+    assert _schedule_states(sweep_env.engine, [1, 2]) == {
+        1: (ScheduleState.DONE.value, None),
+        2: (ScheduleState.WAITING.value, None),
+    }
+    sweep_env.throttle.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _throttle_recovery_sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('batch_seconds,expected', [
+    (0.0, None),
+    (0.4, 0.4),
+    (3.0, 3.0),
+    (60.0, managed_job_utils._RECOVERY_SWEEP_MAX_PAUSE_SECONDS),
+])
+def test_throttle_scales_with_batch_cost_and_is_capped(monkeypatch,
+                                                       batch_seconds, expected):
+    sleeps = []
+    monkeypatch.setattr(managed_job_utils.time, 'sleep', sleeps.append)
+
+    managed_job_utils._throttle_recovery_sweep(batch_seconds, mock.Mock())
+
+    assert sleeps == ([] if expected is None else [expected])


### PR DESCRIPTION
`ha_recovery_for_consolidation_mode` runs one unbounded pass over the entire jobs history at every leader election. Its read is `get_managed_jobs_with_filters()` with no filters — a `COUNT(DISTINCT)` plus a `spot` × `job_info` × batch-progress join returning one row per task, for every job the deployment ever ran. It then issues one `UPDATE` transaction per job needing recovery, and hands every one of them to a controller, including jobs whose tasks are already cancelled and have nothing left to run.

That shape scales with history rather than with work. On a deployment with a large jobs table a single pass can take long enough to contend with the heartbeats and lease renewals that decide which replica holds the leader role — which loses the lease, moves the sweep to another replica, and starts it over.

The sweep now:

- **reads only `job_info`**, filtered on the indexed `schedule_state` column, so its cost tracks the number of jobs that could still have a controller. No join, no per-task fan-out, and none of the multi-MB TOASTed yaml columns.
- **settles already-finished jobs directly.** A job whose every task is `CANCELLED` goes straight to `DONE` instead of being reset to `WAITING` for a controller to claim, read the DAG, and observe the same thing. `CANCELLED` specifically, not any terminal status: it is the one terminal status a controller only writes *after* its cleanup returned (a cleanup failure leaves the task `FAILED_CONTROLLER`), and the other route to it is a job cancelled while still `PENDING`, which never provisioned anything. As belt and braces, a job that still has a cluster row goes through the normal reset path so a controller cleans up after it.
- **writes in batches** rather than one transaction per job, guarded by the same `schedule_state` predicate as the read, so a job that transitioned in between keeps its newer state and an interrupted sweep resumes instead of restarting.
- **pauses between batches for as long as the previous batch took** (capped at 5s). A batch's own duration is the cheapest available measure of how loaded the DB is — it includes connection wait — so this holds the sweep to at most half the throughput it could take and backs it off further the slower the DB gets, with no separate latency probe to interpret.

One user-visible side effect: a job left with a non-terminal `schedule_state` but all tasks cancelled (e.g. a job cancelled from `PENDING` after a controller claimed it, which never calls `job_done`) is now reconciled to `DONE` by the next sweep in one step instead of via a full controller claim.

`sky/jobs/state.py::reset_job_for_recovery` is removed — the batched form replaces its only caller.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New `tests/unit_tests/test_sky/jobs/test_ha_recovery_sweep.py` (24 tests, passing) drives the new state-layer queries against a real SQLite state DB and then the sweep end to end:

- the candidate query skips `DONE`/`WAITING`/`INACTIVE`, keeps a NULL `schedule_state`, and returns one row per job rather than per task
- `all tasks CANCELLED` partitioning: multi-task jobs, a job with one live task, terminal-but-not-cancelled jobs, a job with no task rows (mid-submission), and more ids than one IN-chunk
- batched writes set `WAITING`/`DONE` and clear the pid, and leave rows that no longer need recovery untouched
- the sweep settles cancelled jobs, recovers live ones, recovers a cancelled job whose cluster survives, skips a job with a live controller pid, still recovers when the liveness check raises, and pauses between batches but not after the last one
- the throttle scales with batch cost and is capped

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->