### PR TITLE
[Metrics][Dashboard] Slurm: federate GPU metrics via the login node, and up-node/power-saved infra handling

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -284,15 +284,32 @@ class SlurmClient:
                 slurm_user=slurm_user,
             )
 
-    def _run_slurm_cmd(self, cmd: str) -> Tuple[int, str, str]:
+    def _run_slurm_cmd(self,
+                       cmd: str,
+                       timeout: Optional[int] = None) -> Tuple[int, str, str]:
+        # Forward `timeout` only when set so the existing callers keep the
+        # runner's default (unbounded) invocation unchanged.
+        if timeout is None:
+            return self._runner.run(cmd,
+                                    require_outputs=True,
+                                    separate_stderr=True,
+                                    stream_logs=False)
         return self._runner.run(cmd,
                                 require_outputs=True,
                                 separate_stderr=True,
-                                stream_logs=False)
+                                stream_logs=False,
+                                timeout=timeout)
 
-    def _run_slurm_cmds(self,
-                        commands: Sequence[str]) -> List[Tuple[int, str, str]]:
-        """Run independent commands concurrently in one remote invocation."""
+    def _run_slurm_cmds(
+            self,
+            commands: Sequence[str],
+            timeout: Optional[int] = None) -> List[Tuple[int, str, str]]:
+        """Run independent commands concurrently in one remote invocation.
+
+        ``timeout`` bounds the whole remote invocation in seconds (SSH
+        connect included); on expiry the SSH process is killed and
+        subprocess.TimeoutExpired is raised.
+        """
         if not commands:
             return []
 
@@ -334,7 +351,7 @@ class SlurmClient:
             ])
 
         script = '\n'.join(script_lines)
-        rc, stdout, stderr = self._run_slurm_cmd(script)
+        rc, stdout, stderr = self._run_slurm_cmd(script, timeout=timeout)
         subprocess_utils.handle_returncode(
             rc,
             'concurrent Slurm inventory commands',
@@ -342,16 +359,21 @@ class SlurmClient:
             stderr=f'{stdout}\n{stderr}',
             stream_logs=False)
 
+        # The login shell may print before the script runs (profile.d
+        # banners, module-system notices, MOTD-style greetings); that noise
+        # lands ahead of the header. Skip to the header so it can neither
+        # corrupt the frames nor, if it is non-ASCII, fail the transport.
+        header_index = stdout.find(_BATCH_OUTPUT_HEADER)
+        if header_index == -1:
+            raise RuntimeError('Unexpected output from concurrent Slurm '
+                               'inventory commands: missing header.')
         try:
-            output_bytes = stdout.encode('ascii')
+            output_bytes = stdout[header_index:].encode('ascii')
         except UnicodeEncodeError as e:
             raise RuntimeError('Unexpected output from concurrent Slurm '
                                'inventory commands: non-ASCII transport '
                                'output.') from e
         header_bytes = _BATCH_OUTPUT_HEADER.encode('ascii')
-        if not output_bytes.startswith(header_bytes):
-            raise RuntimeError('Unexpected output from concurrent Slurm '
-                               'inventory commands: missing header.')
         offset = len(header_bytes)
         results = []
         for _ in commands:
@@ -403,6 +425,34 @@ class SlurmClient:
             raise RuntimeError('Unexpected output from concurrent Slurm '
                                'inventory commands: trailing data.')
         return results
+
+    def run_command(self,
+                    cmd: str,
+                    timeout: Optional[int] = None) -> Tuple[int, str, str]:
+        """Runs one shell command on the login node.
+
+        The public entry point for callers outside this client (e.g.
+        GPU-metrics federation) that need a command's output byte-exact. It
+        rides the framed batch transport, so whatever the login shell prints
+        before the command runs (profile.d banners, module-system notices)
+        cannot leak into the returned stdout — a plain SSH invocation would
+        prepend that noise.
+
+        Args:
+            cmd: Shell command to run on the login node.
+            timeout: Optional bound in seconds on the whole remote
+                invocation (SSH connect included); on expiry the SSH process
+                is killed and subprocess.TimeoutExpired is raised.
+
+        Returns:
+            (returncode, stdout, stderr) of ``cmd`` itself.
+
+        Raises:
+            exceptions.CommandError: If the transport itself fails (e.g. the
+                login node is unreachable).
+            subprocess.TimeoutExpired: If ``timeout`` expires.
+        """
+        return self._run_slurm_cmds([cmd], timeout=timeout)[0]
 
     def query_jobs(
         self,

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -12,6 +12,7 @@ import {
   PlayIcon,
   ChevronRightIcon,
   ChevronDownIcon,
+  InfoIcon,
 } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
 import { useUrlFilterState } from '@/hooks/useUrlFilterState';
@@ -335,6 +336,52 @@ const aggregateSlurmPartitions = (nodes) => {
       };
     });
 };
