### PR TITLE
[Server] Never regenerate the JWT signing secret on a DB read failure

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3573,6 +3573,14 @@ def get_all_service_account_tokens() -> List[Dict[str, Any]]:
 
 
 @metrics_lib.time_me
+def count_service_account_tokens() -> int:
+    """Number of service account token rows."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        return session.query(service_account_token_table).count()
+
+
+@metrics_lib.time_me
 def get_system_config(config_key: str) -> Optional[str]:
     """Get a system configuration value by key."""
     engine = _db_manager.get_engine()
@@ -3584,27 +3592,34 @@ def get_system_config(config_key: str) -> Optional[str]:
     return row.config_value
 
 
+def _system_config_insert(engine: sqlalchemy.engine.Engine, config_key: str,
+                          config_value: str, current_time: int):
+    """A dialect-appropriate INSERT for one system_config row.
+
+    The caller adds the ON CONFLICT clause that distinguishes overwriting from
+    insert-if-absent.
+    """
+    if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
+        insert_func = sqlite.insert
+    elif engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value:
+        insert_func = postgresql.insert
+    else:
+        raise ValueError('Unsupported database dialect')
+    return insert_func(system_config_table).values(config_key=config_key,
+                                                   config_value=config_value,
+                                                   created_at=current_time,
+                                                   updated_at=current_time)
+
+
 @metrics_lib.time_me
 def set_system_config(config_key: str, config_value: str) -> None:
-    """Set a system configuration value."""
+    """Set a system configuration value, overwriting any existing one."""
     engine = _db_manager.get_engine()
     current_time = int(time.time())
 
     with orm.Session(engine) as session:
-        if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
-            insert_func = sqlite.insert
-        elif (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
-             ):
-            insert_func = postgresql.insert
-        else:
-            raise ValueError('Unsupported database dialect')
-
-        insert_stmnt = insert_func(system_config_table).values(
-            config_key=config_key,
-            config_value=config_value,
-            created_at=current_time,
-            updated_at=current_time)
-
+        insert_stmnt = _system_config_insert(engine, config_key, config_value,
+                                             current_time)
         upsert_stmnt = insert_stmnt.on_conflict_do_update(
             index_elements=[system_config_table.c.config_key],
             set_={
@@ -3630,20 +3645,8 @@ def get_or_set_system_config(config_key: str, config_value: str) -> str:
     current_time = int(time.time())
 
     with orm.Session(engine) as session:
-        if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
-            insert_func = sqlite.insert
-        elif (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
-             ):
-            insert_func = postgresql.insert
-        else:
-            raise ValueError('Unsupported database dialect')
-
-        insert_stmnt = insert_func(system_config_table).values(
-            config_key=config_key,
-            config_value=config_value,
-            created_at=current_time,
-            updated_at=current_time)
-
+        insert_stmnt = _system_config_insert(engine, config_key, config_value,
+                                             current_time)
         session.execute(
             insert_stmnt.on_conflict_do_nothing(
                 index_elements=[system_config_table.c.config_key]))

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3615,6 +3615,51 @@ def set_system_config(config_key: str, config_value: str) -> None:
         session.commit()
 
 
+@metrics_lib.time_me
+def get_or_set_system_config(config_key: str, config_value: str) -> str:
+    """Read a system configuration value, inserting `config_value` if absent.
+
+    Returns the value that is live in the database after the call, which is
+    the pre-existing one whenever a row was already there -- callers must use
+    the return value rather than assume `config_value` won. Unlike
+    `set_system_config` this can never overwrite, so servers racing to
+    bootstrap the same key converge on a single value. Use it for keys others
+    already depend on, where losing the original is not recoverable.
+    """
+    engine = _db_manager.get_engine()
+    current_time = int(time.time())
+
+    with orm.Session(engine) as session:
+        if engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
+            insert_func = sqlite.insert
+        elif (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
+             ):
+            insert_func = postgresql.insert
+        else:
+            raise ValueError('Unsupported database dialect')
+
+        insert_stmnt = insert_func(system_config_table).values(
+            config_key=config_key,
+            config_value=config_value,
+            created_at=current_time,
+            updated_at=current_time)
+
+        session.execute(
+            insert_stmnt.on_conflict_do_nothing(
+                index_elements=[system_config_table.c.config_key]))
+        session.commit()
+
+        # Read back rather than trusting `config_value`: on conflict the row
+        # kept whatever the winner wrote, and that is the value callers must
+        # use.
+        row = session.query(system_config_table).filter_by(
+            config_key=config_key).first()
+    if row is None:
+        raise RuntimeError(f'System config {config_key!r} is missing right '
+                           'after inserting it; it was concurrently deleted.')
+    return row.config_value
+
+
 def get_max_db_connections() -> Optional[int]:
     """Get the maximum number of connections for the engine."""
     engine = _db_manager.get_engine()

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -169,6 +169,24 @@ def role_seed_unavailable_response() -> fastapi.responses.JSONResponse:
         })
 
 
+def jwt_secret_unavailable_response() -> fastapi.responses.JSONResponse:
+    """503 for service-account auth that cannot load its signing secret.
+
+    Not a 401: the token is well-formed and the server simply cannot reach the
+    secret to check it. A 401 reads as "this credential is bad" and pushes
+    operators to rotate tokens over what is a transient database problem.
+    """
+    return fastapi.responses.JSONResponse(
+        status_code=503,
+        headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
+        content={
+            'detail': ('Service account authentication is temporarily '
+                       'unavailable: the token signing secret could not be '
+                       'read from the server database. Your token is still '
+                       'valid -- please try again.')
+        })
+
+
 def worker_exhausted_response() -> fastapi.responses.JSONResponse:
     """503 for auth-path work rejected by a saturated thread executor.
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4013,6 +4013,30 @@ def _init_or_restore_server_user_hash():
     apply_user_hash(user_hash)
 
 
+def _bootstrap_jwt_secret() -> None:
+    """Best-effort pre-fork bootstrap of the JWT signing secret.
+
+    Runs in the parent process before uvicorn forks its workers, so generation
+    happens exactly once and before any request exists rather than racing on
+    the first service-account request. Workers do not inherit the cache, so
+    each still reads the row lazily; that makes this an optimisation, not a
+    correctness requirement.
+
+    Hence best-effort. Unlike the database errors that already stop startup one
+    line above, a corrupt `jwt_secret` row is a service-account-auth problem,
+    and letting it abort startup would take the dashboard and every interactive
+    user down with it -- in a crashloop.
+    """
+    try:
+        token_service.token_service.ensure_secret_loaded()
+    except Exception:  # pylint: disable=broad-except
+        logger.error(
+            'Could not bootstrap the JWT signing secret at startup. Service '
+            'account authentication will retry on its first request; nothing '
+            'else is affected.',
+            exc_info=True)
+
+
 if __name__ == '__main__':
     # Raise the websockets library header limits before importing uvicorn.
     # The env vars are read by websockets.http11 and websockets.legacy.http
@@ -4074,13 +4098,8 @@ if __name__ == '__main__':
     # Restore the server user hash
     logger.info('Initializing server user hash')
     _init_or_restore_server_user_hash()
-    # Bootstrap the JWT signing secret here, in the parent process, before
-    # uvicorn forks its workers. Generation then happens exactly once and
-    # before any request exists, so no two workers can race to create it.
-    # Workers do not inherit the cache, so each still reads the row lazily on
-    # its first service-account-authenticated request.
     logger.info('Initializing JWT signing secret')
