### PR TITLE
[Kubernetes] Reuse ephemeral volume pod injection

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -31,6 +31,7 @@ from sky.utils import status_lib
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
+from sky.utils import volume as volume_utils
 from sky.utils.db import db_utils
 
 if TYPE_CHECKING:
@@ -2132,6 +2133,32 @@ def _configure_runtime_class(pod_spec: Dict[str,
         spec['runtimeClassName'] = 'nvidia'
 
 
+def inject_ephemeral_volumes(
+        pod_spec: Dict[str, Any],
+        ephemeral_volumes: List[volume_utils.VolumeInfo]) -> None:
+    """Add provisioned ephemeral volumes to a Kubernetes pod spec."""
+    containers = pod_spec['spec']['containers']
+    if not containers:
+        raise ValueError('Cannot mount ephemeral volumes without a container.')
+    volumes = pod_spec['spec'].setdefault('volumes', [])
+    volume_mounts = containers[0].setdefault('volumeMounts', [])
+    for ephemeral_volume in ephemeral_volumes:
+        volume_entry = {
+            'name': ephemeral_volume.name,
+            'persistentVolumeClaim': {
+                'claimName': ephemeral_volume.volume_name_on_cloud,
+            },
+        }
+        if volume_entry not in volumes:
+            volumes.append(volume_entry)
+        volume_mount = {
+            'name': ephemeral_volume.name,
+            'mountPath': ephemeral_volume.path,
+        }
+        if volume_mount not in volume_mounts:
+            volume_mounts.append(volume_mount)
+
+
 @timeline.event
 def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                  config: common.ProvisionConfig) -> common.ProvisionRecord:
@@ -2167,22 +2194,7 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
 
     ephemeral_volumes = provider_config.get('ephemeral_volume_infos')
     if ephemeral_volumes:
-        for ephemeral_volume in ephemeral_volumes:
-            # Update the volumes and volume mounts in the pod spec
-            if 'volumes' not in pod_spec['spec']:
-                pod_spec['spec']['volumes'] = []
-            pod_spec['spec']['volumes'].append({
-                'name': ephemeral_volume.name,
-                'persistentVolumeClaim': {
-                    'claimName': ephemeral_volume.volume_name_on_cloud,
-                },
-            })
-            if 'volumeMounts' not in pod_spec['spec']['containers'][0]:
-                pod_spec['spec']['containers'][0]['volumeMounts'] = []
-            pod_spec['spec']['containers'][0]['volumeMounts'].append({
-                'name': ephemeral_volume.name,
-                'mountPath': ephemeral_volume.path,
-            })
+        inject_ephemeral_volumes(pod_spec, ephemeral_volumes)
 
     # Docker sidecar cache volume injection: if a SkyPilot volume was
     # specified for the enable_docker cache, look up the PVC name. The actual

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -19,6 +19,7 @@ from sky.provision.kubernetes import instance
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.instance import logger
 from sky.utils import subprocess_utils
+from sky.utils import volume as volume_utils
 
 
 def _remove_colorama_escape_codes(error_output):
@@ -128,6 +129,60 @@ def test_create_pods_raises_on_more_pods_than_requested(monkeypatch):
     config = _make_provision_config(count=2)
     with pytest.raises(RuntimeError, match='resource leak'):
         instance._create_pods('us', cluster_on_cloud, cluster_on_cloud, config)
+
+
+def test_inject_ephemeral_volumes():
+    pod_spec = {
+        'spec': {
+            'containers': [{
+                'name': 'ray-node',
+                'volumeMounts': [{
+                    'name': 'config',
+                    'mountPath': '/etc/config',
+                }],
+            }],
+            'volumes': [{
+                'name': 'config',
+                'configMap': {
+                    'name': 'config',
+                },
+            }],
+        },
+    }
+    volume_info = volume_utils.VolumeInfo(
+        name='scratch',
+        path='/scratch',
+        volume_name_on_cloud='scratch-pvc',
+        volume_id_on_cloud='pvc-id',
+    )
+
+    instance.inject_ephemeral_volumes(pod_spec, [volume_info])
+    instance.inject_ephemeral_volumes(pod_spec, [volume_info])
+
+    assert pod_spec['spec']['volumes'] == [
+        {
+            'name': 'config',
+            'configMap': {
+                'name': 'config',
+            },
+        },
+        {
+            'name': 'scratch',
+            'persistentVolumeClaim': {
+                'claimName': 'scratch-pvc',
+            },
+        },
+    ]
+    assert pod_spec['spec']['containers'][0]['volumeMounts'] == [
+        {
+            'name': 'config',
+            'mountPath': '/etc/config',
+        },
+        {
+            'name': 'scratch',
+            'mountPath': '/scratch',
+        },
+    ]
 
 
 def test_out_of_cpus(monkeypatch):


### PR DESCRIPTION
## Summary

- extract ephemeral PVC volume and mount materialization from `_create_pods()` into a reusable Kubernetes helper
- make exact repeated materialization idempotent while preserving existing pod volumes and mounts

## Why

Ephemeral volume provisioning stores resolved `VolumeInfo` objects in the provider configuration, and `_create_pods()` then translated them into Kubernetes `volumes` and `volumeMounts` inline. Keeping that translation inside pod creation prevented other Kubernetes pod-building paths from using the same behavior. Reapplying the inline append logic could also duplicate an already-materialized entry.

The shared helper keeps the existing PVC and mount shapes, preserves unrelated entries, and skips only exact duplicates.

## Test plan

- `pytest -n0 tests/unit_tests/kubernetes/test_provision.py` (`209 passed`)
- `bash format.sh --files sky/provision/kubernetes/instance.py` (YAPF, isort, mypy, pylint, and dashboard checks completed without diagnostics)

Manual verification after merge:

1. Launch a Kubernetes task with an ephemeral PVC volume.
2. Inspect the created pod and confirm the resolved PVC appears once in `spec.volumes` and once in the main container's `volumeMounts`.
