### PR TITLE
[API] Add rbac.restrict_all_users_mutations to reserve -u for admins

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -3181,7 +3181,7 @@ setting restricts what a user may *do*, not what they may see.
   so the restriction also holds for SDK callers. ``sky down``/``stop``/
   ``autostop`` expand ``-u`` into one request per cluster in the client, so
   for those three the check is client-side and a caller driving the Python SDK
-  directly is not stopped by it. Use :ref:`workspaces <config-yaml-workspaces>`
+  directly is not stopped by it. Use :ref:`Workspaces <workspaces>`
   if you need a hard isolation boundary between users' clusters.
 
 Like the rest of RBAC, this is only functional when

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -273,6 +273,7 @@ Below is the configuration syntax and some example values. See detailed explanat
 
   :ref:`rbac <config-yaml-rbac>`:
     :ref:`default_role <config-yaml-rbac-default-role>`: admin
+    :ref:`restrict_all_users_mutations <config-yaml-rbac-restrict-all-users-mutations>`: false
 
   :ref:`db <config-yaml-db>`: postgresql://postgres@localhost/skypilot
 
@@ -3148,6 +3149,44 @@ If not specified, the default role is ``admin``.
 .. TODO(aylei): Refine this after unified authentication.
 
 Note: RBAC is only functional when :ref:`OAuth <api-server-oauth>` is configured.
