### PR TITLE
[Volumes] Read only the names when scoping the listing refresh

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3013,6 +3013,42 @@ def _volume_record_from_row(row: Any) -> Dict[str, Any]:
     }
 
 
+def _query_volumes(
+    columns: List[Any],
+    is_ephemeral: Optional[bool],
+    workspaces_filter: Optional[Set[str]],
+    volume_names: Optional[List[str]],
+) -> List[Any]:
+    """Rows of `columns` for the volumes every given filter allows."""
+    engine = _db_manager.get_engine()
+
+    def filtered(session: 'orm.Session') -> Any:
+        query = session.query(*columns)
+        if is_ephemeral is not None:
+            query = query.filter_by(is_ephemeral=int(is_ephemeral))
+        if workspaces_filter is not None:
+            query = query.filter(
+                volume_table.c.workspace.in_(workspaces_filter))
+        return query
+
+    rows: List[Any] = []
+    with orm.Session(engine) as session:
+        if volume_names is None:
+            rows = filtered(session).all()
+        else:
+            # Chunk the IN list for the same reason as
+            # get_volumes_from_names: SQLite caps bound parameters and
+            # PostgreSQL plans huge IN clauses badly.
+            for offset in range(0, len(volume_names),
+                                _CLUSTER_IN_QUERY_CHUNK_SIZE):
+                batch = volume_names[offset:offset +
+                                     _CLUSTER_IN_QUERY_CHUNK_SIZE]
+                rows.extend(
+                    filtered(session).filter(
+                        volume_table.c.name.in_(batch)).all())
+    return rows
+
+
 @metrics_lib.time_me
 def get_volumes(
     is_ephemeral: Optional[bool] = None,
@@ -3034,33 +3070,28 @@ def get_volumes(
             An empty list therefore matches nothing, while None means "do not
             filter by name". Names with no row are simply absent.
     """
-    engine = _db_manager.get_engine()
+    return [
+        _volume_record_from_row(row) for row in _query_volumes(
+            [volume_table], is_ephemeral, workspaces_filter, volume_names)
+    ]
 
-    def filtered(session: 'orm.Session') -> Any:
-        query = session.query(volume_table)
-        if is_ephemeral is not None:
-            query = query.filter_by(is_ephemeral=int(is_ephemeral))
-        if workspaces_filter is not None:
-            query = query.filter(
-                volume_table.c.workspace.in_(workspaces_filter))
-        return query
 
-    rows = []
-    with orm.Session(engine) as session:
-        if volume_names is None:
-            rows = filtered(session).all()
-        else:
-            # Chunk the IN list for the same reason as
-            # get_volumes_from_names: SQLite caps bound parameters and
-            # PostgreSQL plans huge IN clauses badly.
-            for offset in range(0, len(volume_names),
-                                _CLUSTER_IN_QUERY_CHUNK_SIZE):
-                batch = volume_names[offset:offset +
-                                     _CLUSTER_IN_QUERY_CHUNK_SIZE]
-                rows.extend(
-                    filtered(session).filter(
-                        volume_table.c.name.in_(batch)).all())
-    return [_volume_record_from_row(row) for row in rows]
+@metrics_lib.time_me
+def get_volume_names(
+    is_ephemeral: Optional[bool] = None,
+    workspaces_filter: Optional[Set[str]] = None,
+    volume_names: Optional[List[str]] = None,
+) -> List[str]:
+    """Names of the volumes every given filter allows.
+
+    Same filters as `get_volumes`, but reads only the name column: building a
+    record unpickles the handle and decodes the usedby fields, which a caller
+    that wants names alone pays for and throws away.
+    """
+    return [
+        row.name for row in _query_volumes([volume_table.c.name], is_ephemeral,
+                                           workspaces_filter, volume_names)
+    ]
 
 
 @metrics_lib.time_me

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -318,14 +318,16 @@ def volume_list(
         # calls by the (context, namespace) pairs of the volumes it is handed,
         # so narrowing the set narrows the calls. The daemon in
         # sky/server/daemons.py still refreshes the whole table.
-        # Requested names narrow this again. get_volumes applies every filter
+        # Requested names narrow this again. The lookup applies every filter
         # it is given, so naming a volume outside the accessible workspaces
         # reconciles nothing -- which would otherwise confirm it exists.
-        volume_refresh(volume_names=[
-            volume['name'] for volume in global_user_state.get_volumes(
-                workspaces_filter=accessible_workspaces,
-                volume_names=volume_names)
-        ])
+        # Ephemeral volumes are excluded here rather than inside
+        # volume_refresh, which drops them anyway: handing them over only
+        # lengthens the IN list.
+        volume_refresh(volume_names=global_user_state.get_volume_names(
+            is_ephemeral=False,
+            workspaces_filter=accessible_workspaces,
+            volume_names=volume_names))
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
         volumes = global_user_state.get_volumes(
             is_ephemeral=is_ephemeral,

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -2310,7 +2310,20 @@ class TestVolumeListScopedToNames:
                 out = [r for r in out if r['name'] in volume_names]
             return out
 
+        def fake_get_volume_names(is_ephemeral=None,
+                                  workspaces_filter=None,
+                                  volume_names=None):
+            """The name-only lookup, filtering as the record one does."""
+            return [
+                row['name']
+                for row in fake_get_volumes(is_ephemeral=is_ephemeral,
+                                            workspaces_filter=workspaces_filter,
+                                            volume_names=volume_names)
+            ]
+
         monkeypatch.setattr(global_user_state, 'get_volumes', fake_get_volumes)
+        monkeypatch.setattr(global_user_state, 'get_volume_names',
+                            fake_get_volume_names)
         monkeypatch.setattr(global_user_state, 'get_all_users',
                             mock.MagicMock(return_value=[]))
         monkeypatch.setattr(

--- a/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
+++ b/tests/unit_tests/test_sky/volumes/test_volumes_workspace_filter.py
@@ -128,7 +128,25 @@ def test_refresh_is_scoped_to_the_accessible_workspaces(isolated_database):
                                'volume_refresh') as volume_refresh:
             volumes_core.volume_list(refresh=True)
 
-    volume_refresh.assert_called_once_with(volume_names=['vol-a'])
+    volume_refresh.assert_called_once()
+    # Sorted: the names come from a query with no ORDER BY.
+    assert sorted(volume_refresh.call_args.kwargs['volume_names']) == ['vol-a']
+
+
+def test_refresh_is_not_handed_ephemeral_volumes(isolated_database):
+    """volume_refresh reconciles persistent volumes only, so an ephemeral name
+    can only lengthen the IN list it looks up."""
+    _add('vol-a', workspace='ws-a')
+    _add('vol-a-ephemeral', workspace='ws-a', is_ephemeral=True)
+
+    with mock.patch.object(volumes_core.workspaces_core,
+                           'get_accessible_workspace_names',
+                           return_value={'ws-a'}):
+        with mock.patch.object(volumes_core,
+                               'volume_refresh') as volume_refresh:
+            volumes_core.volume_list(refresh=True)
+
+    assert sorted(volume_refresh.call_args.kwargs['volume_names']) == ['vol-a']
 
 
 def test_filters_to_the_given_names(isolated_database):
@@ -182,3 +200,18 @@ def test_names_are_chunked_but_all_are_returned(isolated_database, monkeypatch):
         volume_names=[f'vol-{i}' for i in range(5)])
 
     assert sorted(r['name'] for r in records) == [f'vol-{i}' for i in range(5)]
+
+
+def test_get_volume_names_applies_the_same_filters(isolated_database):
+    """The name-only lookup must not be a wider door than get_volumes."""
+    _add('vol-a', workspace='ws-a')
+    _add('vol-a-ephemeral', workspace='ws-a', is_ephemeral=True)
+    _add('vol-b', workspace='ws-b')
+
+    names = global_user_state.get_volume_names(
+        is_ephemeral=False,
+        workspaces_filter={'ws-a'},
+        volume_names=['vol-a', 'vol-a-ephemeral', 'vol-b'])
+
+    assert names == ['vol-a']
+    assert global_user_state.get_volume_names(workspaces_filter=set()) == []


### PR DESCRIPTION
## Summary

Follow-ups from the review of #10531, none of them behavior changes.

* `volume_list(refresh=True)` picks the volumes to reconcile by listing full records and keeping `volume['name']`. Building a record unpickles the handle and decodes the usedby fields, all of which that caller discards — and since #10564 made `volume_list(volume_names=..., refresh=True)` the poll path for "is this volume ready yet", it pays that on every poll. Add `get_volume_names()`, same filters as `get_volumes()` but selecting the name column alone, and use it there. Both go through one query builder, so a filter cannot be applied by one and not the other.
* Ask for persistent volumes only while there. `volume_refresh` looks its names up with `is_ephemeral=False` and drops the rest, so an ephemeral name could only lengthen the `IN` list.
* The refresh-scoping test compared the reconciled names against a list, but they come from a query with no `ORDER BY`. Compare sorted — one more volume in that fixture's workspace would have made it flaky, and more so on PostgreSQL than on the SQLite the test runs against.

The same volumes are reconciled and the same records are listed as before.

## Tested

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

`pytest tests/unit_tests/test_sky/volumes/` — 498 passed. mypy and pylint (10.00/10) clean on both source files.

Two new tests, against a real SQLite database rather than mock assertions:

* `test_get_volume_names_applies_the_same_filters` — the name-only lookup is not a wider door than `get_volumes`.
* `test_refresh_is_not_handed_ephemeral_volumes` — an ephemeral volume in the caller's workspace is not passed to `volume_refresh`.

Negative control, each run on a scratch checkout of this commit:

* Restoring the old record-listing lookup in `volume_list`: `test_refresh_is_not_handed_ephemeral_volumes` fails, and the pre-existing `test_refresh_is_scoped_to_the_accessible_workspaces` still passes — as it should, since that behavior is untouched.
* Dropping `workspaces_filter` from `get_volume_names`: both `test_get_volume_names_applies_the_same_filters` and `test_refresh_is_scoped_to_the_accessible_workspaces` fail, so the workspace scoping #10531 added is still guarded through the new path.

Smoke tests not run: this is server-side listing logic with no provisioning path. Happy to trigger them if you would like.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->