### PR TITLE
[Client] sky api login: follow an HTTP->HTTPS redirect

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -3121,6 +3121,58 @@ def _resolve_login_endpoint(endpoint: Optional[str]) -> Tuple[str, bool]:
     return _validate_endpoint(env_endpoint), True
 
 
+def _detect_https_redirect(endpoint: str) -> Optional[str]:
+    """Returns the HTTPS endpoint an ``http://`` one redirects to, if any.
+
+    An API server behind an ingress that force-redirects HTTP to HTTPS is a
+    silent trap. ``/api/health`` is a GET, so it follows the redirect intact
+    and ``sky api info`` reports the server as HEALTHY -- but every POST-based
+    command is turned into a GET by that same redirect (dropping the method and
+    body on a 301/302 is what every mainstream HTTP client does) and comes back
+    as an opaque ``405 Method Not Allowed``. Secure session cookies are
+    withheld from a plain-HTTP request too, so SSO auth silently does not apply
+    either. The result is a server that looks healthy while nothing works.
+
+    Login is the cheap place to catch this: the endpoint has not been persisted
+    yet and nothing has been authenticated against it.
+
+    Best-effort -- returns None on any failure and leaves the regular health
+    check to report an unreachable or unhealthy server.
+    """
+    parsed = urlparse.urlparse(endpoint)
+    if parsed.scheme != 'http':
+        return None
+    try:
+        # Cached (5s TTL) and keyed on the endpoint, so the check_server_healthy
+        # call that follows reuses this response when there is no redirect.
+        response = server_common.get_api_server_status_response(endpoint)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Endpoint redirect probe failed, using {endpoint} '
+                     f'as configured: {e}')
+        return None
+    if response is None:
+        return None
+    # Walk the redirect chain and take the first hop that is the same host and
+    # path over HTTPS. Requiring all three to match keeps us off an SSO proxy's
+    # login page, which is a legitimate redirect out of /api/health to somewhere
+    # that is emphatically not the API server endpoint.
+    request_path = f'{parsed.path}/api/health'
+    for hop in list(response.history) + [response]:
+        hop_parsed = urlparse.urlparse(hop.url)
+        if (hop_parsed.scheme != 'https' or
+                hop_parsed.hostname != parsed.hostname or
+                hop_parsed.path != request_path):
+            continue
+        # Rebuild from the redirect target so a port change is picked up, but
+        # carry over any credentials embedded in the configured endpoint --
+        # requests strips those from the URL it reports back.
+        netloc = hop_parsed.netloc
+        if parsed.username is not None:
+            netloc = f'{parsed.netloc.rsplit("@", 1)[0]}@{netloc}'
+        return urlparse.urlunparse(('https', netloc, parsed.path, '', '', ''))
+    return None
+
+
 def _check_endpoint_in_env_var() -> None:
     """Rejects logout when the endpoint is set in the environment variable."""
     # Logging out clears the endpoint and credentials from the config file, but
