### PR TITLE
[API] Stop rewriting the whole policy table on every casbin write

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -359,12 +359,11 @@ class PermissionService:
                             password=password,
                             user_type=models.UserType.BASIC.value))
             enforcer = self._ensure_enforcer()
-            # Same reason as `_maybe_initialize_policies`: `save_policy()`
-            # rewrites the whole table from this model, which predates the
-            # lock unless refreshed.
+            # Same reason as `_maybe_initialize_policies`: the mutator below
+            # decides against this model, which predates the lock unless
+            # refreshed.
             self._load_policy_no_lock()
             enforcer.add_grouping_policy(user_hash, rbac.RoleName.ADMIN.value)
-            enforcer.save_policy()
             logger.info(f'Basic auth user {username} initialized')
 
     def _maybe_initialize_policies(self) -> None:
@@ -376,13 +375,9 @@ class PermissionService:
 
         # The model was loaded by the enforcer's constructor, before the lock
         # was acquired -- and waiting for it can take seconds. Anything another
-        # replica wrote in that window is missing here, and this method both
-        # ends in a full-table `save_policy()` and deletes whatever it
-        # considers redundant, so it would erase those writes rather than
-        # merely miss them.
+        # replica wrote in that window is missing here, so this method would
+        # consider it redundant and delete it.
         self._load_policy_no_lock()
-
-        policy_updated = False
 
         # Check if policies are already initialized by looking for existing
         # permission policies in the enforcer
@@ -436,7 +431,6 @@ class PermissionService:
             for p in missing_policies:
                 logger.debug(f'Adding policy: {p}')
                 enforcer.add_policy(*p)
-                policy_updated = True
             logger.debug('Missing policies added successfully')
 
         if redundant_policies:
@@ -446,7 +440,6 @@ class PermissionService:
             for p in redundant_policies:
                 logger.debug(f'Removing policy: {p}')
                 enforcer.remove_policy(*p)
-                policy_updated = True
             logger.debug('Redundant policies removed successfully')
 
         if not missing_policies and not redundant_policies:
@@ -464,9 +457,7 @@ class PermissionService:
             if str(existing_user.id) not in users_with_roles:
                 logger.debug(f'Adding role for user: {existing_user.name}'
                              f'({existing_user.id})')
