### PR TITLE
[Core] Record who requested a cluster stop/termination in its event log

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -868,6 +868,21 @@ def _graceful_job_cancel(handle: backends.ResourceHandle,
         logger.debug(f'All MOUNT_CACHED uploads completed on {cluster_name!r}')
 
 
+def _user_action_event_reason(action: str) -> str:
+    """The cluster-event reason for a user-requested lifecycle action.
+
+    Names the requesting user and the API request that carried the action
+    when they are known, so the cluster's event log records who stopped or
+    terminated a cluster -- the attribution the managed-job event log keeps
+    for a cancellation. Falls back to the plain text when there is no request
+    context to name (an in-process caller).
+    """
+    actor = common_utils.get_current_request_actor()
+    if actor is None:
+        return f'Cluster was {action} by user.'
+    return f'Cluster was {action} by user {actor}.'
+
+
 def user_initiated_down(cluster_name: str,
                         purge: bool = False,
                         graceful: bool = False,
@@ -918,7 +933,7 @@ def down(cluster_name: str,
         # so its hash can be resolved (teardown deletes the row). There is no
         # TERMINATED cluster status, so new_status is None.
         global_user_state.add_cluster_event(
-            cluster_name, None, 'Cluster was terminated by user.',
+            cluster_name, None, _user_action_event_reason('terminated'),
             global_user_state.ClusterEventType.STATUS_CHANGE)
 
     backend = backend_utils.get_backend_from_handle(handle)
@@ -1060,7 +1075,7 @@ def stop(cluster_name: str,
 
     global_user_state.add_cluster_event(
         cluster_name, status_lib.ClusterStatus.STOPPED,
-        'Cluster was stopped by user.',
+        _user_action_event_reason('stopped'),
         global_user_state.ClusterEventType.STATUS_CHANGE)
 
     backend = backend_utils.get_backend_from_handle(handle)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -415,6 +415,24 @@ def is_in_request_context() -> bool:
     return context.get_context_var(_REQUEST_ID_KEY) is not None
 
 
+def get_current_request_actor() -> Optional[str]:
+    """Names who is making the current API request, for audit messages.
+
+    Returns e.g. ``alice (request ID: 2f0c8e2b-...)``, suitable for embedding
+    in an event log so a record says who asked for an action and under which
+    request. Returns None outside a server-side request execution (see
+    ``set_request_context``): an in-process caller has no requesting user or
+    request to name.
+    """
+    if not is_in_request_context():
+        return None
+    user = get_current_user()
+    # The hash is the fallback identity: a display name is not guaranteed
+    # (e.g. an identity recorded before names were stored).
+    who = user.name or user.id
+    return f'{who} (request ID: {get_current_request_id()})'
+
+
 def get_current_command() -> str:
     """Returns the command related to this operation.
 

--- a/tests/unit_tests/test_sky/test_core_down_event.py
+++ b/tests/unit_tests/test_sky/test_core_down_event.py
@@ -1,8 +1,12 @@
-"""Unit tests for the cluster event recorded by core.down()."""
+"""Unit tests for the cluster events recorded by core.down()/core.stop().
+"""
 import unittest.mock as mock
 
 from sky import core
 from sky import global_user_state
+from sky import models
+from sky.utils import common_utils
+from sky.utils import status_lib
 
 
 def _patch_down(monkeypatch, handle, backend, add_event):
@@ -16,6 +20,27 @@ def _patch_down(monkeypatch, handle, backend, add_event):
     monkeypatch.setattr(core, '_maybe_run_down_hooks',
                         lambda *args, **kwargs: None)
     monkeypatch.setattr(global_user_state, 'add_cluster_event', add_event)
+
+
+def _patch_stop(monkeypatch, handle, backend, add_event):
+    monkeypatch.setattr(global_user_state, 'get_handle_from_cluster_name',
+                        lambda name: handle)
+    monkeypatch.setattr(core.backend_utils, 'get_backend_from_handle',
+                        lambda h: backend)
+    monkeypatch.setattr(core.usage_lib,
+                        'record_cluster_name_for_current_operation',
+                        lambda name: None)
+    monkeypatch.setattr(core, '_maybe_run_stop_hooks',
+                        lambda *args, **kwargs: None)
+    monkeypatch.setattr(global_user_state, 'add_cluster_event', add_event)
+
+
+def _patch_request_context(monkeypatch, name='alice', user_hash='abcd1234'):
+    """Make the call look like it runs inside a server-side API request."""
+    monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: True)
+    monkeypatch.setattr(common_utils, 'get_current_user',
+                        lambda: models.User(id=user_hash, name=name))
+    monkeypatch.setattr(common_utils, 'get_current_request_id', lambda: 'req-1')
 
 
 def test_down_records_termination_event(monkeypatch):
@@ -61,3 +86,73 @@ def test_down_without_user_initiated_records_no_event(monkeypatch):
     backend.teardown.assert_called_once_with(handle,
                                              terminate=True,
                                              purge=False)
+
+
+def test_down_event_names_the_requesting_user(monkeypatch):
+    """Run inside an API request, the event names the user and request."""
+    handle = mock.MagicMock()
+    add_event = mock.MagicMock()
+    _patch_down(monkeypatch, handle, mock.MagicMock(), add_event)
+    _patch_request_context(monkeypatch)
+
+    core.down('evt-test', user_initiated=True)
+
+    add_event.assert_called_once_with(
+        'evt-test', None,
+        'Cluster was terminated by user alice (request ID: req-1).',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
+
+
+def test_down_event_falls_back_to_the_user_hash(monkeypatch):
+    """With no display name, the event still identifies the requester."""
+    handle = mock.MagicMock()
+    add_event = mock.MagicMock()
+    _patch_down(monkeypatch, handle, mock.MagicMock(), add_event)
+    _patch_request_context(monkeypatch, name=None)
+
+    core.down('evt-test', user_initiated=True)
+
+    add_event.assert_called_once_with(
+        'evt-test', None,
+        'Cluster was terminated by user abcd1234 (request ID: req-1).',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
+
+
+def test_stop_records_attributed_event(monkeypatch):
+    """core.stop() records the same attribution before tearing down."""
+    handle = mock.MagicMock()
+    backend = mock.MagicMock()
+    add_event = mock.MagicMock()
+    _patch_stop(monkeypatch, handle, backend, add_event)
+    _patch_request_context(monkeypatch)
+
+    order = []
+    add_event.side_effect = lambda *args, **kwargs: order.append('event')
+    backend.teardown.side_effect = lambda *args, **kwargs: order.append(
+        'teardown')
+
+    core.stop('evt-test')
+
+    add_event.assert_called_once_with(
+        'evt-test', status_lib.ClusterStatus.STOPPED,
+        'Cluster was stopped by user alice (request ID: req-1).',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
+    assert order == ['event', 'teardown']
+    backend.teardown.assert_called_once_with(handle,
+                                             terminate=False,
+                                             purge=False)
+
+
+def test_stop_event_without_request_context(monkeypatch):
+    """An in-process caller has nobody to name, so the text is unchanged."""
+    handle = mock.MagicMock()
+    add_event = mock.MagicMock()
+    _patch_stop(monkeypatch, handle, mock.MagicMock(), add_event)
+    monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: False)
+
+    core.stop('evt-test')
+
+    add_event.assert_called_once_with(
+        'evt-test', status_lib.ClusterStatus.STOPPED,
+        'Cluster was stopped by user.',
+        global_user_state.ClusterEventType.STATUS_CHANGE)

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -802,3 +802,35 @@ class TestAtomicWriteText:
         assert not target.exists()
         # Crucially: no hidden .tmp file left behind in the directory.
         assert list(tmp_path.iterdir()) == []
+
+
+class TestGetCurrentRequestActor:
+    """``get_current_request_actor`` names the caller of an API request."""
+
+    def test_names_the_user_and_request(self, monkeypatch):
+        monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: True)
+        monkeypatch.setattr(common_utils, 'get_current_user',
+                            lambda: models.User(id='abcd1234', name='alice'))
+        monkeypatch.setattr(common_utils, 'get_current_request_id',
+                            lambda: 'req-1')
+
+        assert common_utils.get_current_request_actor() == (
+            'alice (request ID: req-1)')
+
+    def test_falls_back_to_the_user_hash(self, monkeypatch):
+        """No display name must not mean no identity."""
+        monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: True)
+        monkeypatch.setattr(common_utils, 'get_current_user',
+                            lambda: models.User(id='abcd1234'))
+        monkeypatch.setattr(common_utils, 'get_current_request_id',
+                            lambda: 'req-1')
+
+        assert common_utils.get_current_request_actor() == (
+            'abcd1234 (request ID: req-1)')
+
+    def test_none_outside_a_request(self, monkeypatch):
+        """An in-process caller has no requesting user or request to name."""
+        monkeypatch.setattr(common_utils, 'is_in_request_context',
+                            lambda: False)
+
+        assert common_utils.get_current_request_actor() is None


### PR DESCRIPTION
## Summary

The cluster equivalent of #10619 (which attributes managed-job cancellations). A cluster's event log recorded `Cluster was terminated by user.` — it said *that* a user did it, never *which* user, or under which API request. Name both when they are known:

```
Cluster was terminated by user alice (request ID: 9c0d796d-d6c3-4c43-8666-bc14aa6ebe03).
Cluster was stopped by user alice (request ID: 2f0c8e2b-...).
```

- `sky down` and `sky stop` run on the API server inside the request that asked for them (`core.user_initiated_down` / `core.stop` are the endpoints' entrypoints), so the identity comes from the ambient request context — no plumbing, no wire-format or version changes.
- A caller with no request context — an in-process SDK call, or a non-user-initiated teardown such as the jobs controller cleaning up a job cluster — keeps the existing unattributed text. `core.down`'s existing `user_initiated` flag still decides whether the event is written at all.
- Falls back to the user hash when the identity has no display name.
- Adds `common_utils.get_current_request_actor()` next to `get_current_user` / `get_current_request_id` for the shared "who asked, under which request" phrasing.

Note on the `request_id` column: `cluster_events` already stores one per row, but no read path exposes it (`get_cluster_events` / `get_cluster_events_by_name` return only `reason` and `transitioned_at`), so it has never been visible. Putting it in the reason makes it visible wherever events are already rendered, without a schema or UI change. Surfacing the column properly would be a reasonable follow-up.

#10619 carries its own copy of this formatting in `sky/jobs/utils.py` so the two PRs stay independent; once both land, converging the jobs one onto `get_current_request_actor()` is a small follow-up.

## Test plan

Unit tests — `pytest tests/unit_tests/test_sky/utils/test_common_utils.py tests/unit_tests/test_sky/test_core_down_event.py tests/unit_tests/test_core.py` (151 passed):

- `get_current_request_actor()`: names user + request, falls back to the hash with no display name, returns None outside a request.
- `core.down()`: attributed reason inside a request; hash fallback; the existing unattributed and no-event-when-not-user-initiated cases still hold, and the event is still written *before* teardown (the cluster row must still resolve).
- `core.stop()`: attributed reason, recorded before teardown; unattributed text with no request context.

Manual, against a local API server on Kubernetes — launched `attr-evt-test`, then `sky down attr-evt-test -y`:

```
1788208662 | Cluster was terminated by user seungjinyang (request ID: 9c0d796d-d6c3-4c43-8666-bc14aa6ebe03).
1788208641 | Cluster successfully provisioned with 1 nodes
```

and `sky api status` resolved that ID to the `sky.down` request by that user. The stop path is covered by unit tests only — Kubernetes does not support stopping a cluster, so it could not be exercised on this infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->