### PR TITLE
[Docs] Add resilient Ray training example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,8 @@ Machine learning examples:
 
 - [**`resnet_distributed_torch.yaml`**](./resnet_distributed_torch.yaml): Run Distributed PyTorch (DDP) training of ResNet50 on 2 nodes.
 
+- [**`ray_resilient_training/`**](./ray_resilient_training/README.md): Run resilient Ray training with a CPU-only head, two GPU workers, node recovery, and RocksDB-backed GCS state.
+
 - [**`detectron2_app.yaml`**](./detectron2_app.yaml): Run Detectron2 on a V100 GPU.
 
 - TPU examples

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -1,0 +1,98 @@
+# Resilient Ray training on SkyPilot
+
+This example runs an RL-style Ray workload with a CPU-only head and two
+single-GPU workers. Dynamic Node Sets replace a failed head or worker while
+the healthy workers keep running.
+
+> [!NOTE]
+> Dynamic Node Sets are available with SkyPilot Platform on Kubernetes.
+> Contact the SkyPilot team to enable them for your deployment.
+
+## Requirements
+
+- A Kubernetes cluster with two available GPUs.
+- A CSI storage class that supports `ReadWriteOncePod` volumes and can reattach
+  a volume to a replacement head pod. Set `storage_class_name` in
+  `gcs-volume.yaml` if the cluster's default class is unsuitable.
+
+## Architecture
+
+The workload is a SkyPilot Job Group with two resource shapes:
+
+- **`ray-head`** is the primary task. It runs the Ray GCS and driver on CPU,
+  with zero logical Ray CPUs and GPUs so actors are scheduled only on workers.
+- **`ray-workers`** runs two GPU replicas. Each replica joins the head and
+  contributes one GPU to the Ray cluster.
+
+The driver creates one named, detached Ray actor per GPU. Actors use
+`max_restarts=-1` and `max_task_retries=-1`, so Ray reconstructs the actor
+whose worker disappeared and retries its synthetic rollout. The other actor
+continues on its original worker.
+
+The head stores GCS metadata in Ray's embedded RocksDB backend on a persistent
+SkyPilot volume. It also checkpoints the last completed application step to
+the same volume. A replacement head reopens that state, reattaches to the
+detached actors, and resumes the driver.
+
+## Run it
+
+From the SkyPilot repository root, create the GCS volume once:
+
+```bash
+sky volumes apply examples/ray_resilient_training/gcs-volume.yaml
+```
+
+Launch the Job Group:
+
+```bash
+sky jobs launch examples/ray_resilient_training/ray-resilient-training.yaml
+```
+
+Use the returned job ID to follow the driver:
+
+```bash
+sky jobs logs <job-id> ray-head
+```
+
+Each completed step prints both actors' worker hostname, process ID, Ray node
+ID, and random `incarnation` value.
+
+## Exercise recovery
+
+Delete one `ray-workers` pod while a step is running:
+
+```bash
+kubectl delete pod <ray-worker-pod>
+```
+
+SkyPilot creates a replacement worker, its raylet joins the existing cluster,
+and Ray reconstructs the lost actor. The next completed step shows a new
+`incarnation` for that actor and the original value for the healthy actor.
+
+Delete the `ray-head` pod to exercise GCS recovery:
+
+```bash
+kubectl delete pod <ray-head-pod>
+```
+
+The replacement head mounts the same volume and restarts Ray against the
+job-specific RocksDB directory. Worker raylets wait up to 600 seconds for the
+GCS endpoint to return, and the driver resumes after its last completed step.
+
+## Configuration
+
+`NUM_GPU_WORKERS` on `ray-head` must equal `ray-workers.num_nodes`. The example
+uses two `L4:1` workers. Change both values together to scale the worker fleet,
+and change `resources.accelerators` to use another GPU type.
+
+The published Ray GPU image does not include PyTorch, so the worker `setup`
+installs it. For shorter replacement times, build an image containing both Ray
+and PyTorch and use it for `ray-workers`.
+
+Ray marks the embedded RocksDB backend as alpha. RocksDB stores Ray cluster
+metadata, not model weights or mutable actor state. Real training code should
+checkpoint application state to its own durable volume or object store and
+make retried work idempotent.
+
+See Ray's [GCS fault-tolerance documentation](https://docs.ray.io/en/latest/ray-core/fault_tolerance/gcs.html#fault-tolerance-gcs-rocksdb)
+for details about the embedded RocksDB backend.

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -1,8 +1,10 @@
 # Resilient Ray training on SkyPilot
 
