### PR TITLE
[Dashboard] Rename "Requested Resources" column to "Resources" on managed jobs page

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1869,7 +1869,7 @@ export function ManagedJobsTable({
             className="sortable whitespace-nowrap"
             onClick={() => requestSort('cluster')}
           >
-            Requested{getSortDirection('cluster')}
+            Resources{getSortDirection('cluster')}
           </TableHead>
         ),
         renderCell: (item, ctx) => {

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1869,7 +1869,7 @@ export function ManagedJobsTable({
             className="sortable whitespace-nowrap"
             onClick={() => requestSort('cluster')}
           >
-            Requested Resources{getSortDirection('cluster')}
+            Requested{getSortDirection('cluster')}
           </TableHead>
         ),
         renderCell: (item, ctx) => {


### PR DESCRIPTION
## Summary
- Rename the managed jobs page column header from "Requested Resources" to "Resources" for a more compact table

## Test plan
- [ ] Open the managed jobs page in the dashboard and confirm the column header reads "Resources"
- [ ] Confirm column sorting still works (sort key unchanged)