### PR TITLE
[Dashboard] Let a jobs-table row link to its own detail page

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1496,18 +1496,21 @@ export function ManagedJobsTable({
             );
           }
 
-          // Single task
+          // Single task. A row may carry its own detail link (e.g. rows
+          // sourced from outside the managed-jobs table); otherwise link to
+          // the managed-job detail page.
+          const detailHref = item.detail_href || `/jobs/${item.id}`;
           return (
             <TableCell>
               {hasAnyJobGroups ? (
                 <div className="flex items-center">
                   <span className="w-6 mr-1" aria-hidden="true" />
-                  <Link href={`/jobs/${item.id}`} className="text-blue-600">
+                  <Link href={detailHref} className="text-blue-600">
                     {item.id}
                   </Link>
                 </div>
               ) : (
-                <Link href={`/jobs/${item.id}`} className="text-blue-600">
+                <Link href={detailHref} className="text-blue-600">
                   {item.id}
                 </Link>
               )}
@@ -1573,11 +1576,13 @@ export function ManagedJobsTable({
             );
           }
 
-          // Single task
+          // Single task. Honor a row-provided detail link (see the ID
+          // column) so externally-sourced rows point at their own page.
+          const detailHref = item.detail_href || `/jobs/${item.id}`;
           return (
             <TableCell className="whitespace-nowrap">
               <div className="flex items-center">
-                <JobNameLink href={`/jobs/${item.id}`} name={item.name} />
+                <JobNameLink href={detailHref} name={item.name} />
                 {isBatch && <BatchBadge className="ml-2" />}
               </div>
             </TableCell>


### PR DESCRIPTION
## Summary

The managed-jobs table hardcodes every row's detail link to `/jobs/<id>`. Rows that represent jobs living outside the managed-jobs store have no record there, so that link 404s.

This lets a row carry an optional `detail_href`. When present, the **ID** and **Name** column links use it; otherwise they fall back to the existing `/jobs/<id>`. No behavior change for existing rows.

## Test plan

- Existing managed-jobs rows (no `detail_href`) link to `/jobs/<id>` exactly as before.
- A row with `detail_href` set links to that path instead — verified both the ID and Name columns honor it, and that a client-side `next/link` navigation to a catch-all-served path (`pages/[...path].js`) resolves correctly.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->