-    token_service.token_service.ensure_secret_loaded()
+    _bootstrap_jwt_secret()
     # Set up consolidation mode signal file. Needs global user state DB access
     # to check for existing controller clusters. Placed after user hash restore
     # to avoid accidentally using the wrong server hash.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -96,6 +96,7 @@ from sky.usage import usage_lib
 from sky.users import permission
 from sky.users import rbac
 from sky.users import server as users_rest
+from sky.users import token_service
 from sky.utils import admin_policy_utils
 from sky.utils import command_runner
 from sky.utils import common as common_lib
@@ -509,12 +510,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             return _bearer_auth_401_response(
                 {'detail': 'Service account authentication disabled'})
 
-        # Imported here rather than at module scope to avoid a circular
-        # import, and outside the `try` because the `except` clauses below
-        # name it.
-        # pylint: disable=import-outside-toplevel
-        from sky.users import token_service as token_service_lib
-        token_service = token_service_lib.token_service
+        service = token_service.token_service
 
         try:
             # Load the signing secret off the event loop and under the same
@@ -522,12 +518,19 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # service-account-authenticated request of a process this reads
             # the database, and every other DB call in this handler is
             # bounded for the reasons db_lookup's docstring gives.
-            await db_lookup.call_with_deadline(
-                token_service.ensure_secret_loaded)
+            #
+            # Gated, because after that first request this is an `is not None`
+            # check. The auth executor rejects rather than queues once its 32
+            # slots are in flight, so dispatching a no-op would let a request
+            # needing no database work be turned away with a worker-exhausted
+            # 503 -- on the scarcest resource in exactly the degraded-database
+            # conditions this path has to survive.
+            if not service.secret_loaded():
+                await db_lookup.call_with_deadline(service.ensure_secret_loaded)
 
             # Verify and decode JWT token. Pure CPU work now that the secret
             # is loaded.
-            payload = token_service.verify_token(sa_token)
+            payload = service.verify_token(sa_token)
 
             if payload is None:
                 logger.warning('Service account token verification failed')
@@ -630,7 +633,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             logger.error(f'Concurrent worker exhausted during service account '
                          f'auth: {e}')
             return db_lookup.worker_exhausted_response()
-        except token_service_lib.JWTSecretUnavailableError as e:
+        except token_service.JWTSecretUnavailableError as e:
             # Above the catch-all on purpose: a 401 would tell the caller its
             # token is bad and send it off to rotate credentials, when the
             # token is fine and the database is not.
@@ -4071,6 +4074,13 @@ if __name__ == '__main__':
     # Restore the server user hash
     logger.info('Initializing server user hash')
     _init_or_restore_server_user_hash()
+    # Bootstrap the JWT signing secret here, in the parent process, before
+    # uvicorn forks its workers. Generation then happens exactly once and
+    # before any request exists, so no two workers can race to create it.
+    # Workers do not inherit the cache, so each still reads the row lazily on
+    # its first service-account-authenticated request.
+    logger.info('Initializing JWT signing secret')
+    token_service.token_service.ensure_secret_loaded()
     # Set up consolidation mode signal file. Needs global user state DB access
     # to check for existing controller clusters. Placed after user hash restore
     # to avoid accidentally using the wrong server hash.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -509,12 +509,24 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             return _bearer_auth_401_response(
                 {'detail': 'Service account authentication disabled'})
 
-        try:
-            # Import here to avoid circular imports
-            # pylint: disable=import-outside-toplevel
-            from sky.users.token_service import token_service
+        # Imported here rather than at module scope to avoid a circular
+        # import, and outside the `try` because the `except` clauses below
+        # name it.
+        # pylint: disable=import-outside-toplevel
+        from sky.users import token_service as token_service_lib
+        token_service = token_service_lib.token_service
 
-            # Verify and decode JWT token
+        try:
+            # Load the signing secret off the event loop and under the same
+            # deadline as the lookups below. On the first
+            # service-account-authenticated request of a process this reads
+            # the database, and every other DB call in this handler is
+            # bounded for the reasons db_lookup's docstring gives.
+            await db_lookup.call_with_deadline(
+                token_service.ensure_secret_loaded)
+
+            # Verify and decode JWT token. Pure CPU work now that the secret
+            # is loaded.
             payload = token_service.verify_token(sa_token)
 
             if payload is None:
@@ -618,6 +630,12 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             logger.error(f'Concurrent worker exhausted during service account '
                          f'auth: {e}')
             return db_lookup.worker_exhausted_response()
+        except token_service_lib.JWTSecretUnavailableError as e:
+            # Above the catch-all on purpose: a 401 would tell the caller its
+            # token is bad and send it off to rotate credentials, when the
+            # token is fine and the database is not.
+            logger.error(f'Service account auth unavailable: {e}')
+            return db_lookup.jwt_secret_unavailable_response()
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'Service account authentication failed: {e}',
                          exc_info=True)
@@ -3983,9 +4001,12 @@ def _init_or_restore_server_user_hash():
         apply_user_hash(user_hash)
         return
 
-    # Initial deployment, generate a user hash and save it to the db.
-    user_hash = common_utils.get_user_hash()
-    global_user_state.set_system_config(_SERVER_USER_HASH_KEY, user_hash)
+    # Initial deployment. Insert-if-absent and apply whatever is live
+    # afterwards: replicas starting together would otherwise each generate a
+    # hash and the last write would win, leaving them disagreeing on the
+    # server id they have already applied locally.
+    user_hash = global_user_state.get_or_set_system_config(
+        _SERVER_USER_HASH_KEY, common_utils.get_user_hash())
     apply_user_hash(user_hash)
 
 

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -51,6 +51,25 @@ def _read_secret_from_db() -> Optional[str]:
         max_retries=_SECRET_READ_MAX_RETRIES)
 
 
