### PR TITLE
[API] Make sync handlers see workspaces created after server boot

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3239,6 +3239,28 @@ async def _get_cluster_and_validate(
             all_users=True,
             summary_response=True)
 
+        if not cluster_records:
+            # A miss here is not necessarily a missing cluster. This is a
+            # sync-style path in the API-server process: `core.status()` ->
+            # `get_clusters()` filters on the workspace config this process
+            # loaded at boot (plus the request-scoped `_load_workspaces()`
+            # memo, which nothing clears in the HTTP process), so a cluster
+            # in a workspace created via `/workspaces/create` after startup
+            # (an executor-side write) is filtered out and looks nonexistent
+            # here, indefinitely. Refresh and retry once, on the miss path
+            # only: the hot path (known cluster) pays nothing, and a genuine
+            # miss pays one config reload before the 404 it was getting
+            # anyway.
+            await context_utils.to_thread_with_executor(
+                thread_pool_executor,
+                common.refresh_workspace_state_for_sync_handler)
+            cluster_records = await context_utils.to_thread_with_executor(
+                thread_pool_executor,
+                core.status,
+                cluster_name,
+                all_users=True,
+                summary_response=True)
+
     if not cluster_records:
         raise fastapi.HTTPException(status_code=404,
                                     detail=f'Cluster {cluster_name} not found')

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -193,6 +193,14 @@ def set_user_preferred_workspace(
     if auth_user is None:
         raise fastapi.HTTPException(status_code=401,
                                     detail='Not authenticated.')
+    # Sync FastAPI handler — same hazard as the GET below: without a refresh,
+    # `set_user_preferred_workspace()` validates against the workspace config
+    # this process loaded at boot (and the request-scoped `_load_workspaces()`
+    # memo, which nothing clears in the HTTP process). A workspace created via
+    # `/workspaces/create` after startup — that runs on an executor worker — is
+    # then invisible here and gets a spurious 404 "does not exist" until some
+    # other call happens to reload this process.
+    server_common.refresh_workspace_state_for_sync_handler()
     try:
         workspaces_core.set_user_preferred_workspace(auth_user, body.preferred)
     except exceptions.PermissionDeniedError as e:

--- a/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
+++ b/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
@@ -13,6 +13,7 @@ import pytest
 
 from sky import clouds
 from sky.server import server
+from sky.utils import status_lib
 
 
 def _make_websocket():
@@ -158,3 +159,65 @@ async def test_validate_cluster_for_ssh_proxy_ws_truncates_long_reason():
 
     assert result is None
     websocket.close.assert_awaited_once_with(code=1008, reason='x' * 123)
+
+
+# _get_cluster_and_validate: stale-workspace-config miss path ---------------
+
+
+def _up_k8s_record():
+    handle = mock.MagicMock()
+    handle.launched_resources.cloud = clouds.Kubernetes()
+    return {'status': status_lib.ClusterStatus.UP, 'handle': handle}
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_and_validate_known_cluster_does_not_refresh():
+    """Hot path: a cluster this process already sees costs no config reload."""
+    record = _up_k8s_record()
+    with mock.patch.object(server.core, 'status', return_value=[record]) as \
+            status, mock.patch.object(
+                server.common,
+                'refresh_workspace_state_for_sync_handler') as refresh:
+        handle = await server._get_cluster_and_validate('my-cluster',
+                                                        clouds.Kubernetes)
+
+    assert handle is record['handle']
+    assert status.call_count == 1
+    refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_and_validate_refreshes_and_retries_on_miss():
+    """A miss caused by a stale process-cached workspace config must not
+    surface as 404: a cluster in a workspace created via `/workspaces/create`
+    after the server booted is filtered out of `core.status()` until this
+    process reloads its config. The reload happens on the miss path only."""
+    record = _up_k8s_record()
+    with mock.patch.object(server.core, 'status',
+                           side_effect=[[], [record]]) as status, \
+            mock.patch.object(
+                server.common,
+                'refresh_workspace_state_for_sync_handler') as refresh:
+        handle = await server._get_cluster_and_validate('new-ws-cluster',
+                                                        clouds.Kubernetes)
+
+    assert handle is record['handle']
+    assert status.call_count == 2
+    refresh.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_and_validate_genuine_miss_still_404s():
+    """A cluster that is missing even after a refresh is a real 404."""
+    with mock.patch.object(server.core, 'status',
+                           side_effect=[[], []]) as status, \
+            mock.patch.object(
+                server.common,
+                'refresh_workspace_state_for_sync_handler') as refresh:
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await server._get_cluster_and_validate('ghost', clouds.Kubernetes)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == 'Cluster ghost not found'
+    assert status.call_count == 2
+    refresh.assert_called_once_with()

--- a/tests/unit_tests/test_sky/server/test_stale_workspace_config_sync_handlers.py
+++ b/tests/unit_tests/test_sky/server/test_stale_workspace_config_sync_handlers.py
@@ -1,0 +1,204 @@
+"""Regression tests: sync handlers must see workspaces created after boot.
+
+Sync FastAPI handlers run in the API-server HTTP process and never go through
+the executor's ``reload_for_new_request`` pipeline. They see the workspace
+config this process loaded at boot plus the request-scoped
+``_load_workspaces()`` memo, which nothing in the HTTP process clears. A
+workspace created via ``/workspaces/create`` after startup (an executor-side
+write) is therefore invisible to them until something reloads the process.
+
+Unlike the handler tests that mock ``refresh_workspace_state_for_sync_handler``
+and only assert it is *called*, these tests drive the real config loader, the
+real ``_load_workspaces()`` memo and the real refresh helper, so they fail if
+any link in that chain stops working — not just if the call is removed.
+
+The scenario mirrors what was observed in production (SkyPilot 0.13.0, 8
+uvicorn workers): ``sky workspace use <new>`` returned 404 "does not exist",
+and ``ssh <cluster>`` into that workspace closed with "Cluster not found",
+indefinitely, from every worker that had not happened to serve a request
+that reloads config.
+"""
+from unittest import mock
+
+import fastapi
+import pytest
+import yaml
+
+from sky import clouds
+from sky import models
+from sky import skypilot_config
+from sky.server import server
+from sky.server.requests import payloads
+from sky.users import server as users_server
+from sky.utils import annotations
+from sky.utils import status_lib
+from sky.workspaces import core as workspaces_core
+
+_NEW_WS = 'ws-created-after-boot'
+
+
+@pytest.fixture
+def stale_workspace_config(tmp_path, monkeypatch):
+    """Load a server config with only ``default``, prime the memo, then add a
+    workspace on disk WITHOUT reloading — the state an HTTP process is in
+    after an executor-side ``/workspaces/create``.
+
+    Yields the config path. Restores the previously loaded config on exit.
+    """
+    config_path = tmp_path / 'config.yaml'
+
+    def _write(workspaces):
+        config_path.write_text(yaml.safe_dump({'workspaces': workspaces}))
+
+    _write({'default': {}})
+    # Internal-file mode: reload_config() reads exactly this file, no DB.
+    monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG,
+                       str(config_path))
+    prev_config = skypilot_config._get_loaded_config()  # pylint: disable=protected-access
+    skypilot_config.reload_config()
+    annotations.clear_request_level_cache()
+
+    # Boot-time read: this primes the request-scoped memo.
+    assert _NEW_WS not in workspaces_core._load_workspaces()  # pylint: disable=protected-access
+
+    # "Executor writes the new workspace." The file moves forward, this
+    # process's loaded config and memo do not.
+    _write({'default': {}, _NEW_WS: {}})
+    # Precondition for both tests below: the process is really stale. If this
+    # ever fails, the tests no longer model the bug and need revisiting.
+    assert _NEW_WS not in workspaces_core._load_workspaces()  # pylint: disable=protected-access
+
+    yield config_path
+
+    annotations.clear_request_level_cache()
+    skypilot_config._set_loaded_config(prev_config)  # pylint: disable=protected-access
+
+
+def _fake_request(auth_user):
+    req = mock.MagicMock(spec=fastapi.Request)
+    req.state.auth_user = auth_user
+    return req
+
+
+def _body(preferred):
+    body = mock.MagicMock(spec=payloads.UserPreferredWorkspaceBody)
+    body.preferred = preferred
+    return body
+
+
+# POST /users/me/workspace ----------------------------------------------------
+
+
+def test_post_users_me_workspace_sees_workspace_created_after_boot(
+        stale_workspace_config):
+    """`sky workspace use <new>` must not 404 for a workspace that exists."""
+    del stale_workspace_config  # fixture side effects only
+    user = models.User(id='alice', name='alice')
+    with mock.patch.object(workspaces_core, 'check_workspace_permission'), \
+            mock.patch.object(workspaces_core.global_user_state,
+                              'set_user_preferred_workspace') as set_pref:
+        resp = users_server.set_user_preferred_workspace(
+            _fake_request(user), _body(_NEW_WS))
+
+    assert resp == {'preferred': _NEW_WS}
+    set_pref.assert_called_once_with('alice', _NEW_WS)
+    # And the process is no longer stale for whatever runs next.
+    assert _NEW_WS in workspaces_core._load_workspaces()  # pylint: disable=protected-access
+
+
+def test_post_users_me_workspace_control_without_refresh_is_404(
+        stale_workspace_config):
+    """Control: with the refresh stubbed out, the same request 404s.
+
+    This pins the mechanism the test above guards. If this control ever
+    passes (no 404), the stale state is being cleared by something else and
+    the regression test above has lost its teeth.
+    """
+    del stale_workspace_config
+    user = models.User(id='alice', name='alice')
+    with mock.patch.object(users_server.server_common,
+                           'refresh_workspace_state_for_sync_handler'), \
+            mock.patch.object(workspaces_core, 'check_workspace_permission'), \
+            mock.patch.object(workspaces_core.global_user_state,
+                              'set_user_preferred_workspace'):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            users_server.set_user_preferred_workspace(_fake_request(user),
+                                                      _body(_NEW_WS))
+    assert exc_info.value.status_code == 404
+    assert 'does not exist' in exc_info.value.detail
+
+
+# /kubernetes-pod-ssh-proxy cluster lookup -----------------------------------
+
+
+def _status_filtered_like_get_clusters(record):
+    """Stand-in for ``core.status`` that applies the same workspace filter
+    ``backend_utils.get_clusters()`` does (``WHERE workspace IN
+    accessible``), against the REAL accessible-workspace resolution — so a
+    stale ``_load_workspaces()`` memo hides the cluster exactly as in
+    production, minus the database."""
+
+    def _status(*args, **kwargs):
+        del args, kwargs
+        accessible = workspaces_core.get_accessible_workspace_names()
+        return [record] if record['workspace'] in accessible else []
+
+    return _status
+
+
+@pytest.mark.asyncio
+async def test_ssh_proxy_lookup_sees_cluster_in_workspace_created_after_boot(
+        stale_workspace_config):
+    """`ssh <cluster>` into a post-boot workspace must not be refused as
+    "Cluster not found"."""
+    del stale_workspace_config
+    handle = mock.MagicMock()
+    handle.launched_resources.cloud = clouds.Kubernetes()
+    record = {
+        'status': status_lib.ClusterStatus.UP,
+        'handle': handle,
+        'workspace': _NEW_WS,
+    }
+    # The API-server process resolves clusters as the server user, which has
+    # access to every workspace it knows about; the bug is in *which
+    # workspaces it knows about*, so let the ACL step pass everything through.
+    with mock.patch.object(workspaces_core,
+                           '_accessible_workspace_names_for_user',
+                           side_effect=lambda uid, names, action: names), \
+            mock.patch.object(server.core, 'status',
+                              side_effect=_status_filtered_like_get_clusters(
+                                  record)) as status:
+        result = await server._get_cluster_and_validate(  # pylint: disable=protected-access
+            'cluster-in-new-ws', clouds.Kubernetes)
+
+    assert result is handle
+    # First lookup missed (stale), refresh, second lookup hit.
+    assert status.call_count == 2
+    assert _NEW_WS in workspaces_core._load_workspaces()  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_ssh_proxy_lookup_control_without_refresh_is_not_found(
+        stale_workspace_config):
+    """Control for the test above: stub the refresh and the lookup 404s."""
+    del stale_workspace_config
+    handle = mock.MagicMock()
+    handle.launched_resources.cloud = clouds.Kubernetes()
+    record = {
+        'status': status_lib.ClusterStatus.UP,
+        'handle': handle,
+        'workspace': _NEW_WS,
+    }
+    with mock.patch.object(server.common,
+                           'refresh_workspace_state_for_sync_handler'), \
+            mock.patch.object(workspaces_core,
+                              '_accessible_workspace_names_for_user',
+                              side_effect=lambda uid, names, action: names), \
+            mock.patch.object(server.core, 'status',
+                              side_effect=_status_filtered_like_get_clusters(
+                                  record)):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await server._get_cluster_and_validate(  # pylint: disable=protected-access
+                'cluster-in-new-ws', clouds.Kubernetes)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == 'Cluster cluster-in-new-ws not found'

