### PR TITLE
[Dashboard] Give a log stream's last line the same treatment as the rest, and bound the partial-line carry

### DIFF
--- a/sky/dashboard/src/hooks/useLogStreamer.js
+++ b/sky/dashboard/src/hooks/useLogStreamer.js
@@ -24,6 +24,8 @@ export function useLogStreamer({
 
   const bufferRef = useRef([]);
   const partialLineRef = useRef('');
+  // True while discarding the tail of a line already emitted truncated.
+  const overLongLineRef = useRef(false);
   const progressMapRef = useRef(new Map());
   const flushTimerRef = useRef(null);
   const controllerRef = useRef(null);
@@ -37,6 +39,7 @@ export function useLogStreamer({
   const resetState = useCallback(() => {
     bufferRef.current = [];
     partialLineRef.current = '';
+    overLongLineRef.current = false;
     progressMapRef.current = new Map();
     hasFirstChunkRef.current = false;
     setLogLines([]);
@@ -98,11 +101,45 @@ export function useLogStreamer({
       }
     };
 
+    // Everything a completed line goes through. The last line of a stream
+    // has no trailing newline and used to bypass all of it.
+    const finalizeLine = (line) => {
+      const cleanLine = stripAnsiCodes(line);
+      if (shouldDropLogLine(cleanLine)) return null;
+      return cleanLine.length > maxLineChars
+        ? cleanLine.slice(0, maxLineChars) + ' … [truncated]'
+        : cleanLine;
+    };
+
     const processChunk = (chunk) => {
       const parts = chunk.split('\n');
       parts[0] = partialLineRef.current + parts[0];
       const endsWithNewline = chunk.endsWith('\n');
       partialLineRef.current = endsWithNewline ? '' : parts.pop() || '';
+
+      // maxLineChars only ever applied to lines that had already arrived
+      // whole, so output with no newline in it - one very long line, or a
+      // writer that only emits carriage returns - grew the carry for the
+      // length of the stream. Emit such a line once, truncated, then
+      // discard the rest of it until its newline shows up: carrying the
+      // remainder instead would both regrow the carry and make the dropped
+      // tail reappear as a line of its own.
+      if (overLongLineRef.current) {
+        if (parts.length > 0) {
+          parts.shift();
+          overLongLineRef.current = false;
+        } else {
+          partialLineRef.current = '';
+        }
+      }
+      if (
+        !overLongLineRef.current &&
+        partialLineRef.current.length > maxLineChars
+      ) {
+        parts.push(partialLineRef.current);
+        partialLineRef.current = '';
+        overLongLineRef.current = true;
+      }
 
       const newLines = parts.filter((line) => line.trim());
       if (!hasFirstChunkRef.current && newLines.length > 0) {
@@ -111,12 +148,9 @@ export function useLogStreamer({
       }
 
       for (const line of newLines) {
-        let cleanLine = stripAnsiCodes(line);
-        if (shouldDropLogLine(cleanLine)) {
+        const cleanLine = finalizeLine(line);
+        if (cleanLine === null) {
           continue;
-        }
-        if (cleanLine.length > maxLineChars) {
-          cleanLine = cleanLine.slice(0, maxLineChars) + ' … [truncated]';
         }
 
         const isProgressBar = /\d+%\s*\|/.test(cleanLine);
@@ -147,10 +181,17 @@ export function useLogStreamer({
     })
       .then(() => {
         if (!active) return;
-        if (partialLineRef.current) {
-          bufferRef.current.push(partialLineRef.current);
-          partialLineRef.current = '';
+        // The stream's last line has no trailing newline; give it the same
+        // treatment as every other line rather than pushing it raw. Nothing
+        // to emit if it is only the tail of an already-truncated line.
+        if (partialLineRef.current && !overLongLineRef.current) {
+          const finalLine = finalizeLine(partialLineRef.current);
+          if (finalLine !== null) {
+            bufferRef.current.push(finalLine);
+          }
         }
+        partialLineRef.current = '';
+        overLongLineRef.current = false;
         flushBufferedLines();
         setIsLoading(false);
       })

--- a/sky/dashboard/src/hooks/useLogStreamer.js
+++ b/sky/dashboard/src/hooks/useLogStreamer.js
@@ -111,6 +111,24 @@ export function useLogStreamer({
         : cleanLine;
     };
 
+    // Where a finished line lands: a progress bar collapses onto its
+    // previous update, everything else appends. Shared with the
+    // stream-completion path below, so a final progress update replaces its
+    // predecessor instead of appearing beside it.
+    const emitLine = (cleanLine) => {
+      const isProgressBar = /\d+%\s*\|/.test(cleanLine);
+      if (isProgressBar) {
+        appendProgressLine(cleanLine);
+        return;
+      }
+      bufferRef.current.push(cleanLine);
+      if (bufferRef.current.length > maxRenderLines * 2) {
+        bufferRef.current = bufferRef.current.slice(
+          bufferRef.current.length - maxRenderLines
+        );
+      }
+    };
+
     const processChunk = (chunk) => {
       const parts = chunk.split('\n');
       parts[0] = partialLineRef.current + parts[0];
@@ -132,9 +150,14 @@ export function useLogStreamer({
           partialLineRef.current = '';
         }
       }
+      // Compared on the stripped length, the same thing finalizeLine caps
+      // on. Against the raw string a colour-heavy fragment crosses the
+      // threshold while its visible text is still short, and would then be
+      // emitted whole - with no truncation marker - while the rest of the
+      // line was discarded.
       if (
         !overLongLineRef.current &&
-        partialLineRef.current.length > maxLineChars
+        stripAnsiCodes(partialLineRef.current).length > maxLineChars
       ) {
         parts.push(partialLineRef.current);
         partialLineRef.current = '';
@@ -149,20 +172,8 @@ export function useLogStreamer({
 
       for (const line of newLines) {
         const cleanLine = finalizeLine(line);
-        if (cleanLine === null) {
-          continue;
-        }
-
-        const isProgressBar = /\d+%\s*\|/.test(cleanLine);
-        if (isProgressBar) {
-          appendProgressLine(cleanLine);
-        } else {
-          bufferRef.current.push(cleanLine);
-          if (bufferRef.current.length > maxRenderLines * 2) {
-            bufferRef.current = bufferRef.current.slice(
-              bufferRef.current.length - maxRenderLines
-            );
-          }
+        if (cleanLine !== null) {
+          emitLine(cleanLine);
         }
       }
       scheduleFlush();
@@ -187,7 +198,7 @@ export function useLogStreamer({
         if (partialLineRef.current && !overLongLineRef.current) {
           const finalLine = finalizeLine(partialLineRef.current);
           if (finalLine !== null) {
-            bufferRef.current.push(finalLine);
+            emitLine(finalLine);
           }
         }
         partialLineRef.current = '';
@@ -220,6 +231,7 @@ export function useLogStreamer({
       }
       bufferRef.current = [];
       partialLineRef.current = '';
+      overLongLineRef.current = false;
       progressMapRef.current.clear();
     };
   }, [

--- a/sky/dashboard/src/hooks/useLogStreamer.js
+++ b/sky/dashboard/src/hooks/useLogStreamer.js
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { stripAnsiCodes, shouldDropLogLine } from '@/components/utils';
 
+const TRUNCATION_MARK = ' … [truncated]';
+
+// Ceiling on the raw carry, as a multiple of the visible cap. Only reached
+// by output whose visible length barely grows - a writer emitting mostly
+// escape sequences - where the visible cap alone would never trip.
+const RAW_CARRY_FACTOR = 4;
+
 /**
  * Shared log streaming hook used by both managed job and cluster pages.
  */
@@ -76,6 +83,8 @@ export function useLogStreamer({
     const controller = new AbortController();
     controllerRef.current = controller;
 
+    const maxRawCarryChars = maxLineChars * RAW_CARRY_FACTOR;
+
     const scheduleFlush = () => {
       if (flushTimerRef.current) return;
       flushTimerRef.current = setTimeout(() => {
@@ -107,7 +116,7 @@ export function useLogStreamer({
       const cleanLine = stripAnsiCodes(line);
       if (shouldDropLogLine(cleanLine)) return null;
       return cleanLine.length > maxLineChars
-        ? cleanLine.slice(0, maxLineChars) + ' … [truncated]'
+        ? cleanLine.slice(0, maxLineChars) + TRUNCATION_MARK
         : cleanLine;
     };
 
@@ -150,22 +159,34 @@ export function useLogStreamer({
           partialLineRef.current = '';
         }
       }
-      // Compared on the stripped length, the same thing finalizeLine caps
-      // on. Against the raw string a colour-heavy fragment crosses the
-      // threshold while its visible text is still short, and would then be
-      // emitted whole - with no truncation marker - while the rest of the
-      // line was discarded.
-      if (
-        !overLongLineRef.current &&
-        stripAnsiCodes(partialLineRef.current).length > maxLineChars
-      ) {
-        parts.push(partialLineRef.current);
-        partialLineRef.current = '';
-        overLongLineRef.current = true;
+      const newLines = parts.filter((line) => line.trim());
+
+      // Bound the carry on both axes. maxLineChars is a cap on what the
+      // reader sees, so measuring the raw string cuts a colour-heavy line
+      // short of it; but output that is almost entirely escape sequences
+      // keeps a short visible length while the raw string grows without
+      // limit, which is the unbounded carry this is here to prevent.
+      // Whichever bound trips, the rest of the line is dropped, so what is
+      // emitted always says it was truncated.
+      let forcedLine = null;
+      if (!overLongLineRef.current) {
+        const visible = stripAnsiCodes(partialLineRef.current);
+        if (
+          visible.length > maxLineChars ||
+          partialLineRef.current.length > maxRawCarryChars
+        ) {
+          if (!shouldDropLogLine(visible)) {
+            forcedLine = visible.slice(0, maxLineChars) + TRUNCATION_MARK;
+          }
+          partialLineRef.current = '';
+          overLongLineRef.current = true;
+        }
       }
 
-      const newLines = parts.filter((line) => line.trim());
-      if (!hasFirstChunkRef.current && newLines.length > 0) {
+      if (
+        !hasFirstChunkRef.current &&
+        (newLines.length > 0 || forcedLine !== null)
+      ) {
         hasFirstChunkRef.current = true;
         setHasReceivedFirstChunk(true);
       }
@@ -175,6 +196,10 @@ export function useLogStreamer({
         if (cleanLine !== null) {
           emitLine(cleanLine);
         }
+      }
+      // After this chunk's completed lines: the carry sits behind them.
+      if (forcedLine !== null) {
+        emitLine(forcedLine);
       }
       scheduleFlush();
     };

--- a/sky/dashboard/src/hooks/useLogStreamer.test.jsx
+++ b/sky/dashboard/src/hooks/useLogStreamer.test.jsx
@@ -119,4 +119,26 @@ describe('useLogStreamer line assembly', () => {
     const lines = await linesFrom(['(w1) 50%|##\n', '(w1) 100%|####']);
     expect(lines).toEqual(['(w1) 100%|####']);
   });
+
+  // Measuring only what the reader sees leaves the raw carry unbounded for
+  // a writer that emits mostly escape sequences: six chunks here carry 48
+  // raw characters but 6 visible ones, so the visible cap alone never
+  // trips and the carry grows for the length of the stream.
+  it('bounds a carry that is almost entirely escape sequences', async () => {
+    const streamFn = streamOf(
+      Array.from({ length: 6 }, () => '\x1b[0m\x1b[0m\x1b[0mx'),
+      { ends: false }
+    );
+    const { result } = renderHook(() =>
+      useLogStreamer({
+        streamFn,
+        streamArgs: STREAM_ARGS,
+        flushIntervalMs: 0,
+        maxLineChars: 10,
+      })
+    );
+    // maxRawCarryChars is 40 here, crossed on the fourth chunk.
+    await waitFor(() => expect(result.current.lines).toHaveLength(1));
+    expect(result.current.lines[0]).toBe('xxxx … [truncated]');
+  });
 });

--- a/sky/dashboard/src/hooks/useLogStreamer.test.jsx
+++ b/sky/dashboard/src/hooks/useLogStreamer.test.jsx
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLogStreamer } from './useLogStreamer';
+
+// `streamFn` and `streamArgs` are effect dependencies, so they have to be
+// stable across renders or the hook restarts its stream forever.
+const STREAM_ARGS = {};
+
+function streamOf(chunks, { ends = true } = {}) {
+  return async ({ onNewLog }) => {
+    for (const chunk of chunks) {
+      onNewLog(chunk);
+    }
+    // A stream that never closes is the only way to see what the hook has
+    // rendered *while* output is still arriving, as opposed to what it
+    // flushes on the way out.
+    if (!ends) await new Promise(() => {});
+  };
+}
+
+async function linesFrom(chunks, options = {}) {
+  const streamFn = streamOf(chunks);
+  const { result } = renderHook(() =>
+    useLogStreamer({
+      streamFn,
+      streamArgs: STREAM_ARGS,
+      flushIntervalMs: 0,
+      ...options,
+    })
+  );
+  await waitFor(() => expect(result.current.isLoading).toBe(false));
+  await waitFor(() => expect(result.current.lines.length).toBeGreaterThan(0));
+  return result.current.lines;
+}
+
+describe('useLogStreamer line assembly', () => {
+  it('joins a line split across chunks', async () => {
+    expect(await linesFrom(['par', 'tial line\n'])).toEqual(['partial line']);
+  });
+
+  it('emits the last line when the stream ends without a newline', async () => {
+    expect(await linesFrom(['one\n', 'two'])).toEqual(['one', 'two']);
+  });
+
+  // The last line used to be pushed raw: no ANSI stripping, no drop filter
+  // and no length cap, unlike every line before it.
+  it('strips ANSI from the last line, like any other line', async () => {
+    expect(await linesFrom(['\x1b[32mgreen\x1b[0m\n', '\x1b[31mred'])).toEqual([
+      'green',
+      'red',
+    ]);
+  });
+
+  it('drops a control line that arrives last, like any other line', async () => {
+    const lines = await linesFrom([
+      'real output\n',
+      '<sky-payload>{"returncode": 0}</sky-payload>',
+    ]);
+    expect(lines).toEqual(['real output']);
+  });
+
+  it('bounds a carry built from many newline-free chunks', async () => {
+    const chunks = Array.from({ length: 20 }, () => 'y'.repeat(10));
+    const lines = await linesFrom(chunks, { maxLineChars: 30 });
+    // One truncated line, not twenty, and not one 200-character line.
+    expect(lines).toEqual(['y'.repeat(30) + ' … [truncated]']);
+  });
+
+  // The bound has to act during the stream, not on the way out: an
+  // unbounded carry produces the same final render, and differs only in
+  // how much of it the browser was holding while the job ran.
+  it('surfaces an over-long line while the stream is still open', async () => {
+    const streamFn = streamOf(
+      Array.from({ length: 20 }, () => 'y'.repeat(10)),
+      { ends: false }
+    );
+    const { result } = renderHook(() =>
+      useLogStreamer({
+        streamFn,
+        streamArgs: STREAM_ARGS,
+        flushIntervalMs: 0,
+        maxLineChars: 30,
+      })
+    );
+    await waitFor(() => expect(result.current.lines).toHaveLength(1));
+    expect(result.current.lines[0]).toBe('y'.repeat(30) + ' … [truncated]');
+    // Still streaming: this is not the end-of-stream flush.
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('discards the rest of an over-long line, then resumes', async () => {
+    const lines = await linesFrom(
+      ['z'.repeat(60), 'still the same line\n', 'next line\n'],
+      { maxLineChars: 10 }
+    );
+    expect(lines).toEqual(['z'.repeat(10) + ' … [truncated]', 'next line']);
+  });
+
+  it('keeps ordinary lines intact around an over-long one', async () => {
+    const lines = await linesFrom(['a\n', 'b'.repeat(40) + '\n', 'c\n'], {
+      maxLineChars: 10,
+    });
+    expect(lines).toEqual(['a', 'b'.repeat(10) + ' … [truncated]', 'c']);
+  });
+});

--- a/sky/dashboard/src/hooks/useLogStreamer.test.jsx
+++ b/sky/dashboard/src/hooks/useLogStreamer.test.jsx
@@ -101,4 +101,22 @@ describe('useLogStreamer line assembly', () => {
     });
     expect(lines).toEqual(['a', 'b'.repeat(10) + ' … [truncated]', 'c']);
   });
+
+  // The cap is on what the user sees. Measuring the carry with its escape
+  // sequences still in it cuts a colour-heavy line short of the cap - and
+  // without the truncation marker, so nothing shows that text was dropped.
+  it('measures the carry by visible length, not by escape sequences', async () => {
+    const lines = await linesFrom(['\x1b[32mabc\x1b[0m', 'def\n'], {
+      maxLineChars: 10,
+    });
+    expect(lines).toEqual(['abcdef']);
+  });
+
+  // A progress bar's last update usually arrives without a trailing
+  // newline. Pushing it straight into the buffer leaves the previous
+  // update sitting in the progress map, so the bar renders twice.
+  it('collapses a final progress update onto its predecessor', async () => {
+    const lines = await linesFrom(['(w1) 50%|##\n', '(w1) 100%|####']);
+    expect(lines).toEqual(['(w1) 100%|####']);
+  });
 });


### PR DESCRIPTION
Two defects in `useLogStreamer`, both on the path that turns streamed chunks into display lines.

## The last line of a stream skipped every filter

A stream's final line has no trailing newline, so it sits in `partialLineRef` until the stream closes and is then pushed straight into the buffer:

```js
if (partialLineRef.current) {
  bufferRef.current.push(partialLineRef.current);
  partialLineRef.current = '';
}
```

Every other line goes through `stripAnsiCodes`, `shouldDropLogLine` and the `maxLineChars` cap first. So a job whose last line was coloured showed raw escape codes, and — the case that actually shows up — a `<sky-payload>` control line arriving last was rendered as log content instead of being dropped.

Both paths now go through one `finalizeLine`.

## The partial-line carry was unbounded

`maxLineChars` was only ever applied to lines that had already arrived whole. Output containing no newline at all — one very long line, or a writer that only emits carriage returns — accumulated in `partialLineRef` for the length of the stream with nothing bounding it.

Such a line is now emitted once at the cap, and the remainder discarded until its newline arrives. Carrying the remainder instead would both regrow the carry and make the dropped tail reappear as a line of its own.

## Tests

`useLogStreamer.test.jsx` is new — this hook had no tests. It covers chunk splitting, the last line's ANSI and drop-filter treatment, and the carry bound.

Worth noting how the carry-bound test is written: an unbounded carry produces the **same** final render, because the last-line path truncates it on the way out. The two differ only in how much the browser was holding while the job ran, so the test asserts that the over-long line is surfaced *while the stream is still open* rather than only at the end. Each fix was reverted in turn to confirm the tests fail without it.

- `npx jest` in `sky/dashboard`: 20 suites, 208 tests passing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->