### PR TITLE
[Kubernetes] Resolve a volume's default context through allowed_contexts

### DIFF
--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -1233,9 +1233,16 @@ def create_persistent_volume_claim(
             logger.debug(f'Found existing PVC {pvc.metadata.name} for volume '
                          f'{volume_name}')
             return
+        # Name the context and namespace searched. When the volume config
+        # carried no context of its own, `_resolve_context_for_new_volume`
+        # chose one, and "does not exist" on its own reads as "your PVC is
+        # gone" when the truth may be that it lives on a context
+        # `allowed_contexts` excludes.
         raise ValueError(
             f'PVC with name or label skypilot-name={volume_name} does not '
-            f'exist while use_existing is True.')
+            f'exist in namespace {namespace!r} on context {context!r} while '
+            f'use_existing is True. If the PVC lives on another cluster, '
+            f'name it explicitly with `--infra k8s/<context>`.')
 
     # Try to read PVC by name_on_cloud (for non-use_existing case)
     try:

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -5,6 +5,7 @@ import re
 import time as time_module
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from sky import clouds
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
@@ -126,10 +127,51 @@ def _is_rbac_permission_error(e: Exception) -> bool:
     return getattr(e, 'status', None) in (401, 403)
 
 
-def _get_context_namespace(config: models.VolumeConfig) -> Tuple[str, str]:
-    """Gets the context and namespace of a volume."""
+def _resolve_default_context() -> Optional[str]:
+    """The context to use for a volume whose config names no context.
+
+    A Kubernetes volume's `region` is its kubeconfig context. When the user
+    leaves it unset (e.g. `sky volumes apply --infra k8s`), the context has to
+    be inferred -- and the inference has to agree with where workloads
+    actually run, or the PVC is created on a cluster no pod can ever mount it
+    from.
+
+    The kubeconfig's `current-context` alone is not that answer on a server
+    with several contexts: `allowed_contexts` may exclude it entirely, in
+    which case every pod lands somewhere else. So resolve through
+    `Kubernetes.existing_allowed_contexts()`, the same list the scheduling
+    path uses, and keep `current-context` only when it is actually allowed --
+    which preserves the existing behavior for the ordinary single-cluster
+    case.
+    """
+    current_context = kubernetes_utils.get_current_kube_config_context_name()
+    allowed_contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
+    if not allowed_contexts:
+        # Nothing to cross-check against: no kubeconfig, or Kubernetes is not
+        # enabled. Fall back to the previous behavior rather than failing
+        # here -- the K8s API call that follows raises a clearer error.
+        return current_context
+    if current_context in allowed_contexts:
+        return current_context
+    context = allowed_contexts[0]
+    logger.info(
+        f'Volume does not specify a context and the kubeconfig\'s current '
+        f'context {current_context!r} is not in allowed_contexts; using '
+        f'{context!r}. Set the volume\'s infra to a specific context '
+        f'(e.g. `--infra k8s/<context>`) to choose explicitly.')
+    return context
+
+
+def _get_context_namespace(
+        config: models.VolumeConfig) -> Tuple[Optional[str], str]:
+    """Gets the context and namespace of a volume.
+
+    The context is None only when no context could be resolved at all (no
+    kubeconfig and no in-cluster auth); the K8s adaptor treats that as "use
+    whatever config loading finds", which is the pre-existing behavior.
+    """
     if config.region is None:
-        context = kubernetes_utils.get_current_kube_config_context_name()
+        context = _resolve_default_context()
         config.region = context
     else:
         context = config.region
