### PR TITLE
[API Server] Batch cancellation checks for parked requests

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -108,6 +108,10 @@ _AUTH_THREADS_LIMIT = 32
 # reason comes from the exception message, so truncate to keep it readable.
 _RETRY_STATUS_MSG_REASON_MAX_LEN = 200
 
+_CANCELLATION_WATCH_INTERVAL_SECONDS = 10
+_CANCELLATION_QUERY_BATCH_SIZE = 500
+_CANCELLATION_WARNING_INTERVAL_SECONDS = 60
+
 _REQUEST_THREAD_EXECUTOR_LOCK = threading.Lock()
 # A dedicated thread pool executor for synced requests execution in coroutine to
 # avoid:
@@ -228,14 +232,99 @@ def executor_initializer(proc_group: str,
                      daemon=True).start()
 
 
-def _request_is_gone_or_cancelled(request_id: str) -> bool:
-    """Cancellation check passed to ``ContinueCondition.wait()``.
+class CancellationWatcher:
+    """Batches cancellation checks for requests waiting to resume."""
 
-    A request cancelled (or gone) while paused must not be re-queued.
-    """
-    request = api_requests.get_request(request_id, fields=['status'])
-    return (request is None or
-            request.status == api_requests.RequestStatus.CANCELLED)
+    def __init__(
+        self,
+        watch_interval_seconds: float = _CANCELLATION_WATCH_INTERVAL_SECONDS
+    ) -> None:
+        self._watch_interval_seconds = watch_interval_seconds
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._verdicts: Dict[str, bool] = {}
+        self._thread: Optional[threading.Thread] = None
+        self._last_warning_time: Optional[float] = None
+
+    def register(self, request_id: str) -> None:
+        """Start watching a request, with a fail-open initial verdict."""
+        with self._condition:
+            was_empty = not self._verdicts
+            self._verdicts[request_id] = False
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run,
+                    name='request-cancellation-watcher',
+                    daemon=True)
+                self._thread.start()
+            if was_empty:
+                self._condition.notify()
+
+    def deregister(self, request_id: str) -> None:
+        """Stop watching a request."""
+        with self._condition:
+            self._verdicts.pop(request_id, None)
+            if not self._verdicts:
+                self._condition.notify()
+
+    def is_cancelled(self, request_id: str) -> bool:
+        """Return the cached cancellation verdict without querying storage."""
+        with self._lock:
+            return self._verdicts.get(request_id, False)
+
+    def _log_query_failure(self, error: Exception) -> None:
+        now = time.monotonic()
+        with self._lock:
+            if (self._last_warning_time is not None and
+                    now - self._last_warning_time <
+                    _CANCELLATION_WARNING_INTERVAL_SECONDS):
+                return
+            self._last_warning_time = now
+        logger.warning(
+            'Request cancellation watch query failed; keeping cached '
+            f'verdicts: {common_utils.format_exception(error)}')
+
+    def _poll_once(self) -> None:
+        with self._lock:
+            request_ids = list(self._verdicts)
+        for batch_start in range(0, len(request_ids),
+                                 _CANCELLATION_QUERY_BATCH_SIZE):
+            request_id_chunk = request_ids[batch_start:batch_start +
+                                           _CANCELLATION_QUERY_BATCH_SIZE]
+            try:
+                requests = api_requests.get_request_tasks(
+                    api_requests.RequestTaskFilter(
+                        request_ids=request_id_chunk,
+                        fields=['request_id', 'status']))
+            except Exception as e:  # pylint: disable=broad-except
+                self._log_query_failure(e)
+                continue
+
+            returned_ids = {request.request_id for request in requests}
+            cancelled_ids = {
+                request.request_id
+                for request in requests
+                if request.status == api_requests.RequestStatus.CANCELLED
+            }
+            with self._lock:
+                for request_id in request_id_chunk:
+                    if request_id in self._verdicts:
+                        self._verdicts[request_id] = (
+                            request_id not in returned_ids or
+                            request_id in cancelled_ids)
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                while not self._verdicts:
+                    self._condition.wait()
+                self._condition.wait(timeout=self._watch_interval_seconds)
+                if not self._verdicts:
+                    continue
+            self._poll_once()
+
+
+_CANCELLATION_WATCHER = CancellationWatcher()
 
 
 def _waiting_status_msg(reason: str, retry_suffix: str) -> str:
@@ -451,14 +540,18 @@ class RequestWorker:
                 request_task.status_msg = status_msg
             try:
                 if condition is not None:
-                    should_reschedule = _wait_for_continue_condition(
-                        condition,
-                        is_cancelled=lambda: _request_is_gone_or_cancelled(
-                            request_id),
-                        fallback_wait_seconds=retry_wait_seconds,
-                        update_status_msg=functools.partial(
-                            _refresh_waiting_status_msg, request_id,
-                            retry_suffix))
+                    _CANCELLATION_WATCHER.register(request_id)
+                    try:
+                        should_reschedule = _wait_for_continue_condition(
+                            condition,
+                            is_cancelled=lambda: _CANCELLATION_WATCHER.
+                            is_cancelled(request_id),
+                            fallback_wait_seconds=retry_wait_seconds,
+                            update_status_msg=functools.partial(
+                                _refresh_waiting_status_msg, request_id,
+                                retry_suffix))
+                    finally:
+                        _CANCELLATION_WATCHER.deregister(request_id)
                 else:
                     time.sleep(retry_wait_seconds)
                     should_reschedule = True

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1028,6 +1028,7 @@ class RequestTaskFilter:
 
     Args:
         status: a list of statuses of the requests to filter on.
+        request_ids: a list of request IDs to filter requests on.
         cluster_names: a list of cluster names to filter requests on.
         exclude_request_names: a list of request names to exclude from results.
             Mutually exclusive with include_request_names.
