### PR TITLE
[Server] Rebuild the state DB engine once the connection budget is known

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -206,9 +206,13 @@ _queue_factory: Optional[queue_base.QueueBackendFactory] = None
 
 
 def executor_initializer(proc_group: str,
-                         clean_env: Optional[Dict[str, str]] = None):
+                         clean_env: Optional[Dict[str, str]] = None,
+                         num_db_connections_per_worker: int = 0):
     setproctitle.setproctitle(f'SkyPilot:executor:{proc_group}:'
                               f'{multiprocessing.current_process().pid}')
+    # Before anything that touches the state DB, so that plugin install and
+    # every request afterwards share one engine built for this budget.
+    db_utils.set_max_connections(num_db_connections_per_worker)
     # Load plugins for executor process.
     plugins.load_plugins(
         plugins.ExtensionContext(context=plugins.PluginContext.EXECUTOR))
@@ -361,9 +365,8 @@ class RequestWorker:
             # multiple requests can share the same process pid, which may cause
             # issues with SkyPilot core functions if they rely on the exit of
             # the process, such as subprocess_daemon.py.
-            fut = executor.submit_until_success(
-                _request_execution_wrapper, request_id, ignore_return_value,
-                self.num_db_connections_per_worker)
+            fut = executor.submit_until_success(_request_execution_wrapper,
+                                                request_id, ignore_return_value)
             # Decrement the free executor count when a request starts
             if metrics_utils.METRICS_ENABLED:
                 if self.schedule_type == api_requests.ScheduleType.LONG:
@@ -496,7 +499,8 @@ class RequestWorker:
                 garanteed_workers=self.garanteed_parallelism,
                 burst_workers=self.burstable_parallelism,
                 initializer=executor_initializer,
-                initargs=(proc_group, clean_env_module.get_clean_server_env()))
+                initargs=(proc_group, clean_env_module.get_clean_server_env(),
+                          self.num_db_connections_per_worker))
             # Initialize the appropriate gauge for the number of free executors
             total_executors = (self.garanteed_parallelism +
                                self.burstable_parallelism)
