### PR TITLE
Run config reload off the background event loop in cleanup_sky_logs

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -915,7 +915,11 @@ async def cleanup_sky_logs():
     await asyncio_utils.sleep_startup_jitter('sky_logs cleanup daemon')
     while True:
         try:
-            skypilot_config.reload_config()
+            # reload_config() does a blocking file read and, with the
+            # Postgres backend, a synchronous SELECT on the config DB.
+            # Run it off the event loop so it can't stall the other
+            # background daemons sharing this loop.
+            await asyncio.to_thread(skypilot_config.reload_config)
             retention_hours = skypilot_config.get_nested(
                 ('api_server', 'logs_retention_hours'),
                 server_constants.DEFAULT_LOGS_RETENTION_HOURS)

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1202,6 +1202,88 @@ def test_prune_sky_logs_missing_dir_is_noop(tmp_path, monkeypatch):
     assert server._prune_sky_logs(cutoff=1_000_000.0) == 0
 
 
+@pytest.mark.asyncio
+async def test_cleanup_sky_logs_reads_reloaded_retention_in_to_thread(
+        monkeypatch):
+    """A config swap done by reload_config inside asyncio.to_thread must be
+    visible to the subsequent get_nested on the loop thread.
+
+    cleanup_sky_logs runs the blocking reload off-loop with
+    `await asyncio.to_thread(skypilot_config.reload_config)` and then reads
+    retention_hours back on the loop thread. This guards the cross-thread
+    visibility the daemon relies on: a config swap performed in the
+    to_thread worker must reach the on-loop get_nested, or the daemon would
+    prune on a stale retention.
+
+    The real reload_config's source I/O (file read / DB SELECT) is stubbed
+    here to keep the unit test env/DB-free; its swap tail
+    (_set_loaded_config, the mechanism the real reload uses) and the real
+    get_nested read are exercised unchanged through the real cleanup_sky_logs
+    + real asyncio.to_thread.
+    """
+    from sky import skypilot_config
+
+    fresh_retention = 7
+    # Stale value (2) so a successful reload is observable: if the swap never
+    # reaches get_nested, the assertion below sees 2 instead of 7.
+    stale = config_utils.Config()
+    stale.set_nested(('api_server', 'logs_retention_hours'), 2)
+    # Swap in the stale config through the real accessor and let monkeypatch
+    # restore the original value at teardown: the loaded config is
+    # process-global, and leaving a swapped value behind would leak into
+    # later tests in this xdist worker (including when this test fails).
+    loaded_context = skypilot_config._get_config_context()
+    monkeypatch.setattr(loaded_context, 'config', stale)
+
+    def fake_reload():
+        # Mirrors the tail of the real _reload_config_as_server: build the
+        # new config and swap it in with _set_loaded_config. Runs from inside
+        # asyncio.to_thread, i.e. a worker thread.
+        cfg = config_utils.Config()
+        cfg.set_nested(('api_server', 'logs_retention_hours'), fresh_retention)
+        skypilot_config._set_loaded_config(cfg)
+
+    monkeypatch.setattr(server.skypilot_config, 'reload_config', fake_reload)
+
+    observed_cutoffs = []
+
+    def fake_prune(cutoff):
+        observed_cutoffs.append(cutoff)
+        return 0
+
+    monkeypatch.setattr(server, '_prune_sky_logs', fake_prune)
+
+    # asyncio.sleep is the while-True's last statement, outside the try/except,
+    # so raising a BaseException here exits cleanup_sky_logs after exactly one
+    # iteration; a BaseException subclass is chosen so the daemon's broad
+    # `except Exception` cannot swallow it.
+    class _StopLoop(BaseException):
+        pass
+
+    async def bail(_seconds):
+        raise _StopLoop
+
+    # No-op the daemon's startup jitter first: it awaits asyncio.sleep before
+    # the loop, so the patched sleep below would otherwise raise _StopLoop
+    # before a single iteration ran and the reload would never be exercised.
+    async def _noop_jitter(*_args, **_kwargs):
+        pass
+
+    monkeypatch.setattr(server.asyncio_utils, 'sleep_startup_jitter',
+                        _noop_jitter)
+    monkeypatch.setattr(server.asyncio, 'sleep', bail)
+
+    with pytest.raises(_StopLoop):
+        await server.cleanup_sky_logs()
+
+    # reload ran in a worker thread; get_nested ran on the loop thread.
+    assert skypilot_config.get_nested(('api_server', 'logs_retention_hours'),
+                                      -1) == fresh_retention
+    assert len(observed_cutoffs) == 1
+    expected_cutoff = time.time() - fresh_retention * 3600
+    assert abs(observed_cutoffs[0] - expected_cutoff) < 2
+
+
 # --- Tests for cleanup_clients_tmp (client tmp dir GC) ---
 
 


### PR DESCRIPTION
## What

`cleanup_sky_logs()` called `skypilot_config.reload_config()` inline in its coroutine body. That call is blocking I/O, so it ran **on the background event loop** and stalled every other daemon sharing that loop. Offload it via `asyncio.to_thread`, the same way the fs walk (`_prune_sky_logs`) already is.

## Why it matters

`cleanup_sky_logs` is a task on the dedicated background `uvloop` (created in the `__main__` block as `background = uvloop.new_event_loop()` and driven by a daemon thread via `background.run_forever`). That loop is shared by the other singleton daemons: `metrics_server.serve()` (the `/metrics` endpoint), `multiproc_reaper_daemon`, `requests_gc_daemon`, the two retention daemons, and the other `cleanup_*` tasks.

`reload_config()` on the server path (`_reload_config_as_server`) is not an in-memory op:
- it reads the config file (`_get_config_from_path`), and
- with the Postgres backend (`SKYPILOT_DB_CONNECTION_URI` set), it opens a `orm.Session` and runs a synchronous SQLAlchemy `SELECT` on `config_yaml_table`, then parses YAML.

All inline, so the loop blocks for one DB round trip (+ file I/O) once per hourly iteration. While the query is in flight the `/metrics` endpoint on the metrics port goes unresponsive on that replica, along with the other daemons. For a healthy Postgres this is a few ms once an hour — operationally small — but it is a real, unnecessary stall of the shared loop; if the config DB ever gets slow or locked it stalls all of them.

## The fix

```diff
         try:
-            skypilot_config.reload_config()
+            await asyncio.to_thread(skypilot_config.reload_config)
             retention_hours = skypilot_config.get_nested(
```

`get_nested` (the next line) reads the in-memory loaded config — no I/O — so it stays inline.

## Why the config swap still takes effect

`asyncio.to_thread` copies the current `contextvars` context to the worker thread, so the worker sees the same `SkyPilotContext` object. `_set_loaded_config` mutates its `config` attribute (`_get_config_context().config = config`) — an attribute assignment on a shared object, **not** a `ContextVar.set` — so the swap is visible to the loop thread. (A `ContextVar.set` inside the worker would NOT propagate; `_set_loaded_config` doesn't do that.) Verified empirically:

```python
import asyncio, contextvars
class Box: pass
CV = contextvars.ContextVar('cv', default=None)
async def main():
    b = Box(); b.val = 1; CV.set(b)
    await asyncio.to_thread(lambda: setattr(CV.get(), 'val', 2))
    print(CV.get().val)  # -> 2  (visible to the loop thread)
asyncio.run(main())
```

## Test plan

- `bash format.sh` — yapf (0.32.0) keeps the diff to exactly this hunk.
- `tests/unit_tests/test_sky/server/test_server.py -k prune_sky_logs` — 4 passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->