### PR TITLE
[Test] task_labels_kubernetes: scope the label check to the cluster's own pod

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1389,14 +1389,23 @@ def test_task_labels_kubernetes():
                 # so its in-cluster kubectl can see the target's resources.
                 smoke_tests_utils.resolve_k8s_context_cmd(name),
                 smoke_tests_utils.launch_cloud_cmd_on_landed_context(name),
-                # Verify with kubectl that the labels are set.
+                # Verify with kubectl that the labels are set. Scope the
+                # selector to this cluster's own pods: the namespace is shared
+                # (other API servers and concurrent smoke runs land their pods
+                # in it too), and `jsonpath={.items[*].metadata.name}` emits
+                # every match space-joined on a single line, so an anchored
+                # `grep '^<name>'` on that line only passes when this cluster's
+                # pod happens to sort first among the matches. Ask the API
+                # server for the intersection instead and just require a hit.
+                # One `--selector` flag, not three: kubectl's `-l/--selector`
+                # is a plain string flag, so repeating it silently keeps only
+                # the last occurrence.
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name, 'kubectl get pods '
-                    '--selector inlinelabel1=inlinevalue1 '
-                    '--selector inlinelabel2=inlinevalue2 '
-                    '-o jsonpath=\'{.items[*].metadata.name}\' | '
-                    f'grep \'^{common_utils.make_cluster_name_on_cloud(name, sky.Kubernetes.max_cluster_name_length())}\''
-                )
+                    '--selector inlinelabel1=inlinevalue1,'
+                    'inlinelabel2=inlinevalue2,'
+                    f'skypilot-cluster-name={common_utils.make_cluster_name_on_cloud(name, sky.Kubernetes.max_cluster_name_length())} '
+                    '-o jsonpath=\'{.items[*].metadata.name}\' | grep .')
             ],
             smoke_tests_utils.chain_teardown(
                 f'sky down -y {name}',


### PR DESCRIPTION
`test_task_labels_kubernetes` verifies the inline labels by listing every pod in the namespace that carries them and grepping the result for the cluster's on-cloud name:

```
kubectl get pods --selector inlinelabel1=inlinevalue1 \
                 --selector inlinelabel2=inlinevalue2 \
  -o jsonpath='{.items[*].metadata.name}' | grep '^<name_on_cloud>'
```

`jsonpath={.items[*].metadata.name}` emits every match space-joined on a **single line**, and the grep is anchored to the start of that line. So the list is only greppable when this cluster's pod happens to come first — i.e. when no other pod in the namespace carries the same labels and sorts ahead of it (the API server returns pods in lexicographic name order). The namespace is not exclusively ours: a concurrent run of this test, or a pod leaked by an interrupted one, is enough to displace the target and fail the check.

It fails silently when that happens. kubectl's stdout goes into the pipe, so nothing but stderr can reach the job log; a non-matching list and an empty list are indistinguishable, and both surface only as `return code list: [1]` with no output at all.

## Confirmed on the cluster that hit it

This is not hypothetical — the displacing pod was found still sitting in the namespace.

In the failure that prompted this, the cloud-cmd helper and the cluster under test were verifiably co-located (same context, same namespace, same node, same `skypilot-service-account`), and the target pod was alive with both labels on it, confirmed from the pod object logged at teardown well after the check ran. The check still returned 1 with an empty job log. Listing pods by `inlinelabel1` on that cluster afterwards turned up a second one:

```
NS        NAME                                        CREATED
default   t-task-labels-kub-t-1n-<user-hash-A>-head   2026-08-27T22:39:08Z   # leaked, still Running
default   t-task-labels-kub-t-d5-<user-hash-B>-head                          # the cluster under test
```

The first is a pod left behind by an earlier, interrupted run of this same test — a different user identity, ~19 hours old at the moment of the failure, and still Running when this was written. Both names reproduce exactly from `make_cluster_name_on_cloud(display_name, 42)`, so the shape is not in doubt.

Within a namespace the API server lists pods in lexicographic name order, and `t-1n` sorts before `t-d5`. The jsonpath output was therefore one line beginning with the *leaked* pod's name, and `grep '^t-task-labels-kub-t-d5-…'` could not match it. That is the whole failure.

The truncation suffix is `base36(md5(display_name))[:2]` over `[0-9a-z]`, so it is effectively uniform: while that leaked pod exists, only a run whose suffix sorts below `1n` can pass — 59 of 1296, about 1 run in 20. So this is not an occasional flake; the test is close to deterministically broken for as long as a leaked pod with a low-sorting suffix sits in the namespace.

## Change

Ask the API server for the intersection instead: add the cluster's own `skypilot-cluster-name` label (set to `cluster_name_on_cloud` in `kubernetes-ray.yml.j2`) to the selector and just require a hit. The assertion is the same one — this cluster's pod carries both inline labels — but it no longer depends on what else lives in the namespace.

The list stays namespace-scoped, so it remains permitted under the least-privilege `skypilot-service-account` identity the command runs as inside the cloud-cmd helper (a cluster-scoped `-A` list is Forbidden there, cf. #10433).

Also collapse the three flags into one selector: kubectl's `-l/--selector` is a plain string flag, so repeating it keeps only the last occurrence — the check was only ever testing `inlinelabel2`.

Deleting the leaked pod would unblock the test today, but the next leak re-breaks it; the check should not depend on what else is in the namespace.

## Tested

- `pytest --collect-only tests/smoke_tests/test_cluster_job.py::test_task_labels_kubernetes`
- Smoke: `test_task_labels_kubernetes` on Kubernetes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