+def _validated_secret(secret: str) -> str:
+    """Return `secret`, refusing an empty stored value.
+
+    An empty value is corruption and neither of the two cases the bootstrap
+    handles: generating over it would clobber whatever is really meant to be
+    there, and using it hands PyJWT a key it rejects (`InvalidKeyError`) on
+    every request. That is not an `InvalidTokenError`, so it escapes
+    `verify_token` and surfaces as a misleading 401.
+
+    Applied at each point a value is obtained rather than once at the end, so
+    a value about to be refused is never first announced as a healthy secret.
+    """
+    if not secret:
+        raise ValueError(f'System config {JWT_SECRET_DB_KEY!r} holds an empty '
+                         'value. Restore or delete the row to let the server '
+                         'bootstrap a secret.')
+    return secret
+
+
 def _warn_if_tokens_predate_new_secret() -> None:
     """Flag a freshly generated secret that orphans existing tokens.
 
@@ -140,26 +159,17 @@ class TokenService:
             secret = _read_secret_from_db()
             if secret is None:
                 candidate = secrets.token_urlsafe(64)
-                secret = global_user_state.get_or_set_system_config(
-                    JWT_SECRET_DB_KEY, candidate)
+                secret = _validated_secret(
+                    global_user_state.get_or_set_system_config(
+                        JWT_SECRET_DB_KEY, candidate))
                 if secret == candidate:
                     _warn_if_tokens_predate_new_secret()
                 else:
                     logger.info('Adopted the JWT signing secret stored '
                                 'concurrently by another API server.')
             else:
+                secret = _validated_secret(secret)
                 logger.debug('Retrieved existing JWT secret from database')
-            # One check for both exits above. An empty stored value is
-            # corruption and neither of the two cases this function handles:
-            # generating over it would clobber whatever is really meant to be
-            # there, and using it hands PyJWT a key it rejects
-            # (`InvalidKeyError`) on every request, which is not an
-            # `InvalidTokenError` and so surfaces as a misleading 401.
-            if not secret:
-                raise ValueError(
-                    f'System config {JWT_SECRET_DB_KEY!r} holds an empty '
-                    'value. Restore or delete the row to let the server '
-                    'bootstrap a secret.')
         except Exception as e:  # pylint: disable=broad-except
             # Never fall back to an in-memory secret: this process would sign
             # tokens nothing else -- including itself after a restart -- can

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -1,19 +1,17 @@
 """JWT-based service account token management for SkyPilot."""
 
-import contextlib
 import datetime
 import hashlib
 import secrets
 import threading
 import time
-from typing import Any, Dict, Generator, Optional
+from typing import Any, Dict, Optional
 
-import filelock
 import jwt
 
 from sky import global_user_state
 from sky import sky_logging
-from sky.skylet import runtime_utils
+from sky.utils.db import retries as db_retries
 
 logger = sky_logging.init_logger(__name__)
 
@@ -22,24 +20,59 @@ JWT_ALGORITHM = 'HS256'
 JWT_ISSUER = 'sky'  # Shortened for compact tokens
 JWT_SECRET_DB_KEY = 'jwt_secret'
 
-# File lock for JWT secret initialization
-JWT_SECRET_LOCK_PATH = runtime_utils.expanduser('~/.sky/.jwt_secret_init.lock')
-JWT_SECRET_LOCK_TIMEOUT_SECONDS = 20
+# Deliberately below `db_retries` default of 5. This read happens on the
+# request path, and the deadline in `db_lookup.call_with_deadline` releases the
+# caller but never the executor thread, so every extra attempt is another
+# multiple of the DB layer's own timeout that the thread stays held. Two
+# attempts ride out a single blip without turning one lookup into minutes.
+_SECRET_READ_MAX_RETRIES = 2
+
+# How long a thread waits for another thread's in-flight secret load. A healthy
+# load is one indexed query, so a waiting burst after a restart still gets
+# through; a load stuck on a degraded database releases its waiters here
+# instead of parking them on the lock for its whole duration, which would
+# convoy the auth executor.
+_SECRET_LOAD_LOCK_TIMEOUT_SECONDS = 2.0
 
 
-@contextlib.contextmanager
-def _jwt_secret_lock() -> Generator[None, None, None]:
-    """Context manager for JWT secret initialization lock."""
+class JWTSecretUnavailableError(Exception):
+    """The JWT signing secret could not be loaded from the database."""
+
+
+def _read_secret_from_db() -> Optional[str]:
+    """The persisted JWT secret, or None when the row does not exist.
+
+    Raises on a database failure. A failed read must never be reported as
+    "no secret exists yet": the caller would mint a replacement, and every
+    token already issued would stop verifying.
+    """
+    return db_retries.with_db_retries(
+        lambda _attempt: global_user_state.get_system_config(JWT_SECRET_DB_KEY),
+        max_retries=_SECRET_READ_MAX_RETRIES)
+
+
+def _warn_if_tokens_predate_new_secret() -> None:
+    """Flag a freshly generated secret that orphans existing tokens.
+
+    Generating the secret on a new deployment is routine. Generating one while
+    token rows already exist means those tokens can no longer be verified,
+    which should be impossible and is worth an alertable log line.
+    """
     try:
-        with filelock.FileLock(JWT_SECRET_LOCK_PATH,
-                               JWT_SECRET_LOCK_TIMEOUT_SECONDS):
-            yield
-    except filelock.Timeout as e:
-        raise RuntimeError(f'Failed to initialize JWT secret due to a timeout '
-                           f'when trying to acquire the lock at '
-                           f'{JWT_SECRET_LOCK_PATH}. '
-                           'Please try again or manually remove the lock '
-                           f'file if you believe it is stale.') from e
+        tokens = global_user_state.get_all_service_account_tokens()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Generated a new JWT signing secret; could not check '
+                       f'whether service account tokens predate it: {e}')
+        return
+    if tokens:
+        logger.error(
+            f'Generated a NEW JWT signing secret while {len(tokens)} service '
+            f'account token(s) already exist. Those tokens can no longer be '
+            f'verified and have to be rotated. This means the previous secret '
+            f'was lost from the database.')
+    else:
+        logger.info('Generated the JWT signing secret and stored it in the '
+                    'database. It persists across API server restarts.')
 
 
 class TokenService:
@@ -49,52 +82,82 @@ class TokenService:
         self.secret_key = None
         self.init_lock = threading.Lock()
 
+    def ensure_secret_loaded(self) -> None:
+        """Load the signing secret, generating it on a new deployment.
+
+        Blocks on the database. Callers on the request path should run this
+        off the event loop under a deadline before reaching `verify_token`,
+        which is then pure CPU work.
+
+        Raises:
+            JWTSecretUnavailableError: the secret could not be loaded. Nothing
+                is cached, so a later call retries.
+        """
+        self._lazy_initialize()
+
     def _lazy_initialize(self):
         if self.secret_key is not None:
             return
-        with self.init_lock:
+        if not self.init_lock.acquire(
+                timeout=_SECRET_LOAD_LOCK_TIMEOUT_SECONDS):
+            # Re-check before giving up: the holder may have finished within
+            # the last instant of the wait, and failing a caller whose secret
+            # is now loaded would 503 a request that can be served.
+            if self.secret_key is not None:
+                return
+            raise JWTSecretUnavailableError(
+                f'Another request is still loading the JWT signing secret '
+                f'after {_SECRET_LOAD_LOCK_TIMEOUT_SECONDS}s, which means the '
+                f'server database is not answering.')
+        try:
             if self.secret_key is not None:
                 return
             self.secret_key = self._get_or_generate_secret()
+        finally:
+            self.init_lock.release()
 
     def _get_or_generate_secret(self) -> str:
-        """Get JWT secret from database or generate a new one."""
+        """Get the JWT secret from the database, generating it if absent.
 
-        def _get_secret_from_db():
-            try:
-                db_secret = global_user_state.get_system_config(
-                    JWT_SECRET_DB_KEY)
-                if db_secret:
-                    logger.debug('Retrieved existing JWT secret from database')
-                    return db_secret
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to get JWT secret from database: {e}')
-            return None
-
-        # Try to get from database (persistent across deployments)
-        token_from_db = _get_secret_from_db()
-        if token_from_db:
-            return token_from_db
-
-        with _jwt_secret_lock():
-            token_from_db = _get_secret_from_db()
-            if token_from_db:
-                return token_from_db
-            # Generate a new secret and store in database
+        Generation happens only after a *successful* read found no row. A read
+        that raised is propagated: treating it as "absent" would overwrite the
+        live secret and invalidate every token already issued. The write is
+        insert-if-absent for the same reason, so a racing replica adopts the
+        stored secret instead of clobbering it.
+        """
+        try:
+            secret = _read_secret_from_db()
+            if secret:
+                logger.debug('Retrieved existing JWT secret from database')
+                return secret
+            if secret is not None:
+                # An empty stored value is corruption, and it is neither of the
+                # two cases this function handles. Generating would clobber
+                # whatever is really meant to be there, and adopting it would
+                # hand PyJWT a key it rejects (`InvalidKeyError`) on every
+                # single request, surfacing as a misleading 401.
+                raise ValueError(
+                    f'System config {JWT_SECRET_DB_KEY!r} holds an empty '
+                    'value. Restore or delete the row to let the server '
+                    'bootstrap a secret.')
             new_secret = secrets.token_urlsafe(64)
-            try:
-                global_user_state.set_system_config(JWT_SECRET_DB_KEY,
-                                                    new_secret)
-                logger.info(
-                    'Generated new JWT secret and stored in database. '
-                    'This secret will persist across API server restarts.')
-            except Exception as e:  # pylint: disable=broad-except
-                logger.warning(
-                    f'Failed to store new JWT secret in database: {e}. '
-                    f'Using in-memory secret (tokens will not persist '
-                    f'across restarts).')
-
-            return new_secret
+            stored = global_user_state.get_or_set_system_config(
+                JWT_SECRET_DB_KEY, new_secret)
+        except Exception as e:  # pylint: disable=broad-except
+            # Never fall back to an in-memory secret: this process would sign
+            # tokens nothing else -- including itself after a restart -- can
+            # verify.
+            logger.error(f'Failed to load the JWT signing secret: {e}',
+                         exc_info=True)
+            raise JWTSecretUnavailableError(
+                'The JWT signing secret could not be loaded from the server '
+                'database.') from e
+        if stored == new_secret:
+            _warn_if_tokens_predate_new_secret()
+        else:
+            logger.info('Adopted the JWT signing secret stored concurrently '
+                        'by another API server.')
+        return stored
 
     def create_token(self,
                      creator_user_id: str,

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -59,14 +59,16 @@ def _warn_if_tokens_predate_new_secret() -> None:
     which should be impossible and is worth an alertable log line.
     """
     try:
