### PR TITLE
[Docs] Add NeMo Automodel example link to Training examples

### DIFF
--- a/docs/source/examples/training/index.rst
+++ b/docs/source/examples/training/index.rst
@@ -16,6 +16,7 @@ Training
    Finetuning Llama 2 <llama-2-finetuning.md>
    nanochat <nanochat.md>
    NeMo <nemo.md>
+   NeMo Automodel <https://docs.nvidia.com/nemo/automodel/latest/job-launchers/skypilot>
    NeMo RL <nemorl.md>
    OpenRLHF <openrlhf.md>
    PyTorch Monarch <https://github.com/meta-pytorch/monarch/tree/main/examples/skypilot>


### PR DESCRIPTION
Adds a "NeMo Automodel" entry to the Training examples list in the docs, linking out to NVIDIA's SkyPilot job launcher page: https://docs.nvidia.com/nemo/automodel/latest/job-launchers/skypilot

- Follows the same external-link pattern already used for the PyTorch Monarch and Vertex AI entries in `docs/source/examples/training/index.rst`
- Placed alphabetically between `NeMo` and `NeMo RL`

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual verification: docs-only change (one line in a Sphinx toctree). Build the docs and confirm "NeMo Automodel" appears in the Examples → Training list/sidebar between "NeMo" and "NeMo RL", and that it links to the NVIDIA docs page:

```bash
cd docs && make html && open build/html/examples/training/index.html
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7fEBLVMD491Mp9bvLwXVJ)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->