### PR TITLE
[Server][Jobs] Do not start a local API server from inside the API server

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -942,8 +942,28 @@ class StrategyExecutor:
                                                      f'{env_var}')
                                     logger.debug('Env vars for api_start: '
                                                  f'{os.environ}')
-                                    await asyncio.to_thread(sdk.api_start)
-                                    logger.info('API server started.')
+                                    if server_common.is_running_in_api_server():
+                                        # Running inside the API server
+                                        # (consolidation mode): the server is
+                                        # this process's parent, so there is
+                                        # nothing to start. Calling api_start
+                                        # here is at best redundant and, if a
+                                        # transient healthz probe fails under
+                                        # load, actively destructive --
+                                        # check_server_healthy_or_start_fn
+                                        # would route into _start_api_server,
+                                        # whose _set_metrics_env_var rmtrees
+                                        # the prometheus multiproc dir. The
+                                        # env-clearing above is a harmless
+                                        # no-op without a fresh server to
+                                        # inherit it; it is restored below.
+                                        logger.debug(
+                                            'Skipping local API server start; '
+                                            'already running inside the API '
+                                            'server.')
+                                    else:
+                                        await asyncio.to_thread(sdk.api_start)
+                                        logger.info('API server started.')
                                 finally:
                                     for env_var, value in (
                                             vars_to_restore.items()):

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -135,6 +135,19 @@ RETRY_COUNT_ON_TIMEOUT = 3
 # (e.g. in high contention env) and we will exit eagerly if server exit.
 WAIT_APISERVER_START_TIMEOUT_SEC = 60
 
+# When a healthz probe transiently fails *from inside the API server* (e.g. a
+# consolidation-mode jobs/serve controller probing its own parent under load),
+# the server is local and recovers in well under a second. We retry the probe
+# briefly in place rather than falling through to _start_api_server (which
+# wipes the metrics dir) or surfacing an error that would send the caller
+# (e.g. the jobs controller) into its full launch-retry backoff. Bounded by
+# wall clock so a persistent outage is not amplified: a single check_server_
+# healthy probe can itself spend RETRY_COUNT_ON_TIMEOUT * 2.5s on a slow
+# (Timeout) probe, after which the deadline is already exhausted and we
+# surface the error.
+_IN_SERVER_HEALTHZ_RETRY_TIMEOUT_SEC = 3.0
+_IN_SERVER_HEALTHZ_RETRY_INTERVAL_SEC = 0.5
+
 _LOCAL_API_SERVER_RESTART_HINT = (
     f'{colorama.Fore.YELLOW}The local SkyPilot API server is not compatible '
     'with the client. Please restart the API server with:\n'
@@ -853,6 +866,70 @@ def check_local_api_server_enabled_or_raise() -> None:
                 'sky api login -e <endpoint>')
 
 
