### PR TITLE
[Slurm] Apply workspace config to sbatch options

### DIFF
--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -574,14 +574,15 @@ class Slurm(clouds.Cloud):
         # Read sbatch_options with three-level merge:
         # global < cluster < partition.
         sbatch_options: Dict[str, Any] = {}
+        slurm_config = skypilot_config.get_workspace_cloud('slurm')
         for config_keys in [
-            ('slurm', 'sbatch_options'),
-            ('slurm', 'cluster_configs', cluster, 'sbatch_options'),
-            ('slurm', 'cluster_configs', cluster, 'partition_configs',
-             partition, 'sbatch_options'),
+            ('sbatch_options',),
+            ('cluster_configs', cluster, 'sbatch_options'),
+            ('cluster_configs', cluster, 'partition_configs', partition,
+             'sbatch_options'),
         ]:
-            level_config = skypilot_config.get_nested(config_keys,
-                                                      default_value=None)
+            level_config = slurm_config.get_nested(config_keys,
+                                                   default_value=None)
             if level_config is not None:
                 sbatch_options.update(level_config)
         # Merge task-level config overrides (from `config:` in task YAML).

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2594,11 +2594,11 @@ def get_config_schema():
 
     allowed_workspace_cloud_names = list(
         constants.ALL_CLOUDS) + constants.STORAGE_ONLY_CLOUDS
-    # Create pattern for not supported clouds, i.e.
-    # all clouds except aws, gcp, kubernetes, ssh, nebius
+    # Create pattern for not supported clouds, i.e. all clouds except aws,
+    # gcp, kubernetes, ssh, nebius, slurm.
     not_supported_clouds = [
-        cloud for cloud in allowed_workspace_cloud_names
-        if cloud.lower() not in ['aws', 'gcp', 'kubernetes', 'ssh', 'nebius']
+        cloud for cloud in allowed_workspace_cloud_names if cloud.lower() not in
+        ['aws', 'gcp', 'kubernetes', 'ssh', 'nebius', 'slurm']
     ]
     not_supported_cloud_regex = '|'.join(not_supported_clouds)
     workspaces_schema = {
@@ -2794,6 +2794,15 @@ def get_config_schema():
                     # unknown properties to pass through for
                     # server-side validation.
                     'additionalProperties': _allow_additional_properties(),
+                },
+                'slurm': {
+                    **cloud_configs['slurm'],
+                    'properties': {
+                        **cloud_configs['slurm']['properties'],
+                        'disabled': {
+                            'type': 'boolean'
+                        },
+                    },
                 },
                 'nebius': {
                     'type': 'object',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2601,6 +2601,8 @@ def get_config_schema():
         ['aws', 'gcp', 'kubernetes', 'ssh', 'nebius', 'slurm']
     ]
     not_supported_cloud_regex = '|'.join(not_supported_clouds)
+    slurm_allowed_clusters_schema = cloud_configs['slurm']['properties'][
+        'allowed_clusters']
     workspaces_schema = {
         'type': 'object',
         'required': [],
@@ -2796,11 +2798,40 @@ def get_config_schema():
                     'additionalProperties': _allow_additional_properties(),
                 },
                 'slurm': {
-                    **cloud_configs['slurm'],
+                    'type': 'object',
+                    'required': [],
+                    'additionalProperties': False,
                     'properties': {
-                        **cloud_configs['slurm']['properties'],
                         'disabled': {
                             'type': 'boolean'
+                        },
+                        'allowed_clusters': slurm_allowed_clusters_schema,
+                        'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                        'cluster_configs': {
+                            'type': 'object',
+                            'required': [],
+                            'properties': {},
+                            'additionalProperties': {
+                                'type': 'object',
+                                'required': [],
+                                'additionalProperties': False,
+                                'properties': {
+                                    'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                                    'partition_configs': {
+                                        'type': 'object',
+                                        'required': [],
+                                        'properties': {},
+                                        'additionalProperties': {
+                                            'type': 'object',
+                                            'required': [],
+                                            'additionalProperties': False,
+                                            'properties': {
+                                                'sbatch_options': _SBATCH_OPTIONS_SCHEMA,  # pylint: disable=line-too-long
+                                            },
+                                        },
+                                    },
+                                },
+                            },
                         },
                     },
                 },

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -9,6 +9,7 @@ import unittest.mock as mock
 import pytest
 
 from sky import resources as resources_lib
+from sky import skypilot_config
 from sky.adaptors import slurm
 from sky.clouds import slurm as slurm_cloud
 from sky.provision.slurm import instance as slurm_instance
@@ -961,7 +962,6 @@ class TestSbatchOptionsPrecedence:
                                             skypilot_config_dict,
                                             cluster_config_overrides=None):
         """Write config to tmp file, reload, and call make_deploy_resources_variables."""
-        from sky import skypilot_config
         from sky.utils import yaml_utils
 
         # Write config dict to a tmp YAML file.
@@ -1059,34 +1059,34 @@ class TestSbatchOptionsPrecedence:
         }
 
     def test_workspace_cluster_overrides_global(self, tmp_path):