-This example runs an RL-style Ray workload with a CPU-only head and two
-single-GPU workers. Dynamic Node Sets replace a failed head or worker while
-the healthy workers keep running.
+This example keeps a multi-node Ray training job alive through head and worker
+failures. Dynamic Node Sets provide fast failover to warm standby capacity:
+only the failed pod is replaced, healthy workers keep running, and training
+resumes without a full-cluster restart. This minimizes training downtime
+during failures.
 
 > [!NOTE]
 > This example uses **Frontier Trainer** for Dynamic Node Set recovery, which

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -5,8 +5,8 @@ single-GPU workers. Dynamic Node Sets replace a failed head or worker while
 the healthy workers keep running.
 
 > [!NOTE]
-> Dynamic Node Sets are available with SkyPilot Platform on Kubernetes.
-> Contact the SkyPilot team to enable them for your deployment.
+> This example uses **Frontier Trainer** for Dynamic Node Set recovery, which
+> is available on the **[SkyPilot Platform](https://docs.skypilot.ai/en/latest/skypilot-platform.html)**.
 
 ## Requirements
 

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -29,12 +29,17 @@ The workload is a SkyPilot Job Group with two resource shapes:
 The driver creates one named, detached Ray actor per GPU. Actors use
 `max_restarts=-1` and `max_task_retries=-1`, so Ray reconstructs the actor
 whose worker disappeared and retries its synthetic rollout. The other actor
-continues on its original worker.
+continues on its original worker. Each rollout runs a fixed number of GPU
+batches and waits for every batch to finish, making retried computation
+deterministic and preventing asynchronous GPU work from accumulating past the
+configured batch count.
 
 The head stores GCS metadata in Ray's embedded RocksDB backend on a persistent
 SkyPilot volume. It also checkpoints the last completed application step to
 the same volume. A replacement head reopens that state, reattaches to the
-detached actors, and resumes the driver.
+detached actors, and resumes the driver. When resuming from a completed step,
+the driver requires every named actor to exist so failed reattachment cannot
+silently create a new training topology.
 
 ## Run it
 

--- a/examples/ray_resilient_training/gcs-volume.yaml
+++ b/examples/ray_resilient_training/gcs-volume.yaml
@@ -1,0 +1,10 @@
+name: ray-gcs-rocksdb
+type: k8s-pvc
+infra: kubernetes
+size: 20Gi
+
+config:
+  # Embedded RocksDB permits exactly one GCS writer. A recovered head waits
+  # for the previous pod to release the claim before mounting it.
+  access_mode: ReadWriteOncePod
+  # storage_class_name: <durable-storage-class>

--- a/examples/ray_resilient_training/ray-resilient-training.yaml
+++ b/examples/ray_resilient_training/ray-resilient-training.yaml
@@ -1,0 +1,113 @@
+# A CPU-only Ray head and two single-GPU workers run as one Job Group.
+#
+# Prerequisite:
+#   sky volumes apply examples/ray_resilient_training/gcs-volume.yaml
+#
+# Launch:
+#   sky jobs launch examples/ray_resilient_training/ray-resilient-training.yaml
+---
+name: ray-resilient-training
+execution: parallel
+inter_connection: true
+primary_tasks: [ray-head]
+termination_delay: 20s
+
+---
+name: ray-head
+
+resources:
+  infra: kubernetes
+  cpus: 4+
+  memory: 16+
+  image_id: docker:rayproject/ray:2.58.0-py311
+  job_recovery:
+    strategy: DYNAMIC_NODE_SET
+
+volumes:
+  /ray-gcs: ray-gcs-rocksdb
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        securityContext:
+          fsGroup: 100
+          fsGroupChangePolicy: OnRootMismatch
+
+envs:
+  NUM_GPU_WORKERS: 2
+  TOTAL_STEPS: 1000
+  STEP_SECONDS: 10
+  MATRIX_SIZE: 2048
+  RECOVERY_TIMEOUT_SECONDS: 900
+
+workdir: examples/ray_resilient_training
+
+run: |
+  set -euo pipefail
+  ulimit -n 65536
+
+  RAY_HEAD_HOST="ray-head-0.${SKYPILOT_JOBGROUP_NAME}"
+  RAY_GCS_ROOT="/ray-gcs/job-${SKYPILOT_MANAGED_JOB_ID}"
+  mkdir -p "${RAY_GCS_ROOT}"
+
+  export RAY_gcs_storage=rocksdb
+  export RAY_gcs_storage_path="${RAY_GCS_ROOT}/rocksdb"
+
+  ray start \
+    --head \
+    --port=6379 \
+    --dashboard-host=0.0.0.0 \
+    --num-cpus=0 \
+    --num-gpus=0 \
+    --disable-usage-stats
+
+  python train.py \
+    --address "${RAY_HEAD_HOST}:6379" \
+    --num-workers "${NUM_GPU_WORKERS}" \
+    --steps "${TOTAL_STEPS}" \
+    --step-seconds "${STEP_SECONDS}" \
+    --matrix-size "${MATRIX_SIZE}" \
+    --recovery-timeout "${RECOVERY_TIMEOUT_SECONDS}" \
+    --state-path "${RAY_GCS_ROOT}/driver-state.json"
+
+---
+name: ray-workers
+
+num_nodes: 2
+
+resources:
+  infra: kubernetes
+  cpus: 4+
+  memory: 32+
+  accelerators: L4:1
+  image_id: docker:rayproject/ray:2.58.0-py311-cu128
+  job_recovery:
+    strategy: DYNAMIC_NODE_SET
+
+envs:
+  RAY_gcs_rpc_server_reconnect_timeout_s: 600
+
+workdir: examples/ray_resilient_training
+
+setup: |
+  python -m pip install --no-cache-dir \
+    "torch==2.9.0+cu128" \
+    --extra-index-url https://download.pytorch.org/whl/cu128
+
+run: |
+  set -euo pipefail
+  ulimit -n 65536
+
+  RAY_HEAD_HOST="ray-head-0.${SKYPILOT_JOBGROUP_NAME}"
+  python wait_for_head.py \
+    --host "${RAY_HEAD_HOST}" \
+    --port 6379 \
+    --timeout 900
+
+  ray start \
+    --address="${RAY_HEAD_HOST}:6379" \
+    --num-cpus=4 \
+    --num-gpus=1 \
+    --disable-usage-stats \
+    --block

--- a/examples/ray_resilient_training/ray-resilient-training.yaml
+++ b/examples/ray_resilient_training/ray-resilient-training.yaml
@@ -37,7 +37,7 @@ config:
 envs:
   NUM_GPU_WORKERS: 2
   TOTAL_STEPS: 1000
-  STEP_SECONDS: 10
+  BATCHES_PER_STEP: 5000
   MATRIX_SIZE: 2048
   RECOVERY_TIMEOUT_SECONDS: 900
 
@@ -66,7 +66,7 @@ run: |
     --address "${RAY_HEAD_HOST}:6379" \
     --num-workers "${NUM_GPU_WORKERS}" \
     --steps "${TOTAL_STEPS}" \
-    --step-seconds "${STEP_SECONDS}" \
+    --batches-per-step "${BATCHES_PER_STEP}" \
     --matrix-size "${MATRIX_SIZE}" \
     --recovery-timeout "${RECOVERY_TIMEOUT_SECONDS}" \
     --state-path "${RAY_GCS_ROOT}/driver-state.json"

--- a/examples/ray_resilient_training/train.py
+++ b/examples/ray_resilient_training/train.py
@@ -42,7 +42,7 @@ class GPUWorker:
             flush=True,
         )
 