@@ -555,7 +597,7 @@ def refresh_volume_config(
 
 def get_all_volumes_usedby(
     configs: List[models.VolumeConfig],
-) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
+) -> Tuple[Dict[Optional[str], Any], Dict[Optional[str], Any], Set[str]]:
     """Gets the usedby resources of all volumes.
 
     Args:
@@ -575,9 +617,9 @@ def get_all_volumes_usedby(
         for phase in k8s_constants.PVC_NOT_HOLD_POD_PHASES
     ])
     label_selector = 'parent=skypilot'
-    context_to_namespaces: Dict[str, Set[str]] = {}
+    context_to_namespaces: Dict[Optional[str], Set[str]] = {}
     pvc_names = set()
-    original_volume_names: Dict[str, Dict[str, List[str]]] = {}
+    original_volume_names: Dict[Optional[str], Dict[str, List[str]]] = {}
     for config in configs:
         # Skip hostPath volumes — they have no PVC to track
         if config.type == volume_lib.VolumeType.HOSTPATH.value:
@@ -590,8 +632,8 @@ def get_all_volumes_usedby(
         pvc_names.add(config.name_on_cloud)
     cloud_to_name_map = _get_cluster_name_on_cloud_to_cluster_name_map()
     # Get all pods in the namespace
-    used_by_pods: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
-    used_by_clusters: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
+    used_by_pods: Dict[Optional[str], Dict[str, Dict[str, List[str]]]] = {}
+    used_by_clusters: Dict[Optional[str], Dict[str, Dict[str, List[str]]]] = {}
     failed_volume_names: Set[str] = set()
     for context, namespaces in context_to_namespaces.items():
         used_by_pods[context] = {}
@@ -643,7 +685,8 @@ def get_all_volumes_usedby(
 
 
 def map_all_volumes_usedby(
-        used_by_pods: Dict[str, Any], used_by_clusters: Dict[str, Any],
+        used_by_pods: Dict[Optional[str],
+                           Any], used_by_clusters: Dict[Optional[str], Any],
         config: models.VolumeConfig) -> Tuple[List[str], List[str]]:
     """Maps the usedby resources of a volume."""
     context, namespace = _get_context_namespace(config)
@@ -756,8 +799,8 @@ def get_all_volumes_state(
     """
     # Keyed by (context, namespace): the same PVC name may exist in several
     # namespaces, and resolving it against the wrong one would mismatch.
-    configs_by_location: Dict[Tuple[str, str], Dict[str,
-                                                    models.VolumeConfig]] = {}
+    configs_by_location: Dict[Tuple[Optional[str], str],
+                              Dict[str, models.VolumeConfig]] = {}
 
     volume_errors: Dict[str, Optional[str]] = {}
     observed: Dict[str, models.ObservedVolumeState] = {}

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -127,14 +127,13 @@ def _is_rbac_permission_error(e: Exception) -> bool:
     return getattr(e, 'status', None) in (401, 403)
 
 
-def _resolve_default_context() -> Optional[str]:
-    """The context to use for a volume whose config names no context.
+def _resolve_context_for_new_volume() -> Optional[str]:
+    """The context to create a volume on when its config names none.
 
     A Kubernetes volume's `region` is its kubeconfig context. When the user
     leaves it unset (e.g. `sky volumes apply --infra k8s`), the context has to
-    be inferred -- and the inference has to agree with where workloads
-    actually run, or the PVC is created on a cluster no pod can ever mount it
-    from.
+    be chosen -- and the choice has to agree with where workloads actually
+    run, or the PVC is created on a cluster no pod can ever mount it from.
 
     The kubeconfig's `current-context` alone is not that answer on a server
     with several contexts: `allowed_contexts` may exclude it entirely, in
@@ -143,6 +142,9 @@ def _resolve_default_context() -> Optional[str]:
     path uses, and keep `current-context` only when it is actually allowed --
     which preserves the existing behavior for the ordinary single-cluster
     case.
+
+    Only for volumes being created. Looking up a volume that already exists
+    is a different question -- see `_get_context_namespace`.
     """
     current_context = kubernetes_utils.get_current_kube_config_context_name()
     allowed_contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
@@ -162,16 +164,27 @@ def _resolve_default_context() -> Optional[str]:
     return context
 
 
-def _get_context_namespace(
-        config: models.VolumeConfig) -> Tuple[Optional[str], str]:
+def _get_context_namespace(config: models.VolumeConfig,
+                           creating: bool = False) -> Tuple[Optional[str], str]:
     """Gets the context and namespace of a volume.
