### PR TITLE
[Metrics] Compact stale Prometheus multiprocess files

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -261,12 +261,14 @@ SKY_APISERVER_PROCESS_PEAK_RSS = prom.Gauge(
     'sky_apiserver_process_peak_rss',
     'Peak RSS we saw in each process in last 30 seconds',
     ['pid', 'type'],
+    multiprocess_mode='liveall',
 )
 
 SKY_APISERVER_PROCESS_CPU_TOTAL = prom.Gauge(
     'sky_apiserver_process_cpu_total',
     'Total CPU times a worker process has been running',
     ['pid', 'type', 'mode'],
+    multiprocess_mode='liveall',
 )
 
 SKY_APISERVER_REQUEST_MEMORY_USAGE_BYTES = prom.Histogram(
@@ -291,11 +293,35 @@ SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS = prom.Histogram(
 SKY_APISERVER_LONG_EXECUTORS = prom.Gauge(
     'sky_apiserver_long_executors',
     'Total number of long-running request executors in the API server',
+    multiprocess_mode='livesum',
 )
 
 SKY_APISERVER_SHORT_EXECUTORS = prom.Gauge(
     'sky_apiserver_short_executors',
     'Total number of short-running request executors in the API server',
+    multiprocess_mode='livesum',
+)
+
+# --- prometheus_client multiprocess compaction ---
+
+SKY_APISERVER_MULTIPROC_FILES_REMOVED_TOTAL = prom.Counter(
+    'sky_apiserver_multiproc_files_removed_total',
+    'Prometheus multiprocess files removed by compaction',
+    ['operation', 'type', 'mode'],
+)
+
+SKY_APISERVER_MULTIPROC_ACCUMULATOR_BYTES = prom.Gauge(
+    'sky_apiserver_multiproc_accumulator_bytes',
+    'Size of each Prometheus multiprocess accumulator file',
+    ['pid', 'type', 'mode'],
+    multiprocess_mode='liveall',
+)
+
+SKY_APISERVER_MULTIPROC_COMPACTION_DURATION_SECONDS = prom.Gauge(
+    'sky_apiserver_multiproc_compaction_duration_seconds',
+    'Wall time of the last Prometheus multiprocess compaction',
+    ['pid'],
+    multiprocess_mode='liveall',
 )
 
 # Active threads in on-demand thread executors. Each process has its own

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -2,17 +2,21 @@
 
 import asyncio
 import atexit
+import collections
+import contextlib
 import glob
+import json
 import multiprocessing
 import os
 import re
 import threading
 import time
-from typing import Dict, List, Optional, Set, Tuple
+from typing import DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 import fastapi
 from prometheus_client import core as prom_core
 from prometheus_client import generate_latest
+from prometheus_client import mmap_dict as prom_mmap
 from prometheus_client import multiprocess
 import prometheus_client as prom
 import psutil
@@ -70,6 +74,9 @@ def register_multiproc_cleanup_atexit() -> None:
 # files without measurable overhead: one directory glob + one pid_exists()
 # check per unique pid per tick.
 _REAPER_INTERVAL_SECONDS = 60
+_COMPACTION_DEAD_FILE_THRESHOLD = 50
+_GAUGE_ALL_GRACE_CYCLES = 2
+_AGGREGATING_GAUGE_MODES = frozenset(('sum', 'min', 'max', 'mostrecent'))
 # Matches the per-pid live-gauge file names written by
 # ``prometheus_client.multiprocess``: ``gauge_live{all,sum,max,min}_<pid>.db``.
 # These are the only files that ``mark_process_dead(pid)`` would remove; the
@@ -77,6 +84,252 @@ _REAPER_INTERVAL_SECONDS = 60
 # non-live gauges so their accumulated values keep contributing to aggregate
 # readings after the writer exits.
 _LIVE_GAUGE_FILE_PID_RE = re.compile(r'^gauge_live[a-z]+_([0-9]+)\.db$')
+_MULTIPROC_FILE_RE = re.compile(
+    r'^(?:(counter|histogram)_([0-9]+)|gauge_([a-z]+)_([0-9]+))\.db$')
+_MultiprocGroup = Tuple[str, str]
+
+
+class _ReadWriteLock:
+    """A writer-preferring read/write lock for scrapes and file swaps."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._readers = 0
+        self._writer = False
+        self._waiting_writers = 0
+
+    @contextlib.contextmanager
+    def read(self) -> Iterator[None]:
+        with self._condition:
+            while self._writer or self._waiting_writers:
+                self._condition.wait()
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._condition.notify_all()
+
+    @contextlib.contextmanager
+    def write(self) -> Iterator[None]:
+        with self._condition:
+            self._waiting_writers += 1
+            try:
+                while self._writer or self._readers:
+                    self._condition.wait()
+                self._writer = True
+            finally:
+                self._waiting_writers -= 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._writer = False
+                self._condition.notify_all()
+
+
+_MULTIPROC_FILES_LOCK = _ReadWriteLock()
+# Full path -> number of consecutive maintenance ticks where the file's pid
+# was dead.
+_dead_gauge_all_cycles: Dict[str, int] = {}
+
+
+def _parse_multiproc_file(path: str) -> Optional[Tuple[str, str, int]]:
+    match = _MULTIPROC_FILE_RE.match(os.path.basename(path))
+    if match is None:
+        return None
+    typ, simple_pid, gauge_mode, gauge_pid = match.groups()
+    if typ is not None:
+        return typ, '', int(simple_pid)
+    assert gauge_mode is not None and gauge_pid is not None
+    return 'gauge', gauge_mode, int(gauge_pid)
+
+
+def _accumulator_path(multiproc_dir: str, typ: str, mode: str) -> str:
+    prefix = typ if typ != 'gauge' else f'gauge_{mode}'
+    return os.path.join(multiproc_dir, f'{prefix}_0.db')
+
+
+def _write_merged_multiproc_file(output_path: str, files: List[str],
+                                 mode: str) -> None:
+    """Write the merge of immutable ``files`` to ``output_path``."""
+    try:
+        os.unlink(output_path)
+    except FileNotFoundError:
+        pass
+
+    output = prom_mmap.MmapedDict(output_path)
+    try:
+        if mode == 'mostrecent':
+            # The upstream merge API uses timestamps to choose each winner but
+            # omits them from its returned Samples. Retain them because they
+            # must participate when this accumulator is merged again.
+            newest: Dict[str, Tuple[float, float]] = {}
+            for path in files:
+                for key, value, timestamp, _ in (
+                        prom_mmap.MmapedDict.read_all_values_from_file(path)):
+                    current = newest.get(key)
+                    if current is None or current[1] < timestamp:
+                        newest[key] = (value, timestamp)
+            for key, (value, timestamp) in newest.items():
+                output.write_value(key, value, timestamp)
+            return
+
+        merged = multiprocess.MultiProcessCollector.merge(files,
+                                                          accumulate=False)
+        for metric in merged:
+            for sample in metric.samples:
+                labelnames = list(sample.labels)
+                labelvalues = [sample.labels[name] for name in labelnames]
+                key = prom_mmap.mmap_key(metric.name, sample.name, labelnames,
+                                         labelvalues, metric.documentation)
+                output.write_value(key, sample.value, 0.0)
+    finally:
+        output.close()
+
+
+def _metric_names_in_multiproc_files(files: List[str]) -> Set[str]:
+    names: Set[str] = set()
+    for path in files:
+        try:
+            values = prom_mmap.MmapedDict.read_all_values_from_file(path)
+            for key, _, _, _ in values:
+                metric_name, _, _, _ = json.loads(key)
+                names.add(metric_name)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to read metric names from dead gauge file {path}.',
+                exc_info=True)
+    return names
+
+
+def _record_multiproc_compaction_metrics(compacted_by_group: Dict[
+    _MultiprocGroup,
+    int], deleted: int, accumulator_sizes: Dict[_MultiprocGroup, int],
+                                         duration: float) -> None:
+    if not metrics_utils.METRICS_ENABLED:
+        return
+    pid = str(os.getpid())
+    for (typ, mode), count in compacted_by_group.items():
+        metrics_utils.SKY_APISERVER_MULTIPROC_FILES_REMOVED_TOTAL.labels(
+            operation='compacted', type=typ, mode=mode or 'none').inc(count)
+    if deleted:
+        metrics_utils.SKY_APISERVER_MULTIPROC_FILES_REMOVED_TOTAL.labels(
+            operation='deleted', type='gauge', mode='all').inc(deleted)
+    for (typ, mode), size in accumulator_sizes.items():
+        metrics_utils.SKY_APISERVER_MULTIPROC_ACCUMULATOR_BYTES.labels(
+            pid=pid, type=typ, mode=mode or 'none').set(size)
+    metrics_utils.SKY_APISERVER_MULTIPROC_COMPACTION_DURATION_SECONDS.labels(
+        pid=pid).set(duration)
+
+
+def _compact_dead_multiproc_files(
+    dead_file_threshold: int = _COMPACTION_DEAD_FILE_THRESHOLD,
+    gauge_all_grace_cycles: int = _GAUGE_ALL_GRACE_CYCLES,
+) -> Tuple[int, int]:
+    """Compact aggregating files and expire all-mode files from dead pids.
+
+    Returns ``(compacted_files, deleted_gauge_all_files)``.
+    """
+    multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+    if not multiproc_dir:
+        return 0, 0
+
+    parsed_files: List[Tuple[str, str, str, int]] = []
+    for path in sorted(glob.glob(os.path.join(multiproc_dir, '*.db'))):
+        parsed = _parse_multiproc_file(path)
+        if parsed is not None:
+            typ, mode, pid = parsed
+            parsed_files.append((path, typ, mode, pid))
+
+    writer_pids = {pid for _, _, _, pid in parsed_files if pid != 0}
+    liveness = {pid: psutil.pid_exists(pid) for pid in writer_pids}
+    dead_files = [
+        item for item in parsed_files if item[3] != 0 and not liveness[item[3]]
+    ]
+    dead_gauge_all = {
+        path for path, typ, mode, _ in dead_files
+        if typ == 'gauge' and mode == 'all'
+    }
+    for path in list(_dead_gauge_all_cycles):
+        if path not in dead_gauge_all:
+            del _dead_gauge_all_cycles[path]
+    for path in dead_gauge_all:
+        _dead_gauge_all_cycles[path] = _dead_gauge_all_cycles.get(path, 0) + 1
+
+    gauge_all_to_delete = sorted(
+        path for path in dead_gauge_all
+        if _dead_gauge_all_cycles[path] >= gauge_all_grace_cycles)
+    should_compact = len(dead_files) > dead_file_threshold
+    if not should_compact and not gauge_all_to_delete:
+        return 0, 0
+
+    start_time = time.monotonic()
+    groups: DefaultDict[_MultiprocGroup,
+                        List[str]] = collections.defaultdict(list)
+    if should_compact:
+        for path, typ, mode, _ in dead_files:
+            if typ in ('counter', 'histogram'):
+                groups[(typ, '')].append(path)
+            elif typ == 'gauge' and mode in _AGGREGATING_GAUGE_MODES:
+                groups[(typ, mode)].append(path)
+
+    existing_paths = {path for path, _, _, _ in parsed_files}
+    prepared: Dict[_MultiprocGroup, Tuple[str, str, List[str]]] = {}
+    for group, source_files in groups.items():
+        typ, mode = group
+        accumulator = _accumulator_path(multiproc_dir, typ, mode)
+        merge_files = list(source_files)
+        if accumulator in existing_paths:
+            merge_files.insert(0, accumulator)
+        temporary = f'{accumulator}.tmp'
+        _write_merged_multiproc_file(temporary, merge_files, mode)
+        prepared[group] = (temporary, accumulator, source_files)
+
+    dropped_metric_names = _metric_names_in_multiproc_files(gauge_all_to_delete)
+
+    with _MULTIPROC_FILES_LOCK.write():
+        for temporary, accumulator, _ in prepared.values():
+            os.replace(temporary, accumulator)
+        for _, _, source_files in prepared.values():
+            for path in source_files:
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+        for path in gauge_all_to_delete:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+    compacted_by_group = {
+        group: len(source_files)
+        for group, (_, _, source_files) in prepared.items()
+    }
+    accumulator_sizes = {
+        group: os.path.getsize(accumulator)
+        for group, (_, accumulator, _) in prepared.items()
+    }
+    compacted = sum(compacted_by_group.values())
+    deleted = len(gauge_all_to_delete)
+    for path in gauge_all_to_delete:
+        _dead_gauge_all_cycles.pop(path, None)
+    duration = time.monotonic() - start_time
+    _record_multiproc_compaction_metrics(compacted_by_group, deleted,
+                                         accumulator_sizes, duration)
+    if compacted:
+        logger.info(f'Compacted {compacted} dead prometheus multiproc file(s) '
+                    f'into {len(prepared)} accumulator(s).')
+    if deleted:
+        names = ', '.join(sorted(dropped_metric_names)) or '<unknown>'
+        logger.warning(
+            f'Deleted {deleted} dead prometheus gauge_all file(s) after '
+            f'{gauge_all_grace_cycles} maintenance ticks; dropped metrics: '
+            f'{names}')
+    return compacted, deleted
 
 
 def _scan_multiproc_pids(multiproc_dir: str) -> Set[int]:
@@ -124,7 +377,7 @@ def _reap_stale_multiproc_files() -> int:
 
 async def multiproc_reaper_daemon(
         interval_seconds: int = _REAPER_INTERVAL_SECONDS) -> None:
-    """Periodically reap multiproc prometheus files from dead workers.
+    """Periodically reap and compact files from dead metrics writers.
 
     Per the prometheus_client multiprocess docs, an exiting writer
     process should call ``multiprocess.mark_process_dead(pid)`` so its
@@ -164,6 +417,7 @@ async def multiproc_reaper_daemon(
     while True:
         try:
             reaped = await asyncio.to_thread(_reap_stale_multiproc_files)
+            await asyncio.to_thread(_compact_dead_multiproc_files)
             if reaped:
                 logger.info(
                     f'Reaped prometheus multiproc files for {reaped} dead '
@@ -979,21 +1233,23 @@ metrics_app = fastapi.FastAPI()
 def metrics() -> fastapi.Response:
     """Expose aggregated Prometheus metrics from all worker processes."""
     if os.environ.get('PROMETHEUS_MULTIPROC_DIR'):
-        # In multiprocess mode, we need to collect metrics from all processes.
-        registry = prom.CollectorRegistry()
-        multiprocess.MultiProcessCollector(registry)
-        registry.register(_BURN_RATE_COLLECTOR)
-        registry.register(_SQLITE_DB_SIZE_COLLECTOR)
-        registry.register(_WORKSPACE_USAGE_COLLECTOR)
-        registry.register(_COLLECTOR_HEALTH_COLLECTOR)
-        if _MANAGED_JOBS_COLLECTOR is not None:
-            registry.register(_MANAGED_JOBS_COLLECTOR)
-        for c in _plugin_collectors:
-            try:
-                registry.register(c)
-            except ValueError:
-                pass
-        data = generate_latest(registry)
+        with _MULTIPROC_FILES_LOCK.read():
+            # In multiprocess mode, we need to collect metrics from all
+            # processes.
+            registry = prom.CollectorRegistry()
+            multiprocess.MultiProcessCollector(registry)
+            registry.register(_BURN_RATE_COLLECTOR)
+            registry.register(_SQLITE_DB_SIZE_COLLECTOR)
+            registry.register(_WORKSPACE_USAGE_COLLECTOR)
+            registry.register(_COLLECTOR_HEALTH_COLLECTOR)
+            if _MANAGED_JOBS_COLLECTOR is not None:
+                registry.register(_MANAGED_JOBS_COLLECTOR)
+            for c in _plugin_collectors:
+                try:
+                    registry.register(c)
+                except ValueError:
+                    pass
+            data = generate_latest(registry)
     else:
         data = generate_latest()
     return fastapi.Response(content=data,

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -3,6 +3,9 @@
 import base64
 import os
 import socket
+import subprocess
+import sys
+import tempfile
 import threading
 import time
 from unittest.mock import AsyncMock
@@ -15,6 +18,9 @@ from prometheus_client import CollectorRegistry
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client import core as prom_core
 from prometheus_client import generate_latest
+from prometheus_client import mmap_dict as prom_mmap
+from prometheus_client import multiprocess
+from prometheus_client import parser as prom_parser
 import prometheus_client as prom
 import pytest
 
@@ -136,9 +142,6 @@ with open(os.environ['_PID_OUT'], 'w') as f:
 
 def _spawn_writer(multiproc_dir: str, with_fix: bool) -> int:
     """Run the writer subprocess; return its pid."""
-    import subprocess  # local — only the e2e tests need it
-    import sys
-    import tempfile
     env = os.environ.copy()
     env['PROMETHEUS_MULTIPROC_DIR'] = multiproc_dir
     pid_file = tempfile.NamedTemporaryFile(delete=False, suffix='.pid')
@@ -183,6 +186,101 @@ def _touch_live_gauge_files(directory, pid):
         path = os.path.join(directory, f'gauge_{mode}_{pid}.db')
         with open(path, 'wb'):
             pass
+
+
+def _write_multiproc_value(path,
+                           metric_name,
+                           sample_name,
+                           value,
+                           timestamp=0.0):
+    mmap = prom_mmap.MmapedDict(str(path))
+    try:
+        key = prom_mmap.mmap_key(metric_name, sample_name, [], [], 'test')
+        mmap.write_value(key, value, timestamp)
+    finally:
+        mmap.close()
+
+
+def _render_multiproc_samples(multiproc_dir):
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=str(multiproc_dir))
+    exposition = generate_latest(registry).decode('utf-8')
+    return {(sample.name, tuple(sorted(sample.labels.items()))): sample.value
+            for family in prom_parser.text_string_to_metric_families(exposition)
+            for sample in family.samples}
+
+
+_COMPACTION_WRITER_SCRIPT = """
+import os
+import time
+from prometheus_client import Counter, Gauge, Histogram
+
+value = float(os.environ['TEST_VALUE'])
+Counter('__test_compaction_counter', 'test').inc(value)
+histogram = Histogram(
+    '__test_compaction_histogram',
+    'test',
+    buckets=(1.0, 10.0, float('inf')),
+)
+histogram.observe(value)
+for mode in (
+    'all',
+    'liveall',
+    'sum',
+    'livesum',
+    'min',
+    'livemin',
+    'max',
+    'livemax',
+    'mostrecent',
+    'livemostrecent',
+):
+    Gauge(
+        f'__test_compaction_gauge_{mode}',
+        'test',
+        multiprocess_mode=mode,
+    ).set(value)
+with open(os.environ['READY_FILE'], 'w') as f:
+    f.write(str(os.getpid()))
+while True:
+    time.sleep(1)
+"""
+
+
+def _spawn_compaction_writer(multiproc_dir, ready_file, value):
+    env = os.environ.copy()
+    env['PROMETHEUS_MULTIPROC_DIR'] = str(multiproc_dir)
+    env['READY_FILE'] = str(ready_file)
+    env['TEST_VALUE'] = str(value)
+    process = subprocess.Popen(
+        [sys.executable, '-c', _COMPACTION_WRITER_SCRIPT],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.time() + 10
+    while not ready_file.exists():
+        returncode = process.poll()
+        if returncode is not None:
+            stdout, stderr = process.communicate()
+            pytest.fail(f'metrics writer exited {returncode}: '
+                        f'stdout={stdout!r}, stderr={stderr!r}')
+        if time.time() >= deadline:
+            process.kill()
+            stdout, stderr = process.communicate()
+            pytest.fail('metrics writer did not become ready: '
+                        f'stdout={stdout!r}, stderr={stderr!r}')
+        time.sleep(0.01)
+    return process
+
+
+def _without_all_mode(samples):
+    return {
+        key: value
+        for key, value in samples.items()
+        if key[0] != '__test_compaction_gauge_all'
+    }
 
 
 def test_scan_multiproc_pids_only_returns_live_gauge_pids(tmp_path):
@@ -279,6 +377,173 @@ def test_reap_stale_multiproc_files_swallows_per_pid_errors(tmp_path):
     assert successes == [pid_b]
 
 
+# pylint: disable=protected-access
+def test_server_writer_gauges_have_explicit_live_modes():
+    assert (metrics_utils.SKY_APISERVER_PROCESS_PEAK_RSS._multiprocess_mode ==
+            'liveall')
+    assert (metrics_utils.SKY_APISERVER_PROCESS_CPU_TOTAL._multiprocess_mode ==
+            'liveall')
+    assert (metrics_utils.SKY_APISERVER_LONG_EXECUTORS._multiprocess_mode ==
+            'livesum')
+    assert (metrics_utils.SKY_APISERVER_SHORT_EXECUTORS._multiprocess_mode ==
+            'livesum')
+
+
+def test_compactor_runs_only_above_dead_file_threshold(tmp_path):
+    source = tmp_path / 'counter_991.db'
+    _write_multiproc_value(source, '__test_threshold', '__test_threshold_total',
+                           3.0)
+    metrics._dead_gauge_all_cycles.clear()
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists', return_value=False):
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=1) == (0, 0)
+        assert source.exists()
+
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=0) == (1, 0)
+
+    assert not source.exists()
+    assert (tmp_path / 'counter_0.db').exists()
+    assert _render_multiproc_samples(tmp_path)[('__test_threshold_total',
+                                                ())] == 3.0
+
+
+def test_compactor_deletes_dead_gauge_all_after_grace(tmp_path):
+    source = tmp_path / 'gauge_all_991.db'
+    _write_multiproc_value(source, '__test_gauge_all', '__test_gauge_all', 4.0)
+    metrics._dead_gauge_all_cycles.clear()
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists', return_value=False), \
+         patch.object(metrics.logger, 'warning') as mock_warning:
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=50, gauge_all_grace_cycles=2) == (0, 0)
+        assert source.exists()
+
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=50, gauge_all_grace_cycles=2) == (0, 1)
+
+    assert not source.exists()
+    assert '__test_gauge_all' in mock_warning.call_args.args[0]
+
+
+def test_compactor_overwrites_leftover_temporary_file(tmp_path):
+    source = tmp_path / 'counter_991.db'
+    temporary = tmp_path / 'counter_0.db.tmp'
+    _write_multiproc_value(source, '__test_current', '__test_current_total',
+                           5.0)
+    _write_multiproc_value(temporary, '__test_stale', '__test_stale_total',
+                           99.0)
+    metrics._dead_gauge_all_cycles.clear()
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists', return_value=False):
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=0) == (1, 0)
+
+    samples = _render_multiproc_samples(tmp_path)
+    assert samples[('__test_current_total', ())] == 5.0
+    assert ('__test_stale_total', ()) not in samples
+    assert not temporary.exists()
+
+
+def test_compactor_preserves_multiprocess_exposition_across_cycles(tmp_path):
+    dead_ready = tmp_path / 'dead.ready'
+    live_ready = tmp_path / 'live.ready'
+    next_dead_ready = tmp_path / 'next-dead.ready'
+    dead_writer = _spawn_compaction_writer(tmp_path, dead_ready, 2.0)
+    live_writer = _spawn_compaction_writer(tmp_path, live_ready, 4.0)
+    try:
+        dead_writer.kill()
+        assert dead_writer.wait(timeout=5) != 0
+        metrics._dead_gauge_all_cycles.clear()
+        with patch.dict(os.environ,
+                        {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}):
+            assert metrics._reap_stale_multiproc_files() == 1
+            before = _render_multiproc_samples(tmp_path)
+            assert metrics._compact_dead_multiproc_files(
+                dead_file_threshold=0, gauge_all_grace_cycles=2)[0] == 6
+            after_first = _render_multiproc_samples(tmp_path)
+
+            assert after_first == before
+
+            next_dead_writer = _spawn_compaction_writer(tmp_path,
+                                                        next_dead_ready, 9.0)
+            next_dead_writer.kill()
+            assert next_dead_writer.wait(timeout=5) != 0
+            assert metrics._reap_stale_multiproc_files() == 1
+            before_second = _render_multiproc_samples(tmp_path)
+            assert metrics._compact_dead_multiproc_files(
+                dead_file_threshold=0, gauge_all_grace_cycles=2)[0] == 6
+            after_second = _render_multiproc_samples(tmp_path)
+
+        assert _without_all_mode(after_second) == _without_all_mode(
+            before_second)
+        assert after_second[('__test_compaction_counter_total', ())] == 15.0
+        assert after_second[('__test_compaction_gauge_mostrecent', ())] == 9.0
+    finally:
+        live_writer.kill()
+        live_writer.wait(timeout=5)
+
+
+def test_scrape_does_not_observe_partial_compaction_swap(tmp_path, monkeypatch):
+    total = 0.0
+    for index, value in enumerate((1.0, 2.0, 4.0, 8.0), start=991):
+        _write_multiproc_value(tmp_path / f'counter_{index}.db',
+                               '__test_atomic', '__test_atomic_total', value)
+        total += value
+    metrics._dead_gauge_all_cycles.clear()
+    original_replace = metrics.os.replace
+
+    def delayed_replace(source, destination):
+        original_replace(source, destination)
+        time.sleep(0.05)
+
+    monkeypatch.setattr(metrics.os, 'replace', delayed_replace)
+    stop = threading.Event()
+    values = []
+    errors = []
+
+    def scrape_repeatedly():
+        while not stop.is_set():
+            try:
+                response = metrics.metrics()
+                samples = {
+                    sample.name: sample.value
+                    for family in prom_parser.text_string_to_metric_families(
+                        response.body.decode('utf-8'))
+                    for sample in family.samples
+                }
+                values.append(samples['__test_atomic_total'])
+            except Exception as e:  # pylint: disable=broad-except
+                errors.append(e)
+                return
+
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists', return_value=False):
+        thread = threading.Thread(target=scrape_repeatedly)
+        thread.start()
+        deadline = time.time() + 5
+        while not values and thread.is_alive() and time.time() < deadline:
+            time.sleep(0.01)
+        assert values, errors
+        assert metrics._compact_dead_multiproc_files(
+            dead_file_threshold=0) == (4, 0)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert not errors
+    assert values
+    assert set(values) == {total}
+
+
+# pylint: enable=protected-access
+
+
 @pytest.mark.asyncio
 async def test_multiproc_reaper_daemon_returns_when_env_unset():
     """Daemon exits immediately if PROMETHEUS_MULTIPROC_DIR is unset."""
@@ -301,7 +566,9 @@ async def test_multiproc_reaper_daemon_loops_and_cancels(tmp_path):
     with patch.dict(os.environ,
                     {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
          patch('sky.server.metrics._reap_stale_multiproc_files',
-               side_effect=fake_reap):
+               side_effect=fake_reap), \
+         patch('sky.server.metrics._compact_dead_multiproc_files',
+               return_value=(0, 0)) as mock_compact:
         task = asyncio.create_task(
             metrics.multiproc_reaper_daemon(interval_seconds=0))
         # The daemon reaps on a worker thread (asyncio.to_thread), so
@@ -317,6 +584,7 @@ async def test_multiproc_reaper_daemon_loops_and_cancels(tmp_path):
             pass
 
     assert call_count['n'] >= 1
+    mock_compact.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`prometheus_client` multiprocess mode writes a separate mmap file per metric type and writer PID. `mark_process_dead()` removes only `gauge_live*` files, while counters, histograms, and non-live gauges survive every writer exit. The `/metrics` collector globs and merges every surviving `*.db` file on each scrape. As executor processes churn, scrape CPU time and temporary-disk use therefore grow with all historical writers rather than current live writers. This is the failure mode reported in [prometheus/client_python#367](https://github.com/prometheus/client_python/issues/367).

This PR:

- gives the API process and executor gauges explicit `liveall` or `livesum` modes so the existing reaper removes them when their writers die;
- extends the existing reaper tick with a compactor that merges dead counter, histogram, and aggregating-gauge files into PID-0 accumulators after the dead-file count exceeds 50;
- preserves raw timestamps for `mostrecent` gauges so later compaction cycles still select the correct winner;
- builds replacement mmap files outside the scrape lock, then atomically renames them and removes their source files while holding the exclusive side of the lock used by `/metrics`;
- removes dead `gauge_all` files after two consecutive maintenance observations and logs the affected metric names; and
- exports compaction counts, accumulator sizes, and duration.

Counter and histogram samples, plus `sum`, `min`, `max`, and `mostrecent` gauges, are safe to collapse because their exposed samples do not retain the source PID. Every cycle includes the existing accumulator, so repeated compaction remains additive and idempotent. The rename-and-unlink window is locked against scrapes, preventing a scrape from observing both the accumulator and its source files or neither set.

Tests cover real multiprocess writer subprocesses, every gauge mode, repeated accumulator compaction, dead-`gauge_all` grace, stale temporary-file recovery, threshold gating, and concurrent scrapes during an intentionally widened rename/unlink window.

Tested (run the relevant ones):

- [x] Code formatting: `yapf --diff` and `isort --check-only` on the changed files
- [x] New and existing metrics tests: `python -m pytest -n0 tests/unit_tests/test_sky/server/test_metrics.py` (58 passed)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual smoke tests
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)