-        result = self._load_config_and_get_sbatch_options(
-            tmp_path, {
-                'active_workspace': 'research',
-                'slurm': {
-                    'cluster_configs': {
-                        'mycluster': {
-                            'sbatch_options': {
-                                'account': 'global-account',
-                                'constraint': 'skylake',
+        with skypilot_config.local_active_workspace_ctx('research'):
+            result = self._load_config_and_get_sbatch_options(
+                tmp_path, {
+                    'slurm': {
+                        'cluster_configs': {
+                            'mycluster': {
+                                'sbatch_options': {
+                                    'account': 'global-account',
+                                    'constraint': 'skylake',
+                                },
                             },
                         },
                     },
-                },
-                'workspaces': {
-                    'research': {
-                        'slurm': {
-                            'cluster_configs': {
-                                'mycluster': {
-                                    'sbatch_options': {
-                                        'account': 'workspace-account',
-                                        'qos': 'workspace-qos',
+                    'workspaces': {
+                        'research': {
+                            'slurm': {
+                                'cluster_configs': {
+                                    'mycluster': {
+                                        'sbatch_options': {
+                                            'account': 'workspace-account',
+                                            'qos': 'workspace-qos',
+                                        },
                                     },
                                 },
                             },
                         },
                     },
-                },
-            })
+                })
         assert result == {
             'account': 'workspace-account',
             'qos': 'workspace-qos',

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1058,6 +1058,41 @@ class TestSbatchOptionsPrecedence:
             'constraint': 'skylake',
         }
 
+    def test_workspace_cluster_overrides_global(self, tmp_path):
+        result = self._load_config_and_get_sbatch_options(
+            tmp_path, {
+                'active_workspace': 'research',
+                'slurm': {
+                    'cluster_configs': {
+                        'mycluster': {
+                            'sbatch_options': {
+                                'account': 'global-account',
+                                'constraint': 'skylake',
+                            },
+                        },
+                    },
+                },
+                'workspaces': {
+                    'research': {
+                        'slurm': {
+                            'cluster_configs': {
+                                'mycluster': {
+                                    'sbatch_options': {
+                                        'account': 'workspace-account',
+                                        'qos': 'workspace-qos',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+        assert result == {
+            'account': 'workspace-account',
+            'qos': 'workspace-qos',
+            'constraint': 'skylake',
+        }
+
     def test_partition_overrides_cluster_and_global(self, tmp_path):
         """Level 3 overrides levels 1 and 2 for same key."""
         result = self._load_config_and_get_sbatch_options(

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -606,6 +606,80 @@ class TestWorkspaceSchema(unittest.TestCase):
                 jsonschema.validate(instance=config,
                                     schema=self.workspaces_schema)
 
+    def test_workspace_slurm_sbatch_options(self):
+        config = {
+            'my-workspace': {
+                'slurm': {
+                    'disabled': False,
+                    'allowed_clusters': ['my-cluster'],
+                    'sbatch_options': {
+                        'account': 'workspace-account',
+                    },
+                    'cluster_configs': {
+                        'my-cluster': {
+                            'sbatch_options': {
+                                'qos': 'workspace-qos',
+                            },
+                            'partition_configs': {
+                                'gpu': {
+                                    'sbatch_options': {
+                                        'constraint': 'h100',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.validate(instance=config, schema=self.workspaces_schema)
+
+    def test_workspace_slurm_rejects_global_only_properties(self):
+        invalid_configs = [
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'provision_timeout': 600,
+                    },
+                },
+            },
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'cluster_configs': {
+                            'my-cluster': {
+                                'workdir': '/shared/workspace',
+                            },
+                        },
+                    },
+                },
+            },
+            {
+                'my-workspace': {
+                    'slurm': {
+                        'cluster_configs': {
+                            'my-cluster': {
+                                'partition_configs': {
+                                    'gpu': {
+                                        'pricing': {
+                                            'on_demand': 1.0,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+        for config in invalid_configs:
+            with self.assertRaises(
+                    jsonschema.exceptions.ValidationError,
+                    msg=f'Unsupported workspace Slurm config {config!r} '
+                    'should be rejected'):
+                jsonschema.validate(instance=config,
+                                    schema=self.workspaces_schema)
+
 
 class TestKubernetesSchema(unittest.TestCase):
     """Tests for the kubernetes schema in schemas.py."""


### PR DESCRIPTION
## Summary

- allow Slurm configuration under workspaces
- resolve Slurm `sbatch_options` from the active workspace
- add regression coverage for workspace/global precedence

## Why this broke

Launch requests activate their selected workspace, but
`Slurm.make_deploy_resources_variables()` read `sbatch_options` directly from
the global `slurm` configuration. This bypassed the workspace merge, so fields
such as `account` and `qos` configured on a workspace never reached `sbatch`.

The workspace schema also classified Slurm as unsupported, rejecting
workspace-level `slurm.cluster_configs` before launch.

This change allows Slurm workspace configuration and reads the active
workspace's merged Slurm config. The existing global → cluster → partition
precedence remains intact, with task-level overrides still applied last.

## Test plan

- `python -m pytest -n0 tests/unit_tests/test_sky/clouds/test_slurm.py::TestSbatchOptionsPrecedence tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py::TestSbatchConfigSchema` (`16 passed`)
- `bash format.sh --files sky/clouds/slurm.py sky/utils/schemas.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->