-        tokens = global_user_state.get_all_service_account_tokens()
+        # A count, not the rows: this runs while holding the load lock and an
+        # auth executor thread, against a database that may be degraded.
+        count = global_user_state.count_service_account_tokens()
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Generated a new JWT signing secret; could not check '
                        f'whether service account tokens predate it: {e}')
         return
-    if tokens:
+    if count:
         logger.error(
-            f'Generated a NEW JWT signing secret while {len(tokens)} service '
+            f'Generated a NEW JWT signing secret while {count} service '
             f'account token(s) already exist. Those tokens can no longer be '
             f'verified and have to be rotated. This means the previous secret '
             f'was lost from the database.')
@@ -81,6 +83,15 @@ class TokenService:
     def __init__(self):
         self.secret_key = None
         self.init_lock = threading.Lock()
+
+    def secret_loaded(self) -> bool:
+        """Whether the signing secret is already in memory.
+
+        Lets the request path skip dispatching `ensure_secret_loaded` to the
+        auth executor in the steady state. `secret_key` is assigned once and
+        never reassigned, so reading it unlocked is safe.
+        """
+        return self.secret_key is not None
 
     def ensure_secret_loaded(self) -> None:
         """Load the signing secret, generating it on a new deployment.
@@ -127,22 +138,28 @@ class TokenService:
         """
         try:
             secret = _read_secret_from_db()
-            if secret:
+            if secret is None:
+                candidate = secrets.token_urlsafe(64)
+                secret = global_user_state.get_or_set_system_config(
+                    JWT_SECRET_DB_KEY, candidate)
+                if secret == candidate:
+                    _warn_if_tokens_predate_new_secret()
+                else:
+                    logger.info('Adopted the JWT signing secret stored '
+                                'concurrently by another API server.')
+            else:
                 logger.debug('Retrieved existing JWT secret from database')
-                return secret
-            if secret is not None:
-                # An empty stored value is corruption, and it is neither of the
-                # two cases this function handles. Generating would clobber
-                # whatever is really meant to be there, and adopting it would
-                # hand PyJWT a key it rejects (`InvalidKeyError`) on every
-                # single request, surfacing as a misleading 401.
+            # One check for both exits above. An empty stored value is
+            # corruption and neither of the two cases this function handles:
+            # generating over it would clobber whatever is really meant to be
+            # there, and using it hands PyJWT a key it rejects
+            # (`InvalidKeyError`) on every request, which is not an
+            # `InvalidTokenError` and so surfaces as a misleading 401.
+            if not secret:
                 raise ValueError(
                     f'System config {JWT_SECRET_DB_KEY!r} holds an empty '
                     'value. Restore or delete the row to let the server '
                     'bootstrap a secret.')
-            new_secret = secrets.token_urlsafe(64)
-            stored = global_user_state.get_or_set_system_config(
-                JWT_SECRET_DB_KEY, new_secret)
         except Exception as e:  # pylint: disable=broad-except
             # Never fall back to an in-memory secret: this process would sign
             # tokens nothing else -- including itself after a restart -- can
@@ -152,12 +169,7 @@ class TokenService:
             raise JWTSecretUnavailableError(
                 'The JWT signing secret could not be loaded from the server '
                 'database.') from e
-        if stored == new_secret:
-            _warn_if_tokens_predate_new_secret()
-        else:
-            logger.info('Adopted the JWT signing secret stored concurrently '
-                        'by another API server.')
-        return stored
+        return secret
 
     def create_token(self,
                      creator_user_id: str,

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -709,6 +709,45 @@ class TestBearerTokenMiddleware:
                 f'asyncio.to_thread).')
 
     @pytest.mark.asyncio
+    async def test_loaded_secret_costs_no_executor_dispatch(
+            self, middleware, base_mock_request, mock_call_next,
+            mock_token_row):
+        """Once the secret is loaded, the request must not dispatch at all.
+
+        The auth executor rejects rather than queues past its 32 in-flight
+        slots, so a no-op dispatch can turn away a request that needs no
+        database work -- while the database is degraded, which is when that
+        matters most.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+        mock_user_info = mock.Mock()
+        mock_user_info.name = 'test-service-account'
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash',
+                           return_value=mock_token_row), \
+                mock.patch('sky.global_user_state.get_user',
+                           return_value=mock_user_info):
+
+            mock_token_service.secret_loaded.return_value = True
+            mock_token_service.verify_token.return_value = mock_payload
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 200
+            mock_token_service.ensure_secret_loaded.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_secret_unavailable_is_503_not_401(self, middleware,
                                                      base_mock_request,
                                                      mock_call_next):
@@ -724,6 +763,7 @@ class TestBearerTokenMiddleware:
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service:
 
+            mock_token_service.secret_loaded.return_value = False
             mock_token_service.ensure_secret_loaded.side_effect = (
                 token_service_lib.JWTSecretUnavailableError('db down'))
 
@@ -749,6 +789,7 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
                 mock.patch.object(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.05):
 
+            mock_token_service.secret_loaded.return_value = False
             mock_token_service.ensure_secret_loaded.side_effect = _blocking(
                 None)
 
@@ -784,6 +825,7 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.global_user_state.get_user',
                            return_value=mock_user_info):
 
+            mock_token_service.secret_loaded.return_value = False
             mock_token_service.ensure_secret_loaded.side_effect = _blocking(
                 None)
             mock_token_service.verify_token.return_value = mock_payload

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -8,9 +8,11 @@ import unittest.mock as mock
 import fastapi
 import pytest
 
+from sky.server.auth import db_lookup
 from sky.server.server import _SA_LAST_USED_UPDATE_INTERVAL_SECONDS
 from sky.server.server import BearerTokenMiddleware
 from sky.skylet import constants
+from sky.users import token_service as token_service_lib
 
 # The service-account auth path runs on the request event loop for every
 # request, so its DB lookups must be offloaded. A slow (mocked) DB call that
@@ -705,3 +707,99 @@ class TestBearerTokenMiddleware:
                 f'were in flight — the service-account user/token lookups run '
                 f'synchronously on the request loop. Offload them (e.g. '
                 f'asyncio.to_thread).')
+
+    @pytest.mark.asyncio
+    async def test_secret_unavailable_is_503_not_401(self, middleware,
+                                                     base_mock_request,
+                                                     mock_call_next):
+        """A DB failure loading the signing secret must not read as a bad token.
+
+        A 401 tells the caller its credential is invalid and sends operators
+        off to rotate tokens, when the token is fine and the database is not.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service:
+
+            mock_token_service.ensure_secret_loaded.side_effect = (
+                token_service_lib.JWTSecretUnavailableError('db down'))
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 503
+            assert 'Retry-After' in response.headers
+            assert 'Your token is still valid' in response.body.decode()
+            # The token was never even looked at.
+            mock_token_service.verify_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_secret_load_timeout_is_503(self, middleware,
+                                              base_mock_request,
+                                              mock_call_next):
+        """A secret load that outlives the auth deadline gets the same 503."""
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch.object(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.05):
+
+            mock_token_service.ensure_secret_loaded.side_effect = _blocking(
+                None)
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_secret_load_does_not_block_event_loop(
+            self, middleware, base_mock_request, mock_call_next,
+            mock_token_row):
+        """The secret load is a DB read too, and runs on the first
+        SA-authenticated request of a process. It must be offloaded like the
+        lookups around it.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+        mock_user_info = mock.Mock()
+        mock_user_info.name = 'test-service-account'
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash',
+                           return_value=mock_token_row), \
+                mock.patch('sky.global_user_state.get_user',
+                           return_value=mock_user_info):
+
+            mock_token_service.ensure_secret_loaded.side_effect = _blocking(
+                None)
+            mock_token_service.verify_token.return_value = mock_payload
+
+            stop = asyncio.Event()
+            monitor = asyncio.create_task(_measure_max_loop_lag(stop))
+            await asyncio.sleep(0.05)
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            stop.set()
+            worst_lag = await monitor
+
+            assert response.status_code == 200
+            assert worst_lag < _MAX_ACCEPTABLE_LOOP_LAG_SECONDS, (
+                f'Loading the JWT signing secret starved the event loop for '
+                f'{worst_lag:.2f}s. Run it on the auth executor via '
+                f'db_lookup.call_with_deadline.')

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1455,17 +1455,16 @@ class TestJwtSecretStartupBootstrap:
     """
 
     def test_a_failed_bootstrap_does_not_abort_startup(self):
