### PR TITLE
[Server] Cap numeric-library thread pools in executor workers

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -38,10 +38,13 @@ import setproctitle
 # Cap native thread pools before any import below can pull numpy in (sky ->
 # sky.optimizer imports it at module scope): a spawned worker re-imports this
 # module to resolve executor_initializer, so this runs first in that process.
+# NUMEXPR_MAX_THREADS must track NUMEXPR_NUM_THREADS's own final value
+# (default or operator-set), never default independently: numexpr raises at
+# import time if NUM_THREADS ends up greater than MAX_THREADS.
 for _numeric_threads_env_var in ('OPENBLAS_NUM_THREADS', 'OMP_NUM_THREADS',
-                                 'MKL_NUM_THREADS', 'NUMEXPR_NUM_THREADS',
-                                 'NUMEXPR_MAX_THREADS'):
+                                 'MKL_NUM_THREADS', 'NUMEXPR_NUM_THREADS'):
     os.environ.setdefault(_numeric_threads_env_var, '1')
+os.environ.setdefault('NUMEXPR_MAX_THREADS', os.environ['NUMEXPR_NUM_THREADS'])
 
 # pylint: disable=wrong-import-position
 from sky import exceptions

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -35,6 +35,15 @@ from typing import Any, Callable, Dict, Generator, List, Optional, TextIO, Tuple
 import psutil
 import setproctitle
 
+# Cap native thread pools before any import below can pull numpy in (sky ->
+# sky.optimizer imports it at module scope): a spawned worker re-imports this
+# module to resolve executor_initializer, so this runs first in that process.
+for _numeric_threads_env_var in ('OPENBLAS_NUM_THREADS', 'OMP_NUM_THREADS',
+                                 'MKL_NUM_THREADS', 'NUMEXPR_NUM_THREADS',
+                                 'NUMEXPR_MAX_THREADS'):
+    os.environ.setdefault(_numeric_threads_env_var, '1')
+
+# pylint: disable=wrong-import-position
 from sky import exceptions
 from sky import global_user_state
 from sky import models

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -2,9 +2,12 @@
 import asyncio
 import concurrent.futures
 import functools
+import json
 import os
 import pathlib
 import queue as queue_lib
+import subprocess
+import sys
 import threading
 import time
 from typing import List
@@ -1928,3 +1931,48 @@ def test_maybe_observe_request_pending_first_execution_only():
         executor._maybe_observe_request_pending(  # pylint: disable=protected-access
             make_request(requests_lib.RequestStatus.WAITING))
         assert observe.call_count == 1
+
+
+_NUMERIC_THREAD_ENV_VARS = ('OPENBLAS_NUM_THREADS', 'OMP_NUM_THREADS',
+                            'MKL_NUM_THREADS', 'NUMEXPR_NUM_THREADS',
+                            'NUMEXPR_MAX_THREADS')
+
+
+def _numeric_thread_envs_after_importing_executor(env_overrides):
+    """Report these vars right after the only import that can pull sky's
+    numpy chain in, in a fresh subprocess so no earlier import in this test
+    process's own history can taint the result."""
+    env = {
+        k: v for k, v in os.environ.items() if k not in _NUMERIC_THREAD_ENV_VARS
+    }
+    # The suite runs with SKYPILOT_DEBUG=1 (pyproject.toml), which makes the
+    # sky.* import chain itself print debug lines to stdout ahead of ours.
+    env['SKYPILOT_DEBUG'] = '0'
+    env.update(env_overrides)
+    script = ('import os, json\n'
+              'from sky.server.requests import executor\n'
+              'print(json.dumps({v: os.environ.get(v) for v in %r}))' %
+              (_NUMERIC_THREAD_ENV_VARS,))
+    result = subprocess.run([sys.executable, '-c', script],
+                            env=env,
+                            capture_output=True,
+                            text=True,
+                            check=True,
+                            timeout=60)
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_executor_import_caps_numeric_threads_before_numpy():
+    """A freshly spawned executor worker must default OpenBLAS/NumExpr's
+    thread pools before numpy loads, or every burst worker's own pool
+    compounds toward the container's PID limit (#10559)."""
+    envs = _numeric_thread_envs_after_importing_executor({})
+    assert envs == {var: '1' for var in _NUMERIC_THREAD_ENV_VARS}
+
+
+def test_executor_import_does_not_override_explicit_thread_env():
+    """setdefault must not clobber an operator's own numeric-thread config."""
+    envs = _numeric_thread_envs_after_importing_executor(
+        {'OPENBLAS_NUM_THREADS': '8'})
+    assert envs['OPENBLAS_NUM_THREADS'] == '8'
+    assert envs['OMP_NUM_THREADS'] == '1'

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -1976,3 +1976,13 @@ def test_executor_import_does_not_override_explicit_thread_env():
         {'OPENBLAS_NUM_THREADS': '8'})
     assert envs['OPENBLAS_NUM_THREADS'] == '8'
     assert envs['OMP_NUM_THREADS'] == '1'
