### PR TITLE
[Server] Release the GIL during the hourly sky_logs prune (use os.stat over DirEntry.stat)

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -341,6 +341,46 @@ SKY_APISERVER_QUEUE_WAIT_SECONDS = prom.Histogram(
              120.0, 300.0, 600.0, float('inf')),
 )
 
+# --- ~/sky_logs retention ---
+#
+# Written once per hourly sweep by _prune_sky_logs() in the main API server
+# process. The gauges take a pid label + 'liveall' so only the process that
+# actually runs the sweep produces a series: the aggregating modes strip the
+# pid label and would merge in a phantom 0.0 from every worker process that
+# merely imports this module, and their non-live variants would keep serving
+# the last value after the writer exits.
+
+# Prune cost scales with this number, not with the number of dirs actually
+# expired, so it is the series to watch when the hourly sweep gets slow.
+SKY_APISERVER_SKY_LOGS_TOP_LEVEL_ENTRIES = prom.Gauge(
+    'sky_apiserver_sky_logs_top_level_entries',
+    'Top-level entries in ~/sky_logs at the last retention sweep',
+    ['pid'],
+    multiprocess_mode='liveall',
+)
+
+SKY_APISERVER_SKY_LOGS_PRUNE_DURATION_SECONDS = prom.Gauge(
+    'sky_apiserver_sky_logs_prune_duration_seconds',
+    'Wall time of the last ~/sky_logs retention sweep',
+    ['pid'],
+    multiprocess_mode='liveall',
+)
+
+# Measures the filesystem hosting ~/sky_logs, not the directory itself: exact
+# for deployments that give ~/sky_logs its own volume, an over-estimate for
+# those where it shares a filesystem with other data.
+SKY_APISERVER_SKY_LOGS_FS_USED_BYTES = prom.Gauge(
+    'sky_apiserver_sky_logs_fs_used_bytes',
+    'Used bytes on the filesystem hosting ~/sky_logs',
+    ['pid'],
+    multiprocess_mode='liveall',
+)
+
+SKY_APISERVER_SKY_LOGS_PRUNED_ENTRIES_TOTAL = prom.Counter(
+    'sky_apiserver_sky_logs_pruned_entries_total',
+    'Expired ~/sky_logs artifacts removed by the retention sweep',
+)
+
 # --- Managed Jobs Metrics ---
 
 # Per-controller-process gauges (consolidation mode only).

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -18,6 +18,7 @@ import resource
 import shlex
 import shutil
 import socket
+import stat
 import struct
 import subprocess
 import sys
@@ -851,12 +852,18 @@ def _prune_sky_logs(cutoff: float) -> int:
         for path in global_user_state.get_all_cluster_provision_log_paths()
     }
     removed = 0
+    # os.stat releases the GIL during the stat syscall; DirEntry.stat() and
+    # is_dir() on Python 3.10 do not (fixed in 3.11.0, python/cpython#89175).
+    # On a high-latency filesystem (e.g. ~/sky_logs on NFS at ~1ms per stat),
+    # a DirEntry-based walk over tens of thousands of entries becomes one long
+    # GIL critical section that starves every other thread in the process.
+    # Safe to use the DirEntry methods again once the minimum Python is 3.11.
     for entry in os.scandir(sky_logs_dir):
         if not entry.name.startswith('sky-') or entry.name in protected_dirs:
             continue
         try:
-            if (entry.is_dir(follow_symlinks=False) and
-                    entry.stat().st_mtime < cutoff):
+            st = os.stat(entry.path, follow_symlinks=False)
+            if stat.S_ISDIR(st.st_mode) and st.st_mtime < cutoff:
                 shutil.rmtree(entry.path, ignore_errors=True)
                 removed += 1
         except OSError:
@@ -867,8 +874,8 @@ def _prune_sky_logs(cutoff: float) -> int:
     if os.path.isdir(file_uploads_dir):
         for entry in os.scandir(file_uploads_dir):
             try:
-                if (entry.is_file(follow_symlinks=False) and
-                        entry.stat().st_mtime < cutoff):
+                st = os.stat(entry.path, follow_symlinks=False)
+                if stat.S_ISREG(st.st_mode) and st.st_mtime < cutoff:
                     os.remove(entry.path)
                     removed += 1
             except OSError:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -835,6 +835,27 @@ async def cleanup_clients_tmp():
                          f'{common_utils.format_exception(e)}')
 
 