+def is_running_in_api_server() -> bool:
+    """True if this process is running inside the API server.
+
+    The API server sets ENV_VAR_IS_SKYPILOT_SERVER ('IS_SKYPILOT_SERVER') in its
+    own environment (see _start_api_server), and every in-server child -- most
+    importantly the consolidation-mode jobs/serve controllers, which the API
+    server spawns via subprocess_utils.launch_new_process_tree and which
+    therefore inherit its env -- inherits it. A standalone jobs/serve
+    controller running on its own VM does NOT have it (the VM is not an API
+    server), nor does a fresh CLI shell.
+
+    This is the correct signal for "the API server is THIS process tree, so do
+    not attempt to start a new local one." It is deliberately NOT
+    OVERRIDE_CONSOLIDATION_MODE ('IS_SKYPILOT_JOB_CONTROLLER'): that env is
+    exported by scheduler.start_controller() inside *both* the standalone and
+    the consolidation controller, so is_jobs_consolidation_mode() (in
+    controller_utils) returns True unconditionally in every controller process.
+    Gating auto-start on it would also skip the standalone controller, which
+    *must* start a local API server on its own VM -- breaking non-consolidation
+    mode.
+    """
+    return os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None
+
+
+def _wait_for_local_server_in_api_server(
+        endpoint: str, exc: exceptions.ApiServerConnectionError) -> None:
+    """Retry a transient local healthz failure from inside the API server.
+
+    We are running inside the API server whose healthz is briefly unreachable
+    (under load the probe times out or the connection drops, but the server
+    recovers in well under a second and is still serving). Starting a new local
+    server is never correct here -- the server is this process tree, the port is
+    held, and the phantom would die at its own port guard *after*
+    _set_metrics_env_var rmtree'd the prometheus multiproc dir and truncated
+    the log. So retry the probe briefly in place; if it stays unreachable,
+    surface the connection error so the caller (e.g. the jobs controller)
+    retries the operation through its own backoff, instead of us silently
+    wiping every process's metrics.
+    """
+    deadline = time.monotonic() + _IN_SERVER_HEALTHZ_RETRY_TIMEOUT_SEC
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(_IN_SERVER_HEALTHZ_RETRY_INTERVAL_SEC, remaining))
+        # Probe a fresh status each iteration; the previous probe may have
+        # been served a stale/unhealthy response mid-blip.
+        get_api_server_status_response.cache_clear()  # type: ignore
+        try:
+            status, _ = check_server_healthy(endpoint)
+        except exceptions.ApiServerConnectionError:
+            continue  # still transient -- keep retrying until the deadline
+        # check_server_healthy raises on VERSION_MISMATCH (let it propagate,
+        # matching the non-start path) and UNHEALTHY (caught above). Mirror the
+        # original try-block for the remaining outcomes: HEALTHY succeeds,
+        # NEEDS_AUTH surfaces auth.
+        if status == ApiServerStatus.NEEDS_AUTH:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ApiServerAuthenticationError(endpoint)
+        return
+    with ux_utils.print_exception_no_traceback():
+        raise exceptions.ApiServerConnectionError(endpoint) from exc
+
+
 def _start_api_server(deploy: bool = False,
                       host: str = '127.0.0.1',
                       foreground: bool = False,
@@ -1126,6 +1203,18 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
         if not is_api_server_local(endpoint):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ApiServerConnectionError(endpoint) from exc
+        # Running inside the API server (consolidation-mode jobs/serve
+        # controllers, request handlers, daemons): the server is THIS process
+        # tree -- never start a new local one. _start_api_server would, as a
+        # side effect of _set_metrics_env_var, rmtree the prometheus multiproc
+        # dir (wiping every process's metrics files) and truncate server.log
+        # before the spawned phantom dies at its own port guard (the real
+        # server holds the port). Retry the transient healthz blip in place;
+        # surface the error if it persists. See is_running_in_api_server for
+        # why this is gated on IS_SKYPILOT_SERVER and not on consolidation mode.
+        if is_running_in_api_server():
+            _wait_for_local_server_in_api_server(endpoint, exc)
+            return
         # Fail early (before taking the creation lock) if silently starting
         # a local API server is disabled on this machine.
         check_local_api_server_enabled_or_raise()

--- a/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
@@ -322,6 +322,52 @@ async def test_launch_parks_and_reattaches_without_teardown(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_launch_skips_api_start_inside_api_server(monkeypatch):
+    """A consolidation-mode controller (IS_SKYPILOT_SERVER set) must not call
+    sdk.api_start.
+
+    The controller runs as a child of the API server and inherits
+    IS_SKYPILOT_SERVER, so the server is its own parent -- there is nothing to
+    start. Calling sdk.api_start here is at best redundant and, on a transient
+    healthz blip under load, actively destructive:
+    check_server_healthy_or_start_fn would route into _start_api_server, whose
+    _set_metrics_env_var rmtree's the prometheus multiproc dir.
+    sdk.launch still runs against the local parent.
+    """
+    executor = _make_launch_executor()
+    patches = _patch_launch_environment(monkeypatch)
+    executor._await_launch_request = mock.AsyncMock(return_value=None)
+    monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+
+    result = await executor._launch(max_retry=1, raise_on_failure=True)
+
+    assert result == 123.45
+    patches.sdk_launch.assert_called_once()
+    recovery_strategy.sdk.api_start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_launch_calls_api_start_on_standalone_controller(monkeypatch):
+    """A standalone controller (IS_SKYPILOT_SERVER unset) still calls
+    sdk.api_start to start a local API server on its own VM.
+
+    Guards the non-consolidation path: the IS_SKYPILOT_SERVER gate is the only
+    thing that should suppress the start, and it is intentionally absent on a
+    standalone controller VM (see server.common.is_running_in_api_server).
+    """
+    executor = _make_launch_executor()
+    patches = _patch_launch_environment(monkeypatch)
+    executor._await_launch_request = mock.AsyncMock(return_value=None)
+    monkeypatch.delenv('IS_SKYPILOT_SERVER', raising=False)
+
+    result = await executor._launch(max_retry=1, raise_on_failure=True)
+
+    assert result == 123.45
+    patches.sdk_launch.assert_called_once()
+    recovery_strategy.sdk.api_start.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_launch_parking_does_not_consume_retry_budget(monkeypatch):
     """Park cycles must not count against max_retry."""
     executor = _make_launch_executor()

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -174,6 +174,140 @@ def test_start_api_server_disabled_by_env_var():
     assert 'SKYPILOT_DISABLE_LOCAL_API_SERVER' in str(exc_info.value)
 
 
+@mock.patch('sky.server.common._start_api_server')
+@mock.patch('sky.server.common.filelock.FileLock')
+@mock.patch('sky.server.common.make_authenticated_request')
+@mock.patch('sky.server.common.is_api_server_local', return_value=True)
+@mock.patch('sky.server.common.get_server_url',
+            return_value='http://127.0.0.1:1111')
+def test_check_server_healthy_or_start_in_server_never_starts(
+        unused_url, unused_local, mock_make_request, mock_filelock,
+        mock_start_server):
+    """Inside the API server, a transient healthz failure never starts a new
+    local server.
+
+    A consolidation-mode controller runs as a child of the API server and
+    inherits IS_SKYPILOT_SERVER. When its localhost /api/health probe drops
+    transiently under load, the old code routed into _start_api_server, whose
+    _set_metrics_env_var rmtree'd the prometheus multiproc dir. Here the
+    in-server branch retries the probe briefly and surfaces an
+    ApiServerConnectionError instead; _start_api_server and the creation lock
+    are never reached (the lock is only for coordinating a real start).
+    """
+    mock_make_request.side_effect = requests.exceptions.ConnectionError()
+
+    with mock.patch.dict(os.environ, {'IS_SKYPILOT_SERVER': 'true'}), \
+            mock.patch.object(common, '_IN_SERVER_HEALTHZ_RETRY_TIMEOUT_SEC', 0):
+        with pytest.raises(exceptions.ApiServerConnectionError):
+            common.check_server_healthy_or_start_fn()
+
+    mock_start_server.assert_not_called()
+    # The creation lock is only needed to start a server.
+    mock_filelock.assert_not_called()
+
+
+@mock.patch('sky.server.common._start_api_server')
+@mock.patch('sky.server.common.filelock.FileLock')
+@mock.patch('sky.server.common.check_server_healthy')
+@mock.patch('sky.server.common.is_api_server_local', return_value=True)
+def test_check_server_healthy_or_start_in_server_retries_transient(
+        unused_local, mock_check, mock_filelock, mock_start_server):
+    """A transient healthz blip inside the API server recovers via the retry.
+
+    The first probe fails (the blip), the retry succeeds, and the call returns
+    normally -- no _start_api_server, no error surfaced to the caller, so a
+    sub-second blip does not push the jobs controller into its full launch-retry
+    backoff.
+    """
+    healthy = (ApiServerStatus.HEALTHY, mock.Mock())
+    mock_check.side_effect = [
+        exceptions.ApiServerConnectionError('http://127.0.0.1:1111'), healthy
+    ]
+
+    with mock.patch.dict(os.environ, {'IS_SKYPILOT_SERVER': 'true'}), \
+            mock.patch.object(common, '_IN_SERVER_HEALTHZ_RETRY_TIMEOUT_SEC',
+                              2.0), \
+            mock.patch.object(common, '_IN_SERVER_HEALTHZ_RETRY_INTERVAL_SEC',
+                              0.0):
+        common.check_server_healthy_or_start_fn()
+
+    assert mock_check.call_count == 2
+    mock_start_server.assert_not_called()
+    mock_filelock.assert_not_called()
+
+
+@mock.patch('sky.server.common._start_api_server')
+@mock.patch('sky.server.common.filelock.FileLock')
+@mock.patch('sky.server.common.make_authenticated_request')
+@mock.patch('sky.server.common.is_api_server_local', return_value=True)
+@mock.patch('sky.server.common.get_server_url',
+            return_value='http://127.0.0.1:1111')
+def test_check_server_healthy_or_start_non_server_still_auto_starts(
+        unused_url, unused_local, mock_make_request, mock_filelock,
+        mock_start_server):
+    """A standalone controller (IS_SKYPILOT_SERVER unset) still auto-starts a
+    local server -- the fix must not break non-consolidation mode.
+    """
+    mock_make_request.side_effect = requests.exceptions.ConnectionError()
+
+    env = {k: v for k, v in os.environ.items() if k != 'IS_SKYPILOT_SERVER'}
+    with mock.patch.dict(os.environ, env, clear=True):
+        common.check_server_healthy_or_start_fn()
+
+    mock_start_server.assert_called_once()
+    # The normal auto-start path still coordinates via the creation lock.
+    mock_filelock.assert_called_once()
+
+
+def test_check_server_healthy_or_start_in_server_preserves_metrics_dir(
+        monkeypatch, tmp_path):
+    """Regression: _set_metrics_env_var must not rmtree the prometheus
+    multiproc dir when an in-server process hits a transient healthz failure.
+
+    Exercises the REAL _start_api_server / _set_metrics_env_var (only the
+    trigger and external side effects are mocked) against a populated metrics
+    dir. With the fix, _start_api_server is never reached, so the markers
+    survive. If the in-server gate is removed, _start_api_server runs, the real
+    _set_metrics_env_var rmtree's the dir, and the markers vanish -- failing
+    this test -- which is exactly the production bug.
+    """
+    metrics_root = tmp_path / 'metrics_root'
+    metrics_dir = metrics_root / 'metrics'
+    metrics_dir.mkdir(parents=True)
+    (metrics_dir / 'gauge_liveall.db').write_text('multiproc-gauge')
+    (metrics_dir / 'histogram_liveall.db').write_text('multiproc-histogram')
+
+    monkeypatch.setattr(common.tempfile, 'gettempdir',
+                        lambda: str(metrics_root))
+    monkeypatch.setattr(common, '_IN_SERVER_HEALTHZ_RETRY_TIMEOUT_SEC', 0)
+    monkeypatch.setattr(
+        common, 'check_server_healthy',
+        mock.Mock(side_effect=exceptions.ApiServerConnectionError(
+            'http://127.0.0.1:46580')))
+    monkeypatch.setattr(common, 'is_api_server_local', lambda *a, **k: True)
+    monkeypatch.setattr(common, 'get_server_url',
+                        lambda *a, **k: 'http://127.0.0.1:46580')
+    monkeypatch.setattr(common.filelock, 'FileLock', mock.MagicMock())
+    # External side effects of a *real* _start_api_server, in case the gate is
+    # ever removed: keep them inert so the rmtree (the thing under test) is the
+    # only real side effect that could fire.
+    monkeypatch.setattr(common.common_utils, 'get_mem_size_gb', lambda: 16.0)
+    monkeypatch.setattr(common.os, 'makedirs', lambda *a, **k: None)
+    monkeypatch.setattr(
+        common.subprocess, 'Popen',
+        mock.Mock(return_value=mock.Mock(poll=mock.Mock(return_value=1))))
+    monkeypatch.setattr('builtins.open', mock.mock_open())
+
+    monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+    monkeypatch.setenv('SKY_API_SERVER_METRICS_ENABLED', 'true')
+
+    with pytest.raises(exceptions.ApiServerConnectionError):
+        common.check_server_healthy_or_start_fn()
+
+    assert (metrics_dir / 'gauge_liveall.db').exists()
+    assert (metrics_dir / 'histogram_liveall.db').exists()
+
+
 def test_local_api_server_not_disabled_by_default():
     """Without the env var, the guard is a no-op."""
     env = os.environ.copy()


### PR DESCRIPTION
## Summary

- A process running **inside the API server** (in-process jobs/serve controllers, request handlers) that made any `@check_server_healthy_or_start`-decorated SDK call could, on a **transient local `/api/health` probe failure under load**, be routed into the local API server start path (`_start_api_server`).
- That path wipes the prometheus multiproc metrics directory (`shutil.rmtree` in `_set_metrics_env_var`) and truncates `server.log` as a **side effect**, while the Popen'd "new" server immediately dies at its own port guard — the real server already holds the port. `prometheus_client` writers keep the mmap of the deleted inode, so every pre-wipe process stops exporting prometheus metrics until restart.
- **Fix:** detect that the current process is already running inside the API server (`IS_SKYPILOT_SERVER`) and never start a new local one from there — on a local healthz failure, retry the probe briefly (wall-clock bounded) and surface the error if it persists instead of starting a new server. This covers every decorated SDK call. The jobs controller also skips its explicit `sdk.api_start()` call in this case.
- The detection deliberately uses `IS_SKYPILOT_SERVER` (set in the API server env, inherited by in-server children; absent on a standalone controller VM and in a fresh CLI shell) and **not** the jobs-controller consolidation env var (`IS_SKYPILOT_JOB_CONTROLLER`), which is exported inside *both* the standalone and the in-process controller and therefore cannot distinguish them — gating on it would also suppress the standalone controller, which **must** start a local server on its own VM. This invariant is documented in the new `is_running_in_api_server()` docstring.

## Test plan

- New unit tests in `tests/unit_tests/test_sky/server/test_common.py`:
  - inside-the-server healthz failure never starts a server (retries, then raises `ApiServerConnectionError`); `_start_api_server` and the creation lock are never reached.
  - a transient healthz blip inside the server recovers via the retry (no error surfaced, no start).
  - a populated prometheus multiproc dir survives an in-server transient failure (regression — **fails if the gate is removed**).
  - a non-server process (`IS_SKYPILOT_SERVER` unset) still auto-starts a local server.
- New unit tests in `tests/unit_tests/test_sky/jobs/test_recovery_strategy.py`:
  - the jobs controller skips `sdk.api_start` when inside the API server but still calls `sdk.launch`.
  - a standalone controller (env unset) still calls `sdk.api_start`.
- `pytest tests/unit_tests/test_sky/server/test_common.py tests/unit_tests/test_sky/jobs/test_recovery_strategy.py` — green.
- Verified the standalone/CLI auto-start path with a real local server boot (no regression).

-Claude