### PR TITLE
[API] Run async continue-condition waits on a shared event loop

### DIFF
--- a/sky/server/requests/continue_condition.py
+++ b/sky/server/requests/continue_condition.py
@@ -6,6 +6,27 @@ the resume signal. The scheduler calls ``wait()`` from the request's monitor
 thread, so the worker is freed meanwhile. Subclass to own the polling/backoff/
 fallback policy; instances are pickled onto the exception, so keep state
 picklable and define subclasses in a module importable by the scheduler.
+
+A ``wait()`` holds one OS thread for its whole duration, and parked requests
+can outnumber executor workers by orders of magnitude (each is only waiting on
+an external signal). An implementation may therefore also define
+``wait_async()``, a coroutine the scheduler prefers and drives from a single
+shared event loop, so any number of parked requests cost coroutines instead of
+threads. Same signature and semantics as ``wait()``, with two differences:
+
+* ``is_cancelled`` and ``update_status_msg`` are **async** callables
+  (``await is_cancelled()``); the scheduler runs the blocking work behind
+  them in a thread pool.
+* The coroutine shares one event loop with every other parked request, so it
+  must not block: sleep with ``asyncio.sleep`` and push any blocking probe
+  (an HTTP poll, a DB read) through ``loop.run_in_executor``.
+
+The contract stays duck-typed for cross-version tolerance: the scheduler uses
+``wait_async`` only when the condition defines it as a coroutine function, and
+falls back to running ``wait()`` in the monitor thread otherwise. The base
+class deliberately does not define ``wait_async`` — inheriting a default here
+would make every subclass look async-capable while hiding its overridden
+``wait()`` policy.
 """
 import time
 from typing import Callable, Optional
@@ -15,7 +36,8 @@ class ContinueCondition:
     """A resumable wait attached to ``ExecutionPausedError``.
 
     Subclass and override ``wait()`` to customize how a paused request waits
-    before being rescheduled.
+    before being rescheduled; optionally also define ``wait_async()`` (see
+    module docstring) so the wait does not hold an OS thread.
     """
 
     def wait(self,

--- a/sky/server/requests/event_loop.py
+++ b/sky/server/requests/event_loop.py
@@ -25,7 +25,14 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     with _LOCK:
         if _EVENT_LOOP is None or _EVENT_LOOP.is_closed():
             _EVENT_LOOP = asyncio.new_event_loop()
+            # Name the loop thread and its offload pool so they are
+            # identifiable in stack dumps, and size the pool explicitly
+            # instead of inheriting asyncio's cpu-count-dependent default.
+            _EVENT_LOOP.set_default_executor(
+                concurrent.futures.ThreadPoolExecutor(
+                    max_workers=32, thread_name_prefix='request-event-loop'))
             loop_thread = threading.Thread(target=_EVENT_LOOP.run_forever,
+                                           name='request-event-loop',
                                            daemon=True)
             loop_thread.start()
     return _EVENT_LOOP

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -50,6 +50,7 @@ from sky.server import daemons
 from sky.server import metrics as metrics_lib
 from sky.server import plugins
 from sky.server import versions
+from sky.server.requests import event_loop
 from sky.server.requests import payloads
 from sky.server.requests import preconditions
 from sky.server.requests import process
@@ -270,19 +271,17 @@ def _refresh_waiting_status_msg(request_id: str, retry_suffix: str,
         request_task.status_msg = _waiting_status_msg(reason, retry_suffix)
 
 
-def _wait_for_continue_condition(
-        condition: Any, *, is_cancelled: Callable[[], bool],
-        fallback_wait_seconds: float,
-        update_status_msg: Callable[[str], None]) -> bool:
-    """Run a continue condition's wait, tolerating an older ``wait()``.
+def _condition_wait_kwargs(wait_fn: Callable, *, is_cancelled: Callable,
+                           fallback_wait_seconds: float,
+                           update_status_msg: Callable) -> Dict[str, Any]:
+    """Build the kwargs for a wait, tolerating an older signature.
 
     The continue-condition contract is duck-typed (see
     ``continue_condition.ContinueCondition``), and implementations live in
     separately versioned packages, so ``update_status_msg`` is passed only to
-    a ``wait()`` that accepts it rather than raising TypeError on one that
-    does not.
+    a wait that accepts it rather than raising TypeError on one that does not.
 
-    The probe reads the signature, so a ``wait()`` wrapped by a decorator that
+    The probe reads the signature, so a wait wrapped by a decorator that
     neither ``functools.wraps`` it nor declares ``**kwargs`` is treated as not
     accepting the callback: the wait still runs, it just never reports a
     reason.
@@ -291,12 +290,36 @@ def _wait_for_continue_condition(
         'is_cancelled': is_cancelled,
         'fallback_wait_seconds': fallback_wait_seconds,
     }
-    parameters = inspect.signature(condition.wait).parameters
+    parameters = inspect.signature(wait_fn).parameters
     if ('update_status_msg' in parameters or
             any(parameter.kind is inspect.Parameter.VAR_KEYWORD
                 for parameter in parameters.values())):
         kwargs['update_status_msg'] = update_status_msg
+    return kwargs
+
+
+def _wait_for_continue_condition(
+        condition: Any, *, is_cancelled: Callable[[], bool],
+        fallback_wait_seconds: float,
+        update_status_msg: Callable[[str], None]) -> bool:
+    """Run a continue condition's wait in the calling thread."""
+    kwargs = _condition_wait_kwargs(condition.wait,
+                                    is_cancelled=is_cancelled,
+                                    fallback_wait_seconds=fallback_wait_seconds,
+                                    update_status_msg=update_status_msg)
     return condition.wait(**kwargs)