@@ -782,8 +786,7 @@ def _gated_sigterm_handler(signum: int,
 
 
 def _request_execution_wrapper(request_id: str,
-                               ignore_return_value: bool,
-                               num_db_connections_per_worker: int = 0) -> None:
+                               ignore_return_value: bool) -> None:
     """Wrapper for a request execution.
 
     It wraps the execution of a request to:
@@ -797,7 +800,6 @@ def _request_execution_wrapper(request_id: str,
     pid = multiprocessing.current_process().pid
     proc = psutil.Process(pid)
     rss_begin = proc.memory_info().rss
-    db_utils.set_max_connections(num_db_connections_per_worker)
     # Handle the SIGTERM signal to abort the request processing gracefully.
     # Only set up signal handlers in the main thread, as signal.signal() raises
     # ValueError if called from a non-main thread (e.g., in tests).

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -210,8 +210,8 @@ def executor_initializer(proc_group: str,
                          num_db_connections_per_worker: int = 0):
     setproctitle.setproctitle(f'SkyPilot:executor:{proc_group}:'
                               f'{multiprocessing.current_process().pid}')
-    # Before anything that touches the state DB, so that plugin install and
-    # every request afterwards share one engine built for this budget.
+    # Must precede plugin install: a plugin that keeps the engine it gets
+    # during install() would otherwise hold one built for the wrong budget.
     db_utils.set_max_connections(num_db_connections_per_worker)
     # Load plugins for executor process.
     plugins.load_plugins(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4141,6 +4141,10 @@ if __name__ == '__main__':
         logger.error(f'Port {cmd_args.port} is not available, exiting.')
         raise RuntimeError(f'Port {cmd_args.port} is not available')
 
+    # Must precede plugin install: a plugin that keeps the engine it gets
+    # during install() would otherwise hold one built for the wrong budget.
+    db_utils.set_max_connections(1)
+
     # Always load plugin in main process, an edge case is that the main process
     # will also run uvicorn server when num_worker=1 and then the plugins will
     # be installed twice in main process (second time with the uvicorn app).
@@ -4153,7 +4157,6 @@ if __name__ == '__main__':
     usage_lib.maybe_show_privacy_policy()
 
     # Initialize global user state db
-    db_utils.set_max_connections(1)
     logger.info('Initializing database engine')
     global_user_state.initialize_and_get_db()
     logger.info('Database engine initialized')

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -440,18 +440,31 @@ class DatabaseManager:
         self._post_init_fn = post_init_fn
         self._lock = threading.Lock()
         self._engine: Optional[sqlalchemy.engine.Engine] = None
-        self._engine_generation = -1
+        # The engine this manager built for itself, and the cache generation
+        # it came from. Together they answer "is self._engine still the one
+        # get_engine() would hand out?" without taking the creation lock on
+        # every call. An engine assigned to self._engine from outside (tests
+        # substitute one) is never ours, so it is always returned as-is.
+        self._own_engine: Optional[sqlalchemy.engine.Engine] = None
+        self._own_engine_generation = -1
         self._initialized = False
         self._engine_async: Optional[sqlalchemy_async.AsyncEngine] = None
 
+    def _engine_is_current(self) -> bool:
+        if self._engine is None:
+            return False
+        if self._engine is not self._own_engine:
+            return True
+        return self._own_engine_generation == get_engine_generation()
+
     def get_engine(self) -> sqlalchemy.engine.Engine:
         """Lazy sync engine init with double-checked locking."""
-        if (self._engine is not None and
-                self._engine_generation == get_engine_generation()):
+        if self._engine_is_current():
+            assert self._engine is not None
             return self._engine
         with self._lock:
-            if (self._engine is not None and
-                    self._engine_generation == get_engine_generation()):
+            if self._engine_is_current():
+                assert self._engine is not None
                 return self._engine
             generation = get_engine_generation()
             engine = get_engine(self._db_name)
@@ -460,8 +473,8 @@ class DatabaseManager:
                 # set_max_connections). Only the engine is replaced: the
                 # schema and any post-init side effects belong to the
                 # database, not to the engine, and must not be redone.
-                self._engine = engine
-                self._engine_generation = generation
+                self._engine = self._own_engine = engine
+                self._own_engine_generation = generation
                 return self._engine
             # Run schema creation / migrations on a direct (unpooled)
             # connection: Alembic's autocommit_block DDL relies on
@@ -474,8 +487,8 @@ class DatabaseManager:
             self._create_table_fn(get_engine(self._db_name, direct=True))
             # Set _engine before post_init_fn so that post_init_fn
             # can access self.engine (e.g. _sqlite_supports_returning).
-            self._engine = engine
-            self._engine_generation = generation
+            self._engine = self._own_engine = engine
+            self._own_engine_generation = generation
             if self._post_init_fn is not None:
                 self._post_init_fn(engine)
             self._initialized = True

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -440,16 +440,29 @@ class DatabaseManager:
         self._post_init_fn = post_init_fn
         self._lock = threading.Lock()
         self._engine: Optional[sqlalchemy.engine.Engine] = None
+        self._engine_generation = -1
+        self._initialized = False
         self._engine_async: Optional[sqlalchemy_async.AsyncEngine] = None
 
     def get_engine(self) -> sqlalchemy.engine.Engine:
         """Lazy sync engine init with double-checked locking."""
-        if self._engine is not None:
+        if (self._engine is not None and
+                self._engine_generation == get_engine_generation()):
             return self._engine
         with self._lock:
-            if self._engine is not None:
+            if (self._engine is not None and
+                    self._engine_generation == get_engine_generation()):
                 return self._engine
+            generation = get_engine_generation()
             engine = get_engine(self._db_name)
+            if self._initialized:
+                # A previously built engine was discarded (see
+                # set_max_connections). Only the engine is replaced: the
+                # schema and any post-init side effects belong to the
+                # database, not to the engine, and must not be redone.
+                self._engine = engine
+                self._engine_generation = generation
+                return self._engine
             # Run schema creation / migrations on a direct (unpooled)
             # connection: Alembic's autocommit_block DDL relies on
             # session-scoped COMMIT/BEGIN control that a transaction-mode
@@ -462,8 +475,10 @@ class DatabaseManager:
             # Set _engine before post_init_fn so that post_init_fn
             # can access self.engine (e.g. _sqlite_supports_returning).
             self._engine = engine
+            self._engine_generation = generation
             if self._post_init_fn is not None:
                 self._post_init_fn(engine)
+            self._initialized = True
             return self._engine
 
     async def get_async_engine(self) -> sqlalchemy_async.AsyncEngine:
@@ -492,10 +507,46 @@ _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
 _db_creation_lock = threading.Lock()
 
+# Bumped whenever a cached engine is discarded, so that holders of a cached
+# engine (DatabaseManager) know to re-fetch instead of using a stale one.
+_engine_generation = 0
+
+
+def get_engine_generation() -> int:
+    """Generation of the engine cache; changes when engines are discarded."""
+    return _engine_generation
+
 
 def set_max_connections(max_connections: int):
-    global _max_connections
+    """Set the per-process connection budget for sync Postgres engines.
+
+    Discards any sync Postgres engine already built under the previous
+    budget, so the next ``get_engine()`` rebuilds it with the right pool.
+    This matters because ``skypilot_config`` reads the server config from the
+    state DB while being imported, which happens in every server process long
+    before that process knows its budget: without the rebuild, every process
+    would keep the ``NullPool`` engine chosen at import time and open a fresh
+    connection for every query for the rest of its life.
+    """
+    global _max_connections, _engine_generation
+    if max_connections == _max_connections:
+        return
     _max_connections = max_connections
+    with _db_creation_lock:
+        # Only the plain sync engines take their pool from _max_connections.
+        # Async engines and no_pool engines are unconditionally NullPool.
+        stale = [
+            key for key in _postgres_engine_cache
+            if not key.startswith('async:') and not key.startswith('nopool:')
+        ]
+        for key in stale:
+            engine = _postgres_engine_cache.pop(key)
+            logger.info(
+                f'Rebuilding the {type(engine.pool).__name__} sync state '
+                f'engine for a budget of {max_connections} connections.')
+            engine.dispose()
+        if stale:
+            _engine_generation += 1
 
 
 def get_max_connections():
@@ -677,10 +728,6 @@ def get_engine(
             cache_key = f'nopool:{conn_string}'
         with _db_creation_lock:
             if cache_key not in _postgres_engine_cache:
-                engine_type = 'sync' if not async_engine else 'async'
-                logger.debug(
-                    f'Creating a new postgres {engine_type} engine with '
-                    f'maximum {_max_connections} connections')
                 # The engine role that labels this engine's metrics. Derived
                 # from the same conditions as the cache key, so one cached
                 # engine always carries one role: when `direct` resolves to
@@ -740,7 +787,12 @@ def get_engine(
                             max_overflow=max(0, 5 - _max_connections),
                             pool_pre_ping=True,
                             pool_recycle=1800))
-                sql_metrics.install(_postgres_engine_cache[cache_key], role)
+                new_engine = _postgres_engine_cache[cache_key]
+                sql_metrics.install(new_engine, role)
+                pool_name = type(new_engine.pool).__name__
+                logger.info(f'Created the {role} postgres engine on '
+                            f'{pool_name} (max {_max_connections} '
+                            'connections).')
             engine = _postgres_engine_cache[cache_key]
     else:
         assert db_name is not None, 'db_name must be provided for SQLite'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -7,7 +7,7 @@ import pathlib
 import sqlite3
 import threading
 import typing
-from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Set, Union
 import urllib.parse
 
 import aiosqlite
@@ -440,58 +440,52 @@ class DatabaseManager:
         self._post_init_fn = post_init_fn
         self._lock = threading.Lock()
         self._engine: Optional[sqlalchemy.engine.Engine] = None
-        # The engine this manager built for itself, and the cache generation
-        # it came from. Together they answer "is self._engine still the one
-        # get_engine() would hand out?" without taking the creation lock on
-        # every call. An engine assigned to self._engine from outside (tests
-        # substitute one) is never ours, so it is always returned as-is.
+        # The engine this manager built for itself. An engine assigned to
+        # _engine from outside is never replaced by a rebuild.
         self._own_engine: Optional[sqlalchemy.engine.Engine] = None
-        self._own_engine_generation = -1
-        self._initialized = False
+        self._own_engine_generation = 0
         self._engine_async: Optional[sqlalchemy_async.AsyncEngine] = None
 
-    def _engine_is_current(self) -> bool:
+    def _current_engine(self) -> Optional[sqlalchemy.engine.Engine]:
+        """The cached engine, or None when it must be re-fetched."""
         if self._engine is None:
-            return False
+            return None
         if self._engine is not self._own_engine:
-            return True
-        return self._own_engine_generation == get_engine_generation()
+            return self._engine
+        if self._own_engine_generation != _engine_generation:
+            return None
+        return self._engine
 
     def get_engine(self) -> sqlalchemy.engine.Engine:
         """Lazy sync engine init with double-checked locking."""
-        if self._engine_is_current():
-            assert self._engine is not None
-            return self._engine
+        engine = self._current_engine()
+        if engine is not None:
+            return engine
         with self._lock:
-            if self._engine_is_current():
-                assert self._engine is not None
-                return self._engine
-            generation = get_engine_generation()
+            engine = self._current_engine()
+            if engine is not None:
+                return engine
+            generation = _engine_generation
             engine = get_engine(self._db_name)
-            if self._initialized:
-                # A previously built engine was discarded (see
-                # set_max_connections). Only the engine is replaced: the
-                # schema and any post-init side effects belong to the
-                # database, not to the engine, and must not be redone.
-                self._engine = self._own_engine = engine
-                self._own_engine_generation = generation
-                return self._engine
-            # Run schema creation / migrations on a direct (unpooled)
-            # connection: Alembic's autocommit_block DDL relies on
-            # session-scoped COMMIT/BEGIN control that a transaction-mode
-            # pooler does not preserve, whereas the runtime engine returned to
-            # callers may be pooled. Tables live in the same physical database
-            # either way, so the pooled runtime engine sees them. When no
-            # pooler is configured, direct == pooled (same cached engine), so
-            # this is a no-op.
-            self._create_table_fn(get_engine(self._db_name, direct=True))
+            first_init = self._own_engine is None
+            if first_init:
+                # Run schema creation / migrations on a direct (unpooled)
+                # connection: Alembic's autocommit_block DDL relies on
+                # session-scoped COMMIT/BEGIN control that a transaction-mode
+                # pooler does not preserve, whereas the runtime engine returned
+                # to callers may be pooled. Tables live in the same physical
+                # database either way, so the pooled runtime engine sees them.
+                # When no pooler is configured, direct == pooled (same cached
+                # engine), so this is a no-op.
+                self._create_table_fn(get_engine(self._db_name, direct=True))
             # Set _engine before post_init_fn so that post_init_fn
             # can access self.engine (e.g. _sqlite_supports_returning).
             self._engine = self._own_engine = engine
             self._own_engine_generation = generation
-            if self._post_init_fn is not None:
+            # Schema and post-init side effects belong to the database, not to
+            # the engine, and must not be redone when only the engine changes.
+            if first_init and self._post_init_fn is not None:
                 self._post_init_fn(engine)
-            self._initialized = True
             return self._engine
 
     async def get_async_engine(self) -> sqlalchemy_async.AsyncEngine:
@@ -520,9 +514,12 @@ _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
 _db_creation_lock = threading.Lock()
 
-# Bumped whenever a cached engine is discarded, so that holders of a cached
-# engine (DatabaseManager) know to re-fetch instead of using a stale one.
+# Bumped when a cached engine is discarded, so holders know to re-fetch.
 _engine_generation = 0
+# Cache keys whose pool was chosen from _max_connections, recorded by
+# get_engine() where that choice is made. Every other engine is
+# unconditionally NullPool and a new budget cannot change it.
+_budget_scoped_keys: Set[str] = set()
 
 
 def get_engine_generation() -> int:
@@ -535,28 +532,21 @@ def set_max_connections(max_connections: int):
 
     Discards any sync Postgres engine already built under the previous
     budget, so the next ``get_engine()`` rebuilds it with the right pool.
-    This matters because ``skypilot_config`` reads the server config from the
-    state DB while being imported, which happens in every server process long
-    before that process knows its budget: without the rebuild, every process
-    would keep the ``NullPool`` engine chosen at import time and open a fresh
-    connection for every query for the rest of its life.
+    ``skypilot_config`` reads the state DB while being imported, i.e. before
+    any process knows its budget, so an engine already exists by this point.
     """
     global _max_connections, _engine_generation
     if max_connections == _max_connections:
         return
     _max_connections = max_connections
     with _db_creation_lock:
-        # Only the plain sync engines take their pool from _max_connections.
-        # Async engines and no_pool engines are unconditionally NullPool.
-        stale = [
-            key for key in _postgres_engine_cache
-            if not key.startswith('async:') and not key.startswith('nopool:')
-        ]
+        stale = _budget_scoped_keys & set(_postgres_engine_cache)
         for key in stale:
             engine = _postgres_engine_cache.pop(key)
+            _budget_scoped_keys.discard(key)
             logger.info(
-                f'Rebuilding the {type(engine.pool).__name__} sync state '
-                f'engine for a budget of {max_connections} connections.')
+                f'Rebuilding the {type(engine.pool).__name__} state engine '
+                f'for a budget of {max_connections} connections.')
             engine.dispose()
         if stale:
             _engine_generation += 1
@@ -777,6 +767,8 @@ def get_engine(
                 elif _max_connections == 0 or (direct and _pooler_configured()):
                     if direct and _pooler_configured():
                         role = sql_metrics.DB_STATE_DIRECT
+                    else:
+                        _budget_scoped_keys.add(cache_key)
                     # NullPool: no persistent connections. Used when no pool
                     # size is configured, and — crucially — for the direct
                     # engine when a pooler IS configured. The direct engine
@@ -791,6 +783,7 @@ def get_engine(
                         sqlalchemy.create_engine(conn_string,
                                                  poolclass=sqlalchemy.NullPool))
                 else:
+                    _budget_scoped_keys.add(cache_key)
                     # Sync engines can safely use QueuePool for connection reuse
                     _postgres_engine_cache[cache_key] = (
                         sqlalchemy.create_engine(

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -209,12 +209,9 @@ class PostgresLock(DistributedLock):
         # Session-scoped advisory locks hold one connection across their whole
         # lifetime, which is unsafe through a transaction-mode pooler (the
         # backend can change between statements). Use a direct engine so the
-        # lock connection bypasses any configured pooler.
-        # It must also be its own unpooled engine rather than the shared state
-        # engine: a lock held for the life of a process would occupy that
-        # pool's single persistent connection, pushing every other query onto
-        # overflow connections that are closed on return -- i.e. silently
-        # turning the pooled engine back into a connect-per-query one.
+        # lock connection bypasses any configured pooler. It must also be its
+        # own unpooled engine: a lock held for the life of a process would
+        # otherwise occupy the shared pool's single persistent connection.
         engine = db_utils.get_engine(None, direct=True, no_pool=True)
         if engine.dialect.name != db_utils.SQLAlchemyDialect.POSTGRESQL.value:
             raise ValueError('PostgresLock requires PostgreSQL database. '

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -209,9 +209,13 @@ class PostgresLock(DistributedLock):
         # Session-scoped advisory locks hold one connection across their whole
         # lifetime, which is unsafe through a transaction-mode pooler (the
         # backend can change between statements). Use a direct engine so the
-        # lock connection bypasses any configured pooler; when none is
-        # configured this is the same engine global_user_state uses.
-        engine = db_utils.get_engine(None, direct=True)
+        # lock connection bypasses any configured pooler.
+        # It must also be its own unpooled engine rather than the shared state
+        # engine: a lock held for the life of a process would occupy that
+        # pool's single persistent connection, pushing every other query onto
+        # overflow connections that are closed on return -- i.e. silently
+        # turning the pooled engine back into a connect-per-query one.
+        engine = db_utils.get_engine(None, direct=True, no_pool=True)
         if engine.dialect.name != db_utils.SQLAlchemyDialect.POSTGRESQL.value:
             raise ValueError('PostgresLock requires PostgreSQL database. '
                              f'Current dialect: {engine.dialect.name}')

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -1598,3 +1598,29 @@ def test_saturating_request_executor_does_not_block_auth():
             except Exception:  # pylint: disable=broad-except
                 pass
         _reset_thread_executors()
+
+
+def test_executor_initializer_sets_budget_before_plugin_install():
+    """The connection budget must be applied before plugins install.
+
+    A plugin that keeps the engine it gets during install() would otherwise
+    hold one built for the wrong budget for the life of the worker, and
+    disposing the cached engine does not invalidate a reference someone
+    already holds.
+    """
+    calls = []
+    with mock.patch.object(executor.db_utils,
+                           'set_max_connections',
+                           side_effect=lambda n: calls.append(
+                               ('set_max_connections', n))), \
+         mock.patch.object(executor.plugins,
+                           'load_plugins',
+                           side_effect=lambda _: calls.append(
+                               ('load_plugins', None))), \
+         mock.patch.object(executor.metrics_lib,
+                           'register_multiproc_cleanup_atexit'), \
+         mock.patch.object(executor.setproctitle, 'setproctitle'), \
+         mock.patch.object(executor.threading, 'Thread'):
+        executor.executor_initializer('short', None, 1)
+
+    assert calls == [('set_max_connections', 1), ('load_plugins', None)]

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -636,6 +636,25 @@ class TestSetMaxConnectionsRebuild:
         assert db_utils.get_engine(None, async_engine=True) is async_engine
         assert db_utils.get_engine(None, direct=True, no_pool=True) is no_pool
 
+    def test_only_budget_dependent_engines_are_registered(self, monkeypatch):
+        # An engine is rebuilt iff it was registered when its pool was chosen.
+        # A budget-dependent engine that forgets to register would silently
+        # keep the pool it was first built with -- the original bug.
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        db_utils.set_max_connections(1)
+        pooled = db_utils.get_engine(None)
+        assert isinstance(pooled.pool, sqlalchemy.pool.QueuePool)
+        assert db_utils._budget_scoped_keys == set(
+            db_utils._postgres_engine_cache)
+
+        db_utils.get_engine(None, async_engine=True)
+        db_utils.get_engine(None, direct=True, no_pool=True)
+        db_utils.get_engine(None, direct=True)
+
+        registered = db_utils._budget_scoped_keys
+        assert len(registered) == 1
+        assert registered < set(db_utils._postgres_engine_cache)
+
     def test_direct_engine_behind_a_pooler_is_not_rebuilt(self, monkeypatch):
         # With a pooler configured the direct engine is unconditionally
         # NullPool, so the budget cannot change it and discarding it would

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -580,6 +580,83 @@ class TestGetEngine:
                 sqlalchemy.pool.QueuePool)
 
 
+class TestSetMaxConnectionsRebuild:
+    """set_max_connections must re-decide the pool of an existing engine.
+
+    Every server process reads the server config from the state DB while
+    importing skypilot_config, i.e. before it knows its connection budget. The
+    engine that read is served by is cached, so without a rebuild the whole
+    process stays on the NullPool chosen at import time.
+    """
+
+    @pytest.fixture(autouse=True)
+    def server_postgres(self, monkeypatch):
+        db_utils._postgres_engine_cache.clear()
+        db_utils._sqlite_engine_cache.clear()
+        db_utils.set_max_connections(0)
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://user:pass@10.0.0.5:5432/db')
+        monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_CONNECTION_URI', raising=False)
+
+    def test_import_time_nullpool_is_rebuilt_as_queuepool(self):
+        before = db_utils.get_engine(None)
+        assert isinstance(before.pool, sqlalchemy.NullPool)
+        generation = db_utils.get_engine_generation()
+
+        db_utils.set_max_connections(1)
+
+        after = db_utils.get_engine(None)
+        assert after is not before
+        assert isinstance(after.pool, sqlalchemy.pool.QueuePool)
+        assert after.pool.size() == 1
+        assert db_utils.get_engine_generation() != generation
+
+    def test_same_budget_keeps_the_engine(self):
+        db_utils.set_max_connections(1)
+        engine = db_utils.get_engine(None)
+        generation = db_utils.get_engine_generation()
+
+        db_utils.set_max_connections(1)
+
+        assert db_utils.get_engine(None) is engine
+        assert db_utils.get_engine_generation() == generation
+
+    def test_async_and_no_pool_engines_are_not_rebuilt(self):
+        # Both are unconditionally NullPool, so the budget cannot change them
+        # and discarding them would only churn connections.
+        async_engine = db_utils.get_engine(None, async_engine=True)
+        no_pool = db_utils.get_engine(None, direct=True, no_pool=True)
+
+        db_utils.set_max_connections(1)
+
+        assert db_utils.get_engine(None, async_engine=True) is async_engine
+        assert db_utils.get_engine(None, direct=True, no_pool=True) is no_pool
+
+    def test_database_manager_picks_up_the_rebuilt_engine(self):
+        create_table = mock.MagicMock()
+        post_init = mock.MagicMock()
+        manager = db_utils.DatabaseManager('state', create_table, post_init)
+
+        before = manager.get_engine()
+        assert isinstance(before.pool, sqlalchemy.NullPool)
+        assert create_table.call_count == 1
+        assert post_init.call_count == 1
+
+        db_utils.set_max_connections(1)
+
+        after = manager.get_engine()
+        assert after is not before
+        assert isinstance(after.pool, sqlalchemy.pool.QueuePool)
+        # The schema and the post-init side effects belong to the database,
+        # not to the engine: swapping the engine must not redo them.
+        assert create_table.call_count == 1
+        assert post_init.call_count == 1
+        # Stable once the generation matches again.
+        assert manager.get_engine() is after
+
+
 class TestConnStringResolution:
     """Tests for _rewrite_hostport and _resolve_conn_string."""
 

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -634,6 +634,21 @@ class TestSetMaxConnectionsRebuild:
         assert db_utils.get_engine(None, async_engine=True) is async_engine
         assert db_utils.get_engine(None, direct=True, no_pool=True) is no_pool
 
+    def test_database_manager_keeps_an_externally_assigned_engine(self):
+        # Substituting DatabaseManager._engine is how tests point a component
+        # at a scratch database. Only engines the manager built for itself may
+        # be replaced by a rebuild, whatever the cache generation is.
+        manager = db_utils.DatabaseManager('state', mock.MagicMock())
+        db_utils.set_max_connections(1)
+        substitute = sqlalchemy.create_engine('sqlite://')
+        manager._engine = substitute
+
+        assert manager.get_engine() is substitute
+
+        db_utils.set_max_connections(2)
+
+        assert manager.get_engine() is substitute
+
     def test_database_manager_picks_up_the_rebuilt_engine(self):
         create_table = mock.MagicMock()
         post_init = mock.MagicMock()

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -104,6 +104,7 @@ class TestGetEngine:
         # Clear the module-level caches
         db_utils._postgres_engine_cache.clear()
         db_utils._sqlite_engine_cache.clear()
+        db_utils._budget_scoped_keys.clear()
         # Reset max_connections to default
         db_utils.set_max_connections(0)
         # Ensure we're not in server mode by default
@@ -593,6 +594,7 @@ class TestSetMaxConnectionsRebuild:
     def server_postgres(self, monkeypatch):
         db_utils._postgres_engine_cache.clear()
         db_utils._sqlite_engine_cache.clear()
+        db_utils._budget_scoped_keys.clear()
         db_utils.set_max_connections(0)
         monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
         monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
@@ -633,6 +635,20 @@ class TestSetMaxConnectionsRebuild:
 
         assert db_utils.get_engine(None, async_engine=True) is async_engine
         assert db_utils.get_engine(None, direct=True, no_pool=True) is no_pool
+
+    def test_direct_engine_behind_a_pooler_is_not_rebuilt(self, monkeypatch):
+        # With a pooler configured the direct engine is unconditionally
+        # NullPool, so the budget cannot change it and discarding it would
+        # only churn connections.
+        monkeypatch.setenv('SKYPILOT_DB_POOL_HOSTPORT', '127.0.0.1:6432')
+        pooled = db_utils.get_engine(None)
+        direct = db_utils.get_engine(None, direct=True)
+        assert direct is not pooled
+
+        db_utils.set_max_connections(1)
+
+        assert db_utils.get_engine(None, direct=True) is direct
+        assert db_utils.get_engine(None) is not pooled
 
     def test_database_manager_keeps_an_externally_assigned_engine(self):
         # Substituting DatabaseManager._engine is how tests point a component


### PR DESCRIPTION
`skypilot_config` reads the server config from the state DB while it is being imported (`reload_config()` at module scope). That import happens in every server process — the main process, every uvicorn worker, every executor worker — long before the process calls `set_max_connections()`. So the engine serving that read is built while `_max_connections` is still `0` and gets a `NullPool`. `get_engine()` caches by connection string and `set_max_connections()` did not invalidate that cache, so the engine stayed unpooled for the life of the process: on Postgres, **every state query opened and closed its own connection**, including the auth lookups on the request hot path.

This is not deployment-specific and not a startup race — it happens on every Postgres server process, whatever `num_db_connections_per_worker` resolves to. Nothing reports it either, because `NullPool` exports no `size()`/`checkedout()`, so the pool gauges are empty by construction.

What changed:

- `set_max_connections()` discards sync Postgres engines built under the previous budget, and `DatabaseManager` re-fetches (via a cache generation counter) instead of pinning the engine it first saw. It only ever replaces an engine it built itself, so an engine substituted from outside is left alone.
- Every process type now sets its budget **before plugin install** — the main process, the executor pool initializer, and the uvicorn worker. Plugins that keep the engine they get during `install()` would otherwise hold one built for the wrong budget, and `Engine.dispose()` does not invalidate a reference someone already holds.
- Which cache entries take their pool from the budget is recorded where that choice is made, rather than re-derived from the cache key. Behind a pooler the `direct` engine's key carries no prefix, so a prefix-based filter discarded and rebuilt it on every budget change even though it is unconditionally `NullPool`.
- `PostgresLock` moves to its own `no_pool` engine, matching `leader_election`. A session-scoped advisory lock held for the life of a process would otherwise occupy the shared pool's single persistent connection and push every other query onto overflow connections that are closed on return. Note this *preserves* today's behaviour — the lock engine has always been `NullPool` in practice, because `_max_connections` was always 0 at creation.
- Engine creation logs role and pool class at INFO, so an unpooled state engine is visible rather than silent.

Async engines are untouched: `state_async`'s `NullPool` is deliberate (asyncpg pools bind to the event loop).

Worth noting for review: this activates a `QueuePool` path for the state engine that, because of the bug, has never actually run. Each server process now holds `pool_size=1` persistent connections plus overflow, which is what `compute_server_config` already assumed when it gated `num_db_connections_per_worker = 1` on `max_parallel_all_workers <= max_db_connections` — though that accounting counts one connection per process and ignores overflow. Controller processes never call `set_max_connections()` and so remain on `NullPool`; that is unchanged here and deliberate, since one pooled connection per controller process would be a much larger connection footprint.

## Tested

- [x] Code formatting: pre-commit (isort, mypy, yapf, pylint) passes
- [x] New unit tests in `tests/unit_tests/test_sky/utils/test_db_utils.py::TestSetMaxConnectionsRebuild`: import-time `NullPool` is rebuilt as `QueuePool`; an unchanged budget keeps the engine; async, `no_pool`, and pooler-fronted `direct` engines are not rebuilt; `DatabaseManager` picks up the rebuilt engine without re-running schema creation or post-init; an externally assigned engine is never replaced.
- [x] Manual A/B on a deploy-mode API server against a real Postgres, 12 uvicorn + 6 executor workers, identical load from a fresh start: connections for `db="state"` **239 → 112** for the same ~324 statements. Before, no `pool="QueuePool"` series existed for `db="state"` at all and `sky_apiserver_db_pool_size{db="state"}` was empty.
- [x] End-to-end on a hosted deployment (12 processes, Postgres behind a pgbouncer sidecar): all 12 processes log `NullPool` at import → `Rebuilding` → `QueuePool`; `sky_apiserver_db_pool_size{db="state",pool="QueuePool"}` is populated; the `direct` engine is created once and never rebuilt; **7.77 statements per connection** under load with `NullPool` connects flat at 23 (import-time only). PG backends stayed at 11 (one per process) across ~1200 requests, a cluster launch and a managed job. Advisory locks and leader election healthy (consolidation lock acquired via `PostgresLock`); zero pool errors and zero tracebacks.
- [x] `sky status`, `sky launch` on Kubernetes, and a managed job all reached terminal success through that deployment.