+
+// A Slurm node whose sinfo state carries a '~' suffix is a powered-down cloud
+// node (POWER_SAVE) with no backing instance — Slurm's dynamic capacity that
+// only materializes when a job needs it (the scheduler still places jobs on
+// such nodes and powers them up on demand). Count only "up" nodes so the infra
+// total reflects the nodes that exist right now, and report the powered-down
+// tally for a tooltip.
+export function countUpSlurmNodes(nodes) {
+  let poweredDown = 0;
+  for (const node of nodes || []) {
+    const state = node?.node_state;
+    if (typeof state === 'string' && state.includes('~')) {
+      poweredDown += 1;
+    }
+  }
+  return { up: (nodes?.length || 0) - poweredDown, poweredDown };
+}
+
+// Info icon whose tooltip explains the power-saved nodes folded out of a
+// Slurm node count. Shared by the infra table cell and the context detail
+// page so both surfaces tell the same story.
+function PowerSavedNodesHint({ poweredDown }) {
+  return (
+    <NonCapitalizedTooltip
+      content={`${poweredDown.toLocaleString()} power-saved`}
+      className="text-sm text-muted-foreground"
+    >
+      <InfoIcon className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 cursor-help" />
+    </NonCapitalizedTooltip>
+  );
+}
+
+// The "Nodes" cell for a Slurm cluster: the up-node count, plus an info icon
+// whose tooltip explains the power-saved nodes folded out of it.
+function SlurmNodesCell({ nodes }) {
+  const { up, poweredDown } = countUpSlurmNodes(nodes);
+  if (poweredDown === 0) {
+    return up;
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      {up}
+      <PowerSavedNodesHint poweredDown={poweredDown} />
+    </span>
+  );
+}
 
 // Reusable component for infrastructure sections (SSH Node Pool or Kubernetes)
 export function InfrastructureSection({
@@ -855,7 +902,13 @@ export function InfrastructureSection({
                           className={`${sharedCellClass} text-gray-500 tabular-nums whitespace-nowrap`}
                           rowSpan={subRowCount}
                         >
-                          {!hasNodeData ? <SkeletonBadge /> : nodes.length}
+                          {!hasNodeData ? (
+                            <SkeletonBadge />
+                          ) : isSlurm ? (
+                            <SlurmNodesCell nodes={nodes} />
+                          ) : (
+                            nodes.length
+                          )}
                         </td>
                         {!isSlurm && (
                           <td
@@ -938,7 +991,11 @@ export function InfrastructureSection({
                   loading: isJobsDataLoading,
                   value: jobsData[contextStatsKey]?.jobs || 0,
                 },
-                { label: 'Nodes', loading: !hasNodeData, value: nodes.length },
+                {
+                  label: 'Nodes',
+                  loading: !hasNodeData,
+                  value: isSlurm ? countUpSlurmNodes(nodes).up : nodes.length,
+                },
                 ...(!isSlurm
                   ? [
                       {
@@ -1058,6 +1115,21 @@ export function ContextDetails({
   const isSSHContext = contextName.startsWith('ssh-');
   const displayTitle = isSSHContext ? 'Node Pool' : 'Context';
 
+  // Slurm exposes power-saved (POWER_SAVE, `~`-state) cloud nodes with no
+  // backing instance; fold them out of the node table so it lists only nodes
+  // that are actually up, and surface the hidden tally in a badge next to the
+  // total. `visibleNodes` stays === nodesInContext for every other case.
+  const slurmPoweredDown = isSlurm
+    ? countUpSlurmNodes(nodesInContext).poweredDown
+    : 0;
+  const visibleNodes =
+    slurmPoweredDown > 0
+      ? nodesInContext.filter(
+          (n) =>
+            !(typeof n?.node_state === 'string' && n.node_state.includes('~'))
+        )
+      : nodesInContext;
+
   // Pagination for the node table — contexts can have hundreds of nodes.
   const [nodesCurrentPage, setNodesCurrentPage] = useState(1);
   const [nodesPageSize, setNodesPageSize] = useState(() =>
@@ -1067,13 +1139,13 @@ export function ContextDetails({
       10
     )
   );
-  const nodesTotalPages = Math.ceil(nodesInContext.length / nodesPageSize);
+  const nodesTotalPages = Math.ceil(visibleNodes.length / nodesPageSize);
   const nodesStartIndex = (nodesCurrentPage - 1) * nodesPageSize;
   const nodesEndIndex = Math.min(
     nodesStartIndex + nodesPageSize,
-    nodesInContext.length
+    visibleNodes.length
   );
-  const paginatedNodes = nodesInContext.slice(nodesStartIndex, nodesEndIndex);
+  const paginatedNodes = visibleNodes.slice(nodesStartIndex, nodesEndIndex);
 
   // Reset to the first page when switching contexts; clamp when the node
   // list shrinks under the current page (e.g. on a data refresh).
@@ -1279,17 +1351,21 @@ export function ContextDetails({
             </div>
           )}
 
-          {nodesInContext.length === 0 && (
+          {visibleNodes.length === 0 && (
             <div className="rounded-md border border-gray-200 shadow-sm">
               <EmptyState
                 icon={<ServerIcon className="w-5 h-5" />}
                 title="No nodes found"
-                description="No nodes are available in this context"
+                description={
+                  slurmPoweredDown > 0
+                    ? `No nodes are up in this context (${slurmPoweredDown.toLocaleString()} power-saved)`
+                    : 'No nodes are available in this context'
+                }
               />
             </div>
           )}
 
-          {nodesInContext.length > 0 && (
+          {visibleNodes.length > 0 && (
             <div className="rounded-md border border-gray-200 shadow-sm">
               <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
@@ -1476,11 +1552,11 @@ export function ContextDetails({
                   </tbody>
                 </table>
               </div>
-              {nodesInContext.length > nodesPageSize && (
+              {visibleNodes.length > nodesPageSize && (
                 <PaginationControls
                   currentPage={nodesCurrentPage}
                   totalPages={nodesTotalPages}
-                  totalCount={nodesInContext.length}
+                  totalCount={visibleNodes.length}
                   startIndex={nodesStartIndex}
                   endIndex={nodesEndIndex}
                   onPageChange={setNodesCurrentPage}

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -16,6 +16,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import {
   InfrastructureSection,
   slurmRequestableCounts,
+  countUpSlurmNodes,
 } from '@/components/infra';
 
 // The infrastructure table renders one sub-row per GPU type. A Slurm cluster
@@ -248,6 +249,68 @@ describe('slurmRequestableCounts', () => {
 
   it('returns nothing for a CPU-only node', () => {
     expect(slurmRequestableCounts(0)).toEqual([]);
+  });
+});
+
+describe('countUpSlurmNodes', () => {
+  const n = (state) => ({ node_name: 'x', node_state: state });
+
+  it('excludes powered-down (~) nodes from the up count', () => {
+    const nodes = [n('alloc'), n('idle'), n('idle~'), n('idle~'), n('mix')];
+    expect(countUpSlurmNodes(nodes)).toEqual({ up: 3, poweredDown: 2 });
+  });
+
+  it('treats every node as up when none are powered down', () => {
+    expect(countUpSlurmNodes([n('alloc'), n('idle')])).toEqual({
+      up: 2,
+      poweredDown: 0,
+    });
+  });
+
+  it('tolerates missing/blank state and empty input', () => {
+    expect(countUpSlurmNodes([{ node_name: 'x' }, n('')])).toEqual({
+      up: 2,
+      poweredDown: 0,
+    });
+    expect(countUpSlurmNodes([])).toEqual({ up: 0, poweredDown: 0 });
+    expect(countUpSlurmNodes(undefined)).toEqual({ up: 0, poweredDown: 0 });
+  });
+});
+
+describe('InfrastructureSection Slurm node count', () => {
+  const nodeWithState = (nodeName, state) => ({
+    node_name: nodeName,
+    partition: 'all*',
+    gpu_name: 'H100',
+    gpu_total: 8,
+    gpu_free: 0,
+    cluster: 'prod-gpu',
+    node_state: state,
+  });
+
+  it('shows the up-node count, folding out powered-down cloud nodes', () => {
+    const { container } = renderSection({
+      isSlurm: true,
+      contexts: ['prod-gpu'],
+      gpus: [{ gpu_name: 'H100', gpu_total: 24, gpu_free: 0 }],
+      groupedPerContextGPUs: {
+        'prod-gpu': [{ gpu_name: 'H100', gpu_total: 24, gpu_free: 0 }],
+      },
+      groupedPerNodeGPUs: {
+        'prod-gpu': [
+          nodeWithState('n1', 'alloc'),
+          nodeWithState('n2', 'mix'),
+          nodeWithState('n3', 'idle~'),
+          nodeWithState('n4', 'idle~'),
+          nodeWithState('n5', 'idle~'),
+        ],
+      },
+    });
+    const rows = tableRows(container);
+    // 2 up + 3 power-saved: the Nodes cell shows 2, never the raw 5.
+    expect(normalize(rows[0])).toMatch(/prod-gpu\s*2/);
+    // The power-saved hint is informational, not a warning.
+    expect(rows[0].querySelector('svg.lucide-info')).not.toBeNull();
   });
 });
 

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -499,6 +499,11 @@ export function ManagedJobs() {
           refreshDataRef={poolsRefreshRef}
         />
       </div>
+
+      {/* Extension point for jobs not managed by SkyPilot (e.g. foreign
+          Slurm jobs surfaced by the GPU Manager plugin). Renders nothing
+          when no plugin fills it. */}
+      <PluginSlot name="jobs.page.external-section" />
     </>
   );
 }

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -1275,6 +1275,9 @@ async function getSlurmServiceGPUs() {
         gpu_free: node.free_gpus || 0,
         cluster: clusterName,
         partition: node.partition || 'default', // partition might be null
+        // Raw sinfo state (e.g. 'idle~'); the '~' suffix marks a powered-down
+        // cloud node. Carried so the infra table can count only up nodes.
+        node_state: node.node_state,
       };
     }
 

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1427,14 +1427,16 @@ def get_slurm_metrics_clusters() -> List[str]:
 
     A cluster participates when it is allowed by ``slurm.allowed_clusters``
     (the analog of ``kubernetes.allowed_contexts``; defaults to every cluster
-    in ``~/.slurm/config``) *and* ``slurm.cluster_configs.<name>.prometheus_url``
-    is set: the URL of a Prometheus reachable *from the cluster's login node*
-    (typically running inside the cluster) that scrapes the cluster's node/DCGM
-    exporters. No SSH probing happens here — enumeration reads only local config.
+    in ``~/.slurm/config``) *and*
+    ``slurm.cluster_configs.<name>.prometheus_url`` is set: the URL of a
+    Prometheus reachable *from the cluster's login node* (typically running
+    inside the cluster) that scrapes the cluster's node/DCGM exporters. No SSH
+    probing happens here — enumeration reads only local config.
     """
     try:
         # pylint: disable=import-outside-toplevel
         from sky import clouds
+
         # Scope federation to the same clusters the rest of SkyPilot uses,
         # honoring slurm.allowed_clusters (mirrors how the Kubernetes federation
         # respects allowed_contexts). Defaults to all clusters in

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1425,16 +1425,21 @@ _SLURM_FEDERATE_CURL_HEADROOM_SECONDS = 5
 def get_slurm_metrics_clusters() -> List[str]:
     """Slurm clusters opted into GPU metrics federation.
 
-    A cluster participates when ``slurm.cluster_configs.<name>.
-    prometheus_url`` is set: the URL of a Prometheus reachable *from the
-    cluster's login node* (typically running inside the cluster) that
-    scrapes the cluster's node/DCGM exporters. No SSH probing happens
-    here — enumeration reads only local config.
+    A cluster participates when it is allowed by ``slurm.allowed_clusters``
+    (the analog of ``kubernetes.allowed_contexts``; defaults to every cluster
+    in ``~/.slurm/config``) *and* ``slurm.cluster_configs.<name>.prometheus_url``
+    is set: the URL of a Prometheus reachable *from the cluster's login node*
+    (typically running inside the cluster) that scrapes the cluster's node/DCGM
+    exporters. No SSH probing happens here — enumeration reads only local config.
     """
     try:
         # pylint: disable=import-outside-toplevel
-        from sky.provision.slurm import utils as slurm_utils
-        names = slurm_utils.get_all_slurm_cluster_names()
+        from sky import clouds
+        # Scope federation to the same clusters the rest of SkyPilot uses,
+        # honoring slurm.allowed_clusters (mirrors how the Kubernetes federation
+        # respects allowed_contexts). Defaults to all clusters in
+        # ~/.slurm/config when allowed_clusters is unset.
+        names = clouds.Slurm.existing_allowed_clusters(silent=True)
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Could not enumerate Slurm clusters: {e}')
         return []

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -7,10 +7,12 @@ import queue
 import random
 import re
 import select
+import shlex
 import subprocess
 import threading
 import time
 from typing import Dict, List, Optional, Set, Tuple
+import urllib.parse
 
 import httpx
 import prometheus_client as prom
@@ -579,7 +581,8 @@ def _record_served_verdict(context: str, result: str) -> None:
 class FederationStats:
     """Mutable per-context timing/size record for one federation attempt.
 
-    send_metrics_request_with_port_forward() fills this in phase-by-phase. The
+    send_metrics_request_with_port_forward() fills this in phase-by-phase
+    (get_metrics_for_slurm_cluster() fills only the federate phase). The
     caller (the /gpu-metrics or /endpoints-metrics gather loop) holds a
     reference and reads it when logging the result — crucially, this still
     works when the attempt is cancelled by asyncio.wait_for(): the fields
@@ -587,7 +590,11 @@ class FederationStats:
     so the timeout log can show exactly how far the attempt got.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, has_port_forward: bool = True) -> None:
+        # False on transports with no port-forward phase (a Slurm cluster's
+        # login-node curl over SSH); summary() then omits that phase instead
+        # of reporting it as 'incomplete'.
+        self.has_port_forward = has_port_forward
         self.port_forward_seconds: Optional[float] = None
         self.federate_seconds: Optional[float] = None
         self.body_bytes: Optional[int] = None
@@ -616,6 +623,8 @@ class FederationStats:
                    f'wire={wire}, enc={self.content_encoding}')
         else:
             fed = 'incomplete'
+        if not self.has_port_forward:
+            return f'federate={fed}'
         return f'port_forward={pf}, federate={fed}'
 
 
@@ -1211,9 +1220,16 @@ _CLUSTER_LABEL_RE = re.compile(r'(?<![A-Za-z0-9_])cluster="')
 # this loop, while the (almost always false) substring test is a C-level
 # scan an order of magnitude cheaper.
 _CLUSTER_LABEL_LITERAL = 'cluster="'
+# The whole `cluster="..."` token, value included, for replace_existing.
+# Label values escape '"' and '\\' with a backslash, so the value is any run
+# of non-quote/non-backslash characters or backslash escapes.
+_CLUSTER_LABEL_TOKEN_RE = re.compile(
+    r'(?<![A-Za-z0-9_])cluster="(?:[^"\\]|\\.)*"')
 
 
-def _stamp_cluster_label(metrics_text: str, context: str) -> str:
+def _stamp_cluster_label(metrics_text: str,
+                         context: str,
+                         replace_existing: bool = False) -> str:
     """Body of add_cluster_name_label(); see it for semantics.
 
     Split out as a plain sync function so it can be handed to a worker
@@ -1225,6 +1241,7 @@ def _stamp_cluster_label(metrics_text: str, context: str) -> str:
     lines = metrics_text.strip().split('\n')
     modified_lines = []
     already_labeled = 0
+    replaced = 0
     prefix = f'cluster="{context}",'
     only_label = f'cluster="{context}"'
 
@@ -1245,10 +1262,21 @@ def _stamp_cluster_label(metrics_text: str, context: str) -> str:
 
             if (_CLUSTER_LABEL_LITERAL in existing_labels and
                     _CLUSTER_LABEL_RE.search(existing_labels)):
-                # Already attributed; re-stamping would duplicate the
-                # cluster label and invalidate the whole scrape body.
-                already_labeled += 1
-                modified_lines.append(line)
+                if not replace_existing:
+                    # Already attributed; re-stamping would duplicate the
+                    # cluster label and invalidate the whole scrape body.
+                    already_labeled += 1
+                    modified_lines.append(line)
+                    continue
+                # The source stamped its own identity (Prometheus /federate
+                # applies global.external_labels to every exported series);
+                # re-attribute the series to this context. A lambda keeps
+                # re.sub from interpreting backslashes in the context.
+                replaced += 1
+                new_labels = _CLUSTER_LABEL_TOKEN_RE.sub(
+                    lambda _: only_label, existing_labels)
+                modified_lines.append(
+                    f'{metric_name}{{{new_labels}}}{rest_of_line}')
                 continue
 
             if existing_labels:
@@ -1271,11 +1299,18 @@ def _stamp_cluster_label(metrics_text: str, context: str) -> str:
             f'{already_labeled}/{len(lines)} series federated from context '
             f'{context!r} already carried a cluster label and were left '
             f'unstamped.')
+    if replaced:
+        logger.debug(
+            f'{replaced}/{len(lines)} series federated from context '
+            f'{context!r} carried a source-side cluster label (e.g. the '
+            f'source Prometheus\'s external_labels) and were re-attributed.')
 
     return '\n'.join(modified_lines)
 
 
-async def add_cluster_name_label(metrics_text: str, context: str) -> str:
+async def add_cluster_name_label(metrics_text: str,
+                                 context: str,
+                                 replace_existing: bool = False) -> str:
     """Adds a cluster label to each metric line.
 
     Skips lines that already carry a `cluster` label (stamped by a
@@ -1289,6 +1324,14 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
     skipping keeps them byte-identical to the stored series so ingestion
     collapses them to a no-op instead of poisoning the scrape.
 
+    With ``replace_existing`` an existing label is overwritten instead.
+    That is only safe where the safety net above can never be needed,
+    i.e. the payload cannot be this server's own stamped series. Slurm
+    federation qualifies: there is no "local" Slurm context, while a
+    cluster's own Prometheus commonly sets a `cluster` external label
+    (which /federate applies to every exported series); left in place it
+    would hide the series from every `cluster="slurm/<name>"` query.
+
     Runs in a worker thread: the metrics server serves /metrics,
     /gpu-metrics and /endpoints-metrics from a single event loop, and a
     large fleet's federated payload takes tens of seconds of pure CPU to
@@ -1301,7 +1344,8 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
         metrics_text: The text containing the metrics
         context: The cluster name
     """
-    return await asyncio.to_thread(_stamp_cluster_label, metrics_text, context)
+    return await asyncio.to_thread(_stamp_cluster_label, metrics_text, context,
+                                   replace_existing)
 
 
 # Series federated from each context's Prometheus by /gpu-metrics: DCGM, host
@@ -1358,6 +1402,122 @@ async def get_metrics_for_context(context: str,
     metrics_text = await add_cluster_name_label(metrics_text, context)
 
     return metrics_text
+
+
+# Series federated from a Slurm cluster's Prometheus. Slurm clusters run no
+# kube-state-metrics or cAdvisor, so only node-exporter + DCGM series are
+# requested.
+SLURM_GPU_METRICS_MATCH_PATTERNS = [
+    '{__name__=~"node_memory_MemAvailable_bytes|node_memory_MemTotal_bytes|DCGM_.*"}',  # pylint: disable=line-too-long
+    'node_cpu_seconds_total{mode="idle"}',
+]
+
+# Context-string prefix under which Slurm series are stamped; matches the
+# GPU Manager's Slurm context vocabulary ('slurm/<cluster>').
+SLURM_CONTEXT_PREFIX = 'slurm/'
+
+# Headroom, in seconds, that curl's own limit leaves inside a Slurm cluster's
+# federation budget: the SSH connect before the request and the cluster-label
+# stamping after it have to fit in the same budget.
+_SLURM_FEDERATE_CURL_HEADROOM_SECONDS = 5
+
+
+def get_slurm_metrics_clusters() -> List[str]:
+    """Slurm clusters opted into GPU metrics federation.
+
+    A cluster participates when ``slurm.cluster_configs.<name>.
+    prometheus_url`` is set: the URL of a Prometheus reachable *from the
+    cluster's login node* (typically running inside the cluster) that
+    scrapes the cluster's node/DCGM exporters. No SSH probing happens
+    here — enumeration reads only local config.
+    """
+    try:
+        # pylint: disable=import-outside-toplevel
+        from sky.provision.slurm import utils as slurm_utils
+        names = slurm_utils.get_all_slurm_cluster_names()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not enumerate Slurm clusters: {e}')
+        return []
+    return [
+        name for name in names
+        if skypilot_config.get_nested(('slurm', 'cluster_configs', name,
+                                       'prometheus_url'), None)
+    ]
+
+
+async def get_metrics_for_slurm_cluster(cluster_name: str,
+                                        stats: Optional[FederationStats] = None,
+                                        timeout: float = 30.0) -> str:
+    """Federate GPU metrics from a Slurm cluster's own Prometheus.
+
+    The /federate request is executed *on* the login node (curl) through
+    the cluster's SSH transport, so it traverses outbound-only tunnel
+    agents unchanged and never requires network reachability from the API
+    server to the cluster's Prometheus. Series are stamped with
+    ``cluster="slurm/<name>"``, mirroring the Kubernetes federation path,
+    so every downstream consumer (central Prometheus, Grafana dashboards,
+    GPU Manager queries) treats the Slurm cluster like any other context.
+
+    Timeouts mirror the Kubernetes path's single per-context budget: the
+    SSH invocation is hard-killed at ``timeout`` (a hung login node cannot
+    leak the worker thread past the scrape — asyncio.wait_for() cancels
+    only the awaiting coroutine, never the thread), and curl's own limit
+    sits a few seconds inside it to leave room for the SSH connect.
+
+    Args:
+        cluster_name: Slurm cluster name (a Host alias in ~/.slurm/config).
+        stats: Optional FederationStats; only the federate timing/size are
+            populated (there is no port-forward phase on this path).
+        timeout: Budget in seconds for the whole fetch. Must fit within the
+            per-context timeout in sky/server/metrics.py
+            (_PER_CONTEXT_TIMEOUT_SECONDS).
+
+    Raises:
+        Exception: If the login-node curl or the federate request fails.
+    """
+    prometheus_url = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name, 'prometheus_url'), None)
+    if not prometheus_url:
+        raise ValueError(
+            f'No prometheus_url configured for Slurm cluster {cluster_name!r}')
+
+    query = '&'.join('match[]=' + urllib.parse.quote(pattern)
+                     for pattern in SLURM_GPU_METRICS_MATCH_PATTERNS)
+    federate_url = prometheus_url.rstrip('/') + '/federate?' + query
+    curl_timeout = max(1, int(timeout) - _SLURM_FEDERATE_CURL_HEADROOM_SECONDS)
+    # -g (--globoff): curl otherwise parses the '[]' of 'match[]' as a URL
+    # glob; curl < 7.61 (e.g. CentOS 7 login nodes) rejects it outright.
+    curl_cmd = (f'curl -g -sS --fail -m {curl_timeout} '
+                f'{shlex.quote(federate_url)}')
+
+    def _fetch() -> str:
+        # pylint: disable=import-outside-toplevel
+        from sky.provision.slurm import utils as slurm_utils
+
+        # The framed transport keeps login-shell noise (profile.d banners,
+        # module notices) out of stdout: a stray line ahead of the
+        # exposition text would make Prometheus reject the *entire*
+        # /gpu-metrics body, every cluster included.
+        returncode, stdout, stderr = slurm_utils.run_on_login_node(
+            cluster_name, curl_cmd, timeout=int(timeout))
+        if returncode != 0:
+            raise RuntimeError(
+                f'Federate curl on Slurm cluster {cluster_name!r} exited '
+                f'{returncode}: {(stderr or stdout).strip()[:500]}')
+        return stdout
+
+    start = time.monotonic()
+    metrics_text = await asyncio.to_thread(_fetch)
+    if stats is not None:
+        stats.federate_seconds = time.monotonic() - start
+        stats.body_bytes = len(metrics_text.encode('utf-8'))
+
+    # replace_existing: the cluster's Prometheus may stamp its own
+    # `cluster` external label on every federated series; that must become
+    # the SkyPilot context or the series never match cluster="slurm/<name>".
+    return await add_cluster_name_label(metrics_text,
+                                        SLURM_CONTEXT_PREFIX + cluster_name,
+                                        replace_existing=True)
 
 
 # Series federated from each context's Prometheus by /endpoints-metrics: the

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1057,6 +1057,29 @@ def _get_slurm_inventory_client(slurm_cluster_name: str) -> 'slurm.SlurmClient':
     )
 
 
+def run_on_login_node(slurm_cluster_name: str,
+                      cmd: str,
+                      timeout: Optional[int] = None) -> Tuple[int, str, str]:
+    """Runs a shell command on a Slurm cluster's login node.
+
+    Public entry point for callers outside the provisioner (e.g. the
+    GPU-metrics federation in sky/metrics/utils.py) that need to execute
+    something over the cluster's SSH transport without reaching into the
+    inventory client. See SlurmClient.run_command for the framing and
+    timeout semantics.
+
+    Args:
+        slurm_cluster_name: A Host alias in the Slurm SSH config.
+        cmd: Shell command to run on the login node.
+        timeout: Optional bound in seconds on the whole remote invocation.
+
+    Returns:
+        (returncode, stdout, stderr) of ``cmd``.
+    """
+    client = _get_slurm_inventory_client(slurm_cluster_name)
+    return client.run_command(cmd, timeout=timeout)
+
+
 def _get_slurm_node_info_list(slurm_cluster_name: str) -> List[Dict[str, Any]]:
     """Gathers detailed information about each node in the Slurm cluster.
 

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1091,8 +1091,8 @@ def _handle_federation_result(context: str, route: str, result: object,
         logger.error(
             f'Failed to get metrics for context {context} (route {route}): '
             f'timed out after {_PER_CONTEXT_TIMEOUT_SECONDS}s '
-            f'({stats.summary()}); kubectl port-forward + /federate exceeded '
-            f'the per-context budget; series for this cluster are omitted from '
+            f'({stats.summary()}); the federation attempt exceeded the '
+            f'per-context budget; series for this cluster are omitted from '
             f'this scrape')
         return
     if isinstance(result, Exception):
@@ -1151,10 +1151,36 @@ async def gpu_metrics() -> fastapi.Response:
             )) for context, stats in zip(remote_contexts, stats_list)
     ]
 
+    # Slurm clusters federate through their login node (see
+    # get_metrics_for_slurm_cluster); only clusters with a configured
+    # prometheus_url participate. Their series ride the same scrape,
+    # stamped cluster="slurm/<name>", under the same per-context budget:
+    # the budget is passed down so the SSH invocation is hard-killed at
+    # the same instant wait_for() gives up on it. There is no port-forward
+    # phase on this path, so its stats omit that phase.
+    slurm_clusters = metrics_utils.get_slurm_metrics_clusters()
+    slurm_contexts = [
+        metrics_utils.SLURM_CONTEXT_PREFIX + name for name in slurm_clusters
+    ]
+    slurm_stats = [
+        metrics_utils.FederationStats(has_port_forward=False)
+        for _ in slurm_clusters
+    ]
+    tasks += [
+        asyncio.create_task(
+            asyncio.wait_for(
+                metrics_utils.get_metrics_for_slurm_cluster(
+                    name, stats=stats, timeout=_PER_CONTEXT_TIMEOUT_SECONDS),
+                timeout=_PER_CONTEXT_TIMEOUT_SECONDS,
+            )) for name, stats in zip(slurm_clusters, slurm_stats)
+    ]
+    result_contexts = remote_contexts + slurm_contexts
+    stats_list = stats_list + slurm_stats
+
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     for i, result in enumerate(results):
-        _handle_federation_result(remote_contexts[i], 'gpu-metrics', result,
+        _handle_federation_result(result_contexts[i], 'gpu-metrics', result,
                                   stats_list[i], all_metrics)
 
     combined_metrics = '\n\n'.join(all_metrics)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2171,6 +2171,13 @@ def get_config_schema():
                             'submit_as_user': {
                                 'type': 'boolean',
                             },
+                            # URL of a Prometheus reachable from the
+                            # cluster's login node that scrapes the
+                            # cluster's node/DCGM exporters; opts the
+                            # cluster into /gpu-metrics federation.
+                            'prometheus_url': {
+                                'type': 'string',
+                            },
                             'pricing': _PRICING_SCHEMA,
                             'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
                             'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,

--- a/tests/unit_tests/test_metrics_federation.py
+++ b/tests/unit_tests/test_metrics_federation.py
@@ -94,6 +94,19 @@ def test_federation_stats_summary_never_raises_on_missing_bytes():
     assert 'wire=unknown' in out
 
 
+def test_federation_stats_summary_without_port_forward_phase():
+    # Slurm federation runs curl on the login node over SSH: there is no
+    # port-forward phase, so the breakdown must not report one as
+    # 'incomplete'.
+    stats = metrics_utils.FederationStats(has_port_forward=False)
+    assert stats.summary() == 'federate=incomplete'
+    stats.federate_seconds = 0.5
+    stats.body_bytes = 2 * 1024 * 1024
+    out = stats.summary()
+    assert out.startswith('federate=0.50s, body=2.0MiB')
+    assert 'port_forward' not in out
+
+
 # --- _handle_federation_result() classification ---
 
 

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -135,6 +135,59 @@ class TestRunSlurmCmds:
 
         assert exc_info.value.returncode == 255
 
+    def test_parser_skips_login_shell_noise_before_header(self):
+        # A login shell may print profile.d banners or module-system notices
+        # (possibly non-ASCII) before the transport script runs; they land
+        # ahead of the header and must neither corrupt nor fail the frames.
+        client = self._client()
+        noise = 'Welcome to hpc-login \u2603\nLmod: loading site modules\n'
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, noise + _batch_output(
+                (0, 'DCGM_FI_DEV_GPU_UTIL{gpu="0"} 5\n', '')), '')
+            results = client._run_slurm_cmds(['curl ...'])
+        assert results == [(0, 'DCGM_FI_DEV_GPU_UTIL{gpu="0"} 5\n', '')]
+
+    def test_missing_header_is_rejected(self):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, 'no header here\n', '')
+            with pytest.raises(RuntimeError, match='missing header'):
+                client._run_slurm_cmds(['command'])
+
+    def test_timeout_forwarded_only_when_set(self):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, _batch_output((0, '', '')), '')
+            client._run_slurm_cmds(['command'])
+            assert 'timeout' not in mock_run.call_args.kwargs
+            client._run_slurm_cmds(['command'], timeout=7)
+            assert mock_run.call_args.kwargs['timeout'] == 7
+
+
+class TestRunCommand:
+    """Tests for the public single-command entry point."""
+
+    @staticmethod
+    def _client():
+        return slurm.SlurmClient(ssh_host='localhost',
+                                 ssh_port=22,
+                                 ssh_user='root',
+                                 ssh_key=None)
+
+    def test_round_trip_returns_the_commands_own_streams(self):
+        client = self._client()
+        client._runner = command_runner_lib.LocalProcessCommandRunner()
+        assert client.run_command(
+            'printf \'a\\nb\\n\'; printf \'oops\' >&2; exit 3') == (3, 'a\nb\n',
+                                                                    'oops')
+
+    def test_forwards_timeout_to_the_transport(self):
+        client = self._client()
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, _batch_output((0, 'ok\n', '')), '')
+            assert client.run_command('true', timeout=9) == (0, 'ok\n', '')
+        assert mock_run.call_args.kwargs['timeout'] == 9
+
 
 class TestGetPartitions:
     """Test SlurmClient.get_partitions()."""

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -910,16 +910,35 @@ def _slurm_config(keys, default_value=None, **_):
 
 def test_get_slurm_metrics_clusters_requires_prometheus_url(monkeypatch):
     monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
-    with mock.patch('sky.provision.slurm.utils.get_all_slurm_cluster_names',
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
                     return_value=['hpc', 'other']):
         assert utils.get_slurm_metrics_clusters() == ['hpc']
 
 
 def test_get_slurm_metrics_clusters_tolerates_enumeration_failure(monkeypatch):
     monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
-    with mock.patch('sky.provision.slurm.utils.get_all_slurm_cluster_names',
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
                     side_effect=ValueError('bad slurm ssh config')):
         assert utils.get_slurm_metrics_clusters() == []
+
+
+def test_get_slurm_metrics_clusters_respects_allowed_clusters(monkeypatch):
+    # A cluster with a prometheus_url that is NOT in allowed_clusters is
+    # excluded: federation is scoped to slurm.allowed_clusters (via
+    # Slurm.existing_allowed_clusters), mirroring the Kubernetes federation's
+    # use of allowed_contexts.
+    def _cfg(keys, default_value=None, **_):
+        if tuple(keys) in (
+            ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'),
+            ('slurm', 'cluster_configs', 'blocked', 'prometheus_url'),
+        ):
+            return _SLURM_PROM_URL
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['hpc']):
+        assert utils.get_slurm_metrics_clusters() == ['hpc']
 
 
 def test_get_metrics_for_slurm_cluster_curl_and_stamping(monkeypatch):

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -748,6 +748,32 @@ def test_add_cluster_name_label_skips_already_labeled():
         assert line.count('cluster=') == 1
 
 
+def test_add_cluster_name_label_replace_existing():
+    """replace_existing re-attributes source-side cluster labels.
+
+    Prometheus /federate applies the source's global.external_labels to
+    every exported series; on the Slurm path that label must become the
+    SkyPilot context or the series are invisible to cluster="slurm/<c>"
+    queries. Escaped quotes and braces in values must not confuse it, and
+    unlabeled / differently named labels behave as before.
+    """
+    text = ('foo{cluster="site-prom",bar="baz"} 1.0\n'
+            'foo{bar="}",cluster="a \\"quoted\\" name"} 2.0\n'
+            'foo{k8s_cluster="other"} 3.0\n'
+            'foo{cluster=""} 4.0')
+    result = asyncio.run(
+        utils.add_cluster_name_label(text, 'slurm/hpc', replace_existing=True))
+    assert result.split('\n') == [
+        'foo{cluster="slurm/hpc",bar="baz"} 1.0',
+        'foo{bar="}",cluster="slurm/hpc"} 2.0',
+        'foo{cluster="slurm/hpc",k8s_cluster="other"} 3.0',
+        'foo{cluster="slurm/hpc"} 4.0',
+    ]
+    for line in result.split('\n'):
+        # Exactly one real cluster label per line (k8s_cluster is not one).
+        assert len(utils._CLUSTER_LABEL_RE.findall(line)) == 1
+
+
 def test_add_cluster_name_label_does_not_match_cluster_suffix_labels():
     """A label like `k8s_cluster` is not mistaken for a `cluster` label."""
     text = 'foo{k8s_cluster="other"} 1.0'
@@ -865,3 +891,98 @@ def test_start_svc_port_forward_terminates_on_timeout():
         # Verify subprocess was terminated
         mock_process.terminate.assert_called_once()
         mock_process.wait.assert_called()
+
+
+# --- Slurm federation ---
+# get_slurm_metrics_clusters() / get_metrics_for_slurm_cluster(): the login-
+# node curl transport, its timeout budget, and the cluster="slurm/<name>"
+# stamping that keeps Slurm series interchangeable with Kubernetes contexts.
+
+_SLURM_PROM_URL = 'http://prometheus.hpc.internal:9090/'
+
+
+def _slurm_config(keys, default_value=None, **_):
+    # Only cluster 'hpc' opted in via slurm.cluster_configs.hpc.prometheus_url.
+    if tuple(keys) == ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'):
+        return _SLURM_PROM_URL
+    return default_value
+
+
+def test_get_slurm_metrics_clusters_requires_prometheus_url(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    with mock.patch('sky.provision.slurm.utils.get_all_slurm_cluster_names',
+                    return_value=['hpc', 'other']):
+        assert utils.get_slurm_metrics_clusters() == ['hpc']
+
+
+def test_get_slurm_metrics_clusters_tolerates_enumeration_failure(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    with mock.patch('sky.provision.slurm.utils.get_all_slurm_cluster_names',
+                    side_effect=ValueError('bad slurm ssh config')):
+        assert utils.get_slurm_metrics_clusters() == []
+
+
+def test_get_metrics_for_slurm_cluster_curl_and_stamping(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    body = (
+        'DCGM_FI_DEV_GPU_UTIL{gpu="0",instance="n1:9400"} 5\n'
+        'node_cpu_seconds_total{instance="n1:9100",mode="idle"} 9\n'
+        # The cluster's Prometheus stamped its own external label.
+        'node_memory_MemTotal_bytes{cluster="site-prom",instance="n1"} 7\n')
+    stats = utils.FederationStats(has_port_forward=False)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, body, '')) as run:
+        out = asyncio.run(
+            utils.get_metrics_for_slurm_cluster('hpc', stats=stats))
+
+    cluster, cmd = run.call_args.args
+    assert cluster == 'hpc'
+    # The SSH invocation is bounded by the whole (default 30s) budget; curl's
+    # own limit leaves headroom inside it for the SSH connect.
+    assert run.call_args.kwargs == {'timeout': 30}
+    assert cmd.startswith("curl -g -sS --fail -m 25 '")
+    # Trailing slash folded, match[] patterns percent-encoded, DCGM + node
+    # exporter series only.
+    assert "'http://prometheus.hpc.internal:9090/federate?match[]=" in cmd
+    assert '%7B__name__%3D~%22node_memory_MemAvailable_bytes%7C' in cmd
+    assert 'DCGM_.%2A' in cmd
+    assert 'node_cpu_seconds_total%7Bmode%3D%22idle%22%7D' in cmd
+
+    assert out.splitlines() == [
+        'DCGM_FI_DEV_GPU_UTIL{cluster="slurm/hpc",gpu="0",instance="n1:9400"} 5',
+        'node_cpu_seconds_total{cluster="slurm/hpc",instance="n1:9100",'
+        'mode="idle"} 9',
+        # Re-attributed, not skipped: the Slurm path replaces the label.
+        'node_memory_MemTotal_bytes{cluster="slurm/hpc",instance="n1"} 7',
+    ]
+    assert stats.federate_seconds is not None
+    assert stats.body_bytes == len(body.encode('utf-8'))
+    # No port-forward phase on this transport.
+    assert stats.summary().startswith('federate=')
+
+
+def test_get_metrics_for_slurm_cluster_budget_scales_curl_limit(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('hpc', timeout=12))
+    assert run.call_args.kwargs == {'timeout': 12}
+    assert run.call_args.args[1].startswith('curl -g -sS --fail -m 7 ')
+
+
+def test_get_metrics_for_slurm_cluster_nonzero_exit_raises(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(22, '',
+                                  'curl: (22) The requested URL returned '
+                                  'error: 404')):
+        with pytest.raises(RuntimeError, match=r'exited 22: curl: \(22\)'):
+            asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+
+
+def test_get_metrics_for_slurm_cluster_unconfigured_raises(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node') as run:
+        with pytest.raises(ValueError, match='No prometheus_url'):
+            asyncio.run(utils.get_metrics_for_slurm_cluster('other'))
+    run.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -804,3 +804,17 @@ class TestGetSlurmClusterInventory:
 
         with pytest.raises(RuntimeError, match='squeue failed'):
             utils.get_slurm_cluster_inventory('cluster-a')
+
+
+class TestRunOnLoginNode:
+
+    def test_delegates_to_the_inventory_client(self, monkeypatch):
+        client = mock.MagicMock()
+        client.run_command.return_value = (0, 'out\n', '')
+        monkeypatch.setattr(
+            utils, '_get_slurm_inventory_client', lambda name: client
+            if name == 'hpc' else pytest.fail(name))
+
+        assert utils.run_on_login_node('hpc', 'curl x',
+                                       timeout=9) == (0, 'out\n', '')
+        client.run_command.assert_called_once_with('curl x', timeout=9)


### PR DESCRIPTION
## Summary

Two changes that let Slurm clusters participate in the same GPU-metrics and infra surfaces as Kubernetes contexts.

**[Metrics] Federate GPU metrics from Slurm clusters via their login node.** A Slurm cluster whose config sets `slurm.cluster_configs.<name>.prometheus_url` now participates in the `/gpu-metrics` federation scrape. The federate request runs as a `curl` on the cluster's login node over the existing SSH transport — no direct network path from the API server to the cluster's Prometheus is required — and the returned node/DCGM series are stamped `cluster="slurm/<name>"` so downstream consumers treat a Slurm cluster uniformly with a Kubernetes context. The login-node transport is framed over a single SSH channel with bounded curl timeouts.

**[Dashboard] Slurm infra: up-node count, power-saved handling, external-jobs slot.**

- A Slurm cluster's node count on the Infra page reflects only nodes that are actually up. Power-saved (POWER_SAVE, sinfo `~`-state) cloud nodes — dynamic capacity that materializes only when a job needs it, and which can vastly outnumber the running nodes — are folded out, with an info icon whose tooltip reports the hidden power-saved tally.
- The context detail page's node table lists only up nodes, consistent with the count.
- Adds a `jobs.page.external-section` PluginSlot below the managed-jobs and pools tables — an extension point for jobs not managed by SkyPilot; it renders nothing when no component fills it.

## Test plan

- Unit tests: federation query builder, the Slurm adaptor's framed transport, the login-node runner, and the up-node-count / power-saved folding (`tests/unit_tests/...`, `sky/dashboard/src/components/infra.test.jsx`).
- `sky/dashboard` builds; `npx jest src/components/infra.test.jsx` → 16 passing.
- Federation exercised end-to-end against a live Slurm cluster with `prometheus_url` set: `/gpu-metrics` federated the cluster's node/DCGM series stamped `cluster="slurm/<name>"`, and the Infra page + detail page render the up-node count and the filtered node list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
