### PR TITLE
[Kubernetes] Make ingress controller discovery configurable

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1663,7 +1663,7 @@ Default: ``loadbalancer``.
 
 Settings for the Ingress objects SkyPilot generates when :ref:`kubernetes.ports <config-yaml-kubernetes-ports>` is ``ingress`` (optional).
 
-The defaults match a stock `ingress-nginx <https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md>`_ install; set these if you run a different controller, or nginx under a different class or namespace.
+The defaults match a stock `ingress-nginx <https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md>`_ install; set these if you run nginx under a different class or namespace.
 
 - ``class_name``: ``ingressClassName`` written on the generated Ingresses. Default: ``nginx``.
 - ``controller_service``: name of the ingress controller's Service, which SkyPilot reads to resolve endpoints. Default: ``ingress-nginx-controller``.
@@ -1674,9 +1674,18 @@ The defaults match a stock `ingress-nginx <https://github.com/kubernetes/ingress
   kubernetes:
     ports: ingress
     ingress:
-      class_name: traefik
-      controller_service: traefik
-      controller_namespace: traefik
+      class_name: internal-nginx
+      controller_service: internal-nginx-controller
+      controller_namespace: platform-ingress
+
+.. note::
+
+  The generated Ingresses carry ingress-nginx-specific routing annotations
+  (``use-regex`` and ``rewrite-target``) to strip the
+  ``/skypilot/<namespace>/<cluster>/<port>`` prefix before traffic reaches the
+  workload. A controller that does not honor those annotations will resolve
+  endpoints correctly but will not strip the prefix, so these settings are
+  only expected to work with ingress-nginx today.
 
 .. _config-yaml-kubernetes-remote-identity:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1651,10 +1651,32 @@ Port configuration mode (optional).
 Can be one of:
 
 - ``loadbalancer``: Use LoadBalancer service to expose ports.
-- ``nodeport``: Use NodePort service to expose ports.
+- ``ingress``: Use an Ingress to expose ports. See :ref:`kubernetes.ingress <config-yaml-kubernetes-ingress>`.
 - ``podip``: Use Pod IPs to expose ports. Cannot be accessed from outside the cluster.
 
 Default: ``loadbalancer``.
+
+.. _config-yaml-kubernetes-ingress:
+
+``kubernetes.ingress``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Settings for the Ingress objects SkyPilot generates when :ref:`kubernetes.ports <config-yaml-kubernetes-ports>` is ``ingress`` (optional).
+
+The defaults match a stock `ingress-nginx <https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md>`_ install; set these if you run a different controller, or nginx under a different class or namespace.
+
+- ``class_name``: ``ingressClassName`` written on the generated Ingresses. Default: ``nginx``.
+- ``controller_service``: name of the ingress controller's Service, which SkyPilot reads to resolve endpoints. Default: ``ingress-nginx-controller``.
+- ``controller_namespace``: namespace of that Service. Default: ``ingress-nginx``.
+
+.. code-block:: yaml
+
+  kubernetes:
+    ports: ingress
+    ingress:
+      class_name: traefik
+      controller_service: traefik
+      controller_namespace: traefik
 
 .. _config-yaml-kubernetes-remote-identity:
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4535,11 +4535,19 @@ def get_endpoints(cluster: str,
                              f'for {cluster!r} on {cloud}.') from None
 
     config = global_user_state.get_cluster_yaml_dict(handle.cluster_yaml)
+    provider_config = config['provider']
+    # Mirror CloudVmRayBackend._open_ports: the overrides that selected where
+    # the ports were opened must also be in scope when we resolve the
+    # endpoints they are reachable on.
+    cluster_config_overrides = (
+        handle.launched_resources.cluster_config_overrides)
+    if cluster_config_overrides:
+        provider_config['cluster_config_overrides'] = cluster_config_overrides
     port_details = provision_lib.query_ports(repr(cloud),
                                              handle.cluster_name_on_cloud,
                                              handle.launched_resources.ports,
                                              head_ip=handle.head_ip,
-                                             provider_config=config['provider'])
+                                             provider_config=provider_config)
 
     launched_resources = handle.launched_resources.assert_launchable()
     # Validation before returning the endpoints

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -83,12 +83,28 @@ def _open_ports_using_ingress(
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
     overrides = provider_config.get('cluster_config_overrides')
     # Check if an ingress controller exists
-    if not network_utils.ingress_controller_exists(context):
+    settings = network_utils.get_ingress_settings(context, overrides)
+    if not network_utils.ingress_controller_exists(context,
+                                                   settings['class_name']):
         raise Exception(
-            'Ingress controller not found. '
-            'Install Nginx ingress controller first: '
-            'https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md.'  # pylint: disable=line-too-long
-        )
+            f'No IngressClass named {settings["class_name"]!r} in the cluster. '
+            'Install the Nginx ingress controller '
+            '(https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md), '  # pylint: disable=line-too-long
+            'or set kubernetes.ingress.class_name to the IngressClass of the '
+            'controller you run.')
+    # An IngressClass can exist without the controller Service that endpoints
+    # are resolved from: a Gateway API controller, a leftover CRD, or nginx
+    # installed under other names. Creating Ingress objects anyway leaves the
+    # cluster in PROVISIONING with nothing in the logs pointing at networking.
+    if network_utils.get_ingress_controller_service(context, overrides) is None:
+        raise Exception(
+            'Ingress controller Service '
+            f'{settings["controller_namespace"]}/'
+            f'{settings["controller_service"]} not found; SkyPilot resolves '
+            'ingress endpoints from it. Install the Nginx ingress controller, '
+            'or set kubernetes.ingress.controller_service and '
+            'kubernetes.ingress.controller_namespace to the Service of the '
+            'controller you run.')
 
     # URL path namespace must match the Service's namespace (resolved above
     # from `provider_config`); per-workspace overrides can make these differ.
@@ -296,6 +312,14 @@ def _query_ports_for_ingress(
     ingress_details = network_utils.get_ingress_external_ip_and_ports(context)
     external_ip, external_ports = ingress_details
     if external_ip is None:
+        # Do not raise: this runs on every status refresh, and returning no
+        # endpoints keeps polling alive. The warning is the only signal the
+        # user gets that the ingress controller is not where we look for it.
+        settings = network_utils.get_ingress_settings(context)
+        logger.warning('Cannot resolve ingress endpoints: Service '
+                       f'{settings["controller_namespace"]}/'
+                       f'{settings["controller_service"]} not found. See '
+                       'kubernetes.ingress in ~/.sky/config.yaml.')
         return {}
 
     namespace = provider_config.get(

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -309,13 +309,18 @@ def _query_ports_for_ingress(
 ) -> Dict[int, List[common.Endpoint]]:
     context = provider_config.get(
         'context', kubernetes_utils.get_current_kube_config_context_name())
-    ingress_details = network_utils.get_ingress_external_ip_and_ports(context)
+    # Must match what _open_ports_using_ingress resolved: a per-launch
+    # override selects the controller Service that endpoints come from, so
+    # dropping it here would query the default controller and find nothing.
+    overrides = provider_config.get('cluster_config_overrides')
+    ingress_details = network_utils.get_ingress_external_ip_and_ports(
+        context, overrides)
     external_ip, external_ports = ingress_details
     if external_ip is None:
         # Do not raise: this runs on every status refresh, and returning no
         # endpoints keeps polling alive. The warning is the only signal the
         # user gets that the ingress controller is not where we look for it.
-        settings = network_utils.get_ingress_settings(context)
+        settings = network_utils.get_ingress_settings(context, overrides)
         logger.warning('Cannot resolve ingress endpoints: Service '
                        f'{settings["controller_namespace"]}/'
                        f'{settings["controller_service"]} not found. See '

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -25,6 +25,39 @@ logger = sky_logging.init_logger(__name__)
 _INGRESS_TEMPLATE_NAME = 'kubernetes-ingress.yml.j2'
 _LOADBALANCER_TEMPLATE_NAME = 'kubernetes-loadbalancer.yml.j2'
 
+# Defaults match an out-of-the-box ingress-nginx install, which is what
+# SkyPilot assumed before these were configurable.
+_DEFAULT_INGRESS_SETTINGS = {
+    'class_name': 'nginx',
+    'controller_service': 'ingress-nginx-controller',
+    'controller_namespace': 'ingress-nginx',
+}
+
+
+def get_ingress_settings(
+    context: Optional[str],
+    cluster_config_overrides: Optional[Dict[str,
+                                            Any]] = None) -> Dict[str, str]:
+    """Returns `kubernetes.ingress`, filled in with the ingress-nginx defaults.
+
+    Keys: `class_name` (the ingressClassName SkyPilot writes on the Ingress
+    objects it generates) and `controller_service` / `controller_namespace`
+    (the controller Service that endpoints are resolved from).
+    """
+    context, cloud_str = kubernetes_utils.get_cleaned_context_and_cloud_str(
+        context)
+    configured = skypilot_config.get_effective_region_config(
+        cloud=cloud_str,
+        region=context,
+        keys=('ingress',),
+        default_value={},
+        override_configs=cluster_config_overrides,
+        merge_dicts=True) or {}
+    return {
+        key: str(configured.get(key) or default)
+        for key, default in _DEFAULT_INGRESS_SETTINGS.items()
+    }
+
 
 def get_port_mode(
         mode_str: Optional[str],
@@ -141,6 +174,8 @@ def fill_ingress_template(
         selector_value=selector_value,
         annotations=annotations,
         labels=labels,
+        ingress_class_name=get_ingress_settings(
+            context, cluster_config_overrides)['class_name'],
     )
     content = yaml_utils.safe_load(cont)
 
@@ -230,8 +265,8 @@ def delete_namespaced_service(context: Optional[str], namespace: str,
 
 
 def ingress_controller_exists(context: Optional[str],
-                              ingress_class_name: str = 'nginx') -> bool:
-    """Checks if an ingress controller exists in the cluster."""
+                              ingress_class_name: str) -> bool:
+    """Checks if an IngressClass with this name exists in the cluster."""
     networking_api = kubernetes.networking_api(context)
     ingress_classes = networking_api.list_ingress_class(
         _request_timeout=kubernetes.API_TIMEOUT).items
@@ -240,21 +275,40 @@ def ingress_controller_exists(context: Optional[str],
             ingress_classes))
 
 
-def get_ingress_external_ip_and_ports(
-    context: Optional[str],
-    namespace: str = 'ingress-nginx'
-) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
-    """Returns external ip and ports for the ingress controller."""
+def get_ingress_controller_service(
+        context: Optional[str],
+        cluster_config_overrides: Optional[Dict[str,
+                                                Any]] = None) -> Optional[Any]:
+    """Returns the ingress controller Service, or None if it is not there.
+
+    None means SkyPilot cannot resolve ingress endpoints: either no ingress
+    controller is installed, or `kubernetes.ingress.controller_service` /
+    `controller_namespace` do not point at the one that is.
+    """
+    settings = get_ingress_settings(context, cluster_config_overrides)
     core_api = kubernetes.core_api(context)
-    ingress_services = [
-        item for item in core_api.list_namespaced_service(
-            namespace, _request_timeout=kubernetes.API_TIMEOUT).items
-        if item.metadata.name == 'ingress-nginx-controller'
-    ]
-    if not ingress_services:
+    try:
+        services = core_api.list_namespaced_service(
+            settings['controller_namespace'],
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.kubernetes.client.ApiException as e:
+        if e.status == 404:
+            # The namespace itself does not exist.
+            return None
+        raise
+    for service in services:
+        if service.metadata.name == settings['controller_service']:
+            return service
+    return None
+
+
+def get_ingress_external_ip_and_ports(
+    context: Optional[str],) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
+    """Returns external ip and ports for the ingress controller."""
+    ingress_service = get_ingress_controller_service(context)
+    if ingress_service is None:
         return (None, None)
 
-    ingress_service = ingress_services[0]
     if ingress_service.status.load_balancer.ingress is None:
         # We try to get an IP/host for the service in the following order:
         # 1. Try to use assigned external IP if it exists

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -288,24 +288,27 @@ def get_ingress_controller_service(
     settings = get_ingress_settings(context, cluster_config_overrides)
     core_api = kubernetes.core_api(context)
     try:
-        services = core_api.list_namespaced_service(
+        # Read the Service by name rather than listing the namespace: it only
+        # needs `get` on that one Service instead of `list` on all of them.
+        return core_api.read_namespaced_service(
+            settings['controller_service'],
             settings['controller_namespace'],
-            _request_timeout=kubernetes.API_TIMEOUT).items
+            _request_timeout=kubernetes.API_TIMEOUT)
     except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
-            # The namespace itself does not exist.
+            # Either the namespace or the Service is absent; both mean the
+            # controller is not where SkyPilot is looking for it.
             return None
         raise
-    for service in services:
-        if service.metadata.name == settings['controller_service']:
-            return service
-    return None
 
 
 def get_ingress_external_ip_and_ports(
-    context: Optional[str],) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
+    context: Optional[str],
+    cluster_config_overrides: Optional[Dict[str, Any]] = None
+) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
     """Returns external ip and ports for the ingress controller."""
-    ingress_service = get_ingress_controller_service(context)
+    ingress_service = get_ingress_controller_service(context,
+                                                     cluster_config_overrides)
     if ingress_service is None:
         return (None, None)
 

--- a/sky/templates/kubernetes-ingress.yml.j2
+++ b/sky/templates/kubernetes-ingress.yml.j2
@@ -15,7 +15,7 @@ ingress_spec:
     name: {{ ingress_name }}
     namespace: {{ namespace }}
   spec:
-    ingressClassName: nginx
+    ingressClassName: {{ ingress_class_name }}
     rules:
     - http:
         paths:

--- a/sky/templates/kubernetes-ingress.yml.j2
+++ b/sky/templates/kubernetes-ingress.yml.j2
@@ -15,7 +15,7 @@ ingress_spec:
     name: {{ ingress_name }}
     namespace: {{ namespace }}
   spec:
-    ingressClassName: {{ ingress_class_name }}
+    ingressClassName: {{ ingress_class_name|tojson }}
     rules:
     - http:
         paths:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1678,6 +1678,22 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             type.value for type in kubernetes_enums.KubernetesPortMode
         ],
     },
+    'ingress': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'class_name': {
+                'type': 'string',
+            },
+            'controller_service': {
+                'type': 'string',
+            },
+            'controller_namespace': {
+                'type': 'string',
+            },
+        },
+    },
     **_CONTEXT_CONFIG_SCHEMA_MINIMAL,
     'namespace': {
         'type': 'string',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -324,6 +324,22 @@ def test_invalid_indent_config(monkeypatch, tmp_path) -> None:
     assert 'Invalid config YAML' in e.value.args[0]
 
 
+def test_kubernetes_ingress_config_accepted(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / 'ok.yaml'
+    config_path.write_text(
+        textwrap.dedent("""\
+            kubernetes:
+                ingress:
+                    class_name: traefik
+                    controller_service: traefik
+                    controller_namespace: traefik
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    skypilot_config.reload_config()
+    assert skypilot_config.get_nested(('kubernetes', 'ingress', 'class_name'),
+                                      None) == 'traefik'
+
+
 def test_invalid_enum_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file contains an invalid enum value."""
     config_path = tmp_path / 'invalid.yaml'

--- a/tests/unit_tests/kubernetes/test_network.py
+++ b/tests/unit_tests/kubernetes/test_network.py
@@ -224,6 +224,30 @@ class TestQueryPortsForIngress:
         warning = mock_logger.warning.call_args[0][0]
         assert 'ingress-nginx/ingress-nginx-controller' in warning
 
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_external_ip_and_ports')
+    def test_overrides_are_passed_through(self, mock_get_ip):
+        """The endpoint lookup must see the overrides open_ports used.
+
+        Otherwise a cluster launched with a per-launch ingress override has
+        its Ingress created against one controller and its endpoints
+        resolved from another.
+        """
+        mock_get_ip.return_value = ('1.2.3.4', (80, 443))
+        overrides = {'kubernetes': {'ingress': {'controller_service': 'other'}}}
+
+        network._query_ports_for_ingress(  # pylint: disable=protected-access
+            cluster_name_on_cloud='cluster0',
+            ports=[8080],
+            provider_config={
+                'context': 'ctx',
+                'namespace': 'default',
+                'cluster_config_overrides': overrides,
+            },
+        )
+
+        assert mock_get_ip.call_args.args[1] == overrides
+
 
 def _fake_region_config(ingress=None):
     """Stub for skypilot_config.get_effective_region_config."""
@@ -312,24 +336,22 @@ class TestGetIngressExternalIpAndPorts:
             'controller_service': 'traefik',
             'controller_namespace': 'traefik-system',
         }
-        list_services = mock_api.return_value.list_namespaced_service
-        list_services.return_value = types.SimpleNamespace(items=[
-            _service('ingress-nginx-controller', '10.0.0.1'),
-            _service('traefik', '10.0.0.2'),
-        ])
+        read_service = mock_api.return_value.read_namespaced_service
+        read_service.return_value = _service('traefik', '10.0.0.2')
 
         ip, ports = network_utils.get_ingress_external_ip_and_ports('ctx')
 
         assert (ip, ports) == ('10.0.0.2', None)
-        assert list_services.call_args.args[0] == 'traefik-system'
+        # Read by name, so the call names both the Service and its namespace.
+        assert read_service.call_args.args[:2] == ('traefik', 'traefik-system')
 
     @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
     @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
     def test_missing_namespace_is_not_an_error(self, mock_settings, mock_api):
-        """A 404 on the namespace means "not installed", not a crash."""
+        """A 404 means "not installed", not a crash."""
         mock_settings.return_value = _DEFAULT_SETTINGS
         api_exception = kubernetes.kubernetes.client.ApiException(status=404)
-        mock_api.return_value.list_namespaced_service.side_effect = (
+        mock_api.return_value.read_namespaced_service.side_effect = (
             api_exception)
 
         assert network_utils.get_ingress_controller_service('ctx') is None
@@ -339,7 +361,7 @@ class TestGetIngressExternalIpAndPorts:
     def test_other_api_errors_propagate(self, mock_settings, mock_api):
         mock_settings.return_value = _DEFAULT_SETTINGS
         api_exception = kubernetes.kubernetes.client.ApiException(status=403)
-        mock_api.return_value.list_namespaced_service.side_effect = (
+        mock_api.return_value.read_namespaced_service.side_effect = (
             api_exception)
 
         with pytest.raises(kubernetes.kubernetes.client.ApiException):
@@ -349,8 +371,21 @@ class TestGetIngressExternalIpAndPorts:
     @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
     def test_missing_service(self, mock_settings, mock_api):
         mock_settings.return_value = _DEFAULT_SETTINGS
-        mock_api.return_value.list_namespaced_service.return_value = (
-            types.SimpleNamespace(items=[]))
+        mock_api.return_value.read_namespaced_service.side_effect = (
+            kubernetes.kubernetes.client.ApiException(status=404))
 
         assert network_utils.get_ingress_external_ip_and_ports('ctx') == (None,
                                                                           None)
+
+    @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
+    @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
+    def test_overrides_reach_the_service_lookup(self, mock_settings, mock_api):
+        """Per-launch overrides must select the Service endpoints come from."""
+        mock_settings.return_value = _DEFAULT_SETTINGS
+        mock_api.return_value.read_namespaced_service.return_value = _service(
+            'ingress-nginx-controller', '10.0.0.1')
+        overrides = {'kubernetes': {'ingress': {'controller_service': 'other'}}}
+
+        network_utils.get_ingress_external_ip_and_ports('ctx', overrides)
+
+        assert mock_settings.call_args.args[1] == overrides

--- a/tests/unit_tests/kubernetes/test_network.py
+++ b/tests/unit_tests/kubernetes/test_network.py
@@ -1,8 +1,20 @@
 """Tests for `sky/provision/kubernetes/network.py`."""
 
+import types
 from unittest.mock import patch
 
+import pytest
+
+from sky.adaptors import kubernetes
 from sky.provision.kubernetes import network
+from sky.provision.kubernetes import network_utils
+
+# What get_ingress_settings returns when kubernetes.ingress is unset.
+_DEFAULT_SETTINGS = {
+    'class_name': 'nginx',
+    'controller_service': 'ingress-nginx-controller',
+    'controller_namespace': 'ingress-nginx',
+}
 
 
 class TestOpenPortsUsingIngress:
@@ -17,6 +29,8 @@ class TestOpenPortsUsingIngress:
     @patch('sky.provision.kubernetes.network.network_utils'
            '.fill_ingress_template')
     @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_controller_service')
+    @patch('sky.provision.kubernetes.network.network_utils'
            '.ingress_controller_exists')
     @patch('sky.provision.kubernetes.network.kubernetes_utils'
            '.get_kube_config_context_namespace')
@@ -26,8 +40,8 @@ class TestOpenPortsUsingIngress:
            '.get_context_from_config')
     def test_url_path_uses_provider_namespace_not_kubeconfig_default(
             self, mock_get_context, mock_get_ns_from_config, mock_kubeconfig_ns,
-            mock_ingress_exists, mock_fill_template, mock_create_service,
-            mock_create_ingress, mock_merge_metadata):
+            mock_ingress_exists, mock_controller_svc, mock_fill_template,
+            mock_create_service, mock_create_ingress, mock_merge_metadata):
         """The Ingress URL path must reference the same namespace as the Service.
 
         Regression: when a workspace/per-context override sets
@@ -82,6 +96,8 @@ class TestOpenPortsUsingIngress:
     @patch('sky.provision.kubernetes.network.network_utils'
            '.fill_ingress_template')
     @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_controller_service')
+    @patch('sky.provision.kubernetes.network.network_utils'
            '.ingress_controller_exists')
     @patch('sky.provision.kubernetes.network.kubernetes_utils'
            '.get_kube_config_context_namespace')
@@ -91,8 +107,8 @@ class TestOpenPortsUsingIngress:
            '.get_context_from_config')
     def test_url_path_namespace_matches_service_namespace_for_all_ports(
             self, mock_get_context, mock_get_ns_from_config, mock_kubeconfig_ns,
-            mock_ingress_exists, mock_fill_template, mock_create_service,
-            mock_create_ingress, mock_merge_metadata):
+            mock_ingress_exists, mock_controller_svc, mock_fill_template,
+            mock_create_service, mock_create_ingress, mock_merge_metadata):
         """Multiple ports all share the same namespace in their URL paths."""
         provider_config = {
             'context': 'shared-ctx',
@@ -120,3 +136,221 @@ class TestOpenPortsUsingIngress:
             assert 'team-b' in url_path, (
                 f'Every port URL path must use the resolved namespace, '
                 f'got: {url_path!r}')
+
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.ingress_controller_exists')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_settings')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_checks_the_configured_ingress_class(self, mock_get_context,
+                                                 mock_settings,
+                                                 mock_ingress_exists):
+        """The IngressClass we look for is the one we will write, not nginx."""
+        mock_get_context.return_value = 'ctx'
+        mock_settings.return_value = {'class_name': 'traefik'}
+        mock_ingress_exists.return_value = False
+
+        with pytest.raises(Exception, match='traefik'):
+            network._open_ports_using_ingress(  # pylint: disable=protected-access
+                cluster_name_on_cloud='cluster0',
+                ports=[8080],
+                provider_config={
+                    'context': 'ctx',
+                    'namespace': 'default'
+                },
+            )
+
+        mock_ingress_exists.assert_called_once_with('ctx', 'traefik')
+
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.create_or_replace_namespaced_ingress')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.fill_ingress_template')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_controller_service')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.ingress_controller_exists')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_raises_when_controller_service_missing(self, mock_get_context,
+                                                    mock_ingress_exists,
+                                                    mock_controller_svc,
+                                                    mock_fill_template,
+                                                    mock_create_ingress):
+        """An IngressClass alone is not enough: endpoints need the Service."""
+        mock_get_context.return_value = 'ctx'
+        mock_ingress_exists.return_value = True
+        mock_controller_svc.return_value = None
+
+        with pytest.raises(Exception,
+                           match='ingress-nginx/ingress-nginx-controller'):
+            network._open_ports_using_ingress(  # pylint: disable=protected-access
+                cluster_name_on_cloud='cluster0',
+                ports=[8080],
+                provider_config={
+                    'context': 'ctx',
+                    'namespace': 'default'
+                },
+            )
+
+        # Nothing is created: Ingress objects that cannot resolve are worse
+        # than a failed launch.
+        mock_fill_template.assert_not_called()
+        mock_create_ingress.assert_not_called()
+
+
+class TestQueryPortsForIngress:
+    """Tests for `_query_ports_for_ingress`."""
+
+    @patch('sky.provision.kubernetes.network.logger')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.get_ingress_external_ip_and_ports')
+    def test_warns_when_endpoints_cannot_be_resolved(self, mock_get_ip,
+                                                     mock_logger):
+        """Status polling must not raise, but it must say why it is empty."""
+        mock_get_ip.return_value = (None, None)
+
+        result = network._query_ports_for_ingress(  # pylint: disable=protected-access
+            cluster_name_on_cloud='cluster0',
+            ports=[8080],
+            provider_config={
+                'context': 'ctx',
+                'namespace': 'default'
+            },
+        )
+
+        assert result == {}
+        warning = mock_logger.warning.call_args[0][0]
+        assert 'ingress-nginx/ingress-nginx-controller' in warning
+
+
+def _fake_region_config(ingress=None):
+    """Stub for skypilot_config.get_effective_region_config."""
+
+    def fake_get(cloud,
+                 keys,
+                 region=None,
+                 default_value=None,
+                 override_configs=None,
+                 merge_dicts=False):
+        del cloud, region, override_configs, merge_dicts  # Unused.
+        if keys == ('ingress',):
+            return default_value if ingress is None else ingress
+        return default_value
+
+    return fake_get
+
+
+def _service(name, ip='1.2.3.4'):
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(name=name, annotations=None),
+        spec=types.SimpleNamespace(external_i_ps=None, ports=[]),
+        status=types.SimpleNamespace(load_balancer=types.SimpleNamespace(
+            ingress=[types.SimpleNamespace(ip=ip, hostname=None)])),
+    )
+
+
+@patch('sky.provision.kubernetes.network_utils.kubernetes_utils'
+       '.get_cleaned_context_and_cloud_str',
+       return_value=('ctx', 'kubernetes'))
+@patch('sky.provision.kubernetes.network_utils.skypilot_config'
+       '.get_effective_region_config')
+class TestIngressSettings:
+    """`kubernetes.ingress` falls back to the ingress-nginx defaults."""
+
+    def test_defaults_when_unset(self, mock_get, mock_ctx):
+        mock_get.side_effect = _fake_region_config()
+        assert network_utils.get_ingress_settings('ctx') == _DEFAULT_SETTINGS
+
+    def test_partial_config_keeps_other_defaults(self, mock_get, mock_ctx):
+        mock_get.side_effect = _fake_region_config({'class_name': 'traefik'})
+        assert network_utils.get_ingress_settings('ctx') == {
+            **_DEFAULT_SETTINGS,
+            'class_name': 'traefik',
+        }
+
+
+@patch('sky.provision.kubernetes.network_utils.kubernetes_utils'
+       '.get_cleaned_context_and_cloud_str',
+       return_value=('ctx', 'kubernetes'))
+@patch('sky.provision.kubernetes.network_utils.skypilot_config'
+       '.get_effective_region_config')
+class TestFillIngressTemplate:
+    """Generated Ingresses carry the configured ingressClassName."""
+
+    @staticmethod
+    def _render():
+        return network_utils.fill_ingress_template(
+            namespace='ns',
+            context='ctx',
+            service_details=[('svc', 8080, 'skypilot/ns/c/8080')],
+            ingress_name='ing',
+            selector_key='k',
+            selector_value='v',
+        )
+
+    def test_default_class_is_nginx(self, mock_get, mock_ctx):
+        mock_get.side_effect = _fake_region_config()
+        content = self._render()
+        assert content['ingress_spec']['spec']['ingressClassName'] == 'nginx'
+
+    def test_configured_class_name_is_rendered(self, mock_get, mock_ctx):
+        mock_get.side_effect = _fake_region_config({'class_name': 'traefik'})
+        content = self._render()
+        assert content['ingress_spec']['spec']['ingressClassName'] == 'traefik'
+
+
+class TestGetIngressExternalIpAndPorts:
+    """Endpoints resolve from the configured controller Service."""
+
+    @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
+    @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
+    def test_looks_up_the_configured_service(self, mock_settings, mock_api):
+        mock_settings.return_value = {
+            'class_name': 'traefik',
+            'controller_service': 'traefik',
+            'controller_namespace': 'traefik-system',
+        }
+        list_services = mock_api.return_value.list_namespaced_service
+        list_services.return_value = types.SimpleNamespace(items=[
+            _service('ingress-nginx-controller', '10.0.0.1'),
+            _service('traefik', '10.0.0.2'),
+        ])
+
+        ip, ports = network_utils.get_ingress_external_ip_and_ports('ctx')
+
+        assert (ip, ports) == ('10.0.0.2', None)
+        assert list_services.call_args.args[0] == 'traefik-system'
+
+    @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
+    @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
+    def test_missing_namespace_is_not_an_error(self, mock_settings, mock_api):
+        """A 404 on the namespace means "not installed", not a crash."""
+        mock_settings.return_value = _DEFAULT_SETTINGS
+        api_exception = kubernetes.kubernetes.client.ApiException(status=404)
+        mock_api.return_value.list_namespaced_service.side_effect = (
+            api_exception)
+
+        assert network_utils.get_ingress_controller_service('ctx') is None
+
+    @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
+    @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
+    def test_other_api_errors_propagate(self, mock_settings, mock_api):
+        mock_settings.return_value = _DEFAULT_SETTINGS
+        api_exception = kubernetes.kubernetes.client.ApiException(status=403)
+        mock_api.return_value.list_namespaced_service.side_effect = (
+            api_exception)
+
+        with pytest.raises(kubernetes.kubernetes.client.ApiException):
+            network_utils.get_ingress_controller_service('ctx')
+
+    @patch('sky.provision.kubernetes.network_utils.kubernetes.core_api')
+    @patch('sky.provision.kubernetes.network_utils.get_ingress_settings')
+    def test_missing_service(self, mock_settings, mock_api):
+        mock_settings.return_value = _DEFAULT_SETTINGS
+        mock_api.return_value.list_namespaced_service.return_value = (
+            types.SimpleNamespace(items=[]))
+
+        assert network_utils.get_ingress_external_ip_and_ports('ctx') == (None,
+                                                                          None)


### PR DESCRIPTION
SkyPilot hardcodes a stock ingress-nginx install: generated Ingress
objects always set ingressClassName: nginx, and endpoints are always
resolved from Service ingress-nginx-controller in namespace
ingress-nginx. Clusters running nginx under another class or namespace
either get an Ingress nothing claims or get no endpoint back, so
`ports: ingress` never becomes reachable.

An IngressClass named nginx is also not proof that ingress works: it can
exist with no controller Service behind it (a Gateway API controller, a
leftover CRD). open_ports created Ingress objects anyway, and the
replica sat in PROVISIONING with nothing in the logs about networking.

- kubernetes.ingress.class_name is rendered into the Ingress template;
  controller_service / controller_namespace select the Service that
  endpoints are read from. All three default to today's names, so
  existing installs need no config change.
- open_ports now fails when that Service is absent, naming it and the
  config keys that point SkyPilot at an install under other names.
  Port queries log a warning and still return no endpoints, so status
  polling does not raise.
- The controller Service is read by name rather than listed out of its
  namespace, so a 404 covers both a missing namespace and a missing
  Service and means "not installed" rather than an exception.

Scope: this makes controller discovery configurable -- the IngressClass
written on the generated Ingresses, and the Service that endpoints are
resolved from. The generated Ingress still carries ingress-nginx-specific
routing annotations (`use-regex`, `rewrite-target`), so a controller that
ignores them resolves endpoints but does not strip the
`/skypilot/<namespace>/<cluster>/<port>` prefix. Routing support for other
controllers is out of scope here.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
