### PR TITLE
[Server] Cache the multiprocess metrics merge across scrapes

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -335,6 +335,26 @@ def _wrap_collector(collector) -> ResilientCollector:
     return wrapped
 
 
+_multiproc_collector: Optional[ResilientCollector] = None
+_multiproc_collector_lock = threading.Lock()
+
+
+def _get_multiproc_collector() -> ResilientCollector:
+    """Process-wide wrapper for the multiprocess merge.
+
+    The merge reads every per-pid file under ``PROMETHEUS_MULTIPROC_DIR``
+    and is CPU-bound under the GIL, so wrapping it keeps concurrent
+    scrapes from each running their own copy. Built lazily because
+    ``MultiProcessCollector()`` raises unless that directory is set.
+    """
+    global _multiproc_collector
+    with _multiproc_collector_lock:
+        if _multiproc_collector is None:
+            _multiproc_collector = _wrap_collector(
+                multiprocess.MultiProcessCollector(None))
+        return _multiproc_collector
+
+
 class BurnRateCollector:
     """Collector for SkyPilot cluster burn rate metrics.
     This collector calculates the total hourly burn rate (in USD) of all
@@ -981,7 +1001,7 @@ def metrics() -> fastapi.Response:
     if os.environ.get('PROMETHEUS_MULTIPROC_DIR'):
         # In multiprocess mode, we need to collect metrics from all processes.
         registry = prom.CollectorRegistry()
-        multiprocess.MultiProcessCollector(registry)
+        registry.register(_get_multiproc_collector())
         registry.register(_BURN_RATE_COLLECTOR)
         registry.register(_SQLITE_DB_SIZE_COLLECTOR)
         registry.register(_WORKSPACE_USAGE_COLLECTOR)

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -15,6 +15,7 @@ from prometheus_client import CollectorRegistry
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client import core as prom_core
 from prometheus_client import generate_latest
+from prometheus_client import multiprocess
 import prometheus_client as prom
 import pytest
 
@@ -325,8 +326,8 @@ async def test_metrics_endpoint_with_multiprocess():
     with patch.dict(os.environ, {'PROMETHEUS_MULTIPROC_DIR': '/tmp/prom'}):
         with patch('sky.server.metrics.prom.CollectorRegistry') as \
                 mock_registry, \
-             patch('sky.server.metrics.multiprocess.'
-                   'MultiProcessCollector') as mock_collector, \
+             patch('sky.server.metrics._get_multiproc_collector') as \
+                mock_multiproc, \
              patch('sky.server.metrics.generate_latest') as mock_gen:
 
             mock_registry_instance = MagicMock()
@@ -337,7 +338,8 @@ async def test_metrics_endpoint_with_multiprocess():
 
             assert isinstance(response, fastapi.Response)
             mock_registry.assert_called_once()
-            mock_collector.assert_called_once_with(mock_registry_instance)
+            mock_registry_instance.register.assert_any_call(
+                mock_multiproc.return_value)
             mock_gen.assert_called_once_with(mock_registry_instance)
 
 
@@ -1268,6 +1270,21 @@ def test_collector_health_active_flips_on_staleness():
                 'sky_apiserver_metrics_collector_active'] == 0.0)
         finally:
             wrapped.release.set()
+
+
+def test_multiproc_collector_wrapped_once_and_shared(tmp_path):
+    """The multiprocess merge is wrapped, and shared across scrapes."""
+    with patch.object(metrics, '_multiproc_collector', None), \
+         patch.object(metrics, '_resilient_collectors', []), \
+         patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}):
+        first = metrics._get_multiproc_collector()
+        second = metrics._get_multiproc_collector()
+
+        assert first is second
+        assert isinstance(first, metrics.ResilientCollector)
+        assert isinstance(first._wrapped, multiprocess.MultiProcessCollector)
+        assert metrics._resilient_collectors == [first]
 
 
 def test_wrap_collector_dedupes_health_names():


### PR DESCRIPTION
`/metrics` built a fresh `MultiProcessCollector` on every request, so each scrape walked every per-pid file under `PROMETHEUS_MULTIPROC_DIR` and merged them again. That directory only grows: `mark_process_dead()` reclaims the `gauge_live*` files, but the `counter`/`histogram`/`gauge_all` files persist for every process the server has spawned, so the merge gets steadily more expensive over a server's lifetime. It is also pure Python, so it holds the GIL for its whole duration.

Overlapping scrapes therefore each ran their own copy of the same merge and split one GIL between them, and per-scrape latency grew with the number in flight. A sync endpoint cannot be cancelled once Starlette has dispatched it to a worker thread, so a client giving up at its `scrape_timeout` does not shed the load — the abandoned merge runs to completion anyway and the next scrape adds another on top. Observed on a long-running server: a merge that costs ~5s of CPU on its own, run by ~40 concurrent handlers, so no scrape ever completed and the target stayed down while the server was otherwise healthy.

Wrap the merge in `ResilientCollector`, as the other custom collectors already are: `collect()` serves the last snapshot and refreshes in the background with at most one refresh in flight, so scrape cost no longer depends on how many scrapes overlap. The snapshot can lag by up to the shared refresh TTL, and `sky_apiserver_metrics_collector_active` now covers the merge like every other collector.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit test `test_multiproc_collector_wrapped_once_and_shared` asserts the merge is wrapped in a `ResilientCollector` and shared process-wide rather than rebuilt per scrape; `test_metrics_endpoint_with_multiprocess` updated for the new registration path. The single-in-flight and stale-snapshot behaviour this relies on is already covered by the existing `ResilientCollector` tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->