### PR TITLE
[AWS] Stage São Paulo catalog support

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -41,6 +41,7 @@ ALL_REGIONS = [
     'us-west-1',
     'us-west-2',
     'ca-central-1',
+    'sa-east-1',
     'eu-central-1',
     # 'eu-central-2', # no supported AMI
     'eu-west-1',

--- a/sky/catalog/images/aws_utils/image_gen.py
+++ b/sky/catalog/images/aws_utils/image_gen.py
@@ -32,13 +32,14 @@ parser.add_argument('--output-csv',
                     help='The output CSV file name')
 args = parser.parse_args()
 
-# 25 regions
+# 26 regions
 ALL_REGIONS = [
     # 'us-east-1',  # Source AMI is already in this region
     'us-east-2',
     'us-west-1',
     'us-west-2',
     'ca-central-1',
+    'sa-east-1',
     'eu-central-1',  # need for smoke test
     'eu-central-2',
     'eu-west-1',

--- a/sky/catalog/images/aws_utils/image_gen.py
+++ b/sky/catalog/images/aws_utils/image_gen.py
@@ -32,7 +32,7 @@ parser.add_argument('--output-csv',
                     help='The output CSV file name')
 args = parser.parse_args()
 
-# 26 regions
+# Target regions (excluding the source region, us-east-1).
 ALL_REGIONS = [
     # 'us-east-1',  # Source AMI is already in this region
     'us-east-2',

--- a/tests/unit_tests/test_aws_catalog_fetcher.py
+++ b/tests/unit_tests/test_aws_catalog_fetcher.py
@@ -1,0 +1,23 @@
+"""Tests for the AWS catalog region source lists."""
+
+from pathlib import Path
+import runpy
+import sys
+
+from sky.catalog.data_fetchers import fetch_aws
+
+
+def test_sao_paulo_region_is_fetched():
+    assert 'sa-east-1' in fetch_aws.ALL_REGIONS
+
+
+def test_sao_paulo_region_is_a_curated_image_copy_target(monkeypatch):
+    image_gen_path = (Path(__file__).parents[2] / 'sky' / 'catalog' / 'images' /
+                      'aws_utils' / 'image_gen.py')
+    monkeypatch.setattr(
+        sys, 'argv',
+        [str(image_gen_path), '--image-id', 'ami-test', '--processor', 'gpu'])
+
+    image_gen_globals = runpy.run_path(str(image_gen_path))
+
+    assert 'sa-east-1' in image_gen_globals['ALL_REGIONS']

--- a/tests/unit_tests/test_aws_catalog_sao_paulo.py
+++ b/tests/unit_tests/test_aws_catalog_sao_paulo.py
@@ -1,4 +1,4 @@
-"""Tests for the AWS catalog region source lists."""
+"""Tests for São Paulo in the AWS service-catalog source."""
 
 from pathlib import Path
 import runpy


### PR DESCRIPTION
## Summary

- add AWS São Paulo (`sa-east-1`) to the catalog fetcher's region source
- add São Paulo to the curated AMI copy targets
- test both source lists without checking in generated catalog data

This PR stages source support only. It does **not** contain generated
`aws/vms.csv` or `aws/images.csv` changes and does not mutate AWS
infrastructure.

The AWS catalog update workflow publishes every enumerated region after a
source merge. Keep this PR in draft and do not merge it until every gate below
has evidence.

## Required merge gates

- [ ] A qualified `skypilot:custom-gpu-ubuntu-cuda13` AMI exists in
      `sa-east-1` and is verified public, launchable, available, and `x86_64`
      from the catalog publisher account.
- [ ] The catalog publisher account and credentials have attested
      `sa-east-1` region readiness, including account opt-in/enablement if
      applicable, and the all-regions-enabled check passes. AWS classifies São
      Paulo as default-enabled; this gate still requires publisher-account
      access to be proven.
- [ ] A generated v8 candidate contains validated `G6` / `g6.xlarge` L4 Spot
      rows for `sa-east-1`, with expected zone availability and non-null
      `SpotPrice` values.
- [ ] After the controlled catalog publication, the GitHub raw and S3 mirror
      copies of `aws/vms.csv` and `aws/images.csv` converge to identical
      checksums.

## Test plan

- `PYTHONPATH=. python -m pytest -n 0 tests/unit_tests/test_aws_catalog_sao_paulo.py -rA` — 2 passed
- `isort --check-only sky/catalog/data_fetchers/fetch_aws.py sky/catalog/images/aws_utils/image_gen.py tests/unit_tests/test_aws_catalog_sao_paulo.py`
- `yapf --diff sky/catalog/data_fetchers/fetch_aws.py sky/catalog/images/aws_utils/image_gen.py tests/unit_tests/test_aws_catalog_sao_paulo.py`
- `pylint sky/catalog/data_fetchers/fetch_aws.py sky/catalog/images/aws_utils/image_gen.py tests/unit_tests/test_aws_catalog_sao_paulo.py` — 10.00/10
- `git diff --check`

Manual release verification after all preconditions are met:

1. Run the AWS catalog generator with the publisher credentials and
   `--check-all-regions-enabled-for-account`.
2. Verify the generated São Paulo AMI and L4 Spot rows before publication.
3. Publish through the normal catalog workflow, then compare SHA-256 checksums
   for both AWS catalog files across GitHub raw and S3.