+
+
+def test_executor_import_derives_numexpr_max_threads_from_num_threads():
+    """NUMEXPR_MAX_THREADS must track an operator-set NUMEXPR_NUM_THREADS,
+    not default to 1 independently: numexpr raises at import time if
+    NUM_THREADS ends up greater than MAX_THREADS."""
+    envs = _numeric_thread_envs_after_importing_executor(
+        {'NUMEXPR_NUM_THREADS': '4'})
+    assert envs['NUMEXPR_NUM_THREADS'] == '4'
+    assert envs['NUMEXPR_MAX_THREADS'] == '4'


### PR DESCRIPTION
## Root cause

`executor_initializer()` runs inside each freshly spawned launch executor
worker, but `sky/server/requests/executor.py` reaches it only after `from
sky import exceptions`, which triggers the whole `sky` package import,
including `sky.optimizer`'s module-level `import numpy`. OpenBLAS and
NumExpr size their thread pools to the CPU count the first time they are
imported in a process, so by the time `executor_initializer()`'s own body
runs, that sizing has already happened. A fix placed inside the initializer
(as this issue's own suggestion first pointed at) is one step too late to
change it.

With `multiprocessing.set_start_method('spawn', force=True)` (already set a
few lines below in this file), each burst worker is a fresh interpreter that
re-imports `executor.py` from scratch to resolve `executor_initializer`, so
whatever runs earliest in that file runs first in every worker. Confirmed
with `threadpoolctl` in a minimal reproduction of this exact import shape
(module-level `import numpy` followed by an "initializer" function in the
same module, driven through a real `ProcessPoolExecutor(mp_context=spawn,
initializer=...)`): setting `OPENBLAS_NUM_THREADS` etc. inside the
initializer body has no effect (`num_threads=4` either way), while setting
it at module scope, ahead of the numpy-importing chain, reliably caps it
(`num_threads=1`).

## Fix

Set `OPENBLAS_NUM_THREADS`, `OMP_NUM_THREADS`, `MKL_NUM_THREADS`,
`NUMEXPR_NUM_THREADS` and `NUMEXPR_MAX_THREADS` via `os.environ.setdefault`
at the top of `sky/server/requests/executor.py`, before its own `from sky
import ...` lines. `setdefault` keeps an operator's own value if one is
already set. This also affects the main API server process's own thread
pool if `executor.py` happens to be its first `sky`-importing module, which
matches this issue's own suggested defaults and is a low-risk trade-off
given the workload here is launch orchestration, not numerical compute.

## Scope

This addresses possible-fix #1 from the issue (conservative defaults for the
numerical thread pools). It does not touch burst-worker admission control,
PID-limit-aware scheduling, or request queuing (possible fixes #2-5), which
are separate, larger design changes.

## Verified

- New regression tests in `tests/unit_tests/test_sky/server/requests/test_executor.py`
  spawn a real subprocess that imports only `sky.server.requests.executor`
  and reads back the five env vars: fails on unmodified `master` (all unset)
  and passes on this branch (all default to `'1'`, or keep an explicit
  override), confirmed both ways in the same environment.
- Full `tests/unit_tests/test_sky/server/requests/test_executor.py` (44
  tests) passes on this branch, Python 3.9 (matching the CI matrix), no
  regressions.
- `yapf --diff`, `isort --diff --check`, `pylint --load-plugins pylint_quotes`
  (2.14.5, this repo's pinned version) all clean on both changed files;
  `mypy` (1.19.1) clean scoped to `sky/server/requests/executor.py` (a full
  `sky`-package run needs the `[all]` extras, which this environment could
  not provision; not run).
- Not run: the cgroup-PID-exhaustion reproduction itself (needs the
  `--pids-limit` container setup from the issue plus real AWS credentials
  for the dry-run launches), and the buildkite-gated smoke tests.

`sky/server/requests/executor.py` currently has 11 other open PRs touching
it (competing-PR sweep, adjudicated by patch); none touch this function or
this import region, but `#10437` adds an import one line above where this
diff inserts, so a rebase may be needed depending on merge order.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->