### PR TITLE
[Metrics] Measure the SSH round trip past the API server

### DIFF
--- a/charts/skypilot/manifests/api-server-overview.json
+++ b/charts/skypilot/manifests/api-server-overview.json
@@ -1422,7 +1422,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Does not include latency to reach cluster, lag on pod, or overhead to send to k8s tunnel.",
+      "description": "Synthetic 10s PING/PONG on the client\u2194API-server websocket, NOT keystroke latency and not tied to user input. Excludes the k8s port-forward tunnel and the pod sshd by construction \u2014 the server echoes the PING without forwarding it. See \"SSH backend turnaround\" for that leg. Also an indirect event-loop responsiveness probe: the PONG cannot ship until the websocket read loop is free. Empty (not zero) for clients older than API version 21, when SKYPILOT_SSH_DISABLE_LATENCY_MEASUREMENT=1, or when a plugin redirected the session off this server \u2014 check \"SSH sessions by path\".",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1507,7 +1507,200 @@
           "refId": "A"
         }
       ],
-      "title": "SSH RTT to API Server P95",
+      "title": "SSH websocket heartbeat RTT P95 (client\u2194API server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Round trip from the API server to the SSH backend and back, paired on real traffic: port-forward tunnel + both sshd hops + shell echo. This is everything the heartbeat panel excludes. A distribution, not a per-keystroke truth. Flat here while the heartbeat is spiky means the problem is on the client leg or in the event loop, not in the cluster.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency (s)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 5,
+        "y": 47
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.5,\n  sum by (le, path) (\n    rate(sky_apiserver_ssh_backend_turnaround_seconds_bucket{app=\"$app\"}[5m])\n  )\n)",
+          "legendFormat": "p50 {{path}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, path) (\n    rate(sky_apiserver_ssh_backend_turnaround_seconds_bucket{app=\"$app\"}[5m])\n  )\n)",
+          "legendFormat": "p95 {{path}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "SSH backend turnaround P50/P95 (API server\u2194pod)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Sessions accepted per second, split by how each was served. Read this before concluding anything from the two panels above: if `redirected` is the only line, both histograms are empty because the sessions never touched this server \u2014 not because SSH is fast.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Sessions/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 5,
+        "y": 55
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (path) (rate(sky_apiserver_ssh_sessions_total{app=\"$app\"}[5m]))",
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SSH sessions by path",
       "type": "timeseries"
     },
     {

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -155,6 +155,14 @@ _anchor_read_failed = False
 _LATENCY_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
                     60, 120, 300, 600, 1000, float('inf'))
 
+# Interactive-SSH scale, for the round trips a keystroke takes. _LATENCY_BUCKETS
+# starts at 5ms and runs to 1000s because it is sized for request durations; a
+# healthy API-server-to-pod round trip inside one cluster is sub-millisecond to
+# a few ms, so every good value would land in that ladder's first bucket. Top
+# out at 10s: an SSH echo that slow is a dead session, not a slow one.
+_SSH_ROUND_TRIP_BUCKETS = (0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+                           0.5, 1, 2.5, 5, 10, float('inf'))
+
 # Time spent processing a piece of code, refer to time_it().
 SKY_APISERVER_CODE_DURATION_SECONDS = prom.Histogram(
     'sky_apiserver_code_duration_seconds',
@@ -281,11 +289,52 @@ SKY_APISERVER_REQUEST_RSS_INCR_BYTES = prom.Histogram(
 
 SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS = prom.Histogram(
     'sky_apiserver_websocket_ssh_latency_seconds',
-    ('Time taken for ssh message to go from client to API server and back'
-     'to the client. This does not include: latency to reach the pod, '
-     'overhead from sending through the k8s port-forward tunnel, or '
-     'ssh server lag on the destination pod.'),
+    # NOT keystroke latency. Read the whole string before alerting on it.
+    ('SSH websocket heartbeat round trip, client to API server and back. '
+     'This is a synthetic PING the client sends every 10s while a session is '
+     'open -- NOT keystroke latency, and not tied to any user input. The '
+     'server echoes the PING without forwarding it, so the k8s port-forward '
+     'tunnel and the destination pod sshd are excluded by construction; see '
+     'sky_apiserver_ssh_backend_turnaround_seconds for those. Because the '
+     'PONG cannot be sent until the websocket read loop is free, this is '
+     'also an indirect event-loop responsiveness probe. Empty -- not zero -- '
+     'when clients are older than API version 21, when '
+     'SKYPILOT_SSH_DISABLE_LATENCY_MEASUREMENT=1, or when a plugin redirected '
+     'the session away from this API server.'),
     buckets=_LATENCY_BUCKETS,
+)
+
+# The leg the heartbeat above cannot see: API server -> (k8s API server ->
+# kubelet -> pod sshd, or a plugin's direct in-cluster connection) -> shell
+# echo -> back. Measured by pairing a small write to the backend with the next
+# read from it, so it costs two clock reads on a path that already inspects
+# every frame -- no injected bytes, no added latency, and no client support
+# needed. See sky.server.websocket_utils._BackendTurnaroundSampler for the
+# pairing rules and what makes a sample get dropped.
+#
+# `path` distinguishes how the session reached the pod: 'portforward' for this
+# server's kubectl port-forward, or a plugin-supplied value when a hook routes
+# the connection elsewhere. Two or three values in practice, so no cardinality
+# concern.
+SKY_APISERVER_SSH_BACKEND_TURNAROUND_SECONDS = prom.Histogram(
+    'sky_apiserver_ssh_backend_turnaround_seconds',
+    ('Round trip from the API server to the SSH backend and back, measured by '
+     'pairing a keystroke-sized write with the next read. Covers everything '
+     'the websocket heartbeat excludes: the port-forward tunnel, both sshd '
+     'hops and the shell echo. A distribution, not a per-keystroke truth -- '
+     'unpaired backend traffic can attach a read to the wrong write.'),
+    ['path'],
+    buckets=_SSH_ROUND_TRIP_BUCKETS,
+)
+
+# Denominator for the histograms above. Without it an empty
+# sky_apiserver_ssh_backend_turnaround_seconds is ambiguous: nobody is SSHing,
+# or every session was redirected away, or the pairing never fires. An alert on
+# the histogram alone is a rule that can go silently dead.
+SKY_APISERVER_SSH_SESSIONS_TOTAL = prom.Counter(
+    'sky_apiserver_ssh_sessions_total',
+    'SSH proxy sessions accepted, by how the session was served',
+    ['path'],
 )
 
 SKY_APISERVER_LONG_EXECUTORS = prom.Gauge(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3402,6 +3402,12 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
                      json.dumps(redirect_info).encode())
             await websocket.send_bytes(frame)
             await websocket.close()
+            # Counted before returning: this session is handed off, so none of
+            # the SSH metrics below will ever see it. Without this label an
+            # all-redirected deployment is indistinguishable from one where
+            # nobody SSHes at all.
+            metrics_utils.SKY_APISERVER_SSH_SESSIONS_TOTAL.labels(
+                path=websocket_utils.SSH_PATH_REDIRECTED).inc()
             return
 
     handle = await _validate_cluster_for_ssh_proxy_ws(websocket, cluster_name,
@@ -3478,6 +3484,8 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
     ssh_failed = False
     try:
         conn_gauge.inc()
+        metrics_utils.SKY_APISERVER_SSH_SESSIONS_TOTAL.labels(
+            path=websocket_utils.SSH_PATH_PORT_FORWARD).inc()
         # Connect to the local port
         reader, writer = await asyncio.open_connection('127.0.0.1', local_port)
 
@@ -3494,6 +3502,7 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
             write_to_backend=write_and_drain,
             close_backend=close_writer,
             timestamps_supported=timestamps_supported,
+            path=websocket_utils.SSH_PATH_PORT_FORWARD,
         )
     finally:
         conn_gauge.dec()
@@ -3656,6 +3665,8 @@ async def slurm_job_ssh_proxy(websocket: fastapi.WebSocket,
     ssh_failed = False
     try:
         conn_gauge.inc()
+        metrics_utils.SKY_APISERVER_SSH_SESSIONS_TOTAL.labels(
+            path=websocket_utils.SSH_PATH_SLURM).inc()
 
         async def write_and_drain(data: bytes) -> None:
             stdin.write(data)
@@ -3670,6 +3681,9 @@ async def slurm_job_ssh_proxy(websocket: fastapi.WebSocket,
             write_to_backend=write_and_drain,
             close_backend=close_stdin,
             timestamps_supported=timestamps_supported,
+            # srun's stdio, not a port-forward: keep the two out of one
+            # histogram, their latency profiles have nothing in common.
+            path=websocket_utils.SSH_PATH_SLURM,
         )
 
     finally:

--- a/sky/server/websocket_utils.py
+++ b/sky/server/websocket_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 from enum import IntEnum
 import struct
+import time
 from typing import Awaitable, Callable, Optional
 
 import fastapi
@@ -11,6 +12,12 @@ from sky import sky_logging
 from sky.metrics import utils as metrics_utils
 
 logger = sky_logging.init_logger(__name__)
+
+# How the session reached the SSH backend, for the `path` metric label. A
+# plugin that redirects a session elsewhere reports its own value.
+SSH_PATH_PORT_FORWARD = 'portforward'
+SSH_PATH_SLURM = 'slurm'
+SSH_PATH_REDIRECTED = 'redirected'
 
 # Hook for plugins to inject SSH redirect logic. When set, it is called after
 # WebSocket accept for clients that support the redirect protocol.
@@ -42,12 +49,99 @@ class SSHMessageType(IntEnum):
     REDIRECT = 3
 
 
+class _BackendTurnaroundSampler:
+    """Times the backend round trip by pairing a small write with a read.
+
+    The SSH stream is opaque and must stay byte-exact, so we cannot inject a
+    probe into it. But an interactive session is a request/response
+    conversation: a keystroke goes out as one small frame and its echo comes
+    back. Pairing on that shape measures everything past this process -- the
+    port-forward tunnel, both sshd hops, the pty, the shell -- for the cost of
+    two clock reads on a loop that already unpacks a header per frame.
+
+    This is a distribution, not a per-keystroke truth. Backend traffic that
+    answers no write (window adjusts, server keepalives, program output) can
+    attach a read to the wrong write, so a sample is only taken when both of
+    these hold:
+
+    * the write is keystroke-sized (``_MAX_WRITE_BYTES``) -- a paste, an scp
+      or a terminal resize burst is not a request/response exchange, and a
+      large write also *clears* any outstanding stamp, because the next read
+      is then far more likely to be its echo than the keystroke's;
+    * the reply arrives within ``_MAX_PENDING_SECONDS`` -- past that it is
+      far more likely to be unrelated output than a very slow echo, and
+      including it would corrupt the tail we are trying to measure.
+
+    Only the *first* read after a stamped write is paired; a long echo split
+    across several reads contributes one sample, timed to first byte, which is
+    what the user perceives.
+
+    When typing pipelines -- a second keystroke sent before the first is
+    answered -- the *oldest* outstanding stamp is kept rather than discarded.
+    The stream is ordered, so the first read back is the first write's echo,
+    which makes the oldest stamp the correct attribution. An earlier version
+    dropped the sample instead, on the theory that pipelined frames are
+    ambiguous; e2e testing showed that throws away precisely the samples
+    worth having, because a stalled backend is exactly when a user keeps
+    typing into the lag.
+
+    Not thread-safe and does not need to be: both callers are coroutines on
+    one event loop.
+    """
+
+    # Keystroke-sized. One keypress on a doubly-encrypted SSH stream is
+    # ~60-120 bytes; 512 leaves room for escape sequences and small control
+    # frames without admitting a paste.
+    _MAX_WRITE_BYTES = 512
+    _MAX_PENDING_SECONDS = 2.0
+
+    def __init__(self, path: str) -> None:
+        self._enabled = metrics_utils.METRICS_ENABLED
+        self._histogram = None
+        if self._enabled:
+            self._histogram = (
+                metrics_utils.SKY_APISERVER_SSH_BACKEND_TURNAROUND_SECONDS.
+                labels(path=path))
+        self._pending_at: Optional[float] = None
+
+    def on_write(self, size: int) -> None:
+        """Called just before handing ``size`` bytes to the backend."""
+        if not self._enabled:
+            return
+        if size == 0 or size > self._MAX_WRITE_BYTES:
+            # Not a request/response exchange. Drop any outstanding stamp too:
+            # the next read is more likely to answer this bulk write than the
+            # keystroke before it.
+            self._pending_at = None
+            return
+        if self._pending_at is not None:
+            # Pipelined typing. Keep the older stamp: the stream is ordered,
+            # so the next read answers the earlier write.
+            return
+        self._pending_at = time.monotonic()
+
+    def on_read(self) -> None:
+        """Called as soon as bytes come back from the backend."""
+        if not self._enabled:
+            return
+        pending_at = self._pending_at
+        self._pending_at = None
+        if pending_at is None:
+            return
+        elapsed = time.monotonic() - pending_at
+        if elapsed > self._MAX_PENDING_SECONDS:
+            return
+        assert self._histogram is not None
+        self._histogram.observe(elapsed)
+
+
 async def run_websocket_proxy(
     websocket: fastapi.WebSocket,
     read_from_backend: Callable[[], Awaitable[bytes]],
     write_to_backend: Callable[[bytes], Awaitable[None]],
     close_backend: Callable[[], Awaitable[None]],
     timestamps_supported: bool,
+    path: str = SSH_PATH_PORT_FORWARD,
 ) -> bool:
     """Run bidirectional WebSocket-to-backend proxy.
 
@@ -57,12 +151,18 @@ async def run_websocket_proxy(
         write_to_backend: Async callable to write bytes to backend
         close_backend: Async callable to close backend connection
         timestamps_supported: Whether to use message type framing
+        path: How this session reaches the backend, used as the `path` label
+            on sky_apiserver_ssh_backend_turnaround_seconds. Callers that
+            reach the pod some other way (a plugin connecting in-cluster,
+            say) should pass their own value so the two are not averaged
+            together.
 
     Returns:
         True if SSH failed, False otherwise
     """
     ssh_failed = False
     websocket_closed = False
+    turnaround = _BackendTurnaroundSampler(path)
 
     async def websocket_to_backend():
         try:
@@ -100,6 +200,7 @@ async def run_websocket_proxy(
                             f'Unknown message type: {message_type}')
 
                 try:
+                    turnaround.on_write(len(message))
                     await write_to_backend(message)
                 except Exception as e:  # pylint: disable=broad-except
                     # Typically we will not reach here, if the conn to backend
@@ -120,6 +221,8 @@ async def run_websocket_proxy(
         try:
             while True:
                 data = await read_from_backend()
+                if data:
+                    turnaround.on_read()
                 if not data:
                     if not websocket_closed:
                         logger.warning(

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -126,7 +126,12 @@ async def latency_monitor(websocket: ClientConnection,
                 # We are not getting responses, clear the dictionary so
                 # as not to grow unbounded.
                 last_ping_time_dict.clear()
-            ping_time = time.time()
+            # monotonic(), not time(): both ends of this interval are read in
+            # this process, and the wall clock can step (NTP) or jump (laptop
+            # suspend/resume) mid-window. A step charges the adjustment to SSH
+            # latency; a backwards step makes the interval negative, which
+            # wraps when packed into the unsigned '!Q' below.
+            ping_time = time.monotonic()
             next_id += 1
             last_ping_time_dict[next_id] = ping_time
             message_header_bytes = struct.pack('!BI',
@@ -206,7 +211,7 @@ async def websocket_to_stdout(websocket: ClientConnection,
                         raise ValueError(
                             f'Invalid PONG message length: {len(message)}')
                     pong_id = struct.unpack('!I', message[1:5])[0]
-                    pong_time = time.time()
+                    pong_time = time.monotonic()
 
                     ping_time = last_ping_time_dict.pop(pong_id, None)
 

--- a/tests/unit_tests/test_sky/server/test_websocket_utils.py
+++ b/tests/unit_tests/test_sky/server/test_websocket_utils.py
@@ -1,0 +1,244 @@
+"""Tests for the SSH-over-websocket proxy instrumentation."""
+import asyncio
+import struct
+from unittest import mock
+
+import pytest
+
+from sky.server import websocket_utils
+
+
+def _sampler(enabled=True):
+    """A sampler with a stub histogram, so observations are inspectable."""
+    with mock.patch.object(websocket_utils.metrics_utils, 'METRICS_ENABLED',
+                           enabled):
+        sampler = websocket_utils._BackendTurnaroundSampler('portforward')
+    observed = []
+    sampler._histogram = mock.Mock(observe=observed.append)
+    return sampler, observed
+
+
+def test_small_write_pairs_with_next_read():
+    sampler, observed = _sampler()
+    sampler.on_write(64)
+    sampler.on_read()
+    assert len(observed) == 1
+    assert observed[0] >= 0
+
+
+def test_only_first_read_is_paired():
+    """A long echo split across reads must contribute one sample, not many."""
+    sampler, observed = _sampler()
+    sampler.on_write(64)
+    sampler.on_read()
+    sampler.on_read()
+    sampler.on_read()
+    assert len(observed) == 1
+
+
+def test_oversized_write_is_not_sampled():
+    """A paste or an scp is not a request/response exchange."""
+    sampler, observed = _sampler()
+    sampler.on_write(
+        websocket_utils._BackendTurnaroundSampler._MAX_WRITE_BYTES + 1)
+    sampler.on_read()
+    assert observed == []
+
+
+def test_empty_write_is_not_sampled():
+    sampler, observed = _sampler()
+    sampler.on_write(0)
+    sampler.on_read()
+    assert observed == []
+
+
+def test_pipelined_writes_keep_the_oldest_stamp():
+    """Typing into a stalled backend must still be measured.
+
+    The stream is ordered, so the first read answers the first write. Keeping
+    the oldest stamp is both the correct attribution and the only way a stall
+    -- when a user keeps typing into the lag -- shows up at all.
+    """
+    sampler, observed = _sampler()
+    with mock.patch.object(websocket_utils.time,
+                           'monotonic',
+                           side_effect=[10.0, 10.9]):
+        sampler.on_write(64)  # stamped at 10.0
+        sampler.on_write(64)  # pipelined; must NOT reset the stamp
+        sampler.on_read()  # at 10.9
+    assert observed == [
+        pytest.approx(0.9)
+    ], ('a stalled backend with continued typing must produce a slow sample')
+
+
+def test_pipelining_does_not_wedge_the_sampler():
+    """After a paired round, the next exchange is sampled independently."""
+    sampler, observed = _sampler()
+    sampler.on_write(64)
+    sampler.on_write(64)
+    sampler.on_read()
+    assert len(observed) == 1
+    sampler.on_write(64)
+    sampler.on_read()
+    assert len(observed) == 2
+
+
+def test_bulk_write_clears_an_outstanding_stamp():
+    """A paste mid-keystroke: the next read answers the paste, not the key."""
+    sampler, observed = _sampler()
+    sampler.on_write(64)
+    sampler.on_write(
+        websocket_utils._BackendTurnaroundSampler._MAX_WRITE_BYTES + 1)
+    sampler.on_read()
+    assert observed == []
+
+
+def test_read_without_a_write_is_ignored():
+    """Unsolicited backend output (a `yes` loop, a keepalive) is not a reply."""
+    sampler, observed = _sampler()
+    sampler.on_read()
+    assert observed == []
+
+
+def test_stale_reply_is_discarded():
+    """Past the cap, a read is far likelier to be unrelated than a slow echo."""
+    sampler, observed = _sampler()
+    cap = websocket_utils._BackendTurnaroundSampler._MAX_PENDING_SECONDS
+    with mock.patch.object(websocket_utils.time,
+                           'monotonic',
+                           side_effect=[100.0, 100.0 + cap + 0.1]):
+        sampler.on_write(64)
+        sampler.on_read()
+    assert observed == []
+
+
+def test_elapsed_is_measured_not_guessed():
+    sampler, observed = _sampler()
+    with mock.patch.object(websocket_utils.time,
+                           'monotonic',
+                           side_effect=[10.0, 10.025]):
+        sampler.on_write(64)
+        sampler.on_read()
+    assert observed == [pytest.approx(0.025)]
+
+
+def test_disabled_sampler_never_touches_the_histogram():
+    """Metrics off is the default; the sampler must cost nothing there."""
+    sampler, observed = _sampler(enabled=False)
+    sampler.on_write(64)
+    sampler.on_read()
+    assert observed == []
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for fastapi.WebSocket over a fixed inbound script."""
+
+    def __init__(self, inbound):
+        self._inbound = list(inbound)
+        self.sent = []
+        self.closed = False
+
+    async def iter_bytes(self):
+        for message in self._inbound:
+            yield message
+
+    async def send_bytes(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        self.closed = True
+
+
+def _framed(payload: bytes) -> bytes:
+    return struct.pack('!B',
+                       websocket_utils.SSHMessageType.REGULAR_DATA) + payload
+
+
+@pytest.mark.asyncio
+async def test_proxy_records_turnaround_end_to_end():
+    """Drive the real proxy loop: a keystroke in, an echo out, one sample."""
+    websocket = _FakeWebSocket([_framed(b'a')])
+    written = []
+    # One echo, then EOF so backend_to_websocket terminates.
+    reads = [b'a', b'']
+
+    async def read_from_backend():
+        await asyncio.sleep(0)
+        return reads.pop(0) if reads else b''
+
+    async def write_to_backend(data):
+        written.append(data)
+
+    async def close_backend():
+        pass
+
+    observed = []
+    real_init = websocket_utils._BackendTurnaroundSampler.__init__
+
+    def init_with_stub(self, path):
+        real_init(self, path)
+        self._enabled = True
+        self._histogram = mock.Mock(observe=observed.append)
+
+    with mock.patch.object(websocket_utils._BackendTurnaroundSampler,
+                           '__init__', init_with_stub):
+        await websocket_utils.run_websocket_proxy(
+            websocket,
+            read_from_backend=read_from_backend,
+            write_to_backend=write_to_backend,
+            close_backend=close_backend,
+            timestamps_supported=True,
+        )
+
+    # The type byte is stripped before the backend sees the keystroke.
+    assert written == [b'a']
+    assert len(observed) == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_does_not_pair_a_heartbeat_ping():
+    """A PING is echoed by the server and never forwarded, so it is not a
+    write to the backend and must not produce a turnaround sample."""
+    ping = struct.pack('!BI', websocket_utils.SSHMessageType.PINGPONG, 7)
+    websocket = _FakeWebSocket([ping])
+
+    async def read_from_backend():
+        await asyncio.sleep(0)
+        return b''
+
+    async def write_to_backend(data):
+        raise AssertionError(f'PING must not reach the backend: {data!r}')
+
+    async def close_backend():
+        pass
+
+    observed = []
+    real_init = websocket_utils._BackendTurnaroundSampler.__init__
+
+    def init_with_stub(self, path):
+        real_init(self, path)
+        self._enabled = True
+        self._histogram = mock.Mock(observe=observed.append)
+
+    with mock.patch.object(websocket_utils._BackendTurnaroundSampler,
+                           '__init__', init_with_stub):
+        await websocket_utils.run_websocket_proxy(
+            websocket,
+            read_from_backend=read_from_backend,
+            write_to_backend=write_to_backend,
+            close_backend=close_backend,
+            timestamps_supported=True,
+        )
+
+    assert websocket.sent == [ping]
+    assert observed == []
+
+
+def test_heartbeat_help_string_says_it_is_not_keystroke_latency():
+    """The whole point of the rename: nobody should read this metric as
+    keystroke latency or as covering the pod leg."""
+    from sky.metrics import utils as metrics_utils
+    documentation = (metrics_utils.SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS.
+                     _documentation)
+    assert 'NOT keystroke latency' in documentation
+    assert 'sky_apiserver_ssh_backend_turnaround_seconds' in documentation


### PR DESCRIPTION
## Problem

`sky_apiserver_websocket_ssh_latency_seconds` is widely read as keystroke latency. It is neither keystroke latency nor a measurement of the path to the pod:

- It is a synthetic PING the client's ws-proxy sends every 10s (`websocket_proxy.py`, `HEARTBEAT_INTERVAL_SECONDS`), not something a keypress triggers.
- The server echoes that PING and `continue`s without forwarding it (`websocket_utils.py`), so the `kubectl port-forward` tunnel and the pod's sshd are excluded **by construction**.
- Because the PONG cannot be sent until the websocket read loop is free, it doubles as an event-loop responsiveness probe.

The practical consequence: a short interactive session can produce **zero** samples while every keystroke is measurably slow. Measured on a kind cluster, a ~12s `ssh` session recorded `..._count = 0` on the heartbeat while 29 keystroke round trips were happening.

## What this adds

`sky_apiserver_ssh_backend_turnaround_seconds{path}` covers exactly the excluded leg: API server → port-forward → kubelet → pod sshd → shell echo → back.

It adds **no bytes to the wire and needs no client support**. The proxy loop already unpacks a header per frame, so a keystroke-sized write to the backend is timestamped and paired with the next read. A stream of keystrokes is an ordered request/response conversation, which is what makes the pairing sound; when typing pipelines, the *oldest* outstanding stamp is kept, since the first read answers the first write. Samples are dropped when the write is too large to be a keystroke (a paste also clears any outstanding stamp) or when the reply takes longer than 2s and is more likely unrelated output than a very slow echo.

This is a distribution, not a per-keystroke truth — backend traffic that answers no write can attach a read to the wrong write. The docstring says so.

`sky_apiserver_ssh_sessions_total{path}` is the denominator. Without it an empty histogram is ambiguous: nobody is SSHing, every session was redirected away by a plugin hook, or the pairing broke. The redirect branch increments it before returning, so a handed-off session is still counted.

Also here:

- The heartbeat metric's `Help` string now says what it is, what it excludes, and when it is empty rather than zero.
- The "SSH RTT to API Server P95" dashboard panel is retitled accordingly, with panels added for the two new metrics.
- `time.monotonic()` replaces `time.time()` for the heartbeat interval. Both ends are read in one process, so the wall clock buys nothing and costs correctness: an NTP step or a laptop suspend inside the 10s window is charged to SSH latency, and a backwards step yields a negative interval that wraps when packed into the unsigned `!Q`.
- The new metrics get a bucket ladder starting at 1ms. `_LATENCY_BUCKETS` starts at 5ms because it is sized for request durations; this leg measures a ~3ms median in-cluster, so every healthy value would land in one bucket.

## Testing

15 unit tests in `tests/unit_tests/test_sky/server/test_websocket_utils.py` cover the pairing rules and drive the real `run_websocket_proxy` loop, including that a heartbeat PING must not produce a turnaround sample.

Measured end to end against a kind cluster, typing over a real `ssh`:

- 284 paired samples at a ~3ms median, ~76% of keystrokes sampled.
- Pausing the node container for 0.7s mid-keystroke put **exactly three** samples in the (0.5s, 1s] bucket, while the heartbeat — 17 pings in the same window — stayed at a 0.88ms mean, blind to the stall.
- Verified in the deployed process shape (`--deploy`, 10 server processes): samples written by a worker process are correctly aggregated by the multiprocess collector into the `/metrics` served from the main process.
- `promtool check metrics` on the live endpoint reports no issues for the new metrics.

An earlier version of the pairing discarded a sample whenever a second keystroke arrived before the first was answered. The end-to-end stall test showed that throws away precisely the samples worth having, since a stalled backend is exactly when a user keeps typing into the lag. Hence keeping the oldest stamp.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->