-    def rollout(self, step: int, duration_seconds: float) -> Dict[str, Any]:
+    def rollout(self, step: int, num_batches: int) -> Dict[str, Any]:
         """Run an idempotent synthetic rollout for one policy step."""
         generator = self.torch.Generator(device=self.device)
         generator.manual_seed(step * 10_000 + self.rank)
@@ -52,18 +52,18 @@ class GPUWorker:
             device=self.device,
         )
 
-        deadline = time.monotonic() + duration_seconds
-        batches = 0
-        while time.monotonic() < deadline:
+        started_at = time.monotonic()
+        for _ in range(num_batches):
             activations = self.torch.tanh(activations @ self.weight)
-            batches += 1
-        self.torch.cuda.synchronize()
+            self.torch.cuda.synchronize()
+        elapsed_seconds = time.monotonic() - started_at
 
         return {
             'rank': self.rank,
             'step': step,
             'reward': float(activations.square().mean().item()),
-            'batches': batches,
+            'batches': num_batches,
+            'elapsed_seconds': elapsed_seconds,
             'incarnation': self.incarnation,
             'host': socket.gethostname(),
             'pid': os.getpid(),
@@ -114,15 +114,19 @@ def wait_for_cluster_gpus(num_workers: int, timeout: int) -> None:
         f'Ray did not register {num_workers} GPUs within {timeout}s')
 
 
