### PR TITLE
[AWS] Have tag volumes be an enabled feature

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -802,6 +802,8 @@ Apply to all new instances but not existing ones.
 ~~~~~~~~~~~~~~~
 
 Tags to assign to all instances and buckets created by SkyPilot (optional).
+If :ref:`aws.tag_volumes <config-yaml-aws-tag-volumes>` is enabled, these tags
+are also applied to AWS EBS volumes managed by SkyPilot.
 
 Example use case: cost tracking by user/team/project.
 
@@ -827,6 +829,38 @@ Example:
       Owner: user-unique-name
       # Other examples:
       my-tag: my-value
+
+
+.. _config-yaml-aws-tag-volumes:
+
+``aws.tag_volumes``
+~~~~~~~~~~~~~~~~~~~
+
+Whether to propagate ``aws.labels`` to AWS EBS volumes created or resumed by
+SkyPilot.
+
+This is disabled by default for backward compatibility and to avoid requiring
+additional AWS IAM permissions in existing setups. When enabled, SkyPilot will:
+
+- include your configured labels in launch-time EBS volume tags
+- attempt to re-apply those labels to attached EBS volumes when resuming stopped
+  instances
+
+If volume tagging is not permitted by IAM during resume, SkyPilot will warn and
+continue. During initial launch, AWS may still reject the launch if tag
+permissions are insufficient.
+
+Default: ``false``.
+
+Example:
+
+.. code-block:: yaml
+
+  aws:
+    labels:
+      Owner: user-unique-name
+      Service: skypilot
+    tag_volumes: true
 
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1015,6 +1015,12 @@ def write_cluster_config(
     if to_provision.labels:
         labels.update(to_provision.labels)
 
+    tag_volumes = skypilot_config.get_effective_region_config(
+        cloud=str(cloud).lower(),
+        region=region.name,
+        keys=('tag_volumes',),
+        default_value=False)
+
     install_conda = skypilot_config.get_nested(('provision', 'install_conda'),
                                                False)
 
@@ -1233,6 +1239,7 @@ def write_cluster_config(
                 override_configs=to_provision.cluster_config_overrides),
             # User-supplied labels.
             'labels': labels,
+            'tag_volumes': tag_volumes,
             # User-supplied remote_identity
             'remote_identity': remote_identity,
             # The reservation pools that specified by the user. This is

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -13,6 +13,7 @@ import typing
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
 
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import aws
 from sky.clouds import aws as aws_cloud
 from sky.clouds.utils import aws_utils
@@ -347,6 +348,8 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
     resumed_instance_ids: List[str] = []
     created_instance_ids: List[str] = []
     max_efa_interfaces = config.provider_config.get('max_efa_interfaces', 0)
+    tag_volumes = skypilot_config.get_effective_region_config(
+        cloud='aws', region=region, keys=('tag_volumes',), default_value=False)
 
     # sort tags by key to support deterministic unit test stubbing
     tags = dict(sorted(copy.deepcopy(config.tags).items()))
@@ -493,7 +496,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
             ec2.meta.client.create_tags(Resources=resumed_instance_ids,
                                         Tags=_format_tags(tags))
             resumed_volume_ids = _get_attached_volume_ids(resumed_instances)
-            if resumed_volume_ids:
+            if tag_volumes and resumed_volume_ids:
                 try:
                     ec2.meta.client.create_tags(Resources=resumed_volume_ids,
                                                 Tags=_format_tags(tags))

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -151,6 +151,7 @@ available_node_types:
             - Key: {{ label_key }}
               Value: {{ label_value|tojson }}
             {%- endfor %}
+        {%- if tag_volumes %}
         - ResourceType: volume
           Tags:
             - Key: skypilot-user
@@ -159,6 +160,7 @@ available_node_types:
             - Key: {{ label_key }}
               Value: {{ label_value|tojson }}
             {%- endfor %}
+        {%- endif %}
       # Use IDMSv2
       MetadataOptions:
         HttpTokens: required

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1942,6 +1942,9 @@ def get_config_schema():
                 'disk_encrypted': {
                     'type': 'boolean',
                 },
+                'tag_volumes': {
+                    'type': 'boolean',
+                },
                 'ssh_user': {
                     'type': 'string',
                 },

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -17,6 +17,7 @@ from sky.provision import common as provision_common
 from sky.provision import constants as provision_constants
 from sky.provision.aws import config
 from sky.provision.aws import instance as aws_instance
+from sky.utils import auth_utils
 from sky.utils import common_utils
 from sky.utils import config_utils
 
@@ -179,7 +180,10 @@ def test_run_instances_tags_resumed_instance_volumes():
                       return_value=mock_ec2), patch.object(
                           aws_instance.aws,
                           'resource',
-                          return_value=mock_ec2_fail_fast):
+                          return_value=mock_ec2_fail_fast), patch.object(
+                              aws_instance.skypilot_config,
+                              'get_effective_region_config',
+                              return_value=True):
         record = aws_instance.run_instances(region='us-east-1',
                                             cluster_name='cluster',
                                             cluster_name_on_cloud='cluster',
@@ -261,7 +265,10 @@ def test_run_instances_volume_tag_failure_does_not_abort_resume(mock_logger):
                       return_value=mock_ec2), patch.object(
                           aws_instance.aws,
                           'resource',
-                          return_value=mock_ec2_fail_fast):
+                          return_value=mock_ec2_fail_fast), patch.object(
+                              aws_instance.skypilot_config,
+                              'get_effective_region_config',
+                              return_value=True):
         record = aws_instance.run_instances(region='us-east-1',
                                             cluster_name='cluster',
                                             cluster_name_on_cloud='cluster',
@@ -655,6 +662,46 @@ def test_ssm_default(monkeypatch):
     monkeypatch.setattr(common_utils, 'fill_template',
                         fill_template_side_effect)
     with pytest.raises(RuntimeError) as e:
+        backend_utils.write_cluster_config(
+            to_provision=resources.Resources(cloud=AWS(),
+                                             instance_type='c2.xlarge'),
+            num_nodes=1,
+            cluster_config_template='aws-ray.yml.j2',
+            cluster_name='fake-cluster',
+            local_wheel_path=pathlib.Path('fake-wheel-path'),
+            wheel_hash='fake-wheel-hash',
+            region=Region(name='fake-region'),
+            zones=[Zone(name='fake-zone')])
+
+
+def test_aws_tag_volumes_passed_to_cluster_template(monkeypatch):
+    monkeypatch.setattr(common_utils, 'make_cluster_name_on_cloud',
+                        lambda *args, **kwargs: args[0])
+    tmp_yaml_path = '/tmp/fake-yaml-path'
+    monkeypatch.setattr(backend_utils, '_get_yaml_path_from_cluster_name',
+                        lambda *args, **kwargs: tmp_yaml_path)
+    monkeypatch.setattr(
+        auth_utils, 'get_or_generate_keys', lambda *args, **kwargs:
+        ('/tmp/fake-key', '/tmp/fake-key.pub'))
+    monkeypatch.setattr(resources.Resources, 'make_deploy_variables',
+                        lambda *args, **kwargs: {'region': 'us-east-1'})
+    monkeypatch.setattr(logs, 'get_logging_agent', lambda *args, **kwargs: None)
+    config_dict = config_utils.Config.from_dict({
+        'aws': {
+            'tag_volumes': True,
+        },
+    })
+    monkeypatch.setattr(skypilot_config, '_get_loaded_config',
+                        lambda *args, **kwargs: config_dict)
+
+    def fill_template_side_effect(*args, **kwargs):
+        template_vars = args[1]
+        assert template_vars['tag_volumes'] is True
+        raise RuntimeError('fake-error')
+
+    monkeypatch.setattr(common_utils, 'fill_template',
+                        fill_template_side_effect)
+    with pytest.raises(RuntimeError):
         backend_utils.write_cluster_config(
             to_provision=resources.Resources(cloud=AWS(),
                                              instance_type='c2.xlarge'),

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -220,14 +220,16 @@ def test_aws_template_applies_labels_to_volume_tags() -> None:
     template_path = pathlib.Path('sky/templates/aws-ray.yml.j2')
     template = template_path.read_text(encoding='utf-8')
 
-    expected_block = """        - ResourceType: volume
+    expected_block = """        {%- if tag_volumes %}
+        - ResourceType: volume
           Tags:
             - Key: skypilot-user
               Value: {{ user }}
             {%- for label_key, label_value in labels.items() %}
             - Key: {{ label_key }}
               Value: {{ label_value|tojson }}
-            {%- endfor %}"""
+            {%- endfor %}
+        {%- endif %}"""
 
     assert expected_block in template
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
