### PR TITLE
[Serve] Fix autoscaler latest_version reset on controller restart

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -160,7 +160,12 @@ class Autoscaler:
         self.num_overprovision: Optional[int] = spec.num_overprovision
         # Target number of replicas is initialized to min replicas
         self.target_num_replicas: int = spec.min_replicas
-        self.latest_version: int = constants.INITIAL_VERSION
+        # Restore latest_version from DB on (re)start so that controller
+        # restarts do not reset the version counter to INITIAL_VERSION and
+        # cause spurious scale-churn or version-guard failures.
+        db_version = serve_state.get_latest_version(service_name)
+        self.latest_version: int = (db_version if db_version is not None else
+                                    constants.INITIAL_VERSION)
         # The latest_version_ever_ready should be smaller than the
         # latest_version, so we can fail early if the initial version got
         # unrecoverable failure.
@@ -379,12 +384,17 @@ class Autoscaler:
 
     def dump_dynamic_states(self) -> Dict[str, Any]:
         """Dump dynamic states from autoscaler."""
-        states = {'latest_version_ever_ready': self.latest_version_ever_ready}
+        states = {
+            'latest_version': self.latest_version,
+            'latest_version_ever_ready': self.latest_version_ever_ready,
+        }
         states.update(self._dump_dynamic_states())
         return states
 
     def load_dynamic_states(self, dynamic_states: Dict[str, Any]) -> None:
         """Load dynamic states to autoscaler."""
+        self.latest_version = dynamic_states.pop('latest_version',
+                                                  self.latest_version)
         self.latest_version_ever_ready = dynamic_states.pop(
             'latest_version_ever_ready', constants.INITIAL_VERSION)
         self._load_dynamic_states(dynamic_states)

--- a/tests/unit_tests/test_serve_autoscaler.py
+++ b/tests/unit_tests/test_serve_autoscaler.py
@@ -153,5 +153,92 @@ class TestSelectNonterminalReplicasToScaleDown(unittest.TestCase):
         self.assertEqual(result, [1])
 
 
+class TestAutoscalerLatestVersionRestore(unittest.TestCase):
+    """Tests for latest_version restoration on controller restart (issue #8562).
+
+    On restart, Autoscaler.__init__ must read the persisted version from the DB
+    rather than resetting to INITIAL_VERSION, which would cause scale-churn and
+    version-guard failures.
+    """
+
+    def _make_spec(self, min_replicas: int = 1):
+        spec = mock.MagicMock()
+        spec.min_replicas = min_replicas
+        spec.max_replicas = min_replicas
+        spec.num_overprovision = None
+        spec.upscale_delay_seconds = None
+        spec.downscale_delay_seconds = None
+        spec.qps_upper_threshold = None
+        spec.qps_lower_threshold = None
+        return spec
+
+    @mock.patch('sky.serve.autoscalers.serve_state.get_latest_version')
+    def test_init_restores_version_from_db(self, mock_get_version):
+        """Autoscaler.__init__ must use the DB version, not INITIAL_VERSION."""
+        mock_get_version.return_value = 5
+
+        from sky.serve import constants as serve_constants
+        from sky.serve.autoscalers import RequestRateAutoscaler
+        autoscaler = RequestRateAutoscaler('svc', self._make_spec())
+
+        mock_get_version.assert_called_once_with('svc')
+        self.assertEqual(autoscaler.latest_version, 5)
+        # latest_version_ever_ready should track latest_version - 1
+        self.assertEqual(autoscaler.latest_version_ever_ready, 4)
+
+    @mock.patch('sky.serve.autoscalers.serve_state.get_latest_version')
+    def test_init_falls_back_to_initial_version_when_db_empty(
+            self, mock_get_version):
+        """When the DB has no version yet, fall back to INITIAL_VERSION."""
+        mock_get_version.return_value = None
+
+        from sky.serve import constants as serve_constants
+        from sky.serve.autoscalers import RequestRateAutoscaler
+        autoscaler = RequestRateAutoscaler('svc', self._make_spec())
+
+        self.assertEqual(autoscaler.latest_version,
+                         serve_constants.INITIAL_VERSION)
+
+    @mock.patch('sky.serve.autoscalers.serve_state.get_latest_version')
+    def test_dump_and_load_dynamic_states_roundtrip(self, mock_get_version):
+        """dump/load_dynamic_states must preserve latest_version."""
+        mock_get_version.return_value = 3
+
+        from sky.serve.autoscalers import RequestRateAutoscaler
+        autoscaler = RequestRateAutoscaler('svc', self._make_spec())
+        autoscaler.latest_version_ever_ready = 3
+
+        states = autoscaler.dump_dynamic_states()
+        self.assertIn('latest_version', states)
+        self.assertEqual(states['latest_version'], 3)
+
+        # Simulate type-change: new autoscaler inherits state via load
+        mock_get_version.return_value = None
+        new_autoscaler = RequestRateAutoscaler('svc', self._make_spec())
+        new_autoscaler.load_dynamic_states(states)
+
+        self.assertEqual(new_autoscaler.latest_version, 3)
+        self.assertEqual(new_autoscaler.latest_version_ever_ready, 3)
+
+    @mock.patch('sky.serve.autoscalers.serve_state.get_latest_version')
+    def test_load_dynamic_states_backwards_compat_no_latest_version_key(
+            self, mock_get_version):
+        """load_dynamic_states must not crash on old dumps lacking the key."""
+        mock_get_version.return_value = 7
+
+        from sky.serve.autoscalers import RequestRateAutoscaler
+        autoscaler = RequestRateAutoscaler('svc', self._make_spec())
+
+        # Simulate an old dump that only has latest_version_ever_ready
+        old_states = autoscaler._dump_dynamic_states()
+        old_states['latest_version_ever_ready'] = 6
+        # No 'latest_version' key — old format
+
+        autoscaler.load_dynamic_states(old_states)
+        # Falls back to DB-restored value (7) set in __init__
+        self.assertEqual(autoscaler.latest_version, 7)
+        self.assertEqual(autoscaler.latest_version_ever_ready, 6)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Title: [Serve] Fix autoscaler latest_version reset on controller restart

Body:

## Problem

When the SkyServe controller restarts, `Autoscaler.__init__` always sets
`self.latest_version = INITIAL_VERSION` (hardcoded to 1) instead of reading
the actual current version from the database. This means the version-guard
in `update_version()` sees `version <= self.latest_version` for any version
already in the DB, silently ignores the update, and the autoscaler continues
operating with stale spec — causing scale churn and blocking service updates
after any controller restart.

Fixes #8562

## Changes

- **`sky/serve/autoscalers.py`** — `Autoscaler.__init__`: call
  `serve_state.get_latest_version(service_name)` and use the DB value when
  available, falling back to `INITIAL_VERSION` for new services.
- **`sky/serve/autoscalers.py`** — `dump_dynamic_states` / `load_dynamic_states`:
  include `latest_version` in the persisted state dict (alongside the existing
  `latest_version_ever_ready`) so the value also survives autoscaler type
  changes. Backwards-compatible: missing key falls back to the DB-restored value.

## Tested

```bash
pytest tests/unit_tests/test_serve_autoscaler.py -v
# 8 passed (4 pre-existing + 4 new tests covering the bug)

New test cases:
- test_init_restores_version_from_db — DB version 5 is used on init
- test_init_falls_back_to_initial_version_when_db_empty — None → INITIAL_VERSION
- test_dump_and_load_dynamic_states_roundtrip — dump/load preserves version
- test_load_dynamic_states_backwards_compat_no_latest_version_key — old dumps without the key still work
