### PR TITLE
[Examples] Add Hugging Face storage batch transcription example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,8 @@ Machine learning examples:
 
 - [**`cosmos3-finetuning/`**](./cosmos3-finetuning/README.md): Fine-tune [NVIDIA Cosmos 3](https://github.com/NVIDIA/cosmos-framework) (`Cosmos3-Nano`, a 16B world foundation model for Physical AI) on robot-manipulation video as a managed job, using NVIDIA's `vision_sft_nano` SFT recipe with checkpoint-to-bucket auto-recovery.
 
+- [**`hf-storage-transcription/`**](./hf-storage-transcription/README.md): Batch audio transcription with [Hugging Face storage](https://huggingface.co/docs/hub/storage-buckets) as the only storage layer — audio bucket in, transcript bucket out, same YAML on any cloud.
+
 - [**`resnet_distributed_torch.yaml`**](./resnet_distributed_torch.yaml): Run Distributed PyTorch (DDP) training of ResNet50 on 2 nodes.
 
 - [**`detectron2_app.yaml`**](./detectron2_app.yaml): Run Detectron2 on a V100 GPU.

--- a/examples/hf-storage-transcription/README.md
+++ b/examples/hf-storage-transcription/README.md
@@ -1,0 +1,78 @@
+# Batch Audio Transcription with Hugging Face Storage
+
+Transcribe a folder of audio files on any cloud, using Hugging Face Buckets as storage. Audio is read from one bucket and transcripts are written to another.
+
+A [Hugging Face Bucket](https://huggingface.co/docs/hub/storage-buckets) is S3-like object storage on the Hub: mutable, non-versioned, and mountable as a filesystem from any machine. It is the working-storage counterpart to model and dataset repos — the place for inputs, outputs, and intermediate data rather than finished artifacts.
+
+For this example we use a small speech-to-text model ([Cohere Transcribe](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026), 2B) and an existing script from [`uv-scripts/transcription`](https://huggingface.co/datasets/uv-scripts/transcription), so the only new thing to read is the storage setup. The same script and the same two buckets work on Hugging Face Jobs, on SkyPilot on Lambda, and on SkyPilot on AWS, with no changes.
+
+```
+hf://buckets/<you>/skypilot-tutorial-audio
+        │  mounted at /input
+        ▼
+  GPU on any cloud  (transcribe.yaml)
+        │  writes to /output
+        ▼
+hf://buckets/<you>/skypilot-tutorial-transcripts
+```
+
+Files in this example:
+
+- `transcribe.yaml`: the SkyPilot task — mounts the two buckets and runs the transcription script.
+
+## Prerequisites
+
+- SkyPilot with the Hugging Face extra and at least one cloud enabled:
+  ```bash
+  uv tool install --with pip "skypilot[huggingface,lambda]"   # or aws, gcp, ...
+  sky check
+  ```
+- A Hugging Face account and token (`hf auth login`). SkyPilot forwards the token to the cloud VM, so bucket mounts authenticate with no extra setup.
+- Accept the (auto-approved) terms on the [Cohere Transcribe model page](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) once.
+
+> **Note:** Mounting requires `/dev/fuse` and glibc ≥ 2.34 on the VM — true on bare-VM clouds; on Kubernetes set a newer `image_id` (e.g. `docker:mirror.gcr.io/ubuntu:22.04`). Container-only clouds (e.g. RunPod) do not support object-store mounting in SkyPilot. See the [SkyPilot storage docs](https://docs.skypilot.co/en/latest/reference/storage.html) and the [Hugging Face storage integrations page](https://huggingface.co/docs/hub/storage-buckets-integrations#skypilot).
+
+## Step 1: Put some audio in a bucket
+
+Create the two buckets, then fill the input one. You can copy local files:
+
+```bash
+hf buckets create skypilot-tutorial-audio
+hf buckets create skypilot-tutorial-transcripts
+hf buckets cp ./my-audio/ hf://buckets/<you>/skypilot-tutorial-audio/
+```
+
+or, for something to try right away, pull ten episodes of a public-domain radio show from the Internet Archive with a CPU job on Hugging Face Jobs — the bucket is mounted there the same way (`-v`):
+
+```bash
+hf jobs uv run -v hf://buckets/<you>/skypilot-tutorial-audio:/output \
+  https://huggingface.co/datasets/uv-scripts/transcription/raw/main/download-ia.py \
+  SUSPENSE /output --max-files 10
+```
+
+## Step 2: Transcribe on a GPU, anywhere
+
+```bash
+export HF_TOKEN=$(hf auth whoami --token)   # or paste your token
+sky launch -c transcribe transcribe.yaml --env HF_USER=<you> --secret HF_TOKEN
+```
+
+SkyPilot picks the cheapest available GPU across your enabled clouds. To pin one: `--infra lambda`, `--infra aws`, `--infra k8s`. The YAML does not change.
+
+What happens on the VM:
+
+1. Both buckets are FUSE-mounted (via [hf-mount](https://github.com/huggingface/hf-mount)) at `/input` and `/output`.
+2. `uv` installs the script's pinned dependencies and downloads the model.
+3. Each `/input/*.mp3` becomes `/output/*.txt`. Writes go straight to the Hub — open the transcripts bucket in another tab and watch them appear.
+
+Measured on a Lambda 1× A10: ten episodes (295 minutes of audio) transcribed in 1.7 minutes — 173× realtime — and about 4 minutes wall-clock from `sky launch` to `Job finished`, including provisioning, dependency install, and the 2B model download.
+
+```bash
+sky down transcribe          # tear down; the transcripts are already on the Hub
+hf buckets ls <you>/skypilot-tutorial-transcripts
+```
+
+## Going further
+
+- **Managed job**: `sky jobs launch transcribe.yaml ...` runs the same task with automatic recovery if the VM is preempted or lost. Transcripts already written to the bucket survive; the recovered job re-runs the script from the start.
+- **Larger collections**: one bucket pair per collection or language; point the two mounts at them and launch again. To spread a single bucket across several GPUs, add a shard argument to the script and use [SkyPilot Pools](../pools_batch_inference/); each worker mounts the same two buckets.

--- a/examples/hf-storage-transcription/transcribe.yaml
+++ b/examples/hf-storage-transcription/transcribe.yaml
@@ -1,0 +1,45 @@
+# Transcribe a bucket of audio files into a bucket of transcripts,
+# using Hugging Face storage as the only storage layer.
+#
+# Usage:
+#   sky launch -c transcribe transcribe.yaml --env HF_USER=<your-hf-username> --secret HF_TOKEN
+#   sky down transcribe
+#
+# Same buckets, same script, any cloud: swap `--infra` and nothing else changes.
+name: hf-storage-transcription
+
+resources:
+  accelerators: {A10:1, L4:1, A100:1}   # any single 24GB+ GPU
+
+envs:
+  HF_USER:        # your Hugging Face username or org (owner of the two buckets)
+  LANGUAGE: en    # en, de, fr, it, es, pt, el, nl, pl, ar, vi, zh, ja, ko
+
+secrets:
+  HF_TOKEN:       # pass with `--secret HF_TOKEN`; the model is gated (auto-approved)
+
+file_mounts:
+  # Audio in: a bucket you filled earlier (see README). Mounted read-write, used read-only.
+  /input:
+    source: hf://buckets/${HF_USER}/skypilot-tutorial-audio
+    store: hf
+    mode: MOUNT
+  # Transcripts out: every .txt the script writes lands on the Hub as it is written.
+  /output:
+    source: hf://buckets/${HF_USER}/skypilot-tutorial-transcripts
+    store: hf
+    mode: MOUNT
+
+setup: |
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+
+run: |
+  set -euo pipefail
+  export PATH="$HOME/.local/bin:$PATH"
+  # The script is a self-contained uv script (PEP 723) hosted on the Hub;
+  # uv resolves its dependencies on first run. Pinned to a revision.
+  # --python 3.12: torch wheels lag new CPython releases; don't let uv pick the newest.
+  UV_TORCH_BACKEND=auto uv run --python 3.12 \
+    https://huggingface.co/datasets/uv-scripts/transcription/resolve/caa60d95d008741a5fb0a8b33a22eed6fbf1165a/cohere-transcribe.py \
+    /input /output --language ${LANGUAGE}
+  echo "Done. Transcripts: https://huggingface.co/buckets/${HF_USER}/skypilot-tutorial-transcripts"


### PR DESCRIPTION
Adds `examples/hf-storage-transcription/`: batch audio transcription with Hugging Face Buckets for storage. 

Audio is read from one bucket mounted at `/input`, and transcripts are written to a second bucket mounted at `/output`; the model and script are off-the-shelf (Cohere Transcribe 2B via a `uv-scripts` script), so the example is about the storage setup rather than the workload.

Files:
- `examples/hf-storage-transcription/README.md`
- `examples/hf-storage-transcription/transcribe.yaml`
- one line in `examples/README.md`

Tested (run the relevant ones):
- [x] Manual: `sky launch -c transcribe transcribe.yaml --infra lambda --env HF_USER=... --secret HF_TOKEN` on Lambda `gpu_1x_a10` (SkyPilot 0.13.0, `[huggingface]` extra). 10 files / 295 min audio transcribed in 1.7 min (173x realtime), ~4 min wall-clock from launch to `Job finished`; all outputs visible in the Hub bucket. Both mounts via `hf-mount` (`/dev/fuse`, glibc 2.35).
- [x] `yamllint` on `transcribe.yaml`
- [ ] Smoke tests — none added; example only.

Notes for review:
- The script is run from a Hub URL pinned to a commit. Happy to vendor a copy into the directory instead if that's preferred for examples.
- `uv run --python 3.12` is deliberate: on a bare VM `uv` picks CPython 3.14, for which torch 2.6.0 has no wheel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->