+
+.. _config-yaml-rbac-restrict-all-users-mutations:
+
+``rbac.restrict_all_users_mutations``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Reserve the ``--all-users`` / ``-u`` flag on **mutating** commands for admins
+(optional, defaults to ``false``).
+
+``-u`` on a mutating command fans the operation out over every user's
+resources, so one user can tear down or cancel a teammate's work in a single
+command. Set this to ``true`` to allow it for admins only:
+
+.. code-block:: yaml
+
+  rbac:
+    restrict_all_users_mutations: true
+
+Affected commands: ``sky down -u``, ``sky stop -u``, ``sky autostop -u``,
+``sky cancel -u`` and ``sky jobs cancel -u``. Non-admins must target their own
+resources (``-a`` / ``--all``) or name resources explicitly instead.
+
+Read-only uses of ``-u`` are **not** affected: ``sky status -u``,
+``sky queue -u`` and ``sky jobs queue -u`` keep working for everyone. This
+setting restricts what a user may *do*, not what they may see.
+
+.. note::
+
+  ``sky cancel -u`` and ``sky jobs cancel -u`` are rejected by the API server,
+  so the restriction also holds for SDK callers. ``sky down``/``stop``/
+  ``autostop`` expand ``-u`` into one request per cluster in the client, so
+  for those three the check is client-side and a caller driving the Python SDK
+  directly is not stopped by it. Use :ref:`workspaces <config-yaml-workspaces>`
+  if you need a hard isolation boundary between users' clusters.
+
+Like the rest of RBAC, this is only functional when
+:ref:`OAuth <api-server-oauth>` is configured; without per-user identity every
+caller is treated as an admin.
 
 .. _config-yaml-db:
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2986,6 +2986,11 @@ def cancel(
     Job IDs can be looked up by ``sky queue cluster_name``.
     Cluster names support glob patterns (e.g., px* matches px1, px2).
     """
+    if all_users:
+        # The server rejects this too; checking here keeps the confirmation
+        # prompt from asking about an operation that cannot go through.
+        _reject_all_users_if_restricted('sky cancel')
+
     # Handle glob patterns in cluster names
     matching_clusters = []
     if '*' in cluster or '?' in cluster or '[' in cluster:
@@ -3699,6 +3704,29 @@ def _controller_to_hint_or_raise(
     return _hint_or_raise_for_down_sky_serve_controller
 
 
+def _reject_all_users_if_restricted(command: str) -> None:
+    """Rejects ``-u``/``--all-users`` if the server reserves it for admins.
+
+    Mirrors the server-side gate (``rbac.restrict_all_users_mutations``,
+    surfaced per caller on ``GET /api/health``). For ``sky cancel`` and
+    ``sky jobs cancel`` the server is the real enforcement and this only moves
+    the error ahead of the confirmation prompt. For ``sky down``/``stop``/
+    ``autostop`` it is the *only* gate: those expand ``--all-users`` into one
+    request per cluster here on the client, so the server never sees the flag
+    and cannot reject it.
+
+    An unreachable or older server reports False, so the command proceeds and
+    fails (or succeeds) on its own terms rather than on a misleading
+    permission error.
+    """
+    if server_common.get_api_server_status().restrict_all_users_mutations:
+        raise click.UsageError(
+            f'`{command} -u/--all-users` is not allowed: this API server '
+            'restricts all-users operations to admins '
+            '(rbac.restrict_all_users_mutations). Target your own resources '
+            'instead, or ask an administrator.')
+
+
 def _down_or_stop_clusters(
         names: List[str],
         apply_to_all: bool = False,
@@ -3746,6 +3774,8 @@ def _down_or_stop_clusters(
             '(see `sky status`), or the -a/--all flag for all your '
             'clusters, or the -u/--all-users flag for all clusters in '
             'your team.')
+    if all_users:
+        _reject_all_users_if_restricted(f'sky {command}')
 
     operation = 'Terminating' if down else 'Stopping'
     if idle_minutes_to_autostop is not None:
@@ -6465,6 +6495,11 @@ def jobs_cancel(
         raise click.UsageError(
             'Can only specify one of JOB_IDS, --name, --pool, or '
             f'--all/--all-users. Provided {" ".join(arguments)!r}.')
+
+    if all_users:
+        # The server rejects this too; checking here keeps the confirmation
+        # prompt from asking about an operation that cannot go through.
+        _reject_all_users_if_restricted('sky jobs cancel')
 
     if not yes:
         plural = 's' if len(job_ids) > 1 else ''

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -113,8 +113,11 @@ async def wait(request: fastapi.Request,
 
 
 @router.post('/cancel')
-async def cancel(request: fastapi.Request,
-                 jobs_cancel_body: payloads.JobsCancelBody) -> None:
+async def cancel(
+    request: fastapi.Request,
+    jobs_cancel_body: payloads.JobsCancelBody = fastapi.Depends(
+        role_filter.reject_all_users_jobs_cancel_body),
+) -> None:
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.JOBS_CANCEL,

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -94,6 +94,12 @@ class APIHealthResponse(ResponseBaseModel):
     # includes admin-only secrets). Lets the dashboard hide the config UI for
     # non-admins when enabled.
     restrict_config_to_admins: bool = True
+    # Whether this caller may NOT use `--all-users`/`-u` on mutating commands
+    # (rbac.restrict_all_users_mutations). Already resolved for the caller --
+    # admins and no-auth servers always get False. The CLI reads it to reject
+    # `sky down/stop/autostop -u` up front, since those expand `--all-users`
+    # into per-cluster requests client-side and never send the flag.
+    restrict_all_users_mutations: bool = False
 
 
 class StatusResponse(ResponseBaseModel):

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -196,6 +196,11 @@ class ApiServerInfo:
     basic_auth_enabled: bool = False
     error: Optional[str] = None
     latest_version: Optional[str] = None
+    # Whether this caller may NOT use `--all-users`/`-u` on mutating commands
+    # (server-side `rbac.restrict_all_users_mutations`, already resolved for
+    # this caller). Defaults to False so an older server -- which omits the
+    # field -- keeps today's behaviour.
+    restrict_all_users_mutations: bool = False
 
 
 def check_and_print_upgrade_hint(api_server_info: ApiServerInfo,
@@ -673,6 +678,8 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
         commit = result.get('commit')
         user = result.get('user')
         latest_version = result.get('latest_version')
+        restrict_all_users_mutations = bool(
+            result.get('restrict_all_users_mutations'))
         # Cache basic_auth_enabled and set client user hash on the
         # client-side usage singleton.
         global basic_auth_enabled, client_user_hash
@@ -681,14 +688,16 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
             if client_user_hash is None:
                 client_user_hash = common_utils.generate_user_hash()
             usage_lib.messages.usage.client_user_hash = client_user_hash
-        server_info = ApiServerInfo(status=ApiServerStatus(server_status),
-                                    api_version=api_version,
-                                    version=version,
-                                    version_on_disk=version_on_disk,
-                                    commit=commit,
-                                    user=user,
-                                    basic_auth_enabled=basic_auth_enabled,
-                                    latest_version=latest_version)
+        server_info = ApiServerInfo(
+            status=ApiServerStatus(server_status),
+            api_version=api_version,
+            version=version,
+            version_on_disk=version_on_disk,
+            commit=commit,
+            user=user,
+            basic_auth_enabled=basic_auth_enabled,
+            latest_version=latest_version,
+            restrict_all_users_mutations=restrict_all_users_mutations)
         if api_version is None or version is None or commit is None:
             server_url = endpoint if endpoint is not None else get_server_url()
             logger.warning(f'API server response missing '

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -187,6 +187,14 @@ class ApiServerStatus(enum.Enum):
 
 @dataclasses.dataclass
 class ApiServerInfo:
+    """What `GET /api/health` told us about the server, for this caller.
+
+    Some fields describe the deployment (versions, which auth modes are on)
+    and some are resolved per caller (`user`,
+    `restrict_all_users_mutations`). Every field must have a default that
+    means "an older server did not send this", since the client talks to
+    servers that predate any field added here.
+    """
     status: ApiServerStatus
     api_version: ApiVersion = None
     version: Optional[str] = None

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -16,6 +16,14 @@ For viewers, these fields are forced to their read-only / no-side-
 effect values *before* the handler runs.  Non-viewer callers see no
 behaviour change.
 
+A second, related family of shims lives here: gates that *reject* a
+body field the caller is not entitled to set, rather than rewriting it.
+`force_caller_scope_cancel_body` (own requests only) and
+`reject_all_users_{cancel,jobs_cancel}_body` (the ``--all-users`` flag on
+mutating endpoints, see `rbac.restrict_all_users_mutations`) are of that
+kind. They belong here for the same reason: the decision needs the
+caller's role, which only the dispatch context has.
+
 The shim is wired into FastAPI as a `Depends()` dependency rather
 than a middleware so it can mutate the parsed pydantic body
 in-place; standard Starlette middlewares run before body parsing.
@@ -76,6 +84,60 @@ def force_caller_scope_cancel_body(
     if scope is not None:
         request_cancel_body.user_id = scope
     return request_cancel_body
+
+
+def all_users_mutations_restricted(request: fastapi.Request) -> bool:
+    """Whether this caller is barred from `--all-users` on mutating endpoints.
+
+    True only when the operator has set ``rbac.restrict_all_users_mutations``
+    *and* the caller is a restricted principal. "Restricted" reuses
+    `request_owner_scope`, which returns None for exactly the two callers the
+    rest of RBAC exempts: an admin, and a server with no per-user identity for
+    the caller (single-user/local, or auth terminated upstream).
+
+    Also surfaced to clients on ``GET /api/health`` so the CLI can reject
+    ``-u`` up front for the down/stop/autostop commands, which expand
+    ``--all-users`` into per-cluster requests client-side and so never send the
+    flag to the server.
+    """
+    if not rbac.restrict_all_users_mutations():
+        return False
+    return request_owner_scope(request) is not None
+
+
+def _reject_all_users(request: fastapi.Request, all_users: bool,
+                      operation: str) -> None:
+    """Raises 403 if `all_users` is set and this caller may not use it."""
+    if not all_users:
+        return
+    if not all_users_mutations_restricted(request):
+        return
+    raise fastapi.HTTPException(
+        status_code=403,
+        detail=(f'--all-users/-u is not allowed for {operation}: this API '
+                'server restricts all-users operations to admins '
+                '(rbac.restrict_all_users_mutations). Target your own '
+                'resources instead, or ask an administrator.'))
+
+
+def reject_all_users_cancel_body(
+    request: fastapi.Request,
+    cancel_body: payloads.CancelBody,
+) -> payloads.CancelBody:
+    """Gate `POST /cancel` (`sky cancel -u`) on the all-users restriction."""
+    _reject_all_users(request, cancel_body.all_users,
+                      'cancelling jobs on a cluster')
+    return cancel_body
+
+
+def reject_all_users_jobs_cancel_body(
+    request: fastapi.Request,
+    jobs_cancel_body: payloads.JobsCancelBody,
+) -> payloads.JobsCancelBody:
+    """Gate `POST /jobs/cancel` (`sky jobs cancel -u`) on the restriction."""
+    _reject_all_users(request, jobs_cancel_body.all_users,
+                      'cancelling managed jobs')
+    return jobs_cancel_body
 
 
 def _is_viewer(request: fastapi.Request) -> bool:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2322,8 +2322,11 @@ async def job_status(request: fastapi.Request,
 
 
 @app.post('/cancel')
-async def cancel(request: fastapi.Request,
-                 cancel_body: payloads.CancelBody) -> None:
+async def cancel(
+    request: fastapi.Request,
+    cancel_body: payloads.CancelBody = fastapi.Depends(
+        role_filter.reject_all_users_cancel_body),
+) -> None:
     """Cancels jobs on a cluster."""
     await _reject_cluster_write_for_unauthorized(request,
                                                  cancel_body.cluster_name)
@@ -3275,6 +3278,12 @@ async def health(request: fastapi.Request) -> responses.APIHealthResponse:
         # Whether GET /workspaces/config is restricted to admins (so the
         # dashboard can hide the config UI for non-admins when enabled)
         restrict_config_to_admins=rbac.restrict_config_to_admins(),
+        # Whether this caller is barred from `--all-users` on mutating
+        # commands. Resolved per caller (admins are exempt) so the CLI can
+        # reject `-u` up front for down/stop/autostop, which expand the flag
+        # client-side and never send it to the server.
+        restrict_all_users_mutations=role_filter.all_users_mutations_restricted(
+            request),
     )
 
 

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -544,6 +544,24 @@ def restrict_config_to_admins() -> bool:
                                    default_value=True))
 
 
+def restrict_all_users_mutations() -> bool:
+    """Whether the ``--all-users`` flag on mutating commands is admin-only.
+
+    ``--all-users``/``-u`` on a *mutating* command (``sky down``, ``sky stop``,
+    ``sky autostop``, ``sky cancel``, ``sky jobs cancel``) fans the operation
+    out over every user's clusters/jobs, not just the caller's. Operators who
+    do not want one user tearing down a teammate's work opt in with
+    ``rbac.restrict_all_users_mutations: true``; admins keep the flag.
+
+    Off by default, so an upgrade does not change behaviour. Read-only uses of
+    ``-u`` (``sky status``, ``sky queue``, ``sky jobs queue``) are never
+    affected -- this restricts what a user may *do*, not what they may see.
+    """
+    return bool(
+        skypilot_config.get_nested(('rbac', 'restrict_all_users_mutations'),
+                                   default_value=False))
+
+
 def get_role_permissions(
     plugin_rules: Optional[Dict[str, List[Dict[str, str]]]] = None
 ) -> Dict[str, Dict[str, Dict[str, List[Dict[str, str]]]]]:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2570,6 +2570,14 @@ def get_config_schema():
             'restrict_config_to_admins': {
                 'type': 'boolean',
             },
+            # When true, the `--all-users` (`-u`) flag on *mutating* commands
+            # (sky down/stop/autostop/cancel, sky jobs cancel) is reserved for
+            # admins, so a regular user cannot tear down or cancel another
+            # user's resources in bulk. Read-only `-u` (sky status, sky queue,
+            # sky jobs queue) is unaffected. Defaults to false.
+            'restrict_all_users_mutations': {
+                'type': 'boolean',
+            },
             # Per-role permission overrides. Schema is intentionally
             # permissive (additionalProperties: True on
             # `permissions`) because admin/user use `blocklist`

--- a/tests/unit_tests/test_sky/server/test_role_filter.py
+++ b/tests/unit_tests/test_sky/server/test_role_filter.py
@@ -200,3 +200,98 @@ def test_force_caller_scope_cancel_body_viewer_forbidden(mock_svc):
     with pytest.raises(fastapi.HTTPException) as exc:
         role_filter.force_caller_scope_cancel_body(_viewer_request(), body)
     assert exc.value.status_code == 403
+
+
+# --- rbac.restrict_all_users_mutations --------------------------------------
+
+
+def _restrict(enabled: bool):
+    return mock.patch.object(role_filter.rbac,
+                             'restrict_all_users_mutations',
+                             return_value=enabled)
+
+
+def _cancel_body(all_users: bool):
+    return payloads.CancelBody(cluster_name='c',
+                               job_ids=None,
+                               all_users=all_users)
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_cancel_body_user_denied(mock_svc):
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(True):
+        with pytest.raises(fastapi.HTTPException) as exc:
+            role_filter.reject_all_users_cancel_body(_user_request(),
+                                                     _cancel_body(True))
+    assert exc.value.status_code == 403
+    assert '--all-users' in exc.value.detail
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_cancel_body_admin_allowed(mock_svc):
+    _roles_returning(mock_svc,
+                     [rbac.RoleName.ADMIN.value, rbac.RoleName.USER.value])
+    with _restrict(True):
+        body = _cancel_body(True)
+        assert role_filter.reject_all_users_cancel_body(_admin_request(),
+                                                        body) is body
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_cancel_body_disabled_by_default(mock_svc):
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(False):
+        body = _cancel_body(True)
+        assert role_filter.reject_all_users_cancel_body(_user_request(),
+                                                        body) is body
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_cancel_body_without_flag_allowed(mock_svc):
+    # `-a/--all` (own jobs only) is untouched by the restriction.
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(True):
+        body = _cancel_body(False)
+        assert role_filter.reject_all_users_cancel_body(_user_request(),
+                                                        body) is body
+
+
+def test_reject_all_users_cancel_body_no_auth_allowed():
+    # No per-user identity (local/single-user server): no RBAC applies.
+    with _restrict(True):
+        body = _cancel_body(True)
+        assert role_filter.reject_all_users_cancel_body(_anonymous_request(),
+                                                        body) is body
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_jobs_cancel_body_user_denied(mock_svc):
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(True):
+        with pytest.raises(fastapi.HTTPException) as exc:
+            role_filter.reject_all_users_jobs_cancel_body(
+                _user_request(), payloads.JobsCancelBody(all_users=True))
+    assert exc.value.status_code == 403
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_reject_all_users_jobs_cancel_body_all_own_allowed(mock_svc):
+    # `sky jobs cancel -a` cancels only the caller's jobs; not restricted.
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(True):
+        body = payloads.JobsCancelBody(all=True)
+        assert role_filter.reject_all_users_jobs_cancel_body(
+            _user_request(), body) is body
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_all_users_mutations_restricted_flag(mock_svc):
+    _roles_returning(mock_svc, [rbac.RoleName.USER.value])
+    with _restrict(True):
+        assert role_filter.all_users_mutations_restricted(_user_request())
+    with _restrict(False):
+        assert not role_filter.all_users_mutations_restricted(_user_request())
+    _roles_returning(mock_svc, [rbac.RoleName.ADMIN.value])
+    with _restrict(True):
+        assert not role_filter.all_users_mutations_restricted(_admin_request())

--- a/tests/unit_tests/test_sky/test_cli_restrict_all_users.py
+++ b/tests/unit_tests/test_sky/test_cli_restrict_all_users.py
@@ -1,0 +1,70 @@
+"""Tests for the client-side `-u/--all-users` gate on mutating commands.
+
+The API server rejects `--all-users` on `POST /cancel` and `POST /jobs/cancel`
+(see `role_filter.reject_all_users_*`), but `sky down/stop/autostop` expand the
+flag into one request per cluster here on the client, so for those three the
+CLI check is the only gate. These tests pin that it fires (and that it stays
+out of the way when the server has not enabled the restriction).
+"""
+from unittest import mock
+
+from click.testing import CliRunner
+import pytest
+
+from sky.client.cli import command
+from sky.server import common as server_common
+
+
+def _server_info(restricted: bool) -> server_common.ApiServerInfo:
+    return server_common.ApiServerInfo(
+        status=server_common.ApiServerStatus.HEALTHY,
+        restrict_all_users_mutations=restricted,
+    )
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize('cmd,args', [
+    (command.down, ['-u', '-y']),
+    (command.stop, ['-u', '-y']),
+    (command.autostop, ['-u', '-y']),
+    (command.cancel, ['some-cluster', '-u', '-y']),
+    (command.jobs_cancel, ['-u', '-y']),
+])
+def test_all_users_rejected_when_restricted(runner, cmd, args):
+    with mock.patch.object(server_common,
+                           'get_api_server_status',
+                           return_value=_server_info(True)):
+        result = runner.invoke(cmd, args)
+    assert result.exit_code != 0
+    assert 'rbac.restrict_all_users_mutations' in result.output
+
+
+@pytest.mark.parametrize('cmd,args', [
+    (command.down, ['-u', '-y']),
+    (command.cancel, ['some-cluster', '-u', '-y']),
+    (command.jobs_cancel, ['-u', '-y']),
+])
+def test_all_users_allowed_when_unrestricted(runner, cmd, args):
+    """The gate must not fire; the command may still fail further along."""
+    with mock.patch.object(server_common,
+                           'get_api_server_status',
+                           return_value=_server_info(False)):
+        result = runner.invoke(cmd, args)
+    assert 'rbac.restrict_all_users_mutations' not in result.output
+
+
+@pytest.mark.parametrize('cmd,args', [
+    (command.down, ['-a', '-y']),
+    (command.cancel, ['some-cluster', '-a', '-y']),
+    (command.jobs_cancel, ['-a', '-y']),
+])
+def test_gate_not_consulted_without_all_users(runner, cmd, args):
+    """`-a/--all` targets only the caller's own resources; never gated."""
+    with mock.patch.object(command,
+                           '_reject_all_users_if_restricted') as mock_gate:
+        runner.invoke(cmd, args)
+    mock_gate.assert_not_called()

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -224,3 +224,31 @@ class TestDefaultRoleConfig:
         with mock.patch('sky.skypilot_config.get_nested',
                         return_value='viewer'):
             assert rbac.get_default_role() == 'viewer'
+
+
+class TestRestrictAllUsersMutations:
+    """`--all-users` on mutating commands is admin-only only when opted in."""
+
+    @staticmethod
+    def _with_config(value):
+
+        def fake_get_nested(keys, default_value=None, *args, **kwargs):
+            if keys == ('rbac', 'restrict_all_users_mutations'):
+                return default_value if value is None else value
+            return default_value
+
+        return mock.patch('sky.skypilot_config.get_nested',
+                          side_effect=fake_get_nested)
+
+    def test_defaults_to_false(self):
+        # Unset: an upgrade must not start rejecting `-u`.
+        with self._with_config(None):
+            assert rbac.restrict_all_users_mutations() is False
+
+    def test_enabled(self):
+        with self._with_config(True):
+            assert rbac.restrict_all_users_mutations() is True
+
+    def test_disabled_explicitly(self):
+        with self._with_config(False):
+            assert rbac.restrict_all_users_mutations() is False


### PR DESCRIPTION
## Summary

- Adds an opt-in API server config, `rbac.restrict_all_users_mutations` (default `false`), that reserves the `--all-users`/`-u` flag on **mutating** commands for admins: `sky down -u`, `sky stop -u`, `sky autostop -u`, `sky cancel -u`, `sky jobs cancel -u`. Without it, any user can tear down or cancel a teammate's work in a single command.
- Read-only uses of `-u` (`sky status`, `sky queue`, `sky jobs queue`) are unaffected — this restricts what a user may *do*, not what they may see.
- Admins are exempt, as is a server with no per-user identity (local/single-user, or auth terminated upstream). That exemption reuses `role_filter.request_owner_scope`, which the rest of RBAC already treats as "unrestricted caller".

```yaml
rbac:
  restrict_all_users_mutations: true
```

## Enforcement is split, by necessity

| Command | Where it's enforced |
|---|---|
| `sky cancel -u`, `sky jobs cancel -u` | **Server** — `all_users` is in the request body, so `POST /cancel` and `POST /jobs/cancel` reject with 403. Holds for SDK callers. |
| `sky down/stop/autostop -u` | **Client** — these expand `-u` into one request per cluster in `_down_or_stop_clusters`, so the server never receives the flag and cannot reject it. |

For those three the check is therefore a guardrail, not a boundary: a caller driving the Python SDK directly is not stopped by it. The CLI drives it off a per-caller flag surfaced on `GET /api/health` (already resolved server-side, so the client never has to reason about roles; an older server omits the field and the client defaults to `false`). This is called out in the docstring and in the config docs, which point at workspaces as the hard isolation mechanism.

Making down/stop/autostop server-enforced needs a per-resource ownership check rather than a flag check — deliberately out of scope here, and a reasonable follow-up.

## Implementation notes

- `sky/server/requests/role_filter.py` — the two 403 gates are `Depends()` shims, matching the existing `force_caller_scope_cancel_body`; the decision needs the caller's role, which only the dispatch context has.
- No dashboard change: it has no all-users mutation affordance, it acts per-resource.

## Test plan

Automated (55 pass):

```
pytest tests/unit_tests/test_sky/server/test_role_filter.py \
       tests/unit_tests/test_sky/users/test_rbac.py \
       tests/unit_tests/test_sky/test_cli_restrict_all_users.py
```

covering: restricted user denied, admin allowed, flag off by default, no-auth server allowed, `-a/--all` never gated, and the CLI gate firing for all five commands.

Also ran a FastAPI `TestClient` against both endpoints to confirm the request body still parses as JSON through the new `Depends`, and that restricted → 403, admin → 200, config-off → 200.

Manual:

1. Set `rbac.restrict_all_users_mutations: true` in `~/.sky/config.yaml`; `sky api stop && sky api start`.
2. As a **non-admin**, confirm each of `sky down -u`, `sky stop -u`, `sky autostop -u`, `sky cancel <cluster> -u`, `sky jobs cancel -u` is refused with a message naming the config key.
3. Confirm `sky status -u`, `sky queue <cluster> -u`, `sky jobs queue -u` and every `-a/--all` variant still work.
4. Repeat step 2 as an **admin**; all five are allowed.
5. Unset the key, restart, confirm every `-u` works for everyone (default behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->