### PR TITLE
[Test] Don't lose a smoke test's real failure to an unbound `proc`

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -813,6 +813,14 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
     if test.env:
         env_dict.update(test.env)
 
+    # The test's overall exit status. Tracked separately from any single
+    # `proc` because a command may be a callable, which has no process
+    # behind it: a test whose first command is a callable would otherwise
+    # reach the reporting block below with `proc` unbound and die with
+    # `UnboundLocalError`, masking the real failure in the pytest summary.
+    returncode = 0
+    command = None
+
     with override_sky_config(test, env_dict, config_dict=test.config_dict):
         for command in test.commands:
             if callable(command):
@@ -828,7 +836,7 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
                     test.echo(error_in_callable)
                     write(error_in_callable + '\n')
                     flush()
-                    proc.returncode = 1
+                    returncode = 1
                     break
                 continue
             write(f'+ {command}\n')
@@ -851,18 +859,18 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
                 flush()
                 # Kill the current process.
                 proc.terminate()
-                proc.returncode = 1  # None if we don't set it.
+                returncode = 1  # proc.returncode is None if we don't set it.
                 break
 
-            if proc.returncode:
+            returncode = proc.returncode
+            if returncode:
                 break
 
         style = colorama.Style
         fore = colorama.Fore
-        outcome = (
-            f'{fore.RED}Failed{style.RESET_ALL} (returned {proc.returncode})'
-            if proc.returncode else f'{fore.GREEN}Passed{style.RESET_ALL}')
-        reason = f'\nReason: {command}' if proc.returncode else ''
+        outcome = (f'{fore.RED}Failed{style.RESET_ALL} (returned {returncode})'
+                   if returncode else f'{fore.GREEN}Passed{style.RESET_ALL}')
+        reason = f'\nReason: {command}' if returncode else ''
         msg = (f'{outcome}.'
                f'{reason}')
         if log_to_stdout:
@@ -872,7 +880,7 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
             test.echo(msg)
             write(msg)
 
-        if proc.returncode:
+        if returncode:
             # Fetch controller logs for failed jobs
             script_path = os.path.join(os.path.dirname(__file__), 'scripts',
                                        'fetch_failed_job_logs.sh')
@@ -917,7 +925,7 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
                     write(f'Server log file not found: {log_path}')
                 write('=== End of Sky API Server Log ===')
 
