### PR TITLE
[Pools] Fix incorrect worker resource-fit checks

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -6,6 +6,7 @@ import contextvars
 import dataclasses
 import datetime
 import enum
+import math
 import os
 import pathlib
 import pickle
@@ -30,6 +31,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.jobs import state as managed_job_state
+from sky.resources import _parse_value
 from sky.serve import constants
 from sky.serve import serve_state
 from sky.serve import spot_placer
@@ -1054,12 +1056,25 @@ def _task_fits(task_resources: 'resources_lib.Resources',
                                               check_cloud=False):
         return False
     if task_resources.cpus is not None:
-        if (free_resources.cpus is None or
-                task_resources.cpus > free_resources.cpus):
+        task_cpus = _parse_value(task_resources.cpus)
+        free_cpus = _parse_value(free_resources.cpus)
+        if (task_cpus is None or free_cpus is None or
+                not math.isfinite(task_cpus) or not math.isfinite(free_cpus) or
+                task_cpus > free_cpus):
             return False
     if task_resources.memory is not None:
-        if (free_resources.memory is None or
-                task_resources.memory > free_resources.memory):
+        if task_resources.memory.endswith('x'):
+            task_cpus = _parse_value(task_resources.cpus)
+            memory_multiplier = _parse_value(task_resources.memory[:-1])
+            task_memory = (None if task_cpus is None or
+                           memory_multiplier is None else task_cpus *
+                           memory_multiplier)
+        else:
+            task_memory = _parse_value(task_resources.memory)
+        free_memory = _parse_value(free_resources.memory)
+        if (task_memory is None or free_memory is None or
+                not math.isfinite(task_memory) or
+                not math.isfinite(free_memory) or task_memory > free_memory):
             return False
     return True
 

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -22,24 +22,41 @@ def test_task_fits():
     assert serve_utils._task_fits(task_resources, free_resources) is True
 
     # Test less CPUs than free.
-    task_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())
-    free_resources = Resources(cpus=2, memory=1, cloud=clouds.AWS())
+    task_resources = Resources(cpus=3, memory=1, cloud=clouds.AWS())
+    free_resources = Resources(cpus=16, memory=1, cloud=clouds.AWS())
     assert serve_utils._task_fits(task_resources, free_resources) is True
 
     # Test more CPUs than free.
-    task_resources = Resources(cpus=2, memory=1, cloud=clouds.AWS())
-    free_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())
+    task_resources = Resources(cpus=12, memory=1, cloud=clouds.AWS())
+    free_resources = Resources(cpus=9, memory=1, cloud=clouds.AWS())
     assert serve_utils._task_fits(task_resources, free_resources) is False
 
     # Test less  memory than free.
-    task_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())
-    free_resources = Resources(cpus=1, memory=2, cloud=clouds.AWS())
+    task_resources = Resources(cpus=1, memory=3, cloud=clouds.AWS())
+    free_resources = Resources(cpus=1, memory=16, cloud=clouds.AWS())
     assert serve_utils._task_fits(task_resources, free_resources) is True
 
     # Test more memory than free.
-    task_resources = Resources(cpus=1, memory=2, cloud=clouds.AWS())
-    free_resources = Resources(cpus=1, memory=1, cloud=clouds.AWS())
+    task_resources = Resources(cpus=1, memory=12, cloud=clouds.AWS())
+    free_resources = Resources(cpus=1, memory=9, cloud=clouds.AWS())
     assert serve_utils._task_fits(task_resources, free_resources) is False
+
+    task_resources = Resources(cpus=3, memory='3x', cloud=clouds.AWS())
+    free_resources = Resources(cpus=16, memory=9, cloud=clouds.AWS())
+    assert serve_utils._task_fits(task_resources, free_resources) is True
+
+    free_resources = Resources(cpus=16, memory=8, cloud=clouds.AWS())
+    assert serve_utils._task_fits(task_resources, free_resources) is False
+
+    task_resources = Resources(cpus='nan', cloud=clouds.AWS())
+    free_resources = Resources(cpus=1, cloud=clouds.AWS())
+    assert serve_utils._task_fits(task_resources, free_resources) is False
+    assert serve_utils._task_fits(free_resources, task_resources) is False
+
+    task_resources = Resources(memory='nan', cloud=clouds.AWS())
+    free_resources = Resources(memory=1, cloud=clouds.AWS())
+    assert serve_utils._task_fits(task_resources, free_resources) is False
+    assert serve_utils._task_fits(free_resources, task_resources) is False
 
     # Test GPU exact fit.
     task_resources = Resources(accelerators='A10:1', cloud=clouds.AWS())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resources.cpus and absolute Resources.memory values are strings, so
_task_fits() compares them lexicographically. Parse them with the existing
resource arithmetic parser before checking capacity. Preserve memory-per-CPU
values such as 3x by resolving the multiplier against the task CPU request.
Reject non-finite parsed demand or capacity values so NaN cannot pass a fit
check.

Extend the existing unit test with multi-digit CPU and memory values, fitting
and non-fitting 3x cases, and non-finite CPU and memory demand and capacity.
These cover false rejection, false acceptance, and fail-closed validation.

<!-- Describe the tests ran -->

Tested:

- [x] bash format.sh
- [x] pytest tests/unit_tests/test_serve_utils.py::test_task_fits
