### PR TITLE
[Slurm] Run credential check as the SSH user; keep infra partition toggle collapsible

### DIFF
--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -885,7 +885,16 @@ class Slurm(clouds.Cloud):
                     ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
                     identities_only=slurm_utils.get_identities_only(
                         ssh_config_dict),
-                    slurm_user=slurm_utils.get_submit_user(cluster),
+                    # The check's probes (sinfo, env, a stat of the workdir)
+                    # are read-only: run them as the SSH user rather than the
+                    # submit user. With submit_as_user, acting as the submit
+                    # user goes through su/sudo, and clusters commonly grant
+                    # passwordless sudo only for the submission commands
+                    # (sbatch/srun/scancel/squeue) — wrapping sinfo would fail
+                    # the whole credential check and silently disable Slurm,
+                    # taking down every consumer of the enabled-clouds cache
+                    # (e.g. GPU availability on the infra page).
+                    slurm_user=None,
                 )
                 info = client.info()
                 logger.debug(f'Slurm cluster {cluster} sinfo: {info}')

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -676,9 +676,16 @@ export function InfrastructureSection({
                     isExpandable && expandedContexts.has(context);
                   // Expanding appends the partition breakdown under the
                   // cluster's own totals, so the aggregate stays on screen and
-                  // the toggle keeps its place.
+                  // the toggle keeps its place. When the cluster has no GPU
+                  // type rows (e.g. its availability sweep failed), a null
+                  // summary row stands in — otherwise every expanded row would
+                  // be a partition row, and the toggle cell (the only way to
+                  // collapse) would never render again.
                   const subRows = isExpanded
-                    ? [...typeRows, ...partitionRows]
+                    ? [
+                        ...(typeRows.length ? typeRows : [null]),
+                        ...partitionRows,
+                      ]
                     : typeRows;
                   const summaryRowCount = Math.max(1, typeRows.length);
 

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -93,6 +93,58 @@ class TestSlurmClientSubmitUser:
                                                   slurm_user='alice')
 
 
+class TestCheckComputeCredentials:
+    """The credential check must not impersonate the submit user.
+
+    Sites that enable submit_as_user commonly grant passwordless sudo for
+    the submission commands only (sbatch/srun/scancel/squeue), so an
+    impersonated read-only probe (sinfo) is denied — and a failed check
+    disables the cluster for every consumer of the enabled-clouds cache.
+    The check's probes carry no identity requirement, so they run as the
+    SSH user (slurm_user=None).
+    """
+
+    @patch('sky.clouds.slurm.skypilot_config.get_effective_region_config',
+           return_value=None)
+    @patch('sky.clouds.slurm.slurm_utils.get_identities_only',
+           return_value=True)
+    @patch('sky.clouds.slurm.slurm_utils.get_identity_file',
+           return_value='/root/.ssh/key')
+    @patch('sky.clouds.slurm.Slurm.existing_allowed_clusters',
+           return_value=['restricted'])
+    @patch('sky.clouds.slurm.slurm_utils.get_slurm_ssh_config')
+    @patch('sky.clouds.slurm.slurm.SlurmClient')
+    def test_check_runs_as_ssh_user_under_restricted_sudo(
+            self, mock_client_class, mock_get_ssh_config, *_mocks):
+        mock_get_ssh_config.return_value.lookup.return_value = {
+            'hostname': 'login.example.com',
+            'port': 22,
+            'user': 'svc',
+        }
+
+        def make_client(*args, **kwargs):
+            del args  # unused
+            client = mock.MagicMock()
+            if kwargs.get('slurm_user') is not None:
+                # Restricted-sudo cluster: any impersonated command is
+                # denied, exactly what the check must not depend on.
+                client.info.side_effect = RuntimeError(
+                    'sudo: a password is required')
+            else:
+                client.info.return_value = 'PARTITION AVAIL NODES'
+                client.get_env.return_value = {'HOME': '/home/svc'}
+                client.check_dir_shared_fs.return_value = 'nfs'
+            return client
+
+        mock_client_class.side_effect = make_client
+
+        success, ctx2text = slurm_cloud.Slurm._check_compute_credentials()
+
+        assert success
+        assert 'enabled' in ctx2text['restricted']
+        assert mock_client_class.call_args.kwargs['slurm_user'] is None
+
+
 class TestSubmitUserDeployVariables:
 
     @staticmethod


### PR DESCRIPTION
## Problem

On a Slurm deployment with `submit_as_user: true`, the credential check builds its `SlurmClient` with `slurm_user=<submit user>`, so even its read-only probes (`sinfo`, reading the remote env, a stat of the workdir) run through `su`/`sudo` as that user. Clusters commonly grant passwordless sudo only for the submission commands (`sbatch`/`srun`/`scancel`/`squeue`), so the check fails (`sudo: a password is required` / `su: Authentication failure`), Slurm gets cached as disabled, and everything downstream of the enabled-clouds cache silently goes dark: `slurm_gpu_availability` short-circuits to empty and the infra page renders dashes for every cluster's GPU columns — while node counts (which don't gate on enabled clouds) keep rendering, making the failure look like a data bug rather than a disabled cloud.

A second, related UX bug: once a cluster's GPU type rows are empty (exactly the state the above produces), expanding its partitions removes the expand/collapse control — every expanded row is a partition row and the toggle cell only rendered on a GPU-type summary row — so the breakdown cannot be collapsed again.

## Change

- `sky/clouds/slurm.py`: the credential check's client now passes `slurm_user=None` — its probes are read-only and need no impersonation. Submission paths keep the as-user wrapping (which the standard sudoers grants cover).
- `sky/dashboard/src/components/infra.jsx`: when a cluster has no GPU type rows, a null summary row stands in on expansion so the toggle cell (and the aggregate row it anchors) always renders; the null row shows dashes in the GPU columns.

## Tested

- Reproduced live on a real deployment: `sky check` failed per cluster on the wrapped `sinfo` while plain `sinfo` as the SSH user succeeds; with the fix's behavior (no impersonation) the same probes pass.
- Dashboard: `jest infra.test` — 19 passed with the change; `prettier --check` clean.
- `yapf` clean on `sky/clouds/slurm.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRE6WbKydERcgKRTdtX6d9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->