### PR TITLE
[Metrics] Slurm: scope and route /federate for a shared Prometheus (filter, via)

### DIFF
--- a/docs/source/reference/api-server/examples/api-server-gpu-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-gpu-metrics-setup.rst
@@ -205,6 +205,65 @@ The flags do the following:
   scrape both the SkyPilot API server and DCGM-Exporter.
 * ``grafana.enabled`` – deploy Grafana with an out-of-the-box dashboard that will be embedded in the SkyPilot dashboard.
 
+.. _api-server-gpu-metrics-slurm:
+
+GPU metrics for Slurm clusters
+------------------------------
+
+Slurm clusters can surface GPU metrics in the same dashboard. Instead of
+scraping the cluster directly, the API server runs ``GET /federate`` against
+a Prometheus of yours *from the cluster's login node* over SSH, so the API
+server never needs network access to the Prometheus.
+
+Requirements:
+
+* **DCGM-Exporter** runs on each GPU node (port ``9400``) and **Node
+  Exporter** (port ``9100``, optional, for CPU/memory metrics) — for
+  example as containers or system services, since there is no Kubernetes on
+  the nodes.
+* A **Prometheus** (or compatible store, e.g. VictoriaMetrics) scrapes those
+  exporters and is reachable from a login node.
+* The ``Hostname`` label on DCGM series must match the Slurm node name
+  (``sinfo -N``) — the dashboard joins metrics to nodes by hostname. When
+  running DCGM-Exporter in Docker, pass ``--hostname "$(hostname)"``, since
+  the container otherwise reports its container ID as the hostname.
+
+Opt a cluster in via :ref:`config <config-yaml-slurm-cluster-configs>`:
+
+.. code-block:: yaml
+
+  slurm:
+    cluster_configs:
+      mycluster1:
+        prometheus:
+          url: http://prometheus.internal:9090
+
+If the Prometheus aggregates metrics from several clusters, scope each
+cluster's slice with ``filter`` (label matchers applied server-side), and use
+``via`` when the Prometheus is reachable from only some login nodes:
+
+.. code-block:: yaml
+
+  slurm:
+    cluster_configs:
+      mycluster1:
+        prometheus:
+          url: http://prometheus.internal:9090
+          filter:
+            cluster: mycluster1-fleet
+      mycluster2:
+        prometheus:
+          url: http://prometheus.internal:9090
+          # mycluster2's login node cannot reach the Prometheus; run the
+          # /federate request on mycluster1's login node instead. The
+          # series are still attributed to mycluster2.
+          via: mycluster1
+          filter:
+            cluster: mycluster2-fleet
+
+Clusters sharing a ``url`` automatically exclude each other's filtered
+slices, so a fleet is never attributed to two clusters.
+
 What metrics are exposed?
 ---------------------------
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -2554,6 +2554,30 @@ Supported fields:
   ``prometheus.url`` and is still honored; ``prometheus.url`` wins when both
   are set.
 
+  ``url`` and ``via`` can also be set once at the cloud level under
+  ``slurm.prometheus`` as shared defaults, inherited by any cluster that does
+  not override them. This suits the common case of one central Prometheus,
+  reachable through a single fleet's login node, serving every cluster: set
+  ``url`` (and ``via``) once and give each cluster only its own ``filter``.
+
+  .. code-block:: yaml
+
+    slurm:
+      # Shared defaults: one central Prometheus, reachable only through
+      # hub's login node, serving every cluster.
+      prometheus:
+        url: http://prometheus.internal:9090
+        via: hub
+      cluster_configs:
+        hub:
+          prometheus:
+            filter:
+              cluster: hub-fleet
+        edge:
+          prometheus:
+            filter:
+              cluster: edge-fleet
+
 Example:
 
 .. code-block:: yaml

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -165,6 +165,10 @@ Below is the configuration syntax and some example values. See detailed explanat
         gpu_partition_map:
           H100: h100-custom
         cpu_partition: cpu-only
+        prometheus:
+          url: http://prometheus.internal:9090
+          filter:
+            cluster: mycluster1-fleet
 
   :ref:`aws <config-yaml-aws>`:
     :ref:`labels <config-yaml-aws-labels>`:
@@ -2528,6 +2532,28 @@ Supported fields:
   the cluster level. Entries are merged per container path, with per-cluster
   values overriding global values.
 
+- ``prometheus``: Opts the cluster into GPU metrics federation, surfacing its
+  DCGM and node-exporter metrics in the SkyPilot dashboard. Sub-fields:
+
+  - ``url``: URL of a Prometheus that scrapes the cluster's DCGM and
+    node exporters, reachable from a login node (the cluster's own, or the
+    ``via`` cluster's). SkyPilot runs ``GET /federate`` against it from the
+    login node, so the API server never needs direct network access to it.
+  - ``filter``: Label matchers (label name to exact value) scoping this
+    cluster's slice of ``url``, for a central Prometheus that aggregates
+    metrics from several clusters. Without a filter, all series returned by
+    ``url`` are attributed to this cluster. Clusters sharing a ``url``
+    automatically exclude each other's filtered slices, so a fleet is never
+    counted twice.
+  - ``via``: Name of another Slurm cluster whose login node runs the
+    ``/federate`` request instead of this cluster's own, for a central
+    Prometheus reachable from only some login nodes. The fetched series are
+    still attributed to this cluster.
+
+  The flat ``prometheus_url`` field is a deprecated spelling of
+  ``prometheus.url`` and is still honored; ``prometheus.url`` wins when both
+  are set.
+
 Example:
 
 .. code-block:: yaml
@@ -2553,6 +2579,14 @@ Example:
           cpu: 0.06
           accelerators:
             A100: 4.00   # Override A100; V100 inherited
+        # Surface this cluster's GPU metrics in the SkyPilot dashboard,
+        # federated from a Prometheus reachable from the login node.
+        prometheus:
+          url: http://prometheus.internal:9090
+          # Only needed when the Prometheus aggregates several clusters:
+          # collect only the series carrying these labels.
+          filter:
+            cluster: mycluster1-fleet
 
       mycluster2:
         workdir: /home/$USER
@@ -2572,6 +2606,15 @@ Example:
             pricing:
               accelerators:
                 H100: 5.00
+        # GPU metrics federation from a central Prometheus that aggregates
+        # both clusters but is reachable only from mycluster1's login node.
+        prometheus:
+          url: http://prometheus.internal:9090
+          # Run the /federate request on mycluster1's login node.
+          via: mycluster1
+          # Collect only this cluster's slice of the shared Prometheus.
+          filter:
+            cluster: mycluster2-fleet
 
 .. _config-yaml-oci:
 

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1557,9 +1557,10 @@ def get_slurm_metrics_clusters() -> List[str]:
     (the analog of ``kubernetes.allowed_contexts``; defaults to every cluster
     in ``~/.slurm/config``) *and*
     ``slurm.cluster_configs.<name>.prometheus.url`` is set: the URL of a
-    Prometheus reachable *from the cluster's login node* (typically running
-    inside the cluster) that scrapes the cluster's node/DCGM exporters. No SSH
-    probing happens here — enumeration reads only local config.
+    Prometheus reachable *from a login node* — the cluster's own, or the
+    ``prometheus.via`` cluster's — that scrapes the cluster's node/DCGM
+    exporters. No SSH probing happens here — enumeration reads only local
+    config.
     """
     try:
         # pylint: disable=import-outside-toplevel
@@ -1581,13 +1582,18 @@ async def get_metrics_for_slurm_cluster(cluster_name: str,
                                         timeout: float = 30.0) -> str:
     """Federate GPU metrics from a Slurm cluster's own Prometheus.
 
