### PR TITLE
[Volumes] Make a volume's readiness cheap to ask about

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -649,8 +649,10 @@ List volumes managed by SkyPilot.
 **Options:**
 
 - `--config` — Path to a config file or a single key-value pair. To add multiple key-value pairs add multiple flags (e.g. --config nested.key1=val1 --config nested.key2=val2).
+- `NAMES` — text
 - `--verbose`, `-v` — Show all information in full.
 - `--refresh`, `-r` — Refresh volume state from cloud APIs before listing. Without this flag, cached data is returned which is updated periodically by the background daemon.
+- `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.
 
 ## API Server Commands
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5684,15 +5684,24 @@ def volumes_ls(names: List[str],
             volume for volume in all_volumes if volume.name in requested
         ]
         if not json_output:
-            # Report a name that matched nothing, as `sky volumes delete`
-            # does, rather than showing an empty table and letting a typo read
-            # as "the volume is gone" -- the message a not-ready volume points
-            # here with makes that an easy mistake. Not on the json path,
-            # where an empty array already says it and a stray line would
-            # break parsing.
-            found = {volume.name for volume in all_volumes}
-            for missing in sorted(requested - found):
-                click.echo(f'Volume {missing} not found.')
+            # Report what matched nothing, rather than showing an empty table
+            # and letting a typo read as "the volume is gone" -- the message a
+            # not-ready volume points here with makes that an easy mistake.
+            # Not on the json path, where an empty array already says it and a
+            # stray line would break parsing.
+            missing = sorted(requested - {v.name for v in all_volumes})
+            if len(missing) == 1:
+                # Worded as `sky volumes delete` words it.
+                click.echo(f'Volume {missing[0]} not found.')
+            elif missing:
+                # One line rather than one per name: here a miss is the whole
+                # answer for that name, so a list reads better than a stack.
+                click.echo(f'Volumes not found: {", ".join(missing)}.')
+            if not all_volumes:
+                # Nothing left to tabulate. The empty table renders as "No
+                # existing volumes.", which is a claim about the whole table --
+                # and a filtered listing never looked at the whole table.
+                return
     if json_output:
         click.echo(
             json.dumps(

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5645,10 +5645,34 @@ def volumes_ls(names: List[str],
 
     Pass one or more volume names to show only those. Combined with --refresh,
     only the named volumes are re-probed, which is much cheaper than refreshing
-    every volume when you are waiting on one you just created.
+    every volume when you are waiting on one you just created. Names are exact;
+    unlike sky volumes delete, this does not take glob patterns.
+
+    Examples:
+
+    .. code-block:: bash
+
+        # Show every volume.
+        sky volumes ls
+        \b
+        # Show one volume, re-probing just that one.
+        sky volumes ls my-vol -r
+        \b
+        # Read a volume's status from a script.
+        sky volumes ls my-vol -o json
     """
     request_id = volumes_sdk.ls(refresh=refresh, names=names)
-    all_volumes = sdk.stream_and_get(request_id)
+    json_output = output_format == flags.OUTPUT_FORMAT_JSON
+    if json_output:
+        # Keep stdout parseable. A request's server-side logs are streamed back
+        # here, and volume_refresh logs a line exactly when a volume's status
+        # changes -- the NOT_READY -> READY tick a poller is waiting for. Ahead
+        # of the JSON that is the one iteration a parser cannot read, so send
+        # the stream to a sink, as `sky check -o json` does.
+        all_volumes = sdk.stream_and_get(request_id,
+                                         output_stream=io.StringIO())
+    else:
+        all_volumes = sdk.stream_and_get(request_id)
     if names:
         # Filter here as well as on the server. An API server older than this
         # change ignores the names and returns every volume; narrowing again
@@ -5659,7 +5683,17 @@ def volumes_ls(names: List[str],
         all_volumes = [
             volume for volume in all_volumes if volume.name in requested
         ]
-    if output_format == flags.OUTPUT_FORMAT_JSON:
+        if not json_output:
+            # Report a name that matched nothing, as `sky volumes delete`
+            # does, rather than showing an empty table and letting a typo read
+            # as "the volume is gone" -- the message a not-ready volume points
+            # here with makes that an easy mistake. Not on the json path,
+            # where an empty array already says it and a stray line would
+            # break parsing.
+            found = {volume.name for volume in all_volumes}
+            for missing in sorted(requested - found):
+                click.echo(f'Volume {missing} not found.')
+    if json_output:
         click.echo(
             json.dumps(
                 [volume.model_dump(mode='json') for volume in all_volumes],

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5616,6 +5616,11 @@ def _build_volume_override_config(
 
 @volumes.command('ls', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
+@click.argument('names',
+                required=False,
+                type=str,
+                nargs=-1,
+                **_get_shell_complete_args(_complete_volume_name))
 @click.option('--verbose',
               '-v',
               default=False,
@@ -5630,11 +5635,36 @@ def _build_volume_override_config(
               help='Refresh volume state from cloud APIs before listing. '
               'Without this flag, cached data is returned which is updated '
               'periodically by the background daemon.')
+@flags.output_format_option()
 @usage_lib.entrypoint
-def volumes_ls(verbose: bool, refresh: bool):
-    """List volumes managed by SkyPilot."""
-    request_id = volumes_sdk.ls(refresh=refresh)
+def volumes_ls(names: List[str],
+               verbose: bool,
+               refresh: bool,
+               output_format: str = 'table'):
+    """List volumes managed by SkyPilot.
+
+    Pass one or more volume names to show only those. Combined with --refresh,
+    only the named volumes are re-probed, which is much cheaper than refreshing
+    every volume when you are waiting on one you just created.
+    """
+    request_id = volumes_sdk.ls(refresh=refresh, names=names)
     all_volumes = sdk.stream_and_get(request_id)
+    if names:
+        # Filter here as well as on the server. An API server older than this
+        # change ignores the names and returns every volume; narrowing again
+        # keeps the output correct against those servers, which is what lets
+        # the names be sent without an API version gate. Against a current
+        # server the response is already narrowed and this is a no-op.
+        requested = set(names)
+        all_volumes = [
+            volume for volume in all_volumes if volume.name in requested
+        ]
+    if output_format == flags.OUTPUT_FORMAT_JSON:
+        click.echo(
+            json.dumps(
+                [volume.model_dump(mode='json') for volume in all_volumes],
+                indent=2))
+        return
     volume_table = table_utils.format_volume_table(all_volumes,
                                                    show_all=verbose)
     click.echo(volume_table)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3002,24 +3002,49 @@ def _volume_record_from_row(row: Any) -> Dict[str, Any]:
 def get_volumes(
     is_ephemeral: Optional[bool] = None,
     workspaces_filter: Optional[Set[str]] = None,
+    volume_names: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Get volumes from the database.
+
+    Every filter given is applied, so a caller narrowing by name cannot widen
+    what another filter allows -- naming a volume outside `workspaces_filter`
+    still returns nothing.
 
     Args:
         is_ephemeral: If specified, only include volumes with this
             ephemerality.
         workspaces_filter: If specified, only include volumes whose workspace
             is in this set. Use workspace names.
+        volume_names: If specified, only include volumes with these names.
+            An empty list therefore matches nothing, while None means "do not
+            filter by name". Names with no row are simply absent.
     """
     engine = _db_manager.get_engine()
-    with orm.Session(engine) as session:
+
+    def filtered(session: 'orm.Session') -> Any:
         query = session.query(volume_table)
         if is_ephemeral is not None:
             query = query.filter_by(is_ephemeral=int(is_ephemeral))
         if workspaces_filter is not None:
             query = query.filter(
                 volume_table.c.workspace.in_(workspaces_filter))
-        rows = query.all()
+        return query
+
+    rows = []
+    with orm.Session(engine) as session:
+        if volume_names is None:
+            rows = filtered(session).all()
+        else:
+            # Chunk the IN list for the same reason as
+            # get_volumes_from_names: SQLite caps bound parameters and
+            # PostgreSQL plans huge IN clauses badly.
+            for offset in range(0, len(volume_names),
+                                _CLUSTER_IN_QUERY_CHUNK_SIZE):
+                batch = volume_names[offset:offset +
+                                     _CLUSTER_IN_QUERY_CHUNK_SIZE]
+                rows.extend(
+                    filtered(session).filter(
+                        volume_table.c.name.in_(batch)).all())
     return [_volume_record_from_row(row) for row in rows]
 
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -581,6 +581,9 @@ class VolumeDeleteBody(RequestBody):
 class VolumeListBody(RequestBody):
     """The request body for the volume list endpoint."""
     refresh: bool = False
+    # None means every volume, so a client that predates this field and never
+    # sends it keeps getting the whole listing.
+    volume_names: Optional[List[str]] = None
 
 
 class VolumeValidateBody(RequestBody):

--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -1,7 +1,7 @@
 """SDK functions for volumes."""
 import json
 import typing
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 from sky import exceptions
 from sky import sky_logging
@@ -125,22 +125,31 @@ def validate(volume: volume_lib.Volume) -> None:
 @server_common.check_server_healthy_or_start
 @annotations.client_api
 def ls(
-    refresh: bool = False
+    refresh: bool = False,
+    names: Optional[List[str]] = None,
 ) -> server_common.RequestId[List[responses.VolumeRecord]]:
-    """Lists all volumes.
+    """Lists volumes.
 
     Args:
         refresh: If True, refresh volume state from cloud APIs before returning.
             This makes the call slower but returns the most up-to-date data.
             If False (default), return cached data from the database which is
             updated periodically by the background daemon.
+        names: If given, list only these volumes, and narrow a `refresh` to
+            them instead of re-probing every volume. An API server older than
+            this argument ignores it and returns every volume, so callers that
+            need exactly the named ones must narrow the result themselves.
 
     Returns:
         The request ID of the list request.
     """
-    params = {}
+    params: Dict[str, Union[str, List[str]]] = {}
     if refresh:
         params['refresh'] = 'true'
+    if names:
+        # Repeated `names=` query params; a server that predates this one
+        # ignores them and returns every volume.
+        params['names'] = list(names)
     response = server_common.make_authenticated_request(
         'GET',
         '/volumes',

--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -136,8 +136,10 @@ def ls(
             updated periodically by the background daemon.
         names: If given, list only these volumes, and narrow a `refresh` to
             them instead of re-probing every volume. An API server older than
-            this argument ignores it and returns every volume, so callers that
-            need exactly the named ones must narrow the result themselves.
+            this argument ignores it: it returns every volume, and a `refresh`
+            re-probes the whole table rather than the named subset. The result
+            is still correct but the call is no cheaper, and callers that need
+            exactly the named volumes must narrow the result themselves.
 
     Returns:
         The request ID of the list request.
@@ -147,7 +149,11 @@ def ls(
         params['refresh'] = 'true'
     if names:
         # Repeated `names=` query params; a server that predates this one
-        # ignores them and returns every volume.
+        # ignores them and returns every volume. Note this is the only
+        # list-valued param here: `requests` expands a list into repeated
+        # params, but make_authenticated_request_async str()s each value, so
+        # an async caller would send "['a']" and needs to join the names
+        # itself.
         params['names'] = list(names)
     response = server_common.make_authenticated_request(
         'GET',

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -202,12 +202,16 @@ def volume_refresh(volume_names: Optional[List[str]] = None) -> None:
 def volume_list(
     is_ephemeral: Optional[bool] = None,
     refresh: bool = False,
+    volume_names: Optional[List[str]] = None,
 ) -> List[responses.VolumeRecord]:
     """Gets volumes from the database.
 
     Args:
         is_ephemeral: Whether to include ephemeral volumes.
         refresh: If True, refresh volume state from cloud APIs before returning.
+        volume_names: If given, return only these volumes, and scope a
+            `refresh` to them rather than re-probing the whole table. Names
+            with no volume are ignored, the same as an empty listing.
 
     Returns:
         [
@@ -235,9 +239,13 @@ def volume_list(
         ]
     """
     if refresh:
-        volume_refresh()
+        volume_refresh(volume_names)
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
-        volumes = global_user_state.get_volumes(is_ephemeral=is_ephemeral)
+        if volume_names is None:
+            volumes = global_user_state.get_volumes(is_ephemeral=is_ephemeral)
+        else:
+            volumes = global_user_state.get_volumes_from_names(
+                volume_names, is_ephemeral=is_ephemeral)
         all_users = global_user_state.get_all_users()
         user_map = {user.id: user.name for user in all_users}
 
@@ -446,7 +454,19 @@ def volume_apply(
                 creation_yaml=creation_yaml,
                 error_message=initial_error,
             )
-        logger.info(f'Created volume {name} on cloud {cloud}')
+        # Report the status that was just recorded, not the fact that the API
+        # call returned. Creating the backing resource is not the same as it
+        # being mountable: an Immediate-binding storage class provisions the
+        # PersistentVolume asynchronously, so a launch against the volume right
+        # now would be refused with VolumeNotReadyError. Saying "Created" and
+        # nothing else sends the user straight into that.
+        if initial_status == status_lib.VolumeStatus.NOT_READY:
+            reason = f' {initial_error}' if initial_error else ''
+            logger.info(f'Created volume {name} on cloud {cloud}. It is not '
+                        f'ready to be mounted yet.{reason}\n'
+                        f'Check its status with: sky volumes ls {name} -r')
+        else:
+            logger.info(f'Created volume {name} on cloud {cloud}')
 
 
 def _same_backend_resource(a: models.VolumeConfig,

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -294,7 +294,6 @@ def volume_list(
     # backend_utils for clusters.
     accessible_workspaces = workspaces_core.get_accessible_workspace_names(
         action=workspace_constants.WORKSPACE_ACTION_READ)
-    requested_names = None if volume_names is None else set(volume_names)
     if refresh:
         # Keep the reconcile proportional to what this caller can see: a user
         # who reads one workspace should not drive cloud API calls against
@@ -302,24 +301,19 @@ def volume_list(
         # calls by the (context, namespace) pairs of the volumes it is handed,
         # so narrowing the set narrows the calls. The daemon in
         # sky/server/daemons.py still refreshes the whole table.
-        # Requested names narrow this again, within the accessible set.
+        # Requested names narrow this again. get_volumes applies every filter
+        # it is given, so naming a volume outside the accessible workspaces
+        # reconciles nothing -- which would otherwise confirm it exists.
         volume_refresh(volume_names=[
-            volume['name']
-            for volume in global_user_state.get_volumes(
-                workspaces_filter=accessible_workspaces)
-            if requested_names is None or volume['name'] in requested_names
+            volume['name'] for volume in global_user_state.get_volumes(
+                workspaces_filter=accessible_workspaces,
+                volume_names=volume_names)
         ])
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
         volumes = global_user_state.get_volumes(
-            is_ephemeral=is_ephemeral, workspaces_filter=accessible_workspaces)
-        if requested_names is not None:
-            # Applied after the workspace filter and never instead of it, so
-            # naming a volume in a workspace the caller cannot read reveals
-            # nothing.
-            volumes = [
-                volume for volume in volumes
-                if volume['name'] in requested_names
-            ]
+            is_ephemeral=is_ephemeral,
+            workspaces_filter=accessible_workspaces,
+            volume_names=volume_names)
         all_users = global_user_state.get_all_users()
         user_map = {user.id: user.name for user in all_users}
 

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -1,5 +1,7 @@
 """REST API for storage management."""
 
+from typing import List, Optional
+
 import fastapi
 
 from sky import clouds
@@ -21,8 +23,10 @@ router = fastapi.APIRouter()
 
 @router.get('')
 async def volume_list(
-    request: fastapi.Request,
-    refresh: bool = fastapi.Depends(role_filter.force_viewer_volume_refresh),
+        request: fastapi.Request,
+        refresh: bool = fastapi.Depends(
+            role_filter.force_viewer_volume_refresh),
+        names: Optional[List[str]] = fastapi.Query(None),
 ) -> None:
     """Gets the volumes.
 
@@ -31,8 +35,11 @@ async def volume_list(
             If False (default), return cached data from the database.
             For viewer-role callers this is forced to False by
             `role_filter.force_viewer_volume_refresh`.
+        names: If given, return only these volumes, and narrow a `refresh` to
+            them. Optional so that a client older than this parameter, which
+            never sends it, keeps getting every volume.
     """
-    request_body = payloads.VolumeListBody(refresh=refresh)
+    request_body = payloads.VolumeListBody(refresh=refresh, volume_names=names)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.VOLUME_LIST,

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1612,6 +1612,14 @@ def test_volumes_on_kubernetes():
             smoke_tests_utils.get_cmd_wait_until_volume_is_ready('existing0'),
             smoke_tests_utils.get_cmd_wait_until_volume_is_ready(
                 'vol-existing1'),
+            # Name filter and `-o json` end to end: exactly the named volume
+            # comes back, and stdout parses -- which it would not if a
+            # server-side log line were streamed onto it.
+            'vols=$(sky volumes ls pvc0 -o json) && echo "$vols" && '
+            'echo "$vols" | python3 -c \''
+            'import json, sys; '
+            'sys.exit(0 if [v["name"] for v in json.load(sys.stdin)] == '
+            '["pvc0"] else 1)\'',
             f'sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume.yaml',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
             f'vols=$(sky volumes ls) && echo "$vols" && echo "$vols" | grep "{name}"',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1649,7 +1649,11 @@ def test_volumes_on_kubernetes():
             # case that `-o json` also has to survive is not reachable here --
             # without `-r` nothing refreshes, and the volume is READY by now so
             # a refresh would log nothing either -- so it is a unit test.
-            f'vols=$(sky volumes ls {pvc0} -o json) && echo "$vols" && '
+            # SKYPILOT_DEBUG=0 because this suite sets it to 1 for every
+            # test (pyproject.toml) and SkyPilot logs to stdout by design, so
+            # the JSON would arrive behind a wall of debug lines.
+            f'vols=$(SKYPILOT_DEBUG=0 sky volumes ls {pvc0} -o json) && '
+            'echo "$vols" && '
             'echo "$vols" | python3 -c \''
             'import json, sys; '
             'sys.exit(0 if [v["name"] for v in json.load(sys.stdin)] == '

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1645,8 +1645,10 @@ def test_volumes_on_kubernetes():
             smoke_tests_utils.get_cmd_wait_until_volume_is_ready(existing0),
             smoke_tests_utils.get_cmd_wait_until_volume_is_ready(vol_existing1),
             # Name filter and `-o json` end to end: exactly the named volume
-            # comes back, and stdout parses -- which it would not if a
-            # server-side log line were streamed onto it.
+            # comes back, and stdout is a parseable document. The streamed-log
+            # case that `-o json` also has to survive is not reachable here --
+            # without `-r` nothing refreshes, and the volume is READY by now so
+            # a refresh would log nothing either -- so it is a unit test.
             f'vols=$(sky volumes ls {pvc0} -o json) && echo "$vols" && '
             'echo "$vols" | python3 -c \''
             'import json, sys; '

--- a/tests/unit_tests/test_sky/test_cli_volumes.py
+++ b/tests/unit_tests/test_sky/test_cli_volumes.py
@@ -1339,3 +1339,92 @@ class TestVolumesLsJsonOutput:
         # The table only shows MESSAGE conditionally; JSON must always carry
         # the reason, since that is the whole point of polling it.
         assert payload[0]['error_message'] == 'PVC is pending: still binding.'
+
+
+class TestVolumesLsJsonStaysParseable:
+    """A request's server-side logs are streamed back to the client, so the
+    json path has to keep them off stdout.
+
+    volume_refresh logs a line exactly when a volume's status changes -- the
+    NOT_READY -> READY tick a poller is waiting on -- so the polluted iteration
+    would be the one the caller actually cares about.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch):
+        monkeypatch.setattr('sky.volumes.client.sdk.ls',
+                            mock.MagicMock(return_value='request-id'))
+
+        def fake_stream_and_get(request_id, output_stream=None, **kwargs):
+            del request_id, kwargs
+            # What the real one does: replay the request's log to
+            # output_stream, where None means stdout.
+            print('Update volume vol-a status to READY',
+                  file=output_stream,
+                  flush=True)
+            return [TestVolumesLsByName._record('vol-a', 'READY')]
+
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            fake_stream_and_get)
+
+    def test_a_streamed_log_line_does_not_break_the_json(self, monkeypatch):
+        self._patch(monkeypatch)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['-r', '-o', 'json'])
+
+        assert not result.exit_code, result.output
+        assert [v['name'] for v in json.loads(result.output)] == ['vol-a']
+
+    def test_the_table_still_shows_the_line(self, monkeypatch):
+        """Only json suppresses the stream; a human reading the table wants
+        to see what the server is doing."""
+        self._patch(monkeypatch)
+        monkeypatch.setattr('sky.client.cli.table_utils.format_volume_table',
+                            lambda *args, **kwargs: 'TABLE')
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls, ['-r'])
+
+        assert not result.exit_code, result.output
+        assert 'Update volume vol-a status to READY' in result.output
+
+
+class TestVolumesLsReportsNamesThatMatchNothing:
+    """A typo must not read as "the volume is gone".
+
+    The message a not-ready volume points here with makes that an easy mistake,
+    and `sky volumes delete` already reports an unmatched name.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch):
+        monkeypatch.setattr('sky.volumes.client.sdk.ls',
+                            mock.MagicMock(return_value='request-id'))
+        monkeypatch.setattr(
+            'sky.client.sdk.stream_and_get',
+            mock.MagicMock(
+                return_value=[TestVolumesLsByName._record('vol-a', 'READY')]))
+        monkeypatch.setattr('sky.client.cli.table_utils.format_volume_table',
+                            lambda *args, **kwargs: 'TABLE')
+
+    def test_an_unmatched_name_is_reported(self, monkeypatch):
+        self._patch(monkeypatch)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['vol-a', 'nope'])
+
+        assert not result.exit_code, result.output
+        assert 'Volume nope not found.' in result.output
+        # The one that does exist is still listed.
+        assert 'TABLE' in result.output
+
+    def test_json_says_it_with_an_empty_array_instead(self, monkeypatch):
+        """Stdout on the json path stays machine-readable."""
+        self._patch(monkeypatch)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['nope', '-o', 'json'])
+
+        assert not result.exit_code, result.output
+        assert json.loads(result.output) == []
+        assert 'not found' not in result.output

--- a/tests/unit_tests/test_sky/test_cli_volumes.py
+++ b/tests/unit_tests/test_sky/test_cli_volumes.py
@@ -1,5 +1,6 @@
 """Unit tests for CLI volumes commands."""
 from datetime import datetime
+import json
 from unittest import mock
 
 from click import testing as cli_testing
@@ -7,6 +8,7 @@ import pytest
 
 from sky.client.cli import command
 from sky.client.cli import table_utils
+from sky.schemas.api import responses
 from sky.utils import volume as volume_utils
 
 
@@ -1239,3 +1241,101 @@ class TestRunPodVolumeTable:
         assert 'Kubernetes PVCs:' in out
         assert 'RunPod Network Volumes:' in out
         assert '\n\n' in out
+
+
+class TestVolumesLsByName:
+    """`sky volumes ls NAME` narrows the listing, and the refresh with it."""
+
+    @staticmethod
+    def _record(name, status, error_message=None):
+        return responses.VolumeRecord(name=name,
+                                      type='k8s-pvc',
+                                      launched_at=0,
+                                      cloud='Kubernetes',
+                                      config={},
+                                      name_on_cloud=f'{name}-abc123',
+                                      user_hash='uhash',
+                                      user_name='alice',
+                                      workspace='default',
+                                      status=status,
+                                      usedby_pods=[],
+                                      usedby_clusters=[],
+                                      error_message=error_message)
+
+    @staticmethod
+    def _patch(monkeypatch, returned):
+        mock_ls = mock.MagicMock(return_value='request-id')
+        monkeypatch.setattr('sky.volumes.client.sdk.ls', mock_ls)
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            mock.MagicMock(return_value=returned))
+        return mock_ls
+
+    def test_names_are_sent_to_the_server(self, monkeypatch):
+        mock_ls = self._patch(monkeypatch, [self._record('vol-a', 'READY')])
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['vol-a', '-r', '-o', 'json'])
+
+        assert not result.exit_code, result.output
+        # Sent so a current server can scope the refresh instead of re-probing
+        # every volume.
+        assert mock_ls.call_args.kwargs['names'] == ('vol-a',)
+        assert mock_ls.call_args.kwargs['refresh'] is True
+
+    def test_unfiltered_response_is_narrowed_by_the_client(self, monkeypatch):
+        """An API server older than the `names` parameter ignores it and
+        returns every volume. Narrowing again here is what keeps the output
+        correct against those servers -- and therefore what lets the parameter
+        ship without an API version gate. If this breaks, that reasoning does
+        too.
+        """
+        self._patch(monkeypatch, [
+            self._record('vol-a', 'NOT_READY', 'PVC is pending.'),
+            self._record('vol-a-longer', 'READY'),
+            self._record('unrelated', 'READY'),
+        ])
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['vol-a', '-o', 'json'])
+
+        assert not result.exit_code, result.output
+        listed = [volume['name'] for volume in json.loads(result.output)]
+        # Exactly the requested volume: not the one whose name merely starts
+        # with it, and not the rest of the table.
+        assert listed == ['vol-a']
+
+    def test_no_names_lists_everything(self, monkeypatch):
+        mock_ls = self._patch(monkeypatch, [
+            self._record('vol-a', 'READY'),
+            self._record('vol-b', 'READY'),
+        ])
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['-o', 'json'])
+
+        assert not result.exit_code, result.output
+        assert mock_ls.call_args.kwargs['names'] == ()
+        assert len(json.loads(result.output)) == 2
+
+
+class TestVolumesLsJsonOutput:
+    """`-o json` is the machine-readable path, so the fields callers poll on
+    have to be there."""
+
+    def test_json_carries_status_and_reason(self, monkeypatch):
+        record = TestVolumesLsByName._record('vol-a', 'NOT_READY',
+                                             'PVC is pending: still binding.')
+        monkeypatch.setattr('sky.volumes.client.sdk.ls',
+                            mock.MagicMock(return_value='request-id'))
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            mock.MagicMock(return_value=[record]))
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['-o', 'json'])
+
+        assert not result.exit_code, result.output
+        payload = json.loads(result.output)
+        assert payload[0]['status'] == 'NOT_READY'
+        # The table only shows MESSAGE conditionally; JSON must always carry
+        # the reason, since that is the whole point of polling it.
+        assert payload[0]['error_message'] == 'PVC is pending: still binding.'

--- a/tests/unit_tests/test_sky/test_cli_volumes.py
+++ b/tests/unit_tests/test_sky/test_cli_volumes.py
@@ -1397,15 +1397,17 @@ class TestVolumesLsReportsNamesThatMatchNothing:
     """
 
     @staticmethod
-    def _patch(monkeypatch):
+    def _patch(monkeypatch, stub_table=True):
         monkeypatch.setattr('sky.volumes.client.sdk.ls',
                             mock.MagicMock(return_value='request-id'))
         monkeypatch.setattr(
             'sky.client.sdk.stream_and_get',
             mock.MagicMock(
                 return_value=[TestVolumesLsByName._record('vol-a', 'READY')]))
-        monkeypatch.setattr('sky.client.cli.table_utils.format_volume_table',
-                            lambda *args, **kwargs: 'TABLE')
+        if stub_table:
+            monkeypatch.setattr(
+                'sky.client.cli.table_utils.format_volume_table',
+                lambda *args, **kwargs: 'TABLE')
 
     def test_an_unmatched_name_is_reported(self, monkeypatch):
         self._patch(monkeypatch)
@@ -1428,3 +1430,39 @@ class TestVolumesLsReportsNamesThatMatchNothing:
         assert not result.exit_code, result.output
         assert json.loads(result.output) == []
         assert 'not found' not in result.output
+
+    def test_several_unmatched_names_are_reported_on_one_line(
+            self, monkeypatch):
+        self._patch(monkeypatch)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['nope', 'alsonope'])
+
+        assert not result.exit_code, result.output
+        assert 'Volumes not found: alsonope, nope.' in result.output
+        # One line for the lot, not one per name.
+        assert result.output.count('not found') == 1
+
+    def test_matching_nothing_does_not_claim_the_table_is_empty(
+            self, monkeypatch):
+        """`format_volume_table` renders an empty list as "No existing
+        volumes.", which is a statement about the whole table -- untrue, and
+        confusing, when the caller filtered by name and simply missed.
+        """
+        self._patch(monkeypatch, stub_table=False)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls, ['nope'])
+
+        assert not result.exit_code, result.output
+        assert 'Volume nope not found.' in result.output
+        assert 'No existing volumes.' not in result.output
+
+    def test_a_partial_match_still_lists_what_did_match(self, monkeypatch):
+        self._patch(monkeypatch, stub_table=False)
+
+        result = cli_testing.CliRunner().invoke(command.volumes_ls,
+                                                ['vol-a', 'nope'])
+
+        assert not result.exit_code, result.output
+        assert 'Volume nope not found.' in result.output
+        assert 'vol-a' in result.output

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2007,30 +2007,35 @@ class TestVolumeRefreshErrorFetchFailure:
             'status'] == status_lib.VolumeStatus.NOT_READY
 
 
+def _mock_volume_apply_deps(monkeypatch):
+    """Stubs everything volume_apply touches; returns the add_volume mock."""
+    mock_cloud = mock.MagicMock()
+    mock_cloud.max_cluster_name_length.return_value = 63
+    mock_cloud.validate_region_zone.return_value = ('my-context', None)
+    mock_cloud_registry = mock.MagicMock()
+    mock_cloud_registry.from_str.return_value = mock_cloud
+    monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
+                        mock_cloud_registry)
+    monkeypatch.setattr(
+        'sky.volumes.server.core.common_utils.make_cluster_name_on_cloud',
+        mock.MagicMock(return_value='test-vol'))
+    monkeypatch.setattr(global_user_state, 'get_volume_by_name',
+                        mock.MagicMock(return_value=None))
+    monkeypatch.setattr(provision, 'apply_volume',
+                        mock.MagicMock(side_effect=lambda cloud, c: c))
+    monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
+                        mock.MagicMock())
+    mock_add_volume = mock.MagicMock()
+    monkeypatch.setattr(global_user_state, 'add_volume', mock_add_volume)
+    return mock_add_volume
+
+
 class TestVolumeApplyRecordsInitialStatus:
     """volume_apply must record what the volume actually looks like."""
 
     @staticmethod
     def _setup(monkeypatch):
-        mock_cloud = mock.MagicMock()
-        mock_cloud.max_cluster_name_length.return_value = 63
-        mock_cloud.validate_region_zone.return_value = ('my-context', None)
-        mock_cloud_registry = mock.MagicMock()
-        mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
-                            mock_cloud_registry)
-        monkeypatch.setattr(
-            'sky.volumes.server.core.common_utils.make_cluster_name_on_cloud',
-            mock.MagicMock(return_value='test-vol'))
-        monkeypatch.setattr(global_user_state, 'get_volume_by_name',
-                            mock.MagicMock(return_value=None))
-        monkeypatch.setattr(provision, 'apply_volume',
-                            mock.MagicMock(side_effect=lambda cloud, c: c))
-        monkeypatch.setattr('sky.volumes.server.core.filelock.FileLock',
-                            mock.MagicMock())
-        mock_add_volume = mock.MagicMock()
-        monkeypatch.setattr(global_user_state, 'add_volume', mock_add_volume)
-        return mock_add_volume
+        return _mock_volume_apply_deps(monkeypatch)
 
     def test_unbound_volume_is_recorded_not_ready(self, monkeypatch):
         mock_add_volume = self._setup(monkeypatch)
@@ -2189,3 +2194,95 @@ class TestVolumeRefreshScopedToNames:
         assert sorted(c.args[0] for c in mock_update.call_args_list) == [
             'vol-a', 'vol-b'
         ]
+
+
+class TestVolumeApplyReportsInitialStatus:
+    """What `volume_apply` tells the user must match what it recorded.
+
+    Creating the backing resource is not the same as it being mountable: with
+    an Immediate-binding storage class the PersistentVolume is provisioned
+    asynchronously, and a launch against the volume in that window is refused
+    with VolumeNotReadyError. A bare "Created" sends the user straight into it.
+    """
+
+    @staticmethod
+    def _apply(monkeypatch, error_message):
+        _mock_volume_apply_deps(monkeypatch)
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_errors', lambda cloud, configs: ({
+                'test-vol': error_message
+            }, set()))
+        mock_logger = mock.MagicMock()
+        monkeypatch.setattr('sky.volumes.server.core.logger', mock_logger)
+
+        core.volume_apply(name='test-vol',
+                          volume_type='k8s-pvc',
+                          cloud='kubernetes',
+                          region='my-context',
+                          zone=None,
+                          size='1000',
+                          config={})
+
+        return ' '.join(
+            str(call.args[0]) for call in mock_logger.info.call_args_list)
+
+    def test_not_ready_volume_is_not_announced_as_usable(self, monkeypatch):
+        reported = self._apply(monkeypatch, 'PVC is pending: still binding.')
+
+        assert 'not ready to be mounted yet' in reported
+        # The reason the status check produced, not a generic hint.
+        assert 'PVC is pending: still binding.' in reported
+        # And where to look next.
+        assert 'sky volumes ls test-vol' in reported
+
+    def test_ready_volume_is_announced_plainly(self, monkeypatch):
+        reported = self._apply(monkeypatch, None)
+
+        assert 'Created volume test-vol on cloud kubernetes' in reported
+        assert 'not ready' not in reported
+
+
+class TestVolumeListScopedToNames:
+    """`volume_list(volume_names=...)` narrows both the refresh and the read."""
+
+    @staticmethod
+    def _patch(monkeypatch):
+        mock_refresh = mock.MagicMock()
+        monkeypatch.setattr(core, 'volume_refresh', mock_refresh)
+        mock_all = mock.MagicMock(return_value=[])
+        mock_scoped = mock.MagicMock(return_value=[])
+        monkeypatch.setattr(global_user_state, 'get_volumes', mock_all)
+        monkeypatch.setattr(global_user_state, 'get_volumes_from_names',
+                            mock_scoped)
+        monkeypatch.setattr(global_user_state, 'get_all_users',
+                            mock.MagicMock(return_value=[]))
+        return mock_refresh, mock_all, mock_scoped
+
+    def test_names_scope_the_refresh_and_the_read(self, monkeypatch):
+        mock_refresh, mock_all, mock_scoped = self._patch(monkeypatch)
+
+        core.volume_list(refresh=True, volume_names=['vol-a'])
+
+        # The whole point: waiting on one volume must not re-probe the table.
+        mock_refresh.assert_called_once_with(['vol-a'])
+        mock_scoped.assert_called_once_with(['vol-a'], is_ephemeral=None)
+        mock_all.assert_not_called()
+
+    def test_names_narrow_the_read_without_refresh(self, monkeypatch):
+        mock_refresh, mock_all, mock_scoped = self._patch(monkeypatch)
+
+        core.volume_list(volume_names=['vol-a'])
+
+        mock_refresh.assert_not_called()
+        mock_scoped.assert_called_once_with(['vol-a'], is_ephemeral=None)
+        mock_all.assert_not_called()
+
+    def test_no_names_keeps_listing_everything(self, monkeypatch):
+        """The dashboard and a bare `sky volumes ls` pass nothing."""
+        mock_refresh, mock_all, mock_scoped = self._patch(monkeypatch)
+
+        core.volume_list(refresh=True)
+
+        mock_refresh.assert_called_once_with(None)
+        mock_all.assert_called_once_with(is_ephemeral=None)
+        mock_scoped.assert_not_called()

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2280,25 +2280,25 @@ class TestVolumeListScopedToNames:
             self._volume('theirs', 'other'),
         ]
 
-        def fake_get_volumes(is_ephemeral=None, workspaces_filter=None):
-            """Stands in for the database, including its workspace filter."""
-            del is_ephemeral
-            if workspaces_filter is None:
-                return list(rows)
-            return [r for r in rows if r['workspace'] in workspaces_filter]
+        def fake_get_volumes(is_ephemeral=None,
+                             workspaces_filter=None,
+                             volume_names=None):
+            """Stands in for the database, applying every filter it is given.
 
-        def fake_get_volumes_from_names(volume_names, is_ephemeral=None):
-            """Faithful to the real one, which has no workspace filter.
-
-            Stubbed so that reaching for it as the *only* filter shows up as a
-            leak here rather than as an empty result from an empty test DB.
+            Faithful on the point that matters: the filters compose. Dropping
+            either one in volume_list therefore surfaces here as rows the
+            caller should not have seen, rather than as an empty result from an
+            empty test database.
             """
             del is_ephemeral
-            return [r for r in rows if r['name'] in set(volume_names)]
+            out = rows
+            if workspaces_filter is not None:
+                out = [r for r in out if r['workspace'] in workspaces_filter]
+            if volume_names is not None:
+                out = [r for r in out if r['name'] in volume_names]
+            return out
 
         monkeypatch.setattr(global_user_state, 'get_volumes', fake_get_volumes)
-        monkeypatch.setattr(global_user_state, 'get_volumes_from_names',
-                            fake_get_volumes_from_names)
         monkeypatch.setattr(global_user_state, 'get_all_users',
                             mock.MagicMock(return_value=[]))
         monkeypatch.setattr(

--- a/tests/unit_tests/test_sky/volumes/test_server.py
+++ b/tests/unit_tests/test_sky/volumes/test_server.py
@@ -644,3 +644,51 @@ class TestVolumeServer:
             assert response.status_code == 400
             assert 'Runpod network volume is only supported on Runpod' in response.json(
             )['detail']
+
+
+class TestVolumeListNamesReachTheRequestBody:
+    """The `names` query parameter has to survive the trip to core.volume_list.
+
+    It is renamed on the way -- `?names=` on the wire, `volume_names` in the
+    body, matched to the core signature only by `to_kwargs()` doing a
+    model_dump. Nothing else exercises that seam: the CLI tests stop at the SDK
+    call and the core tests start at volume_list.
+    """
+
+    @staticmethod
+    def _request_body(monkeypatch, url):
+        mock_schedule_async = mock.AsyncMock()
+        monkeypatch.setattr(executor, 'schedule_request_async',
+                            mock_schedule_async)
+        app = fastapi.FastAPI()
+        app.include_router(server.router, prefix='/volumes')
+        client = TestClient(app)
+        with mock.patch.object(fastapi.Request, 'state') as mock_state:
+            mock_state.request_id = 'test-request-id'
+            mock_state.auth_user = None
+            assert client.get(url).status_code == 200
+        return mock_schedule_async.call_args[1]['request_body']
+
+    def test_repeated_names_arrive_as_a_list(self, monkeypatch):
+        body = self._request_body(monkeypatch, '/volumes?names=a&names=b')
+
+        assert body.volume_names == ['a', 'b']
+
+    def test_no_names_means_every_volume(self, monkeypatch):
+        """None, not [] -- an empty list would mean "no volumes"."""
+        body = self._request_body(monkeypatch, '/volumes')
+
+        assert body.volume_names is None
+
+    def test_the_body_field_matches_the_core_signature(self):
+        """to_kwargs() feeds the body straight into volume_list as kwargs, so a
+        field renamed on either side would only fail at request time."""
+        import inspect
+
+        from sky.volumes.server import core
+
+        kwargs = payloads.VolumeListBody(refresh=False,
+                                         volume_names=['a']).to_kwargs()
+        parameters = inspect.signature(core.volume_list).parameters
+        assert set(kwargs).issubset(set(parameters))
+        assert kwargs['volume_names'] == ['a']

--- a/tests/unit_tests/test_sky/volumes/test_server.py
+++ b/tests/unit_tests/test_sky/volumes/test_server.py
@@ -1,5 +1,6 @@
 """Unit tests for volume server API."""
 
+import inspect
 from unittest import mock
 
 import fastapi
@@ -683,12 +684,8 @@ class TestVolumeListNamesReachTheRequestBody:
     def test_the_body_field_matches_the_core_signature(self):
         """to_kwargs() feeds the body straight into volume_list as kwargs, so a
         field renamed on either side would only fail at request time."""
-        import inspect
-
-        from sky.volumes.server import core
-
         kwargs = payloads.VolumeListBody(refresh=False,
                                          volume_names=['a']).to_kwargs()
-        parameters = inspect.signature(core.volume_list).parameters
+        parameters = inspect.signature(server.core.volume_list).parameters
         assert set(kwargs).issubset(set(parameters))
         assert kwargs['volume_names'] == ['a']

--- a/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
+++ b/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
@@ -129,3 +129,56 @@ def test_refresh_is_scoped_to_the_accessible_workspaces(isolated_database):
             volumes_core.volume_list(refresh=True)
 
     volume_refresh.assert_called_once_with(volume_names=['vol-a'])
+
+
+def test_filters_to_the_given_names(isolated_database):
+    _seed_two_workspaces()
+
+    records = global_user_state.get_volumes(volume_names=['vol-a'])
+
+    assert [r['name'] for r in records] == ['vol-a']
+
+
+def test_a_name_outside_the_workspace_filter_returns_nothing(isolated_database):
+    """The filters compose, so a name cannot widen what the workspace filter
+    allows. Doing the name filter in a query of its own -- the shape
+    get_volumes_from_names has, which takes no workspaces_filter -- would
+    return the volume instead."""
+    _seed_two_workspaces()
+
+    records = global_user_state.get_volumes(workspaces_filter={'ws-a'},
+                                            volume_names=['vol-b'])
+
+    assert records == []
+
+
+def test_no_name_filter_returns_every_name(isolated_database):
+    """None means "do not filter by name"; the daemon and a bare listing rely
+    on it."""
+    _seed_two_workspaces()
+
+    records = global_user_state.get_volumes(volume_names=None)
+
+    assert sorted(r['name'] for r in records) == ['vol-a', 'vol-b']
+
+
+def test_an_empty_name_list_matches_nothing(isolated_database):
+    """[] is "these zero volumes", not "all of them" -- the same contract
+    get_volumes_from_names has, and what volume_refresh relies on to reconcile
+    nothing when the caller can see nothing."""
+    _seed_two_workspaces()
+
+    assert global_user_state.get_volumes(volume_names=[]) == []
+
+
+def test_names_are_chunked_but_all_are_returned(isolated_database, monkeypatch):
+    """A long name list is split across queries; every match must still come
+    back exactly once."""
+    monkeypatch.setattr(global_user_state, '_CLUSTER_IN_QUERY_CHUNK_SIZE', 2)
+    for i in range(5):
+        _add(f'vol-{i}', workspace='ws-a')
+
+    records = global_user_state.get_volumes(
+        volume_names=[f'vol-{i}' for i in range(5)])
+
+    assert sorted(r['name'] for r in records) == [f'vol-{i}' for i in range(5)]


### PR DESCRIPTION
## Summary

`sky volumes apply` returns as soon as the backing resource is created, which is not the same as it being mountable. With an Immediate-binding storage class the PersistentVolume is provisioned asynchronously, so the claim is still Pending — the volume recorded `NOT_READY` — when the command returns, and a launch against it in that window is refused with `VolumeNotReadyError`.

Three changes, all about making that state cheap to observe:

- **`volume_apply` reports the status it recorded.** It already computes it, and threw it away.
- **`sky volumes ls [NAMES...]`** — names narrow the listing and, with `--refresh`, narrow the reconcile to those volumes.
- **`sky volumes ls -o json`** — joins the six commands already carrying `flags.output_format_option()`.

## Why not `apply --wait`

It was the first thing considered, and it is the wrong answer twice over:

- Under **WaitForFirstConsumer**, now the common case, the wait would return the moment it started. The claim stays Pending until a pod needs it, so nothing has been provisioned and the "ready" it reported guarantees nothing — worse than no flag.
- On the **Immediate** classes where a wait would mean something, an RWX filesystem legitimately takes minutes. That is exactly when the user should be free to go do something else.

Every mature CLI here (`kubectl wait`, `aws ec2 wait`) makes waiting a separate verb rather than a flag on create, and none of them reports a resource as created while it is still coming up — `kubectl` shows `Pending`. This brings us back to that line.

## `volume_apply` output

Before, regardless of what it had just recorded:

```
Created volume my-vol on cloud kubernetes
```

After, when the recorded status is `NOT_READY`:

```
Created volume my-vol on cloud kubernetes. It is not ready to be mounted yet. PVC is
pending: the PersistentVolume is still being provisioned. If this does not resolve, the
storage class may be misconfigured or the cluster may be out of storage capacity. To
debug, run: kubectl describe pvc my-vol-... -n my-ns
Check its status with: sky volumes ls my-vol -r
```

A `READY` volume is unchanged.

## Composition with the workspace filter

#10531 filtered the listing to the caller's readable workspaces and scoped its refresh to that set. Requested names are a *second, narrower* scope, and they compose in one direction only: the accessible workspaces are resolved first, and the names narrow within them. Naming a volume in a workspace the caller holds no grant on returns nothing, and is not reconciled either — which would otherwise confirm it exists.

Reading the named volumes straight from `get_volumes_from_names` would have bypassed that, since that function has no `workspaces_filter` of its own. The listing filters the workspace-scoped rows in place instead.

## No `API_VERSION` bump

`names` is an optional query parameter. An API server that predates it ignores it — verified: it answers `200`, not `422` — and returns everything, so the client narrows the response itself. The result is identical either way, so there is nothing to warn the user about, and a bump would only buy the ability to report a difference they cannot act on, at the cost of moving a constant shared with the plugin repo.

The client-side narrowing is what makes that safe, so it has its own test against an unfiltered response.

## Test plan

**Unit.** Both `apply` branches; the scoped refresh; the name filter; the json fields; the workspace-composition guard. Reverting any of the production changes fails its test — checked by actually reverting each, not by inspection. The workspace guard needed a second pass: it first passed against a deliberate bypass, because the bypass path called a function the fixture had not stubbed and hit an empty test DB. The fixture now stubs `get_volumes_from_names` as faithfully as the real one, so a bypass shows up as a leak.

**End to end**, two local API servers side by side (old and new code, separate state), against a GKE cluster with both binding modes:

| client | server | result |
|---|---|---|
| new | new | all three changes work; `volume_names` reaches the server; server-side narrowing |
| new | old | correct — server returns everything, client narrows to the exact name |
| old | new | unchanged full listing, cached and `-r` paths |
| old | old | baseline: `Created volume X` with no readiness signal |

Both P0 branches were exercised on real storage classes rather than a fixture: on `standard-rwo` (WaitForFirstConsumer) the PVC was genuinely `Pending` and is still reported as plainly created, and on `standard` (Immediate) the new message appears. A naive "Pending ⇒ warn" would have been wrong on the first.

The name filter was checked against a decoy volume whose name contains the requested one, on both servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->