+def _record_sky_logs_metrics(sky_logs_dir: str, top_level_entries: int,
+                             removed: int, duration: float) -> None:
+    """Publish the ~/sky_logs retention instruments for one sweep."""
+    if not metrics_utils.METRICS_ENABLED:
+        return
+    pid = str(os.getpid())
+    metrics_utils.SKY_APISERVER_SKY_LOGS_TOP_LEVEL_ENTRIES.labels(
+        pid=pid).set(top_level_entries)
+    metrics_utils.SKY_APISERVER_SKY_LOGS_PRUNE_DURATION_SECONDS.labels(
+        pid=pid).set(duration)
+    metrics_utils.SKY_APISERVER_SKY_LOGS_PRUNED_ENTRIES_TOTAL.inc(removed)
+    try:
+        fs = os.statvfs(sky_logs_dir)
+    except OSError as e:
+        logger.debug(f'Failed to stat the filesystem hosting {sky_logs_dir}: '
+                     f'{e}')
+        return
+    metrics_utils.SKY_APISERVER_SKY_LOGS_FS_USED_BYTES.labels(pid=pid).set(
+        (fs.f_blocks - fs.f_bfree) * fs.f_frsize)
+
+
 def _prune_sky_logs(cutoff: float) -> int:
     """Remove ~/sky_logs artifacts older than cutoff; returns count removed.
 
@@ -844,6 +865,7 @@ def _prune_sky_logs(cutoff: float) -> int:
     of age so /provision_logs keeps serving live clusters; once the cluster
     is terminated its logs fall back to the age-based retention.
     """
+    start_time = time.time()
     sky_logs_dir = os.path.expanduser(constants.SKY_LOGS_DIRECTORY)
     if not os.path.isdir(sky_logs_dir):
         return 0
@@ -852,6 +874,7 @@ def _prune_sky_logs(cutoff: float) -> int:
         for path in global_user_state.get_all_cluster_provision_log_paths()
     }
     removed = 0
+    top_level_entries = 0
     # os.stat releases the GIL during the stat syscall; DirEntry.stat() and
     # is_dir() on Python 3.10 do not (fixed in 3.11.0, python/cpython#89175).
     # On a high-latency filesystem (e.g. ~/sky_logs on NFS at ~1ms per stat),
@@ -859,6 +882,7 @@ def _prune_sky_logs(cutoff: float) -> int:
     # GIL critical section that starves every other thread in the process.
     # Safe to use the DirEntry methods again once the minimum Python is 3.11.
     for entry in os.scandir(sky_logs_dir):
+        top_level_entries += 1
         if not entry.name.startswith('sky-') or entry.name in protected_dirs:
             continue
         try:
@@ -880,6 +904,8 @@ def _prune_sky_logs(cutoff: float) -> int:
                     removed += 1
             except OSError:
                 pass
+    _record_sky_logs_metrics(sky_logs_dir, top_level_entries, removed,
+                             time.time() - start_time)
     return removed
 
 

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1145,6 +1145,25 @@ def test_prune_sky_logs_removes_expired_file_upload_logs(
     assert fresh_log.exists()
 
 
+def test_prune_sky_logs_does_not_follow_symlinks(tmp_path, monkeypatch,
+                                                 _no_provision_log_paths):
+    """Symlinks are never traversed, so their targets are left untouched."""
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
+    now = 1_000_000.0
+    outside = _touch_dir(tmp_path / 'outside' / 'target', now - 10_000)
+    (tmp_path / 'sky-2020-01-01-00-00-00-000000').symlink_to(outside)
+    outside_file = _touch_file(tmp_path / 'outside' / 'target.log',
+                               now - 10_000)
+    (tmp_path / 'file_uploads').mkdir()
+    (tmp_path / 'file_uploads' / 'sky-link.log').symlink_to(outside_file)
+
+    removed = server._prune_sky_logs(cutoff=now - 5_000)
+
+    assert removed == 0
+    assert outside.exists()
+    assert outside_file.exists()
+
+
 def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY',
                         str(tmp_path / 'does-not-exist'))

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -10,6 +10,7 @@ import time
 from unittest import mock
 
 import fastapi
+import prometheus_client as prom
 import pytest
 import uvicorn
 
