### PR TITLE
[Core] Add register_slurm_property for plugin schema extension

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -566,11 +566,14 @@ function ExternalJobId({ item, href }) {
 }
 
 function JobNameLink({ href, name }) {
+  // max-w (not fixed w): the box shrinks to the name so a trailing badge
+  // sits next to the text instead of parking at the 240px edge after a
+  // short name; long names still truncate at 240px.
   return (
     <NonCapitalizedTooltip content={name}>
       <Link
         href={href}
-        className="text-blue-600 block w-[240px] truncate"
+        className="text-blue-600 block max-w-[240px] truncate"
       >
         {name}
       </Link>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -625,6 +625,10 @@ export function ManagedJobsTable({
     [setView]
   );
   const [statusCounts, setStatusCounts] = useState({});
+  // Per-cluster failures from the external (Slurm) jobs sweep; non-empty
+  // means external rows may be incomplete or stale. Dismissible warning.
+  const [externalFetchErrors, setExternalFetchErrors] = useState([]);
+  const [externalErrorsDismissed, setExternalErrorsDismissed] = useState('');
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const moreMenuRef = useRef(null);
   const [controllerStopped, setControllerStopped] = useState(false);
@@ -812,6 +816,7 @@ export function ManagedJobsTable({
             setTotalCount(response.total || 0);
             setTotalNoFilter(response.totalNoFilter || response.total || 0);
             setStatusCounts(response.statusCounts || {});
+            setExternalFetchErrors(response.externalFetchErrors || []);
             // Controller is reachable: clear any stale banner state from a
             // previous fetch and skip the cluster-status lookup below.
             setControllerStopped(false);
@@ -2350,6 +2355,36 @@ export function ManagedJobsTable({
           </div>
         </div>
       </div>
+
+      {/* Slurm sweep failures: external rows may be incomplete or stale.
+          Dismiss is keyed on the message text so a NEW failure re-surfaces
+          the warning while the same one stays dismissed. */}
+      {externalFetchErrors.length > 0 &&
+        (() => {
+          const errorText = externalFetchErrors
+            .map((f) => `${f.cluster}: ${f.error}`)
+            .join(' · ');
+          if (errorText === externalErrorsDismissed) return null;
+          return (
+            <div className="mb-3 flex items-start justify-between rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              <span>
+                Failed to fetch Slurm jobs from{' '}
+                {externalFetchErrors.length === 1
+                  ? 'cluster'
+                  : 'clusters'}{' '}
+                {externalFetchErrors.map((f) => f.cluster).join(', ')} — their
+                jobs may be missing or stale. ({errorText})
+              </span>
+              <button
+                onClick={() => setExternalErrorsDismissed(errorText)}
+                className="ml-3 flex-shrink-0 font-medium text-amber-800 hover:text-amber-900"
+                title="Dismiss"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })()}
 
       {/* Mobile-specific controller stopped message outside table */}
       {isMobile &&

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -550,6 +550,21 @@ function ExternalPill() {
   );
 }
 
+// A Slurm job id lives in the CLUSTER's id space, not SkyPilot's — the raw
+// number can collide with a managed job id in the same column. Muted so the
+// two id spaces cannot be conflated; the tooltip names the owner.
+function ExternalJobId({ item, href }) {
+  return (
+    <NonCapitalizedTooltip
+      content={`External ID managed by Slurm cluster ${item.external_cluster}`}
+    >
+      <Link href={href} className="text-gray-400 underline decoration-dotted">
+        {item.external_job_id}
+      </Link>
+    </NonCapitalizedTooltip>
+  );
+}
+
 function JobNameLink({ href, name }) {
   return (
     <NonCapitalizedTooltip content={name}>
@@ -1529,19 +1544,22 @@ export function ManagedJobsTable({
           const detailHref =
             item.detail_href ||
             (item.is_external ? externalJobHref(item) : `/jobs/${item.id}`);
+          const idLink = item.is_external ? (
+            <ExternalJobId item={item} href={detailHref} />
+          ) : (
+            <Link href={detailHref} className="text-blue-600">
+              {item.id}
+            </Link>
+          );
           return (
             <TableCell>
               {hasAnyJobGroups ? (
                 <div className="flex items-center">
                   <span className="w-6 mr-1" aria-hidden="true" />
-                  <Link href={detailHref} className="text-blue-600">
-                    {item.id}
-                  </Link>
+                  {idLink}
                 </div>
               ) : (
-                <Link href={detailHref} className="text-blue-600">
-                  {item.id}
-                </Link>
+                idLink
               )}
             </TableCell>
           );
@@ -1945,9 +1963,14 @@ export function ManagedJobsTable({
             return <TableCell>-</TableCell>;
           }
 
-          // Use task_job_id for group children to avoid conflicts
+          // Use task_job_id for group children to avoid conflicts, and for
+          // external rows always: their raw id is the Slurm cluster's id
+          // space, so equal ids across clusters (or against a managed id)
+          // would co-expand on plain item.id.
           const rowId =
-            ctx?.renderMode === 'groupChild' ? item.task_job_id : item.id;
+            ctx?.renderMode === 'groupChild' || item.is_external
+              ? item.task_job_id
+              : item.id;
 
           return (
             <TableCell>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -555,7 +555,7 @@ function JobNameLink({ href, name }) {
     <NonCapitalizedTooltip content={name}>
       <Link
         href={href}
-        className="text-blue-600 block min-w-[200px] max-w-[240px] truncate"
+        className="text-blue-600 block w-[240px] truncate"
       >
         {name}
       </Link>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -531,6 +531,25 @@ function BatchProgressBar({ completed, total }) {
   );
 }
 
+// External (non-managed) rows merged in by the server carry
+// is_external + external_cluster/external_job_id; their detail pages
+// live under /slurm-jobs instead of /jobs.
+function externalJobHref(item) {
+  return `/slurm-jobs/${encodeURIComponent(item.external_cluster)}/${encodeURIComponent(item.external_job_id)}`;
+}
+
+function ExternalPill() {
+  return (
+    <span
+      className="inline-flex items-center flex-shrink-0 ml-2 px-2 rounded-full border border-gray-200 bg-gray-100 text-gray-600 text-xs font-medium"
+      style={{ paddingTop: 1, paddingBottom: 1, lineHeight: 1.4 }}
+      title="This workload is launched and managed outside of SkyPilot"
+    >
+      External
+    </span>
+  );
+}
+
 function JobNameLink({ href, name }) {
   return (
     <NonCapitalizedTooltip content={name}>
@@ -1496,10 +1515,12 @@ export function ManagedJobsTable({
             );
           }
 
-          // Single task. A row may carry its own detail link (e.g. rows
-          // sourced from outside the managed-jobs table); otherwise link to
-          // the managed-job detail page.
-          const detailHref = item.detail_href || `/jobs/${item.id}`;
+          // Single task. A row may carry its own detail link; external
+          // rows without one derive it from their identity fields, and
+          // everything else links to the managed-job detail page.
+          const detailHref =
+            item.detail_href ||
+            (item.is_external ? externalJobHref(item) : `/jobs/${item.id}`);
           return (
             <TableCell>
               {hasAnyJobGroups ? (
@@ -1576,13 +1597,16 @@ export function ManagedJobsTable({
             );
           }
 
-          // Single task. Honor a row-provided detail link (see the ID
-          // column) so externally-sourced rows point at their own page.
-          const detailHref = item.detail_href || `/jobs/${item.id}`;
+          // Single task. Same link resolution as the ID column: a
+          // row-provided detail link wins, external rows derive theirs.
+          const detailHref =
+            item.detail_href ||
+            (item.is_external ? externalJobHref(item) : `/jobs/${item.id}`);
           return (
             <TableCell className="whitespace-nowrap">
               <div className="flex items-center">
                 <JobNameLink href={detailHref} name={item.name} />
+                {item.is_external && <ExternalPill />}
                 {isBatch && <BatchBadge className="ml-2" />}
               </div>
             </TableCell>
@@ -1626,12 +1650,16 @@ export function ManagedJobsTable({
         renderCell: (item) =>
           shouldShowWorkspace ? (
             <TableCell>
-              <Link
-                href="/workspaces"
-                className="text-gray-700 hover:text-blue-600 hover:underline"
-              >
-                {item.workspace || 'default'}
-              </Link>
+              {item.is_external ? (
+                <span className="text-gray-400">—</span>
+              ) : (
+                <Link
+                  href="/workspaces"
+                  className="text-gray-700 hover:text-blue-600 hover:underline"
+                >
+                  {item.workspace || 'default'}
+                </Link>
+              )}
             </TableCell>
           ) : null,
       },
@@ -1935,6 +1963,23 @@ export function ManagedJobsTable({
         renderHeader: () => <TableHead>Logs</TableHead>,
         renderCell: (item, ctx) => {
           const { renderMode, jobId } = ctx || {};
+
+          if (item.is_external) {
+            // External Slurm rows: logs live on their detail page.
+            return (
+              <TableCell>
+                <div className="flex items-center space-x-2">
+                  <Link
+                    href={externalJobHref(item)}
+                    title="View logs"
+                    className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
+                  >
+                    <FileSearchIcon className="w-4 h-4" />
+                  </Link>
+                </div>
+              </TableCell>
+            );
+          }
 
           // For group parent, use jobId; otherwise use item.id
           const logJobId = renderMode === 'groupParent' ? jobId : item.id;

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -571,10 +571,7 @@ function JobNameLink({ href, name }) {
   // short name; long names still truncate at 240px.
   return (
     <NonCapitalizedTooltip content={name}>
-      <Link
-        href={href}
-        className="text-blue-600 block max-w-[240px] truncate"
-      >
+      <Link href={href} className="text-blue-600 block max-w-[240px] truncate">
         {name}
       </Link>
     </NonCapitalizedTooltip>
@@ -2405,11 +2402,9 @@ export function ManagedJobsTable({
               <div>
                 <div>
                   Failed to fetch Slurm jobs from{' '}
-                  {externalFetchErrors.length === 1
-                    ? 'cluster'
-                    : 'clusters'}{' '}
-                  {externalFetchErrors.map((f) => f.cluster).join(', ')} —
-                  their jobs may be missing or stale.
+                  {externalFetchErrors.length === 1 ? 'cluster' : 'clusters'}{' '}
+                  {externalFetchErrors.map((f) => f.cluster).join(', ')} — their
+                  jobs may be missing or stale.
                 </div>
                 {externalFetchErrors.map((f) => (
                   <div

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1233,7 +1233,10 @@ export function ManagedJobsTable({
   const groupedJobs = React.useMemo(() => {
     const groups = new Map();
     paginatedData.forEach((job) => {
-      const jobId = job.id;
+      // External rows never form job groups; key them by their globally
+      // unique task_job_id so equal Slurm ids across clusters (or a
+      // Slurm id matching a managed id) can't collapse into one group.
+      const jobId = job.is_external ? job.task_job_id : job.id;
       if (!groups.has(jobId)) {
         groups.set(jobId, []);
       }

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2367,14 +2367,24 @@ export function ManagedJobsTable({
           if (errorText === externalErrorsDismissed) return null;
           return (
             <div className="mb-3 flex items-start justify-between rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-              <span>
-                Failed to fetch Slurm jobs from{' '}
-                {externalFetchErrors.length === 1
-                  ? 'cluster'
-                  : 'clusters'}{' '}
-                {externalFetchErrors.map((f) => f.cluster).join(', ')} — their
-                jobs may be missing or stale. ({errorText})
-              </span>
+              <div>
+                <div>
+                  Failed to fetch Slurm jobs from{' '}
+                  {externalFetchErrors.length === 1
+                    ? 'cluster'
+                    : 'clusters'}{' '}
+                  {externalFetchErrors.map((f) => f.cluster).join(', ')} —
+                  their jobs may be missing or stale.
+                </div>
+                {externalFetchErrors.map((f) => (
+                  <div
+                    key={f.cluster}
+                    className="mt-1 font-mono text-xs text-amber-700"
+                  >
+                    {f.cluster}: {f.error}
+                  </div>
+                ))}
+              </div>
               <button
                 onClick={() => setExternalErrorsDismissed(errorText)}
                 className="ml-3 flex-shrink-0 font-medium text-amber-800 hover:text-amber-900"

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -828,6 +828,9 @@ export function ManagedJobsTable({
             setTotalCount(0);
             setTotalNoFilter(0);
             setStatusCounts({});
+            // No rows are shown, so a Slurm-sweep failure banner from a
+            // previous fetch would hang over an empty table.
+            setExternalFetchErrors([]);
           } else {
             setHookControllerStopped(false);
             setData(response.jobs || []);
@@ -899,6 +902,7 @@ export function ManagedJobsTable({
           setTotalNoFilter(0);
           setStatusCounts({});
           setControllerStopped(false);
+          setExternalFetchErrors([]);
           setIsInitialLoad(false);
         }
       } finally {
@@ -1259,7 +1263,12 @@ export function ManagedJobsTable({
       // External rows never form job groups; key them by their globally
       // unique task_job_id so equal Slurm ids across clusters (or a
       // Slurm id matching a managed id) can't collapse into one group.
-      const jobId = job.is_external ? job.task_job_id : job.id;
+      // Fall back to a prefixed id if a producer ever omits task_job_id,
+      // so such rows degrade to per-id groups instead of one undefined
+      // group rendering as a bogus JobGroup.
+      const jobId = job.is_external
+        ? (job.task_job_id ?? `external:${job.id}`)
+        : job.id;
       if (!groups.has(jobId)) {
         groups.set(jobId, []);
       }

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -334,6 +334,7 @@ class JobsCacheManager {
     const hasNext = result.hasNext || result.has_next || page < totalPages;
     const hasPrev = result.hasPrev || result.has_prev || page > 1;
     const statusCounts = result.statusCounts || {};
+    const externalFetchErrors = result.externalFetchErrors || [];
 
     // Cache this specific page
     this.pageCache.set(cacheKey, {
@@ -345,6 +346,7 @@ class JobsCacheManager {
       hasPrev,
       controllerStopped: false,
       statusCounts,
+      externalFetchErrors,
       timestamp: Date.now(),
     });
 
@@ -357,6 +359,7 @@ class JobsCacheManager {
       hasPrev,
       controllerStopped: false,
       statusCounts,
+      externalFetchErrors,
       fromCache: false,
       cacheStatus: 'plugin_path_fetched',
     };
@@ -424,6 +427,7 @@ class JobsCacheManager {
           hasPrev: cachedPage.hasPrev,
           controllerStopped: cachedPage.controllerStopped,
           statusCounts: cachedPage.statusCounts,
+          externalFetchErrors: cachedPage.externalFetchErrors || [],
           fromCache: true,
           cacheStatus: 'cache_hit',
         };

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -47,6 +47,8 @@ _extra_jobs_properties: Dict[str, Any] = {}
 
 _extra_kubernetes_properties: Dict[str, Any] = {}
 
+_extra_slurm_properties: Dict[str, Any] = {}
+
 # Registry for plugin-provided properties under the top-level
 # `plugins:` config section. Keyed by plugin name.
 _extra_plugin_properties: Dict[str, Any] = {}
@@ -106,6 +108,23 @@ def register_kubernetes_property(name: str, schema: Dict[str, Any]) -> None:
             (e.g., {'type': 'string'}).
     """
     _extra_kubernetes_properties[name] = schema
+
+
+def register_slurm_property(name: str, schema: Dict[str, Any]) -> None:
+    """Register an additional property for the slurm schema.
+
+    This allows plugins to extend the slurm dict schema with slurm-specific
+    configuration fields. The property is merged into the schema's properties
+    dict (both at the top level and under each per-cluster ``cluster_configs``
+    entry), so it passes JSON schema validation even with
+    additionalProperties: False.
+
+    Args:
+        name: The property name.
+        schema: The JSON Schema for the property
+            (e.g., {'type': 'string'}).
+    """
+    _extra_slurm_properties[name] = schema
 
 
 def _check_not_both_fields_present(field1: str, field2: str):
@@ -2127,7 +2146,11 @@ def get_config_schema():
         'slurm': {
             'type': 'object',
             'required': [],
-            'additionalProperties': False,
+            # On the server, plugins have registered their properties via
+            # register_slurm_property(), so we can be strict. On the client we
+            # allow unknown properties to pass through for server-side
+            # validation.
+            'additionalProperties': _allow_additional_properties(),
             'properties': {
                 'allowed_clusters': {
                     'oneOf': [{
@@ -2160,7 +2183,10 @@ def get_config_schema():
                     'additionalProperties': {
                         'type': 'object',
                         'required': [],
-                        'additionalProperties': False,
+                        # Strict on the server (plugins have registered their
+                        # per-cluster properties via register_slurm_property);
+                        # permissive on the client for server-side validation.
+                        'additionalProperties': _allow_additional_properties(),
                         'properties': {
                             'workdir': {
                                 'type': 'string',
@@ -2199,9 +2225,15 @@ def get_config_schema():
                                     },
                                 },
                             },
+                            # Plugin-registered per-cluster slurm properties
+                            # via register_slurm_property().
+                            **_extra_slurm_properties,
                         },
                     },
                 },
+                # Plugin-registered top-level slurm properties via
+                # register_slurm_property().
+                **_extra_slurm_properties,
             }
         },
         'oci': {


### PR DESCRIPTION
## Summary

Adds a `register_slurm_property()` hook to the config schema, mirroring the existing `register_kubernetes_property()`. Plugins can now register slurm-specific config properties that are merged into the slurm schema at both the top level and under each per-cluster `cluster_configs` entry. The slurm schema's `additionalProperties` now uses `_allow_additional_properties()` — permissive on the client (or before plugins load) so unknown keys pass through for server-side validation, and strict on the server once plugins have registered their properties — matching how the kubernetes schema already works.

This lets a plugin add slurm-scoped config keys that pass client-side validation and are validated strictly server-side, instead of being rejected as unsupported fields.

## Test plan

- Schema check: register a property via `register_slurm_property`, build the config schema with `get_config_schema()`, and confirm the property appears in both `slurm.properties` and `slurm.cluster_configs.additionalProperties.properties`, and that a config using the key validates via `common_utils.validate_schema`.
- `yapf` / format clean; existing schema handling is unchanged for the kubernetes path (this only adds the symmetric slurm path).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->