-                user_added = self._add_user_if_not_exists_no_lock(
-                    existing_user.id)
-                policy_updated = policy_updated or user_added
+                self._add_user_if_not_exists_no_lock(existing_user.id)
         for system_user_id, system_user_role in _system_user_roles().items():
             global_user_state.add_or_update_user(
                 models.User(id=system_user_id,
@@ -475,11 +466,8 @@ class PermissionService:
             if system_user_id not in users_with_roles:
                 logger.debug(f'Adding role for system user: {system_user_id} '
                              f'({system_user_role})')
-                user_added = self._add_user_if_not_exists_no_lock(
-                    system_user_id, system_user_role)
-                policy_updated = policy_updated or user_added
-        if policy_updated:
-            enforcer.save_policy()
+                self._add_user_if_not_exists_no_lock(system_user_id,
+                                                     system_user_role)
 
     def add_user_if_not_exists(self,
                                user_id: str,
@@ -533,9 +521,8 @@ class PermissionService:
             removed_grants = enforcer.remove_filtered_policy(
                 0, user_id, '', '*')
             if not removed_roles and not removed_grants:
-                # Nothing to persist, and nothing to invalidate.
+                # Nothing was removed, so nothing to invalidate.
                 return
-            enforcer.save_policy()
             self.invalidate_user_permission_cache(user_id)
 
     def update_role(self, user_id: str, new_role: str) -> None:
@@ -551,7 +538,6 @@ class PermissionService:
             # lets admin win over the other role.
             enforcer.remove_filtered_grouping_policy(0, user_id)
             enforcer.add_grouping_policy(user_id, new_role)
-            enforcer.save_policy()
             # Always invalidate: even a first role assignment can grant
             # workspace access that was previously denied and cached.
             self.invalidate_user_permission_cache(user_id)
@@ -1216,18 +1202,17 @@ class PermissionService:
                    For private workspaces, this should be specific user IDs.
         """
         with _policy_lock():
-            # Reload from the DB inside the lock before mutating: save_policy()
-            # rewrites the whole casbin_rule table from this enforcer's
-            # in-memory view, so a stale view (e.g. missing another workspace's
-            # policies added by a different worker) would clobber those rows on
-            # save. update_workspace_policy already does this; mirror it here.
+            # Reload from the DB inside the lock before mutating: casbin's
+            # mutators decide against this enforcer's in-memory view and skip
+            # the adapter when it already agrees, so a stale view makes the
+            # write a silent no-op rather than a deferred one.
+            # update_workspace_policy already does this; mirror it here.
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
             for user in users:
                 logger.debug(f'Adding workspace policy: user={user}, '
                              f'workspace={workspace_name}')
                 enforcer.add_policy(user, workspace_name, '*')
-            enforcer.save_policy()
             # Invalidate stale cached denials (e.g. from checks between a
             # workspace deletion and its re-creation with the same name).
             self.invalidate_workspace_permission_cache(workspace_name)
@@ -1252,7 +1237,6 @@ class PermissionService:
                 logger.debug(f'Updating workspace policy: user={user}, '
                              f'workspace={workspace_name}')
                 enforcer.add_policy(user, workspace_name, '*')
-            enforcer.save_policy()
             # Invalidate cached permission entries after the policy is
             # persisted so other processes re-compute permissions on next
             # check.
@@ -1352,8 +1336,6 @@ class PermissionService:
                                 'creation (matched allowed_users after the '
                                 'user record was created).')
                             added_any = True
-                    if added_any:
-                        enforcer.save_policy()
         except locks.LockTimeout:
             logger.warning(
                 f'Timed out acquiring the config lock; skipping the '
@@ -1366,15 +1348,14 @@ class PermissionService:
     def remove_workspace_policy(self, workspace_name: str) -> None:
         """Remove workspace policy."""
         with _policy_lock():
-            # Reload from the DB inside the lock before mutating: save_policy()
-            # rewrites the whole table from this process's in-memory model, so
-            # without this a stale worker deleting a workspace also erases
-            # every policy another worker wrote since this one last loaded.
+            # Reload from the DB inside the lock before mutating: a stale model
+            # makes `remove_filtered_policy` find nothing to remove, and casbin
+            # then skips the adapter entirely -- so the rows survive in the DB
+            # and the caller is told the workspace was cleared.
             # Same reason as `add_workspace_policy` / `update_workspace_policy`.
             self._load_policy_no_lock()
             enforcer = self._ensure_enforcer()
             enforcer.remove_filtered_policy(1, workspace_name)
-            enforcer.save_policy()
             # Invalidate cached permission entries after the policy is
             # persisted so other processes re-compute permissions on next
             # check.

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -174,9 +174,6 @@ class TestPermissionService:
             constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
             rbac.RoleName.VIEWER.value)
 
-        # Verify policy was saved
-        mock_enforcer.save_policy.assert_called()
-
     @mock.patch('sky.users.permission._policy_lock')
     @mock.patch('sky.users.permission.PermissionService._get_plugin_rbac_rules')
     @mock.patch('sky.users.rbac.get_workspace_policy_permissions')
@@ -239,9 +236,6 @@ class TestPermissionService:
 
         # Verify no new policies were added (since they already exist)
         mock_enforcer.add_policy.assert_not_called()
-        # save_policy should not be called if no updates were made
-        # (users already have roles, policies already exist)
-        mock_enforcer.save_policy.assert_not_called()
 
     def test_add_user_if_not_exists_new_user(self):
         """Test adding a new user that doesn't exist."""
@@ -297,7 +291,6 @@ class TestPermissionService:
             0, 'user1')
         mock_enforcer.add_grouping_policy.assert_called_once_with(
             'user1', 'admin')
-        mock_enforcer.save_policy.assert_called_once()
 
     @mock.patch('sky.users.permission._policy_lock')
     def test_update_role_no_existing_roles(self, mock_policy_lock):
@@ -317,10 +310,9 @@ class TestPermissionService:
 
         # Verify no removal was attempted (no existing role to remove)
         mock_enforcer.remove_grouping_policy.assert_not_called()
-        # Verify new role was added and policy saved
+        # Verify the new role was added
         mock_enforcer.add_grouping_policy.assert_called_once_with(
             'user1', 'user')
-        mock_enforcer.save_policy.assert_called_once()
 
     @mock.patch('sky.users.permission._policy_lock')
     def test_update_role_same_role(self, mock_policy_lock):
@@ -341,21 +333,25 @@ class TestPermissionService:
         # Verify no changes were made
         mock_enforcer.remove_grouping_policy.assert_not_called()
         mock_enforcer.add_grouping_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
 
     @mock.patch('sky.users.permission.kv_cache')
     @mock.patch('sky.users.permission._policy_lock')
-    def test_update_role_invalidates_cache_after_save(self, mock_policy_lock,
-                                                      mock_kv_cache):
-        """Test that update_role invalidates cache after save_policy."""
+    def test_update_role_invalidates_cache_after_the_write(
+            self, mock_policy_lock, mock_kv_cache):
+        """The cache must not be cleared before the new role is persisted.
+
+        Clearing first opens a window where a reader repopulates it from the
+        old role and the entry survives the update.
+        """
         mock_policy_lock.return_value.__enter__ = mock.Mock()
         mock_policy_lock.return_value.__exit__ = mock.Mock()
 
         call_order = []
         mock_enforcer = mock.Mock()
         mock_enforcer.get_roles_for_user.return_value = ['user']
-        mock_enforcer.save_policy.side_effect = (
-            lambda: call_order.append('save_policy'))
+        # Auto-save persists inside the mutator, so that is the write.
+        mock_enforcer.add_grouping_policy.side_effect = (
+            lambda *a: call_order.append('add_grouping_policy'))
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.side_effect = (
             lambda *a, **kw: call_order.append('invalidate'))
 
@@ -365,12 +361,12 @@ class TestPermissionService:
 
         service.update_role('user1', 'admin')
 
-        # Verify cache invalidation was called after save_policy
+        # Verify cache invalidation was called after the write
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_called_once()
         call_kwargs = (
             mock_kv_cache.delete_cache_entries_by_prefix_suffix.call_args[1])
         assert 'user1' in call_kwargs['suffix']
-        assert call_order == ['save_policy', 'invalidate']
+        assert call_order == ['add_grouping_policy', 'invalidate']
 
     @mock.patch('sky.users.permission.kv_cache')
     @mock.patch('sky.users.permission._policy_lock')
@@ -395,7 +391,6 @@ class TestPermissionService:
 
         mock_enforcer.add_grouping_policy.assert_called_once_with(
             'user1', 'user')
-        mock_enforcer.save_policy.assert_called_once()
         # Cache must be invalidated even for first role assignment
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_called_once()
         call_kwargs = (
@@ -625,7 +620,6 @@ class TestPermissionService:
         # Verify policies were added for each user
         mock_enforcer.add_policy.assert_any_call('user1', 'test-workspace', '*')
         mock_enforcer.add_policy.assert_any_call('user2', 'test-workspace', '*')
-        mock_enforcer.save_policy.assert_called_once()
 
     @mock.patch('sky.users.permission.kv_cache')
     @mock.patch('sky.users.permission._policy_lock')
@@ -690,7 +684,6 @@ class TestPermissionService:
         # Verify enforcer policy removal
         mock_enforcer.remove_filtered_policy.assert_called_once_with(
             1, 'test-workspace')
-        mock_enforcer.save_policy.assert_called_once()
         # Verify cache invalidation was called
         mock_kv_cache.delete_cache_entries_by_prefix.assert_called_once()
         prefix_arg = mock_kv_cache.delete_cache_entries_by_prefix.call_args[0][
@@ -751,7 +744,6 @@ class TestPermissionService:
 
             mock_enforcer.remove_filtered_grouping_policy.assert_called_once_with(
                 0, 'user1')
-            mock_enforcer.save_policy.assert_called_once()
             # Verify cache invalidation
             mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_called_once(
             )
@@ -777,7 +769,6 @@ class TestPermissionService:
 
             mock_enforcer.remove_filtered_grouping_policy.assert_called_once_with(
                 0, 'user2')
-            mock_enforcer.save_policy.assert_not_called()
             # No cache invalidation for user without role (early return)
             mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called(
             )
@@ -905,7 +896,6 @@ class TestPermissionService:
 
         mock_enforcer = mock.Mock()
         mock_enforcer.add_grouping_policy.return_value = True
-        mock_enforcer.save_policy.return_value = True
 
         service = permission.PermissionService()
         service.enforcer = mock_enforcer
@@ -919,8 +909,6 @@ class TestPermissionService:
         assert call_args.password == 'password123'
         # Verify admin role was assigned
         mock_enforcer.add_grouping_policy.assert_called_once()
-        # Verify policy was saved
-        mock_enforcer.save_policy.assert_called_once()
 
     @mock.patch('sky.users.permission._policy_lock')
     @mock.patch('sky.global_user_state.get_user')
@@ -948,7 +936,6 @@ class TestPermissionService:
 
         # Verify no new user was created and no role was assigned
         mock_enforcer.add_grouping_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
 
     @mock.patch('sky.users.permission._policy_lock')
     def test_maybe_initialize_basic_auth_user_no_env_var(
@@ -970,7 +957,6 @@ class TestPermissionService:
 
         # Verify nothing was called
         mock_enforcer.add_grouping_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
 
     @mock.patch('sky.users.permission._policy_lock')
     @mock.patch('sky.users.permission.PermissionService._get_plugin_rbac_rules')
@@ -1098,10 +1084,10 @@ class TestPermissionService:
     @mock.patch('sky.users.rbac.get_workspace_policy_permissions')
     @mock.patch('sky.users.rbac.get_role_permissions')
     @mock.patch('sky.global_user_state.get_all_users')
-    def test_maybe_initialize_policies_no_save_when_no_changes(
+    def test_maybe_initialize_policies_writes_nothing_when_in_sync(
             self, mock_get_users, mock_get_role_perms, mock_get_workspace_perms,
             mock_get_plugin_rules, mock_policy_lock, mock_users):
-        """Test that save_policy is not called when no changes are made."""
+        """A boot that finds the policy already correct must not write."""
         mock_policy_lock.return_value.__enter__ = mock.Mock()
         mock_policy_lock.return_value.__exit__ = mock.Mock()
 
@@ -1142,8 +1128,6 @@ class TestPermissionService:
         # Verify no policies were added or removed
         mock_enforcer.add_policy.assert_not_called()
         mock_enforcer.remove_policy.assert_not_called()
-        # Verify save_policy was NOT called since no changes were made
-        mock_enforcer.save_policy.assert_not_called()
 
     @mock.patch('sky.users.permission._policy_lock')
     @mock.patch('sky.users.permission.PermissionService._get_plugin_rbac_rules')
@@ -1201,8 +1185,6 @@ class TestPermissionService:
         # Verify redundant policy was removed
         mock_enforcer.remove_policy.assert_called_once_with(
             'user-to-be-removed', 'some-workspace', '*')
-        # Verify save_policy was called
-        mock_enforcer.save_policy.assert_called()
 
     def test_cache_key_format(self):
         """Test that cache keys use the expected prefix and separator."""
@@ -1505,7 +1487,6 @@ class TestPermissionServiceMultiProcess:
         # Mock enforcer
         mock_enforcer = mock.Mock()
         mock_enforcer.add_policy.return_value = True
-        mock_enforcer.save_policy.return_value = True
 
         service = permission.PermissionService()
         service.enforcer = mock_enforcer
@@ -1682,7 +1663,6 @@ class TestResyncWorkspacePoliciesForNewUser:
         mock_reload.assert_called_once()
         mock_enforcer.add_policy.assert_called_once_with(
             'u-alice', 'private-ws', '*')
-        mock_enforcer.save_policy.assert_called_once()
         # The user's cached (stale) denial must be invalidated.
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_called_once()
         call_kwargs = (
@@ -1722,7 +1702,6 @@ class TestResyncWorkspacePoliciesForNewUser:
         mock_reload.assert_called_once()
         mock_enforcer.add_policy.assert_called_once_with(
             'u-alice', 'private-ws', '*')
-        mock_enforcer.save_policy.assert_called_once()
 
     @mock.patch('sky.users.permission.kv_cache')
     @mock.patch('sky.users.permission._policy_lock')
@@ -1752,7 +1731,6 @@ class TestResyncWorkspacePoliciesForNewUser:
         service.resync_workspace_policies_for_new_user('u-bob')
 
         mock_enforcer.add_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called()
 
     @mock.patch('sky.users.permission.kv_cache')
@@ -1782,7 +1760,6 @@ class TestResyncWorkspacePoliciesForNewUser:
         service.resync_workspace_policies_for_new_user('u-alice')
 
         mock_enforcer.add_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
 
     @mock.patch('sky.users.permission.skypilot_config.reload_config')
     @mock.patch('sky.users.permission.skypilot_config.get_skypilot_config_lock')
@@ -1818,8 +1795,7 @@ class TestResyncWorkspacePoliciesForNewUser:
         mock_reload.assert_called_once()
         mock_enforcer.add_policy.assert_called_once_with(
             'u-alice', 'private-ws', '*')
-        # Nothing changed, so no persist and no invalidation.
-        mock_enforcer.save_policy.assert_not_called()
+        # Nothing changed, so no invalidation.
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called()
 
     @mock.patch('sky.users.permission.skypilot_config.reload_config')
@@ -1871,7 +1847,6 @@ class TestResyncWorkspacePoliciesForNewUser:
         mock_reload.assert_called_once()
         assert mock_get_nested.call_count == 2
         mock_enforcer.add_policy.assert_not_called()
-        mock_enforcer.save_policy.assert_not_called()
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called()
 
     @mock.patch('sky.users.permission.skypilot_config.reload_config')
@@ -2216,8 +2191,9 @@ class TestStalePolicyWrites:
 
         worker_b.remove_workspace_policy('ws_victim')
 
-        # save_policy() rewrites the whole table from the caller's model, so
-        # without the reload this also erases everything A just wrote.
+        # Without the reload, B's `remove_filtered_policy` runs against a
+        # model that predates A's writes -- and casbin skips the adapter for
+        # rows its model does not have, so B would also report success.
         worker_a.enforcer.load_policy()
         remaining = worker_a.enforcer.get_policy()
         assert ['alice', 'ws_keep', '*'] in remaining
@@ -2355,7 +2331,6 @@ class TestRolelessPrincipalIsDenied:
         worker, writer = policy_db(), policy_db()
         worker.enforcer.load_policy()  # stale from here on
         writer.enforcer.add_grouping_policy('fresh_admin', 'admin')
-        writer.enforcer.save_policy()
 
         assert not worker.check_endpoint_permission('fresh_admin',
                                                     '/users/export', 'GET')
@@ -2393,7 +2368,6 @@ class TestRoleSeedMissing:
         worker, writer = policy_db(), policy_db()
         worker.enforcer.load_policy()
         writer.enforcer.add_grouping_policy('elsewhere', 'user')
-        writer.enforcer.save_policy()
 
         assert not worker.role_seed_missing('elsewhere')
 
@@ -2902,3 +2876,94 @@ class TestDefaultRoleCasing:
         with mock.patch('sky.users.rbac.skypilot_config.get_nested',
                         return_value=configured):
             assert rbac.get_default_role() == expected
+
+
+class TestWritesPersistWithoutSavePolicy:
+    """Every write path must reach the database on the mutator alone.
+
+    Casbin's auto-save calls the adapter from inside `add_policy` /
+    `remove_filtered_policy` / etc., so the `save_policy()` rewrite that used to
+    follow each mutation was persisting what had already been persisted. These
+    read back through a *second* service over the same database -- what one
+    service holds in memory proves nothing about what reached storage.
+    """
+
+    @staticmethod
+    def _reader(policy_db):
+        reader = policy_db()
+        reader.enforcer.load_policy()
+        return reader
+
+    def test_a_role_assignment_persists(self, policy_db):
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        writer.update_role('u1', 'admin')
+
+        assert _grouping_rows(self._reader(policy_db), 'u1') == ['admin']
+
+    def test_a_role_replacement_persists(self, policy_db):
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        writer.update_role('u1', 'admin')
+        writer.update_role('u1', 'viewer')
+
+        # Both halves have to have landed: the removal as well as the add, or
+        # the user keeps admin alongside viewer and admin wins.
+        assert _grouping_rows(self._reader(policy_db), 'u1') == ['viewer']
+
+    def test_a_workspace_grant_persists(self, policy_db):
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        writer.add_workspace_policy('ws', ['u1'])
+
+        grants = self._reader(policy_db).enforcer.get_policy()
+        assert ['u1', 'ws', '*'] in grants
+
+    def test_a_workspace_removal_persists(self, policy_db):
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        writer.add_workspace_policy('ws', ['u1'])
+        # Confirm it landed before removing it. Otherwise a broken *add* also
+        # satisfies the assertion below, and the test passes for the one reason
+        # it exists to rule out.
+        before = self._reader(policy_db).enforcer.get_policy()
+        assert ['u1', 'ws', '*'] in before
+
+        writer.remove_workspace_policy('ws')
+
+        after = self._reader(policy_db).enforcer.get_policy()
+        assert ['u1', 'ws', '*'] not in after
+
+    def test_a_user_deletion_persists(self, policy_db):
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        writer.update_role('u1', 'admin')
+        writer.add_workspace_policy('ws', ['u1'])
+        seeded = self._reader(policy_db)
+        assert _grouping_rows(seeded, 'u1') == ['admin']
+        assert ['u1', 'ws', '*'] in seeded.enforcer.get_policy()
+
+        writer.delete_user('u1')
+
+        reader = self._reader(policy_db)
+        assert _grouping_rows(reader, 'u1') == []
+        assert ['u1', 'ws', '*'] not in reader.enforcer.get_policy()
+
+    def test_no_write_path_calls_save_policy(self, policy_db):
+        """The rewrite is gone, not merely unnecessary.
+
+        Without this, someone re-adding one `save_policy()` for symmetry would
+        pass every test above -- they assert the row is there, and a rewrite
+        also puts it there.
+        """
+        writer = policy_db()
+        writer.enforcer.load_policy()
+        with mock.patch.object(writer.enforcer,
+                               'save_policy',
+                               side_effect=AssertionError(
+                                   'save_policy() is back on a write path')):
+            writer.update_role('u1', 'admin')
+            writer.add_workspace_policy('ws', ['u1'])
+            writer.update_workspace_policy('ws', ['u2'])
+            writer.remove_workspace_policy('ws')
+            writer.delete_user('u1')


### PR DESCRIPTION
## What

Every casbin write path in `sky/users/permission.py` ended with
`enforcer.save_policy()` — a `DELETE FROM casbin_rule` plus a full rewrite of
the table from the calling process's in-memory model. This removes all eight.

Nothing replaces them. Auto-save is already on (`CoreEnforcer.__init__` sets
`self.auto_save = True`, and we never call `enable_auto_save(False)`) and the
sqlalchemy adapter implements `add_policy` / `add_policies` / `remove_policy` /
`remove_filtered_policy`, so the adapter write has already happened by the time
the rewrite runs. Each write was persisting itself twice, the second time at a
cost that scales with the size of the whole table rather than the change.

Casbin's docs present auto-save and `save_policy()` as alternatives —
`save_policy()` is for the batched pattern, where you deliberately
`enable_auto_save(False)`, mutate N times, and save once. Doing both is outside
the intended usage.

**This is not new machinery.** `add_user_if_not_exists` has never called
`save_policy()`: every new user's default-role seed already persists on the
mutator alone, on the login path. This change makes the other eight paths
consistent with the one that carries the most traffic.

## Measurements

Real `PermissionService` driven through all eight paths against Postgres at
5000 grouping rows, read back **in a separate process**, median of 5
alternating rounds:

| path | before | after | |
| --- | --- | --- | --- |
| `update_role` | 156 ms | 118 ms | −24% |
| `add_workspace_policy` | 291 ms | 189 ms | −35% |
| `update_workspace_policy` | 312 ms | 180 ms | −42% |
| `remove_workspace_policy` | 289 ms | 174 ms | −40% |
| `delete_user` | 304 ms | 170 ms | −44% |
| `resync_workspace_policies_for_new_user` | 299 ms | 183 ms | −39% |
| `add_user_if_not_exists` *(control, code untouched)* | 159 ms | 176 ms | +10% |
| `add_user_if_not_exists` *(control, code untouched)* | 115 ms | 116 ms | +0.7% |

The control path is the noise floor: this change cannot touch it, so its
deviation bounds what any other row's delta can mean. The policy table read
back afterwards is byte-identical to what the unchanged code produces
(`p=17 g=5004` in both arms).

Two of these are on hot paths — `update_role` runs on every SSO/SCIM
reconcile, and `resync_workspace_policies_for_new_user` runs on a new user's
first login.

## Why this is safe now, and was not before

Casbin's incremental mutators decide against the **writer's own in-memory
model** and never reach the adapter when it already agrees:

```python
# _add_policy
if self.model.has_policy(sec, ptype, rule):
    return False                 # adapter never called

# _remove_filtered_policy
rule_removed = self.model.remove_filtered_policy(...)
if not rule_removed:
    return rule_removed          # adapter never called
```

So a stale writer's change is **skipped, not deferred** — in both directions.
Until #10488 added the reload under the lock, `save_policy()` was masking
exactly that: a stale removal removed nothing, and then the rewrite dropped the
row anyway as a side effect of clobbering everything else. Removing the rewrite
before that reload existed would have turned a loud clobber into a silent
no-op.

That reload is present at all eight sites today, and it stays. Three comments
justified it by citing the rewrite; they now give the real reason, since the
old one no longer exists. **A future change must not read "the rewrite is gone"
as licence to drop the reload** — it is now the only thing preventing a stale
writer from silently doing nothing.

One claim I checked and could not confirm: that `save_policy()` incidentally
laundered duplicate grouping rows out of the table. It does not — casbin does
not dedup on load, so the rewrite reproduces duplicates faithfully. Two
byte-identical `g` rows inserted behind casbin's back survive a `save_policy()`
unchanged. Nothing is given up here.

## Tests

The existing suite asserted the *mechanism*: `save_policy` was called, or was
not. The "was not" half of that would have become **vacuously true** — green,
testing nothing. Every one of those ~30 assertions is either already carried by
a companion assertion on the mutator, or converted to one. The ordering test
now pins the cache invalidation after `add_grouping_policy`, which is where
persistence happens now.

New `TestWritesPersistWithoutSavePolicy`: one case per mutator kind, each
reading back through a **second service over the same database** — what one
service holds in memory proves nothing about what reached storage — plus a case
that fails the write if `save_policy()` ever comes back to a write path.

Each new test was revert-checked. Disabling auto-save on the enforcer's
delegate makes five of the six fail, as it should. Two of them initially passed
under that revert for the wrong reason: they assert a row is *absent*, which a
broken *add* satisfies just as well as a working remove. Both now assert the
row landed first.

`tests/unit_tests/test_sky/users/` — 313 passed, 1 failed, and that one
(`test_preferred_workspace_endpoints.py::…::test_set_preferred_workspace_raises_when_server_too_old`)
fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->