### PR TITLE
[AWS] Gate Malaysia catalog region

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -62,6 +62,7 @@ ALL_REGIONS = [
     'ap-southeast-1',
     'ap-southeast-2',
     'ap-southeast-4',
+    'ap-southeast-5',
     'ap-northeast-1',
 ]
 US_REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']

--- a/sky/catalog/images/aws_utils/image_gen.py
+++ b/sky/catalog/images/aws_utils/image_gen.py
@@ -32,7 +32,7 @@ parser.add_argument('--output-csv',
                     help='The output CSV file name')
 args = parser.parse_args()
 
-# 26 regions
+# Target regions (excluding the source region, us-east-1).
 ALL_REGIONS = [
     # 'us-east-1',  # Source AMI is already in this region
     'us-east-2',

--- a/sky/catalog/images/aws_utils/image_gen.py
+++ b/sky/catalog/images/aws_utils/image_gen.py
@@ -32,7 +32,7 @@ parser.add_argument('--output-csv',
                     help='The output CSV file name')
 args = parser.parse_args()
 
-# 25 regions
+# 26 regions
 ALL_REGIONS = [
     # 'us-east-1',  # Source AMI is already in this region
     'us-east-2',
@@ -58,6 +58,7 @@ ALL_REGIONS = [
     'ap-southeast-1',
     'ap-southeast-2',
     'ap-southeast-3',
+    'ap-southeast-5',
     'ap-northeast-1',
 ]
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4922,8 +4922,8 @@ class S3Store(S3CompatibleStore):
     _DEFAULT_REGION = 'us-east-1'
     _CUSTOM_ENDPOINT_REGIONS = [
         'ap-east-1', 'me-south-1', 'af-south-1', 'eu-south-1', 'eu-south-2',
-        'ap-south-2', 'ap-southeast-3', 'ap-southeast-4', 'me-central-1',
-        'il-central-1'
+        'ap-south-2', 'ap-southeast-3', 'ap-southeast-4', 'ap-southeast-5',
+        'me-central-1', 'il-central-1'
     ]
 
     def __init__(self,

--- a/tests/unit_tests/test_aws_catalog_malaysia.py
+++ b/tests/unit_tests/test_aws_catalog_malaysia.py
@@ -1,0 +1,23 @@
+"""Tests for Malaysia in the AWS service-catalog source."""
+
+import pathlib
+import runpy
+import sys
+
+from sky.catalog.data_fetchers import fetch_aws
+
+
+def test_malaysia_region_is_fetched() -> None:
+    assert 'ap-southeast-5' in fetch_aws.ALL_REGIONS
+
+
+def test_malaysia_region_is_a_curated_image_copy_target(monkeypatch) -> None:
+    image_gen_path = (pathlib.Path(__file__).parents[2] / 'sky' / 'catalog' /
+                      'images' / 'aws_utils' / 'image_gen.py')
+    monkeypatch.setattr(
+        sys, 'argv',
+        [str(image_gen_path), '--image-id', 'ami-test', '--processor', 'gpu'])
+
+    image_gen_globals = runpy.run_path(str(image_gen_path))
+
+    assert 'ap-southeast-5' in image_gen_globals['ALL_REGIONS']

--- a/tests/unit_tests/test_aws_catalog_malaysia.py
+++ b/tests/unit_tests/test_aws_catalog_malaysia.py
@@ -5,6 +5,7 @@ import runpy
 import sys
 
 from sky.catalog.data_fetchers import fetch_aws
+from sky.data import storage
 
 
 def test_malaysia_region_is_fetched() -> None:
@@ -21,3 +22,7 @@ def test_malaysia_region_is_a_curated_image_copy_target(monkeypatch) -> None:
     image_gen_globals = runpy.run_path(str(image_gen_path))
 
     assert 'ap-southeast-5' in image_gen_globals['ALL_REGIONS']
+
+
+def test_malaysia_s3_uses_opt_in_region_fallback() -> None:
+    assert 'ap-southeast-5' in storage.S3Store._CUSTOM_ENDPOINT_REGIONS


### PR DESCRIPTION
## Summary

- Add `ap-southeast-5` (Malaysia) to the AWS service-catalog fetch region set.
- Add Malaysia to the curated AWS image copy targets.
- Route Malaysia S3 workdir/storage through the existing opt-in-region endpoint
  fallback instead of attempting the unsupported regional endpoint.
- Add focused source-contract tests; this PR does not generate or publish catalog data.

## Merge gates

Keep this PR in draft and do not merge until all four gates have attached evidence:

1. **Qualified public, launchable CUDA13 AMI:** a curated CUDA13 AMI in `ap-southeast-5` is public and launchable from an account other than the publisher account.
2. **Publisher-account opt-in:** the upstream catalog publisher AWS account has explicitly opted into `ap-southeast-5` and can query the regional EC2 APIs.
3. **Validated L4 Spot rows and workdir:** a catalog-generation dry run produces validated, nonempty L4 Spot rows for `ap-southeast-5` without weakening integrity checks for any other region, and one bounded cross-account launch proves the S3 workdir path.
4. **GitHub + S3 checksum convergence:** the generated GitHub catalog projection and its S3 mirror converge to the same checksum before the region is activated.

No image copy, catalog generation, GitHub catalog-data publication, or S3 publication is performed by this PR.

## Test plan

- `python -m pytest -q -n 0 --confcutdir=tests/unit_tests tests/unit_tests/test_aws_catalog_malaysia.py`
- YAPF 0.32.0 diff check on all changed Python files.
- isort 5.12.0 check on all changed Python files.
- Pylint 2.14.5: 10.00/10 for the changed source and test files.
- `git diff --check`

The repository formatter completed YAPF and isort. Its repository-wide mypy phase could not run cleanly in the local environment because third-party stubs are absent for unchanged modules; the focused source and tests above pass.