-        if (proc.returncode == 0 or
+        if (returncode == 0 or
                 pytest.terminate_on_failure) and test.teardown is not None:
             subprocess_utils.run(
                 test.teardown,
@@ -928,7 +936,7 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
                 env=env_dict,
             )
 
-        if proc.returncode:
+        if returncode:
             if log_to_stdout:
                 raise Exception(f'test failed')
             else:

--- a/tests/unit_tests/test_smoke_test_runner.py
+++ b/tests/unit_tests/test_smoke_test_runner.py
@@ -1,0 +1,106 @@
+"""Tests for smoke_tests_utils.run_one_test() status tracking.
+
+Keep 'smoke_tests' out of this file's path: tests/conftest.py treats a session
+as a smoke-test session when any collected item's path contains it, which
+wraps the whole session in a config override.
+"""
+import os
+
+import pytest
+from smoke_tests import smoke_tests_utils
+
+
+@pytest.fixture
+def quiet_failure_reporting(monkeypatch):
+    """Stop the failure path from shelling out to the real API server.
+
+    On failure `run_one_test` runs `fetch_failed_job_logs.sh` (which calls
+    `sky jobs queue`) and tails the server log. Neither belongs in a unit
+    test, and both are gated on `os.path.exists`, so denying just those two
+    paths takes the documented "not found" branch instead.
+    """
+    real_exists = os.path.exists
+
+    def fake_exists(path):
+        if str(path).endswith(('fetch_failed_job_logs.sh', 'server.log')):
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(smoke_tests_utils.os.path, 'exists', fake_exists)
+    # Log to stderr rather than opening a temp log file per test.
+    monkeypatch.setenv('LOG_TO_STDOUT', '1')
+
+
+@pytest.fixture
+def quiet_reporting(monkeypatch):
+    """The success path's counterpart: only the log-to-stdout switch."""
+    monkeypatch.setenv('LOG_TO_STDOUT', '1')
+
+
+def test_callable_first_failure_reports_the_test_failure(
+        quiet_failure_reporting):
+    """A callable failing as the FIRST command must fail as a test failure.
+
+    Regression: the failure branch used to record the status by mutating
+    `proc.returncode`, but `proc` is only bound by the subprocess branch. A
+    test whose first command is a callable died with `UnboundLocalError`
+    instead, which replaced the callable's real exception in the pytest
+    summary and hid why the test failed.
+    """
+
+    def boom():
+        raise RuntimeError('the real failure')
+
+    test = smoke_tests_utils.Test('callable-first-failure', [boom])
+    with pytest.raises(Exception) as exc_info:
+        smoke_tests_utils.run_one_test(test, check_sky_status=False)
+    # Not an UnboundLocalError, and not the raw RuntimeError: the runner
+    # reports its own failure after logging the callable's traceback.
+    assert not isinstance(exc_info.value, UnboundLocalError)
+    assert str(exc_info.value) == 'test failed'
+
+
+def test_all_callables_succeeding_passes(quiet_reporting):
+    """A test made only of callables must pass.
+
+    Same unbound `proc`, reached from the other side: with no subprocess
+    ever started, the reporting block had nothing to read the status from
+    even when every callable succeeded.
+    """
+    calls = []
+
+    test = smoke_tests_utils.Test(
+        'all-callables', [lambda: calls.append('a'), lambda: calls.append('b')])
+    smoke_tests_utils.run_one_test(test, check_sky_status=False)
+    assert calls == ['a', 'b']
+
+
+def test_callable_failure_stops_later_commands(quiet_failure_reporting,
+                                               tmp_path):
+    """A failing callable must not run the commands after it."""
+    sentinel = tmp_path / 'ran'
+
+    def boom():
+        raise RuntimeError('stop here')
+
+    test = smoke_tests_utils.Test('callable-short-circuits',
+                                  [boom, f'touch {sentinel}'])
+    with pytest.raises(Exception, match='test failed'):
+        smoke_tests_utils.run_one_test(test, check_sky_status=False)
+    assert not sentinel.exists()
+
+
+def test_failing_shell_command_still_fails(quiet_failure_reporting):
+    """The ordinary subprocess path is unchanged: a bad exit code fails."""
+    test = smoke_tests_utils.Test('shell-failure', ['exit 3'])
+    with pytest.raises(Exception, match='test failed'):
+        smoke_tests_utils.run_one_test(test, check_sky_status=False)
+
+
+def test_success_runs_teardown(quiet_reporting, tmp_path):
+    """Teardown is gated on the tracked status, so it still runs on success."""
+    sentinel = tmp_path / 'torn-down'
+    test = smoke_tests_utils.Test('teardown-on-success', [lambda: None],
+                                  teardown=f'touch {sentinel}')
+    smoke_tests_utils.run_one_test(test, check_sky_status=False)
+    assert sentinel.exists()


### PR DESCRIPTION
## Summary

`run_one_test` tracked a test's exit status on the `Popen` object — including for commands that are callables rather than shell strings. The callable-failure branch recorded it by mutating `proc.returncode`:

```python
except Exception as e:
    ...
    proc.returncode = 1   # `proc` may not exist yet
    break
```

But `proc` is only ever bound by the subprocess branch further down, so a test whose **first** command is a callable reaches that line with `proc` unbound. The failure handler then raises `UnboundLocalError` itself, and *that* becomes the test's outcome:

```
E   sky.exceptions.CloudError: kubernetes error (ApiException): (404)
...
During handling of the above exception, another exception occurred:
tests/smoke_tests/smoke_tests_utils.py:831: in run_one_test
    proc.returncode = 1
E   UnboundLocalError: local variable 'proc' referenced before assignment
```

The callable's traceback is still written to the log file, but the pytest summary line reports the `UnboundLocalError` — pointing at the runner rather than at whatever actually broke. On CI, where the summary is usually all anyone reads, the real failure is effectively invisible.

The same unbound `proc` is reachable from the other side: a test made up **only** of callables, all succeeding, has nothing to read a status from when the reporting block runs, so it dies at the outcome line even though every command passed.

Fix: track the status in a `returncode` local initialized before the loop, set from `proc.returncode` after each subprocess and directly on the callable-failure and timeout paths. The shell-command path behaves exactly as before — it just no longer stores the test's status on an object that only some commands have.

## Test plan

New `tests/unit_tests/test_smoke_test_runner.py` (kept out of a `smoke_tests` path, same reason as `test_chain_teardown.py`) covers both directions of the bug plus the behavior that reads the same status:

- a callable failing as the first command surfaces as a test failure, not `UnboundLocalError`
- an all-callable test that succeeds passes
- a failing callable short-circuits the commands after it
- a failing shell command still fails (the unchanged path)
- teardown still runs on success

```
$ pytest tests/unit_tests/test_smoke_test_runner.py tests/unit_tests/test_chain_teardown.py
10 passed
```

Verified the tests actually pin the bug — with the fix reverted, 4 of the 5 new tests fail with exactly `UnboundLocalError: local variable 'proc' referenced before assignment`, and only the shell-command case (the path this PR does not touch) still passes.

`bash format.sh` clean. The one `sky/client/sdk.py` mypy error it reports is pre-existing on master and unrelated.

**Manual verification** — any smoke test whose first command is a callable now reports its own failure. For example, a test defined as:

```python
def boom():
    raise RuntimeError('the real failure')

smoke_tests_utils.run_one_test(
    smoke_tests_utils.Test('demo', [boom]), check_sky_status=False)
```

Before: `UnboundLocalError: local variable 'proc' referenced before assignment`.
After: `Exception: test failed`, with `RuntimeError: the real failure` and its traceback in the run log above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->