### PR TITLE
[Jobs] Record who requested a job cancellation in the event log

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -84,7 +84,7 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # job.utils.ManagedJobCodeGen to handle the version update.
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
-MANAGED_JOBS_VERSION = 22  # add submitted_after/submitted_before to job table
+MANAGED_JOBS_VERSION = 23  # add cancel_request_info to the cancel APIs
 
 # Emergency recovery: when the job controller hits an unexpected internal
 # error (e.g. external mutation of the job state, or an unhandled exception

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -8,6 +8,7 @@ import asyncio
 import collections
 import concurrent.futures
 import contextlib
+import dataclasses
 from datetime import datetime
 import enum
 import json
@@ -1500,15 +1501,93 @@ def generate_managed_job_cluster_name(task_name: str, job_id: int) -> str:
     return f'{cluster_name}-{job_id}'
 
 
-def cancel_jobs_by_id(job_ids: Optional[List[int]],
-                      all_users: bool = False,
-                      current_workspace: Optional[str] = None,
-                      user_hash: Optional[str] = None,
-                      graceful: bool = False,
-                      graceful_timeout: Optional[int] = None) -> str:
+@dataclasses.dataclass
+class CancelRequestInfo:
+    """Who asked for a cancellation, and under which API request.
+
+    Recorded in the job's event log so the events table tells a
+    user-requested cancel (and which user asked for it) apart from an
+    internal one, e.g. a job group tearing down its auxiliary jobs.
+
+    The fields are all optional because the identity is not always
+    knowable: an old client/controller does not send it, and a cancel that
+    does not originate from an API request has no requester at all.
+    """
+    user_hash: Optional[str] = None
+    user_name: Optional[str] = None
+    request_id: Optional[str] = None
+
+    @classmethod
+    def from_request_context(cls) -> Optional['CancelRequestInfo']:
+        """Build from the ambient API request context, or None if there is none.
+
+        Only a server-side request execution has a request context (see
+        ``common_utils.set_request_context``). On a controller -- where the
+        cancel arrives over gRPC or as generated code -- it is unset, and the
+        requester has to be passed in explicitly instead.
+        """
+        if not common_utils.is_in_request_context():
+            return None
+        user = common_utils.get_current_user()
+        return cls(user_hash=user.id,
+                   user_name=user.name,
+                   request_id=common_utils.get_current_request_id())
+
+    def event_reason(self) -> Optional[str]:
+        """The job-event reason for this cancel request.
+
+        None when nothing identifying is known, so the caller can skip
+        writing an event that would say nothing.
+        """
+        # The hash is the fallback identity: a user row (and so the display
+        # name) may be missing on the controller side.
+        who = self.user_name or self.user_hash
+        if who is None and self.request_id is None:
+            return None
+        if who is not None:
+            reason = f'Cancellation requested by user {who}'
+        else:
+            reason = 'Cancellation requested'
+        if self.request_id is not None:
+            reason += f' (request ID: {self.request_id})'
+        return reason
+
+
+def _record_cancel_request_event(job_id: int, reason: Optional[str]) -> None:
+    """Append the cancel-request event to a job's event log, best-effort.
+
+    Written before the cancellation is acted on, so the events table
+    attributes the request even if the job reaches a terminal state (or the
+    signal write fails) immediately after. A failure to record must never
+    fail the cancellation itself -- this is an audit trail, not state.
+    """
+    if reason is None:
+        return
+    try:
+        managed_job_state.add_job_event(
+            job_id, None, managed_job_state.ManagedJobStatus.CANCELLING, reason)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to record the cancel request event for job '
+                       f'{job_id}: {common_utils.format_exception(e)}')
+
+
+def cancel_jobs_by_id(
+        job_ids: Optional[List[int]],
+        all_users: bool = False,
+        current_workspace: Optional[str] = None,
+        user_hash: Optional[str] = None,
+        graceful: bool = False,
+        graceful_timeout: Optional[int] = None,
+        cancel_request_info: Optional[CancelRequestInfo] = None) -> str:
     """Cancel jobs by id.
 
     If job_ids is None, cancel all jobs.
+
+    Args:
+        cancel_request_info: who requested the cancellation, recorded in each
+            job's event log. Defaults to the ambient API request context,
+            which is only set when this runs in-process on the API server
+            (consolidation mode); a remote controller gets it passed in.
     """
     if job_ids is None:
         job_ids = managed_job_state.get_nonterminal_job_ids_by_name(
@@ -1518,6 +1597,11 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
         return 'No job to cancel.'
     if current_workspace is None:
         current_workspace = constants.SKYPILOT_DEFAULT_WORKSPACE
+
+    if cancel_request_info is None:
+        cancel_request_info = CancelRequestInfo.from_request_context()
+    cancel_event_reason = (cancel_request_info.event_reason()
+                           if cancel_request_info is not None else None)
 
     cancelled_job_ids: List[int] = []
     wrong_workspace_job_ids: List[int] = []
@@ -1544,7 +1628,14 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             logger.info(f'Job {job_id} is already in terminal state '
                         f'{job_status.value}. Skipped.')
             continue
-        elif job_status == managed_job_state.ManagedJobStatus.PENDING:
+
+        # Attribute the cancellation in the job's event log. Done here, once
+        # the job is known to be cancellable and before any of the paths
+        # below act on it, so the audit entry precedes the resulting
+        # CANCELLING / CANCELLED events.
+        _record_cancel_request_event(job_id, cancel_event_reason)
+
+        if job_status == managed_job_state.ManagedJobStatus.PENDING:
             # the "if PENDING" is a short circuit, this will be atomic.
             cancelled = managed_job_state.set_pending_cancelled(job_id)
             if cancelled:
@@ -1611,10 +1702,12 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
     return msg
 
 
-def cancel_job_by_name(job_name: str,
-                       current_workspace: Optional[str] = None,
-                       graceful: bool = False,
-                       graceful_timeout: Optional[int] = None) -> str:
+def cancel_job_by_name(
+        job_name: str,
+        current_workspace: Optional[str] = None,
+        graceful: bool = False,
+        graceful_timeout: Optional[int] = None,
+        cancel_request_info: Optional[CancelRequestInfo] = None) -> str:
     """Cancel a job by name."""
     job_ids = managed_job_state.get_nonterminal_job_ids_by_name(job_name)
     if not job_ids:
@@ -1626,17 +1719,22 @@ def cancel_job_by_name(job_name: str,
     msg = cancel_jobs_by_id(job_ids,
                             current_workspace=current_workspace,
                             graceful=graceful,
-                            graceful_timeout=graceful_timeout)
+                            graceful_timeout=graceful_timeout,
+                            cancel_request_info=cancel_request_info)
     return f'{job_name!r} {msg}'
 
 
-def cancel_jobs_by_pool(pool_name: str,
-                        current_workspace: Optional[str] = None) -> str:
+def cancel_jobs_by_pool(
+        pool_name: str,
+        current_workspace: Optional[str] = None,
+        cancel_request_info: Optional[CancelRequestInfo] = None) -> str:
     """Cancel all jobs in a pool."""
     job_ids = managed_job_state.get_nonterminal_job_ids_by_pool(pool_name)
     if not job_ids:
         return f'No running job found in pool {pool_name!r}.'
-    return cancel_jobs_by_id(job_ids, current_workspace=current_workspace)
+    return cancel_jobs_by_id(job_ids,
+                             current_workspace=current_workspace,
+                             cancel_request_info=cancel_request_info)
 
 
 def cancel_managed_jobs(
@@ -1650,6 +1748,7 @@ def cancel_managed_jobs(
     graceful_timeout: Optional[int] = None,
     current_workspace: Optional[str] = None,
     user_hash: Optional[str] = None,
+    cancel_request_info: Optional[CancelRequestInfo] = None,
 ) -> str:
     """Dispatch to the correct cancel variant based on selector args.
 
@@ -1674,6 +1773,7 @@ def cancel_managed_jobs(
             user_hash=user_hash,
             graceful=graceful,
             graceful_timeout=graceful_timeout,
+            cancel_request_info=cancel_request_info,
         )
     if name is not None:
         return cancel_job_by_name(
@@ -1681,11 +1781,13 @@ def cancel_managed_jobs(
             current_workspace=current_workspace,
             graceful=graceful,
             graceful_timeout=graceful_timeout,
+            cancel_request_info=cancel_request_info,
         )
     assert pool is not None, (job_ids, name, pool, all)
     return cancel_jobs_by_pool(
         pool,
         current_workspace=current_workspace,
+        cancel_request_info=cancel_request_info,
     )
 
 
@@ -3973,8 +4075,16 @@ class ManagedJobCodeGen:
         targeted call to the underlying ``utils.cancel_jobs_by_id`` /
         ``cancel_job_by_name`` / ``cancel_jobs_by_pool`` chosen
         client-side based on the selector args.
+
+        The cancel requester (``cancel_request_info``) is only passed to
+        controllers running ``MANAGED_JOBS_VERSION >= 23``; older ones don't
+        have the parameter, and simply record an unattributed cancel.
         """
         active_workspace = skypilot_config.get_active_workspace()
+        # This runs on the API server, inside the request that asked for the
+        # cancellation, so the requester comes from the ambient context; the
+        # controller executing the generated code has no such context.
+        cancel_request_info = CancelRequestInfo.from_request_context()
 
         # ``user_hash`` is intentionally omitted below — the controller runs
         # the generated code under ``_build()``, which exports
@@ -4037,18 +4147,32 @@ class ManagedJobCodeGen:
             ]
 
         legacy_block = '\n'.join(f'    {line}' for line in legacy_call_lines)
+        dispatch_args = (f'        name={name!r},\n'
+                         f'        job_ids={job_ids!r},\n'
+                         f'        pool={pool!r},\n'
+                         f'        all={all!r},\n'
+                         f'        all_users={all_users!r},\n'
+                         f'        graceful={graceful!r},\n'
+                         f'        graceful_timeout={graceful_timeout!r},\n'
+                         f'        current_workspace={active_workspace!r},\n')
+        requester_arg = ''
+        if cancel_request_info is not None:
+            requester_arg = (
+                f'        cancel_request_info=utils.CancelRequestInfo(\n'
+                f'            user_hash={cancel_request_info.user_hash!r},\n'
+                f'            user_name={cancel_request_info.user_name!r},\n'
+                f'            request_id={cancel_request_info.request_id!r},\n'
+                f'        ),\n')
         code = (f'if managed_job_version < 19:\n'
                 f'{legacy_block}\n'
+                f'elif managed_job_version < 23:\n'
+                f'    msg = utils.cancel_managed_jobs(\n'
+                f'{dispatch_args}'
+                f'    )\n'
                 f'else:\n'
                 f'    msg = utils.cancel_managed_jobs(\n'
-                f'        name={name!r},\n'
-                f'        job_ids={job_ids!r},\n'
-                f'        pool={pool!r},\n'
-                f'        all={all!r},\n'
-                f'        all_users={all_users!r},\n'
-                f'        graceful={graceful!r},\n'
-                f'        graceful_timeout={graceful_timeout!r},\n'
-                f'        current_workspace={active_workspace!r},\n'
+                f'{dispatch_args}'
+                f'{requester_arg}'
                 f'    )\n'
                 f'print(msg, end="", flush=True)\n')
         return cls._build(code)

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import pathlib
 import tempfile
 import time
@@ -577,6 +578,60 @@ def test_cancel_signal_file_graceful_with_timeout():
                 assert signal_file.exists()
                 content = signal_file.read_text(encoding='utf-8')
                 assert content == 'graceful:300'
+
+
+def test_cancel_request_info_event_reason():
+    """The event reason names the requester and the request ID."""
+    info = utils.CancelRequestInfo(user_hash='abcd1234',
+                                   user_name='alice',
+                                   request_id='req-1')
+    assert info.event_reason() == ('Cancellation requested by user alice '
+                                   '(request ID: req-1)')
+
+    # No display name available (e.g. no user row on the controller): fall
+    # back to the hash rather than dropping the identity.
+    info = utils.CancelRequestInfo(user_hash='abcd1234', request_id='req-1')
+    assert info.event_reason() == ('Cancellation requested by user abcd1234 '
+                                   '(request ID: req-1)')
+
+    # Partial information is still worth recording.
+    assert utils.CancelRequestInfo(user_name='alice').event_reason() == (
+        'Cancellation requested by user alice')
+    assert utils.CancelRequestInfo(request_id='req-1').event_reason() == (
+        'Cancellation requested (request ID: req-1)')
+
+    # Nothing identifying -> nothing worth writing.
+    assert utils.CancelRequestInfo().event_reason() is None
+
+
+@contextlib.contextmanager
+def _cancellable_job(tmpdir):
+    """Patches around cancel_jobs_by_id for a single cancellable job 42."""
+    with mock.patch('sky.jobs.constants.CONSOLIDATED_SIGNAL_PATH', tmpdir), \
+         mock.patch('sky.jobs.state.is_legacy_controller_process',
+                    return_value=False), \
+         mock.patch('sky.jobs.state.get_status',
+                    return_value=mock.MagicMock(
+                        is_terminal=mock.MagicMock(return_value=False),
+                        __eq__=mock.MagicMock(return_value=False))), \
+         mock.patch('sky.jobs.utils.update_managed_jobs_statuses'), \
+         mock.patch('sky.jobs.state.get_workspace', return_value='default'), \
+         mock.patch('sky.jobs.state.add_job_event') as mock_add_event:
+        yield mock_add_event
+
+
+def test_cancel_event_failure_does_not_block_cancel():
+    """A failed audit write must not fail the cancellation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with _cancellable_job(tmpdir) as mock_add_event:
+            mock_add_event.side_effect = RuntimeError('db is down')
+            msg = utils.cancel_jobs_by_id(
+                job_ids=[42],
+                current_workspace='default',
+                cancel_request_info=utils.CancelRequestInfo(user_name='alice'))
+
+            assert 'scheduled to be cancelled' in msg
+            assert (pathlib.Path(tmpdir) / '42').exists()
 
 
 @mock.patch('sky.utils.subprocess_utils.run_in_parallel')

--- a/tests/unit_tests/test_sky/jobs/test_cancel_events.py
+++ b/tests/unit_tests/test_sky/jobs/test_cancel_events.py
@@ -41,11 +41,19 @@ def _mock_managed_jobs_db_conn(tmp_path, monkeypatch):
 
 @pytest.fixture
 def _signal_dir(tmp_path, monkeypatch):
-    """Keep the cancel signal file out of the real ~/.sky directory."""
+    """Keep the cancel signal file out of the real ~/.sky directory.
+
+    Also stubs out the status reconciliation that cancel_jobs_by_id runs
+    before signalling: it inspects whether the seeded controller PID is alive
+    on this machine, which has nothing to do with the attribution under test
+    and would make the outcome depend on the host's process table.
+    """
     signal_dir = tmp_path / 'signals'
     signal_dir.mkdir()
     monkeypatch.setattr(managed_job_constants, 'CONSOLIDATED_SIGNAL_PATH',
                         str(signal_dir))
+    monkeypatch.setattr(utils, 'update_managed_jobs_statuses',
+                        lambda *args, **kwargs: None)
     yield signal_dir
 
 
@@ -60,6 +68,7 @@ def _seed_running_job(engine, job_id: int, workspace: str = 'default') -> None:
             # signal-file path rather than the legacy one.
             controller_pid=12345,
             controller_pid_started_at=time.time(),
+            schedule_state=state.ManagedJobScheduleState.ALIVE.value,
         ))
         conn.execute(state.spot_table.insert().values(
             job_name=f'job-{job_id}',

--- a/tests/unit_tests/test_sky/jobs/test_cancel_events.py
+++ b/tests/unit_tests/test_sky/jobs/test_cancel_events.py
@@ -1,0 +1,141 @@
+"""Unit tests for cancel-request attribution in the job event log.
+
+Runs against a real temporary SQLite database (fixture pattern from
+test_recovery_metrics_state.py), so the event rows that cancel_jobs_by_id
+writes are asserted as the dashboard's Events table would read them.
+"""
+import contextlib
+import time
+
+import filelock
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sky import models
+from sky.jobs import constants as managed_job_constants
+from sky.jobs import state
+from sky.jobs import utils
+
+
+@pytest.fixture
+def _mock_managed_jobs_db_conn(tmp_path, monkeypatch):
+    """Create a temporary SQLite DB for managed jobs state."""
+    db_path = tmp_path / 'managed_jobs_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(_section: str):
+        lock_path = tmp_path / f'.{_section}.lock'
+        with filelock.FileLock(str(lock_path), timeout=10):
+            yield
+
+    monkeypatch.setattr(state.migration_utils, 'db_lock', _tmp_db_lock)
+    monkeypatch.setattr(state._db_manager, '_engine', engine)
+    monkeypatch.setattr(state._db_manager, '_engine_async', async_engine)
+    state.create_table(engine)
+    yield engine
+
+
+@pytest.fixture
+def _signal_dir(tmp_path, monkeypatch):
+    """Keep the cancel signal file out of the real ~/.sky directory."""
+    signal_dir = tmp_path / 'signals'
+    signal_dir.mkdir()
+    monkeypatch.setattr(managed_job_constants, 'CONSOLIDATED_SIGNAL_PATH',
+                        str(signal_dir))
+    yield signal_dir
+
+
+def _seed_running_job(engine, job_id: int, workspace: str = 'default') -> None:
+    with engine.connect() as conn:
+        conn.execute(state.job_info_table.insert().values(
+            spot_job_id=job_id,
+            name=f'job-{job_id}',
+            workspace=workspace,
+            # A controller pid with a start time marks the job as running on a
+            # modern multi-job controller, so the cancel takes the consolidated
+            # signal-file path rather than the legacy one.
+            controller_pid=12345,
+            controller_pid_started_at=time.time(),
+        ))
+        conn.execute(state.spot_table.insert().values(
+            job_name=f'job-{job_id}',
+            status='RUNNING',
+            spot_job_id=job_id,
+            task_id=0,
+        ))
+        conn.commit()
+
+
+def _event_reasons(job_id: int):
+    return [event['reason'] for event in state.get_job_events(job_id)]
+
+
+def test_explicit_requester_recorded(_mock_managed_jobs_db_conn, _signal_dir):
+    """A requester passed in (the codegen path) reaches the event log."""
+    _seed_running_job(_mock_managed_jobs_db_conn, 1)
+
+    msg = utils.cancel_jobs_by_id(job_ids=[1],
+                                  current_workspace='default',
+                                  cancel_request_info=utils.CancelRequestInfo(
+                                      user_hash='abcd1234',
+                                      user_name='alice',
+                                      request_id='req-1'))
+
+    assert 'scheduled to be cancelled' in msg
+    assert (_signal_dir / '1').exists()
+    assert _event_reasons(1) == [
+        'Cancellation requested by user alice (request ID: req-1)'
+    ]
+
+
+def test_requester_from_request_context(_mock_managed_jobs_db_conn, _signal_dir,
+                                        monkeypatch):
+    """With no requester passed in, the ambient API request context is used.
+
+    This is the in-process path, where cancel_jobs_by_id runs inside the API
+    request that asked for the cancellation.
+    """
+    _seed_running_job(_mock_managed_jobs_db_conn, 1)
+    monkeypatch.setattr(utils.common_utils, 'is_in_request_context',
+                        lambda: True)
+    monkeypatch.setattr(utils.common_utils, 'get_current_user',
+                        lambda: models.User(id='abcd1234', name='alice'))
+    monkeypatch.setattr(utils.common_utils, 'get_current_request_id',
+                        lambda: 'req-1')
+
+    utils.cancel_jobs_by_id(job_ids=[1], current_workspace='default')
+
+    assert _event_reasons(1) == [
+        'Cancellation requested by user alice (request ID: req-1)'
+    ]
+
+
+def test_no_requester_records_no_event(_mock_managed_jobs_db_conn, _signal_dir,
+                                       monkeypatch):
+    """A cancel with no identifiable requester adds no event."""
+    _seed_running_job(_mock_managed_jobs_db_conn, 1)
+    monkeypatch.setattr(utils.common_utils, 'is_in_request_context',
+                        lambda: False)
+
+    utils.cancel_jobs_by_id(job_ids=[1], current_workspace='default')
+
+    assert not _event_reasons(1)
+    assert (_signal_dir / '1').exists()
+
+
+def test_skipped_job_is_not_attributed(_mock_managed_jobs_db_conn, _signal_dir):
+    """A job outside the active workspace is neither cancelled nor attributed."""
+    _seed_running_job(_mock_managed_jobs_db_conn, 1, workspace='other')
+
+    msg = utils.cancel_jobs_by_id(
+        job_ids=[1],
+        current_workspace='default',
+        cancel_request_info=utils.CancelRequestInfo(user_name='alice'))
+
+    assert 'No job to cancel' in msg
+    assert not _event_reasons(1)
+    assert not (_signal_dir / '1').exists()


### PR DESCRIPTION
## Summary

A cancelled managed job's Events table said only `Job is cancelling` — there was no way to tell who asked for the cancellation, or under which API request. This adds one event per affected job, written when the cancel request is handled:

```
2026-08-31 12:38:40 PM  CANCELLING  Job is cancelling
2026-08-31 12:38:32 PM  CANCELLING  Cancellation requested by user seungjinyang (request ID: a2145c3b-9510-41e4-b438-0ef6d2709cec)
2026-08-31 12:36:28 PM  RUNNING     Job has started
```

- The requester (`CancelRequestInfo`: user hash, user name, request ID) reaches `cancel_jobs_by_id` two ways: from the ambient API request context when the cancel runs in-process on the API server (consolidation mode), and embedded in the generated code for controllers running `MANAGED_JOBS_VERSION >= 23`. Older controllers take the existing call and record an unattributed cancel, as today.
- The row is written inside `cancel_jobs_by_id`'s per-job loop, after the terminal-state and workspace-isolation filters, so a job the request skips is not attributed, and one request cancelling several jobs attributes each of them with the same request ID.
- Recording is best-effort: a failed audit write is logged and never fails the cancellation.
- Falls back to the user hash when no display name is available, and writes nothing when neither a user nor a request ID is known.

Under SSO the name is whatever the proxy asserts — the email for oauth2-proxy (`X-Auth-Request-Email`) and for the plaintext external-proxy header; for JWT headers it is the claim named by `auth.external_proxy.jwt_identity_claim`, whose default is `sub`.

Deliberately **not** plumbed over gRPC to a remote controller: that deployment's events live in the controller's own DB, which `core.get_job_events` (in-process on the API server) cannot read, so the row would never be visible. Verified empirically below. If those events ever become readable, the gRPC leg is the piece to add.

## Test plan

Unit tests — `pytest tests/unit_tests/test_jobs_utils.py tests/unit_tests/test_sky/jobs/` (660 passed):

- New `tests/unit_tests/test_sky/jobs/test_cancel_events.py` runs against a real temporary SQLite DB and asserts the event rows as the dashboard reads them: explicit requester (codegen path), requester from the request context (in-process path), no requester → no event, and a wrong-workspace job being neither cancelled nor attributed.
- `test_jobs_utils.py` covers the reason formatting (incl. hash fallback and the "nothing identifying" case) and that a failing audit write does not block the cancellation.

Manual, against a local API server on Kubernetes:

1. **Consolidation mode, single job** — launched a managed job, `sky jobs cancel <id> -y` while RUNNING. `POST /jobs/events` (what the dashboard calls) returned the attribution row ~8s before the CANCELLING rows, and `sky api status <request-id>` resolved the recorded ID to that `sky.jobs.cancel` request by that user.
2. **Consolidation mode, one request cancelling two jobs** — two jobs RUNNING, one `sky jobs cancel -a -y`. Both jobs got a row, same user, same request ID (written 4 ms apart), and that ID resolved to the single `sky.jobs.cancel` request.
3. **Non-consolidation mode (controller pod)** — with consolidation off the cancel takes the codegen path. The controller pod (`MANAGED_JOBS_VERSION: 23`) recorded `Cancellation requested by user seungjinyang (request ID: 359724ab-…)` in its own DB, matching the `sky.jobs.cancel` request on the API server. `get_job_events` on the API server returned 0 rows for that job — confirming that the Events table is empty for remote-controller jobs regardless of this change, which is why the gRPC leg was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->