+
+
+def _async_condition_wait(condition: Any) -> Optional[Callable]:
+    """The condition's ``wait_async`` coroutine function, if it has one.
+
+    Only a real coroutine function opts a condition into the shared waiter
+    loop: a plain callable that happens to be named ``wait_async`` cannot be
+    awaited, and silently degrading it to the fallback wait would discard the
+    condition's actual policy in ``wait()``.
+    """
+    wait_async = getattr(condition, 'wait_async', None)
+    return wait_async if inspect.iscoroutinefunction(wait_async) else None
 
 
 class RequestWorker:
@@ -449,6 +472,18 @@ class RequestWorker:
                 assert request_task is not None, request_id
                 request_task.status = api_requests.RequestStatus.WAITING
                 request_task.status_msg = status_msg
+            if condition is not None:
+                wait_async = _async_condition_wait(condition)
+                if wait_async is not None:
+                    # An async-capable condition waits as a coroutine on the
+                    # shared request event loop; this monitor thread ends here
+                    # instead of blocking for the length of the pause.
+                    event_loop.run(
+                        self._wait_async_and_reschedule(wait_async,
+                                                        request_element,
+                                                        retry_wait_seconds,
+                                                        retry_suffix))
+                    return
             try:
                 if condition is not None:
                     should_reschedule = _wait_for_continue_condition(
@@ -473,6 +508,56 @@ class RequestWorker:
                 queue = _get_queue(self.schedule_type)
                 queue.put(request_element)
                 logger.info(f'Rescheduled request {request_id} for retry')
+
+    async def _wait_async_and_reschedule(self, wait_async: Callable,
+                                         request_element: Tuple[str, bool,
+                                                                bool],
+                                         retry_wait_seconds: float,
+                                         retry_suffix: str) -> None:
+        """Drive a condition's ``wait_async`` and requeue on resume.
+
+        Same policy as the thread path in ``handle_task_result``: a failing
+        wait falls back to one fixed backoff and reschedules, a False verdict
+        drops the request. Runs on the shared waiter loop, so everything
+        blocking — the DB access behind the callbacks, the queue put — must
+        go through the loop's thread pool.
+        """
+        request_id, _, _ = request_element
+        loop = asyncio.get_running_loop()
+
+        async def is_cancelled() -> bool:
+            return await loop.run_in_executor(None,
+                                              _request_is_gone_or_cancelled,
+                                              request_id)
+
+        async def update_status_msg(reason: str) -> None:
+            await loop.run_in_executor(None, _refresh_waiting_status_msg,
+                                       request_id, retry_suffix, reason)
+
+        try:
+            try:
+                kwargs = _condition_wait_kwargs(
+                    wait_async,
+                    is_cancelled=is_cancelled,
+                    fallback_wait_seconds=retry_wait_seconds,
+                    update_status_msg=update_status_msg)
+                should_reschedule = await wait_async(**kwargs)
+            except Exception as wait_err:  # pylint: disable=broad-except
+                logger.error(
+                    f'Continue-condition wait failed for {request_id}: '
+                    f'{common_utils.format_exception(wait_err)}')
+                await asyncio.sleep(retry_wait_seconds)
+                should_reschedule = True
+            if should_reschedule:
+                queue = _get_queue(self.schedule_type)
+                await loop.run_in_executor(None, queue.put, request_element)
+                logger.info(f'Rescheduled request {request_id} for retry')
+        except Exception as e:  # pylint: disable=broad-except
+            # Nothing reads this coroutine's future; an exception escaping
+            # here would otherwise vanish, with the request left parked.
+            logger.error(
+                f'Continue-condition handling failed for {request_id}: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
 
     def run(self) -> None:
         # Handle the SIGTERM signal to abort the executor process gracefully.

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -716,11 +716,13 @@ async def test_request_worker_retry_execution_retryable_error(
 class _PauseHarness:
     """Bundles the worker, queue, and request id for pause/watch tests."""
 
-    def __init__(self, worker, request_id, queue_items, sleep_calls):
+    def __init__(self, worker, request_id, queue_items, sleep_calls, queued):
         self.worker = worker
         self.request_id = request_id
         self.queue_items = queue_items
         self.sleep_calls = sleep_calls
+        # Set on every requeue; the async-path tests wait on it.
+        self.queued = queued
 
     def run(self, condition, retry_wait_seconds=30):
         """Drive handle_task_result with an ExecutionPausedError."""
@@ -754,6 +756,8 @@ def pause_harness(isolated_database, monkeypatch):
     queue_items = []
     backing = queue_lib.Queue()
 
+    queued = threading.Event()
+
     class MockRequestQueue:
 
         def get(self):
@@ -765,6 +769,9 @@ def pause_harness(isolated_database, monkeypatch):
         def put(self, item):
             queue_items.append(item)
             backing.put(item)
+            # Signals the async-path tests, whose requeue happens on the
+            # shared request event loop after handle_task_result returned.
+            queued.set()
 
     request_queue = MockRequestQueue()
     monkeypatch.setattr(executor, '_get_queue',
@@ -783,7 +790,7 @@ def pause_harness(isolated_database, monkeypatch):
         config=server_config.WorkerConfig(garanteed_parallelism=1,
                                           burstable_parallelism=0,
                                           num_db_connections_per_worker=0))
-    return _PauseHarness(worker, request_id, queue_items, sleep_calls)
+    return _PauseHarness(worker, request_id, queue_items, sleep_calls, queued)
 
 
 class _RecordingCondition(continue_condition_lib.ContinueCondition):
@@ -999,6 +1006,182 @@ def test_pause_passes_the_new_kwarg_to_a_kwargs_absorbing_wait(pause_harness):
     pause_harness.run(condition, retry_wait_seconds=30)
 
     assert condition.kwargs == [['update_status_msg']]
+
+
+class _AsyncRecordingCondition(continue_condition_lib.ContinueCondition):
+    """A condition whose wait_async() returns a fixed verdict.
+
+    Records what the executor drives it with, so tests can assert the async
+    contract: awaitable callbacks, and the coroutine running off the monitor
+    thread on the shared request event loop.
+    """
+
+    def __init__(self, verdict: bool, reasons=()):
+        self._verdict = verdict
+        self._reasons = reasons
+        self.calls = []
+        self.done = threading.Event()
+
+    def wait(self, **kwargs) -> bool:
+        raise AssertionError(
+            'sync wait() must not run for an async-capable condition')
+
+    async def wait_async(self,
+                         *,
+                         is_cancelled,
+                         fallback_wait_seconds,
+                         update_status_msg=None) -> bool:
+        self.calls.append({
+            'is_cancelled': await is_cancelled(),
+            'fallback_wait_seconds': fallback_wait_seconds,
+            'thread': threading.current_thread(),
+        })
+        for reason in self._reasons:
+            assert update_status_msg is not None
+            await update_status_msg(reason)
+        self.done.set()
+        return self._verdict
+
+
+def test_pause_async_condition_reschedules(pause_harness):
+    """An async condition's True verdict requeues the request.
+
+    Also pins down the contract: the coroutine runs off the monitor thread,
+    and is_cancelled is awaitable there.
+    """
+    condition = _AsyncRecordingCondition(verdict=True)
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert pause_harness.queued.wait(timeout=10)
+    assert pause_harness.queue_items == [request_element]
+    assert condition.calls == [{
+        'is_cancelled': False,
+        'fallback_wait_seconds': 30,
+        'thread': mock.ANY,
+    }]
+    assert condition.calls[0]['thread'] is not threading.current_thread()
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status'])
+    assert updated.status == requests_lib.RequestStatus.WAITING
+
+
+def test_pause_async_condition_dropped_when_wait_returns_false(pause_harness):
+    """An async condition's False verdict drops the request (no reschedule)."""
+    condition = _AsyncRecordingCondition(verdict=False)
+
+    pause_harness.run(condition)
+
+    assert condition.done.wait(timeout=10)
+    # The requeue (if any, wrongly) would follow right after the verdict on
+    # the same coroutine; give it a beat before asserting it never happened.
+    assert not pause_harness.queued.wait(timeout=0.2)
+    assert pause_harness.queue_items == []
+
+
+def test_pause_async_status_msg_refreshed_while_parked(pause_harness):
+    """A reason pushed through the awaitable updater lands on the request."""
+    condition = _AsyncRecordingCondition(
+        verdict=True, reasons=['Pending (Queue: q, Position: 4)'])
+
+    pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert pause_harness.queued.wait(timeout=10)
+    updated = requests_lib.get_request(pause_harness.request_id,
+                                       fields=['status_msg'])
+    assert updated.status_msg == (
+        'Pending (Queue: q, Position: 4) (waiting to resume)')
+
+
+class _GatedAsyncCondition(continue_condition_lib.ContinueCondition):
+    """A wait_async() that stays parked until the test releases it."""
+
+    def __init__(self):
+        self.release = threading.Event()
+
+    async def wait_async(self,
+                         *,
+                         is_cancelled,
+                         fallback_wait_seconds,
+                         update_status_msg=None) -> bool:
+        del is_cancelled, fallback_wait_seconds, update_status_msg
+        await asyncio.get_running_loop().run_in_executor(
+            None, self.release.wait)
+        return True
+
+
+def test_pause_async_wait_does_not_hold_the_monitor_thread(pause_harness):
+    """handle_task_result returns while the async wait is still parked.
+
+    This is the point of wait_async: parked requests can outnumber executor
+    workers by orders of magnitude, so the wait must not keep the per-request
+    monitor thread alive for its duration.
+    """
+    condition = _GatedAsyncCondition()
+
+    # Returns immediately; on a thread-blocking wait this would deadlock
+    # until the (never-released) gate.
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert pause_harness.queue_items == []
+    condition.release.set()
+    assert pause_harness.queued.wait(timeout=10)
+    assert pause_harness.queue_items == [request_element]
+
+
+class _FailingAsyncCondition(continue_condition_lib.ContinueCondition):
+    """A wait_async() that dies mid-wait."""
+
+    async def wait_async(self, **kwargs) -> bool:
+        del kwargs
+        raise RuntimeError('probe exploded')
+
+
+def test_pause_async_wait_failure_falls_back_to_fixed_wait(pause_harness):
+    """A failing wait_async degrades to one fixed backoff, then reschedules.
+
+    Same policy as the sync path: a broken probe must not drop the request.
+    """
+    condition = _FailingAsyncCondition()
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=0)
+
+    assert pause_harness.queued.wait(timeout=10)
+    assert pause_harness.queue_items == [request_element]
+
+
+class _NonCoroutineWaitAsyncCondition(continue_condition_lib.ContinueCondition):
+    """A condition whose wait_async attribute is not a coroutine function."""
+
+    def __init__(self):
+        self.sync_calls = 0
+
+    def wait_async(self, **kwargs) -> bool:
+        raise AssertionError('a non-coroutine wait_async must be ignored')
+
+    def wait(self,
+             *,
+             is_cancelled,
+             fallback_wait_seconds,
+             update_status_msg=None) -> bool:
+        del is_cancelled, fallback_wait_seconds, update_status_msg
+        self.sync_calls += 1
+        return True
+
+
+def test_pause_non_coroutine_wait_async_uses_sync_path(pause_harness):
+    """Only a real coroutine function opts into the waiter loop.
+
+    A plain callable named wait_async cannot be awaited; degrading it to the
+    fallback wait would silently discard the condition's wait() policy, so
+    the executor must keep the thread-based path instead.
+    """
+    condition = _NonCoroutineWaitAsyncCondition()
+
+    request_element = pause_harness.run(condition, retry_wait_seconds=30)
+
+    assert condition.sync_calls == 1
+    assert pause_harness.queue_items == [request_element]
 
 
 @pytest.mark.parametrize(('reason', 'suffix', 'expected'), [


### PR DESCRIPTION
A request paused via `ExecutionPausedError` waits for its resume signal in `condition.wait()`, which blocks the request's monitor thread for the whole wait — up to hours. Parked requests can outnumber executor workers by orders of magnitude (each is only waiting on an external signal), so at scale this holds one OS thread per parked request in the API server process; we have observed 1,000+ such threads, and a thread population that size degrades everything sharing the GIL in that process.

This PR lets a continue condition optionally define `wait_async()`, a coroutine the scheduler drives from a single shared event loop (one `pause-waiter-loop` daemon thread per process): any number of parked requests then cost kilobytes each instead of an OS thread each. Inside `wait_async` the `is_cancelled` / `update_status_msg` callbacks are awaitables; the scheduler runs the blocking work behind them in the loop's thread pool.

The contract stays duck-typed in both directions, mirroring how `update_status_msg` was introduced:

- a condition without `wait_async` (or whose `wait_async` is not a coroutine function) keeps the current thread-based `wait()` path;
- an older scheduler keeps calling `wait()` on a condition that defines both.

If the coroutine cannot be scheduled at all, the monitor thread falls back to the thread-based wait rather than dropping the request.

## Test plan

- New unit tests in `tests/unit_tests/test_sky/server/requests/test_executor.py`: async verdict reschedules / drops, reason refresh through the awaitable updater, `handle_task_result` returning while the wait is still parked, a failing `wait_async` degrading to the fixed fallback wait, and a non-coroutine `wait_async` being ignored in favor of `wait()`.
- All 19 pause-path executor tests pass locally (`pytest tests/unit_tests/test_sky/server/requests/test_executor.py -k 'pause or waiting_status'`).
- Manual, on a live API server with a plugin-provided condition implementing `wait_async`, A/B against the thread path at the same load:
  - Thread waits (baseline): server-process threads grew exactly 1.0 per parked request (50 idle → 72 at 20 parked).
  - Async waits: flat (56 at 20 parked → 56–58 at 28 parked, slope ≈ 0.1).
  - A parked request resumed and completed 55 s after its external gate lifted; 28 requests cancelled while parked were all dropped without rescheduling; the parked status message kept refreshing through the awaitable updater; a server restart with 20 parked requests recovered and re-parked all of them through the async path with no errors logged.