@@ -1143,6 +1144,36 @@ def test_prune_sky_logs_removes_expired_file_upload_logs(
     assert removed == 1
     assert not old_log.exists()
     assert fresh_log.exists()
+
+
+def test_prune_sky_logs_records_metrics(tmp_path, monkeypatch,
+                                        _no_provision_log_paths):
+    """A sweep publishes the entry population, its duration and what it removed.
+
+    The entry gauge counts every top-level entry the scandir loop walks, not
+    just the expired ones, since that population is what the sweep costs.
+    """
+    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY', str(tmp_path))
+    monkeypatch.setattr(server.metrics_utils, 'METRICS_ENABLED', True)
+    now = 1_000_000.0
+    _touch_dir(tmp_path / 'sky-2020-01-01-00-00-00-000000', now - 10_000)
+    _touch_dir(tmp_path / 'sky-2020-01-02-00-00-00-000000', now - 100)
+    _touch_dir(tmp_path / 'api_server', now - 10_000)
+    pid = {'pid': str(os.getpid())}
+    pruned_before = prom.REGISTRY.get_sample_value(
+        'sky_apiserver_sky_logs_pruned_entries_total') or 0.0
+
+    removed = server._prune_sky_logs(cutoff=now - 5_000)
+
+    assert removed == 1
+    assert prom.REGISTRY.get_sample_value(
+        'sky_apiserver_sky_logs_top_level_entries', pid) == 3
+    assert prom.REGISTRY.get_sample_value(
+        'sky_apiserver_sky_logs_pruned_entries_total') - pruned_before == 1
+    assert prom.REGISTRY.get_sample_value(
+        'sky_apiserver_sky_logs_prune_duration_seconds', pid) >= 0
+    assert prom.REGISTRY.get_sample_value(
+        'sky_apiserver_sky_logs_fs_used_bytes', pid) > 0
 
 
 def test_prune_sky_logs_does_not_follow_symlinks(tmp_path, monkeypatch,


### PR DESCRIPTION
`_prune_sky_logs` reads each entry's mtime with `os.DirEntry.is_dir()` /
`DirEntry.stat()`. On Python 3.10 those methods hold the GIL across the
underlying stat syscall, so the hourly sweep of `~/sky_logs` can stall every
other thread in the API server process for the length of the walk. This
switches both loops to plain `os.stat`, which releases the GIL.

## Why

`DirEntry_fetch_stat` in `Modules/posixmodule.c` has no `Py_BEGIN_ALLOW_THREADS`
around its `fstatat` / `STAT` / `LSTAT` call on the 3.10 branch, while
`posix_do_stat` — which backs plain `os.stat` — wraps its syscall in one.
CPython closed that gap in 3.11.0 with
[`9dc363ee`](https://github.com/python/cpython/commit/9dc363ee7cf2eb6ff374fbf7bbeb0b333f4afb8f)
("bpo-45012: Release GIL around stat in os.scandir",
[GH-28085](https://github.com/python/cpython/pull/28085)). The backport was
explicitly declined in
[gh-89175](https://github.com/python/cpython/issues/89175) — *"we can't backport
this to 3.9 as it's only accepting bugfixes and this is a performance
improvement. 3.10 is out of scope for this too as 3.10.0rc2 shipped last
night."* So on any 3.10 server this is permanent, not something a patch release
fixes. (The original report is the same shape as this one: a threaded
filesystem crawler wedged with one thread inside `dentry.stat()` holding the
GIL.)

That matters because the eval-breaker cannot interrupt C code that holds the
GIL. Where `~/sky_logs` sits on a network filesystem — the helm deployment puts
it on a shared PVC, commonly NFS-backed, where each getattr costs on the order
of a millisecond — a sweep over tens of thousands of `sky-*` directories
becomes one long, effectively unpreemptible critical section. Every other
thread in the main process waits it out. The symptom that led here was `/metrics`
collection, which takes ~1.7 s on its own, stretching past the scrape timeout
once an hour, on the hour.

Measured with `py-spy record --gil` (100 Hz) on a production-scale deployment:
53k `sky-*` dirs on NFS, CPython 3.10.19, same ~54 s walk both times.

| Same ~54 s walk of 53k `sky-*` dirs on NFS | `DirEntry.is_dir()` / `.stat()` | `os.stat(entry.path)` |
| --- | --- | --- |
| Samples with the GIL held by the walk | 5,404 (~98% of wall clock) | 192 (~3.5%) |
| Concurrent CPU-bound thread (the `prometheus_client` multiproc merge behind `/metrics`, 1.7 s standalone) | one merge took 88 s (~4% GIL share) | 1.8–2.2 s per merge (~97% GIL share) |

## Why the replacement is equivalent

`entry.is_dir(follow_symlinks=False)` returning True already establishes that
the entry is a real directory and not a symlink, so follow vs. no-follow on the
*subsequent* `entry.stat()` cannot produce a different answer — one
`os.stat(entry.path, follow_symlinks=False)` gives the same mode and mtime. The
same argument applies to `is_file` in the `file_uploads` loop.

Syscall count is unchanged, not merely no worse. CPython caches the fetched
stat on the `DirEntry`, and because the entry is known not to be a symlink,
`entry.stat()` reuses the `lstat` rather than issuing a second call — so both
the old and new code perform exactly one `lstat` per entry. The only difference
is whether the GIL is held across it.

Error behavior is also unchanged: `DirEntry.is_dir()` swallows
`FileNotFoundError` and returns False, while `os.stat` raises it — and the call
already sits inside the loop's `except OSError: pass`, so a vanished entry is
skipped either way.

## Observability

Nothing currently exports the `~/sky_logs` entry population, which is what the
hourly sweep's cost actually scales with — an operator watching a server that
stalls once an hour has no way to see how many entries the sweep is walking, or
how long it took. Four instruments, all computed once per run from data the
loop already has:

| Metric | Type | Meaning |
| --- | --- | --- |
| `sky_apiserver_sky_logs_top_level_entries` | Gauge | Top-level entries walked by the sweep. The load-bearing one: prune cost tracks this, not the number of dirs that actually expired. |
| `sky_apiserver_sky_logs_prune_duration_seconds` | Gauge | Wall time of the last sweep. |
| `sky_apiserver_sky_logs_pruned_entries_total` | Counter | Expired artifacts removed. |
| `sky_apiserver_sky_logs_fs_used_bytes` | Gauge | Used bytes on the filesystem hosting `~/sky_logs`, from one `os.statvfs`. |

No recursive walk and no per-file stat is involved: the entry count is a
counter increment on the loop that already runs, and the disk figure is a
single `statvfs` on the directory. Computing real directory byte totals would
mean stat-ing every file, which is the pathology this PR exists to remove.
`sky_apiserver_sky_logs_fs_used_bytes` therefore measures the *filesystem*, not
the directory — exact where `~/sky_logs` has its own volume, an over-estimate
where it shares one. The HELP text says so.

The gauges carry a `pid` label with `multiprocess_mode='liveall'`, matching how
the existing `sky_apiserver_*` gauges handle a writer that is not every
process. Only the main process runs this daemon, so an aggregating mode would
strip the pid label and fold in a phantom 0.0 from every worker that merely
imports the module, and the non-live variants would keep serving the last value
after the writer exits. All writes sit behind the usual
`metrics_utils.METRICS_ENABLED` guard.

## Summary

* `_prune_sky_logs`: replace `entry.is_dir(follow_symlinks=False)` +
  `entry.stat()` with a single `os.stat(entry.path, follow_symlinks=False)` and
  `stat.S_ISDIR`; same for the `file_uploads` loop with `stat.S_ISREG`.
* Add a comment recording why, so the DirEntry form isn't restored before the
  minimum supported Python is 3.11.
* Add a regression test pinning that symlinks are never traversed — the
  property the equivalence argument rests on.
* Export the four `sky_apiserver_sky_logs_*` instruments described above.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh --files sky/server/server.py sky/metrics/utils.py` — both rate 10.00/10 on pylint, mypy clean across 595 source files.
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Details:

* `pytest -n0 tests/unit_tests/test_sky/server/test_server.py` — 53 passed,
  covering the four pre-existing `_prune_sky_logs` cases (expired dirs pruned,
  fresh kept, live-cluster provision dirs kept, expired `file_uploads` pruned,
  missing dir no-op) plus the two new ones below.
* New `test_prune_sky_logs_does_not_follow_symlinks`: a `sky-*` symlink pointing
  at an expired directory outside the tree, and a `file_uploads` symlink to an
  expired file, must both be left alone. Mutation-checked — flipping the two new
  calls to `follow_symlinks=True` fails it with `assert 2 == 0`, so it is not
  vacuous.
* New `test_prune_sky_logs_records_metrics`: over a fixture of three top-level
  dirs of which one is expired, asserts the entry gauge reads 3, the counter
  advanced by exactly 1, and the duration and filesystem gauges are populated.
  Mutation-checked — moving the entry increment below the `continue` (so it
  counts only `sky-*` dirs) fails it with `assert 2.0 == 3`.
* The GIL behavior itself is not exercised by the local run: that test
  interpreter is CPython 3.11.13, where `DirEntry.stat()` already releases the
  GIL. The unit tests establish functional equivalence; the GIL evidence is the
  3.10.19 py-spy measurement above and the posixmodule source cited.