-    The /federate request is executed *on* the login node (curl) through
-    the cluster's SSH transport, so it traverses outbound-only tunnel
+    The /federate request is executed *on* a login node (curl) through
+    that cluster's SSH transport, so it traverses outbound-only tunnel
     agents unchanged and never requires network reachability from the API
-    server to the cluster's Prometheus. Series are stamped with
-    ``cluster="slurm/<name>"``, mirroring the Kubernetes federation path,
-    so every downstream consumer (central Prometheus, Grafana dashboards,
-    GPU Manager queries) treats the Slurm cluster like any other context.
+    server to the cluster's Prometheus. By default that is this cluster's
+    own login node; ``prometheus.via`` names a different Slurm cluster to
+    run the curl on, for a central Prometheus reachable from only some
+    login nodes — every cluster it aggregates can then still be collected,
+    each through the login node that can reach it. Series are stamped with
+    ``cluster="slurm/<name>"`` regardless of which login node fetched
+    them, mirroring the Kubernetes federation path, so every downstream
+    consumer (central Prometheus, Grafana dashboards, GPU Manager queries)
+    treats the Slurm cluster like any other context.
 
     Timeouts mirror the Kubernetes path's single per-context budget: the
     SSH invocation is hard-killed at ``timeout`` (a hung login node cannot
@@ -1610,6 +1616,9 @@ async def get_metrics_for_slurm_cluster(cluster_name: str,
     if not prometheus_url:
         raise ValueError(
             f'No prometheus.url configured for Slurm cluster {cluster_name!r}')
+    login_cluster = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name, 'prometheus', 'via'),
+        None) or cluster_name
 
     # Scope the pull when the source Prometheus aggregates several fleets;
     # without this every fleet's series would be stamped with this cluster's
@@ -1634,11 +1643,13 @@ async def get_metrics_for_slurm_cluster(cluster_name: str,
         # exposition text would make Prometheus reject the *entire*
         # /gpu-metrics body, every cluster included.
         returncode, stdout, stderr = slurm_utils.run_on_login_node(
-            cluster_name, curl_cmd, timeout=int(timeout))
+            login_cluster, curl_cmd, timeout=int(timeout))
         if returncode != 0:
+            via = ('' if login_cluster == cluster_name else
+                   f' (via {login_cluster!r})')
             raise RuntimeError(
-                f'Federate curl on Slurm cluster {cluster_name!r} exited '
-                f'{returncode}: {(stderr or stdout).strip()[:500]}')
+                f'Federate curl on Slurm cluster {cluster_name!r}{via} '
+                f'exited {returncode}: {(stderr or stdout).strip()[:500]}')
         return stdout
 
     start = time.monotonic()

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1421,6 +1421,134 @@ SLURM_CONTEXT_PREFIX = 'slurm/'
 # stamping after it have to fit in the same budget.
 _SLURM_FEDERATE_CURL_HEADROOM_SECONDS = 5
 
