### PR TITLE
[Server] Mark request FAILED when enqueue fails instead of leaving it PENDING forever

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -1358,7 +1358,22 @@ async def schedule_prepared_request(request_task: api_requests.Request,
     async def enqueue():
         input_tuple = (request_task.request_id, ignore_return_value, retryable)
         logger.info(f'Queuing request: {request_task.request_id}')
-        await _get_queue(request_task.schedule_type).put_async(input_tuple)
+        try:
+            await _get_queue(request_task.schedule_type).put_async(input_tuple)
+        except Exception as e:  # pylint: disable=broad-except
+            # A PENDING request that never made it onto the queue is
+            # stranded: no worker will pick it up and nothing else moves it to
+            # a terminal state, and a queue backend that recovers stale PENDING
+            # rows would resurrect and execute it long after the caller saw
+            # this error. If the put actually committed despite the error, the
+            # FAILED row is discarded at dequeue (only executable statuses
+            # run).
+            logger.error(
+                f'Failed to enqueue request {request_task.request_id}: '
+                f'{common_utils.format_exception(e)}')
+            await api_requests.set_request_failed_async(request_task.request_id,
+                                                        e)
+            raise
 
     if precondition is not None:
         # Schedule precondition wait as a background task so the caller

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -1372,7 +1372,7 @@ async def schedule_prepared_request(request_task: api_requests.Request,
             logger.error(
                 f'Failed to enqueue request {request_task.request_id}: '
                 f'{common_utils.format_exception(e)}')
-            await api_requests.set_request_failed_if_executable_async(
+            await api_requests.set_request_failed_if_pending_async(
                 request_task.request_id, e)
             raise
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -1360,19 +1360,20 @@ async def schedule_prepared_request(request_task: api_requests.Request,
         logger.info(f'Queuing request: {request_task.request_id}')
         try:
             await _get_queue(request_task.schedule_type).put_async(input_tuple)
-        except Exception as e:  # pylint: disable=broad-except
+        except (Exception, asyncio.CancelledError) as e:  # pylint: disable=broad-except
             # A PENDING request that never made it onto the queue is
             # stranded: no worker will pick it up and nothing else moves it to
             # a terminal state, and a queue backend that recovers stale PENDING
             # rows would resurrect and execute it long after the caller saw
             # this error. If the put actually committed despite the error, the
-            # FAILED row is discarded at dequeue (only executable statuses
-            # run).
+            # request is either still unclaimed (the FAILED mark lands and the
+            # row is discarded at dequeue) or already claimed by a worker (the
+            # mark is skipped and the claimed run's outcome stands).
             logger.error(
                 f'Failed to enqueue request {request_task.request_id}: '
                 f'{common_utils.format_exception(e)}')
-            await api_requests.set_request_failed_async(request_task.request_id,
-                                                        e)
+            await api_requests.set_request_failed_if_executable_async(
+                request_task.request_id, e)
             raise
 
     if precondition is not None:

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1216,14 +1216,14 @@ async def set_request_failed_async(request_id: str, e: BaseException) -> None:
 
 @metrics_lib.time_me_async
 @asyncio_utils.shield
-async def set_request_failed_if_executable_async(request_id: str,
-                                                 e: BaseException) -> bool:
-    """Set a not-yet-claimed request to failed.
+async def set_request_failed_if_pending_async(request_id: str,
+                                              e: BaseException) -> bool:
+    """Set a request to failed only while it is still PENDING.
 
-    The transition only happens while the request is still in an executable
-    status -- the same guard the worker applies at dequeue. Once a worker
-    claimed the request (RUNNING) or it reached a terminal status, the row is
-    left untouched and the owner's outcome stands.
+    PENDING is the only status a request can be in while its initial enqueue
+    is in flight: any other status means a worker already claimed the request
+    (the put actually committed) and the owner's outcome stands -- including
+    WAITING, which is only ever set after a claimed run parks for a retry.
 
     Returns:
         True if the request was transitioned to FAILED.
@@ -1232,7 +1232,7 @@ async def set_request_failed_if_executable_async(request_id: str,
     storage = request_storage.get_request_backend()
     async with storage.update_request_async(request_id) as request_task:
         assert request_task is not None, request_id
-        if request_task.status not in RequestStatus.executable_statuses():
+        if request_task.status != RequestStatus.PENDING:
             return False
         request_task.status = RequestStatus.FAILED
         request_task.finished_at = time.time()

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1214,6 +1214,32 @@ async def set_request_failed_async(request_id: str, e: BaseException) -> None:
         request_task.set_error(e)
 
 
+@metrics_lib.time_me_async
+@asyncio_utils.shield
+async def set_request_failed_if_executable_async(request_id: str,
+                                                 e: BaseException) -> bool:
+    """Set a not-yet-claimed request to failed.
+
+    The transition only happens while the request is still in an executable
+    status -- the same guard the worker applies at dequeue. Once a worker
+    claimed the request (RUNNING) or it reached a terminal status, the row is
+    left untouched and the owner's outcome stands.
+
+    Returns:
+        True if the request was transitioned to FAILED.
+    """
+    set_exception_stacktrace(e)
+    storage = request_storage.get_request_backend()
+    async with storage.update_request_async(request_id) as request_task:
+        assert request_task is not None, request_id
+        if request_task.status not in RequestStatus.executable_statuses():
+            return False
+        request_task.status = RequestStatus.FAILED
+        request_task.finished_at = time.time()
+        request_task.set_error(e)
+        return True
+
+
 def set_request_succeeded(request_id: str, result: Optional[Any]) -> None:
     """Set a request to succeeded and populate the result."""
     with update_request(request_id) as request_task:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -768,8 +768,7 @@ def class_fullname(cls, skip_builtins: bool = True):
     return f'{cls.__module__}.{cls.__name__}'
 
 
-def format_exception(e: Union[Exception, SystemExit, KeyboardInterrupt],
-                     use_bracket: bool = False) -> str:
+def format_exception(e: BaseException, use_bracket: bool = False) -> str:
     """Format an exception to a string.
 
     Args:

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -225,14 +225,19 @@ async def test_enqueue_cancellation_marks_request_failed(isolated_database):
     assert updated.status == requests_lib.RequestStatus.FAILED
 
 
+@pytest.mark.parametrize('claimed_status', [
+    requests_lib.RequestStatus.RUNNING,
+    requests_lib.RequestStatus.WAITING,
+])
 @pytest.mark.asyncio
 async def test_enqueue_failure_does_not_clobber_claimed_request(
-        isolated_database):
+        isolated_database, claimed_status):
     """A row claimed by a worker before the failure mark is left untouched.
 
     The queue put may commit and still raise (e.g. a timeout racing the
-    commit); a worker can then dequeue and claim the request before the
-    failure path runs. The failure mark must not overwrite the claimed run.
+    commit); a worker can then dequeue and claim the request -- and even park
+    it WAITING for a retry -- before the failure path runs. The failure mark
+    must not overwrite the claimed run.
     """
     req = _make_pending_request('enqueue-claimed')
     assert await requests_lib.create_if_not_exists_async(req) is True
@@ -241,7 +246,7 @@ async def test_enqueue_failure_does_not_clobber_claimed_request(
         del input_tuple
         with requests_lib.update_request('enqueue-claimed') as claimed:
             assert claimed is not None
-            claimed.status = requests_lib.RequestStatus.RUNNING
+            claimed.status = claimed_status
         raise RuntimeError('put failed after commit')
 
     queue = mock.Mock()
@@ -252,7 +257,7 @@ async def test_enqueue_failure_does_not_clobber_claimed_request(
 
     updated = requests_lib.get_request('enqueue-claimed')
     assert updated is not None
-    assert updated.status == requests_lib.RequestStatus.RUNNING
+    assert updated.status == claimed_status
 
 
 class _AlwaysMetPrecondition(preconditions.Precondition):

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -208,6 +208,53 @@ async def test_enqueue_failure_marks_request_failed(isolated_database):
     assert 'put failed' in str(error['object'])
 
 
+@pytest.mark.asyncio
+async def test_enqueue_cancellation_marks_request_failed(isolated_database):
+    """A cancelled queue put must not strand the request in PENDING."""
+    req = _make_pending_request('enqueue-cancelled')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    queue = mock.Mock()
+    queue.put_async = mock.AsyncMock(side_effect=asyncio.CancelledError())
+    with mock.patch.object(executor, '_get_queue', return_value=queue):
+        with pytest.raises(asyncio.CancelledError):
+            await executor.schedule_prepared_request(req)
+
+    updated = requests_lib.get_request('enqueue-cancelled')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_does_not_clobber_claimed_request(
+        isolated_database):
+    """A row claimed by a worker before the failure mark is left untouched.
+
+    The queue put may commit and still raise (e.g. a timeout racing the
+    commit); a worker can then dequeue and claim the request before the
+    failure path runs. The failure mark must not overwrite the claimed run.
+    """
+    req = _make_pending_request('enqueue-claimed')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    async def claim_then_fail(input_tuple):
+        del input_tuple
+        with requests_lib.update_request('enqueue-claimed') as claimed:
+            assert claimed is not None
+            claimed.status = requests_lib.RequestStatus.RUNNING
+        raise RuntimeError('put failed after commit')
+
+    queue = mock.Mock()
+    queue.put_async = mock.AsyncMock(side_effect=claim_then_fail)
+    with mock.patch.object(executor, '_get_queue', return_value=queue):
+        with pytest.raises(RuntimeError, match='put failed after commit'):
+            await executor.schedule_prepared_request(req)
+
+    updated = requests_lib.get_request('enqueue-claimed')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.RUNNING
+
+
 class _AlwaysMetPrecondition(preconditions.Precondition):
 
     async def check(self):

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -20,6 +20,7 @@ from sky.server import daemons as server_daemons
 from sky.server.requests import continue_condition as continue_condition_lib
 from sky.server.requests import executor
 from sky.server.requests import payloads
+from sky.server.requests import preconditions
 from sky.server.requests import process
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
@@ -175,6 +176,65 @@ async def test_api_cancel_race_condition(isolated_database):
     updated = requests_lib.get_request('race-cancel-before')
     assert updated is not None
     assert updated.status == requests_lib.RequestStatus.CANCELLED
+
+
+def _make_pending_request(request_id: str) -> requests_lib.Request:
+    return requests_lib.Request(request_id=request_id,
+                                name='test-request',
+                                entrypoint=dummy_entrypoint,
+                                request_body=payloads.RequestBody(),
+                                status=requests_lib.RequestStatus.PENDING,
+                                created_at=0.0,
+                                user_id='test-user')
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_marks_request_failed(isolated_database):
+    """A failed queue put must leave the request FAILED, not PENDING."""
+    req = _make_pending_request('enqueue-fails')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    queue = mock.Mock()
+    queue.put_async = mock.AsyncMock(side_effect=RuntimeError('put failed'))
+    with mock.patch.object(executor, '_get_queue', return_value=queue):
+        with pytest.raises(RuntimeError, match='put failed'):
+            await executor.schedule_prepared_request(req)
+
+    updated = requests_lib.get_request('enqueue-fails')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.FAILED
+    error = updated.get_error()
+    assert error is not None
+    assert 'put failed' in str(error['object'])
+
+
+class _AlwaysMetPrecondition(preconditions.Precondition):
+
+    async def check(self):
+        return True, None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_with_precondition_marks_request_failed(
+        isolated_database):
+    """The terminal-state guard must also cover the precondition path."""
+    req = _make_pending_request('enqueue-fails-precondition')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    queue = mock.Mock()
+    queue.put_async = mock.AsyncMock(side_effect=RuntimeError('put failed'))
+    with mock.patch.object(executor, '_get_queue', return_value=queue):
+        before = set(preconditions.background_tasks)
+        await executor.schedule_prepared_request(
+            req, precondition=_AlwaysMetPrecondition(req.request_id))
+        new_tasks = preconditions.background_tasks - before
+        assert len(new_tasks) == 1
+        with pytest.raises(RuntimeError, match='put failed'):
+            await next(iter(new_tasks))
+
+    updated = requests_lib.get_request('enqueue-fails-precondition')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.FAILED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

If the queue put in `schedule_prepared_request` raises (e.g. a DB-backed queue backend timing out), the request row created by `prepare_request_async` is left `PENDING` forever: it has no queue entry, so no worker ever picks it up and nothing moves it to a terminal state, while the caller has already received the scheduling error. Worse, a queue backend that recovers stale `PENDING` rows can re-enqueue and execute the request long after the caller was told it failed — for `launch` this can recreate a cluster that has since been torn down.

This PR marks the request `FAILED` with the enqueue exception before re-raising, on both scheduling paths (direct await and precondition-gated background task). `asyncio.CancelledError` during the put is handled the same way, so a cancelled enqueue (client disconnect, server shutdown) cannot strand a `PENDING` row either.

The put-committed-but-still-raised race (e.g. a client-side timeout racing the commit) is handled on both sides: the failure mark only transitions rows still PENDING, so if a worker already claimed the row (RUNNING, parked WAITING for a retry, or finished) the claimed run's outcome stands; and if the mark lands first, the execution wrapper discards the row at dequeue, so it is not executed. Retrying the put instead of failing is intentionally out of scope — without a uniqueness guarantee on the queue entry, a blind retry after a committed put double-enqueues the request.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `tests/unit_tests/test_sky/server/requests/test_executor.py::test_enqueue_failure_marks_request_failed`
  - `tests/unit_tests/test_sky/server/requests/test_executor.py::test_enqueue_failure_with_precondition_marks_request_failed`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->


