### PR TITLE
[AWS] Gate Hyderabad catalog region

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -56,7 +56,7 @@ ALL_REGIONS = [
     'ap-east-1',
     'ap-southeast-3',
     'ap-south-1',
-    # 'ap-south-2', # no supported AMI
+    'ap-south-2',
     'ap-northeast-3',
     'ap-northeast-2',
     'ap-southeast-1',

--- a/tests/unit_tests/test_aws_catalog_hyderabad.py
+++ b/tests/unit_tests/test_aws_catalog_hyderabad.py
@@ -1,0 +1,7 @@
+"""Tests for Hyderabad in the AWS service-catalog source."""
+
+from sky.catalog.data_fetchers import fetch_aws
+
+
+def test_hyderabad_region_is_fetched() -> None:
+    assert 'ap-south-2' in fetch_aws.ALL_REGIONS


### PR DESCRIPTION
## Summary

- enable AWS Hyderabad (ap-south-2) in the catalog fetcher region source
- add a focused source-contract test
- do not generate or publish catalog data in this PR

AWS now lists G6 in Asia Pacific (Hyderabad), and the AWS Pricing API returns a Linux g6.xlarge product for regionCode ap-south-2. The hosted v8 image catalog already contains the curated CUDA13 x86_64 AMI for Hyderabad, while its VM catalog has no ap-south-2 rows.

## Required merge gates

Keep this PR in draft until all gates have attached evidence:

- [ ] The catalog-publisher AWS account is opted into ap-south-2 and passes the existing all-regions-enabled check.
- [ ] The hosted CUDA13 AMI is revalidated as public, available, x86_64, and launchable cross-account in ap-south-2.
- [ ] A generated v8 candidate contains validated nonempty G6/L4 Spot rows for ap-south-2 with non-null Spot prices.
- [ ] After controlled publication, the GitHub and S3 copies of aws/vms.csv and aws/images.csv converge to identical checksums.

No generated row, fallback image, integrity relaxation, AWS mutation, or S3 publication is included.

## Test plan

- python -m py_compile sky/catalog/data_fetchers/fetch_aws.py tests/unit_tests/test_aws_catalog_hyderabad.py
- python -m yapf --diff sky/catalog/data_fetchers/fetch_aws.py tests/unit_tests/test_aws_catalog_hyderabad.py
- python -m isort --check-only sky/catalog/data_fetchers/fetch_aws.py tests/unit_tests/test_aws_catalog_hyderabad.py
- pytest -q -n 0 --confcutdir=tests/unit_tests tests/unit_tests/test_aws_catalog_hyderabad.py
- git diff --check