### PR TITLE
[Dashboard] Slurm Infra: per-cluster progressive loading, node-derived GPU columns, bounded inventory SSH

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -27,6 +27,14 @@ _ALL_JOBS_INFO_CMD = (f'squeue -h --states=running,completing '
 _PARTITIONS_INFO_CMD = 'scontrol show partitions -o'
 _BATCH_OUTPUT_HEADER = 'SKYPILOT_SLURM_BATCH\n'
 
+# Wall-clock bound for the batched inventory invocations (SSH connect
+# included). The inventory endpoints fan out over every configured cluster,
+# and a login node that accepts the TCP connect but never answers (e.g. a
+# broken tunnel data path) would otherwise hang the aggregate forever. On
+# expiry the SSH process is killed and subprocess.TimeoutExpired is raised,
+# which the aggregation callers degrade to an empty per-cluster result.
+_INVENTORY_TIMEOUT_SECONDS = 60
+
 # Regex pattern to extract partition names from scontrol output
 # Matches PartitionName=<name> and captures until the next field
 _PARTITION_NAME_REGEX = re.compile(r'PartitionName=(.+?)(?:\s+\w+=|$)')
@@ -551,7 +559,8 @@ class SlurmClient:
     def get_node_inventory(
             self) -> Tuple[List[NodeInfo], Dict[str, Dict[str, str]]]:
         """Get node information and details in one remote invocation."""
-        outputs = self._run_slurm_cmds([_INFO_NODES_CMD, _ALL_NODE_DETAILS_CMD])
+        outputs = self._run_slurm_cmds([_INFO_NODES_CMD, _ALL_NODE_DETAILS_CMD],
+                                       timeout=_INVENTORY_TIMEOUT_SECONDS)
         node_returncode, node_stdout, node_stderr = outputs[0]
         details_returncode, details_stdout, details_stderr = outputs[1]
         subprocess_utils.handle_returncode(
@@ -587,7 +596,8 @@ class SlurmClient:
             _ALL_NODE_DETAILS_CMD,
             _ALL_JOBS_INFO_CMD,
             _PARTITIONS_INFO_CMD,
-        ])
+        ],
+                                       timeout=_INVENTORY_TIMEOUT_SECONDS)
         node_returncode, node_stdout, node_stderr = outputs[0]
         details_returncode, details_stdout, details_stderr = outputs[1]
         jobs_returncode, jobs_stdout, jobs_stderr = outputs[2]

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -40,6 +40,9 @@ import {
   getContextJobs,
   getContextClusters,
   getSlurmInfrastructure,
+  getSlurmClusterNames,
+  getSlurmClusterInfrastructure,
+  aggregateSlurmGPUsByType,
 } from '@/data/connectors/infra';
 import {
   CLOUDS_LIST,
@@ -486,9 +489,9 @@ export function InfrastructureSection({
     const contextStatsKey = buildContextStatsKey(context, { isSSH, isSlurm });
     const stats = contextStats[contextStatsKey] || { clusters: 0, jobs: 0 };
 
-    // Kubernetes uses progressive per-context loading; Slurm/SSH load all at once.
-    const hasGpuData =
-      isSlurm || isSSH ? !isLoading : loadedContexts.has(context);
+    // Kubernetes and Slurm use progressive per-context loading (each
+    // context/cluster settles independently); SSH loads all at once.
+    const hasGpuData = isSSH ? !isLoading : loadedContexts.has(context);
     const hasNodeData = hasGpuData;
 
     const aggregatedCpu = calculateAggregatedResource(nodes, 'cpu_count', true);
@@ -565,12 +568,12 @@ export function InfrastructureSection({
   }
 
   // Determine if table should show refreshing state
-  // For K8s: show during loading or when contexts haven't all loaded yet
-  // For SSH/Slurm: only show during loading
+  // For K8s/Slurm: show during loading or when contexts haven't all loaded
+  // For SSH: only show during loading
   const isTableRefreshing =
     !isInitialLoad &&
     (isLoading ||
-      (!(isSlurm || isSSH) &&
+      (!isSSH &&
         safeContexts.length > 0 &&
         !safeContexts.every((c) => loadedContexts.has(c))));
 
@@ -677,7 +680,7 @@ export function InfrastructureSection({
                   // Expanding appends the partition breakdown under the
                   // cluster's own totals, so the aggregate stays on screen and
                   // the toggle keeps its place. When the cluster has no GPU
-                  // type rows (e.g. its availability sweep failed), a null
+                  // type rows (e.g. its node query failed), a null
                   // summary row stands in — otherwise every expanded row would
                   // be a partition row, and the toggle cell (the only way to
                   // collapse) would never render again.
@@ -2631,9 +2634,11 @@ export function GPUs() {
   const [perNodeGPUs, setPerNodeGPUs] = useState([]);
   // Track which contexts have had their GPU/node data loaded (for progressive loading)
   const [loadedContexts, setLoadedContexts] = useState(new Set());
-  const [allSlurmGPUs, setAllSlurmGPUs] = useState([]);
   const [perClusterSlurmGPUs, setPerClusterSlurmGPUs] = useState([]);
   const [perNodeSlurmGPUs, setPerNodeSlurmGPUs] = useState([]);
+  // Slurm clusters whose GPU/node queries have settled — the Slurm
+  // counterpart of loadedContexts, driving per-cluster skeleton cells.
+  const [slurmLoadedClusters, setSlurmLoadedClusters] = useState(new Set());
   // Slurm clusters from ~/.slurm/config, independent of whether they answer a
   // query right now.
   const [configuredSlurmClusters, setConfiguredSlurmClusters] = useState([]);
@@ -2735,7 +2740,7 @@ export function GPUs() {
           fetchCloudData(forceRefresh),
           fetchManagedJobsData(),
           fetchClusterStatsData(),
-          fetchSlurmData(),
+          fetchSlurmData(forceRefresh, showLoadingIndicators),
         ]);
 
         // Mark main fetch as done, check if we can set isFetching = false
@@ -2768,9 +2773,9 @@ export function GPUs() {
         setSshLoading(false);
         setSlurmLoading(false);
         setConfiguredSlurmClusters([]);
-        setAllSlurmGPUs([]);
         setPerClusterSlurmGPUs([]);
         setPerNodeSlurmGPUs([]);
+        setSlurmLoadedClusters(new Set());
         setSshAndKubeJobsData({});
         setSshAndKubeJobsDataLoading(false);
 
@@ -2999,24 +3004,77 @@ export function GPUs() {
     }
   };
 
-  // Fetch Slurm data separately for parallel loading with Kubernetes/SSH
-  const fetchSlurmData = async () => {
+  // Fetch Slurm data with per-cluster settlement, mirroring the Kubernetes
+  // section's progressive per-context loading: the configured cluster names
+  // (answered without contacting any login node) render the rows
+  // immediately, then each cluster's GPU/node queries fill its row in as
+  // they land — one slow or unreachable cluster can neither blank nor delay
+  // the other clusters' rendering.
+  const fetchSlurmData = async (forceRefresh, showLoadingIndicators = true) => {
     try {
-      const slurmData = await dashboardCache.get(getSlurmInfrastructure);
-      if (slurmData) {
-        setConfiguredSlurmClusters(slurmData.slurmClusterNames || []);
-        setAllSlurmGPUs(slurmData.allSlurmGPUs || []);
-        setPerClusterSlurmGPUs(slurmData.perClusterSlurmGPUs || []);
-        setPerNodeSlurmGPUs(slurmData.perNodeSlurmGPUs || []);
-      }
+      const clusterNames = forceRefresh
+        ? await getSlurmClusterNames()
+        : await dashboardCache.get(getSlurmClusterNames);
+      const validClusters = (clusterNames || []).filter(
+        (name) => name && typeof name === 'string'
+      );
+      setConfiguredSlurmClusters(validClusters);
+      // Names are enough to render the section (rows show skeleton cells
+      // until their own data lands), so clear the panel-level loading state
+      // now rather than after the slowest cluster.
       setSlurmDataLoaded(true);
       setSlurmLoading(false);
+
+      if (validClusters.length === 0) {
+        if (showLoadingIndicators) {
+          setPerClusterSlurmGPUs([]);
+          setPerNodeSlurmGPUs([]);
+          setSlurmLoadedClusters(new Set());
+        }
+        return;
+      }
+
+      // Reset loaded-cluster tracking so cells show skeletons during a
+      // foreground refresh, but keep existing data on screen (progressive
+      // overwrite, like the Kubernetes path).
+      if (showLoadingIndicators) {
+        setSlurmLoadedClusters(new Set());
+      }
+
+      await Promise.allSettled(
+        validClusters.map(async (clusterName) => {
+          try {
+            const data = forceRefresh
+              ? await getSlurmClusterInfrastructure(clusterName)
+              : await dashboardCache.get(getSlurmClusterInfrastructure, [
+                  clusterName,
+                ]);
+            setPerClusterSlurmGPUs((prev) => [
+              ...(prev || []).filter((gpu) => gpu.cluster !== clusterName),
+              ...(data?.perClusterGPUs || []),
+            ]);
+            setPerNodeSlurmGPUs((prev) => [
+              ...(prev || []).filter((node) => node.cluster !== clusterName),
+              ...(data?.perNodeGPUs || []),
+            ]);
+          } catch (error) {
+            console.error(
+              `Error fetching Slurm cluster ${clusterName}:`,
+              error
+            );
+          } finally {
+            // Mark the cluster loaded even on error so its row settles to
+            // empty cells instead of shimmering forever.
+            setSlurmLoadedClusters((prev) => new Set([...prev, clusterName]));
+          }
+        })
+      );
     } catch (error) {
       console.error('Error in fetchSlurmData:', error);
       setConfiguredSlurmClusters([]);
-      setAllSlurmGPUs([]);
       setPerClusterSlurmGPUs([]);
       setPerNodeSlurmGPUs([]);
+      setSlurmLoadedClusters(new Set());
       setSlurmDataLoaded(true);
       setSlurmLoading(false);
     }
@@ -3223,6 +3281,9 @@ export function GPUs() {
     dashboardCache.invalidate(getCloudInfrastructure, [false]); // Keep for backwards compatibility
     dashboardCache.invalidate(getSSHNodePools);
     dashboardCache.invalidate(getSlurmInfrastructure);
+    dashboardCache.invalidate(getSlurmClusterNames);
+    // One cache entry per cluster; invalidateFunction clears every variant.
+    dashboardCache.invalidateFunction(getSlurmClusterInfrastructure);
 
     // Increment GPU metrics refresh trigger to force iframe reload
     setGpuMetricsRefreshTrigger((prev) => prev + 1);
@@ -3460,19 +3521,6 @@ export function GPUs() {
     return [...clusterSet].sort();
   }, [configuredSlurmClusters, perClusterSlurmGPUs, perNodeSlurmGPUs]);
 
-  // Group perClusterSlurmGPUs by cluster
-  const groupedPerClusterSlurmGPUs = React.useMemo(() => {
-    if (!perClusterSlurmGPUs) return {};
-    return perClusterSlurmGPUs.reduce((acc, gpu) => {
-      const { cluster } = gpu;
-      if (!acc[cluster]) {
-        acc[cluster] = [];
-      }
-      acc[cluster].push(gpu);
-      return acc;
-    }, {});
-  }, [perClusterSlurmGPUs]);
-
   // Group perNodeSlurmGPUs by cluster
   const groupedPerNodeSlurmGPUs = React.useMemo(() => {
     if (!perNodeSlurmGPUs) return {};
@@ -3485,6 +3533,29 @@ export function GPUs() {
       return acc;
     }, {});
   }, [perNodeSlurmGPUs]);
+
+  // Group perClusterSlurmGPUs by cluster. These entries are derived from the
+  // node feed (see slurmClusterGPUsFromNodes in the connector), so the
+  // cluster-level GPU cells and the partition breakdown below them always
+  // agree — they read one source.
+  const groupedPerClusterSlurmGPUs = React.useMemo(() => {
+    if (!perClusterSlurmGPUs) return {};
+    return perClusterSlurmGPUs.reduce((acc, gpu) => {
+      const { cluster } = gpu;
+      if (!acc[cluster]) {
+        acc[cluster] = [];
+      }
+      acc[cluster].push(gpu);
+      return acc;
+    }, {});
+  }, [perClusterSlurmGPUs]);
+
+  // Fleet-wide Slurm GPU totals, derived from the per-cluster data so the
+  // summary strip fills in as each cluster's data streams in.
+  const allSlurmGPUs = React.useMemo(
+    () => aggregateSlurmGPUsByType(perClusterSlurmGPUs),
+    [perClusterSlurmGPUs]
+  );
 
   // Group perNodeGPUs by context
   const groupedPerNodeGPUs = React.useMemo(() => {
@@ -3863,6 +3934,7 @@ export function GPUs() {
         isSSH={false}
         isSlurm={true}
         contextWorkspaceMap={{}}
+        loadedContexts={slurmLoadedClusters}
         isInitialLoad={isInitialLoad}
         statusByKey={extraStatusByKey}
       />

--- a/sky/dashboard/src/components/infra.test.jsx
+++ b/sky/dashboard/src/components/infra.test.jsx
@@ -35,6 +35,9 @@ const renderSection = (props) =>
       isInitialLoad={false}
       groupedPerContextGPUs={{}}
       groupedPerNodeGPUs={{}}
+      // Progressive per-context loading: a row renders its data only once
+      // its context has settled, so default every listed context to loaded.
+      loadedContexts={new Set(props.contexts || [])}
       {...props}
     />
   );

--- a/sky/dashboard/src/data/connectors/client.js
+++ b/sky/dashboard/src/data/connectors/client.js
@@ -211,9 +211,12 @@ export const apiClient = {
     }
   },
 
-  get: async (path) => {
+  get: async (path, options = {}) => {
     const baseUrl = window.location.origin;
     const fullUrl = `${baseUrl}${ENDPOINT}${path}`;
-    return await fetch(fullUrl, { headers: withVersionHeader({}) });
+    return await fetch(fullUrl, {
+      headers: withVersionHeader({}),
+      signal: options.signal,
+    });
   },
 };

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -1088,51 +1088,31 @@ export async function getDetailedGpuInfo(filter) {
   }
 }
 
-async function getSlurmClusterGPUs() {
+// Deadline for the Slurm long-polls below. The POST returns instantly with a
+// request id; the /api/get long-poll then blocks server-side until the
+// request completes, so without a deadline a hung backend request (e.g. an
+// unresponsive login node) would pin the returned promise — and the
+// dashboard cache's in-flight dedup — forever. The server bounds each
+// cluster query separately; this is a belt-and-braces bound on top of it.
+const SLURM_FETCH_TIMEOUT_MS = 120 * 1000;
+
+// Long-poll `/api/get` for a scheduled request with an abort deadline.
+async function getSlurmRequestResult(requestId) {
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), SLURM_FETCH_TIMEOUT_MS);
   try {
-    const response = await apiClient.post(`/slurm_gpu_availability`, {});
-    if (!response.ok) {
-      const msg = `Failed to get slurm cluster GPUs with status ${response.status}`;
-      throw new Error(msg);
-    }
-    const id = response.headers.get('X-Skypilot-Request-ID');
-    if (!id) {
-      const msg = 'No request ID received from server for slurm cluster GPUs';
-      throw new Error(msg);
-    }
-    const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
-    if (fetchedData.status === 500) {
-      try {
-        const data = await fetchedData.json();
-        if (data.detail && data.detail.error) {
-          try {
-            const error = JSON.parse(data.detail.error);
-            console.error('Error fetching Slurm cluster GPUs:', error.message);
-          } catch (jsonError) {
-            console.error('Error parsing JSON for Slurm error:', jsonError);
-          }
-        }
-      } catch (parseError) {
-        console.error('Error parsing JSON for Slurm 500 response:', parseError);
-      }
-      return [];
-    }
-    if (!fetchedData.ok) {
-      const msg = `Failed to get slurm cluster GPUs result with status ${fetchedData.status}`;
-      throw new Error(msg);
-    }
-    const data = await fetchedData.json();
-    const clusterGPUs = data.return_value ? JSON.parse(data.return_value) : [];
-    return clusterGPUs;
-  } catch (error) {
-    console.error('Error fetching Slurm cluster GPUs:', error);
-    return [];
+    return await apiClient.get(`/api/get?request_id=${requestId}`, {
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(deadline);
   }
 }
 
-async function getSlurmPerNodeGPUs() {
+async function getSlurmPerNodeGPUs(clusterName = null) {
   try {
-    const response = await apiClient.post(`/slurm_node_info`, {});
+    const body = clusterName ? { slurm_cluster_name: clusterName } : {};
+    const response = await apiClient.post(`/slurm_node_info`, body);
     if (!response.ok) {
       const msg = `Failed to get slurm node info with status ${response.status}`;
       throw new Error(msg);
@@ -1142,7 +1122,7 @@ async function getSlurmPerNodeGPUs() {
       const msg = 'No request ID received from server for slurm node info';
       throw new Error(msg);
     }
-    const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
+    const fetchedData = await getSlurmRequestResult(id);
     if (fetchedData.status === 500) {
       try {
         const data = await fetchedData.json();
@@ -1182,7 +1162,7 @@ async function getSlurmPerNodeGPUs() {
 // contacting any login node. Independent of the GPU and node queries, so it is
 // fetched alongside them rather than before them: a cluster that is
 // unreachable still comes back here after those two report nothing for it.
-async function getSlurmClusterNames() {
+export async function getSlurmClusterNames() {
   try {
     const response = await apiClient.post(`/slurm_cluster_names`, {});
     if (!response.ok) {
@@ -1207,96 +1187,152 @@ async function getSlurmClusterNames() {
   }
 }
 
-// Export Slurm infrastructure fetching for parallel loading
-export async function getSlurmInfrastructure() {
-  return await getSlurmServiceGPUs();
+// Derive a Slurm cluster's per-type GPU entries from its shaped node rows.
+// The /slurm_gpu_availability endpoint reports the same numbers (server-side
+// it iterates slurm_node_info and sums total/free per GPU type, advertising
+// the same powers-of-2 requestable counts per node), but it is additionally
+// gated on the cached enabled-clouds check and would cost this page a second
+// scheduled request — and a second SSH invocation of the login node — per
+// cluster. Deriving from the node feed keeps the cluster cells, the summary
+// strip, and the partition breakdown consistent by construction: one source.
+// Exported for tests.
+export function slurmClusterGPUsFromNodes(clusterName, nodes) {
+  const byType = new Map();
+  (nodes || []).forEach((node) => {
+    const gpuName = node.gpu_name;
+    if (!gpuName || gpuName === '-' || !(node.gpu_total > 0)) {
+      return;
+    }
+    const type = byType.get(gpuName) || {
+      gpu_name: gpuName,
+      gpu_total: 0,
+      gpu_free: 0,
+      cluster: clusterName,
+      requestableCounts: new Set(),
+    };
+    type.gpu_total += node.gpu_total || 0;
+    type.gpu_free += node.gpu_free || 0;
+    // Powers of 2 up to the node's total, plus the total itself — the same
+    // requestable-quantity derivation the catalog advertises per node.
+    for (let count = 1; count <= node.gpu_total; count *= 2) {
+      type.requestableCounts.add(count);
+    }
+    type.requestableCounts.add(node.gpu_total);
+    byType.set(gpuName, type);
+  });
+  return Array.from(byType.values())
+    .map(({ requestableCounts, ...type }) => ({
+      ...type,
+      gpu_requestable_qty_per_node: Array.from(requestableCounts)
+        .sort((a, b) => a - b)
+        .join(', '),
+    }))
+    .sort((a, b) => a.gpu_name.localeCompare(b.gpu_name));
 }
 
-async function getSlurmServiceGPUs() {
-  try {
-    // Fetch the configured cluster names, cluster GPUs and node GPUs in
-    // parallel — none of the three depends on another.
-    const [clusterNames, clusterGPUsRaw, nodeGPUsRaw] = await Promise.all([
-      getSlurmClusterNames(),
-      getSlurmClusterGPUs(),
-      getSlurmPerNodeGPUs(),
-    ]);
+// Shape raw /slurm_node_info rows into perNodeSlurmGPUs entries.
+// nodeGPUsRaw is expected to be like:
+// [ {node_name, slurm_cluster_name, partition, gpu_type, total_gpus,
+//    free_gpus, node_state, ...}, ... ]
+function shapeSlurmNodeGPUs(nodeGPUsRaw) {
+  const perNodeSlurmGPUs = {}; // { 'cluster/node_name/gpu': { ... } }
+  for (const node of nodeGPUsRaw || []) {
+    const clusterName = node.slurm_cluster_name || 'default';
+    const key = `${clusterName}/${node.node_name}/${node.gpu_type || '-'}`;
+    perNodeSlurmGPUs[key] = {
+      node_name: node.node_name,
+      gpu_name: node.gpu_type || '-', // gpu_type might be null
+      gpu_total: node.total_gpus || 0,
+      gpu_free: node.free_gpus || 0,
+      cluster: clusterName,
+      partition: node.partition || 'default', // partition might be null
+      // Raw sinfo state (e.g. 'idle~'); the '~' suffix marks a powered-down
+      // cloud node. Carried so the infra table can count only up nodes.
+      node_state: node.node_state,
+    };
+  }
+  return Object.values(perNodeSlurmGPUs).sort(
+    (a, b) =>
+      (a.cluster || '').localeCompare(b.cluster || '') ||
+      (a.node_name || '').localeCompare(b.node_name || '') ||
+      (a.gpu_name || '').localeCompare(b.gpu_name || '')
+  );
+}
 
-    const allSlurmGPUs = {};
-    const perClusterSlurmGPUs = {}; // Similar to perContextGPUs for Kubernetes
-    const perNodeSlurmGPUs = {}; // { 'cluster/node_name': { ... } }
-
-    // Process cluster GPUs (similar to Kubernetes context GPUs)
-    // clusterGPUsRaw is expected to be like: [ [cluster_name, [ [gpu_name, counts, capacity, available], ... ] ], ... ]
-    for (const clusterData of clusterGPUsRaw) {
-      const clusterName = clusterData[0];
-      const gpusInCluster = clusterData[1];
-
-      for (const gpuRaw of gpusInCluster) {
-        const gpuName = gpuRaw[0];
-        // gpuRaw[1] is counts (list of requestable quantities), e.g., [1, 2, 4]
-        const gpuRequestableQtyPerNode = gpuRaw[1].join(', ');
-        const gpuTotal = gpuRaw[2]; // capacity
-        const gpuFree = gpuRaw[3]; // available
-
-        // Aggregate for allSlurmGPUs
-        if (gpuName in allSlurmGPUs) {
-          allSlurmGPUs[gpuName].gpu_total += gpuTotal;
-          allSlurmGPUs[gpuName].gpu_free += gpuFree;
-        } else {
-          allSlurmGPUs[gpuName] = {
-            gpu_total: gpuTotal,
-            gpu_free: gpuFree,
-            gpu_name: gpuName,
-          };
-        }
-
-        // Store for perClusterSlurmGPUs (similar to perContextGPUs)
-        const clusterGpuKey = `${clusterName}#${gpuName}`; // Unique key for cluster-gpu combo
-        perClusterSlurmGPUs[clusterGpuKey] = {
-          gpu_name: gpuName,
-          gpu_requestable_qty_per_node: gpuRequestableQtyPerNode,
-          gpu_total: gpuTotal,
-          gpu_free: gpuFree,
-          cluster: clusterName,
-        };
-      }
-    }
-
-    // Process node GPUs
-    // nodeGPUsRaw is expected to be like: [ {node_name, slurm_cluster_name, partition, gpu_type, total_gpus, free_gpus}, ... ]
-    for (const node of nodeGPUsRaw) {
-      const clusterName = node.slurm_cluster_name || 'default';
-      const key = `${clusterName}/${node.node_name}/${node.gpu_type || '-'}`;
-      perNodeSlurmGPUs[key] = {
-        node_name: node.node_name,
-        gpu_name: node.gpu_type || '-', // gpu_type might be null
-        gpu_total: node.total_gpus || 0,
-        gpu_free: node.free_gpus || 0,
-        cluster: clusterName,
-        partition: node.partition || 'default', // partition might be null
-        // Raw sinfo state (e.g. 'idle~'); the '~' suffix marks a powered-down
-        // cloud node. Carried so the infra table can count only up nodes.
-        node_state: node.node_state,
+// Fleet-wide totals per GPU type, aggregated from perClusterSlurmGPUs
+// entries. Exported so the Infra page can derive the summary strip from
+// progressively-merged per-cluster data.
+export function aggregateSlurmGPUsByType(perClusterSlurmGPUs) {
+  const allSlurmGPUs = {};
+  for (const gpu of perClusterSlurmGPUs || []) {
+    if (gpu.gpu_name in allSlurmGPUs) {
+      allSlurmGPUs[gpu.gpu_name].gpu_total += gpu.gpu_total || 0;
+      allSlurmGPUs[gpu.gpu_name].gpu_free += gpu.gpu_free || 0;
+    } else {
+      allSlurmGPUs[gpu.gpu_name] = {
+        gpu_total: gpu.gpu_total || 0,
+        gpu_free: gpu.gpu_free || 0,
+        gpu_name: gpu.gpu_name,
       };
     }
+  }
+  return Object.values(allSlurmGPUs).sort((a, b) =>
+    a.gpu_name.localeCompare(b.gpu_name)
+  );
+}
 
-    return {
-      slurmClusterNames: clusterNames,
-      allSlurmGPUs: Object.values(allSlurmGPUs).sort((a, b) =>
+// One cluster's node info plus the per-type GPU totals derived from it,
+// shaped like the matching slices of getSlurmInfrastructure()'s arrays. The
+// Infra page fans out one call per configured cluster and merges each result
+// as it settles, so a single slow or unreachable cluster only affects its own
+// row instead of holding the whole Slurm section on a spinner.
+export async function getSlurmClusterInfrastructure(clusterName) {
+  const nodeGPUsRaw = await getSlurmPerNodeGPUs(clusterName);
+  const perNodeGPUs = shapeSlurmNodeGPUs(nodeGPUsRaw);
+  return {
+    cluster: clusterName,
+    perClusterGPUs: slurmClusterGPUsFromNodes(clusterName, perNodeGPUs),
+    perNodeGPUs,
+  };
+}
+
+// Aggregate Slurm infrastructure across every configured cluster. Kept for
+// cache preloading and consumers that want the whole picture in one call.
+// Internally it settles per cluster (see getSlurmClusterInfrastructure) and
+// shares the per-cluster cache entries with the Infra page, so a single
+// unreachable cluster contributes empty slices instead of hiding the other
+// clusters' data behind its timeout.
+export async function getSlurmInfrastructure() {
+  try {
+    const clusterNames = await dashboardCache.get(getSlurmClusterNames);
+    const results = await Promise.allSettled(
+      (clusterNames || []).map((name) =>
+        dashboardCache.get(getSlurmClusterInfrastructure, [name])
+      )
+    );
+    const perClusterSlurmGPUs = [];
+    const perNodeSlurmGPUs = [];
+    for (const result of results) {
+      if (result.status !== 'fulfilled' || !result.value) continue;
+      perClusterSlurmGPUs.push(...result.value.perClusterGPUs);
+      perNodeSlurmGPUs.push(...result.value.perNodeGPUs);
+    }
+    perClusterSlurmGPUs.sort(
+      (a, b) =>
+        a.cluster.localeCompare(b.cluster) ||
         a.gpu_name.localeCompare(b.gpu_name)
-      ),
-      perClusterSlurmGPUs: Object.values(perClusterSlurmGPUs).sort(
-        (a, b) =>
-          a.cluster.localeCompare(b.cluster) ||
-          a.gpu_name.localeCompare(b.gpu_name)
-      ),
-      perNodeSlurmGPUs: Object.values(perNodeSlurmGPUs).sort(
-        (a, b) =>
-          (a.cluster || '').localeCompare(b.cluster || '') ||
-          (a.node_name || '').localeCompare(b.node_name || '') ||
-          (a.gpu_name || '').localeCompare(b.gpu_name || '')
-      ),
+    );
+    perNodeSlurmGPUs.sort(
+      (a, b) =>
+        (a.cluster || '').localeCompare(b.cluster || '') ||
+        (a.node_name || '').localeCompare(b.node_name || '') ||
+        (a.gpu_name || '').localeCompare(b.gpu_name || '')
+    );
+    return {
+      slurmClusterNames: clusterNames || [],
+      allSlurmGPUs: aggregateSlurmGPUsByType(perClusterSlurmGPUs),
+      perClusterSlurmGPUs,
+      perNodeSlurmGPUs,
     };
   } catch (error) {
     console.error('Error fetching Slurm GPUs:', error);

--- a/sky/dashboard/src/data/connectors/infra.test.jsx
+++ b/sky/dashboard/src/data/connectors/infra.test.jsx
@@ -11,7 +11,11 @@ jest.mock('@/data/connectors/client', () => ({
 }));
 
 import { apiClient } from '@/data/connectors/client';
-import { getSlurmInfrastructure } from '@/data/connectors/infra';
+import {
+  getSlurmInfrastructure,
+  getSlurmClusterInfrastructure,
+  slurmClusterGPUsFromNodes,
+} from '@/data/connectors/infra';
 
 // Every Slurm endpoint answers the same way: POST returns a request id in a
 // header, then /api/get returns the result under a JSON-encoded return_value.
@@ -27,21 +31,29 @@ const result = (returnValue) => ({
   json: async () => ({ return_value: JSON.stringify(returnValue) }),
 });
 
+// Route POSTs to per-cluster request ids so the /api/get mock can key its
+// responses by cluster: req-nodes-<cluster>. The GPU columns are derived
+// from the node feed, so /slurm_gpu_availability must never be called —
+// routing it to a throw makes any such call fail the test that made it.
+const routePosts = () => {
+  apiClient.post.mockImplementation(async (path, body) => {
+    const cluster = body?.slurm_cluster_name || 'all';
+    if (path === '/slurm_cluster_names') return scheduled('req-clusters');
+    if (path === '/slurm_node_info') return scheduled(`req-nodes-${cluster}`);
+    throw new Error(`unexpected POST to ${path}`);
+  });
+};
+
 // The Infra page must list a cluster that is configured but currently
-// unreachable, so the configured-cluster query has to be independent of the
-// node and GPU queries rather than derived from them.
+// unreachable, and one cluster's failure or slowness must only affect its
+// own slice of the data — the queries are fanned out per cluster.
 describe('getSlurmInfrastructure configured clusters', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    apiClient.post.mockImplementation(async (path) => {
-      if (path === '/slurm_cluster_names') return scheduled('req-clusters');
-      if (path === '/slurm_gpu_availability') return scheduled('req-gpus');
-      if (path === '/slurm_node_info') return scheduled('req-nodes');
-      throw new Error(`unexpected POST to ${path}`);
-    });
+    routePosts();
   });
 
-  it('reports a configured cluster whose node and GPU queries are empty', async () => {
+  it('reports a configured cluster whose node query is empty', async () => {
     apiClient.get.mockImplementation(async (path) => {
       if (path.includes('req-clusters')) return result(['offline-cluster']);
       return result([]);
@@ -54,38 +66,66 @@ describe('getSlurmInfrastructure configured clusters', () => {
     expect(data.perClusterSlurmGPUs).toEqual([]);
   });
 
-  it('does not hold the node and GPU queries behind the cluster list', async () => {
-    // Assertions stay in the test body: the connector catches everything a
-    // mock throws, so an assertion made inside one would be swallowed and the
-    // test would pass regardless.
-    let releaseClusters;
-    const clusterListPending = new Promise((resolve) => {
-      releaseClusters = resolve;
-    });
+  it('queries each configured cluster separately, node feed only', async () => {
     apiClient.get.mockImplementation(async (path) => {
-      if (path.includes('req-clusters')) {
-        await clusterListPending;
-        return result(['cluster-a']);
-      }
+      if (path.includes('req-clusters')) return result(['a', 'b']);
       return result([]);
     });
 
-    const pending = getSlurmInfrastructure();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await getSlurmInfrastructure();
 
-    // The cluster list is still in flight, yet the other two have already got
-    // past their own POST to fetching a result. Serializing them behind it
-    // would leave these uncalled.
-    const fetched = apiClient.get.mock.calls.map(([path]) => path);
-    expect(fetched).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('req-nodes'),
-        expect.stringContaining('req-gpus'),
-      ])
+    const clustersQueried = apiClient.post.mock.calls
+      .filter(([path]) => path === '/slurm_node_info')
+      .map(([, body]) => body.slurm_cluster_name)
+      .sort();
+    expect(clustersQueried).toEqual(['a', 'b']);
+    // The GPU columns derive from the node rows; the availability endpoint
+    // is not part of this page's fetch fan-out.
+    const availabilityCalls = apiClient.post.mock.calls.filter(
+      ([path]) => path === '/slurm_gpu_availability'
     );
+    expect(availabilityCalls).toEqual([]);
+  });
 
-    releaseClusters();
-    expect((await pending).slurmClusterNames).toEqual(['cluster-a']);
+  it("keeps one cluster's data when another cluster's query fails", async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-clusters')) return result(['good', 'bad']);
+      if (path.includes('-bad')) throw new Error('login node unreachable');
+      if (path.includes('req-nodes-good'))
+        return result([
+          {
+            node_name: 'n1',
+            slurm_cluster_name: 'good',
+            partition: 'p',
+            gpu_type: 'H100',
+            total_gpus: 8,
+            free_gpus: 4,
+            node_state: 'idle',
+          },
+        ]);
+      return result([]);
+    });
+
+    const data = await getSlurmInfrastructure();
+
+    // The unreachable cluster still gets a row from the configured names;
+    // its failed query just contributes empty slices.
+    expect(data.slurmClusterNames).toEqual(['good', 'bad']);
+    expect(data.perClusterSlurmGPUs).toHaveLength(1);
+    expect(data.perClusterSlurmGPUs[0]).toMatchObject({
+      cluster: 'good',
+      gpu_name: 'H100',
+      gpu_total: 8,
+      gpu_free: 4,
+    });
+    expect(data.perNodeSlurmGPUs).toHaveLength(1);
+    expect(data.perNodeSlurmGPUs[0]).toMatchObject({
+      cluster: 'good',
+      node_name: 'n1',
+    });
+    expect(data.allSlurmGPUs).toEqual([
+      { gpu_name: 'H100', gpu_total: 8, gpu_free: 4 },
+    ]);
   });
 
   it('falls back to an empty list when the cluster query fails', async () => {
@@ -97,5 +137,108 @@ describe('getSlurmInfrastructure configured clusters', () => {
     const data = await getSlurmInfrastructure();
 
     expect(data.slurmClusterNames).toEqual([]);
+  });
+});
+
+describe('getSlurmClusterInfrastructure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    routePosts();
+  });
+
+  it('derives the per-cluster GPU slice from the node rows', async () => {
+    apiClient.get.mockImplementation(async (path) => {
+      if (path.includes('req-nodes-cluster-a'))
+        return result([
+          {
+            node_name: 'gpu-node-1',
+            slurm_cluster_name: 'cluster-a',
+            partition: 'gpu',
+            gpu_type: 'H100',
+            total_gpus: 8,
+            free_gpus: 0,
+            node_state: 'alloc',
+          },
+          {
+            node_name: 'gpu-node-2',
+            slurm_cluster_name: 'cluster-a',
+            partition: 'gpu',
+            gpu_type: 'H100',
+            total_gpus: 8,
+            free_gpus: 4,
+            node_state: 'mix',
+          },
+        ]);
+      return result([]);
+    });
+
+    const data = await getSlurmClusterInfrastructure('cluster-a');
+
+    expect(data.cluster).toBe('cluster-a');
+    expect(data.perClusterGPUs).toEqual([
+      {
+        gpu_name: 'H100',
+        gpu_requestable_qty_per_node: '1, 2, 4, 8',
+        gpu_total: 16,
+        gpu_free: 4,
+        cluster: 'cluster-a',
+      },
+    ]);
+    expect(data.perNodeGPUs).toHaveLength(2);
+    expect(data.perNodeGPUs[0]).toMatchObject({
+      node_name: 'gpu-node-1',
+      cluster: 'cluster-a',
+      node_state: 'alloc',
+    });
+  });
+});
+
+// The per-type derivation itself: aggregates GPU-bearing node rows, skips
+// CPU-only rows, and advertises the same powers-of-2 requestable counts per
+// node shape the catalog does.
+describe('slurmClusterGPUsFromNodes', () => {
+  it('aggregates node rows into per-type cluster entries', () => {
+    const entries = slurmClusterGPUsFromNodes('cluster-x', [
+      { gpu_name: 'H100', gpu_total: 8, gpu_free: 8, cluster: 'cluster-x' },
+      { gpu_name: 'H100', gpu_total: 8, gpu_free: 2, cluster: 'cluster-x' },
+      { gpu_name: 'H200', gpu_total: 4, gpu_free: 4, cluster: 'cluster-x' },
+    ]);
+    expect(entries).toEqual([
+      {
+        gpu_name: 'H100',
+        gpu_total: 16,
+        gpu_free: 10,
+        cluster: 'cluster-x',
+        gpu_requestable_qty_per_node: '1, 2, 4, 8',
+      },
+      {
+        gpu_name: 'H200',
+        gpu_total: 4,
+        gpu_free: 4,
+        cluster: 'cluster-x',
+        gpu_requestable_qty_per_node: '1, 2, 4',
+      },
+    ]);
+  });
+
+  it('includes a non-power-of-2 node total as a requestable count', () => {
+    const entries = slurmClusterGPUsFromNodes('c', [
+      { gpu_name: 'L4', gpu_total: 6, gpu_free: 6, cluster: 'c' },
+    ]);
+    expect(entries[0].gpu_requestable_qty_per_node).toBe('1, 2, 4, 6');
+  });
+
+  it('skips CPU-only node rows', () => {
+    expect(
+      slurmClusterGPUsFromNodes('cpu-cluster', [
+        { gpu_name: '-', gpu_total: 0, gpu_free: 0, cluster: 'cpu-cluster' },
+        { gpu_name: null, gpu_total: 0, gpu_free: 0, cluster: 'cpu-cluster' },
+      ])
+    ).toEqual([]);
+  });
+
+  it('returns no entries for empty or missing node lists', () => {
+    expect(slurmClusterGPUsFromNodes('empty', [])).toEqual([]);
+    expect(slurmClusterGPUsFromNodes('empty', undefined)).toEqual([]);
   });
 });

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -4,6 +4,7 @@ import math
 import os
 import re
 import shlex
+import subprocess
 import time
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
@@ -1311,7 +1312,7 @@ def slurm_node_info(
         try:
             return _get_slurm_node_info_list(
                 slurm_cluster_name=slurm_cluster_name)
-        except (FileNotFoundError, RuntimeError,
+        except (FileNotFoundError, RuntimeError, subprocess.TimeoutExpired,
                 exceptions.NotSupportedError) as e:
             logger.debug(f'Could not retrieve Slurm node info: {e}')
             return []


### PR DESCRIPTION
## Motivation

One unreachable Slurm cluster should not block the Infra page. Today the Slurm section fetches every cluster through a single pair of aggregate requests (`/slurm_gpu_availability`, `/slurm_node_info`) whose per-cluster SSH invocations have no timeout, joins them behind `Promise.all`, and long-polls `/api/get` with no deadline. A login node that accepts the TCP connect but never answers (so SSH's `ConnectTimeout` / `ServerAlive` bounds never fire) therefore hangs the whole aggregate server-side, the `/api/get` long-poll never returns, and the section shows "Loading Slurm..." forever — the 30s auto-refresh dedupes onto the same hung promise via the dashboard cache, so it never retries, and every page reload leaks another pair of never-finishing executor requests. Meanwhile the healthy clusters' data, already collected, is held hostage by the join.

The section's GPU Type / GPUs / Utilization columns also came from a different feed than the partition breakdown right under them: the cluster-level cells read `/slurm_gpu_availability` while the partition rows are built from `/slurm_node_info`. Server-side the availability numbers are computed by iterating the same node info and summing the same fields (`sky/catalog/slurm_catalog.py`), but the two requests fail independently — availability is additionally gated on the cached enabled-clouds check — so a cluster could show dashes in its cluster-level GPU cells while its partition rows rendered real numbers, and every render cost a second scheduled request (and a second SSH invocation of the login node) per cluster.

## Changes

**Backend (`sky/adaptors/slurm.py`, `sky/provision/slurm/utils.py`)**

- `SlurmClient.get_node_inventory()` / `get_inventory_snapshot()` now pass a 60s wall-clock timeout to the batched SSH invocation (the plumbing already existed and kills the SSH process on expiry). A dead cluster degrades to an empty per-cluster result instead of hanging `slurm_node_info` / `slurm_gpu_availability` forever and leaking their executor workers.
- The single-cluster path of `slurm_node_info` treats `subprocess.TimeoutExpired` like the other per-cluster failures (returns `[]`).

**Frontend (`sky/dashboard/src/...`)**

- `connectors/infra.jsx`: `getSlurmPerNodeGPUs` accepts an optional cluster name (the endpoint already supports `slurm_cluster_name`) and bounds its `/api/get` long-poll with an `AbortController` deadline (120s) so a hung request can no longer pin the promise — and the cache's in-flight dedup — forever. New `getSlurmClusterInfrastructure(cluster)` fetches one cluster's node info and derives its per-type GPU entries from the node rows (`slurmClusterGPUsFromNodes` — the same totals and powers-of-2 requestable counts the availability endpoint derives from the same node data server-side). The Infra page no longer calls `/slurm_gpu_availability` at all: one request per cluster instead of two, and the cluster cells, the summary strip, and the partition breakdown are consistent by construction because they read one source. `getSlurmInfrastructure()` keeps its return shape but now settles per cluster, so a failed cluster contributes empty slices instead of hiding every other cluster's data.
- `components/infra.jsx`: the Slurm section renders its rows from the configured cluster names immediately (they are answered without contacting any login node) and fills each row in as its own query settles, with skeleton cells while loading — the same progressive per-context pattern the Kubernetes section already uses (`loadedContexts`). `slurmLoading` clears when the names arrive instead of after the slowest cluster.
- `connectors/client.js`: `apiClient.get` forwards an optional `signal`, matching `post` / `fetchImmediate`.

## Before / after

Before: one dead cluster ⇒ the whole Slurm section spins "Loading Slurm..." indefinitely; healthy clusters render nothing; refresh never recovers without a tab reload. Separately, an empty availability response ⇒ the cluster row shows dashes in GPU Type / GPUs / Utilization while its expanded partition rows show the real numbers.

After: every configured cluster gets a row immediately; each row's cells shimmer until its own query settles (healthy clusters in seconds); a dead cluster settles to empty cells after the 60s server-side bound (120s worst-case client deadline) and the rest of the page is unaffected. The cluster-level GPU cells always agree with the partition rows because both derive from the node feed.

## Testing

- `cd sky/dashboard && npx jest` — 19 suites / 206 tests passed (connector tests rewritten for the node-only per-cluster contract, including an assertion that the page never POSTs `/slurm_gpu_availability`; new unit tests for `slurmClusterGPUsFromNodes`).
- `cd sky/dashboard && npm run build` — full `next build` succeeds.
- `pytest tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py` — pass.
- Exercised against a local api server with a fixture-backed Slurm backend (four configured clusters: three healthy, one dead login node that hangs mid-SSH): the three healthy rows render node counts, GPU types, totals, and utilization within seconds while the dead cluster's row shows skeleton cells; previously the whole section spun indefinitely. Verified the GPU columns render real values with the availability endpoint returning nothing at all.
- `prettier --check` clean on all touched dashboard files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRE6WbKydERcgKRTdtX6d9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->