-        with mock.patch(
-                'sky.users.token_service.token_service') as mock_token_service:
+        """And says so. Swallowing it silently leaves service-account auth
+        degraded with nothing pointing at the corrupt row.
+        """
+        with mock.patch('sky.users.token_service.token_service'
+                       ) as mock_token_service, \
+                mock.patch.object(server, 'logger') as mock_logger:
             mock_token_service.ensure_secret_loaded.side_effect = (
                 token_service.JWTSecretUnavailableError('corrupt row'))
 
             server._bootstrap_jwt_secret()
 
             mock_token_service.ensure_secret_loaded.assert_called_once()
-
-    def test_a_healthy_bootstrap_loads_the_secret(self):
-        with mock.patch(
-                'sky.users.token_service.token_service') as mock_token_service:
-            server._bootstrap_jwt_secret()
-            mock_token_service.ensure_secret_loaded.assert_called_once()
+            mock_logger.error.assert_called_once()

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1404,3 +1404,42 @@ def test_api_stream_log_path_admin_only(_request_authz_env, monkeypatch):
                       headers={
                           'user-agent': 'curl'
                       }).status_code == 404
+
+
+class TestServerUserHashBootstrap:
+    """The server user hash must not be clobbered by a racing replica.
+
+    Replicas apply the hash locally after writing it, so an overwriting write
+    leaves them disagreeing on the server id they have already applied.
+    """
+
+    def test_bootstrap_adopts_the_stored_hash(self):
+        with mock.patch('sky.global_user_state.get_system_config',
+                        return_value=None), \
+                mock.patch('sky.global_user_state.get_or_set_system_config',
+                           return_value='hash-from-the-other-replica') as m, \
+                mock.patch('sky.global_user_state.set_system_config') as m_set, \
+                mock.patch('sky.utils.common_utils.get_user_hash',
+                           return_value='our-own-hash'), \
+                mock.patch('sky.utils.common_utils.set_user_hash_locally') as m_apply, \
+                mock.patch('sky.utils.common.refresh_server_id'):
+
+            server._init_or_restore_server_user_hash()
+
+            m.assert_called_once()
+            # Never the overwriting variant.
+            m_set.assert_not_called()
+            # Applied locally: the winner's hash, not the one we generated.
+            m_apply.assert_called_once_with('hash-from-the-other-replica')
+
+    def test_existing_hash_is_reused_without_a_write(self):
+        with mock.patch('sky.global_user_state.get_system_config',
+                        return_value='existing-hash'), \
+                mock.patch('sky.global_user_state.get_or_set_system_config') as m, \
+                mock.patch('sky.utils.common_utils.set_user_hash_locally') as m_apply, \
+                mock.patch('sky.utils.common.refresh_server_id'):
+
+            server._init_or_restore_server_user_hash()
+
+            m.assert_not_called()
+            m_apply.assert_called_once_with('existing-hash')

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -19,6 +19,7 @@ from sky.server import constants as server_constants
 from sky.server import server
 from sky.server.requests import executor
 from sky.skylet import constants
+from sky.users import token_service
 from sky.utils import common_utils
 from sky.utils import config_utils
 
@@ -1443,3 +1444,28 @@ class TestServerUserHashBootstrap:
 
             m.assert_not_called()
             m_apply.assert_called_once_with('existing-hash')
+
+
+class TestJwtSecretStartupBootstrap:
+    """Pre-forking the secret is an optimisation, not a startup requirement.
+
+    Workers still load it lazily, so a corrupt row must not crashloop the whole
+    server and take the dashboard and every interactive user down with
+    service-account auth.
+    """
+
+    def test_a_failed_bootstrap_does_not_abort_startup(self):
+        with mock.patch(
+                'sky.users.token_service.token_service') as mock_token_service:
+            mock_token_service.ensure_secret_loaded.side_effect = (
+                token_service.JWTSecretUnavailableError('corrupt row'))
+
+            server._bootstrap_jwt_secret()
+
+            mock_token_service.ensure_secret_loaded.assert_called_once()
+
+    def test_a_healthy_bootstrap_loads_the_secret(self):
+        with mock.patch(
+                'sky.users.token_service.token_service') as mock_token_service:
+            server._bootstrap_jwt_secret()
+            mock_token_service.ensure_secret_loaded.assert_called_once()