+# A Prometheus label name. Filter keys are validated against this before
+# being interpolated into a selector: an invalid name would produce a
+# selector Prometheus rejects, failing the whole cluster's federation.
+_PROM_LABEL_NAME_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+
+
+def _escape_prom_label_value(value: str) -> str:
+    """Escapes a string for use inside a double-quoted label matcher."""
+    return value.replace('\\', '\\\\').replace('"', '\\"')
+
+
+def _slurm_prometheus_url(cluster_name: str) -> Optional[str]:
+    """Configured /federate base URL for a Slurm cluster, if any.
+
+    ``slurm.cluster_configs.<name>.prometheus.url`` is the current spelling.
+    The flat ``prometheus_url`` it replaced is still honored as a fallback:
+    it is live in deployed configs, and dropping it would silently stop a
+    cluster's federation on upgrade.
+    """
+    url = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name, 'prometheus', 'url'), None)
+    if url:
+        return url
+    return skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name, 'prometheus_url'), None)
+
+
+def get_slurm_prometheus_filters(cluster_name: str) -> Dict[str, str]:
+    """Label matchers scoping a Slurm cluster's slice of its Prometheus.
+
+    Read from ``slurm.cluster_configs.<name>.prometheus.filter``: a mapping
+    of label name to exact value. Entries whose key is not a valid Prometheus
+    label name are dropped with a warning rather than allowed to corrupt the
+    selector, which would fail the cluster's whole federation.
+    """
+    raw = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name, 'prometheus', 'filter'),
+        None) or {}
+    if not isinstance(raw, dict):
+        logger.warning(
+            f'Ignoring prometheus.filter for Slurm cluster {cluster_name!r}: '
+            f'expected a mapping of label name to value, got {type(raw)}.')
+        return {}
+    filters: Dict[str, str] = {}
+    for label, value in raw.items():
+        if not _PROM_LABEL_NAME_RE.match(str(label)):
+            logger.warning(
+                f'Ignoring prometheus.filter entry {label!r} for Slurm '
+                f'cluster {cluster_name!r}: not a valid Prometheus label '
+                f'name.')
+            continue
+        filters[str(label)] = str(value)
+    return filters
+
+
+def slurm_federate_matchers(cluster_name: str) -> List[str]:
+    """Label matchers appended to this cluster's /federate selectors.
+
+    Two sources, both aimed at the same problem: one Prometheus that
+    aggregates several fleets, where an unscoped ``DCGM_.*`` pull would
+    attribute every fleet's series to whichever Slurm cluster asked.
+
+    1. This cluster's own ``prometheus.filter`` becomes positive matchers,
+       so the source Prometheus does the filtering and only this fleet's
+       series cross the wire.
+    2. Sibling clusters configured against the *same* ``prometheus.url``
+       contribute negative matchers derived from their own filters. This is
+       what keeps a fleet from being double-counted when only some clusters
+       declare a filter: whatever a sibling has positively claimed is
+       excluded here. Only single-label sibling filters are usable — a
+       multi-label filter negates to a disjunction, which a Prometheus
+       selector (an AND of matchers) cannot express — and a label this
+       cluster already constrains is left alone, since its own filter is
+       the more specific statement.
+    """
+    own = get_slurm_prometheus_filters(cluster_name)
+    matchers = [
+        f'{label}="{_escape_prom_label_value(value)}"'
+        for label, value in sorted(own.items())
+    ]
+
+    url = _slurm_prometheus_url(cluster_name)
+    if url is None:
+        return matchers
+
+    # Candidates come from the config mapping first: it is a plain dict read,
+    # where get_slurm_metrics_clusters() enumerates ~/.slurm/config. The
+    # overwhelmingly common case is a cluster that shares its Prometheus with
+    # nobody, and that case should not pay for the enumeration.
+    configs = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs'), None) or {}
+    candidates = [
+        name for name in configs
+        if name != cluster_name and _slurm_prometheus_url(name) == url
+    ]
+    if not candidates:
+        return matchers
+
+    # Narrowed to clusters actually federated: a cluster excluded by
+    # slurm.allowed_clusters claims nothing, so subtracting its slice here
+    # would drop series no cluster goes on to collect.
+    federated = set(get_slurm_metrics_clusters())
+    for sibling in candidates:
+        if sibling not in federated:
+            continue
+        sibling_filters = get_slurm_prometheus_filters(sibling)
+        if len(sibling_filters) != 1:
+            continue
+        label, value = next(iter(sibling_filters.items()))
+        if label in own:
+            continue
+        matchers.append(f'{label}!="{_escape_prom_label_value(value)}"')
+    return matchers
+
+
+def _with_label_matchers(pattern: str, matchers: List[str]) -> str:
+    """Adds ``matchers`` to a /federate selector's label section."""
+    if not matchers:
+        return pattern
+    extra = ','.join(matchers)
+    if pattern.endswith('}'):
+        head = pattern[:-1]
+        # '{}' / a bare '{' would leave a leading comma, which Prometheus
+        # rejects.
+        separator = '' if head.endswith('{') else ','
+        return f'{head}{separator}{extra}}}'
+    return f'{pattern}{{{extra}}}'
+
 
 def get_slurm_metrics_clusters() -> List[str]:
     """Slurm clusters opted into GPU metrics federation.
@@ -1428,7 +1556,7 @@ def get_slurm_metrics_clusters() -> List[str]:
     A cluster participates when it is allowed by ``slurm.allowed_clusters``
     (the analog of ``kubernetes.allowed_contexts``; defaults to every cluster
     in ``~/.slurm/config``) *and*
-    ``slurm.cluster_configs.<name>.prometheus_url`` is set: the URL of a
+    ``slurm.cluster_configs.<name>.prometheus.url`` is set: the URL of a
     Prometheus reachable *from the cluster's login node* (typically running
     inside the cluster) that scrapes the cluster's node/DCGM exporters. No SSH
     probing happens here — enumeration reads only local config.
@@ -1445,11 +1573,7 @@ def get_slurm_metrics_clusters() -> List[str]:
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Could not enumerate Slurm clusters: {e}')
         return []
-    return [
-        name for name in names
-        if skypilot_config.get_nested(('slurm', 'cluster_configs', name,
-                                       'prometheus_url'), None)
-    ]
+    return [name for name in names if _slurm_prometheus_url(name)]
 
 
 async def get_metrics_for_slurm_cluster(cluster_name: str,
@@ -1482,13 +1606,17 @@ async def get_metrics_for_slurm_cluster(cluster_name: str,
     Raises:
         Exception: If the login-node curl or the federate request fails.
     """
-    prometheus_url = skypilot_config.get_nested(
-        ('slurm', 'cluster_configs', cluster_name, 'prometheus_url'), None)
+    prometheus_url = _slurm_prometheus_url(cluster_name)
     if not prometheus_url:
         raise ValueError(
-            f'No prometheus_url configured for Slurm cluster {cluster_name!r}')
+            f'No prometheus.url configured for Slurm cluster {cluster_name!r}')
 
