### PR TITLE
[Server] Stop transient processes from growing the multiproc metrics dir

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -257,16 +257,21 @@ SKY_APISERVER_PROCESS_EXECUTION_START_TOTAL = prom.Counter(
     ['request', 'pid'],
 )
 
+# 'liveall' for the same reason as sky_apiserver_threads_active below: keep
+# the per-pid series, but only for processes that still exist. The default
+# ('all') would keep emitting each dead worker's last value forever.
 SKY_APISERVER_PROCESS_PEAK_RSS = prom.Gauge(
     'sky_apiserver_process_peak_rss',
     'Peak RSS we saw in each process in last 30 seconds',
     ['pid', 'type'],
+    multiprocess_mode='liveall',
 )
 
 SKY_APISERVER_PROCESS_CPU_TOTAL = prom.Gauge(
     'sky_apiserver_process_cpu_total',
     'Total CPU times a worker process has been running',
     ['pid', 'type', 'mode'],
+    multiprocess_mode='liveall',
 )
 
 SKY_APISERVER_REQUEST_MEMORY_USAGE_BYTES = prom.Histogram(
@@ -288,14 +293,19 @@ SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS = prom.Histogram(
     buckets=_LATENCY_BUCKETS,
 )
 
+# Fleet-wide free-executor counts, so 'livesum'. The default ('all') emits
+# one series per pid and never drops dead ones, so the count kept including
+# workers that had exited.
 SKY_APISERVER_LONG_EXECUTORS = prom.Gauge(
     'sky_apiserver_long_executors',
     'Total number of long-running request executors in the API server',
+    multiprocess_mode='livesum',
 )
 
 SKY_APISERVER_SHORT_EXECUTORS = prom.Gauge(
     'sky_apiserver_short_executors',
     'Total number of short-running request executors in the API server',
+    multiprocess_mode='livesum',
 )
 
 # Active threads in on-demand thread executors. Each process has its own

--- a/sky/server/clean_env.py
+++ b/sky/server/clean_env.py
@@ -12,12 +12,23 @@ subprocesses (consolidation-mode controllers) so they don't inherit
 per-request env pollution from `override_request_env_and_config`.
 """
 import os
-from typing import Dict, Optional
+from typing import Dict, Mapping, Optional
 
 # Set once via capture_clean_server_env() in the main API server process, and
 # once per worker via executor_initializer (forwarded from the main process's
 # snapshot through initargs). Reads happen via get_clean_server_env().
 _clean_server_env: Optional[Dict[str, str]] = None
+
+# Never forwarded to a spawned subprocess: prometheus_client reads
+# PROMETHEUS_MULTIPROC_DIR as "join the parent's multiprocess registry", and
+# the per-pid files a child writes outlive it -- mark_process_dead() reclaims
+# only the gauge_live* ones -- so every short-lived subprocess permanently
+# grows the directory /metrics merges on each scrape.
+_DROP_FOR_SUBPROCESSES = frozenset({'PROMETHEUS_MULTIPROC_DIR'})
+
+
+def _for_subprocesses(env: Mapping[str, str]) -> Dict[str, str]:
+    return {k: v for k, v in env.items() if k not in _DROP_FOR_SUBPROCESSES}
 
 
 def capture_clean_server_env() -> None:
@@ -30,7 +41,7 @@ def capture_clean_server_env() -> None:
     """
     global _clean_server_env
     if _clean_server_env is None:
-        _clean_server_env = dict(os.environ)
+        _clean_server_env = _for_subprocesses(os.environ)
 
 
 def set_clean_server_env(env: Dict[str, str]) -> None:
@@ -41,7 +52,7 @@ def set_clean_server_env(env: Dict[str, str]) -> None:
     """
     global _clean_server_env
     if _clean_server_env is None:
-        _clean_server_env = dict(env)
+        _clean_server_env = _for_subprocesses(env)
 
 
 def get_clean_server_env() -> Optional[Dict[str, str]]:

--- a/tests/unit_tests/test_consolidation_env_leak.py
+++ b/tests/unit_tests/test_consolidation_env_leak.py
@@ -53,6 +53,27 @@ class TestCleanServerEnvCapture:
             os.environ.pop('SKY_TEST_CAPTURE_KEY', None)
             os.environ.pop('SKY_TEST_NEW_KEY', None)
 
+    def test_capture_drops_multiproc_dir(self):
+        # A spawned subprocess that inherits this joins the parent's
+        # multiprocess registry and leaves per-pid files behind for good.
+        os.environ['PROMETHEUS_MULTIPROC_DIR'] = '/tmp/does-not-matter'
+        try:
+            clean_env_module.capture_clean_server_env()
+            snapshot = clean_env_module.get_clean_server_env()
+            assert 'PROMETHEUS_MULTIPROC_DIR' not in snapshot
+        finally:
+            os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None)
+
+    def test_adopted_snapshot_drops_multiproc_dir(self):
+        # Workers adopt the snapshot instead of capturing it; that path must
+        # strip the same variable.
+        clean_env_module.set_clean_server_env({
+            'PATH': '/usr/bin',
+            'PROMETHEUS_MULTIPROC_DIR': '/tmp/does-not-matter',
+        })
+        snapshot = clean_env_module.get_clean_server_env()
+        assert snapshot == {'PATH': '/usr/bin'}
+
     def test_capture_is_idempotent(self):
         os.environ['SKY_TEST_IDEMPOTENT'] = 'first'
         try:

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -1395,3 +1395,21 @@ def test_metrics_server_reports_a_bind_failure(monkeypatch):
             assert mock_logger.error.called, 'bind failure was not reported'
     finally:
         blocker.close()
+
+
+# ── multiprocess gauge modes ────────────────────────────────────────
+
+
+def test_no_gauge_defaults_to_all_multiprocess_mode():
+    """'all' keeps serving a dead process's last value forever.
+
+    It also writes gauge_all_<pid>.db, which mark_process_dead() does not
+    reclaim, so the directory /metrics merges grows with every process the
+    server has ever spawned. Fleet-wide totals want 'livesum'; per-pid
+    series want 'liveall'.
+    """
+    offenders = sorted(name for name, obj in vars(metrics_utils).items()
+                       if isinstance(obj, prom.Gauge) and
+                       getattr(obj, '_multiprocess_mode', None) == 'all')
+    assert not offenders, (
+        f'Gauges left on the default multiprocess_mode="all": {offenders}')


### PR DESCRIPTION
The multiprocess metrics directory only grows. `mark_process_dead()` reclaims a process's `gauge_live*` files; its `counter`, `histogram` and `gauge_all` files stay for the lifetime of the container, because a counter's accumulated value has to survive the worker that produced it. That is fine for the API server's resident processes, but it means every process that ever writes a metric leaves a permanent cost behind, and `/metrics` merges the whole directory on every scrape.

Two things were adding to it that should not have been.

**A short-lived subprocess was joining the parent's registry.** Spawned subprocesses inherit `PROMETHEUS_MULTIPROC_DIR` through the clean server env snapshot, which prometheus_client reads as "join the parent's multiprocess registry". In consolidation mode `_consolidated_launch` runs the jobs-controller template's `python -m sky.jobs.scheduler ...` locally, once per managed-job submission — and there that process is very nearly a no-op, because `maybe_start_controllers(from_scheduler=True)` returns immediately when the controller pool is owned by the managed-job refresh daemon. It imports sky, makes a single `cluster_with_name_exists` query, logs one line and exits, leaving five files behind every time.

Measured on a long-running server: 92% of the pids with metric files had already exited; every dead pid sampled had exactly one non-zero instrumented call, `sky.global_user_state/cluster_with_name_exists`; 20,879 of 31,789 `submit-job-*.log` files contain nothing but the "controller startup is owned by the managed-job refresh daemon; skipping in-request start" line; and a 30-minute watch of the directory caught two new writers, both `python -u -m sky.jobs.scheduler`.

Dropping the variable from the snapshot makes that child keep its metrics in-process instead. Nothing scrapes it, and the single existence check it performs is not worth a permanent file.

**Four gauges never declared a `multiprocess_mode`**, so they defaulted to `all`, which writes `gauge_all_<pid>.db` — another file class `mark_process_dead()` does not reclaim — and emits one series per pid forever.

- `sky_apiserver_long_executors` / `sky_apiserver_short_executors` are fleet-wide free-executor counts, so they were summing in workers that had exited. `livesum` is what they meant.
- `sky_apiserver_process_peak_rss` / `sky_apiserver_process_cpu_total` are per-process series and want `liveall` — the mode `sky_apiserver_threads_active` already uses, for the reason given in the comment there.

With those four fixed, no gauge in the module is left on the default, and a test pins that so the next one added has to make the choice deliberately.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New tests: `test_capture_drops_multiproc_dir` and `test_adopted_snapshot_drops_multiproc_dir` cover both paths that populate the snapshot (the main process captures it, workers adopt it through `executor_initializer`), and `test_no_gauge_defaults_to_all_multiprocess_mode` guards the gauge modes.