+
+    `creating` separates the two questions this answers for a config with no
+    `region`. Creating a volume *chooses* a context, and the choice has to
+    agree with where workloads run. Every other caller is *looking up* a
+    volume that already exists somewhere -- and for a volume predating the
+    region pinning below (`refresh_volume_config` repairs those only under
+    in-cluster auth, so elsewhere they stay region-less), the only honest
+    guess is the one its own creation made: the kubeconfig's current context.
+    Re-deciding that on a lookup would point at a different cluster and
+    report a perfectly healthy volume as deleted.
 
     The context is None only when no context could be resolved at all (no
     kubeconfig and no in-cluster auth); the K8s adaptor treats that as "use
     whatever config loading finds", which is the pre-existing behavior.
     """
     if config.region is None:
-        context = _resolve_default_context()
+        context = (_resolve_context_for_new_volume() if creating else
+                   kubernetes_utils.get_current_kube_config_context_name())
         config.region = context
     else:
         context = config.region
@@ -282,7 +295,7 @@ def _validate_explicit_storage_class(context: Optional[str],
 
 def _apply_pvc_volume(config: models.VolumeConfig) -> models.VolumeConfig:
     """Creates or registers a PVC volume."""
-    context, namespace = _get_context_namespace(config)
+    context, namespace = _get_context_namespace(config, creating=True)
     pvc_spec = _get_pvc_spec(namespace, config)
     # use_existing volumes look up an existing PVC; no new provisioning
     # happens. Storage-class validation (either the explicit-name check

--- a/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
+++ b/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
@@ -399,3 +399,78 @@ def test_apply_pvc_empty_string_storage_class_skips_both_checks():
         mock_k8s.storage_api.return_value.read_storage_class.assert_not_called()
         mock_k8s.storage_api.return_value.list_storage_class.assert_not_called()
         mock_create.assert_called_once()
+
+
+# ── default-context resolution: a volume with no context of its own ───────
+
+
+def _patch_context_resolution(current_context, allowed_contexts):
+    """Patch the two inputs `_resolve_default_context` reads."""
+    return (mock.patch.object(volume_provision.kubernetes_utils,
+                              'get_current_kube_config_context_name',
+                              return_value=current_context),
+            mock.patch.object(volume_provision.clouds.Kubernetes,
+                              'existing_allowed_contexts',
+                              return_value=allowed_contexts))
+
+
+def test_resolve_default_context_prefers_allowed_current_context():
+    """The ordinary single-cluster case is unchanged: current-context wins."""
+    patch_current, patch_allowed = _patch_context_resolution(
+        'my-context', ['my-context', 'other-context'])
+    with patch_current, patch_allowed:
+        assert volume_provision._resolve_default_context() == 'my-context'
+
+
+def test_resolve_default_context_skips_disallowed_current_context():
+    """current-context excluded by allowed_contexts → first allowed instead.
+
+    Otherwise the PVC is created on a cluster that `allowed_contexts` keeps
+    every pod off of, so nothing can ever mount it.
+    """
+    patch_current, patch_allowed = _patch_context_resolution(
+        'not-allowed', ['first-allowed', 'second-allowed'])
+    with patch_current, patch_allowed:
+        assert volume_provision._resolve_default_context() == 'first-allowed'
+
+
+def test_resolve_default_context_falls_back_when_no_allowed_contexts():
+    """No allowed contexts to cross-check against → previous behavior."""
+    patch_current, patch_allowed = _patch_context_resolution('my-context', [])
+    with patch_current, patch_allowed:
+        assert volume_provision._resolve_default_context() == 'my-context'
+
+
+def test_get_context_namespace_uses_resolved_context_and_pins_region():
+    """A region-less volume resolves a context and records it on the config.
+
+    Pinning `region` matters beyond this call: every later operation on the
+    volume (mount, delete) reads it back instead of re-resolving.
+    """
+    config = models.VolumeConfig(
+        name='test-vol',
+        type='k8s-pvc',
+        cloud='kubernetes',
+        region=None,
+        zone=None,
+        name_on_cloud='real-pvc',
+        size='5',
+        config={'namespace': 'default'},
+    )
+    patch_current, patch_allowed = _patch_context_resolution(
+        'not-allowed', ['first-allowed'])
+    with patch_current, patch_allowed:
+        context, namespace = volume_provision._get_context_namespace(config)
+    assert context == 'first-allowed'
+    assert config.region == 'first-allowed'
+    assert namespace == 'default'
+
+
+def test_get_context_namespace_keeps_explicit_region():
+    """An explicit context is honored as-is: no resolution, no override."""
+    config = _make_pvc_config(use_existing=False)
+    with mock.patch.object(volume_provision,
+                           '_resolve_default_context') as mock_resolve:
+        context, _ = volume_provision._get_context_namespace(config)
+    mock_resolve.assert_not_called()
+    assert context == 'my-context'

--- a/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
+++ b/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
@@ -405,7 +405,7 @@ def test_apply_pvc_empty_string_storage_class_skips_both_checks():
 
 
 def _patch_context_resolution(current_context, allowed_contexts):
-    """Patch the two inputs `_resolve_default_context` reads."""
+    """Patch the two inputs the context resolution reads."""
     return (mock.patch.object(volume_provision.kubernetes_utils,
                               'get_current_kube_config_context_name',
                               return_value=current_context),
@@ -419,7 +419,8 @@ def test_resolve_default_context_prefers_allowed_current_context():
     patch_current, patch_allowed = _patch_context_resolution(
         'my-context', ['my-context', 'other-context'])
     with patch_current, patch_allowed:
-        assert volume_provision._resolve_default_context() == 'my-context'
+        assert volume_provision._resolve_context_for_new_volume(
+        ) == 'my-context'
 
 
 def test_resolve_default_context_skips_disallowed_current_context():
@@ -431,23 +432,20 @@ def test_resolve_default_context_skips_disallowed_current_context():
     patch_current, patch_allowed = _patch_context_resolution(
         'not-allowed', ['first-allowed', 'second-allowed'])
     with patch_current, patch_allowed:
-        assert volume_provision._resolve_default_context() == 'first-allowed'
+        assert volume_provision._resolve_context_for_new_volume(
+        ) == 'first-allowed'
 
 
 def test_resolve_default_context_falls_back_when_no_allowed_contexts():
     """No allowed contexts to cross-check against → previous behavior."""
     patch_current, patch_allowed = _patch_context_resolution('my-context', [])
     with patch_current, patch_allowed:
-        assert volume_provision._resolve_default_context() == 'my-context'
+        assert volume_provision._resolve_context_for_new_volume(
+        ) == 'my-context'
 
 
-def test_get_context_namespace_uses_resolved_context_and_pins_region():
-    """A region-less volume resolves a context and records it on the config.
-
-    Pinning `region` matters beyond this call: every later operation on the
-    volume (mount, delete) reads it back instead of re-resolving.
-    """
-    config = models.VolumeConfig(
+def _region_less_config() -> models.VolumeConfig:
+    return models.VolumeConfig(
         name='test-vol',
         type='k8s-pvc',
         cloud='kubernetes',
@@ -455,22 +453,76 @@ def test_get_context_namespace_uses_resolved_context_and_pins_region():
         zone=None,
         name_on_cloud='real-pvc',
         size='5',
-        config={'namespace': 'default'},
+        config={
+            'namespace': 'default',
+            'access_mode': 'ReadWriteOnce',
+        },
     )
+
+
+def test_get_context_namespace_creating_uses_allowed_context():
+    """Creating a volume chooses a context, and records it on the config.
+
+    Pinning `region` matters beyond this call: every later operation on the
+    volume (mount, delete) reads it back instead of re-resolving.
+    """
+    config = _region_less_config()
     patch_current, patch_allowed = _patch_context_resolution(
         'not-allowed', ['first-allowed'])
     with patch_current, patch_allowed:
-        context, namespace = volume_provision._get_context_namespace(config)
+        context, namespace = volume_provision._get_context_namespace(
+            config, creating=True)
     assert context == 'first-allowed'
     assert config.region == 'first-allowed'
     assert namespace == 'default'
+
+
+def test_get_context_namespace_lookup_keeps_the_current_context():
+    """Looking up a region-less volume must not re-decide where it lives.
+
+    Volumes created before the region pinning above kept `region=None`, and
+    `refresh_volume_config` repairs those only under in-cluster auth. Their
+    PVC is on whatever the current context was when they were created, so a
+    lookup that resolved through `allowed_contexts` instead would query the
+    wrong cluster and report the volume deleted.
+    """
+    config = _region_less_config()
+    patch_current, patch_allowed = _patch_context_resolution(
+        'not-allowed', ['first-allowed'])
+    with patch_current, patch_allowed:
+        context, _ = volume_provision._get_context_namespace(config)
+    assert context == 'not-allowed'
+    assert config.region == 'not-allowed'
+
+
+def test_apply_pvc_volume_creates_on_an_allowed_context():
+    """The apply path is the one that opts into choosing a context."""
+    config = _region_less_config()
+    patch_current, patch_allowed = _patch_context_resolution(
+        'not-allowed', ['first-allowed'])
+    with patch_current, patch_allowed, \
+         mock.patch.object(volume_provision, 'kubernetes') as mock_k8s, \
+         mock.patch.object(volume_provision,
+                           'create_persistent_volume_claim') as mock_create:
+        _patch_apply_dependencies(mock_k8s)
+        mock_k8s.storage_api.return_value.list_storage_class.return_value = (
+            SimpleNamespace(items=[
+                _make_sc(
+                    'default-sc',
+                    annotations={
+                        'storageclass.kubernetes.io/is-default-class': 'true'
+                    }),
+            ]))
+        volume_provision._apply_pvc_volume(config)
+    assert config.region == 'first-allowed'
+    mock_create.assert_called_once()
 
 
 def test_get_context_namespace_keeps_explicit_region():
     """An explicit context is honored as-is: no resolution, no override."""
     config = _make_pvc_config(use_existing=False)
     with mock.patch.object(volume_provision,
-                           '_resolve_default_context') as mock_resolve:
+                           '_resolve_context_for_new_volume') as mock_resolve:
         context, _ = volume_provision._get_context_namespace(config)
     mock_resolve.assert_not_called()
     assert context == 'my-context'

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -98,15 +98,19 @@ class TestGetContextNamespace:
         assert context == 'my-context'
         assert namespace == 'my-namespace'
 
+    @patch('sky.clouds.Kubernetes.existing_allowed_contexts')
     @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
            'get_current_kube_config_context_name')
     @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
            'get_kube_config_context_namespace')
     def test_get_context_namespace_without_region(self, mock_get_namespace,
-                                                  mock_get_context):
+                                                  mock_get_context,
+                                                  mock_allowed_contexts):
         """Test when region is not specified."""
         mock_get_context.return_value = 'default-context'
         mock_get_namespace.return_value = 'default-namespace'
+        # The current context is allowed, so it is the one that gets used.
+        mock_allowed_contexts.return_value = ['default-context']
 
         config = models.VolumeConfig(
             _version=1,

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1418,6 +1418,12 @@ class TestCreatePersistentVolumeClaim:
                                                       config)
         assert 'does not exist' in str(exc_info.value)
         assert 'use_existing' in str(exc_info.value)
+        # The PVC may well exist -- just on a context this lookup never
+        # searched, e.g. when the volume named none and one was resolved
+        # for it. Say which cluster came up empty, and how to pin another.
+        assert 'my-context' in str(exc_info.value)
+        assert 'my-namespace' in str(exc_info.value)
+        assert '--infra k8s/<context>' in str(exc_info.value)
 
     @patch('sky.provision.kubernetes.volume.kubernetes')
     def test_create_pvc_success(self, mock_k8s):


### PR DESCRIPTION
## Summary

A Kubernetes volume's `region` is its kubeconfig context. When the user leaves it unset — `sky volumes apply --infra k8s`, or a volume YAML with `infra: k8s` — the context has to be inferred, and today `_get_context_namespace` reads the kubeconfig's `current-context` directly.

On an API server with several contexts that is the wrong answer whenever `allowed_contexts` excludes the current one. Pods are scheduled through `Kubernetes.existing_allowed_contexts()`, so the PVC gets created on a cluster no pod can ever mount it from. The failure then surfaces later and somewhere else — an unbindable claim, or a mount that never resolves — with nothing pointing back at the context choice that caused it.

- Resolve the default context through `existing_allowed_contexts()` — the same list the scheduling path uses, so it honors `allowed_contexts` including a workspace-scoped override.
- Keep `current-context` when it *is* in that list, so the ordinary single-cluster case is unchanged.
- Otherwise fall through to the first allowed context and log which one was picked, pointing at `--infra k8s/<context>` for an explicit choice.
- When no allowed context resolves at all (no kubeconfig, or Kubernetes not enabled), keep the previous behavior — the K8s API call that follows raises its own clearer error.

Only the initial apply resolves a context: it is pinned onto `config.region` and persisted, so mount and delete read it back rather than re-resolving.

### Typing

Annotating the new helper `-> Optional[str]` surfaced that `_get_context_namespace` could *always* return `None` for the context — `follow_imports = "skip"` had been hiding it behind `Any`. Rather than paper over it I widened the honest types: `Tuple[Optional[str], str]` on `_get_context_namespace`, plus the four context-keyed containers and `get_all_volumes_usedby`'s return. Runtime behavior is identical — `None` was already a possible dict key — and mypy is now clean on the file where before it was only silent.

## Test plan

**Unit tests** — 5 new cases in `tests/unit_tests/test_sky/provision/test_kubernetes_volume.py`:

- current-context is preferred when it is allowed (the unchanged single-cluster path)
- a disallowed current-context falls through to the first allowed context
- an empty allowed list keeps the previous fallback
- `_get_context_namespace` pins the resolved context onto `config.region`
- an explicit region skips resolution entirely

`tests/unit_tests/test_sky/volumes/test_k8s_volume.py::test_get_context_namespace_without_region` needed updating: it mocked only `get_current_kube_config_context_name`, so it would have read the developer's real kubeconfig through `existing_allowed_contexts`. It now mocks both, which also makes it hermetic — it was machine-dependent by accident before.

```
$ pytest tests/unit_tests/test_sky/provision/ tests/unit_tests/test_sky/volumes/ \
         tests/unit_tests/test_sky/test_cli_volumes.py
826 passed
```

`bash format.sh` clean (yapf / isort / mypy / pylint 10.00). The one `sky/client/sdk.py` mypy error format.sh reports is pre-existing on master and unrelated.

**Manual verification** — on a server whose kubeconfig `current-context` is *not* in `allowed_contexts`:

```yaml
# ~/.sky/config.yaml
kubernetes:
  allowed_contexts:
  - ctx-a          # a cluster with a default StorageClass
```

```bash
kubectl config use-context ctx-b     # deliberately NOT in allowed_contexts

sky volumes apply -y -n testvol --infra k8s --type k8s-pvc --size 1Gi
sky volumes ls
```

Before: the PVC is created against `ctx-b` — visible as `ctx-b` in the volume's context column, and `kubectl --context ctx-b get pvc` shows the claim on a cluster no pod will ever be scheduled to. If `ctx-b` has no default StorageClass, it fails outright at apply time naming `ctx-b`.

After: the volume lands on `ctx-a`, `kubectl --context ctx-a get pvc` shows the claim, and the server log carries `Volume does not specify a context and the kubeconfig's current context 'ctx-b' is not in allowed_contexts; using 'ctx-a'.` A subsequent `sky launch` mounting the volume schedules onto `ctx-a` and mounts it.

Regression check that the common path is untouched: with `current-context` set back to `ctx-a` (allowed), `sky volumes apply` resolves `ctx-a` with no log line, exactly as before.

Pinning explicitly with `--infra k8s/<context>` is unaffected in both cases — an explicit context never goes through this resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->