--- a/tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py
+++ b/tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py
@@ -86,6 +86,37 @@ class TestSetUsersMeWorkspace(unittest.TestCase):
                 _fake_request(auth_user=None), self._body('team-a'))
         self.assertEqual(cm.exception.status_code, 401)
 
+    def test_refreshes_workspace_state_before_validating(self):
+        """The handler is a sync route in the HTTP process, so it must
+        reload the process-cached workspace config (and clear the
+        request-scoped `_load_workspaces()` memo) before validating the
+        target — exactly like its GET sibling. Otherwise a workspace created
+        via `/workspaces/create` after the server booted (an executor-side
+        write) is invisible here and the POST 404s indefinitely."""
+        order = mock.Mock()
+        with mock.patch.object(users_server.server_common,
+                               'refresh_workspace_state_for_sync_handler',
+                               order.refresh), \
+                mock.patch.object(workspaces_core,
+                                  'set_user_preferred_workspace',
+                                  order.set_pref):
+            users_server.set_user_preferred_workspace(_fake_request(self.user),
+                                                      self._body('team-new'))
+        self.assertEqual(order.mock_calls, [
+            mock.call.refresh(),
+            mock.call.set_pref(self.user, 'team-new'),
+        ])
+
+    def test_unauth_post_does_not_refresh(self):
+        """401 short-circuits before the (lock-taking) config reload."""
+        with mock.patch.object(
+                users_server.server_common,
+                'refresh_workspace_state_for_sync_handler') as refresh:
+            with self.assertRaises(fastapi.HTTPException):
+                users_server.set_user_preferred_workspace(
+                    _fake_request(auth_user=None), self._body('team-a'))
+        refresh.assert_not_called()
+
 
 # GET /users/me/workspace --------------------------------------------
 


