### PR TITLE
[Core] Isolate runtime uv commands from user images' uv projects

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -129,7 +129,13 @@ SKY_UV_INSTALL_DIR = '"$HOME/.local/bin"'
 # unset PYTHONPATH in case the user provided docker image set it.
 # UV_LINK_MODE=copy avoids a uv >=0.10.5 bug where clone/reflink mode
 # strips execute permissions on XFS filesystems, breaking Ray binaries.
-SKY_UV_CMD = ('UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false '
+# UV_NO_CONFIG=1 stops uv from discovering a pyproject.toml/uv.toml from the
+# image (we run uv with cwd=$HOME, so an image whose home dir is a uv project
+# would otherwise leak its [tool.uv] settings into the runtime resolution;
+# override-dependencies in particular silently override our own pins and can
+# break the runtime venv). #7259 scoped this to `uv run` only; the same
+# isolation is needed for `uv venv` and `uv pip`.
+SKY_UV_CMD = ('UV_NO_CONFIG=1 UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false '
               f'{SKY_UNSET_PYTHONPATH_AND_SET_CWD} {SKY_UV_INSTALL_DIR}/uv')
 # This won't reinstall uv if it's already installed, so it's safe to re-run.
 SKY_UV_INSTALL_CMD = (f'{SKY_UV_CMD} -V >/dev/null 2>&1 || '

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1431,7 +1431,7 @@ available_node_types:
 
                 # set UV_SYSTEM_PYTHON to false in case the user provided docker image set it to true.
                 # unset PYTHONPATH and set CWD to $HOME to avoid user image interfering with SkyPilot runtime.
-                VIRTUAL_ENV=${SKY_RUNTIME_DIR:-$HOME}/skypilot-runtime UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip install skypilot[kubernetes,remote]
+                VIRTUAL_ENV=${SKY_RUNTIME_DIR:-$HOME}/skypilot-runtime UV_NO_CONFIG=1 UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip install skypilot[kubernetes,remote]
                 # Wait (bounded) for the best-effort `patch` install to land
                 # before applying the Ray patches. An image may ship no `patch`
                 # and have no usable repo, so proceed after 60s rather than hang

--- a/tests/smoke_tests/test_setup.py
+++ b/tests/smoke_tests/test_setup.py
@@ -63,3 +63,61 @@ def test_kubernetes_post_provision_runcmd():
             },
         )
         smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+def test_kubernetes_runtime_ignores_user_uv_project():
+    """Runtime venv setup must not inherit a uv project from the image.
+
+    An image whose home directory is a uv project (pyproject.toml with
+    [tool.uv] settings) must not leak into the SkyPilot runtime venv
+    resolution: `override-dependencies` beats explicit requirement pins by
+    design, so a leaked override can silently install dependency versions
+    that break the runtime (e.g. an old protobuf next to a recent
+    googleapis-common-protos crashes ray's dashboard agent on import, and
+    the raylet fate-shares with the agent, taking the whole node down
+    minutes after a successful launch).
+
+    Uses post_provision_runcmd to plant the hostile pyproject.toml in
+    $HOME before any SkyPilot setup runs (simulating an image that ships
+    one), then asserts the runtime venv's protobuf still honors SkyPilot's
+    own pin. FAILS without UV_NO_CONFIG in SKY_UV_CMD (protobuf resolves
+    to 4.25.x) and PASSES with it.
+    """
+    config = textwrap.dedent("""
+    kubernetes:
+        post_provision_runcmd:
+            - "echo '[project]' > $HOME/pyproject.toml"
+            - "echo 'name = \\"customer-image\\"' >> $HOME/pyproject.toml"
+            - "echo 'version = \\"0.1.0\\"' >> $HOME/pyproject.toml"
+            - "echo 'requires-python = \\">=3.12\\"' >> $HOME/pyproject.toml"
+            - "echo '[tool.uv]' >> $HOME/pyproject.toml"
+            - "echo 'override-dependencies = [\\"protobuf>=4.25.9,<5\\"]' >> $HOME/pyproject.toml"
+    """)
+
+    yaml = textwrap.dedent("""
+    run: |
+      ~/skypilot-runtime/bin/python -c "import google.protobuf as p; assert int(p.__version__.split('.')[0]) >= 5, f'uv override leaked into runtime venv: protobuf {p.__version__}'; print('runtime protobuf OK:', p.__version__)"
+    """)
+
+    with tempfile.NamedTemporaryFile(
+            delete=True) as config_file, tempfile.NamedTemporaryFile(
+                delete=True) as yaml_file:
+        config_file.write(config.encode('utf-8'))
+        config_file.flush()
+        yaml_file.write(yaml.encode('utf-8'))
+        yaml_file.flush()
+
+        name = smoke_tests_utils.get_cluster_name()
+        test = smoke_tests_utils.Test(
+            'kubernetes_runtime_ignores_user_uv_project',
+            [
+                f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra kubernetes {smoke_tests_utils.LOW_RESOURCE_ARG} {yaml_file.name}) && echo "$s" | grep "runtime protobuf OK"',
+            ],
+            teardown=f'sky down -y {name}',
+            timeout=smoke_tests_utils.get_timeout('kubernetes'),
+            env={
+                skypilot_config.ENV_VAR_GLOBAL_CONFIG: config_file.name,
+            },
+        )
+        smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
## Summary