@@ -3293,6 +3345,30 @@ def api_login(endpoint: Optional[str] = None,
     # endpoint came from the environment variable, which already takes
     # precedence over the config file, so the config file must be left alone.
     endpoint, from_env = _resolve_login_endpoint(endpoint)
+    # Resolve the scheme before anything else reads the endpoint: it decides
+    # what gets written to the config file, and whether the cookies minted
+    # below are marked Secure.
+    redirected = _detect_https_redirect(endpoint)
+    if redirected is not None:
+        why = ('Over plain HTTP that redirect rewrites every non-GET request '
+               'as a GET, which the server rejects with "Method Not Allowed", '
+               'and Secure session cookies are not sent at all.')
+        shown = server_common.redact_url_password(redirected)
+        if from_env:
+            # The environment variable outranks the config file for every
+            # command, so correcting the endpoint here would fix this login and
+            # nothing after it. Say what to change instead.
+            click.secho(
+                f'{server_common.redact_url_password(endpoint)} redirects to '
+                f'{shown}. {why}\nSet '
+                f'{constants.SKY_API_SERVER_URL_ENV_VAR} to {shown}.',
+                fg='yellow')
+        else:
+            click.secho(
+                f'{server_common.redact_url_password(endpoint)} redirects to '
+                f'{shown}; using the https endpoint.\n{why}',
+                fg='yellow')
+            endpoint = redirected
 
     def _show_logged_in_message(
             endpoint: str, dashboard_url: str, user: Optional[Dict[str, Any]],

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -3121,6 +3121,11 @@ def _resolve_login_endpoint(endpoint: Optional[str]) -> Tuple[str, bool]:
     return _validate_endpoint(env_endpoint), True
 
 
+# Kept short: all the probe needs to learn is whether the edge redirects, and
+# a server too slow to say so is the regular health check's story to tell.
+_REDIRECT_PROBE_TIMEOUT_SECONDS = 2.5
+
+
 def _detect_https_redirect(endpoint: str) -> Optional[str]:
     """Returns the HTTPS endpoint an ``http://`` one redirects to, if any.
 
@@ -3142,15 +3147,30 @@ def _detect_https_redirect(endpoint: str) -> Optional[str]:
     parsed = urlparse.urlparse(endpoint)
     if parsed.scheme != 'http':
         return None
+    # Probe with a bare request rather than `make_authenticated_request` /
+    # `get_api_server_status_response`, on both counts deliberately:
+    #   * Unauthenticated. This runs before `api_login` has settled which
+    #     credential the login uses, so an authenticated probe would send
+    #     whatever token is left over in the config -- one issued for whatever
+    #     server was configured before -- to this endpoint, in cleartext. The
+    #     OAuth path hides that residual token from its own requests for
+    #     exactly this reason; the probe must not undo that. Credentials
+    #     embedded in the endpoint are dropped for the same reason.
+    #   * Uncached. `get_api_server_status_response` memoizes on the endpoint
+    #     for 5s, so priming it here would hand that pre-authentication
+    #     response straight to the health check that is meant to validate a
+    #     newly supplied service-account token.
+    # Only the redirect chain is read; the status code is never consulted, so
+    # the 401 an unauthenticated probe collects is fine.
+    probe_url = urlparse.urlunparse(('http', parsed.netloc.rsplit('@', 1)[-1],
+                                     f'{parsed.path}/api/health', '', '', ''))
     try:
-        # Cached (5s TTL) and keyed on the endpoint, so the check_server_healthy
-        # call that follows reuses this response when there is no redirect.
-        response = server_common.get_api_server_status_response(endpoint)
+        response = requests.get(probe_url,
+                                timeout=_REDIRECT_PROBE_TIMEOUT_SECONDS,
+                                allow_redirects=True)
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Endpoint redirect probe failed, using {endpoint} '
                      f'as configured: {e}')
-        return None
-    if response is None:
         return None
     # Walk the redirect chain and take the first hop that is the same host and
     # path over HTTPS. Requiring all three to match keeps us off an SSO proxy's
@@ -3163,9 +3183,8 @@ def _detect_https_redirect(endpoint: str) -> Optional[str]:
                 hop_parsed.hostname != parsed.hostname or
                 hop_parsed.path != request_path):
             continue
-        # Rebuild from the redirect target so a port change is picked up, but
-        # carry over any credentials embedded in the configured endpoint --
-        # requests strips those from the URL it reports back.
+        # Rebuild from the redirect target so a port change is picked up,
+        # then put back any credentials the probe URL deliberately dropped.
         netloc = hop_parsed.netloc
         if parsed.username is not None:
             netloc = f'{parsed.netloc.rsplit("@", 1)[0]}@{netloc}'
@@ -3357,7 +3376,8 @@ def api_login(endpoint: Optional[str] = None,
             # nothing after it. Say what to change instead.
             click.secho(
                 f'{server_common.redact_url_password(endpoint)} redirects to '
-                f'{shown}. Set {constants.SKY_API_SERVER_URL_ENV_VAR} to {shown}.',
+                f'{shown}. Set {constants.SKY_API_SERVER_URL_ENV_VAR} to '
+                f'{shown}.',
                 fg='yellow')
         else:
             click.secho(

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -3350,9 +3350,6 @@ def api_login(endpoint: Optional[str] = None,
     # below are marked Secure.
     redirected = _detect_https_redirect(endpoint)
     if redirected is not None:
-        why = ('Over plain HTTP that redirect rewrites every non-GET request '
-               'as a GET, which the server rejects with "Method Not Allowed", '
-               'and Secure session cookies are not sent at all.')
         shown = server_common.redact_url_password(redirected)
         if from_env:
             # The environment variable outranks the config file for every
@@ -3360,13 +3357,12 @@ def api_login(endpoint: Optional[str] = None,
             # nothing after it. Say what to change instead.
             click.secho(
                 f'{server_common.redact_url_password(endpoint)} redirects to '
-                f'{shown}. {why}\nSet '
-                f'{constants.SKY_API_SERVER_URL_ENV_VAR} to {shown}.',
+                f'{shown}. Set {constants.SKY_API_SERVER_URL_ENV_VAR} to {shown}.',
                 fg='yellow')
         else:
             click.secho(
                 f'{server_common.redact_url_password(endpoint)} redirects to '
-                f'{shown}; using the https endpoint.\n{why}',
+                f'{shown}; using the https endpoint.',
                 fg='yellow')
             endpoint = redirected
 

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -23,6 +23,42 @@ from sky.skylet import constants
 from sky.utils import common as common_utils
 
 
+@pytest.fixture(autouse=True)
+def no_health_probe(monkeypatch: pytest.MonkeyPatch):
+    """Keeps `_detect_https_redirect`'s health probe off the network.
+
+    `api_login` probes /api/health to detect an HTTP->HTTPS ingress redirect
+    before it writes the endpoint. Tests that mock `check_server_healthy` do
+    not mock the underlying probe, so stub it out by default; the redirect
+    tests patch over this with their own return value.
+    """
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _stub_health_probe(None))
+
+
+def _stub_health_probe(response=None, side_effect=None) -> mock.Mock:
+    """Stands in for the TTL-cached probe, `cache_clear` and all.
+
+    `api_login` calls `get_api_server_status_response.cache_clear()`, so a bare
+    lambda is not a sufficient stub.
+    """
+    probe = mock.Mock(return_value=response, side_effect=side_effect)
+    probe.cache_clear = mock.Mock()
+    return probe
+
+
+def _health_response(*urls: str) -> mock.Mock:
+    """A /api/health response whose redirect chain ends at `urls[-1]`."""
+    hops = []
+    for url in urls:
+        hop = mock.Mock(spec=requests.Response)
+        hop.url = url
+        hops.append(hop)
+    final = hops[-1]
+    final.history = hops[:-1]
+    return final
+
+
 @pytest.fixture
 def set_api_cookie_jar(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     # Create a temporary file with test cookie content
@@ -696,6 +732,135 @@ def test_api_logout_with_env_endpoint(monkeypatch: pytest.MonkeyPatch):
                        "http://env.skypilot.co")
     with pytest.raises(RuntimeError, match='Cannot logout of API server'):
         client_sdk.api_logout()
+
+
+@pytest.mark.parametrize(
+    ('endpoint', 'chain', 'expected'),
+    [
+        # No redirect: the endpoint is served over HTTP as configured.
+        ('http://test.skypilot.co',
+         ('http://test.skypilot.co/api/health',), None),
+        # The ingress force-redirects to HTTPS on the same host.
+        ('http://test.skypilot.co',
+         ('http://test.skypilot.co/api/health',
+          'https://test.skypilot.co/api/health'), 'https://test.skypilot.co'),
+        # Same, then on to an SSO login page: the first same-host HTTPS hop is
+        # the endpoint, the external one is not.
+        ('http://test.skypilot.co',
+         ('http://test.skypilot.co/api/health',
+          'https://test.skypilot.co/api/health',
+          'https://accounts.example.com/login'), 'https://test.skypilot.co'),
+        # Redirect straight out to another host: not an endpoint change.
+        ('http://test.skypilot.co',
+         ('http://test.skypilot.co/api/health',
+          'https://accounts.example.com/login'), None),
+        # A port change in the redirect target is carried over.
+        ('http://test.skypilot.co:8080',
+         ('http://test.skypilot.co:8080/api/health',
+          'https://test.skypilot.co/api/health'), 'https://test.skypilot.co'),
+        # Credentials embedded in the endpoint survive; requests strips them
+        # from the URL it reports back.
+        ('http://admin:pw@test.skypilot.co',
+         ('http://test.skypilot.co/api/health',
+          'https://test.skypilot.co/api/health'),
+         'https://admin:pw@test.skypilot.co'),
+        # Path-prefixed endpoint behind a shared ingress.
+        ('http://test.skypilot.co/sky',
+         ('http://test.skypilot.co/sky/api/health',
+          'https://test.skypilot.co/sky/api/health'),
+         'https://test.skypilot.co/sky'),
+    ],
+)
+def test_detect_https_redirect(monkeypatch: pytest.MonkeyPatch, endpoint: str,
+                               chain, expected):
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _stub_health_probe(_health_response(*chain)))
+    assert client_sdk._detect_https_redirect(endpoint) == expected
+
+
+def test_detect_https_redirect_skips_https_endpoint(
+        monkeypatch: pytest.MonkeyPatch):
+    """An HTTPS endpoint is left alone without probing the server."""
+
+    def _unexpected(endpoint=None):
+        raise AssertionError('should not probe an https endpoint')
+
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _stub_health_probe(side_effect=_unexpected))
+    assert client_sdk._detect_https_redirect('https://test.skypilot.co') is None
+
+
+def test_detect_https_redirect_unreachable_server(
+        monkeypatch: pytest.MonkeyPatch):
+    """An unreachable server leaves the endpoint to the regular health check."""
+
+    def _raise(endpoint=None):
+        raise requests.exceptions.ConnectionError('boom')
+
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _stub_health_probe(side_effect=_raise))
+    assert client_sdk._detect_https_redirect('http://test.skypilot.co') is None
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _stub_health_probe(None))
+    assert client_sdk._detect_https_redirect('http://test.skypilot.co') is None
+
+
+def _redirecting_probe() -> mock.Mock:
+    return _stub_health_probe(
+        _health_response('http://test.skypilot.co/api/health',
+                         'https://test.skypilot.co/api/health'))
+
+
+def test_api_login_saves_redirected_https_endpoint(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Logging in to an HTTP endpoint that redirects saves the HTTPS one."""
+    config_path = tmp_path / 'config.yaml'
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+    monkeypatch.delenv(constants.SKY_API_SERVER_URL_ENV_VAR, raising=False)
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _redirecting_probe())
+
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        mock_check.return_value = (
+            server_common.ApiServerStatus.HEALTHY,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.HEALTHY,
+                basic_auth_enabled=False))
+        client_sdk.api_login('http://test.skypilot.co')
+
+    config = skypilot_config.get_user_config()
+    assert config['api_server']['endpoint'] == 'https://test.skypilot.co'
+    # The health check runs against the corrected endpoint, never the
+    # configured one.
+    mock_check.assert_has_calls([mock.call('https://test.skypilot.co')])
+
+
+def test_api_login_env_var_endpoint_redirect_warns_only(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys):
+    """An endpoint from the env var is reported on, not silently rewritten."""
+    config_path = tmp_path / 'config.yaml'
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+    monkeypatch.setenv(constants.SKY_API_SERVER_URL_ENV_VAR,
+                       'http://test.skypilot.co')
+    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
+                        _redirecting_probe())
+
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        mock_check.return_value = (
+            server_common.ApiServerStatus.HEALTHY,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.HEALTHY,
+                basic_auth_enabled=False))
+        client_sdk.api_login()
+
+    # Correcting it here would fix this login and nothing after it, since the
+    # variable outranks the config file for every command.
+    mock_check.assert_has_calls([mock.call('http://test.skypilot.co')])
+    out = capsys.readouterr().out
+    assert 'redirects to https://test.skypilot.co' in out
+    assert constants.SKY_API_SERVER_URL_ENV_VAR in out
 
 
 def test_api_login_user_hash_token(monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -24,27 +24,18 @@ from sky.utils import common as common_utils
 
 
 @pytest.fixture(autouse=True)
-def no_health_probe(monkeypatch: pytest.MonkeyPatch):
-    """Keeps `_detect_https_redirect`'s health probe off the network.
+def no_redirect_probe(monkeypatch: pytest.MonkeyPatch):
+    """Keeps `_detect_https_redirect`'s probe off the network.
 
     `api_login` probes /api/health to detect an HTTP->HTTPS ingress redirect
     before it writes the endpoint. Tests that mock `check_server_healthy` do
-    not mock the underlying probe, so stub it out by default; the redirect
-    tests patch over this with their own return value.
+    not mock that probe, so fail it by default; the redirect tests install a
+    response of their own.
     """
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _stub_health_probe(None))
-
-
-def _stub_health_probe(response=None, side_effect=None) -> mock.Mock:
-    """Stands in for the TTL-cached probe, `cache_clear` and all.
-
-    `api_login` calls `get_api_server_status_response.cache_clear()`, so a bare
-    lambda is not a sufficient stub.
-    """
-    probe = mock.Mock(return_value=response, side_effect=side_effect)
-    probe.cache_clear = mock.Mock()
-    return probe
+    monkeypatch.setattr(
+        'requests.get',
+        mock.Mock(
+            side_effect=requests.exceptions.ConnectionError('no network')))
 
 
 def _health_response(*urls: str) -> mock.Mock:
@@ -57,6 +48,13 @@ def _health_response(*urls: str) -> mock.Mock:
     final = hops[-1]
     final.history = hops[:-1]
     return final
+
+
+def _stub_probe(monkeypatch: pytest.MonkeyPatch, *chain: str) -> mock.Mock:
+    """Answers the redirect probe with a chain of hops ending at `chain[-1]`."""
+    probe = mock.Mock(return_value=_health_response(*chain))
+    monkeypatch.setattr('requests.get', probe)
+    return probe
 
 
 @pytest.fixture
@@ -758,8 +756,8 @@ def test_api_logout_with_env_endpoint(monkeypatch: pytest.MonkeyPatch):
         ('http://test.skypilot.co:8080',
          ('http://test.skypilot.co:8080/api/health',
           'https://test.skypilot.co/api/health'), 'https://test.skypilot.co'),
-        # Credentials embedded in the endpoint survive; requests strips them
-        # from the URL it reports back.
+        # Credentials embedded in the endpoint are dropped from the probe and
+        # restored on the result.
         ('http://admin:pw@test.skypilot.co',
          ('http://test.skypilot.co/api/health',
           'https://test.skypilot.co/api/health'),
@@ -773,42 +771,81 @@ def test_api_logout_with_env_endpoint(monkeypatch: pytest.MonkeyPatch):
 )
 def test_detect_https_redirect(monkeypatch: pytest.MonkeyPatch, endpoint: str,
                                chain, expected):
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _stub_health_probe(_health_response(*chain)))
+    _stub_probe(monkeypatch, *chain)
     assert client_sdk._detect_https_redirect(endpoint) == expected
 
 
 def test_detect_https_redirect_skips_https_endpoint(
         monkeypatch: pytest.MonkeyPatch):
     """An HTTPS endpoint is left alone without probing the server."""
-
-    def _unexpected(endpoint=None):
-        raise AssertionError('should not probe an https endpoint')
-
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _stub_health_probe(side_effect=_unexpected))
+    probe = _stub_probe(monkeypatch, 'https://test.skypilot.co/api/health')
     assert client_sdk._detect_https_redirect('https://test.skypilot.co') is None
+    probe.assert_not_called()
 
 
-def test_detect_https_redirect_unreachable_server(
-        monkeypatch: pytest.MonkeyPatch):
+def test_detect_https_redirect_unreachable_server():
     """An unreachable server leaves the endpoint to the regular health check."""
-
-    def _raise(endpoint=None):
-        raise requests.exceptions.ConnectionError('boom')
-
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _stub_health_probe(side_effect=_raise))
-    assert client_sdk._detect_https_redirect('http://test.skypilot.co') is None
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _stub_health_probe(None))
+    # The autouse fixture fails the probe with a ConnectionError.
     assert client_sdk._detect_https_redirect('http://test.skypilot.co') is None
 
 
-def _redirecting_probe() -> mock.Mock:
-    return _stub_health_probe(
-        _health_response('http://test.skypilot.co/api/health',
-                         'https://test.skypilot.co/api/health'))
+def test_detect_https_redirect_probe_sends_no_credentials(
+        monkeypatch: pytest.MonkeyPatch):
+    """The probe authenticates with nothing at all.
+
+    It runs before `api_login` has settled which credential this login uses, so
+    anything it sends is a credential for whichever server was configured
+    before -- over cleartext HTTP, to a server the user has not authenticated
+    to yet. The OAuth path hides a residual token from its own requests for
+    exactly this reason.
+    """
+    monkeypatch.setenv(constants.SERVICE_ACCOUNT_TOKEN_ENV_VAR,
+                       'sky_residual_token_for_another_server')
+    probe = _stub_probe(monkeypatch, 'http://test.skypilot.co/api/health',
+                        'https://test.skypilot.co/api/health')
+
+    assert (client_sdk._detect_https_redirect(
+        'http://admin:hunter2@test.skypilot.co') ==
+            'https://admin:hunter2@test.skypilot.co')
+
+    (probe_url,), kwargs = probe.call_args
+    # No bearer token, no cookie jar, and no basic-auth password on the wire.
+    assert probe_url == 'http://test.skypilot.co/api/health'
+    assert not kwargs.keys() & {'headers', 'cookies', 'auth'}
+
+
+def test_detect_https_redirect_does_not_prime_health_cache(
+        monkeypatch: pytest.MonkeyPatch):
+    """The probe must not answer the health check that validates a token.
+
+    `get_api_server_status_response` memoizes on the endpoint for 5s, so a
+    probe that populated it would hand its own pre-authentication response to
+    the health check `api_login` runs right after saving a newly supplied
+    service-account token.
+    """
+    endpoint = 'http://test.skypilot.co'
+    _stub_probe(monkeypatch, f'{endpoint}/api/health',
+                'https://test.skypilot.co/api/health')
+    health_calls = []
+
+    def _fake_request(method, url, **kwargs):
+        del method, kwargs
+        health_calls.append(url)
+        response = mock.Mock(spec=requests.Response)
+        response.status_code = 200
+        response.url = url
+        response.history = []
+        return response
+
+    monkeypatch.setattr('sky.server.rest.request', _fake_request)
+    server_common.get_api_server_status_response.cache_clear()
+    try:
+        client_sdk._detect_https_redirect(endpoint)
+        assert not health_calls, 'the probe went through the cached helper'
+        server_common.get_api_server_status_response(endpoint)
+        assert health_calls == [f'{endpoint}/api/health']
+    finally:
+        server_common.get_api_server_status_response.cache_clear()
 
 
 def test_api_login_saves_redirected_https_endpoint(
@@ -818,8 +855,8 @@ def test_api_login_saves_redirected_https_endpoint(
     monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
                         lambda: str(config_path))
     monkeypatch.delenv(constants.SKY_API_SERVER_URL_ENV_VAR, raising=False)
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _redirecting_probe())
+    _stub_probe(monkeypatch, 'http://test.skypilot.co/api/health',
+                'https://test.skypilot.co/api/health')
 
     with mock.patch('sky.server.common.check_server_healthy') as mock_check:
         mock_check.return_value = (
@@ -844,8 +881,8 @@ def test_api_login_env_var_endpoint_redirect_warns_only(
                         lambda: str(config_path))
     monkeypatch.setenv(constants.SKY_API_SERVER_URL_ENV_VAR,
                        'http://test.skypilot.co')
-    monkeypatch.setattr('sky.server.common.get_api_server_status_response',
-                        _redirecting_probe())
+    _stub_probe(monkeypatch, 'http://test.skypilot.co/api/health',
+                'https://test.skypilot.co/api/health')
 
     with mock.patch('sky.server.common.check_server_healthy') as mock_check:
         mock_check.return_value = (


### PR DESCRIPTION
An API server behind an ingress that force-redirects HTTP to HTTPS is a silent trap for a client configured with the `http://` endpoint. `/api/health` is a GET, so it follows the redirect intact and `sky api info` reports the server as HEALTHY — but every POST-based command is turned into a GET by that same redirect (dropping the method and body on a 301/302 is what every mainstream HTTP client does), and comes back as:

```
$ sky status my-cluster
Error: Method Not Allowed
```

Secure session cookies are withheld from a plain-HTTP request too, so an SSO session silently does not apply either. The server looks healthy while nothing works, and the endpoint's scheme is the last thing anyone suspects — the health check that would tell you is the one request the redirect does not break.

## What this does

Detect the redirect at login, which is the cheap place to fix it: the endpoint has not been persisted yet, and nothing has been authenticated against it.

`_detect_https_redirect` probes `/api/health` and walks the redirect chain for the first hop that is the **same host and path over HTTPS**. Requiring all three to match keeps us off an SSO proxy's login page, which is a legitimate redirect out of `/api/health` to somewhere that is emphatically not the API server endpoint. Walking the chain rather than looking only at the final URL matters for exactly that case: `http://host` → `https://host` → `https://accounts.example.com/login` still resolves to `https://host`.

`api_login` then warns and logs into the corrected endpoint, so both the persisted config and the `Secure` flag on the cookies it mints come out right:

```
$ sky api login -e http://skypilot.mydomain.com
http://skypilot.mydomain.com redirects to https://skypilot.mydomain.com; using the https endpoint.
Over plain HTTP that redirect rewrites every non-GET request as a GET, which the server rejects with "Method Not Allowed", and Secure session cookies are not sent at all.
Logged into SkyPilot API server at: https://skypilot.mydomain.com
```

When the endpoint came from `SKYPILOT_API_SERVER_ENDPOINT` it only warns, and names the variable — the variable outranks the config file for every command, so correcting it here would fix this login and nothing after it.

## Cost and failure behavior

The probe reuses `get_api_server_status_response`, which is TTL-cached and keyed on the endpoint, so the `check_server_healthy` call right after reuses the same response when there is no redirect. An `https://` endpoint skips the probe entirely. Any failure returns `None` and leaves the regular health check to report an unreachable server, exactly as today.

A port change in the redirect target is carried over, and credentials embedded in the configured endpoint are preserved (`requests` strips those from the URL it reports back).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_sky/server/test_sdk.py` cover the chain-walking rules (no redirect, same-host upgrade, upgrade followed by an external SSO hop, a straight redirect to another host, port change, embedded credentials, path-prefixed endpoint), the https and unreachable-server short circuits, and both `api_login` paths — the corrected endpoint being persisted, and the env-var endpoint being warned about rather than rewritten. An autouse fixture stubs the probe so the existing `api_login` tests stay off the network.

Also confirmed the underlying mechanism against a local redirecting server: `requests` puts the original URL in `.history` and the target in `.url`, and does downgrade `POST` → `GET` across a 301.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->