-    query = '&'.join('match[]=' + urllib.parse.quote(pattern)
+    # Scope the pull when the source Prometheus aggregates several fleets;
+    # without this every fleet's series would be stamped with this cluster's
+    # context. See slurm_federate_matchers().
+    matchers = slurm_federate_matchers(cluster_name)
+    query = '&'.join('match[]=' +
+                     urllib.parse.quote(_with_label_matchers(pattern, matchers))
                      for pattern in SLURM_GPU_METRICS_MATCH_PATTERNS)
     federate_url = prometheus_url.rstrip('/') + '/federate?' + query
     curl_timeout = max(1, int(timeout) - _SLURM_FEDERATE_CURL_HEADROOM_SECONDS)

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1440,17 +1440,22 @@ def _escape_prom_label_value(value: str) -> str:
 def _slurm_prometheus_url(cluster_name: str) -> Optional[str]:
     """Configured /federate base URL for a Slurm cluster, if any.
 
-    ``slurm.cluster_configs.<name>.prometheus.url`` is the current spelling.
-    The flat ``prometheus_url`` it replaced is still honored as a fallback:
-    it is live in deployed configs, and dropping it would silently stop a
-    cluster's federation on upgrade.
+    Resolution order: the per-cluster
+    ``slurm.cluster_configs.<name>.prometheus.url``; the flat
+    ``prometheus_url`` it replaced (still honored — live in deployed configs,
+    and dropping it would silently stop a cluster's federation on upgrade);
+    then the shared ``slurm.prometheus.url`` default, so a single central
+    Prometheus serving every fleet need not be repeated on each cluster.
     """
     url = skypilot_config.get_nested(
         ('slurm', 'cluster_configs', cluster_name, 'prometheus', 'url'), None)
     if url:
         return url
-    return skypilot_config.get_nested(
+    flat = skypilot_config.get_nested(
         ('slurm', 'cluster_configs', cluster_name, 'prometheus_url'), None)
+    if flat:
+        return flat
+    return skypilot_config.get_nested(('slurm', 'prometheus', 'url'), None)
 
 
 def get_slurm_prometheus_filters(cluster_name: str) -> Dict[str, str]:
@@ -1642,7 +1647,8 @@ async def get_metrics_for_slurm_cluster(cluster_name: str,
             f'No prometheus.url configured for Slurm cluster {cluster_name!r}')
     login_cluster = skypilot_config.get_nested(
         ('slurm', 'cluster_configs', cluster_name, 'prometheus', 'via'),
-        None) or cluster_name
+        None) or skypilot_config.get_nested(
+            ('slurm', 'prometheus', 'via'), None) or cluster_name
 
     # Scope the pull when the source Prometheus aggregates several fleets;
     # without this every fleet's series would be stamped with this cluster's

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1428,8 +1428,13 @@ _PROM_LABEL_NAME_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
 
 
 def _escape_prom_label_value(value: str) -> str:
-    """Escapes a string for use inside a double-quoted label matcher."""
-    return value.replace('\\', '\\\\').replace('"', '\\"')
+    """Escapes a string for use inside a double-quoted label matcher.
+
+    Prometheus string literals take backslash escapes; a literal newline,
+    by contrast, ends the selector mid-string and fails the whole request.
+    """
+    return (value.replace('\\', '\\\\').replace('"',
+                                                '\\"').replace('\n', '\\n'))
 
 
 def _slurm_prometheus_url(cluster_name: str) -> Optional[str]:
@@ -1492,7 +1497,9 @@ def slurm_federate_matchers(cluster_name: str) -> List[str]:
        declare a filter: whatever a sibling has positively claimed is
        excluded here. Only single-label sibling filters are usable — a
        multi-label filter negates to a disjunction, which a Prometheus
-       selector (an AND of matchers) cannot express — and a label this
+       selector (an AND of matchers) cannot express; when that leaves an
+       unfiltered cluster unable to carve out a sibling's slice, a warning
+       is logged instead of silently double-counting. A label this
        cluster already constrains is left alone, since its own filter is
        the more specific statement.
     """
@@ -1505,6 +1512,10 @@ def slurm_federate_matchers(cluster_name: str) -> List[str]:
     url = _slurm_prometheus_url(cluster_name)
     if url is None:
         return matchers
+    # Trailing-slash variants are the same service — the federate URL is
+    # built with the same rstrip — and must count as sharing a Prometheus,
+    # or an unfiltered cluster silently re-imports its sibling's slice.
+    url = url.rstrip('/')
 
     # Candidates come from the config mapping first: it is a plain dict read,
     # where get_slurm_metrics_clusters() enumerates ~/.slurm/config. The
@@ -1513,8 +1524,8 @@ def slurm_federate_matchers(cluster_name: str) -> List[str]:
     configs = skypilot_config.get_nested(
         ('slurm', 'cluster_configs'), None) or {}
     candidates = [
-        name for name in configs
-        if name != cluster_name and _slurm_prometheus_url(name) == url
+        name for name in configs if name != cluster_name and
+        (_slurm_prometheus_url(name) or '').rstrip('/') == url
     ]
     if not candidates:
         return matchers
@@ -1528,6 +1539,19 @@ def slurm_federate_matchers(cluster_name: str) -> List[str]:
             continue
         sibling_filters = get_slurm_prometheus_filters(sibling)
         if len(sibling_filters) != 1:
+            if sibling_filters and not own:
+                # This cluster pulls the whole endpoint and cannot carve
+                # out the sibling's compound slice, so that fleet will be
+                # collected twice. Surfaced rather than silent: the fix is
+                # a filter on this cluster (or a single-label one on the
+                # sibling).
+                logger.warning(
+                    f'Slurm cluster {cluster_name!r} has no '
+                    f'prometheus.filter and shares its Prometheus with '
+                    f'{sibling!r}, whose multi-label filter cannot be '
+                    f'excluded from an unscoped pull; {sibling!r} series '
+                    f'may be double-counted. Configure a filter for '
+                    f'{cluster_name!r} to scope its slice.')
             continue
         label, value = next(iter(sibling_filters.items()))
         if label in own:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2222,6 +2222,13 @@ def get_config_schema():
                                             'type': 'string',
                                         },
                                     },
+                                    # Slurm cluster whose login node runs the
+                                    # /federate curl instead of this
+                                    # cluster's own, for a central Prometheus
+                                    # reachable from only some login nodes.
+                                    'via': {
+                                        'type': 'string',
+                                    },
                                 },
                             },
                             # Deprecated: superseded by `prometheus.url`,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2176,6 +2176,25 @@ def get_config_schema():
                     'type': 'string',
                 },
                 'container_mounts': _CONTAINER_MOUNTS_SCHEMA,
+                # Shared GPU-metrics federation defaults, applied to any
+                # cluster that does not override them under cluster_configs.
+                # The common case: one central Prometheus, reachable through a
+                # single fleet's login node, serving every cluster — set `url`
+                # (and `via`) once here rather than on each cluster, and give
+                # each cluster only its own `prometheus.filter`.
+                'prometheus': {
+                    'type': 'object',
+                    'required': [],
+                    'additionalProperties': False,
+                    'properties': {
+                        'url': {
+                            'type': 'string',
+                        },
+                        'via': {
+                            'type': 'string',
+                        },
+                    },
+                },
                 'cluster_configs': {
                     'type': 'object',
                     'required': [],

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2197,10 +2197,35 @@ def get_config_schema():
                             'submit_as_user': {
                                 'type': 'boolean',
                             },
-                            # URL of a Prometheus reachable from the
-                            # cluster's login node that scrapes the
-                            # cluster's node/DCGM exporters; opts the
-                            # cluster into /gpu-metrics federation.
+                            # The Prometheus this cluster's GPU metrics are
+                            # federated from.
+                            'prometheus': {
+                                'type': 'object',
+                                'required': [],
+                                'additionalProperties': False,
+                                'properties': {
+                                    # Reachable from the cluster's login
+                                    # node, scraping the cluster's node/DCGM
+                                    # exporters; opts the cluster into
+                                    # /gpu-metrics federation.
+                                    'url': {
+                                        'type': 'string',
+                                    },
+                                    # Label matchers scoping this cluster's
+                                    # slice of `url`, for a Prometheus that
+                                    # aggregates several fleets. Without them
+                                    # an unscoped DCGM_.* pull attributes
+                                    # every fleet's series to this cluster.
+                                    'filter': {
+                                        'type': 'object',
+                                        'additionalProperties': {
+                                            'type': 'string',
+                                        },
+                                    },
+                                },
+                            },
+                            # Deprecated: superseded by `prometheus.url`,
+                            # kept so deployed configs keep federating.
                             'prometheus_url': {
                                 'type': 'string',
                             },

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1290,6 +1290,82 @@ def test_slurm_via_failure_names_both_clusters(monkeypatch):
             asyncio.run(utils.get_metrics_for_slurm_cluster('edge'))
 
 
+def test_slurm_top_level_prometheus_url_default(monkeypatch):
+    # One central Prometheus for every fleet: set slurm.prometheus.url once,
+    # and a cluster with no per-cluster url inherits it.
+    def _cfg(keys, default_value=None, **_):
+        if tuple(keys) == ('slurm', 'prometheus', 'url'):
+            return _SHARED_PROM_URL
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['hpc']):
+        assert utils.get_slurm_metrics_clusters() == ['hpc']
+        with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                        return_value=(0, '', '')) as run:
+            asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+    assert _SHARED_PROM_URL.rstrip('/') + '/federate?' in run.call_args.args[1]
+
+
+def test_slurm_per_cluster_url_wins_over_top_level_default(monkeypatch):
+
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs', 'hpc', 'prometheus', 'url'):
+            return 'http://per-cluster:9091'
+        if keys == ('slurm', 'prometheus', 'url'):
+            return 'http://shared:9090'
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+    cmd = run.call_args.args[1]
+    assert 'http://per-cluster:9091/federate?' in cmd
+    assert 'shared' not in cmd
+
+
+def test_slurm_flat_url_wins_over_top_level_default(monkeypatch):
+    # The deprecated flat per-cluster spelling is more specific than the
+    # shared default and must not be overridden by it on upgrade.
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'):
+            return 'http://flat:9090'
+        if keys == ('slurm', 'prometheus', 'url'):
+            return 'http://shared:9091'
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+    cmd = run.call_args.args[1]
+    assert 'http://flat:9090/federate?' in cmd
+    assert 'shared' not in cmd
+
+
+def test_slurm_top_level_via_default(monkeypatch):
+    # Central Prometheus reachable only through one fleet's login node: set
+    # slurm.prometheus.{url,via} once, and a cluster with no per-cluster via
+    # routes its curl through that login node.
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'prometheus', 'url'):
+            return _SHARED_PROM_URL
+        if keys == ('slurm', 'prometheus', 'via'):
+            return 'hub'
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('edge'))
+    assert run.call_args.args[0] == 'hub'
+
+
 def test_slurm_filter_newline_is_escaped(monkeypatch):
     # A literal newline in a matcher ends the selector mid-string and fails
     # the whole federate request; it must ride as the \n escape instead.

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -902,8 +902,8 @@ _SLURM_PROM_URL = 'http://prometheus.hpc.internal:9090/'
 
 
 def _slurm_config(keys, default_value=None, **_):
-    # Only cluster 'hpc' opted in via slurm.cluster_configs.hpc.prometheus_url.
-    if tuple(keys) == ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'):
+    # Only cluster 'hpc' opted in, via slurm.cluster_configs.hpc.prometheus.url.
+    if tuple(keys) == ('slurm', 'cluster_configs', 'hpc', 'prometheus', 'url'):
         return _SLURM_PROM_URL
     return default_value
 
@@ -923,14 +923,14 @@ def test_get_slurm_metrics_clusters_tolerates_enumeration_failure(monkeypatch):
 
 
 def test_get_slurm_metrics_clusters_respects_allowed_clusters(monkeypatch):
-    # A cluster with a prometheus_url that is NOT in allowed_clusters is
+    # A cluster with a prometheus.url that is NOT in allowed_clusters is
     # excluded: federation is scoped to slurm.allowed_clusters (via
     # Slurm.existing_allowed_clusters), mirroring the Kubernetes federation's
     # use of allowed_contexts.
     def _cfg(keys, default_value=None, **_):
         if tuple(keys) in (
-            ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'),
-            ('slurm', 'cluster_configs', 'blocked', 'prometheus_url'),
+            ('slurm', 'cluster_configs', 'hpc', 'prometheus', 'url'),
+            ('slurm', 'cluster_configs', 'blocked', 'prometheus', 'url'),
         ):
             return _SLURM_PROM_URL
         return default_value
@@ -1002,6 +1002,237 @@ def test_get_metrics_for_slurm_cluster_nonzero_exit_raises(monkeypatch):
 def test_get_metrics_for_slurm_cluster_unconfigured_raises(monkeypatch):
     monkeypatch.setattr(utils.skypilot_config, 'get_nested', _slurm_config)
     with mock.patch('sky.provision.slurm.utils.run_on_login_node') as run:
-        with pytest.raises(ValueError, match='No prometheus_url'):
+        with pytest.raises(ValueError, match='No prometheus.url'):
             asyncio.run(utils.get_metrics_for_slurm_cluster('other'))
     run.assert_not_called()
+
+
+# --- Slurm federate scoping (prometheus.filter) ---
+# One Prometheus aggregating several fleets: without scoping, an unscoped
+# DCGM_.* pull stamps every fleet's series with whichever cluster asked.
+
+_SHARED_PROM_URL = 'http://central-vm.internal:9091'
+
+
+def _shared_prom_config(filters_by_cluster):
+    """get_nested stub: two clusters on one Prometheus, given filters."""
+
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs'):
+            return {name: {} for name in filters_by_cluster}
+        if (len(keys) == 5 and keys[:2] == ('slurm', 'cluster_configs') and
+                keys[3:] == ('prometheus', 'url')):
+            return (_SHARED_PROM_URL
+                    if keys[2] in filters_by_cluster else default_value)
+        if (len(keys) == 5 and keys[:2] == ('slurm', 'cluster_configs') and
+                keys[3:] == ('prometheus', 'filter')):
+            return filters_by_cluster.get(keys[2]) or default_value
+        return default_value
+
+    return _cfg
+
+
+def test_slurm_filters_become_positive_matchers(monkeypatch):
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({'prod': {
+            'cluster': 'site-prod-gpu'
+        }}))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        assert utils.slurm_federate_matchers('prod') == [
+            'cluster="site-prod-gpu"'
+        ]
+
+
+def test_slurm_sibling_filter_becomes_negative_matcher(monkeypatch):
+    # 'prod' declares nothing; 'lab' claims cluster="site-lab" on the same
+    # Prometheus. 'prod' must not also collect (and re-stamp) that slice.
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({
+            'prod': None,
+            'lab': {
+                'cluster': 'site-lab'
+            },
+        }))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod', 'lab']):
+        assert utils.slurm_federate_matchers('prod') == ['cluster!="site-lab"']
+        # The claimant itself keeps only its positive matcher.
+        assert utils.slurm_federate_matchers('lab') == ['cluster="site-lab"']
+
+
+def test_slurm_own_filter_wins_over_sibling_negation(monkeypatch):
+    # Both constrain `cluster`; 'prod' pinning its own value already excludes
+    # the sibling, and adding cluster!="site-lab" would be redundant noise.
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({
+            'prod': {
+                'cluster': 'site-prod-gpu'
+            },
+            'lab': {
+                'cluster': 'site-lab'
+            },
+        }))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod', 'lab']):
+        assert utils.slurm_federate_matchers('prod') == [
+            'cluster="site-prod-gpu"'
+        ]
+
+
+def test_slurm_sibling_not_federated_is_not_subtracted(monkeypatch):
+    # 'lab' is configured but excluded by allowed_clusters, so it collects
+    # nothing; subtracting its slice would drop those series entirely.
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({
+            'prod': None,
+            'lab': {
+                'cluster': 'site-lab'
+            },
+        }))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        assert utils.slurm_federate_matchers('prod') == []
+
+
+def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch):
+    # Negating an AND of matchers is a disjunction, which a Prometheus
+    # selector cannot express; leave it rather than over-exclude.
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({
+            'prod': None,
+            'lab': {
+                'cluster': 'site-lab',
+                'region': 'us'
+            },
+        }))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod', 'lab']):
+        assert utils.slurm_federate_matchers('prod') == []
+
+
+def test_slurm_distinct_prometheus_urls_do_not_interact(monkeypatch):
+
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs'):
+            return {'prod': {}, 'lab': {}}
+        if keys == ('slurm', 'cluster_configs', 'prod', 'prometheus', 'url'):
+            return _SHARED_PROM_URL
+        if keys == ('slurm', 'cluster_configs', 'lab', 'prometheus', 'url'):
+            return 'http://other-vm.internal:9091'
+        if keys == ('slurm', 'cluster_configs', 'lab', 'prometheus', 'filter'):
+            return {'cluster': 'site-lab'}
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod', 'lab']):
+        assert utils.slurm_federate_matchers('prod') == []
+
+
+def test_slurm_invalid_filter_label_is_dropped(monkeypatch):
+    # An invalid label name would build a selector Prometheus rejects,
+    # failing the cluster's whole federation.
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config(
+            {'prod': {
+                'bad label': 'x',
+                'cluster': 'site-prod-gpu'
+            }}))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        assert utils.slurm_federate_matchers('prod') == [
+            'cluster="site-prod-gpu"'
+        ]
+
+
+def test_slurm_filter_value_is_escaped(monkeypatch):
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested',
+                        _shared_prom_config({'prod': {
+                            'cluster': 'a"b\\c'
+                        }}))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        assert utils.slurm_federate_matchers('prod') == ['cluster="a\\"b\\\\c"']
+
+
+def test_with_label_matchers_selector_shapes():
+    # Braced selector with existing matchers.
+    assert utils._with_label_matchers(
+        'node_cpu{mode="idle"}',
+        ['cluster="c"']) == ('node_cpu{mode="idle",cluster="c"}')
+    # Name-less selector.
+    assert utils._with_label_matchers(
+        '{__name__=~"DCGM_.*"}',
+        ['cluster="c"']) == ('{__name__=~"DCGM_.*",cluster="c"}')
+    # Empty brace section must not produce a leading comma.
+    assert utils._with_label_matchers(
+        'node_cpu{}', ['cluster="c"']) == 'node_cpu{cluster="c"}'
+    # Bare metric name.
+    assert utils._with_label_matchers(
+        'node_cpu', ['cluster="c"']) == 'node_cpu{cluster="c"}'
+    # No matchers leaves the pattern byte-identical.
+    assert utils._with_label_matchers('node_cpu{mode="idle"}',
+                                      []) == 'node_cpu{mode="idle"}'
+
+
+def test_get_metrics_for_slurm_cluster_applies_filters(monkeypatch):
+    monkeypatch.setattr(
+        utils.skypilot_config, 'get_nested',
+        _shared_prom_config({'prod': {
+            'cluster': 'site-prod-gpu'
+        }}))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                        return_value=(0, '', '')) as run:
+            asyncio.run(utils.get_metrics_for_slurm_cluster('prod'))
+    cmd = run.call_args.args[1]
+    # The matcher rides inside every match[] selector, percent-encoded.
+    assert cmd.count('cluster%3D%22site-prod-gpu%22') == len(
+        utils.SLURM_GPU_METRICS_MATCH_PATTERNS)
+
+
+def test_slurm_flat_prometheus_url_still_honored(monkeypatch):
+    # The pre-`prometheus:` spelling is live in deployed configs; dropping it
+    # would silently stop a cluster's federation on upgrade.
+    def _cfg(keys, default_value=None, **_):
+        if tuple(keys) == ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'):
+            return _SLURM_PROM_URL
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['hpc']):
+        assert utils.get_slurm_metrics_clusters() == ['hpc']
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+    assert _SLURM_PROM_URL.rstrip('/') + '/federate?' in run.call_args.args[1]
+
+
+def test_slurm_nested_prometheus_url_wins_over_flat(monkeypatch):
+
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs', 'hpc', 'prometheus', 'url'):
+            return 'http://new.internal:9091'
+        if keys == ('slurm', 'cluster_configs', 'hpc', 'prometheus_url'):
+            return 'http://old.internal:9090'
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(0, '', '')) as run:
+        asyncio.run(utils.get_metrics_for_slurm_cluster('hpc'))
+    cmd = run.call_args.args[1]
+    assert 'http://new.internal:9091/federate?' in cmd
+    assert 'old.internal' not in cmd

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1100,10 +1100,12 @@ def test_slurm_sibling_not_federated_is_not_subtracted(monkeypatch):
         assert utils.slurm_federate_matchers('prod') == []
 
 
-def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch, caplog):
+def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch):
     # Negating an AND of matchers is a disjunction, which a Prometheus
     # selector cannot express; leave it rather than over-exclude — but warn,
     # since the unfiltered cluster will double-count the sibling's slice.
+    # (sky loggers set propagate=False, so pytest's caplog — a root-logger
+    # handler — never sees their records; assert on the logger call instead.)
     monkeypatch.setattr(
         utils.skypilot_config, 'get_nested',
         _shared_prom_config({
@@ -1115,9 +1117,9 @@ def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch, caplog):
         }))
     with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
                     return_value=['prod', 'lab']):
-        with caplog.at_level('WARNING', logger=utils.logger.name):
+        with mock.patch.object(utils.logger, 'warning') as warn:
             assert utils.slurm_federate_matchers('prod') == []
-    assert 'double-counted' in caplog.text
+    assert any('double-counted' in str(call) for call in warn.call_args_list)
 
 
 def test_slurm_distinct_prometheus_urls_do_not_interact(monkeypatch):

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1236,3 +1236,52 @@ def test_slurm_nested_prometheus_url_wins_over_flat(monkeypatch):
     cmd = run.call_args.args[1]
     assert 'http://new.internal:9091/federate?' in cmd
     assert 'old.internal' not in cmd
+
+
+def test_slurm_via_routes_curl_to_other_login_node(monkeypatch):
+    # A central Prometheus reachable only from 'hub': 'edge' collects its own
+    # slice through hub's login node, and the series are still attributed to
+    # 'edge' — transport and attribution are independent.
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs'):
+            return {'hub': {}, 'edge': {}}
+        if keys[-2:] == ('prometheus', 'url') and keys[2] in ('hub', 'edge'):
+            return _SHARED_PROM_URL
+        if keys == ('slurm', 'cluster_configs', 'edge', 'prometheus', 'via'):
+            return 'hub'
+        if keys == ('slurm', 'cluster_configs', 'edge', 'prometheus', 'filter'):
+            return {'cluster': 'site-edge'}
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    body = 'DCGM_FI_DEV_GPU_UTIL{cluster="site-edge",gpu="0"} 5\n'
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['hub', 'edge']):
+        with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                        return_value=(0, body, '')) as run:
+            out = asyncio.run(utils.get_metrics_for_slurm_cluster('edge'))
+    # curl ran on hub's login node...
+    assert run.call_args.args[0] == 'hub'
+    # ...scoped to edge's slice...
+    assert 'cluster%3D%22site-edge%22' in run.call_args.args[1]
+    # ...and the series are stamped as edge, not hub.
+    assert out == 'DCGM_FI_DEV_GPU_UTIL{cluster="slurm/edge",gpu="0"} 5'
+
+
+def test_slurm_via_failure_names_both_clusters(monkeypatch):
+
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs', 'edge', 'prometheus', 'url'):
+            return _SHARED_PROM_URL
+        if keys == ('slurm', 'cluster_configs', 'edge', 'prometheus', 'via'):
+            return 'hub'
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.provision.slurm.utils.run_on_login_node',
+                    return_value=(7, '', 'curl: (7) Failed to connect')):
+        with pytest.raises(RuntimeError,
+                           match=r"'edge' \(via 'hub'\) exited 7"):
+            asyncio.run(utils.get_metrics_for_slurm_cluster('edge'))

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1100,9 +1100,10 @@ def test_slurm_sibling_not_federated_is_not_subtracted(monkeypatch):
         assert utils.slurm_federate_matchers('prod') == []
 
 
-def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch):
+def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch, caplog):
     # Negating an AND of matchers is a disjunction, which a Prometheus
-    # selector cannot express; leave it rather than over-exclude.
+    # selector cannot express; leave it rather than over-exclude — but warn,
+    # since the unfiltered cluster will double-count the sibling's slice.
     monkeypatch.setattr(
         utils.skypilot_config, 'get_nested',
         _shared_prom_config({
@@ -1114,7 +1115,9 @@ def test_slurm_multi_label_sibling_filter_not_negated(monkeypatch):
         }))
     with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
                     return_value=['prod', 'lab']):
-        assert utils.slurm_federate_matchers('prod') == []
+        with caplog.at_level('WARNING', logger=utils.logger.name):
+            assert utils.slurm_federate_matchers('prod') == []
+    assert 'double-counted' in caplog.text
 
 
 def test_slurm_distinct_prometheus_urls_do_not_interact(monkeypatch):
@@ -1285,3 +1288,37 @@ def test_slurm_via_failure_names_both_clusters(monkeypatch):
         with pytest.raises(RuntimeError,
                            match=r"'edge' \(via 'hub'\) exited 7"):
             asyncio.run(utils.get_metrics_for_slurm_cluster('edge'))
+
+
+def test_slurm_filter_newline_is_escaped(monkeypatch):
+    # A literal newline in a matcher ends the selector mid-string and fails
+    # the whole federate request; it must ride as the \n escape instead.
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested',
+                        _shared_prom_config({'prod': {
+                            'cluster': 'a\nb'
+                        }}))
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod']):
+        assert utils.slurm_federate_matchers('prod') == ['cluster="a\\nb"']
+
+
+def test_slurm_trailing_slash_urls_count_as_shared(monkeypatch):
+    # http://vm:9091 and http://vm:9091/ are the same service (federate_url
+    # is built with the same rstrip); the sibling exclusion must agree, or an
+    # unfiltered cluster re-imports its sibling's slice.
+    def _cfg(keys, default_value=None, **_):
+        keys = tuple(keys)
+        if keys == ('slurm', 'cluster_configs'):
+            return {'prod': {}, 'lab': {}}
+        if keys == ('slurm', 'cluster_configs', 'prod', 'prometheus', 'url'):
+            return _SHARED_PROM_URL
+        if keys == ('slurm', 'cluster_configs', 'lab', 'prometheus', 'url'):
+            return _SHARED_PROM_URL + '/'
+        if keys == ('slurm', 'cluster_configs', 'lab', 'prometheus', 'filter'):
+            return {'cluster': 'site-lab'}
+        return default_value
+
+    monkeypatch.setattr(utils.skypilot_config, 'get_nested', _cfg)
+    with mock.patch('sky.clouds.Slurm.existing_allowed_clusters',
+                    return_value=['prod', 'lab']):
+        assert utils.slurm_federate_matchers('prod') == ['cluster!="site-lab"']


### PR DESCRIPTION
## Problem

A Slurm cluster's Prometheus is often not a per-cluster deployment but a central metrics service aggregating several fleets — and it may be reachable from only some of the fleets' login nodes. The Slurm GPU-metrics federation (#10572) handles neither:

- The federate selectors are unscoped (`DCGM_.*` plus the node-exporter series), so every fleet in that Prometheus comes back and gets stamped `cluster="slurm/<name>"` for whichever cluster asked — inflating that cluster's GPU totals, and double-counting every series once a second cluster is configured against the same endpoint.
- The `/federate` curl always runs on the target cluster's own login node, so a cluster whose login node cannot reach the Prometheus is simply uncollectable, even when its series are sitting in a Prometheus we already pull from.

Seen in the field on an endpoint carrying four distinct fleets, reachable from exactly one of their login nodes: the Slurm cluster being federated accounted for only 67% of the `DCGM_FI_DEV_GPU_UTIL` series it was credited with.

## Change

Restructures the per-cluster metrics config under a `prometheus` block with three fields, and adds shared cloud-level defaults under `slurm.prometheus` so the central-service case is configured once:

```yaml
slurm:
  # Shared defaults: one central Prometheus, reachable only through hub's
  # login node, serving every cluster.
  prometheus:
    url: http://central-vm.internal:9091
    via: hub
  cluster_configs:
    hub:
      prometheus:
        filter:
          cluster: site-hub
    edge:
      prometheus:
        filter:
          cluster: site-edge
```

Both fields can equally be set per cluster (the pre-existing shape), which overrides the shared defaults:

```yaml
slurm:
  cluster_configs:
    edge:
      prometheus:
        url: http://edge-prom.internal:9090   # its own Prometheus
```

- **`url`** — as before: a Prometheus reachable from a login node, federated over SSH. The flat `prometheus_url` spelling is kept as a deprecated fallback (it is live in deployed configs; dropping it would silently stop a cluster's federation on upgrade). `prometheus.url` wins when both are set.
- **`filter`** — label matchers (name → exact value) folded into every `match[]` selector, so the source Prometheus does the filtering and only the cluster's own slice crosses the wire. Clusters sharing a `url` also subtract each other: a sibling's single-label filter becomes a negative matcher (`cluster!="site-edge"`), so a fleet is never counted twice even during an incremental rollout where only some clusters declare filters. Guards: a sibling excluded by `slurm.allowed_clusters` claims nothing and is not subtracted; a multi-label sibling filter negates to a disjunction a Prometheus selector cannot express and is left alone; a label the cluster itself constrains is left alone (its own positive filter is the more specific statement).
- **`via`** — a Slurm cluster whose login node runs the `/federate` curl instead of this cluster's own. Transport and attribution stay independent: the series are scoped by this cluster's `filter` and stamped `cluster="slurm/<name>"` regardless of which login node fetched them. Failure messages name both clusters (`'edge' (via 'hub') exited 7`).
- **Shared defaults (`slurm.prometheus.{url, via}`)** — cloud-level defaults inherited by any cluster that doesn't override them under `cluster_configs`, so a central Prometheus serving every fleet is declared once and each cluster carries only its own `filter`. Precedence for `url`: per-cluster `prometheus.url` → deprecated flat `prometheus_url` → shared default (the flat spelling is per-cluster, so it still beats the shared default on upgrade); for `via`: per-cluster → shared default. `filter` stays per-cluster by design — it names exactly one cluster's slice. Sibling subtraction resolves inherited urls, so clusters sharing the Prometheus only via the default are still recognized as siblings.

Behavior is unchanged for anyone not setting the new fields. Invalid filter label names are dropped with a warning rather than interpolated (a malformed selector would fail the cluster's entire federation); values are escaped for quotes and backslashes. The sibling-candidate scan is a plain dict read that short-circuits before enumerating `~/.slurm/config` in the common single-cluster case.

## Docs

- `docs/source/reference/config.rst`: documents the `prometheus` block (`url` / `filter` / `via`) under `slurm.cluster_configs`, the deprecated `prometheus_url` fallback, and the shared `slurm.prometheus` defaults, with examples.
- `docs/source/reference/api-server/examples/api-server-gpu-metrics-setup.rst`: new "GPU metrics for Slurm clusters" section — exporter requirements (including the `--hostname "$(hostname)"` requirement for Docker-run DCGM-Exporter, since the dashboard joins metrics to nodes by hostname), the login-node federation model, and shared-Prometheus scoping/routing examples.

## Testing

- 15 new unit tests: positive matchers, sibling negation, the allowed-clusters and multi-label guards, own-filter precedence, distinct URLs not interacting, invalid-label rejection, value escaping, selector shapes (braced / name-less / empty-brace / bare), end-to-end injection into the curl command, both deprecated-fallback behaviors, `via` routing (curl runs on the via cluster's login node while output is attributed to the target), and the via error shape. `77 passed` across the two federation test files.
- 4 more unit tests for the shared defaults: inheritance by a cluster with no per-cluster config, per-cluster `url` override, deprecated-flat-beats-shared-default precedence, and `via` inheritance.
- Fixed one of the above in CI: the multi-label-sibling warning test asserted via pytest's `caplog`, which sky loggers (`propagate=False`) can never reach; it now asserts on a mock of the logger, the pattern used across the unit tests.
- Schema validated with jsonschema: the nested block accepts `url`/`filter`/`via` and rejects unknown keys; the top-level `slurm.prometheus` accepts `url`/`via` and rejects unknown keys.
- Verified against a real multi-fleet VictoriaMetrics endpoint: the generated selectors returned exactly the target fleet (1,582 and 488 `GPU_UTIL` series respectively, each with a single upstream cluster label and no cross-fleet bleed), versus 2,366 unscoped; the negative-matcher path excluded only the claimed sibling; and the second fleet's scoped fetch was executed from the first fleet's login node — the `via` topology — after confirming the other fleets' login nodes cannot reach the endpoint (connect timeout). Payload for the larger fleet dropped from 26.5 MB to 21.2 MB.
- `pylint` 10.00/10, `yapf` clean.