@@ -1047,6 +1048,7 @@ class RequestTaskFilter:
             provided.
     """
     status: Optional[List[RequestStatus]] = None
+    request_ids: Optional[List[str]] = None
     cluster_names: Optional[List[str]] = None
     user_id: Optional[str] = None
     exclude_request_names: Optional[List[str]] = None
@@ -1080,6 +1082,16 @@ class RequestTaskFilter:
             status_placeholders = ','.join(['?'] * len(self.status))
             filters.append(f'status IN ({status_placeholders})')
             filter_params.extend(status.value for status in self.status)
+        if self.request_ids is not None:
+            if len(self.request_ids) == 0:
+                # Empty IN () is invalid SQL in PostgreSQL.
+                # An empty list means "match nothing".
+                filters.append('1=0')
+            else:
+                request_id_placeholders = ','.join(['?'] *
+                                                   len(self.request_ids))
+                filters.append(f'request_id IN ({request_id_placeholders})')
+                filter_params.extend(self.request_ids)
         if self.include_request_names is not None:
             name_placeholders = ','.join(['?'] *
                                          len(self.include_request_names))

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -713,14 +713,185 @@ async def test_request_worker_retry_execution_retryable_error(
     )
 
 
+def _watcher_request(request_id, status):
+    return requests_lib.Request(request_id=request_id,
+                                name='test-request',
+                                entrypoint=_dummy_entrypoint_for_retry_test,
+                                request_body=payloads.RequestBody(),
+                                status=status,
+                                created_at=0,
+                                user_id='test-user')
+
+
+@pytest.fixture()
+def manual_cancellation_watcher():
+    watcher = executor.CancellationWatcher()
+    watcher._thread = mock.Mock()
+    return watcher
+
+
+def test_cancellation_watcher_updates_cancelled_and_gone_verdicts(
+        manual_cancellation_watcher, monkeypatch):
+    watcher = manual_cancellation_watcher
+    watcher.register('cancelled-request')
+    watcher.register('gone-request')
+    watcher.register('running-request')
+
+    observed_filters = []
+
+    def get_request_tasks(req_filter):
+        observed_filters.append(req_filter)
+        return [
+            _watcher_request('cancelled-request',
+                             requests_lib.RequestStatus.CANCELLED),
+            _watcher_request('running-request',
+                             requests_lib.RequestStatus.RUNNING),
+        ]
+
+    monkeypatch.setattr(executor.api_requests, 'get_request_tasks',
+                        get_request_tasks)
+
+    # A registered request fails open until its first storage poll.
+    assert watcher.is_cancelled('cancelled-request') is False
+    watcher._poll_once()
+
+    assert watcher.is_cancelled('cancelled-request') is True
+    assert watcher.is_cancelled('gone-request') is True
+    assert watcher.is_cancelled('running-request') is False
+    assert len(observed_filters) == 1
+    assert observed_filters[0].request_ids == [
+        'cancelled-request', 'gone-request', 'running-request'
+    ]
+    assert observed_filters[0].fields == ['request_id', 'status']
+
+
+def test_cancellation_watcher_query_failure_preserves_cached_verdicts(
+        manual_cancellation_watcher, monkeypatch):
+    watcher = manual_cancellation_watcher
+    watcher.register('cancelled-request')
+    watcher.register('running-request')
+
+    monkeypatch.setattr(
+        executor.api_requests, 'get_request_tasks', lambda req_filter: [
+            _watcher_request('cancelled-request', requests_lib.RequestStatus.
+                             CANCELLED),
+            _watcher_request('running-request', requests_lib.RequestStatus.
+                             RUNNING),
+        ])
+    watcher._poll_once()
+
+    query_error = RuntimeError('storage unavailable')
+    monkeypatch.setattr(executor.api_requests, 'get_request_tasks',
+                        mock.Mock(side_effect=query_error))
+    warning = mock.Mock()
+    monkeypatch.setattr(executor.logger, 'warning', warning)
+    watcher._poll_once()
+    watcher._poll_once()
+
+    assert watcher.is_cancelled('cancelled-request') is True
+    assert watcher.is_cancelled('running-request') is False
+    warning.assert_called_once()
+
+
+def test_cancellation_watcher_deregistered_and_empty_registry_do_not_query(
+        manual_cancellation_watcher, monkeypatch):
+    watcher = manual_cancellation_watcher
+    watcher.register('request-1')
+    watcher.deregister('request-1')
+    get_request_tasks = mock.Mock()
+    monkeypatch.setattr(executor.api_requests, 'get_request_tasks',
+                        get_request_tasks)
+
+    watcher._poll_once()
+
+    assert watcher.is_cancelled('request-1') is False
+    get_request_tasks.assert_not_called()
+
+
+def test_cancellation_watcher_starts_one_thread_lazily(monkeypatch):
+    thread_class = mock.Mock()
+    monkeypatch.setattr(executor.threading, 'Thread', thread_class)
+    watcher = executor.CancellationWatcher()
+
+    thread_class.assert_not_called()
+    watcher.register('request-1')
+    watcher.register('request-2')
+
+    thread_class.assert_called_once_with(target=watcher._run,
+                                         name='request-cancellation-watcher',
+                                         daemon=True)
+    thread_class.return_value.start.assert_called_once_with()
+
+
+def test_cancellation_watcher_thread_polls_and_idles(monkeypatch):
+    watcher = executor.CancellationWatcher(watch_interval_seconds=0.01)
+    poll_completed = threading.Event()
+    query_count = []
+
+    def get_request_tasks(req_filter):
+        query_count.append(1)
+        return [
+            _watcher_request(req_filter.request_ids[0],
+                             requests_lib.RequestStatus.CANCELLED)
+        ]
+
+    monkeypatch.setattr(executor.api_requests, 'get_request_tasks',
+                        get_request_tasks)
+    poll_once = watcher._poll_once
+
+    def recording_poll_once():
+        poll_once()
+        poll_completed.set()
+
+    monkeypatch.setattr(watcher, '_poll_once', recording_poll_once)
+
+    watcher.register('request-1')
+    assert poll_completed.wait(timeout=1)
+    assert watcher.is_cancelled('request-1') is True
+
+    watcher.deregister('request-1')
+    poll_completed.clear()
+    query_count_after_deregister = len(query_count)
+    assert not poll_completed.wait(timeout=0.05)
+    assert len(query_count) == query_count_after_deregister
+
+
+def test_cancellation_watcher_chunks_queries(manual_cancellation_watcher,
+                                             monkeypatch):
+    watcher = manual_cancellation_watcher
+    request_ids = [
+        f'request-{i}' for i in range(executor._CANCELLATION_QUERY_BATCH_SIZE +
+                                      1)
+    ]
+    for request_id in request_ids:
+        watcher.register(request_id)
+    observed_chunks = []
+
+    def get_request_tasks(req_filter):
+        observed_chunks.append(req_filter.request_ids)
+        return [
+            _watcher_request(request_id, requests_lib.RequestStatus.RUNNING)
+            for request_id in req_filter.request_ids
+        ]
+
+    monkeypatch.setattr(executor.api_requests, 'get_request_tasks',
+                        get_request_tasks)
+
+    watcher._poll_once()
+
+    assert [len(chunk) for chunk in observed_chunks
+           ] == [executor._CANCELLATION_QUERY_BATCH_SIZE, 1]
+
+
 class _PauseHarness:
     """Bundles the worker, queue, and request id for pause/watch tests."""
 
-    def __init__(self, worker, request_id, queue_items, sleep_calls):
+    def __init__(self, worker, request_id, queue_items, sleep_calls, watcher):
         self.worker = worker
         self.request_id = request_id
         self.queue_items = queue_items
         self.sleep_calls = sleep_calls
+        self.watcher = watcher
 
     def run(self, condition, retry_wait_seconds=30):
         """Drive handle_task_result with an ExecutionPausedError."""
@@ -778,12 +949,18 @@ def pause_harness(isolated_database, monkeypatch):
 
     monkeypatch.setattr('time.sleep', mock_sleep)
 
+    watcher = executor.CancellationWatcher()
+    # These tests drive watcher ticks explicitly and must not leave one daemon
+    # thread per fixture waiting for the rest of the pytest process.
+    watcher._thread = mock.Mock()
+    monkeypatch.setattr(executor, '_CANCELLATION_WATCHER', watcher)
+
     worker = executor.RequestWorker(
         schedule_type=requests_lib.ScheduleType.LONG,
         config=server_config.WorkerConfig(garanteed_parallelism=1,
                                           burstable_parallelism=0,
                                           num_db_connections_per_worker=0))
-    return _PauseHarness(worker, request_id, queue_items, sleep_calls)
+    return _PauseHarness(worker, request_id, queue_items, sleep_calls, watcher)
 
 
 class _RecordingCondition(continue_condition_lib.ContinueCondition):
@@ -826,6 +1003,7 @@ def test_pause_reschedules_when_wait_returns_true(pause_harness):
         'is_cancelled': False,
         'fallback_wait_seconds': 30
     }]
+    assert pause_harness.request_id not in pause_harness.watcher._verdicts
     # During the pause the request is WAITING with a "waiting to resume" msg.
     updated = requests_lib.get_request(pause_harness.request_id,
                                        fields=['status', 'status_msg'])
@@ -840,6 +1018,26 @@ def test_pause_dropped_when_wait_returns_false(pause_harness):
     pause_harness.run(condition)
 
     assert pause_harness.queue_items == []
+
+
+def test_pause_wait_exception_deregisters_cancellation_watch(pause_harness):
+    """A failed condition wait cannot leave a stale watched request."""
+
+    class _FailingCondition(continue_condition_lib.ContinueCondition):
+
+        def wait(self,
+                 *,
+                 is_cancelled,
+                 fallback_wait_seconds,
+                 update_status_msg=None):
+            del is_cancelled, fallback_wait_seconds, update_status_msg
+            raise RuntimeError('condition failed')
+
+    request_element = pause_harness.run(_FailingCondition())
+
+    assert pause_harness.request_id not in pause_harness.watcher._verdicts
+    assert pause_harness.sleep_calls == [30]
+    assert pause_harness.queue_items == [request_element]
 
 
 def test_pause_base_condition_does_fixed_fallback_wait(pause_harness):
@@ -867,6 +1065,7 @@ def test_pause_base_condition_dropped_if_cancelled_during_wait(
         pause_harness.sleep_calls.append(seconds)
         with requests_lib.update_request(pause_harness.request_id) as r:
             r.status = requests_lib.RequestStatus.CANCELLED
+        pause_harness.watcher._poll_once()
 
     monkeypatch.setattr('time.sleep', cancel_on_sleep)
 

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1281,6 +1281,25 @@ def test_requests_filter():
     assert sql == expected_sql
     assert params == ['PENDING', 'RUNNING']
 
+    # Test request_ids with status and a partial SELECT list.
+    filter_request_ids = requests.RequestTaskFilter(
+        status=[RequestStatus.WAITING],
+        request_ids=['request-1', 'request-2'],
+        fields=['request_id', 'status'])
+    sql, params = filter_request_ids.build_query()
+    expected_sql = (f'SELECT request_id, status FROM {requests.REQUEST_TABLE} '
+                    'WHERE status IN (?) AND request_id IN (?,?)')
+    assert sql == expected_sql
+    assert params == ['WAITING', 'request-1', 'request-2']
+
+    # An empty request-id filter matches no rows without emitting invalid IN ().
+    filter_no_request_ids = requests.RequestTaskFilter(request_ids=[])
+    sql, params = filter_no_request_ids.build_query()
+    expected_sql = (f'SELECT {expected_columns} FROM {requests.REQUEST_TABLE} '
+                    'WHERE 1=0')
+    assert sql == expected_sql
+    assert params == []
+
     # Test cluster_names filter
     filter_clusters = requests.RequestTaskFilter(
         cluster_names=['cluster1', 'cluster2'], sort=True)


### PR DESCRIPTION
## What this changes

Batch cancellation checks for requests that are parked on a `ContinueCondition`:

- add a process-local `CancellationWatcher` that polls registered request IDs every 10 seconds in chunks of at most 500
- serve each condition's cancellation callback from cached watcher verdicts instead of querying request storage directly
- add `RequestTaskFilter.request_ids` so one `get_request_tasks()` call can fetch each batch
- preserve cached verdicts and throttle warnings when a batch query fails
- deregister requests in a `finally` block when their condition wait ends

## Root cause

[PR #9875](https://github.com/skypilot-org/skypilot/pull/9875) introduced condition-based request parking. `RequestWorker.handle_task_result()` gave every parked request an `is_cancelled` callback backed by `_request_is_gone_or_cancelled()`. Each condition owns its polling loop, and every callback invocation synchronously called `get_request()`. With N parked requests, cancellation checking therefore produced N independent request-table reads per poll cycle and could exhaust a small database connection pool. A storage exception also escaped the callback and aborted that condition wait into the fallback path.

The watcher makes the storage load proportional to the number of batches per process rather than the number of parked requests. A newly registered request initially fails open. After a successful poll, a missing row or a `CANCELLED` row is cached as cancelled; a query failure keeps the previous verdict so the condition can continue waiting.

## Tests

- [x] Code formatting: YAPF diff and isort check on all four changed files
- [x] Focused unit tests for watcher lifecycle, cancellation verdicts, batching, query failures, condition-wait cleanup, and request-ID SQL filtering reported 11 passed. The local pytest process then remained in Python thread shutdown and was interrupted after the summary.
- [ ] All smoke tests
- [ ] Relevant individual smoke tests
- [ ] Backward compatibility
