### PR TITLE
[Serve] Bound the load balancer port search to the declared range

### DIFF
--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -542,6 +542,14 @@ To achieve the above, you can specify custom configs in :code:`~/.sky/config.yam
       # Default: false.
       high_availability: true
 
+      # Port range opened on the controller for service load balancers.
+      # Each service's load balancer picks a free port from this range, so
+      # the range also caps how many services one controller can serve.
+      # A change only takes effect for a newly launched controller.
+      #
+      # Default: 30001-30020.
+      load_balancer_port_range: 30001-30020
+
       resources:
         # All configs below are optional.
         # Specify the location of the SkyServe controller.

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -97,10 +97,12 @@ CONTROLLER_AUTOSTOP = {
 DEFAULT_INITIAL_DELAY_SECONDS = 1200
 DEFAULT_MIN_REPLICAS = 1
 
-# Default port range start for controller and load balancer. Ports will be
-# automatically generated from this start port.
+# Controller ports are automatically generated from this start port.
 CONTROLLER_PORT_START = 20001
-LOAD_BALANCER_PORT_START = 30001
+# Default value of serve.controller.load_balancer_port_range: the ports the
+# controller task opens for service load balancers, and the range each
+# service's port search is bounded to. See
+# serve_utils.get_load_balancer_port_range.
 LOAD_BALANCER_PORT_RANGE = '30001-30020'
 
 # Initial version of service.

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -53,6 +53,7 @@ if typing.TYPE_CHECKING:
 
     import sky
     from sky.serve import replica_managers
+    from sky.utils import config_utils
 else:
     psutil = adaptors_common.LazyImport('psutil')
     requests = adaptors_common.LazyImport('requests')
@@ -372,7 +373,8 @@ LOAD_BALANCER_PORT_RANGE_CONFIG_KEY = ('serve', 'controller',
                                        'load_balancer_port_range')
 
 
-def get_load_balancer_port_range() -> Tuple[int, int]:
+def get_load_balancer_port_range(
+        config: Optional['config_utils.Config'] = None) -> Tuple[int, int]:
     """Returns the inclusive load balancer port range, as (start, end).
 
     Reads ``serve.controller.load_balancer_port_range`` (default
@@ -380,12 +382,23 @@ def get_load_balancer_port_range() -> Tuple[int, int]:
     per-service port search on the controller must stay inside it, otherwise
     a load balancer binds a port that was never exposed. See
     ``sky.serve.service._allocate_load_balancer_port``.
+
+    ``config`` reads the range from an explicit config instead of the ambient
+    one. Callers that run before an admin policy has been applied must pass
+    the policy's mutated config, since that is what the controller is
+    launched with: reading the pre-policy value here would open one range and
+    allocate from another.
     """
     key = '.'.join(LOAD_BALANCER_PORT_RANGE_CONFIG_KEY)
-    range_str = str(
-        skypilot_config.get_nested(
+    if config is None:
+        configured = skypilot_config.get_nested(
             LOAD_BALANCER_PORT_RANGE_CONFIG_KEY,
-            default_value=constants.LOAD_BALANCER_PORT_RANGE))
+            default_value=constants.LOAD_BALANCER_PORT_RANGE)
+    else:
+        configured = config.get_nested(
+            LOAD_BALANCER_PORT_RANGE_CONFIG_KEY,
+            default_value=constants.LOAD_BALANCER_PORT_RANGE)
+    range_str = str(configured)
     match = re.fullmatch(r'(\d{1,5})-(\d{1,5})', range_str)
     if match is None:
         with ux_utils.print_exception_no_traceback():

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -16,7 +16,7 @@ import time
 import traceback
 import typing
 from typing import (Any, Callable, DefaultDict, Deque, Dict, Iterator, List,
-                    Optional, Set, TextIO, Type, Union)
+                    Optional, Set, TextIO, Tuple, Type, Union)
 import uuid
 
 import colorama
@@ -366,6 +366,37 @@ def is_consolidation_mode(pool: bool = False) -> bool:
     if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         _validate_consolidation_mode_config(consolidation_mode, pool)
     return consolidation_mode
+
+
+LOAD_BALANCER_PORT_RANGE_CONFIG_KEY = ('serve', 'controller',
+                                       'load_balancer_port_range')
+
+
+def get_load_balancer_port_range() -> Tuple[int, int]:
+    """Returns the inclusive load balancer port range, as (start, end).
+
+    Reads ``serve.controller.load_balancer_port_range`` (default
+    ``30001-30020``). The controller task opens exactly this range, and the
+    per-service port search on the controller must stay inside it, otherwise
+    a load balancer binds a port that was never exposed. See
+    ``sky.serve.service._allocate_load_balancer_port``.
+    """
+    key = '.'.join(LOAD_BALANCER_PORT_RANGE_CONFIG_KEY)
+    range_str = str(
+        skypilot_config.get_nested(
+            LOAD_BALANCER_PORT_RANGE_CONFIG_KEY,
+            default_value=constants.LOAD_BALANCER_PORT_RANGE))
+    match = re.fullmatch(r'(\d{1,5})-(\d{1,5})', range_str)
+    if match is None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'{key} must be "<start>-<end>", got {range_str!r}.')
+    start, end = int(match.group(1)), int(match.group(2))
+    if not 1 <= start <= end <= 65535:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'{key} must satisfy 1 <= start <= end <= 65535, '
+                             f'got {range_str!r}.')
+    return start, end
 
 
 def ha_recovery_for_consolidation_mode(pool: bool):

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -261,7 +261,12 @@ def up(
         # service._allocate_load_balancer_port, which runs on the controller:
         # a mismatch lets a load balancer bind a port we never opened here.
         if not pool:
-            start, end = serve_utils.get_load_balancer_port_range()
+            # Read the range from the same config the controller is launched
+            # with (mutated_user_config, uploaded above), not the ambient
+            # pre-policy one: an admin policy that rewrites this key would
+            # otherwise open one range here and allocate from another there.
+            start, end = serve_utils.get_load_balancer_port_range(
+                mutated_user_config)
             controller_resources = {
                 r.copy(ports=[f'{start}-{end}']) for r in controller_resources
             }

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -257,10 +257,13 @@ def up(
         # balancer port from the controller? So we don't need to open so many
         # ports here. Or, we should have a nginx traffic control to refuse
         # any connection to the unregistered ports.
+        # Keep this range in lockstep with the port search in
+        # service._allocate_load_balancer_port, which runs on the controller:
+        # a mismatch lets a load balancer bind a port we never opened here.
         if not pool:
+            start, end = serve_utils.get_load_balancer_port_range()
             controller_resources = {
-                r.copy(ports=[serve_constants.LOAD_BALANCER_PORT_RANGE])
-                for r in controller_resources
+                r.copy(ports=[f'{start}-{end}']) for r in controller_resources
             }
         controller_task.set_resources(controller_resources)
 

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -69,15 +69,22 @@ def _handle_signal(service_name: str) -> None:
     raise error_type(f'User signal received: {user_signal.value}')
 
 
-def _allocate_load_balancer_port() -> int:
+def _allocate_load_balancer_port(pool: bool = False) -> int:
     """Picks a free port inside the declared load balancer port range.
 
     The controller task opens ``serve.controller.load_balancer_port_range``
     (default 30001-30020) once, at launch. Searching past that range binds a
     port the cloud or Kubernetes never exposed: the service reports READY but
     its endpoint is unreachable.
+
+    Pools never start a load balancer, and ``serve.server.impl.up`` does not
+    open the range for them, so the bound does not apply: the port is only a
+    placeholder the service row requires. Bounding it there would let an
+    exhausted range block a pool launch that needs no port at all.
     """
     start, end = serve_utils.get_load_balancer_port_range()
+    if pool:
+        return common_utils.find_free_port(start)
     try:
         return common_utils.find_free_port(start, end_port=end)
     except OSError as e:
@@ -602,7 +609,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
             # range that sky.serve.server.impl.up declared as the controller
             # task's ports=; anything outside it is not exposed.
             load_balancer_port = (
-                _allocate_load_balancer_port() if not is_recovery else
+                _allocate_load_balancer_port(
+                    pool=service_spec.pool) if not is_recovery else
                 serve_state.get_service_load_balancer_port(service_name))
             load_balancer_log_file = os.path.expanduser(
                 serve_utils.generate_remote_load_balancer_log_file_name(

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -84,7 +84,11 @@ def _allocate_load_balancer_port(pool: bool = False) -> int:
     """
     start, end = serve_utils.get_load_balancer_port_range()
     if pool:
-        return common_utils.find_free_port(start)
+        # 65535 is a valid port, but find_free_port stops at 65534 by default
+        # to preserve its behavior for every other caller. Leaving that cap in
+        # place here would search an empty span for a range starting at 65535,
+        # failing the pool launch this branch exists to let through.
+        return common_utils.find_free_port(start, end_port=65535)
     try:
         return common_utils.find_free_port(start, end_port=end)
     except OSError as e:

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -69,6 +69,26 @@ def _handle_signal(service_name: str) -> None:
     raise error_type(f'User signal received: {user_signal.value}')
 
 
+def _allocate_load_balancer_port() -> int:
+    """Picks a free port inside the declared load balancer port range.
+
+    The controller task opens ``serve.controller.load_balancer_port_range``
+    (default 30001-30020) once, at launch. Searching past that range binds a
+    port the cloud or Kubernetes never exposed: the service reports READY but
+    its endpoint is unreachable.
+    """
+    start, end = serve_utils.get_load_balancer_port_range()
+    try:
+        return common_utils.find_free_port(start, end_port=end)
+    except OSError as e:
+        key = '.'.join(serve_utils.LOAD_BALANCER_PORT_RANGE_CONFIG_KEY)
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                f'No free load balancer port in {start}-{end}. Widen {key} '
+                'and relaunch the controller; the new range only applies to '
+                'a newly launched controller.') from e
+
+
 def cleanup_storage(yaml_content: str) -> bool:
     """Clean up the storage for the service.
 
@@ -578,10 +598,11 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
 
             controller_addr = f'http://{controller_host}:{controller_port}'
 
-            # Start the load balancer.
+            # Start the load balancer. The port must come from the same
+            # range that sky.serve.server.impl.up declared as the controller
+            # task's ports=; anything outside it is not exposed.
             load_balancer_port = (
-                common_utils.find_free_port(constants.LOAD_BALANCER_PORT_START)
-                if not is_recovery else
+                _allocate_load_balancer_port() if not is_recovery else
                 serve_state.get_service_load_balancer_port(service_name))
             load_balancer_log_file = os.path.expanduser(
                 serve_utils.generate_remote_load_balancer_log_file_name(

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -852,15 +852,15 @@ def open_browser(url: str) -> bool:
     return webbrowser.open(url)
 
 
-def find_free_port(start_port: int) -> int:
-    """Finds first free local port starting with 'start_port'.
+def find_free_port(start_port: int, end_port: int = 65534) -> int:
+    """Finds first free local port in ``[start_port, end_port]``.
 
     Returns: a free local port.
 
     Raises:
-      OSError: If no free ports are available.
+      OSError: If no free ports are available in the range.
     """
-    for port in range(start_port, 65535):
+    for port in range(start_port, end_port + 1):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             try:
                 s.bind(('', port))

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1856,33 +1856,37 @@ def get_config_schema():
     }
     resources_schema['properties'].pop('ports')
 
-    def _get_controller_schema(extra_properties: Optional[Dict[str,
-                                                               Any]] = None,):
+    def _get_controller_schema(
+            extra_properties: Optional[Dict[str, Any]] = None,
+            controller_extra_properties: Optional[Dict[str, Any]] = None):
+        controller_properties: Dict[str, Any] = {
+            'resources': resources_schema,
+            'high_availability': {
+                'type': 'boolean',
+                'default': False,
+            },
+            'autostop': _AUTOSTOP_SCHEMA,
+            'consolidation_mode': {
+                'type': 'boolean',
+                # When unset, automatically enabled for deploy-mode
+                # servers (--deploy) if no existing controller
+                # clusters are found.
+            },
+            'controller_logs_gc_retention_hours': {
+                'type': 'integer',
+            },
+            'task_logs_gc_retention_hours': {
+                'type': 'integer',
+            },
+        }
+        if controller_extra_properties:
+            controller_properties.update(controller_extra_properties)
         props: Dict[str, Any] = {
             'controller': {
                 'type': 'object',
                 'required': [],
                 'additionalProperties': False,
-                'properties': {
-                    'resources': resources_schema,
-                    'high_availability': {
-                        'type': 'boolean',
-                        'default': False,
-                    },
-                    'autostop': _AUTOSTOP_SCHEMA,
-                    'consolidation_mode': {
-                        'type': 'boolean',
-                        # When unset, automatically enabled for deploy-mode
-                        # servers (--deploy) if no existing controller
-                        # clusters are found.
-                    },
-                    'controller_logs_gc_retention_hours': {
-                        'type': 'integer',
-                    },
-                    'task_logs_gc_retention_hours': {
-                        'type': 'integer',
-                    },
-                },
+                'properties': controller_properties,
             },
             'bucket': {
                 'type': 'string',
@@ -3008,7 +3012,13 @@ def get_config_schema():
                 'status_check': jobs_status_check_schema,
                 **_extra_jobs_properties,
             },),
-            'serve': _get_controller_schema(),
+            'serve': _get_controller_schema(
+                controller_extra_properties={
+                    'load_balancer_port_range': {
+                        'type': 'string',
+                        'pattern': r'^[0-9]{1,5}-[0-9]{1,5}$',
+                    },
+                }),
             'allowed_clouds': allowed_clouds,
             'admin_policy': admin_policy_schema,
             'docker': docker_configs,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -324,6 +324,35 @@ def test_invalid_indent_config(monkeypatch, tmp_path) -> None:
     assert 'Invalid config YAML' in e.value.args[0]
 
 
+def test_serve_load_balancer_port_range_accepted(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / 'ok.yaml'
+    config_path.write_text(
+        textwrap.dedent("""\
+            serve:
+                controller:
+                    load_balancer_port_range: 30001-30050
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    skypilot_config.reload_config()
+    assert skypilot_config.get_nested(
+        ('serve', 'controller', 'load_balancer_port_range'),
+        None) == '30001-30050'
+
+
+def test_jobs_controller_rejects_load_balancer_port_range(
+        monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / 'bad.yaml'
+    config_path.write_text(
+        textwrap.dedent("""\
+            jobs:
+                controller:
+                    load_balancer_port_range: 30001-30050
+            """))
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
+    with pytest.raises(ValueError, match='Invalid config YAML'):
+        skypilot_config.reload_config()
+
+
 def test_invalid_enum_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file contains an invalid enum value."""
     config_path = tmp_path / 'invalid.yaml'

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -663,4 +663,22 @@ class TestAllocateLoadBalancerPort:
                             find_free_port)
 
         assert service._allocate_load_balancer_port(pool=True) == 40000
-        find_free_port.assert_called_once_with(30001)
+        find_free_port.assert_called_once_with(30001, end_port=65535)
+
+    def test_pool_search_spans_the_top_of_the_port_space(self, monkeypatch):
+        """A range starting at 65535 must still leave a pool a port to take.
+
+        find_free_port stops at 65534 by default, so inheriting that cap here
+        would search an empty span and fail the launch on the one path that
+        is supposed to be exempt from the range.
+        """
+        monkeypatch.setattr(
+            'sky.serve.service.serve_utils.get_load_balancer_port_range',
+            lambda: (65535, 65535))
+        find_free_port = mock.Mock(return_value=65535)
+        monkeypatch.setattr('sky.serve.service.common_utils.find_free_port',
+                            find_free_port)
+
+        assert service._allocate_load_balancer_port(pool=True) == 65535
+        # Without the explicit end_port the search span would be empty.
+        find_free_port.assert_called_once_with(65535, end_port=65535)

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -19,6 +19,8 @@ from unittest import mock
 
 import pytest
 
+from sky.serve import constants as serve_constants
+from sky.serve import serve_utils
 from sky.serve import service
 
 
@@ -564,3 +566,57 @@ class TestCleanupStorageStaleBucket:
         assert '/persist' in mock_task.storage_mounts
         mock_backend.teardown_ephemeral_storage.assert_called_once_with(
             mock_task)
+
+
+class TestLoadBalancerPortRange:
+    """The in-pod port search must stay inside the declared controller range."""
+
+    @staticmethod
+    def _set_config(monkeypatch, value):
+        monkeypatch.setattr(
+            'sky.serve.serve_utils.skypilot_config.get_nested',
+            lambda keys, default_value=None, **kwargs: default_value
+            if value is None else value)
+
+    def test_default_matches_controller_declaration(self, monkeypatch):
+        """The default must be the range impl.up opens on the controller."""
+        self._set_config(monkeypatch, None)
+        start, end = serve_utils.get_load_balancer_port_range()
+        assert f'{start}-{end}' == serve_constants.LOAD_BALANCER_PORT_RANGE
+
+    def test_custom_range(self, monkeypatch):
+        self._set_config(monkeypatch, '31000-31009')
+        assert serve_utils.get_load_balancer_port_range() == (31000, 31009)
+
+    @pytest.mark.parametrize(
+        'value',
+        ['30001', '30001-', 'a-b', '30001-30000', '0-30000', '30001-70000'])
+    def test_rejects_invalid_range(self, monkeypatch, value):
+        self._set_config(monkeypatch, value)
+        with pytest.raises(ValueError,
+                           match='serve.controller.load_balancer_port_range'):
+            serve_utils.get_load_balancer_port_range()
+
+
+class TestAllocateLoadBalancerPort:
+
+    def test_search_is_bounded_by_the_range(self, monkeypatch):
+        monkeypatch.setattr(
+            'sky.serve.service.serve_utils.get_load_balancer_port_range',
+            lambda: (30001, 30020))
+        find_free_port = mock.Mock(return_value=30005)
+        monkeypatch.setattr('sky.serve.service.common_utils.find_free_port',
+                            find_free_port)
+        assert service._allocate_load_balancer_port() == 30005
+        find_free_port.assert_called_once_with(30001, end_port=30020)
+
+    def test_raises_naming_config_key_when_range_exhausted(self, monkeypatch):
+        monkeypatch.setattr(
+            'sky.serve.service.serve_utils.get_load_balancer_port_range',
+            lambda: (30001, 30020))
+        monkeypatch.setattr(
+            'sky.serve.service.common_utils.find_free_port',
+            mock.Mock(side_effect=OSError('No free ports available.')))
+        with pytest.raises(RuntimeError,
+                           match='serve.controller.load_balancer_port_range'):
+            service._allocate_load_balancer_port()

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -22,6 +22,7 @@ import pytest
 from sky.serve import constants as serve_constants
 from sky.serve import serve_utils
 from sky.serve import service
+from sky.utils import config_utils
 
 
 def _bind_socket_async(host, port, delay):
@@ -597,6 +598,32 @@ class TestLoadBalancerPortRange:
                            match='serve.controller.load_balancer_port_range'):
             serve_utils.get_load_balancer_port_range()
 
+    def test_explicit_config_wins_over_ambient(self, monkeypatch):
+        """impl.up must read the range an admin policy actually produced.
+
+        The controller is launched with the policy's mutated config, so
+        opening ports from the ambient pre-policy config would open one
+        range and allocate from another.
+        """
+        self._set_config(monkeypatch, '31000-31009')
+        mutated = config_utils.Config({
+            'serve': {
+                'controller': {
+                    'load_balancer_port_range': '32000-32005'
+                }
+            }
+        })
+
+        assert serve_utils.get_load_balancer_port_range(mutated) == (32000,
+                                                                     32005)
+
+    def test_explicit_config_falls_back_to_default(self, monkeypatch):
+        """A policy that does not set the key leaves the default in place."""
+        self._set_config(monkeypatch, '31000-31009')
+        start, end = serve_utils.get_load_balancer_port_range(
+            config_utils.Config())
+        assert f'{start}-{end}' == serve_constants.LOAD_BALANCER_PORT_RANGE
+
 
 class TestAllocateLoadBalancerPort:
 
@@ -620,3 +647,20 @@ class TestAllocateLoadBalancerPort:
         with pytest.raises(RuntimeError,
                            match='serve.controller.load_balancer_port_range'):
             service._allocate_load_balancer_port()
+
+    def test_pool_search_is_not_bounded(self, monkeypatch):
+        """A pool needs no load balancer, so the range must not gate it.
+
+        impl.up does not open the range for pools, so an exhausted range is
+        not a reason to refuse a pool launch: the port is only a placeholder
+        the service row requires.
+        """
+        monkeypatch.setattr(
+            'sky.serve.service.serve_utils.get_load_balancer_port_range',
+            lambda: (30001, 30020))
+        find_free_port = mock.Mock(return_value=40000)
+        monkeypatch.setattr('sky.serve.service.common_utils.find_free_port',
+                            find_free_port)
+
+        assert service._allocate_load_balancer_port(pool=True) == 40000
+        find_free_port.assert_called_once_with(30001)

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import os
+import socket
 import tempfile
 from unittest import mock
 
@@ -802,3 +803,16 @@ class TestAtomicWriteText:
         assert not target.exists()
         # Crucially: no hidden .tmp file left behind in the directory.
         assert list(tmp_path.iterdir()) == []
+
+
+class TestFindFreePort:
+
+    def test_respects_end_port(self):
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        holder.bind(('', 0))
+        port = holder.getsockname()[1]
+        try:
+            with pytest.raises(OSError, match='No free ports available'):
+                common_utils.find_free_port(port, end_port=port)
+        finally:
+            holder.close()

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -816,3 +816,12 @@ class TestFindFreePort:
                 common_utils.find_free_port(port, end_port=port)
         finally:
             holder.close()
+
+    def test_default_end_port_excludes_65535(self):
+        """The default cap is 65534, so a search from 65535 spans nothing.
+
+        Callers that need the top of the port space have to ask for it. This
+        pins the default, which exists to preserve the pre-end_port behavior.
+        """
+        with pytest.raises(OSError, match='No free ports available'):
+            common_utils.find_free_port(65535)


### PR DESCRIPTION
The SkyServe controller task opens ports=['30001-30020'], but the
allocator on the controller called find_free_port(30001), which scans up
to 65535. Once 20 services were up, service 21 bound a port that was
never exposed: it reported READY and was unreachable.

serve.controller.load_balancer_port_range (default 30001-30020) is now
the single source for both the controller task's ports= and the port
search, so the two cannot drift. Exhausting the range raises and names
that config key instead of silently binding out of range. find_free_port
grows an end_port bound whose default preserves today's behavior for
every other caller.

A changed range only applies to a newly launched controller; existing
controllers keep the ports they opened at launch.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->