### PR TITLE
[Dashboard] Plugin-registered table filter properties

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -209,10 +209,18 @@ export const JOB_FILTER_SCHEMA = [
   { key: 'name', label: 'Name', kind: 'text' },
   { key: 'id', label: 'ID', kind: 'text' },
   { key: 'user', label: 'User', kind: 'text' },
+  // Slurm accounting fields, populated only on external rows. They stay in
+  // the schema unconditionally so a shared URL always decodes, but the
+  // dropdown only offers them once external rows have been seen.
+  { key: 'account', label: 'Account', kind: 'text' },
+  { key: 'qos', label: 'QOS', kind: 'text' },
   { key: 'workspace', label: 'Workspace', kind: 'text' },
   { key: 'pool', label: 'Pool', kind: 'text' },
   { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
 ];
+
+// Filter properties that can only ever match external rows.
+const EXTERNAL_ONLY_FILTER_KEYS = new Set(['account', 'qos']);
 
 // Non-filter state that belongs in a shared link too.
 //
@@ -360,6 +368,9 @@ export function ManagedJobs() {
   });
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
+  // Latched once any fetched page contains an external row, so the
+  // Account/QOS filter options and column don't flicker across pages.
+  const [hasExternalRows, setHasExternalRows] = useState(false);
 
   const fetchData = React.useCallback(
     async (isRefreshButton = false) => {
@@ -463,7 +474,13 @@ export function ManagedJobs() {
         />
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
-            propertyList={PROPERTY_OPTIONS}
+            propertyList={
+              hasExternalRows
+                ? PROPERTY_OPTIONS
+                : PROPERTY_OPTIONS.filter(
+                    (o) => !EXTERNAL_ONLY_FILTER_KEYS.has(o.value)
+                  )
+            }
             valueList={valueList}
             setFilters={setFilters}
             addFilter={addFilter}
@@ -489,6 +506,8 @@ export function ManagedJobs() {
         setValueList={setValueList}
         preloadingComplete={preloadingComplete}
         lastFetchedTime={lastFetchedTime}
+        hasExternalRows={hasExternalRows}
+        setHasExternalRows={setHasExternalRows}
       />
 
       {/* Pools table - always visible */}
@@ -592,6 +611,8 @@ export function ManagedJobsTable({
   setValueList,
   preloadingComplete,
   lastFetchedTime,
+  hasExternalRows,
+  setHasExternalRows,
 }) {
   const [sortConfig, setSortConfig] = useState({
     key: 'id',
@@ -723,6 +744,18 @@ export function ManagedJobsTable({
     return 'desc';
   }, [sortConfig.key, sortConfig.direction]);
 
+  // Latch external-row presence up to the page component (never unlatches),
+  // which gates the Account/QOS column and filter options.
+  React.useEffect(() => {
+    if (
+      !hasExternalRows &&
+      setHasExternalRows &&
+      (data || []).some((job) => job.is_external)
+    ) {
+      setHasExternalRows(true);
+    }
+  }, [data, hasExternalRows, setHasExternalRows]);
+
   // Determine if we should show the Workspace column
   // Only show if there are multiple workspaces or a workspace other than 'default'
   const shouldShowWorkspace = React.useMemo(() => {
@@ -802,6 +835,8 @@ export function ManagedJobsTable({
           jobIdMatch: jobIdFilter,
           nameMatch: getFilterValue('name'),
           userMatch: effectiveUserMatch,
+          accountMatch: getFilterValue('account'),
+          qosMatch: getFilterValue('qos'),
           workspaceMatch: getFilterValue('workspace'),
           poolMatch: getFilterValue('pool'),
           statuses: computedStatuses.length > 0 ? computedStatuses : undefined,
@@ -1699,6 +1734,33 @@ export function ManagedJobsTable({
           ) : null,
       },
       {
+        id: 'account',
+        order: 2.7,
+        conditional: true,
+        renderHeader: () =>
+          hasExternalRows ? (
+            <TableHead
+              className="sortable whitespace-nowrap"
+              onClick={() => requestSort('account')}
+            >
+              Account / QOS{getSortDirection('account')}
+            </TableHead>
+          ) : null,
+        renderCell: (item) =>
+          hasExternalRows ? (
+            <TableCell>
+              {item.account ? (
+                <span className="whitespace-nowrap">
+                  {item.account}
+                  {item.qos ? ` / ${item.qos}` : ''}
+                </span>
+              ) : (
+                <span className="text-gray-400">—</span>
+              )}
+            </TableCell>
+          ) : null,
+      },
+      {
         id: 'submitted',
         order: 3,
         renderHeader: () => (
@@ -2042,6 +2104,7 @@ export function ManagedJobsTable({
       getSortDirection,
       shouldShowWorkspace,
       shouldShowPool,
+      hasExternalRows,
       expandedRowId,
       poolsLoading,
       poolsData,
@@ -2116,6 +2179,7 @@ export function ManagedJobsTable({
         // Handle conditional columns
         if (columnId === 'workspace') return shouldShowWorkspace;
         if (columnId === 'pool') return shouldShowPool;
+        if (columnId === 'account') return hasExternalRows;
         return true;
       },
     },

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -82,6 +82,7 @@ import {
   useTableColumns,
   usePluginComponents,
   useMergedTableColumns,
+  usePluginTableFilters,
 } from '@/plugins/PluginProvider';
 import {
   FilterDropdown,
@@ -209,18 +210,10 @@ export const JOB_FILTER_SCHEMA = [
   { key: 'name', label: 'Name', kind: 'text' },
   { key: 'id', label: 'ID', kind: 'text' },
   { key: 'user', label: 'User', kind: 'text' },
-  // Slurm accounting fields, populated only on external rows. They stay in
-  // the schema unconditionally so a shared URL always decodes, but the
-  // dropdown only offers them once external rows have been seen.
-  { key: 'account', label: 'Account', kind: 'text' },
-  { key: 'qos', label: 'QOS', kind: 'text' },
   { key: 'workspace', label: 'Workspace', kind: 'text' },
   { key: 'pool', label: 'Pool', kind: 'text' },
   { key: 'labels', label: 'Labels', kind: 'kv', multi: 'repeat' },
 ];
-
-// Filter properties that can only ever match external rows.
-const EXTERNAL_ONLY_FILTER_KEYS = new Set(['account', 'qos']);
 
 // Non-filter state that belongs in a shared link too.
 //
@@ -258,11 +251,6 @@ export function deriveStatusView(statusParam) {
     activeTab: statusGroupName || (selectedStatuses.length > 0 ? null : 'all'),
   };
 }
-
-const PROPERTY_OPTIONS = JOB_FILTER_SCHEMA.map(({ key, label }) => ({
-  label,
-  value: key,
-}));
 
 // Properties that may hold several chips; the rest replace, so the page can
 // never show more filters than the URL is able to carry.
@@ -354,9 +342,17 @@ export function ManagedJobs() {
   const jobsRefreshRef = React.useRef(null);
   const poolsRefreshRef = React.useRef(null);
   const [poolsData, setPoolsData] = useState([]);
+  // Plugins may register extra filter properties for this table (e.g. the
+  // pagination plugin's Slurm Account/QOS filters) — registration is
+  // reactive, typically arriving with the plugin's first data response.
+  const pluginFilterProps = usePluginTableFilters('jobs');
+  const filterSchema = React.useMemo(
+    () => [...JOB_FILTER_SCHEMA, ...pluginFilterProps],
+    [pluginFilterProps]
+  );
   // Filters and the shareable view state both live in the URL, keyed by name.
   const { filters, setFilters, view, setView } = useUrlFilterState(
-    JOB_FILTER_SCHEMA,
+    filterSchema,
     JOB_VIEW_SCHEMA
   );
   const [valueList, setValueList] = useState({
@@ -368,11 +364,6 @@ export function ManagedJobs() {
   });
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
-  // Deployment-level signal from the jobs provider (`externalJobsEnabled`
-  // on the response): external Slurm clusters are configured, so the
-  // Account/QOS column and filter options apply. Independent of which rows
-  // the current page happens to hold.
-  const [hasExternalRows, setHasExternalRows] = useState(false);
 
   const fetchData = React.useCallback(
     async (isRefreshButton = false) => {
@@ -476,13 +467,10 @@ export function ManagedJobs() {
         />
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
-            propertyList={
-              hasExternalRows
-                ? PROPERTY_OPTIONS
-                : PROPERTY_OPTIONS.filter(
-                    (o) => !EXTERNAL_ONLY_FILTER_KEYS.has(o.value)
-                  )
-            }
+            propertyList={filterSchema.map(({ key, label }) => ({
+              label,
+              value: key,
+            }))}
             valueList={valueList}
             setFilters={setFilters}
             addFilter={addFilter}
@@ -508,8 +496,6 @@ export function ManagedJobs() {
         setValueList={setValueList}
         preloadingComplete={preloadingComplete}
         lastFetchedTime={lastFetchedTime}
-        hasExternalRows={hasExternalRows}
-        setHasExternalRows={setHasExternalRows}
       />
 
       {/* Pools table - always visible */}
@@ -613,13 +599,14 @@ export function ManagedJobsTable({
   setValueList,
   preloadingComplete,
   lastFetchedTime,
-  hasExternalRows,
-  setHasExternalRows,
 }) {
   const [sortConfig, setSortConfig] = useState({
     key: 'id',
     direction: 'descending',
   });
+  // Plugin-registered filter properties (see ManagedJobs): their values are
+  // forwarded to the data provider verbatim as {property: key, value}.
+  const pluginFilterProps = usePluginTableFilters('jobs');
   const [loading, setLocalLoading] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [currentPage, setCurrentPage] = useState(() => {
@@ -825,10 +812,16 @@ export function ManagedJobsTable({
           jobIdMatch: jobIdFilter,
           nameMatch: getFilterValue('name'),
           userMatch: effectiveUserMatch,
-          accountMatch: getFilterValue('account'),
-          qosMatch: getFilterValue('qos'),
           workspaceMatch: getFilterValue('workspace'),
           poolMatch: getFilterValue('pool'),
+          // Values of plugin-registered filter properties, keyed by their
+          // schema key — the plugin's fetch function interprets them.
+          pluginFilters: pluginFilterProps
+            .map((f) => {
+              const value = getFilterValue(f.label.toLowerCase());
+              return value ? { property: f.key, value } : null;
+            })
+            .filter(Boolean),
           statuses: computedStatuses.length > 0 ? computedStatuses : undefined,
           page: currentPage,
           limit: pageSize,
@@ -855,13 +848,6 @@ export function ManagedJobsTable({
             setExternalFetchErrors([]);
           } else {
             setHookControllerStopped(false);
-            // Deployment-level signal from the jobs provider (external
-            // Slurm clusters configured) — page contents alone can't tell,
-            // since the current page may hold only managed rows while
-            // external rows sit on later pages.
-            if (response.externalJobsEnabled && setHasExternalRows) {
-              setHasExternalRows(true);
-            }
             setData(response.jobs || []);
             setTotalCount(response.total || 0);
             setTotalNoFilter(response.totalNoFilter || response.total || 0);
@@ -951,7 +937,7 @@ export function ManagedJobsTable({
       sortOrder,
       userScope,
       currentUser,
-      setHasExternalRows,
+      pluginFilterProps,
     ]
   );
 
@@ -1732,37 +1718,6 @@ export function ManagedJobsTable({
           ) : null,
       },
       {
-        id: 'account',
-        order: 2.7,
-        conditional: true,
-        renderHeader: () =>
-          hasExternalRows ? (
-            <TableHead
-              className="sortable whitespace-nowrap"
-              onClick={() => requestSort('account')}
-            >
-              Account / QOS{getSortDirection('account')}
-            </TableHead>
-          ) : null,
-        renderCell: (item) =>
-          hasExternalRows ? (
-            <TableCell>
-              {item.account || item.qos ? (
-                // Either half may be missing (a cluster can stamp QOS
-                // without an account and vice versa); a lone QOS keeps the
-                // '— /' prefix so it can't read as an account name.
-                <span className="whitespace-nowrap">
-                  {item.qos
-                    ? `${item.account || '—'} / ${item.qos}`
-                    : item.account}
-                </span>
-              ) : (
-                <span className="text-gray-400">—</span>
-              )}
-            </TableCell>
-          ) : null,
-      },
-      {
         id: 'submitted',
         order: 3,
         renderHeader: () => (
@@ -2106,7 +2061,6 @@ export function ManagedJobsTable({
       getSortDirection,
       shouldShowWorkspace,
       shouldShowPool,
-      hasExternalRows,
       expandedRowId,
       poolsLoading,
       poolsData,
@@ -2181,7 +2135,6 @@ export function ManagedJobsTable({
         // Handle conditional columns
         if (columnId === 'workspace') return shouldShowWorkspace;
         if (columnId === 'pool') return shouldShowPool;
-        if (columnId === 'account') return hasExternalRows;
         return true;
       },
     },

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -744,8 +744,9 @@ export function ManagedJobsTable({
     return 'desc';
   }, [sortConfig.key, sortConfig.direction]);
 
-  // Latch external-row presence up to the page component (never unlatches),
-  // which gates the Account/QOS column and filter options.
+  // Fallback latch for providers that don't send `externalJobsEnabled`
+  // (older plugin builds): external-row presence in fetched pages also
+  // reveals the Account/QOS column and filter options (never unlatches).
   React.useEffect(() => {
     if (
       !hasExternalRows &&
@@ -865,6 +866,13 @@ export function ManagedJobsTable({
             setExternalFetchErrors([]);
           } else {
             setHookControllerStopped(false);
+            // Deployment-level signal from the jobs provider (external
+            // Slurm clusters configured) — page contents alone can't tell,
+            // since the current page may hold only managed rows while
+            // external rows sit on later pages.
+            if (response.externalJobsEnabled && setHasExternalRows) {
+              setHasExternalRows(true);
+            }
             setData(response.jobs || []);
             setTotalCount(response.total || 0);
             setTotalNoFilter(response.totalNoFilter || response.total || 0);
@@ -954,6 +962,7 @@ export function ManagedJobsTable({
       sortOrder,
       userScope,
       currentUser,
+      setHasExternalRows,
     ]
   );
 

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -368,8 +368,10 @@ export function ManagedJobs() {
   });
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
-  // Latched once any fetched page contains an external row, so the
-  // Account/QOS filter options and column don't flicker across pages.
+  // Deployment-level signal from the jobs provider (`externalJobsEnabled`
+  // on the response): external Slurm clusters are configured, so the
+  // Account/QOS column and filter options apply. Independent of which rows
+  // the current page happens to hold.
   const [hasExternalRows, setHasExternalRows] = useState(false);
 
   const fetchData = React.useCallback(
@@ -743,19 +745,6 @@ export function ManagedJobsTable({
     }
     return 'desc';
   }, [sortConfig.key, sortConfig.direction]);
-
-  // Fallback latch for providers that don't send `externalJobsEnabled`
-  // (older plugin builds): external-row presence in fetched pages also
-  // reveals the Account/QOS column and filter options (never unlatches).
-  React.useEffect(() => {
-    if (
-      !hasExternalRows &&
-      setHasExternalRows &&
-      (data || []).some((job) => job.is_external)
-    ) {
-      setHasExternalRows(true);
-    }
-  }, [data, hasExternalRows, setHasExternalRows]);
 
   // Determine if we should show the Workspace column
   // Only show if there are multiple workspaces or a workspace other than 'default'

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1749,10 +1749,14 @@ export function ManagedJobsTable({
         renderCell: (item) =>
           hasExternalRows ? (
             <TableCell>
-              {item.account ? (
+              {item.account || item.qos ? (
+                // Either half may be missing (a cluster can stamp QOS
+                // without an account and vice versa); a lone QOS keeps the
+                // '— /' prefix so it can't read as an account name.
                 <span className="whitespace-nowrap">
-                  {item.account}
-                  {item.qos ? ` / ${item.qos}` : ''}
+                  {item.qos
+                    ? `${item.account || '—'} / ${item.qos}`
+                    : item.account}
                 </span>
               ) : (
                 <span className="text-gray-400">—</span>

--- a/sky/dashboard/src/components/jobs.urlfilters.test.jsx
+++ b/sky/dashboard/src/components/jobs.urlfilters.test.jsx
@@ -37,6 +37,12 @@ jest.mock('@/plugins/PluginProvider', () => ({
   // Empty on purpose: the table's own columns are not what these assert on, and
   // rendering them here would require emulating the plugin column merge.
   useMergedTableColumns: () => [],
+  // Stable identity, like the real (memoized) hook: a fresh array per render
+  // would churn the fetch effect's dependencies into a loop.
+  usePluginTableFilters: (() => {
+    const empty = [];
+    return () => empty;
+  })(),
   usePluginRoute: () => null,
   getDataEnhancements: () => [],
 }));

--- a/sky/dashboard/src/hooks/useUrlFilterState.js
+++ b/sky/dashboard/src/hooks/useUrlFilterState.js
@@ -62,7 +62,7 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
     }
     return { filters: queryToFilters(filterSchema, named), view };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [readQuery]);
+  }, [readQuery, filterSchema]);
 
   const initial = useRef(null);
   if (initial.current === null) {
@@ -98,6 +98,24 @@ export function useUrlFilterState(filterSchema, viewSchema = []) {
       JSON.stringify(prev) === JSON.stringify(next.view) ? prev : next.view
     );
   }, [router.isReady, router.asPath, readInitial]);
+
+  // Re-decode when the schema itself grows (a plugin registering filter
+  // properties after mount): a deep-linked param that was passing through
+  // as an unowned key may now decode into a chip. The adopt-external effect
+  // above can't cover this — the URL hasn't changed, only the schema has.
+  const lastSchema = useRef(filterSchema);
+  useEffect(() => {
+    if (lastSchema.current === filterSchema) {
+      return;
+    }
+    lastSchema.current = filterSchema;
+    const next = readInitial();
+    setFilters((prev) =>
+      JSON.stringify(prev) === JSON.stringify(next.filters)
+        ? prev
+        : next.filters
+    );
+  }, [filterSchema, readInitial]);
 
   // Mirror state into the address bar. Keys not owned by this hook (a plugin's
   // own params, `tab`, ...) are preserved.

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -46,6 +46,8 @@ class JobsCacheManager {
       jobIdMatch,
       nameMatch,
       userMatch,
+      accountMatch,
+      qosMatch,
       workspaceMatch,
       poolMatch,
       statuses,
@@ -61,6 +63,8 @@ class JobsCacheManager {
       jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
+      accountMatch: accountMatch || null,
+      qosMatch: qosMatch || null,
       workspaceMatch: workspaceMatch || null,
       poolMatch: poolMatch || null,
       statuses: statuses && statuses.length > 0 ? [...statuses].sort() : null,
@@ -79,6 +83,8 @@ class JobsCacheManager {
       jobIdMatch,
       nameMatch,
       userMatch,
+      accountMatch,
+      qosMatch,
       workspaceMatch,
       poolMatch,
       statuses,
@@ -89,6 +95,8 @@ class JobsCacheManager {
       jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
+      accountMatch: accountMatch || null,
+      qosMatch: qosMatch || null,
       workspaceMatch: workspaceMatch || null,
       poolMatch: poolMatch || null,
       statuses: statuses && statuses.length > 0 ? [...statuses].sort() : null,
@@ -379,6 +387,12 @@ class JobsCacheManager {
     }
     if (filterOptions.userMatch) {
       filters.push({ property: 'user', value: filterOptions.userMatch });
+    }
+    if (filterOptions.accountMatch) {
+      filters.push({ property: 'account', value: filterOptions.accountMatch });
+    }
+    if (filterOptions.qosMatch) {
+      filters.push({ property: 'qos', value: filterOptions.qosMatch });
     }
     if (filterOptions.workspaceMatch) {
       filters.push({

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -343,6 +343,7 @@ class JobsCacheManager {
     const hasPrev = result.hasPrev || result.has_prev || page > 1;
     const statusCounts = result.statusCounts || {};
     const externalFetchErrors = result.externalFetchErrors || [];
+    const externalJobsEnabled = result.externalJobsEnabled === true;
 
     // Cache this specific page
     this.pageCache.set(cacheKey, {
@@ -355,6 +356,7 @@ class JobsCacheManager {
       controllerStopped: false,
       statusCounts,
       externalFetchErrors,
+      externalJobsEnabled,
       timestamp: Date.now(),
     });
 
@@ -368,6 +370,7 @@ class JobsCacheManager {
       controllerStopped: false,
       statusCounts,
       externalFetchErrors,
+      externalJobsEnabled,
       fromCache: false,
       cacheStatus: 'plugin_path_fetched',
     };

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -46,10 +46,9 @@ class JobsCacheManager {
       jobIdMatch,
       nameMatch,
       userMatch,
-      accountMatch,
-      qosMatch,
       workspaceMatch,
       poolMatch,
+      pluginFilters,
       statuses,
     } = options;
 
@@ -63,10 +62,9 @@ class JobsCacheManager {
       jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
-      accountMatch: accountMatch || null,
-      qosMatch: qosMatch || null,
       workspaceMatch: workspaceMatch || null,
       poolMatch: poolMatch || null,
+      pluginFilters: this._normalizePluginFilters(pluginFilters),
       statuses: statuses && statuses.length > 0 ? [...statuses].sort() : null,
     };
 
@@ -83,10 +81,9 @@ class JobsCacheManager {
       jobIdMatch,
       nameMatch,
       userMatch,
-      accountMatch,
-      qosMatch,
       workspaceMatch,
       poolMatch,
+      pluginFilters,
       statuses,
     } = options;
 
@@ -95,10 +92,9 @@ class JobsCacheManager {
       jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
-      accountMatch: accountMatch || null,
-      qosMatch: qosMatch || null,
       workspaceMatch: workspaceMatch || null,
       poolMatch: poolMatch || null,
+      pluginFilters: this._normalizePluginFilters(pluginFilters),
       statuses: statuses && statuses.length > 0 ? [...statuses].sort() : null,
     };
 
@@ -343,7 +339,6 @@ class JobsCacheManager {
     const hasPrev = result.hasPrev || result.has_prev || page > 1;
     const statusCounts = result.statusCounts || {};
     const externalFetchErrors = result.externalFetchErrors || [];
-    const externalJobsEnabled = result.externalJobsEnabled === true;
 
     // Cache this specific page
     this.pageCache.set(cacheKey, {
@@ -356,7 +351,6 @@ class JobsCacheManager {
       controllerStopped: false,
       statusCounts,
       externalFetchErrors,
-      externalJobsEnabled,
       timestamp: Date.now(),
     });
 
@@ -370,7 +364,6 @@ class JobsCacheManager {
       controllerStopped: false,
       statusCounts,
       externalFetchErrors,
-      externalJobsEnabled,
       fromCache: false,
       cacheStatus: 'plugin_path_fetched',
     };
@@ -391,12 +384,6 @@ class JobsCacheManager {
     if (filterOptions.userMatch) {
       filters.push({ property: 'user', value: filterOptions.userMatch });
     }
-    if (filterOptions.accountMatch) {
-      filters.push({ property: 'account', value: filterOptions.accountMatch });
-    }
-    if (filterOptions.qosMatch) {
-      filters.push({ property: 'qos', value: filterOptions.qosMatch });
-    }
     if (filterOptions.workspaceMatch) {
       filters.push({
         property: 'workspace',
@@ -406,8 +393,29 @@ class JobsCacheManager {
     if (filterOptions.poolMatch) {
       filters.push({ property: 'pool', value: filterOptions.poolMatch });
     }
+    // Plugin-registered filter properties pass through verbatim — the
+    // plugin's fetch function is the one that interprets them.
+    for (const f of filterOptions.pluginFilters || []) {
+      if (f && f.property && f.value) {
+        filters.push({ property: f.property, value: f.value });
+      }
+    }
 
     return filters;
+  }
+
+  /**
+   * Normalized, order-independent form of the pluginFilters option for
+   * cache keys.
+   */
+  _normalizePluginFilters(pluginFilters) {
+    if (!pluginFilters || pluginFilters.length === 0) {
+      return null;
+    }
+    return pluginFilters
+      .map((f) => `${f.property}:${f.value}`)
+      .sort()
+      .join('|');
   }
 
   /**

--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -27,6 +27,7 @@ const PluginContext = createContext({
   components: {},
   dataEnhancements: {},
   tableColumns: {},
+  tableFilters: {},
   dataProviders: {},
   recipeTypes: [],
 });
@@ -68,6 +69,7 @@ const initialState = {
   components: {}, // Map of slot name → array of component configs
   dataEnhancements: {}, // Map of dataSource → array of enhancements
   tableColumns: {}, // Map of table name → array of column configs
+  tableFilters: {}, // Map of table name → array of filter property configs
   dataProviders: {}, // Map of provider id → provider config (with useHook)
   recipeTypes: [], // Array of { id, label, fullLabel, icon, color, template }
 };
@@ -78,6 +80,7 @@ const actions = {
   REGISTER_COMPONENT: 'REGISTER_COMPONENT',
   REGISTER_DATA_ENHANCEMENT: 'REGISTER_DATA_ENHANCEMENT',
   REGISTER_TABLE_COLUMN: 'REGISTER_TABLE_COLUMN',
+  REGISTER_TABLE_FILTER: 'REGISTER_TABLE_FILTER',
   REGISTER_DATA_PROVIDER: 'REGISTER_DATA_PROVIDER',
   CLEAR_CACHED_NAV_LINKS: 'CLEAR_CACHED_NAV_LINKS',
   REGISTER_RECIPE_TYPE: 'REGISTER_RECIPE_TYPE',
@@ -151,6 +154,19 @@ function pluginReducer(state, action) {
         ...state,
         tableColumns: {
           ...state.tableColumns,
+          [table]: updated,
+        },
+      };
+    }
+    case actions.REGISTER_TABLE_FILTER: {
+      const { table } = action.payload;
+      const existing = state.tableFilters[table] || [];
+      const updated = upsertById(existing, action.payload);
+      updated.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+      return {
+        ...state,
+        tableFilters: {
+          ...state.tableFilters,
           [table]: updated,
         },
       };
@@ -463,6 +479,34 @@ function normalizeTableColumn(config) {
   };
 }
 
+function normalizeTableFilter(config) {
+  if (
+    !config ||
+    typeof config !== 'object' ||
+    !config.id ||
+    !config.table ||
+    !config.key ||
+    !config.label
+  ) {
+    console.warn(
+      '[SkyDashboardPlugin] Invalid table filter registration:',
+      config
+    );
+    return null;
+  }
+  return {
+    id: String(config.id),
+    table: String(config.table),
+    // Shape of the page filter schemas (e.g. JOB_FILTER_SCHEMA): `key` is
+    // what the URL carries and what the fetch path sends to the provider,
+    // `label` is what the dropdown and the filter chip show.
+    key: String(config.key),
+    label: String(config.label),
+    kind: config.kind ? String(config.kind) : 'text',
+    order: Number.isFinite(config.order) ? config.order : 100,
+  };
+}
+
 /**
  * Normalizes a URL by stripping credentials and ensuring it's safe for history API.
  * This prevents SecurityError when the current URL has credentials but the target URL doesn't.
@@ -687,6 +731,17 @@ function createPluginApi(dispatch) {
       }
       dispatch({
         type: actions.REGISTER_TABLE_COLUMN,
+        payload: normalized,
+      });
+      return normalized.id;
+    },
+    registerTableFilter(config) {
+      const normalized = normalizeTableFilter(config);
+      if (!normalized) {
+        return null;
+      }
+      dispatch({
+        type: actions.REGISTER_TABLE_FILTER,
         payload: normalized,
       });
       return normalized.id;
@@ -1062,6 +1117,27 @@ export function useTableColumns(tableName, context = {}) {
       return true;
     });
   }, [tableName, tableColumns, context]);
+}
+
+/**
+ * Hook to access plugin-registered filter properties for a table.
+ *
+ * Each entry is `{ id, table, key, label, kind, order }`, shaped like the
+ * page filter schemas (see e.g. JOB_FILTER_SCHEMA): the page appends these
+ * to its own schema so the dropdown offers them, the URL round-trips them,
+ * and the fetch path forwards their values to the data provider that
+ * registered them. Registration is reactive — a plugin may register after
+ * its first data fetch and the page picks the filters up live.
+ *
+ * @param {string} tableName - The table name (e.g., 'jobs')
+ * @returns {Array} Registered filter property configs, sorted by order
+ */
+export function usePluginTableFilters(tableName) {
+  const { tableFilters } = usePluginState();
+  return useMemo(
+    () => (tableName && tableFilters[tableName]) || [],
+    [tableName, tableFilters]
+  );
 }
 
 export function useDataProvider(id) {


### PR DESCRIPTION
## Summary
- Adds a generic **filter-property registry** to the dashboard plugin system, mirroring `registerTableColumn`: plugins call `registerTableFilter({table, key, label, kind, order})` and pages read `usePluginTableFilters(table)`. The jobs page appends registered properties to its filter schema — they appear in the filter dropdown, round-trip through the URL, and their values are forwarded verbatim to the data provider as `pluginFilters: [{property, value}]` (cache keys included).
- Makes `useUrlFilterState` **schema-reactive**: registration is asynchronous (typically arriving with a plugin's first data response), so a deep-linked param that lands before registration passes through as an unowned key and decodes into a filter chip the moment the schema grows.
- OSS ships **no filter-specific UI of its own** from this PR: concrete filters (e.g. Slurm Account/QOS) and any companion columns are registered by the data-provider plugin via this and the existing `registerTableColumn` mechanism. Deployments without such a plugin see zero change.

## Test plan
- Full dashboard jest suite (200 passed) and `next lint` clean; the jobs URL-filter suites cover schema round-tripping with the (mocked, stable) registry hook.
- Manual, against a provider plugin registering two filters + a column on its first response: dropdown gains the properties after the first fetch; cold-load deep link with a registered param decodes into a chip and serves filtered rows; sort via the registered column's `sortKey`; deployments where the provider never registers show no trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)