### PR TITLE
[Jobs] Scope managed-job log reads to the caller's workspaces

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1641,11 +1641,22 @@ def tail_logs(name: Optional[str],
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend), backend
 
+    # Same reason as in download_logs: the controller-side resolution
+    # (`get_latest_job_id` / `get_nonterminal_job_ids_by_name`) has no
+    # workspace filter, so resolve here through the queue instead and hand the
+    # runner a concrete id. Without `--controller`, streaming only ever
+    # targeted non-terminal jobs, and an ambiguous name was an error rather
+    # than a silent pick -- both preserved here.
+    resolved_job_id = _resolve_accessible_job_id_for_logs(
+        name, job_id, controller, skip_finished=not controller, for_tail=True)
+    if resolved_job_id is None:
+        return exceptions.JobExitCode.NOT_FOUND
+
     return managed_job_runner.current().tail_managed_job_logs(
         handle=handle,
         backend=backend,
-        job_id=job_id,
-        job_name=name,
+        job_id=resolved_job_id,
+        job_name=None,
         follow=follow,
         controller=controller,
         tail=tail,
@@ -1799,11 +1810,112 @@ def download_logs(
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend), backend
 
+    # Resolve to a concrete job id here rather than letting the backend do it.
+    # The backend resolves via ``GetAllJobIdsByName``, which has no workspace
+    # filter, so it would hand back a job the caller cannot read -- and with no
+    # selector it picks the globally newest job, not the newest the caller can
+    # see. Going through the queue applies ``accessible_workspaces`` (on the
+    # controller for new versions, client-side for old ones).
+    resolved_job_id = _resolve_accessible_job_id_for_logs(
+        name, job_id, controller)
+    if resolved_job_id is None:
+        return {}
+
     return backend.sync_down_managed_job_logs(handle,
-                                              job_id=job_id,
-                                              job_name=name,
+                                              job_id=resolved_job_id,
+                                              job_name=None,
                                               controller=controller,
                                               local_dir=local_dir)
+
+
+def _resolve_accessible_job_id_for_logs(
+        name: Optional[str],
+        job_id: Optional[int],
+        controller: bool,
+        *,
+        skip_finished: bool = False,
+        for_tail: bool = False) -> Optional[int]:
+    """The job id to read logs for, or None if the caller cannot see one.
+
+    Scoped by workspace, not by user: a workspace member may read any job in
+    it, which is what the dashboard already shows. Workspace scoping is the
+    only behaviour change here -- each caller's pre-existing name semantics
+    and messages are reproduced exactly, since they are not what this is
+    fixing:
+
+    - ``for_tail`` (``sky jobs logs``): only non-terminal jobs unless
+      ``--controller`` (``skip_finished``), and an ambiguous name raises
+      rather than guessing, matching ``managed_job_utils.stream_logs``.
+    - otherwise (``--sync-down``): every status, ambiguity takes the latest,
+      matching ``sync_down_managed_job_logs``.
+    """
+    if job_id is not None:
+        records, _, _, _ = queue_v2_api(refresh=False,
+                                        all_users=True,
+                                        job_ids=[job_id],
+                                        fields=['job_id'])
+        if not records:
+            logger.info(f'{colorama.Fore.YELLOW}'
+                        f'Managed job {job_id} not found.'
+                        f'{colorama.Style.RESET_ALL}')
+            return None
+        return job_id
+
+    if name is not None:
+        # ``name_match`` is a fuzzy match, so filter to the exact name here --
+        # same two-step the ``wait`` path above uses.
+        records, _, _, _ = queue_v2_api(refresh=False,
+                                        all_users=True,
+                                        skip_finished=skip_finished,
+                                        name_match=name,
+                                        fields=['job_id', 'job_name'])
+        candidates = [r for r in records if r.job_name == name]
+        name_str = f'under the name {name}. '
+    else:
+        # No selector: take the latest job whatever its status. `skip_finished`
+        # is deliberately not applied -- it mirrors the *name* lookup only
+        # (`get_nonterminal_job_ids_by_name`), while the bare path mirrors
+        # `get_latest_job_id`, which has no status filter.
+        records, _, _, _ = queue_v2_api(refresh=False,
+                                        all_users=True,
+                                        fields=['job_id'])
+        candidates = list(records)
+        name_str = ''
+
+    job_ids = sorted((r.job_id for r in candidates if r.job_id is not None),
+                     reverse=True)
+    if not job_ids:
+        if not for_tail:
+            msg = 'No matching job found'
+        elif name is None:
+            msg = 'No managed job found.'
+        elif skip_finished:
+            msg = f'No running managed job found with name {name!r}.'
+        else:
+            msg = f'No managed job found with name {name!r}.'
+        logger.info(f'{colorama.Fore.YELLOW}{msg}{colorama.Style.RESET_ALL}')
+        return None
+    if len(job_ids) > 1 and for_tail and name is not None:
+        # Raise rather than report-and-return, matching `stream_logs`. That
+        # means the message is invisible under `--no-follow` (the client only
+        # fetches the result when following) -- a pre-existing wart of the
+        # streaming endpoints, not something to change here.
+        if controller:
+            ids_str = ', '.join(str(i) for i in job_ids)
+            err = (f'Multiple managed jobs found with name {name!r} '
+                   f'(Job IDs: {ids_str}). Please specify the job_id instead.')
+        else:
+            err = f'Multiple running jobs found with name {name!r}.'
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(err)
+    if len(job_ids) > 1 and not for_tail:
+        # Sync-down only: the tail path picks the latest silently, as before.
+        controller_str = ' (controller)' if controller else ''
+        logger.info(f'{colorama.Fore.YELLOW}'
+                    f'Multiple jobs IDs found {name_str}'
+                    f'Downloading the latest job logs{controller_str}.'
+                    f'{colorama.Style.RESET_ALL}')
+    return job_ids[0]
 
 
 @usage_lib.entrypoint

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1843,9 +1843,10 @@ def _resolve_accessible_job_id_for_logs(
     and messages are reproduced exactly, since they are not what this is
     fixing:
 
-    - ``for_tail`` (``sky jobs logs``): only non-terminal jobs unless
-      ``--controller`` (``skip_finished``), and an ambiguous name raises
-      rather than guessing, matching ``managed_job_utils.stream_logs``.
+    - ``for_tail`` (``sky jobs logs``): a *named* lookup sees only
+      non-terminal jobs unless ``--controller`` (``skip_finished``; the bare
+      lookup ignores it), and an ambiguous name raises rather than guessing,
+      matching ``managed_job_utils.stream_logs``.
     - otherwise (``--sync-down``): every status, ambiguity takes the latest,
       matching ``sync_down_managed_job_logs``.
 
@@ -1875,24 +1876,30 @@ def _resolve_accessible_job_id_for_logs(
                                         name_match=name,
                                         fields=['job_id', 'job_name'])
         candidates = [r for r in records if r.job_name == name]
-        name_str = f'Multiple jobs IDs found under the name {name}. '
+        multiple_str = (f'Multiple jobs IDs found under the name {name}. ')
     else:
         # No selector: take the latest job whatever its status. `skip_finished`
         # is deliberately not applied -- it mirrors the *name* lookup only
         # (`get_nonterminal_job_ids_by_name`), while the bare path mirrors
         # `get_latest_job_id`, which has no status filter.
         #
-        # Ask for a single job rather than the whole table: this replaces a
+        # Ask for two jobs rather than the whole table: this replaces a
         # `LIMIT 1` query, and pagination here is by unique job, not by task.
-        # No `sort_by` is needed -- the query already defaults to job_id
-        # descending, which is the order we want.
+        # Two, not one, so that "is there more than one job" stays answerable
+        # -- sync-down reports that (`Downloading the latest job logs.`) and a
+        # limit of 1 would silently drop the notice. `[0]` is still the newest.
+        #
+        # No `sort_by`: the query already defaults to job_id descending. Note
+        # the old-controller LIST fallback does not re-sort at all -- it slices
+        # `filter_jobs` output directly -- so it leans on that dump already
+        # being `spot_job_id DESC`.
         records, _, _, _ = queue_v2_api(refresh=False,
                                         all_users=True,
                                         fields=['job_id'],
                                         page=1,
-                                        limit=1)
+                                        limit=2)
         candidates = list(records)
-        name_str = ''
+        multiple_str = ''
 
     # De-duplicate: the queue returns one record per *task*, so a multi-task
     # job repeats its id and would otherwise look like several jobs. The
@@ -1930,7 +1937,7 @@ def _resolve_accessible_job_id_for_logs(
         # Downloading the latest job logs."
         controller_str = ' (controller)' if controller else ''
         logger.info(f'{colorama.Fore.YELLOW}'
-                    f'{name_str}'
+                    f'{multiple_str}'
                     f'Downloading the latest job logs{controller_str}.'
                     f'{colorama.Style.RESET_ALL}')
     return job_ids[0]

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1848,6 +1848,11 @@ def _resolve_accessible_job_id_for_logs(
       rather than guessing, matching ``managed_job_utils.stream_logs``.
     - otherwise (``--sync-down``): every status, ambiguity takes the latest,
       matching ``sync_down_managed_job_logs``.
+
+    Costs one queue call on top of the handle the caller already resolved. That
+    is a direct DB read under consolidation, and a controller round-trip
+    otherwise -- a cost of ``queue_v2`` itself (``sky jobs queue`` pays it too),
+    so it belongs there rather than in a special case for this caller.
     """
     if job_id is not None:
         records, _, _, _ = queue_v2_api(refresh=False,

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1882,7 +1882,10 @@ def _resolve_accessible_job_id_for_logs(
         candidates = list(records)
         name_str = ''
 
-    job_ids = sorted((r.job_id for r in candidates if r.job_id is not None),
+    # De-duplicate: the queue returns one record per *task*, so a multi-task
+    # job repeats its id and would otherwise look like several jobs. The
+    # lookups this replaces select `spot_job_id` DISTINCT for the same reason.
+    job_ids = sorted({r.job_id for r in candidates if r.job_id is not None},
                      reverse=True)
     if not job_ids:
         if not for_tail:

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1870,15 +1870,22 @@ def _resolve_accessible_job_id_for_logs(
                                         name_match=name,
                                         fields=['job_id', 'job_name'])
         candidates = [r for r in records if r.job_name == name]
-        name_str = f'under the name {name}. '
+        name_str = f'Multiple jobs IDs found under the name {name}. '
     else:
         # No selector: take the latest job whatever its status. `skip_finished`
         # is deliberately not applied -- it mirrors the *name* lookup only
         # (`get_nonterminal_job_ids_by_name`), while the bare path mirrors
         # `get_latest_job_id`, which has no status filter.
+        #
+        # Ask for a single job rather than the whole table: this replaces a
+        # `LIMIT 1` query, and pagination here is by unique job, not by task.
+        # No `sort_by` is needed -- the query already defaults to job_id
+        # descending, which is the order we want.
         records, _, _, _ = queue_v2_api(refresh=False,
                                         all_users=True,
-                                        fields=['job_id'])
+                                        fields=['job_id'],
+                                        page=1,
+                                        limit=1)
         candidates = list(records)
         name_str = ''
 
@@ -1913,9 +1920,12 @@ def _resolve_accessible_job_id_for_logs(
             raise ValueError(err)
     if len(job_ids) > 1 and not for_tail:
         # Sync-down only: the tail path picks the latest silently, as before.
+        # The whole "Multiple jobs IDs found ..." clause is conditional on a
+        # name, otherwise the sentence reads "Multiple jobs IDs found
+        # Downloading the latest job logs."
         controller_str = ' (controller)' if controller else ''
         logger.info(f'{colorama.Fore.YELLOW}'
-                    f'Multiple jobs IDs found {name_str}'
+                    f'{name_str}'
                     f'Downloading the latest job logs{controller_str}.'
                     f'{colorama.Style.RESET_ALL}')
     return job_ids[0]

--- a/tests/unit_tests/test_jobs_download_logs_workspace.py
+++ b/tests/unit_tests/test_jobs_download_logs_workspace.py
@@ -1,0 +1,214 @@
+"""`sky jobs logs --sync-down` must not reach outside the caller's workspaces.
+
+The backend resolves a bare `--sync-down` through `GetAllJobIdsByName`, which
+has no workspace filter. `download_logs` therefore resolves the job id itself,
+through the queue (which applies `accessible_workspaces`).
+"""
+from unittest import mock
+
+import pytest
+
+from sky.jobs.server import core
+
+
+@pytest.fixture
+def backend():
+    with mock.patch.object(core, '_maybe_restart_controller') as restart, \
+         mock.patch.object(core.backend_utils,
+                           'get_backend_from_handle') as get_backend:
+        restart.return_value = mock.MagicMock()
+        # spec= makes the isinstance(...) assert in download_logs pass.
+        be = mock.MagicMock(spec=core.backends.CloudVmRayBackend)
+        be.sync_down_managed_job_logs.return_value = {1: '/tmp/1'}
+        get_backend.return_value = be
+        yield be
+
+
+def _record(job_id, job_name=None):
+    return mock.MagicMock(job_id=job_id, job_name=job_name)
+
+
+def test_bare_sync_down_picks_latest_accessible_not_latest_global(backend):
+    """Job 99 exists but is in another workspace, so the queue never returns it."""
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(7),
+                                          _record(3)], 2, {}, 2)) as queue:
+        core.download_logs(name=None,
+                           job_id=None,
+                           refresh=False,
+                           controller=False)
+
+    # Workspace is the boundary, not the user: all_users must stay True.
+    assert queue.call_args.kwargs['all_users'] is True
+    backend.sync_down_managed_job_logs.assert_called_once()
+    kwargs = backend.sync_down_managed_job_logs.call_args.kwargs
+    assert kwargs['job_id'] == 7
+    # job_name must be cleared, or the backend re-resolves unfiltered.
+    assert kwargs['job_name'] is None
+
+
+def test_job_id_outside_accessible_workspaces_is_refused(backend):
+    """An explicit id the queue cannot see must not be downloaded."""
+    with mock.patch.object(core, 'queue_v2_api', return_value=([], 0, {}, 0)):
+        assert core.download_logs(name=None,
+                                  job_id=99,
+                                  refresh=False,
+                                  controller=False) == {}
+    backend.sync_down_managed_job_logs.assert_not_called()
+
+
+def test_job_id_inside_accessible_workspaces_is_allowed(backend):
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(42)], 1, {}, 1)) as queue:
+        core.download_logs(name=None,
+                           job_id=42,
+                           refresh=False,
+                           controller=False)
+    assert queue.call_args.kwargs['job_ids'] == [42]
+    assert backend.sync_down_managed_job_logs.call_args.kwargs['job_id'] == 42
+
+
+def test_name_matches_exactly_and_picks_latest(backend):
+    """`name_match` is fuzzy, so a near-miss name must not be selected."""
+    records = [_record(5, 'train'), _record(9, 'train-v2'), _record(6, 'train')]
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=(records, 3, {}, 3)):
+        core.download_logs(name='train',
+                           job_id=None,
+                           refresh=False,
+                           controller=False)
+    assert backend.sync_down_managed_job_logs.call_args.kwargs['job_id'] == 6
+
+
+def test_no_accessible_job_returns_empty(backend):
+    with mock.patch.object(core, 'queue_v2_api', return_value=([], 0, {}, 0)):
+        assert core.download_logs(name=None,
+                                  job_id=None,
+                                  refresh=False,
+                                  controller=False) == {}
+    backend.sync_down_managed_job_logs.assert_not_called()
+
+
+# --- streaming (`sky jobs logs`, no --sync-down) ---
+#
+# Same hole as --sync-down: the controller resolves via `get_latest_job_id` /
+# `get_nonterminal_job_ids_by_name`, neither of which filters by workspace.
+
+
+@pytest.fixture
+def runner():
+    with mock.patch.object(core, '_maybe_restart_controller') as restart, \
+         mock.patch.object(core.backend_utils,
+                           'get_backend_from_handle') as get_backend, \
+         mock.patch.object(core.managed_job_runner, 'current') as current:
+        restart.return_value = mock.MagicMock()
+        get_backend.return_value = mock.MagicMock(
+            spec=core.backends.CloudVmRayBackend)
+        r = mock.MagicMock()
+        r.tail_managed_job_logs.return_value = 0
+        current.return_value = r
+        yield r
+
+
+def _tail(**kw):
+    args = dict(name=None,
+                job_id=None,
+                follow=False,
+                controller=False,
+                refresh=False)
+    args.update(kw)
+    return core.tail_logs(**args)
+
+
+def test_tail_bare_picks_latest_accessible_not_latest_global(runner):
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(7),
+                                          _record(3)], 2, {}, 2)) as queue:
+        _tail()
+    assert queue.call_args.kwargs['all_users'] is True
+    kwargs = runner.tail_managed_job_logs.call_args.kwargs
+    assert kwargs['job_id'] == 7
+    assert kwargs['job_name'] is None
+
+
+def test_tail_job_id_outside_accessible_workspaces_is_refused(runner):
+    with mock.patch.object(core, 'queue_v2_api', return_value=([], 0, {}, 0)):
+        assert _tail(job_id=99) == core.exceptions.JobExitCode.NOT_FOUND
+    runner.tail_managed_job_logs.assert_not_called()
+
+
+def test_name_lookup_is_status_scoped_but_bare_lookup_is_not(runner):
+    """`skip_finished` mirrors the *name* lookup only.
+
+    Master resolves a bare `sky jobs logs` via `get_latest_job_id`, which has
+    no status filter, while `-n <name>` goes through
+    `get_nonterminal_job_ids_by_name`. Applying the status filter to the bare
+    path would stop the newest job being tailable as soon as it finished.
+    """
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(4, 'n')], 1, {}, 1)) as queue:
+        _tail(name='n')
+    assert queue.call_args.kwargs['skip_finished'] is True
+
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(4, 'n')], 1, {}, 1)) as queue:
+        _tail(name='n', controller=True)
+    assert queue.call_args.kwargs['skip_finished'] is False
+
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(4)], 1, {}, 1)) as queue:
+        _tail()
+    assert 'skip_finished' not in queue.call_args.kwargs
+
+
+def test_bare_tail_does_not_announce_a_download(runner):
+    """The sync-down notice must not leak into the streaming path."""
+    with mock.patch.object(core, 'queue_v2_api',
+                           return_value=([_record(9), _record(4)], 2, {}, 2)), \
+         mock.patch.object(core.logger, 'info') as log_info:
+        _tail()
+    msg = ' '.join(str(c.args[0]) for c in log_info.call_args_list)
+    assert 'Downloading' not in msg
+    assert runner.tail_managed_job_logs.call_args.kwargs['job_id'] == 9
+
+
+def test_tail_ambiguous_name_raises_like_master(runner):
+    """Ambiguity must behave exactly as before: raise, do not guess.
+
+    Wording and exception type match `managed_job_utils.stream_logs`, which
+    this resolution replaces -- workspace scoping is the only intended change.
+    """
+    records = [_record(5, 'train'), _record(6, 'train')]
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=(records, 2, {}, 2)):
+        with pytest.raises(ValueError, match='Multiple running jobs found'):
+            _tail(name='train')
+        with pytest.raises(ValueError, match=r'Job IDs: 6, 5'):
+            _tail(name='train', controller=True)
+    runner.tail_managed_job_logs.assert_not_called()
+
+
+def test_not_found_message_matches_master(runner):
+    with mock.patch.object(core, 'queue_v2_api', return_value=([], 0, {}, 0)), \
+         mock.patch.object(core.logger, 'info') as log_info:
+        _tail(name='nope')
+    msg = ' '.join(str(c.args[0]) for c in log_info.call_args_list)
+    assert "No running managed job found with name 'nope'." in msg
+
+
+def test_tail_name_matches_exactly(runner):
+    """`name_match` is fuzzy, so 'train-v2' must not satisfy `-n train`."""
+    records = [_record(9, 'train-v2'), _record(5, 'train')]
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=(records, 2, {}, 2)):
+        _tail(name='train')
+    assert runner.tail_managed_job_logs.call_args.kwargs['job_id'] == 5

--- a/tests/unit_tests/test_jobs_download_logs_workspace.py
+++ b/tests/unit_tests/test_jobs_download_logs_workspace.py
@@ -204,6 +204,52 @@ def test_not_found_message_matches_master(runner):
     assert "No running managed job found with name 'nope'." in msg
 
 
+def test_bare_lookup_asks_for_one_job_not_the_whole_table(runner):
+    """It replaces a `LIMIT 1` query; an unbounded fetch is a real regression.
+
+    Pagination here is by unique job, and the query already defaults to job_id
+    descending, so page/limit alone give the newest job.
+    """
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(7)], 1, {}, 1)) as queue:
+        _tail()
+    kwargs = queue.call_args.kwargs
+    assert kwargs['limit'] == 1 and kwargs['page'] == 1
+    # The name path must stay unbounded: `--controller` ambiguity has to list
+    # every matching id, so a limit there would truncate the message.
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=([_record(7, 'n')], 1, {}, 1)) as queue:
+        _tail(name='n')
+    assert 'limit' not in queue.call_args.kwargs
+
+
+def test_sync_down_multiple_notice_reads_as_a_sentence(backend):
+    """Without a name the "Multiple jobs IDs found" clause must not appear."""
+    with mock.patch.object(core, 'queue_v2_api',
+                           return_value=([_record(9), _record(4)], 2, {}, 2)), \
+         mock.patch.object(core.logger, 'info') as log_info:
+        core.download_logs(name=None,
+                           job_id=None,
+                           refresh=False,
+                           controller=False)
+    msg = ' '.join(str(c.args[0]) for c in log_info.call_args_list)
+    assert 'Multiple jobs IDs found Downloading' not in msg
+    assert 'Downloading the latest job logs.' in msg
+
+    with mock.patch.object(core, 'queue_v2_api',
+                           return_value=([_record(9, 'n'), _record(4, 'n')], 2,
+                                         {}, 2)), \
+         mock.patch.object(core.logger, 'info') as log_info:
+        core.download_logs(name='n',
+                           job_id=None,
+                           refresh=False,
+                           controller=False)
+    msg = ' '.join(str(c.args[0]) for c in log_info.call_args_list)
+    assert 'Multiple jobs IDs found under the name n. Downloading' in msg
+
+
 def test_multi_task_job_is_one_job_not_an_ambiguity(runner):
     """The queue returns a record per task, so one job can repeat its id.
 

--- a/tests/unit_tests/test_jobs_download_logs_workspace.py
+++ b/tests/unit_tests/test_jobs_download_logs_workspace.py
@@ -204,6 +204,36 @@ def test_not_found_message_matches_master(runner):
     assert "No running managed job found with name 'nope'." in msg
 
 
+def test_multi_task_job_is_one_job_not_an_ambiguity(runner):
+    """The queue returns a record per task, so one job can repeat its id.
+
+    Without de-duplication a multi-task job looks like several jobs and log
+    streaming raises a spurious ambiguity error. The lookups this replaces
+    select `spot_job_id` DISTINCT.
+    """
+    two_tasks = [_record(7, 'multi'), _record(7, 'multi')]
+    with mock.patch.object(core,
+                           'queue_v2_api',
+                           return_value=(two_tasks, 2, {}, 2)):
+        _tail(name='multi')
+    assert runner.tail_managed_job_logs.call_args.kwargs['job_id'] == 7
+
+
+def test_multi_task_job_does_not_announce_multiple_on_sync_down(backend):
+    """Same de-duplication on the sync-down path: one job, no 'Multiple' notice."""
+    two_tasks = [_record(7, 'multi'), _record(7, 'multi')]
+    with mock.patch.object(core, 'queue_v2_api',
+                           return_value=(two_tasks, 2, {}, 2)), \
+         mock.patch.object(core.logger, 'info') as log_info:
+        core.download_logs(name='multi',
+                           job_id=None,
+                           refresh=False,
+                           controller=False)
+    msg = ' '.join(str(c.args[0]) for c in log_info.call_args_list)
+    assert 'Multiple' not in msg
+    assert backend.sync_down_managed_job_logs.call_args.kwargs['job_id'] == 7
+
+
 def test_tail_name_matches_exactly(runner):
     """`name_match` is fuzzy, so 'train-v2' must not satisfy `-n train`."""
     records = [_record(9, 'train-v2'), _record(5, 'train')]

--- a/tests/unit_tests/test_jobs_download_logs_workspace.py
+++ b/tests/unit_tests/test_jobs_download_logs_workspace.py
@@ -204,7 +204,7 @@ def test_not_found_message_matches_master(runner):
     assert "No running managed job found with name 'nope'." in msg
 
 
-def test_bare_lookup_asks_for_one_job_not_the_whole_table(runner):
+def test_bare_lookup_is_bounded_not_a_whole_table_scan(runner):
     """It replaces a `LIMIT 1` query; an unbounded fetch is a real regression.
 
     Pagination here is by unique job, and the query already defaults to job_id
@@ -215,7 +215,9 @@ def test_bare_lookup_asks_for_one_job_not_the_whole_table(runner):
                            return_value=([_record(7)], 1, {}, 1)) as queue:
         _tail()
     kwargs = queue.call_args.kwargs
-    assert kwargs['limit'] == 1 and kwargs['page'] == 1
+    # Two, not one: sync-down has to be able to say "more than one job exists",
+    # which a limit of 1 would make unanswerable.
+    assert kwargs['limit'] == 2 and kwargs['page'] == 1
     # The name path must stay unbounded: `--controller` ambiguity has to list
     # every matching id, so a limit there would truncate the message.
     with mock.patch.object(core,

--- a/tests/unit_tests/test_sky/jobs/test_server_core.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_core.py
@@ -14,8 +14,13 @@ def _forwarded_tail(tail):
     fake_backend = mock.MagicMock(spec=backends.CloudVmRayBackend)
     fake_runner = mock.MagicMock()
     fake_runner.tail_managed_job_logs.return_value = 0
+    # `tail_logs` resolves the job id through the queue (to scope it to the
+    # caller's workspaces) before reaching the runner.
+    record = mock.MagicMock(job_id=1, job_name=None)
     with mock.patch.object(jobs_core, '_maybe_restart_controller',
                            return_value=mock.MagicMock()), \
+         mock.patch.object(jobs_core, 'queue_v2_api',
+                           return_value=([record], 1, {}, 1)), \
          mock.patch.object(jobs_core.backend_utils,
                            'get_backend_from_handle',
                            return_value=fake_backend), \


### PR DESCRIPTION
## Summary

- `sky jobs logs` and `sky jobs logs --sync-down` resolved their target job outside the workspace boundary, so they could read logs for a job the caller has no access to. With no job id the resolution went through `get_latest_job_id` / `get_all_job_ids_by_name`, neither of which filters by workspace; an explicit job id and `-n <name>` had the same gap. The executor's own gate does not cover it: `/jobs/logs` and `/jobs/download_logs` are viewer-allowlisted, so they are classified as reads and only the caller's *active* workspace is checked, not the workspace of the job that was selected.
- The same gap also picked the wrong job for everyone: "the newest job" was the newest *globally*, not the newest the caller can see, so a bare `sky jobs logs` could hand you a colleague's job instead of your own.
- Fixed by resolving the job id in `jobs.server.core` through the queue and passing a concrete id to the backend (`job_name=None`, so it cannot re-resolve unfiltered). The queue already threads `accessible_workspaces` into the controller-executed code (`GetJobTableRequest.accessible_workspaces` / `ManagedJobCodeGen.get_job_table`) with a client-side fallback for controllers that predate the filter — so no proto change and no `MANAGED_JOBS_VERSION` bump.

Scoping is by **workspace, not by user**: a workspace member may read any job in that workspace, which is what the dashboard already shows.

Each caller's existing name semantics are reproduced exactly, since they are not what this fixes:

| invocation | behaviour (unchanged) |
|---|---|
| `-n <name>` | non-terminal jobs only, unless `--controller` |
| `-n <name>` matching several | raises, same message as before |
| no selector | latest job whatever its status |
| `--sync-down` with several matches | takes the latest |

Two deliberate behaviour changes beyond the scoping, both worth calling out:

- **Bare selection now orders by `job_id` rather than `submitted_at`.** `submitted_at` is NULL until a job leaves PENDING, and NULL ordering under `DESC` differs by backend (last on SQLite, first on PostgreSQL) — so which job a bare `sky jobs logs` picked was backend-dependent, and a PENDING job was unreachable on SQLite. Ordering by `job_id` makes it consistent, and lets `sky jobs launch` followed by `sky jobs logs` hit the job you just submitted.
- **Resolution now follows the queue's identity rules.** The replaced lookups carried a pre-#1982 fallback (match `spot.task_name` when `job_info.name` is NULL); the queue matches on `job_info.name` only. Jobs predating the `job_info` table are therefore no longer matched by name — already true of `sky jobs queue` and the dashboard.

## Test plan

**Unit** — `tests/unit_tests/test_jobs_download_logs_workspace.py` (16 tests). Each was revert-checked against the specific change it guards.

- a bare `--sync-down` / `jobs logs` picks the newest *accessible* job, not the newest global one
- an explicit job id outside the accessible workspaces is refused, and no download/stream is attempted
- an accessible job id is allowed through
- `-n` matches the name exactly (the queue's `name_match` is fuzzy) and picks the latest
- `all_users=True` is asserted on the queue call, so the boundary cannot silently narrow from workspace to user
- parity guards: ambiguity still raises with both the plain and the `--controller` wording; `skip_finished` is applied to the name lookup but *not* to the bare lookup; the sync-down "Downloading the latest" notice does not leak into the streaming path

**Manual (end to end)** — local API server in jobs consolidation mode, two private workspaces, two users:

| job | workspace | owner | note |
|---|---|---|---|
| 101 | `ws-a` | alice | older |
| 202 | `ws-b` | bob | **newest globally** |

| case | before | after |
|---|---|---|
| alice, no selector | reads bob's `ws-b` job 202 | reads her own `ws-a` job 101 |
| alice, explicit job 202 | reads bob's logs | `Managed job 202 not found.` |
| alice, her own job 101 | works | works |
| bob, no selector | job 202 | job 202 |
| bob, his own job 202 | works | works |

Verified against the same server with the change reverted, to confirm the leak is real and the harness detects it. `sky jobs queue -u` was used first to prove the two users genuinely cannot see each other's jobs — otherwise every case passes vacuously (note `rbac.default_role` defaults to `admin`, and admins bypass workspace checks).

Ambiguity parity re-checked end to end after the fix: with two running jobs sharing a name, `--follow` raises `ValueError: Multiple running jobs found with name 'amb'.` exactly as before.

## Notes

Two pre-existing issues surfaced while testing this. Neither is changed here:

- `log_streamer` only reports a `CANCELLED` request into the stream; for `FAILED` it breaks, so an error raised before anything is logged reaches the client as an empty response. Affects every streaming endpoint.
- The client only fetches the result when following (`get_result=follow`), so under `--no-follow` an error is never raised client-side and the CLI exits 0.

Together these are why an ambiguous `-n` under `--no-follow` prints nothing today. This PR deliberately reproduces the existing raise/return semantics rather than papering over them.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

