### PR TITLE
[Dashboard] Add jobs.detail.gpu-metrics plugin slot

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -766,6 +766,22 @@ function JobDetails() {
               />
             )}
 
+            {/* Plugin Slot: Job Detail GPU metrics. The built-in
+                TelemetrySection above covers Kubernetes; this lets a plugin
+                contribute a GPU-metrics/telemetry panel for other infra
+                (empty when no plugin registers for it). */}
+            <PluginSlot
+              name="jobs.detail.gpu-metrics"
+              context={{
+                clusterName: detailJobData.current_cluster_name,
+                clusterNameOnCloud: detailJobData.cluster_name_on_cloud,
+                nodeNames: detailJobData.node_names,
+                infra: detailJobData.full_infra,
+                status: detailJobData.status,
+              }}
+              wrapperClassName="mt-6"
+            />
+
             {/* Plugin Slot: Job Infra Nodes */}
             <PluginSlot
               name="jobs.detail.nodes"


### PR DESCRIPTION
## Summary

Adds a `jobs.detail.gpu-metrics` `PluginSlot` to the managed-job detail page (`jobs/[job].js`), between the built-in telemetry section and the infra-nodes slot.

The built-in `TelemetrySection` renders GPU/CPU telemetry only for Kubernetes tasks (it keys on a Kubernetes pod-label Grafana dashboard). This slot lets a plugin contribute an equivalent GPU-metrics/telemetry panel for other infra without further core changes, mirroring the existing `jobs.detail.nodes` / `jobs.detail.events` extension points. The slot is passed the same context the nodes slot already receives (`clusterName`, `clusterNameOnCloud`, `nodeNames`, `infra`, `status`).

The slot renders nothing when no plugin registers for it, so this is completely inert for a stock install.

## Test plan

- `npm run build` in `sky/dashboard` succeeds.
- With no plugin registered, the managed-job detail page renders unchanged (the slot is empty).
- A plugin registering a component for `jobs.detail.gpu-metrics` receives the context and renders below the telemetry section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRE6WbKydERcgKRTdtX6d9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->