-def get_or_create_workers(num_workers: int,
-                          matrix_size: int) -> List[ray.actor.ActorHandle]:
+def get_or_create_workers(num_workers: int, matrix_size: int,
+                          allow_create: bool) -> List[ray.actor.ActorHandle]:
     workers = []
     for rank in range(num_workers):
         name = f'gpu-worker-{rank}'
         try:
             worker = ray.get_actor(name)
             print(f'Reattached to detached actor {name}', flush=True)
-        except ValueError:
+        except ValueError as error:
+            if not allow_create:
+                raise RuntimeError(
+                    f'Detached actor {name} is missing while resuming from '
+                    'a completed step') from error
             worker = GPUWorker.options(name=name, lifetime='detached').remote(
                 rank, matrix_size)
             print(f'Created detached actor {name}', flush=True)
@@ -164,7 +168,7 @@ def main() -> None:
     parser.add_argument('--address', required=True)
     parser.add_argument('--num-workers', required=True, type=int)
     parser.add_argument('--steps', default=1000, type=int)
-    parser.add_argument('--step-seconds', default=10, type=float)
+    parser.add_argument('--batches-per-step', default=5000, type=int)
     parser.add_argument('--matrix-size', default=2048, type=int)
     parser.add_argument('--recovery-timeout', default=900, type=int)
     parser.add_argument('--state-path', required=True)
@@ -174,15 +178,20 @@ def main() -> None:
     namespace = f'ray-resilient-training-{managed_job_id}'
     ray.init(address=args.address, namespace=namespace)
 
-    wait_for_cluster_gpus(args.num_workers, args.recovery_timeout)
-    workers = get_or_create_workers(args.num_workers, args.matrix_size)
     state = load_state(args.state_path)
+    wait_for_cluster_gpus(args.num_workers, args.recovery_timeout)
+    workers = get_or_create_workers(
+        args.num_workers,
+        args.matrix_size,
+        allow_create=int(state['last_completed_step']) == -1,
+    )
     first_step = int(state['last_completed_step']) + 1
     print(f'Starting at step {first_step}; state={state}', flush=True)
 
     for step in range(first_step, args.steps):
         refs = [
-            worker.rollout.remote(step, args.step_seconds) for worker in workers
+            worker.rollout.remote(step, args.batches_per_step)
+            for worker in workers
         ]
         results = get_with_recovery_timeout(refs, args.recovery_timeout)
         results.sort(key=lambda result: result['rank'])