- If a user-supplied image's home directory is a **uv project** (a `pyproject.toml` with `[tool.uv]` settings), the runtime setup's `uv venv` and `uv pip` commands — which run with `cwd=$HOME` for isolation from the image — actually *discover the user's project* and apply its configuration to the SkyPilot runtime venv resolution.
- `override-dependencies` is the dangerous case: uv applies overrides **above explicit requirement pins by design**, so an image shipping e.g. `override-dependencies = ["protobuf>=4.25.9,<5"]` silently forces that version into `~/skypilot-runtime` even though our own extras pin `protobuf>=5.29.6,<7`. A recent `googleapis-common-protos` next to an old protobuf then crashes ray's dashboard agent on import (`ImportError: cannot import name 'runtime_version' from 'google.protobuf'` — `runtime_version` only exists in protobuf ≥ 5.26). The raylet **fate-shares with the agent**, so minutes after a clean launch the node drops out of `ray status`, the cluster flips to INIT with "ray cluster is unhealthy (0/1 ready)", and running jobs end in `FAILED_DRIVER` — while the pod itself stays Running/Ready.
- #7259 fixed this class for `uv run` (`--no-project --no-config`); this PR extends the isolation to **every** runtime uv invocation (`uv venv`, `uv pip install`) by setting `UV_NO_CONFIG=1` in `SKY_UV_CMD`.

Behavior note: this also stops uv from reading system/user-level `uv.toml` baked into images during runtime setup. Environments that need a custom package index for the runtime install should set `UV_INDEX_URL` (env var) instead of relying on uv config files.

## Repro

```bash
mkdir /tmp/fakehome && cat > /tmp/fakehome/pyproject.toml <<'EOF'
[project]
name = "customer-image"
version = "0.1.0"
requires-python = ">=3.12"
[tool.uv]
override-dependencies = ["protobuf>=4.25.9,<5"]
EOF
cd /tmp/fakehome
uv venv --seed --python 3.10 skypilot-runtime   # warns: interpreter incompatible with project's requires-python
VIRTUAL_ENV=$PWD/skypilot-runtime uv pip install 'protobuf>=5.29.6,<7' googleapis-common-protos
# -> installs protobuf 4.25.9 (!) despite the explicit pin
skypilot-runtime/bin/python -c 'from google.rpc import status_pb2'
# -> ImportError: cannot import name 'runtime_version' from 'google.protobuf'
```

With `UV_NO_CONFIG=1` on the same commands, protobuf resolves to 6.33.x and the import works.

## Tested

- Manual repro above: without the change the override leaks and the import chain used by ray's dashboard agent breaks; with `UV_NO_CONFIG=1` the same commands resolve correctly.
- Verified the rendered `SKY_UV_CMD` / `SKY_UV_PIP_CMD` / `RAY_INSTALLATION_COMMANDS` / `SKYPILOT_WHEEL_INSTALLATION_COMMANDS` all carry `UV_NO_CONFIG=1`.
- Added `test_kubernetes_runtime_ignores_user_uv_project` smoke test: plants the hostile `pyproject.toml` in $HOME via `post_provision_runcmd` before any setup runs, then asserts the runtime venv's protobuf still honors our pin. Fails without the fix (protobuf 4.25.x), passes with it.
- End-to-end validation on a live Kubernetes cluster (API server at a pre-fix commit vs. this branch; BYO image `python:3.10-bookworm` so the full in-pod runtime resolution actually runs; hostile `pyproject.toml` planted in $HOME at pod start via `post_provision_runcmd`):
  - **Control (pre-fix)**: runtime-setup.log shows uv discovering the project (`warning: ... incompatible with the project's Python requirement`) and the ray install resolving `+ protobuf==4.25.9` despite our pins; the job dies (reproduced twice).
  - **First commit only**: the ray install is protected (resolves protobuf 7.x), but the template's hardcoded PyPI pre-warm still resolved `protobuf==4.25.9` transiently — caught by this e2e, fixed in the second commit.
  - **Complete fix**: `4.25.9` appears zero times in the entire runtime-setup.log across all 9 uv invocations; final venv protobuf 6.33.6 + googleapis-common-protos 1.75.2, `from google.rpc import status_pb2` imports cleanly, job SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)