### PR TITLE
[Server] Fix request log fd leak and orphaned lock files in GC

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -1104,11 +1104,20 @@ async def _execute_request_coroutine(request: api_requests.Request):
         raise
     finally:
         # Always cancel the context to kill potentially running background
-        # routine, and close its log file handle. Without this, a request
-        # that finishes via the success path or any cancellation path never
-        # closes its log fd, so a worker leaks it once GC unlinks the log.
+        # routine.
         ctx.cancel()
-        ctx.cleanup()
+        # Close the request's log file handle: nothing else closes it on the
+        # success path or on either cancellation path, so the worker would
+        # keep the fd -- and, once retention GC unlinks the log, the deleted
+        # file's disk blocks -- for the rest of its life.
+        #
+        # Defer the close until the entrypoint has finished instead of doing
+        # it here. On the cancellation paths the entrypoint thread is still
+        # running (it only observes ctx.cancel() at its next poll) and it
+        # shares this context, so closing the handle now would send its
+        # remaining output to the server's stdout and could raise ValueError
+        # on a write that races the close.
+        fut.add_done_callback(lambda _: ctx.cleanup())
 
 
 async def prepare_request_async(

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -1104,8 +1104,11 @@ async def _execute_request_coroutine(request: api_requests.Request):
         raise
     finally:
         # Always cancel the context to kill potentially running background
-        # routine.
+        # routine, and close its log file handle. Without this, a request
+        # that finishes via the success path or any cancellation path never
+        # closes its log fd, so a worker leaks it once GC unlinks the log.
         ctx.cancel()
+        ctx.cleanup()
 
 
 async def prepare_request_async(

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1268,6 +1268,18 @@ def _get_legacy_log_path(request_id: str) -> pathlib.Path:
     return (legacy_path_prefix / request_id).with_suffix('.log')
 
 
+def _get_legacy_lock_path(request_id: str) -> pathlib.Path:
+    """Get the legacy lock file path for a request.
+
+    Server versions before the request logs moved out of
+    ``~/sky_logs/api_server/requests`` kept the per-request lock file next to
+    the log, under the same name this module still uses.
+    """
+    legacy_path_prefix = pathlib.Path(
+        LEGACY_REQUEST_LOG_PATH_PREFIX).expanduser().absolute()
+    return legacy_path_prefix / f'.{request_id}.lock'
+
+
 # TODO Remove this function on or after v0.15.0
 async def _cleanup_legacy_directory_if_empty():
     """Remove legacy request log directory if empty.
@@ -1343,6 +1355,13 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
             futs.append(
                 asyncio.create_task(
                     anyio.Path(request_lock_path(
+                        req.request_id)).unlink(missing_ok=True)))
+            # And the legacy-path lock file, so that the legacy directory can
+            # eventually be removed as empty.
+            # TODO Remove this on or after v0.15.0
+            futs.append(
+                asyncio.create_task(
+                    anyio.Path(_get_legacy_lock_path(
                         req.request_id)).unlink(missing_ok=True)))
         await asyncio.gather(*futs)
 

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1339,6 +1339,11 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
             futs.append(
                 asyncio.create_task(
                     anyio.Path(debug_log_path).unlink(missing_ok=True)))
+            # Delete the request's lock file; nothing else ever removes it.
+            futs.append(
+                asyncio.create_task(
+                    anyio.Path(request_lock_path(
+                        req.request_id)).unlink(missing_ok=True)))
         await asyncio.gather(*futs)
 
         await _delete_requests([req.request_id for req in reqs])

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -10,6 +10,7 @@ import prettytable
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
+from sky.utils import context_utils
 from sky.utils import rich_utils
 from sky.utils import ux_utils
 
@@ -356,6 +357,12 @@ def follow_logs(
     seconds_without_content: int = 0
 
     while True:
+        # A tail that only exits on its own condition keeps its worker thread
+        # -- and the request's log file handle -- long after the client that
+        # asked for it went away. No-op outside a request context (the CLI,
+        # or code running on a cluster).
+        context_utils.raise_if_canceled()
+
         content = file.readline()
 
         if not content:

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -5,6 +5,7 @@ import functools
 import os
 import pathlib
 import queue as queue_lib
+import sys
 import threading
 import time
 from typing import List
@@ -181,9 +182,93 @@ async def test_execute_request_coroutine_closes_log_handle_on_success(
                     side_effect=capturing_initialize):
         task = executor.execute_request_in_coroutine(request)
         await task.task
+        # The close is deferred to the entrypoint future's done callback, so
+        # give the loop a turn to run it.
+        await asyncio.sleep(0)
 
     assert len(captured_ctx) == 1
     assert captured_ctx[0]._log_file_handle is None
+
+
+_LINGERING_STARTED = threading.Event()
+_LINGERING_RELEASE = threading.Event()
+_LINGERING_MARKER = 'written after the coroutine was cancelled'
+
+
+def _lingering_entrypoint(*args, **kwargs):
+    """An entrypoint that outlives the coroutine that scheduled it.
+
+    Stands in for a log tail that has not yet observed ctx.cancel().
+    """
+    del args, kwargs
+    ctx = context.get()
+    assert ctx is not None
+    _LINGERING_STARTED.set()
+    _LINGERING_RELEASE.wait(timeout=30)
+    # Write the way the contextual stdout does, so this lands in the
+    # request's log file for as long as its handle is open.
+    ctx.output_stream(sys.stdout).write(_LINGERING_MARKER + '\n')
+    return 'ok'
+
+
+@pytest.mark.asyncio
+async def test_execute_request_coroutine_defers_log_close_to_entrypoint(
+        isolated_database):
+    """A cancelled request must not close the log handle under its worker.
+
+    The entrypoint runs in a worker thread that shares the request's
+    context and only observes ctx.cancel() at its next poll. Closing the
+    handle when the coroutine unwinds would send the entrypoint's remaining
+    output to the server's own stdout, and a write racing the close can
+    raise ValueError on a closed file.
+    """
+    _LINGERING_STARTED.clear()
+    _LINGERING_RELEASE.clear()
+    request = requests_lib.Request(
+        request_id='test-request-lingering',
+        name='test-request-name',
+        status=requests_lib.RequestStatus.PENDING,
+        created_at=time.time(),
+        user_id='test-user-id',
+        entrypoint=_lingering_entrypoint,
+        request_body=payloads.RequestBody(),
+    )
+    await requests_lib.create_if_not_exists_async(request)
+
+    captured_ctx: List[context.SkyPilotContext] = []
+    real_initialize = context.initialize
+
+    def capturing_initialize(*args, **kwargs):
+        ctx = real_initialize(*args, **kwargs)
+        captured_ctx.append(ctx)
+        return ctx
+
+    with mock.patch('sky.utils.context.initialize',
+                    side_effect=capturing_initialize):
+        task = executor.execute_request_in_coroutine(request)
+        for _ in range(600):
+            if _LINGERING_STARTED.is_set():
+                break
+            await asyncio.sleep(0.05)
+        assert _LINGERING_STARTED.is_set(), 'entrypoint did not start'
+
+        # Client disconnect: the coroutine unwinds while the entrypoint is
+        # still running.
+        await task.cancel()
+        assert len(captured_ctx) == 1
+        ctx = captured_ctx[0]
+        assert ctx._log_file_handle is not None, (
+            'log handle closed while the entrypoint was still running')
+
+        _LINGERING_RELEASE.set()
+        for _ in range(600):
+            if ctx._log_file_handle is None:
+                break
+            await asyncio.sleep(0.05)
+
+    assert ctx._log_file_handle is None, (
+        'log handle not closed after the entrypoint finished')
+    assert _LINGERING_MARKER in request.log_path.read_text()
 
 
 CALLED_FLAG = [False]

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -23,6 +23,7 @@ from sky.server.requests import payloads
 from sky.server.requests import process
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
+from sky.utils import context
 from sky.utils import context_utils
 
 
@@ -138,6 +139,51 @@ async def test_execute_request_coroutine_ctx_cancelled_on_cancellation(
         await task.task
         # Verify the context is actually cancelled
         mock_ctx.cancel.assert_called()
+
+
+def _quick_success_entrypoint(*args, **kwargs):
+    """A picklable entrypoint that returns immediately."""
+    return 'ok'
+
+
+@pytest.mark.asyncio
+async def test_execute_request_coroutine_closes_log_handle_on_success(
+        isolated_database):
+    """A successfully finished request must close its log file handle.
+
+    Otherwise, once request-retention GC unlinks the (now-orphaned) log
+    file, the worker process keeps the deleted file's disk blocks alive
+    for as long as it keeps running.
+    """
+    request = requests_lib.Request(
+        request_id='test-request-success',
+        name='test-request-name',
+        status=requests_lib.RequestStatus.PENDING,
+        created_at=time.time(),
+        user_id='test-user-id',
+        entrypoint=_quick_success_entrypoint,
+        request_body=payloads.RequestBody(),
+    )
+    await requests_lib.create_if_not_exists_async(request)
+
+    # Use the real Context (not a mock) so redirect_log()/cleanup() actually
+    # run, and capture it via initialize() since the task's contextvar
+    # doesn't propagate back to this coroutine.
+    captured_ctx: List[context.SkyPilotContext] = []
+    real_initialize = context.initialize
+
+    def capturing_initialize(*args, **kwargs):
+        ctx = real_initialize(*args, **kwargs)
+        captured_ctx.append(ctx)
+        return ctx
+
+    with mock.patch('sky.utils.context.initialize',
+                    side_effect=capturing_initialize):
+        task = executor.execute_request_in_coroutine(request)
+        await task.task
+
+    assert len(captured_ctx) == 1
+    assert captured_ctx[0]._log_file_handle is None
 
 
 CALLED_FLAG = [False]

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -190,9 +190,9 @@ async def test_clean_finished_requests_with_retention(isolated_database):
     assert requests.get_request('old-running-1') is not None
 
     # Verify log file unlink was called for current, legacy, debug, and lock
-    # paths (4 calls per deleted request: current path + legacy path +
-    # debug log + lock file)
-    assert mock_unlink.call_count == 4
+    # paths (5 calls per deleted request: current path + legacy path +
+    # debug log + lock file + legacy lock file)
+    assert mock_unlink.call_count == 5
 
     # Verify logging
     mock_logger.info.assert_called_once()
@@ -284,8 +284,9 @@ async def test_clean_finished_requests_with_retention_batch_size_functionality(
     assert call_counts[2] == 5  # Third batch (remaining)
 
     # Verify log file unlink was called for each deleted request
-    # (3 calls per request: current path + legacy path + debug log)
-    assert mock_unlink.call_count == 100
+    # (5 calls per request: current path + legacy path + debug log +
+    # lock file + legacy lock file)
+    assert mock_unlink.call_count == 125
 
     # Verify logging shows correct total
     mock_logger.info.assert_called_once()
@@ -671,13 +672,21 @@ async def test_clean_finished_requests_cleans_both_paths(
                 await requests.clean_finished_requests_with_retention(
                     retention_seconds)
 
-    # Verify that unlink was called for current, legacy, and debug log paths
-    assert len(unlinked_paths) == 4
+    # Verify that unlink was called for the current, legacy and debug log
+    # paths, plus the current and legacy lock paths
+    assert len(unlinked_paths) == 5
 
     # All paths should contain the request ID
     current_path_count = sum(
         1 for p in unlinked_paths if 'legacy-test-req-1.log' in p)
     assert current_path_count == 3  # All paths should have the request ID
+
+    # Both the current-path and legacy-path lock files are removed; nothing
+    # else ever does, and a leftover legacy lock keeps the legacy directory
+    # from being removed as empty.
+    lock_paths = [p for p in unlinked_paths if p.endswith('.lock')]
+    assert len(lock_paths) == 2
+    assert sum(1 for p in lock_paths if str(legacy_log_dir) in p) == 1
 
     # Verify the request was deleted
     assert requests.get_request('legacy-test-req-1') is None

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -189,9 +189,10 @@ async def test_clean_finished_requests_with_retention(isolated_database):
     # Verify old running request was NOT deleted
     assert requests.get_request('old-running-1') is not None
 
-    # Verify log file unlink was called for current, legacy, and debug paths
-    # (3 calls per deleted request: current path + legacy path + debug log)
-    assert mock_unlink.call_count == 3
+    # Verify log file unlink was called for current, legacy, debug, and lock
+    # paths (4 calls per deleted request: current path + legacy path +
+    # debug log + lock file)
+    assert mock_unlink.call_count == 4
 
     # Verify logging
     mock_logger.info.assert_called_once()
@@ -284,7 +285,7 @@ async def test_clean_finished_requests_with_retention_batch_size_functionality(
 
     # Verify log file unlink was called for each deleted request
     # (3 calls per request: current path + legacy path + debug log)
-    assert mock_unlink.call_count == 75
+    assert mock_unlink.call_count == 100
 
     # Verify logging shows correct total
     mock_logger.info.assert_called_once()
@@ -671,7 +672,7 @@ async def test_clean_finished_requests_cleans_both_paths(
                     retention_seconds)
 
     # Verify that unlink was called for current, legacy, and debug log paths
-    assert len(unlinked_paths) == 3
+    assert len(unlinked_paths) == 4
 
     # All paths should contain the request ID
     current_path_count = sum(


### PR DESCRIPTION
_execute_request_coroutine's only unconditional cleanup (finally: ctx.cancel()) never closed the per-request log file handle. Only the exception branches did, via ctx.redirect_log(original_output); the success path and both cancellation paths left the handle open. Once request-retention GC unlinks the (now-orphaned) log file 24h later, the worker keeps the deleted file's disk blocks alive for the rest of its process lifetime.

Adds ctx.cleanup() alongside ctx.cancel() in that finally block. It is idempotent, so it is a no-op on the branches that already close the handle.

clean_finished_requests_with_retention also never removed request_lock_path()'s .lock file alongside the log files it does unlink, leaving one stale zero-byte lock file per garbage-collected request indefinitely. This adds that unlink to the same batch.

Closes #10547

Tested (run the relevant ones):

- [x] Code formatting: bash format.sh (yapf, isort, mypy clean; pylint 10.00/10 on changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests
- [ ] Relevant individual tests
- [ ] Backward compatibility

New/updated tests: added test_execute_request_coroutine_closes_log_handle_on_success, which asserts the real (unmocked) Context's log handle is closed after a successful run; verified with a negative control that it fails (handle stays open) without the fix. Updated test_clean_finished_requests_with_retention, test_clean_finished_requests_with_retention_batch_size_functionality, and test_clean_finished_requests_cleans_both_paths to expect the additional lock-file unlink; verified the same way. Ran tests/unit_tests/test_sky/server/requests/test_executor.py and test_requests.py in full: 112/112 passing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->