### PR DESCRIPTION
## Summary

Sync FastAPI handlers run in the API-server HTTP process and never go through the executor's `reload_for_new_request` pipeline. They therefore see the workspace config this process loaded at boot, plus the request-scoped `_load_workspaces()` memo (`@annotations.lru_cache(scope='request', maxsize=1)`), which nothing in the HTTP process clears. A workspace created via `/workspaces/create` **after** startup — an executor-side write — is invisible to those handlers indefinitely. With `--workers N`, each worker stays stale until *it* happens to serve a request that reloads, so the failure looks random per request and never self-heals on its own.

Two user-facing symptoms, two changes:

### 1. `POST /users/me/workspace` — `sky workspace use <new-workspace>` returns 404

```
$ sky workspace use alice
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: .../users/me/workspace
{"detail":"Workspace 'alice' does not exist."}
```

`set_user_preferred_workspace()` validates against `_load_workspaces()`. The sibling `GET /users/me/workspace` already calls `server_common.refresh_workspace_state_for_sync_handler()` (added with the feature in #9755); the POST directly above it does not. A worker only answers the POST correctly once it has served the GET. Fix: call the same helper in the POST, after the 401 check.

### 2. `/kubernetes-pod-ssh-proxy` — `ssh <cluster>` fails with "Cluster not found"

```
websockets.exceptions.ConnectionClosedError: received 1008 (policy violation) Cluster alice-dev not found
```

`_get_cluster_and_validate` → `core.status()` → `get_clusters()` starts with `get_accessible_workspace_names()`, which resolves through the same stale memo, so every cluster in the unknown workspace is filtered out and looks nonexistent. This path is deliberately cheap (20+ concurrent websocket SSH sessions), so a reload on every call would trade a correctness bug for a latency one. Fix: **refresh and retry once, only when the lookup misses.** The hot path (known cluster) does no extra work; a stale-config miss self-heals; a genuine miss pays one config reload before the 404 it was getting anyway.

## Reproduction

Observed in production on `berkeleyskypilot/skypilot:0.13.0` with 8 uvicorn workers (per-worker: every 404 on the POST came from a PID that had never served the GET; the one PID that had served it answered 200 — and later on different TCP connections, since the reload is process-global). The SSH symptom had the same per-PID split (0 failures on the refreshed worker, 71/31/14 on the others).

Reproduced cleanly against `master` with a **single-worker** local API server and a real Kubernetes cluster, so this is not a multi-worker artifact:

1. `sky api start`, server config has only `default`.
2. `POST /workspaces/create` a new workspace `ws-new` (executor path → `SUCCEEDED`).
3. `POST /users/me/workspace {"preferred":"ws-new"}` ×5 → **404 ×5**. One `GET /users/me/workspace` → next POST 200.
4. `sky launch -w ws-ssh -c test --infra k8s/<ctx> --cpus 1+ …` into a workspace created the same way. `sky status` (executor path) shows the cluster UP; `ssh test hostname` through the generated ProxyCommand → **`1008 Cluster test not found` ×3**; server log: `Closing SSH proxy websocket for cluster test: Cluster test not found`. One GET → ssh succeeds ×3.

With this PR (server rebooted without knowing the workspace, workspace re-created via the API, **no** refreshing GET): POST → 200 ×5; ssh → succeeds ×3 (log shows exactly one initial miss, then the retry taking over); `POST` for a nonexistent workspace and `ssh` to a nonexistent cluster both still return not-found.

## Tests

**Regression tests that reproduce the mechanism** — `tests/unit_tests/test_sky/server/test_stale_workspace_config_sync_handlers.py`. A fixture loads a server config with only `default` (internal-file mode, no DB), primes the real `_load_workspaces()` memo, then adds a workspace **on disk without reloading** — the exact state an HTTP process is in after an executor-side `/workspaces/create`. Against that state, with the real config loader and the real refresh helper (only the ACL/DB writes are mocked):

- `POST /users/me/workspace` for the new workspace succeeds (fails with `404: Workspace … does not exist` on the pre-fix code — verified by running the file against the reverted source).
- `_get_cluster_and_validate` finds a cluster in the new workspace, through a `core.status` stand-in that applies `get_clusters()`' accessible-workspace filter against the real resolution (fails with `404: Cluster … not found` pre-fix).
- Two **control** tests stub the refresh and assert the 404s come back, so the positive tests can't silently lose their teeth if something else starts clearing the memo.

Wiring tests:
- `tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py`: POST calls the refresh helper before validating (order-asserted); 401 short-circuits without taking the config lock.
- `tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py`: known cluster → no refresh, one `core.status` call; miss then hit → refresh called once, handle returned; miss twice → refresh once, still 404.

All four touched test files pass locally (51 tests); `yapf`/`isort` clean.

## Notes

- The refresh helper's own docstring says to call it "at the top of any plugin endpoint that … reads `get_workspaces()` / `get_accessible_workspace_names()`". Correctness currently depends on each sync-handler author remembering that, which is how the same omission ended up in two places. A config version/etag check (a follow-up hinted at in #10048) would make every sync path safe at once; this PR closes the two user-visible holes without a schema change.
- Both source hunks apply cleanly to `v0.13.0` as well.