--- a/tests/unit_tests/test_sky/test_global_user_state_system_config.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_system_config.py
@@ -1,0 +1,71 @@
+"""Unit tests for system_config accessors in global_user_state."""
+from sqlalchemy import orm
+
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file.
+
+    Same construction as `sky/global_user_state.py` (including
+    `post_init_fn`), against a location derived from `SKY_RUNTIME_DIR`.
+    """
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+def _row(config_key):
+    engine = global_user_state._db_manager.get_engine()
+    with orm.Session(engine) as session:
+        return session.query(global_user_state.system_config_table).filter_by(
+            config_key=config_key).first()
+
+
+def test_get_or_set_inserts_when_missing(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    assert global_user_state.get_or_set_system_config('k', 'v1') == 'v1'
+    assert global_user_state.get_system_config('k') == 'v1'
+
+
+def test_get_or_set_never_overwrites(tmp_path, monkeypatch):
+    """The whole point: the loser of a race adopts the winner's value.
+
+    Overwriting a signing secret here is unrecoverable -- every token already
+    issued stops verifying.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    global_user_state.get_or_set_system_config('k', 'first')
+    before = _row('k')
+
+    assert global_user_state.get_or_set_system_config('k', 'second') == 'first'
+
+    after = _row('k')
+    assert after.config_value == 'first'
+    assert after.updated_at == before.updated_at
+    assert after.created_at == before.created_at
+
+
+def test_set_system_config_still_overwrites(tmp_path, monkeypatch):
+    """`set_system_config` keeps its upsert semantics for other callers."""
+    _fresh_db(tmp_path, monkeypatch)
+    global_user_state.set_system_config('k', 'first')
+    global_user_state.set_system_config('k', 'second')
+    assert global_user_state.get_system_config('k') == 'second'
+
+
+def test_get_or_set_is_per_key(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    global_user_state.get_or_set_system_config('a', '1')
+    assert global_user_state.get_or_set_system_config('b', '2') == '2'
+    assert global_user_state.get_system_config('a') == '1'

--- a/tests/unit_tests/test_sky/test_global_user_state_system_config.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_system_config.py
@@ -69,3 +69,17 @@ def test_get_or_set_is_per_key(tmp_path, monkeypatch):
     global_user_state.get_or_set_system_config('a', '1')
     assert global_user_state.get_or_set_system_config('b', '2') == '2'
     assert global_user_state.get_system_config('a') == '1'
+
+
+def test_count_service_account_tokens(tmp_path, monkeypatch):
+    """The orphan-token alarm counts rows instead of loading them."""
+    _fresh_db(tmp_path, monkeypatch)
+    assert global_user_state.count_service_account_tokens() == 0
+
+    global_user_state.add_service_account_token(token_id='t1',
+                                                token_name='ci',
+                                                token_hash='h1',
+                                                creator_user_hash='alice',
+                                                service_account_user_id='sa-1',
+                                                expires_at=None)
+    assert global_user_state.count_service_account_tokens() == 1

--- a/tests/unit_tests/test_sky/users/test_token_service.py
+++ b/tests/unit_tests/test_sky/users/test_token_service.py
@@ -22,7 +22,7 @@ class TestTokenService:
             mock_global_state.get_system_config.return_value = None
             mock_global_state.get_or_set_system_config.side_effect = (
                 lambda _key, value: value)
-            mock_global_state.get_all_service_account_tokens.return_value = []
+            mock_global_state.count_service_account_tokens.return_value = 0
 
             service = token_service.TokenService()
 
@@ -482,29 +482,29 @@ class TestSecretBootstrap:
             mock_global_state.set_system_config.assert_not_called()
 
     @staticmethod
-    def _bootstrap_with_existing_tokens(existing_tokens):
-        """Bootstrap a secret against a DB holding `existing_tokens`."""
+    def _bootstrap_with_existing_tokens(existing_token_count):
+        """Bootstrap a secret against a DB holding that many token rows."""
         with mock.patch('sky.users.token_service.global_user_state'
                        ) as mock_global_state:
             mock_global_state.get_system_config.return_value = None
             mock_global_state.get_or_set_system_config.side_effect = (
                 lambda _key, value: value)
-            mock_global_state.get_all_service_account_tokens.return_value = (
-                existing_tokens)
+            mock_global_state.count_service_account_tokens.return_value = (
+                existing_token_count)
             with mock.patch.object(token_service, 'logger') as mock_logger:
                 token_service.TokenService().ensure_secret_loaded()
             return mock_logger
 
     def test_generating_over_existing_tokens_logs_error(self):
         """The alertable case: a new secret orphans tokens that already exist."""
-        mock_logger = self._bootstrap_with_existing_tokens([{'token_id': 't1'}])
+        mock_logger = self._bootstrap_with_existing_tokens(1)
         mock_logger.error.assert_called_once()
         assert ('NEW JWT signing secret while 1 service'
                 in mock_logger.error.call_args[0][0])
 
     def test_first_time_bootstrap_does_not_log_error(self):
         """A brand-new deployment generating the secret is routine."""
-        mock_logger = self._bootstrap_with_existing_tokens([])
+        mock_logger = self._bootstrap_with_existing_tokens(0)
         mock_logger.error.assert_not_called()
 
     def test_waiting_on_a_stuck_load_gives_up(self):
@@ -568,6 +568,23 @@ class TestSecretBootstrap:
 
         assert service.secret_key == 'loaded-by-the-holder'
 
+    def test_empty_secret_adopted_from_a_race_is_rejected_too(self):
+        """The guard must cover the adopt exit, not only the read exit.
+
+        The read says "no row", then the insert loses to a writer that stored
+        an empty value, so the read-back hands one back. Caching it would sign
+        and verify with a key PyJWT rejects on every request.
+        """
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = None
+            mock_global_state.get_or_set_system_config.return_value = ''
+
+            service = token_service.TokenService()
+            with pytest.raises(token_service.JWTSecretUnavailableError):
+                service.ensure_secret_loaded()
+            assert service.secret_key is None
+
     def test_empty_stored_secret_is_corruption_not_absence(self):
         """An empty row must not be treated as "no secret yet".
 
@@ -584,6 +601,18 @@ class TestSecretBootstrap:
 
             mock_global_state.get_or_set_system_config.assert_not_called()
             assert service.secret_key is None
+
+    def test_secret_loaded_predicate_tracks_the_cache(self):
+        """The request path gates its executor dispatch on this."""
+        existing = secrets.token_urlsafe(32)
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = existing
+
+            service = token_service.TokenService()
+            assert not service.secret_loaded()
+            service.ensure_secret_loaded()
+            assert service.secret_loaded()
 
     def test_loaded_secret_needs_no_further_db_calls(self):
         """The steady state stays off the database."""

--- a/tests/unit_tests/test_sky/users/test_token_service.py
+++ b/tests/unit_tests/test_sky/users/test_token_service.py
@@ -568,6 +568,25 @@ class TestSecretBootstrap:
 
         assert service.secret_key == 'loaded-by-the-holder'
 
+    def test_a_refused_secret_is_never_announced_as_healthy(self):
+        """Validation must precede the log line, not follow it.
+
+        Announcing an adopted secret and then refusing it leaves an operator
+        debugging exactly this corruption reading a success line first.
+        """
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = None
+            mock_global_state.get_or_set_system_config.return_value = ''
+
+            service = token_service.TokenService()
+            with mock.patch.object(token_service, 'logger') as mock_logger:
+                with pytest.raises(token_service.JWTSecretUnavailableError):
+                    service.ensure_secret_loaded()
+
+            assert not any(
+                'Adopted' in str(c) for c in mock_logger.info.mock_calls)
+
     def test_empty_secret_adopted_from_a_race_is_rejected_too(self):
         """The guard must cover the adopt exit, not only the read exit.
 

--- a/tests/unit_tests/test_sky/users/test_token_service.py
+++ b/tests/unit_tests/test_sky/users/test_token_service.py
@@ -2,10 +2,12 @@
 
 import datetime
 import secrets
+import threading
 import time
 from unittest import mock
 
 import pytest
+import sqlalchemy.exc
 
 from sky.users import token_service
 
@@ -18,7 +20,9 @@ class TestTokenService:
         with mock.patch('sky.users.token_service.global_user_state'
                        ) as mock_global_state:
             mock_global_state.get_system_config.return_value = None
-            mock_global_state.set_system_config = mock.Mock()
+            mock_global_state.get_or_set_system_config.side_effect = (
+                lambda _key, value: value)
+            mock_global_state.get_all_service_account_tokens.return_value = []
 
             service = token_service.TokenService()
 
@@ -27,7 +31,9 @@ class TestTokenService:
             service._lazy_initialize()
             assert service.secret_key is not None
             assert len(service.secret_key) >= 32  # Ensure sufficient entropy
-            mock_global_state.set_system_config.assert_called_once()
+            mock_global_state.get_or_set_system_config.assert_called_once()
+            # Bootstrap must never take the overwriting path.
+            mock_global_state.set_system_config.assert_not_called()
 
     def test_token_service_existing_secret(self):
         """Test TokenService initialization with existing secret."""
@@ -394,3 +400,201 @@ class TestTokenService:
             assert captured_payload['u'] == 'sa123'  # service account user ID
             assert 'k' in captured_payload  # token ID
             assert captured_payload['y'] == 'sa'  # type
+
+
+class TestSecretBootstrap:
+    """The signing secret must survive a database failure.
+
+    A read that raised used to be indistinguishable from "no secret yet", so
+    the server minted a replacement and overwrote the live one, permanently
+    invalidating every token already issued.
+    """
+
+    @staticmethod
+    def _db_error() -> Exception:
+        # What pgbouncer pool starvation looks like from SQLAlchemy.
+        return sqlalchemy.exc.OperationalError(
+            'SELECT config_value FROM system_config', {},
+            Exception('server closed the connection unexpectedly'))
+
+    def test_read_error_never_generates(self):
+        """A failed read must not write anything, and must not be cached."""
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.side_effect = self._db_error()
+
+            service = token_service.TokenService()
+            with pytest.raises(token_service.JWTSecretUnavailableError):
+                service.ensure_secret_loaded()
+
+            mock_global_state.get_or_set_system_config.assert_not_called()
+            mock_global_state.set_system_config.assert_not_called()
+            # Nothing cached, so a later call retries instead of the process
+            # being stuck on a secret nobody else knows.
+            assert service.secret_key is None
+
+    def test_transient_read_error_recovers(self):
+        """One blip then success adopts the persisted secret, writing nothing."""
+        existing = secrets.token_urlsafe(32)
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.side_effect = [
+                self._db_error(), existing
+            ]
+
+            service = token_service.TokenService()
+            with mock.patch('sky.utils.db.retries.time.sleep'):
+                service.ensure_secret_loaded()
+
+            assert service.secret_key == existing
+            mock_global_state.get_or_set_system_config.assert_not_called()
+
+    def test_write_error_is_not_cached_in_memory(self):
+        """A failed write must raise, not leave an unpersisted secret behind.
+
+        Signing with a secret no other process (nor this one after a restart)
+        can read produces tokens that are permanently unverifiable.
+        """
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = None
+            mock_global_state.get_or_set_system_config.side_effect = (
+                self._db_error())
+
+            service = token_service.TokenService()
+            with pytest.raises(token_service.JWTSecretUnavailableError):
+                service.ensure_secret_loaded()
+            assert service.secret_key is None
+
+    def test_lost_race_adopts_the_stored_secret(self):
+        """Another replica won the insert; we must use its value, not ours."""
+        winner = secrets.token_urlsafe(32)
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = None
+            mock_global_state.get_or_set_system_config.return_value = winner
+
+            service = token_service.TokenService()
+            service.ensure_secret_loaded()
+
+            assert service.secret_key == winner
+            # The candidate we generated is discarded, not written anywhere.
+            mock_global_state.set_system_config.assert_not_called()
+
+    @staticmethod
+    def _bootstrap_with_existing_tokens(existing_tokens):
+        """Bootstrap a secret against a DB holding `existing_tokens`."""
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = None
+            mock_global_state.get_or_set_system_config.side_effect = (
+                lambda _key, value: value)
+            mock_global_state.get_all_service_account_tokens.return_value = (
+                existing_tokens)
+            with mock.patch.object(token_service, 'logger') as mock_logger:
+                token_service.TokenService().ensure_secret_loaded()
+            return mock_logger
+
+    def test_generating_over_existing_tokens_logs_error(self):
+        """The alertable case: a new secret orphans tokens that already exist."""
+        mock_logger = self._bootstrap_with_existing_tokens([{'token_id': 't1'}])
+        mock_logger.error.assert_called_once()
+        assert ('NEW JWT signing secret while 1 service'
+                in mock_logger.error.call_args[0][0])
+
+    def test_first_time_bootstrap_does_not_log_error(self):
+        """A brand-new deployment generating the secret is routine."""
+        mock_logger = self._bootstrap_with_existing_tokens([])
+        mock_logger.error.assert_not_called()
+
+    def test_waiting_on_a_stuck_load_gives_up(self):
+        """A load stuck on a degraded DB must release its waiters.
+
+        Waiters park on `init_lock` while holding an auth executor thread, so
+        an unbounded wait convoys authentication for every other request.
+
+        Driven from a worker thread and joined with a deadline: an unbounded
+        wait would otherwise hang the suite instead of failing it, and a hang
+        is not a usable failure signal.
+        """
+        service = token_service.TokenService()
+        outcome = {}
+
+        def waiter():
+            try:
+                service.ensure_secret_loaded()
+                outcome['returned'] = True
+            except BaseException as e:  # pylint: disable=broad-except
+                outcome['raised'] = e
+
+        service.init_lock.acquire()
+        try:
+            with mock.patch.object(token_service,
+                                   '_SECRET_LOAD_LOCK_TIMEOUT_SECONDS', 0.05):
+                thread = threading.Thread(target=waiter, daemon=True)
+                thread.start()
+                thread.join(timeout=5)
+
+            assert not thread.is_alive(), (
+                'A waiter blocked on init_lock for 5s while the lock was held. '
+                'Acquire it with a timeout so a stuck load cannot park auth '
+                'executor threads for its whole duration.')
+            assert isinstance(outcome.get('raised'),
+                              token_service.JWTSecretUnavailableError)
+        finally:
+            service.init_lock.release()
+
+    def test_waiter_uses_a_secret_that_landed_during_its_wait(self):
+        """Timing out on the lock must not fail a caller that can be served.
+
+        The holder can finish in the last instant of the wait; answering 503
+        then rejects a request the server is able to serve. A stub lock pins
+        that interleaving instead of racing two threads for it.
+        """
+        service = token_service.TokenService()
+
+        class _TimesOutAfterTheHolderFinished:
+            """acquire() fails, but the secret landed while we waited."""
+
+            def acquire(self, timeout=None):  # pylint: disable=unused-argument
+                service.secret_key = 'loaded-by-the-holder'
+                return False
+
+            def release(self):
+                raise AssertionError('released a lock that was never acquired')
+
+        service.init_lock = _TimesOutAfterTheHolderFinished()
+        service.ensure_secret_loaded()
+
+        assert service.secret_key == 'loaded-by-the-holder'
+
+    def test_empty_stored_secret_is_corruption_not_absence(self):
+        """An empty row must not be treated as "no secret yet".
+
+        Generating would clobber whatever belongs there, and adopting it hands
+        PyJWT a key it rejects on every request, surfacing as a bogus 401.
+        """
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = ''
+
+            service = token_service.TokenService()
+            with pytest.raises(token_service.JWTSecretUnavailableError):
+                service.ensure_secret_loaded()
+
+            mock_global_state.get_or_set_system_config.assert_not_called()
+            assert service.secret_key is None
+
+    def test_loaded_secret_needs_no_further_db_calls(self):
+        """The steady state stays off the database."""
+        existing = secrets.token_urlsafe(32)
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = existing
+
+            service = token_service.TokenService()
+            service.ensure_secret_loaded()
+            mock_global_state.get_system_config.reset_mock()
+            service.ensure_secret_loaded()
+
+            mock_global_state.get_system_config.assert_not_called()


### PR DESCRIPTION
## Summary

The API server could silently overwrite its JWT signing secret when a database
read failed, permanently invalidating every service account token ever issued.

`TokenService._get_or_generate_secret()` could not distinguish "no `jwt_secret`
row exists yet" from "the read raised" — the inner helper caught every
exception and returned `None`. The caller then generated a fresh secret and
persisted it with `set_system_config`, whose `ON CONFLICT DO UPDATE` overwrites.
Two independent faults, and either one alone would have been survivable.

Afterwards every pre-existing token fails signature verification while its row
in `service_account_tokens` still looks healthy, so the dashboard shows it as
valid and unexpired. The only log line emitted was an INFO announcing the new
secret as good news; the read failure was logged at `debug` and therefore
invisible at default log level.

The pod-local file lock at `~/.sky/.jwt_secret_init.lock` did not help. It does
not span HA replicas (separate filesystems when `storage.enabled=false`, the
PostgreSQL deployment mode), and the re-read under it hits the same broken
database.

## Changes

- **Read errors propagate.** Generation happens only after a read that
  *succeeded* and found no row, with a small bounded retry (2 attempts, via the
  existing `sky/utils/db/retries.py`) to ride out a brief blip. Capped
  deliberately below that module's default: the auth deadline releases the
  caller but never the executor thread, so each extra attempt is another
  multiple of the DB layer's own timeout that a thread stays held.
- **New `global_user_state.get_or_set_system_config()`** —
  `INSERT ... ON CONFLICT DO NOTHING` plus a read-back, returning the value
  that is live afterwards. This, not the file lock, is what makes bootstrap
  safe across replicas, so the file lock is removed. `set_system_config` keeps
  its overwrite semantics for other callers.
- **`_init_or_restore_server_user_hash` uses it too.** Same clobbering write:
  replicas starting together each generate a hash and apply it locally, then
  the last write wins and they disagree on the server id they already applied.
  Lower blast radius than the secret, same anti-pattern, and the fix is the
  same primitive.
- **No more in-memory fallback.** A failed write used to return the new secret
  anyway and cache it for the process lifetime, signing tokens that nothing —
  including the process itself after a restart — could ever verify.
- **An empty stored value is corruption, not an absence.** PyJWT rejects an
  empty HMAC key with `InvalidKeyError`, which is *not* an `InvalidTokenError`,
  so it escaped `verify_token` into the catch-all and surfaced as a misleading
  401 on every request. Now neither generated over nor adopted.
- **The secret load moved off the request event loop** onto the bounded auth
  executor, like every other DB call in that handler. It was a synchronous,
  unbounded read running inline on the first service-account-authenticated
  request of a process.
- **"Secret unavailable" answers a retryable 503, not a 401.** A 401 tells the
  caller its credential is bad and pushes operators to rotate tokens over what
  is a transient database problem. Waiters on the in-process load now acquire
  with a timeout, so a load stuck on a degraded database releases them into
  that 503 instead of parking auth executor threads for its whole duration.
- **Generating a secret while token rows already exist logs at ERROR**, naming
  how many tokens were orphaned. A first-ever bootstrap stays at INFO.
- **The secret is bootstrapped in `__main__`**, next to the server user hash
  restore, which already hard-depends on the database. It runs in the parent
  process before uvicorn forks its workers, so generation happens exactly once
  and before any request exists. Workers do not inherit the cache, so each
  still reads the existing row lazily on its first service-account request.
  That makes the bootstrap an optimisation rather than a correctness
  requirement, so it is best-effort: a corrupt row must degrade
  service-account auth, not crashloop the server and take the dashboard and
  every interactive user with it.
- **The load is gated on a `secret_loaded()` predicate** rather than dispatched
  unconditionally. After the first request `ensure_secret_loaded` is an
  `is not None` check, and the auth executor rejects rather than queues once
  its 32 slots are in flight -- a no-op dispatch could turn away a request that
  needs no database work with a worker-exhausted 503, on the scarcest resource
  in exactly the conditions this path has to survive.
- The middleware's in-function import carried a stale "avoid circular imports"
  comment: `sky.users.permission` is already imported at module scope, and
  `sky.users.token_service` adds no cycle and no measurable import time. Moved
  to module scope.
- Drive-bys in the same area: `_system_config_insert` extracts the dialect
  switch the two `system_config` writers duplicated verbatim, and
  `count_service_account_tokens` replaces pulling every token row back just to
  produce a count for the orphan alarm -- which runs while holding the load
  lock and an auth executor thread.

Not addressed here, worth separate changes: an operator-supplied secret (e.g.
from a Kubernetes Secret) so the bootstrap leaves the request path entirely,
and a fallback-key list so a deliberate rotation stops being destructive —
today there is no supported way to rotate at all. A self-healing re-read on
`InvalidSignatureError` was considered and rejected: in this failure the secret
a token was signed with is already destroyed, so a re-read returns the same
cached value, and the case it *would* help stops existing once the write is
insert-only.

During a rolling upgrade, replicas still on the old build keep using the
overwriting `set_system_config`, so the guarantee only holds once every replica
is upgraded.

`API_VERSION` is unchanged — no request/response schema or SDK surface changed,
and 503 is already a retryable status the client maps on this path.

## Test plan

Reproduced first, against a throwaway sqlite state DB: a healthy server
bootstraps the secret, issues a never-expiring token, then restarts while
`get_system_config` raises the `OperationalError` that pgbouncer pool
starvation produces. Before this change the row is overwritten (`updated_at`
bumped), the token fails with `InvalidSignatureError` against the current
secret while decoding fine against the now-unrecoverable original, and its DB
row still reads `expires_at=None`. After it, the load raises, the row is
byte-identical, and once the database recovers the pre-outage token still
authenticates with no rotation.

Unit tests, all revert-checked — each fix was individually reverted and the
test written for it failed:

- `tests/unit_tests/test_sky/users/test_token_service.py` — a read error never
  generates and caches nothing; a transient error then success adopts the
  persisted secret without writing; a failed write raises rather than caching;
  losing the insert race adopts the winner's value; an empty stored value is
  rejected on both the read and the adopt path and is never first announced as
  a healthy secret; `secret_loaded()` tracks the cache; a new secret over existing token rows logs ERROR while a
  first-ever bootstrap does not; a waiter on a stuck load gives up (driven from
  a worker thread joined with a deadline, so an unbounded wait fails the test
  instead of hanging it); a waiter whose secret landed mid-wait is still
  served; the steady state issues no further queries.
- `tests/unit_tests/test_sky/test_global_user_state_system_config.py` — the
  second `get_or_set_system_config` with a different value returns the first
  and leaves `config_value`, `created_at` and `updated_at` untouched;
  `set_system_config` still overwrites; `count_service_account_tokens` counts.
- `tests/unit_tests/test_sky/server/test_bearer_token_middleware.py` — an
  unavailable secret answers 503 with `Retry-After` and never looks at the
  token; a load that outlives the auth deadline gets the same 503; an
  already-loaded secret costs no executor dispatch at all; the load
  does not starve the event loop (measured against a concurrent heartbeat).
- `tests/unit_tests/test_sky/server/test_server.py` — the server user hash
  bootstrap adopts the stored hash and applies *that* locally, never the
  overwriting write; an existing hash is reused with no write at all; a failed
  JWT secret bootstrap does not abort startup.

Manual verification to run on a deployment: note `jwt_secret`'s `updated_at`,
issue a service account token and confirm it authenticates, point the server at
an unreachable database and restart, then hit the API with that token. Expect a
503 with `Retry-After` (not a 401) and `updated_at` unchanged; restore the
database and the same token authenticates again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

