### PR TITLE
[Dashboard] Fix missing favicon

### DIFF
--- a/sky/dashboard/src/pages/_app.js
+++ b/sky/dashboard/src/pages/_app.js
@@ -6,9 +6,9 @@ import * as ReactDOMAll from 'react-dom';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import PropTypes from 'prop-types';
 import '@/app/globals.css';
-import { useEffect } from 'react';
 import { BASE_PATH } from '@/data/connectors/constants';
 import { TourProvider } from '@/hooks/useTour';
 import { PluginProvider } from '@/plugins/PluginProvider';
@@ -35,15 +35,11 @@ const nonce = getNonce();
 const emotionCache = createCache({ key: 'css', nonce: nonce || undefined });
 
 function App({ Component, pageProps }) {
-  useEffect(() => {
-    const link = document.createElement('link');
-    link.rel = 'icon';
-    link.href = `${BASE_PATH}/favicon.ico`;
-    document.head.appendChild(link);
-  }, []);
-
   return (
     <CacheProvider value={emotionCache}>
+      <Head>
+        <link rel="icon" href={`${BASE_PATH}/favicon.ico`} />
+      </Head>
       <PluginProvider>
         <PluginWrapperSlot name="app.providers">
           <VersionProvider>

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -4039,6 +4039,16 @@ async def serve_dashboard(request: fastapi.Request, full_path: str):
         raise fastapi.HTTPException(status_code=500, detail=str(e))
 
 
+# Browsers request /favicon.ico from the origin root regardless of the page's
+# base path, so serve the dashboard icon there too.
+@app.get('/favicon.ico')
+async def favicon():
+    favicon_path = os.path.join(server_constants.DASHBOARD_DIR, 'favicon.ico')
+    if not os.path.isfile(favicon_path):
+        raise fastapi.HTTPException(status_code=404, detail='Not found')
+    return fastapi.responses.FileResponse(favicon_path)
+
+
 # Redirect the root path to dashboard
 @app.get('/')
 async def root():

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -794,6 +794,34 @@ async def test_serve_dashboard_client_route_falls_back_to_index(tmp_path):
     assert response.status_code == 200
 
 
+# --- Tests for the root /favicon.ico route ---
+
+
+@pytest.mark.asyncio
+async def test_root_favicon_serves_dashboard_icon(tmp_path):
+    """Browsers request /favicon.ico at the origin root, not under /dashboard."""
+    d = tmp_path / 'out'
+    d.mkdir()
+    (d / 'favicon.ico').write_bytes(b'icon-bytes')
+
+    with mock.patch.object(server_constants, 'DASHBOARD_DIR', str(d)):
+        response = await server.favicon()
+
+    assert response.status_code == 200
+    assert response.path == str(d / 'favicon.ico')
+
+
+@pytest.mark.asyncio
+async def test_root_favicon_404s_when_dashboard_not_built(tmp_path):
+    """A missing icon 404s instead of raising a 500 from FileResponse."""
+    with mock.patch.object(server_constants, 'DASHBOARD_DIR',
+                           str(tmp_path / 'missing')):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await server.favicon()
+
+    assert exc_info.value.status_code == 404
+
+
 def _api_get_dummy_entrypoint():
     """Module-level entrypoint so Request.encode() can pickle it."""
     pass


### PR DESCRIPTION
The dashboard's `<link rel="icon">` was appended by a `useEffect`, so the statically exported HTML carried no icon link. Browsers fell back to requesting `/favicon.ico` at the origin root, which the API server had no route for.

- Render the link via `next/head` so it is present in the exported HTML.
- Serve the dashboard icon at `/favicon.ico` as well.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/unit_tests/test_sky/server/test_server.py` — new tests cover the `/favicon.ico` route and its 404 when the dashboard is not built.
  - `npm --prefix sky/dashboard test` — 200 passed.
  - After `npm --prefix sky/dashboard run build`, all 23 exported HTML pages contain `rel="icon" href="/dashboard/favicon.ico"`; `/favicon.ico` and `/dashboard/favicon.ico` both return 200 `image/x-icon`.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->