--- a/examples/ray_resilient_training/train.py
+++ b/examples/ray_resilient_training/train.py
@@ -1,0 +1,213 @@
+"""Run an RL-style multi-node GPU workload with recoverable Ray actors."""
+
+import argparse
+import json
+import os
+import socket
+import statistics
+import tempfile
+import time
+from typing import Any, Dict, List
+import uuid
+
+import ray
+
+
+@ray.remote(num_cpus=1, num_gpus=1, max_restarts=-1, max_task_retries=-1)
+class GPUWorker:
+    """A stateless rollout worker that Ray can reconstruct on another node."""
+
+    def __init__(self, rank: int, matrix_size: int):
+        import torch  # pylint: disable=import-outside-toplevel
+
+        if not torch.cuda.is_available():
+            raise RuntimeError('Ray assigned a GPU but PyTorch cannot use CUDA')
+
+        self.rank = rank
+        self.matrix_size = matrix_size
+        self.torch = torch
+        self.device = torch.device('cuda:0')
+        generator = torch.Generator(device=self.device)
+        generator.manual_seed(rank)
+        self.weight = torch.randn((matrix_size, matrix_size),
+                                  generator=generator,
+                                  device=self.device)
+        self.incarnation = uuid.uuid4().hex[:8]
+
+        print(
+            f'GPU worker rank={rank} incarnation={self.incarnation} '
+            f'host={socket.gethostname()} pid={os.getpid()} '
+            f'node_id={ray.get_runtime_context().get_node_id()} '
+            f'gpu={torch.cuda.get_device_name(0)}',
+            flush=True,
+        )
+
+    def rollout(self, step: int, duration_seconds: float) -> Dict[str, Any]:
+        """Run an idempotent synthetic rollout for one policy step."""
+        generator = self.torch.Generator(device=self.device)
+        generator.manual_seed(step * 10_000 + self.rank)
+        activations = self.torch.randn(
+            (self.matrix_size, self.matrix_size),
+            generator=generator,
+            device=self.device,
+        )
+
+        deadline = time.monotonic() + duration_seconds
+        batches = 0
+        while time.monotonic() < deadline:
+            activations = self.torch.tanh(activations @ self.weight)
+            batches += 1
+        self.torch.cuda.synchronize()
+
+        return {
+            'rank': self.rank,
+            'step': step,
+            'reward': float(activations.square().mean().item()),
+            'batches': batches,
+            'incarnation': self.incarnation,
+            'host': socket.gethostname(),
+            'pid': os.getpid(),
+            'node_id': str(ray.get_runtime_context().get_node_id()),
+            'cuda_visible_devices': os.environ.get('CUDA_VISIBLE_DEVICES'),
+        }
+
+
+def load_state(path: str) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return {'last_completed_step': -1, 'policy_version': 0.0}
+    with open(path, encoding='utf-8') as state_file:
+        return json.load(state_file)
+
+
+def save_state(path: str, state: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, temporary_path = tempfile.mkstemp(dir=os.path.dirname(path),
+                                          prefix='.driver-state-',
+                                          text=True)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as state_file:
+            json.dump(state, state_file)
+            state_file.flush()
+            os.fsync(state_file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def wait_for_cluster_gpus(num_workers: int, timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resources = ray.cluster_resources()
+        connected_gpus = int(resources.get('GPU', 0))
+        if connected_gpus >= num_workers:
+            print(f'Ray cluster has {connected_gpus} GPUs: {resources}',
+                  flush=True)
+            return
+        print(
+            f'Waiting for {num_workers} GPUs; Ray currently reports '
+            f'{connected_gpus}: {resources}',
+            flush=True,
+        )
+        time.sleep(5)
+    raise TimeoutError(
+        f'Ray did not register {num_workers} GPUs within {timeout}s')
+
+
+def get_or_create_workers(num_workers: int,
+                          matrix_size: int) -> List[ray.actor.ActorHandle]:
+    workers = []
+    for rank in range(num_workers):
+        name = f'gpu-worker-{rank}'
+        try:
+            worker = ray.get_actor(name)
+            print(f'Reattached to detached actor {name}', flush=True)
+        except ValueError:
+            worker = GPUWorker.options(name=name, lifetime='detached').remote(
+                rank, matrix_size)
+            print(f'Created detached actor {name}', flush=True)
+        workers.append(worker)
+    return workers
+
+
+def get_with_recovery_timeout(object_refs: List[ray.ObjectRef],
+                              timeout: int) -> List[Dict[str, Any]]:
+    deadline = time.monotonic() + timeout
+    remaining = list(object_refs)
+    results: List[Dict[str, Any]] = []
+    while remaining:
+        time_left = deadline - time.monotonic()
+        if time_left <= 0:
+            raise TimeoutError(
+                f'{len(remaining)} Ray rollout(s) did not recover within '
+                f'{timeout}s')
+        ready, remaining = ray.wait(
+            remaining,
+            num_returns=1,
+            timeout=min(10, time_left),
+        )
+        if ready:
+            results.extend(ray.get(ready))
+        else:
+            resources = ray.cluster_resources()
+            alive_nodes = sum(1 for node in ray.nodes() if node['Alive'])
+            print(
+                f'Waiting for {len(remaining)} rollout(s); '
+                f'alive_nodes={alive_nodes}, resources={resources}',
+                flush=True,
+            )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--address', required=True)
+    parser.add_argument('--num-workers', required=True, type=int)
+    parser.add_argument('--steps', default=1000, type=int)
+    parser.add_argument('--step-seconds', default=10, type=float)
+    parser.add_argument('--matrix-size', default=2048, type=int)
+    parser.add_argument('--recovery-timeout', default=900, type=int)
+    parser.add_argument('--state-path', required=True)
+    args = parser.parse_args()
+
+    managed_job_id = os.environ['SKYPILOT_MANAGED_JOB_ID']
+    namespace = f'ray-resilient-training-{managed_job_id}'
+    ray.init(address=args.address, namespace=namespace)
+
+    wait_for_cluster_gpus(args.num_workers, args.recovery_timeout)
+    workers = get_or_create_workers(args.num_workers, args.matrix_size)
+    state = load_state(args.state_path)
+    first_step = int(state['last_completed_step']) + 1
+    print(f'Starting at step {first_step}; state={state}', flush=True)
+
+    for step in range(first_step, args.steps):
+        refs = [
+            worker.rollout.remote(step, args.step_seconds) for worker in workers
+        ]
+        results = get_with_recovery_timeout(refs, args.recovery_timeout)
+        results.sort(key=lambda result: result['rank'])
+
+        mean_reward = statistics.fmean(result['reward'] for result in results)
+        state = {
+            'last_completed_step': step,
+            'policy_version': float(state['policy_version']) + mean_reward,
+        }
+        save_state(args.state_path, state)
+        print(
+            json.dumps(
+                {
+                    'step': step,
+                    'mean_reward': mean_reward,
+                    'policy_version': state['policy_version'],
+                    'workers': results,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+    print(f'Completed {args.steps} steps; final state={state}', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ray_resilient_training/wait_for_head.py
+++ b/examples/ray_resilient_training/wait_for_head.py
@@ -1,0 +1,38 @@
+"""Wait for the Ray head's GCS endpoint before starting a worker raylet."""
+
+import argparse
+import socket
+import time
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', required=True)
+    parser.add_argument('--port', required=True, type=int)
+    parser.add_argument('--timeout', default=900, type=int)
+    args = parser.parse_args()
+
+    deadline = time.monotonic() + args.timeout
+    last_error = 'no connection attempt made'
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((args.host, args.port), timeout=5):
+                print(f'Ray head is reachable at {args.host}:{args.port}',
+                      flush=True)
+                return
+        except OSError as error:
+            last_error = str(error)
+            print(
+                f'Waiting for Ray head at {args.host}:{args.port}: '
+                f'{last_error}',
+                flush=True,
+            )
+            time.sleep(5)
+
+    raise TimeoutError(
+        f'Ray head {args.host}:{args.port} was not reachable within '
+        f'{args.timeout}s; last error: {last_error}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Add a resilient Ray training Job Group with a CPU-only head and two GPU workers.
- Use Dynamic Node Sets for independent head and worker replacement.
- Persist Ray GCS metadata with the embedded RocksDB backend and checkpoint driver progress on the same volume.
- Document setup, launch, worker recovery, head recovery, and application checkpointing boundaries.

## Test plan

- `bash format.sh --files examples/ray_resilient_training/train.py examples/ray_resilient_training/wait_for_head.py`
- Parsed the Job Group and volume manifests with PyYAML and asserted the three-document structure, matching two-worker counts, both recovery strategies, and `ReadWriteOncePod` access mode.
- Compiled both Python entrypoints.
- Launched the same workload code on Kubernetes with a CPU head and two H100 workers. Deleted one worker pod and observed Ray reconstruct only the lost actor while the healthy actor kept its original incarnation; training resumed at the next step.
- Confirmed that the running head wrote GCS RocksDB files and driver state to the mounted volume.

The exact checked-in L4 manifest was not launched. Head replacement and restoration from the persisted GCS state were not exercised in the live run.
