### PR TITLE
[Core] Add ContextSafeThreadPoolExecutor: propagate contextvars into pool threads

### DIFF
--- a/sky/utils/context_utils.py
+++ b/sky/utils/context_utils.py
@@ -244,3 +244,27 @@ def to_thread_with_executor(executor: Optional[concurrent.futures.Executor],
     func_call: Callable[..., T] = functools.partial(pyctx.run, func, *args,
                                                     **kwargs)
     return loop.run_in_executor(executor, func_call)
+
+
+class ContextSafeThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
+    """ThreadPoolExecutor whose tasks run in the submitter's context.
+
+    Worker threads start with an EMPTY contextvars context, so
+    request-scoped state -- the per-request SkyPilotContext installed by
+    @context.contextual, the current user, contextual environment
+    variables -- silently resolves to process-level defaults inside a
+    plain ThreadPoolExecutor. That turns fan-out code that looks correct
+    into code that answers for the wrong identity.
+
+    Each submit() captures contextvars.copy_context() on the submitting
+    thread and runs the task inside that copy: the same semantics
+    asyncio.to_thread and to_thread_with_executor provide, without
+    requiring a running event loop. map() inherits the behavior (the
+    base implementation delegates to submit()), with the context
+    captured once per item at submission time.
+    """
+
+    def submit(self, fn: Callable[P, T], /, *args: P.args,
+               **kwargs: P.kwargs) -> 'concurrent.futures.Future[T]':
+        pyctx = contextvars.copy_context()
+        return super().submit(pyctx.run, functools.partial(fn, *args, **kwargs))

--- a/tests/unit_tests/test_context_safe_executor.py
+++ b/tests/unit_tests/test_context_safe_executor.py
@@ -1,0 +1,76 @@
+"""Tests for ContextSafeThreadPoolExecutor.
+
+Worker threads start with an empty contextvars context, so request-scoped
+state (the per-request SkyPilotContext from @context.contextual, the
+current user, contextual env overrides) resolves to process defaults
+inside a plain ThreadPoolExecutor. ContextSafeThreadPoolExecutor copies
+the submitter's context into each task.
+"""
+import concurrent.futures
+import contextvars
+import threading
+
+from sky.utils import context
+from sky.utils import context_utils
+
+_VAR: contextvars.ContextVar = contextvars.ContextVar('test_var',
+                                                      default='DEFAULT')
+
+
+def test_submit_runs_in_submitter_context():
+    token = _VAR.set('caller-value')
+    try:
+        with context_utils.ContextSafeThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(_VAR.get).result() == 'caller-value'
+    finally:
+        _VAR.reset(token)
+
+
+def test_plain_executor_loses_context():
+    """Documents the failure mode this class exists for."""
+    token = _VAR.set('caller-value')
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(_VAR.get).result() == 'DEFAULT'
+    finally:
+        _VAR.reset(token)
+
+
+def test_context_is_copied_at_submit_time():
+    """Mutations on the submitting thread after submit() are not visible."""
+    release = threading.Event()
+
+    def read_after_release():
+        release.wait(5)
+        return _VAR.get()
+
+    token = _VAR.set('value-at-submit')
+    try:
+        with context_utils.ContextSafeThreadPoolExecutor(max_workers=1) as pool:
+            fut = pool.submit(read_after_release)
+            _VAR.set('value-after-submit')
+            release.set()
+            assert fut.result() == 'value-at-submit'
+    finally:
+        _VAR.reset(token)
+
+
+def test_map_propagates_context():
+    token = _VAR.set('mapped-value')
+    try:
+        with context_utils.ContextSafeThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: _VAR.get(), range(4)))
+        assert results == ['mapped-value'] * 4
+    finally:
+        _VAR.reset(token)
+
+
+def test_skypilot_context_propagates():
+    """The per-request SkyPilotContext travels into the worker."""
+    ctx = context.initialize()
+    assert context.get() is ctx
+    with context_utils.ContextSafeThreadPoolExecutor(max_workers=1) as pool:
+        assert pool.submit(context.get).result() is ctx
+        # A plain executor would see no context at all in the worker.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as plain:
+            assert plain.submit(context.get).result() is None


### PR DESCRIPTION
## Summary

- Adds `context_utils.ContextSafeThreadPoolExecutor`, a `ThreadPoolExecutor` whose `submit()` captures `contextvars.copy_context()` on the submitting thread and runs each task inside that copy. `map()` inherits the behavior via the base implementation.

Worker threads start with an **empty** contextvars context. Server code running under `@context.contextual` that fans out to a plain `ThreadPoolExecutor` silently loses the per-request `SkyPilotContext` — `get_user_hash()`, contextual env overrides, and workspace scoping then resolve to the API server process's own identity instead of the caller's, which can mean answering with the wrong user's data. The async side already has `to_thread_with_executor` with exactly these semantics; this is the synchronous counterpart for code with no running event loop.

## Test plan

- New `tests/unit_tests/test_context_safe_executor.py` (5 tests): task sees the submitter's contextvar; plain executor documents the failure mode (worker sees the default); context is copied at submit time (later mutations invisible); `map()` propagates; the `SkyPilotContext` itself (`context.get()`) travels into the worker while a plain executor sees `None`.
- `pytest tests/unit_tests/test_context_safe_executor.py` → 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->