### PR TITLE
[Kubernetes] Don't abandon port cleanup when one service is already gone

### DIFF
--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -1,6 +1,7 @@
 """Kubernetes network provisioning."""
 from typing import Any, Dict, List, Optional
 
+from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import kubernetes
 from sky.provision import common
@@ -198,11 +199,20 @@ def _cleanup_ports_for_ingress(
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
     for port in ports:
         service_name = f'{cluster_name_on_cloud}--skypilot-svc--{port}'
-        network_utils.delete_namespaced_service(
-            context=context,
-            namespace=namespace,
-            service_name=service_name,
-        )
+        try:
+            network_utils.delete_namespaced_service(
+                context=context,
+                namespace=namespace,
+                service_name=service_name,
+            )
+        except exceptions.PortDoesNotExistError:
+            # The service is already gone. Keep going: the remaining port
+            # services and the shared ingress below still have to be
+            # deleted, and the caller treats this error as a completed
+            # cleanup, so aborting here leaks them silently.
+            logger.warning(
+                f'cleanup_ports: Tried to delete service {service_name}, '
+                'but the service was not found (404).')
 
     # Delete the single ingress used for all ports
     ingress_name = f'{cluster_name_on_cloud}-skypilot-ingress'

--- a/tests/unit_tests/kubernetes/test_network.py
+++ b/tests/unit_tests/kubernetes/test_network.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from sky import exceptions
 from sky.provision.kubernetes import network
 
 
@@ -120,3 +123,88 @@ class TestOpenPortsUsingIngress:
             assert 'team-b' in url_path, (
                 f'Every port URL path must use the resolved namespace, '
                 f'got: {url_path!r}')
+
+
+class TestCleanupPortsUsingIngress:
+    """Tests for `_cleanup_ports_for_ingress`."""
+
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.delete_namespaced_ingress')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.delete_namespaced_service')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_namespace_from_config')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_already_deleted_service_does_not_strand_the_rest(
+            self, mock_get_context, mock_get_ns_from_config,
+            mock_delete_service, mock_delete_ingress):
+        """One already-deleted service must not abort the whole cleanup.
+
+        Regression: `network_utils.delete_namespaced_service` turns a 404
+        into `PortDoesNotExistError`, so a single port service that was
+        already gone raised out of the loop. The remaining port services
+        and the shared ingress were then never deleted. The caller in
+        `cloud_vm_ray_backend` catches that error, logs at debug level and
+        marks ports as cleaned up, so those resources leak silently.
+        """
+        provider_config = {'context': 'ctx', 'namespace': 'ns'}
+        mock_get_context.return_value = 'ctx'
+        mock_get_ns_from_config.return_value = 'ns'
+
+        def _delete(context, namespace, service_name):
+            del context, namespace  # Unused.
+            if service_name.endswith('--8080'):
+                raise exceptions.PortDoesNotExistError(
+                    'Port 8080 does not exist.')
+
+        mock_delete_service.side_effect = _delete
+
+        network._cleanup_ports_for_ingress(  # pylint: disable=protected-access
+            cluster_name_on_cloud='cluster0',
+            ports=[8080, 8081, 8082],
+            provider_config=provider_config,
+        )
+
+        attempted = [
+            call.kwargs['service_name']
+            for call in mock_delete_service.call_args_list
+        ]
+        assert attempted == [
+            'cluster0--skypilot-svc--8080',
+            'cluster0--skypilot-svc--8081',
+            'cluster0--skypilot-svc--8082',
+        ], ('Every port service must still be attempted after an earlier one '
+            f'is found already deleted, got: {attempted}')
+        mock_delete_ingress.assert_called_once()
+
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.delete_namespaced_ingress')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.delete_namespaced_service')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_namespace_from_config')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_genuine_service_delete_failure_still_propagates(
+            self, mock_get_context, mock_get_ns_from_config,
+            mock_delete_service, mock_delete_ingress):
+        """Only "already gone" is tolerated; real failures must surface.
+
+        Tolerating every exception would hide a service that still exists
+        but could not be deleted (RBAC, API server outage), which is the
+        case teardown must not silently report as cleaned up.
+        """
+        provider_config = {'context': 'ctx', 'namespace': 'ns'}
+        mock_get_context.return_value = 'ctx'
+        mock_get_ns_from_config.return_value = 'ns'
+        mock_delete_service.side_effect = RuntimeError('api server is down')
+
+        with pytest.raises(RuntimeError, match='api server is down'):
+            network._cleanup_ports_for_ingress(  # pylint: disable=protected-access
+                cluster_name_on_cloud='cluster0',
+                ports=[8080, 8081],
+                provider_config=provider_config,
+            )
+
+        mock_delete_ingress.assert_not_called()


### PR DESCRIPTION
Fixes #10641

In Ingress port mode, `cleanup_ports` deletes one Service per opened port and
then the single shared Ingress. `network_utils.delete_namespaced_service()`
turns a 404 into `PortDoesNotExistError`, and that call was unguarded inside
the loop, so one already-deleted Service ended the whole cleanup.

**Before:** tearing down a cluster whose port Services are not all present
leaves the remaining Services and the shared Ingress behind in the namespace.
Nothing is printed at default verbosity. `sky down` reports success.

**After:** the missing Service is logged and cleanup continues, so the
remaining Services and the Ingress are deleted as intended. A Service that
exists but genuinely cannot be deleted still raises, unchanged.

**Why:** `_cleanup_ports_for_ingress()` called `delete_namespaced_service()`
directly in the `for port in ports` loop. A 404 on any port raised out of the
loop, so every later port's Service and the `<cluster>-skypilot-ingress`
Ingress below the loop were never attempted.

The leak is silent because of how the caller handles the error. In
`cloud_vm_ray_backend._post_teardown_cleanup()`:

```python
except exceptions.PortDoesNotExistError:
    logger.debug('Ports do not exist. Skipping cleanup.')
    ports_cleaned_up = True
```

It logs at debug level and marks ports as cleaned up, so teardown carries on
and completes normally. The cluster record is removed in the same pass, so
nothing in SkyPilot revisits those objects afterwards and the leftover Services
and Ingress have to be deleted by hand with `kubectl`.

Reaching this needs only a partial set of port Services, for example a launch
that failed after opening some ports, an earlier teardown interrupted midway,
or a Service removed outside SkyPilot.

**How:** wrap the per-port delete in `try/except exceptions.PortDoesNotExistError`,
log a warning, and continue. The warning wording follows
`kubernetes_utils.delete_k8s_resource_with_retry()`, which already treats a 404
on delete as "already gone" and warns.

Deliberately left alone, to keep the change to the path that actually leaks:

- `_cleanup_ports_for_loadbalancer()` deletes a single Service and nothing
  follows it, so a 404 there strands nothing.
- The Ingress delete after the loop is the last operation, so a 404 there also
  strands nothing.
- The `network_utils` helpers keep their 404 to `PortDoesNotExistError`
  contract. Making them swallow 404 instead would be a reasonable alternative
  and would cover both modes at once, but it changes a shared contract and
  leaves `PortDoesNotExistError` with no remaining raiser. Happy to switch to
  that if you prefer it.

Test Plan
---------

New regression tests in `tests/unit_tests/kubernetes/test_network.py`, in the
mock style of the existing `TestOpenPortsUsingIngress` in the same file:

- `test_already_deleted_service_does_not_strand_the_rest` opens three ports,
  makes the first Service delete raise `PortDoesNotExistError`, and asserts all
  three Services are still attempted and the Ingress delete still runs.
- `test_genuine_service_delete_failure_still_propagates` asserts a non-404
  failure is not swallowed, so teardown cannot report a real failure as done.

Reproduction before the fix, with the tests in place and the fix reverted:

```
$ pytest tests/unit_tests/kubernetes/test_network.py -q
1 failed, 3 passed

sky/provision/kubernetes/network.py:201: in _cleanup_ports_for_ingress
    network_utils.delete_namespaced_service(
E   sky.exceptions.PortDoesNotExistError: Port 8080 does not exist.
```

After the fix:

```
$ pytest tests/unit_tests/kubernetes/test_network.py -q
4 passed

$ pytest tests/unit_tests/kubernetes/ -q
592 passed
```

Lint and format, using the tool versions pinned in `requirements-dev.txt`:

```
$ bash format.sh --files sky/provision/kubernetes/network.py \
      tests/unit_tests/kubernetes/test_network.py
SkyPilot yapf: Done
SkyPilot isort: Skipped 17 files
SkyPilot mypy: Success: no issues found in 597 source files
Sky Pylint: rated at 9.61/10
```

The pylint score comes only from warnings that already exist in
`test_network.py` on master (three `unused-argument` per existing test plus one
`line-too-long`, shifted by the two imports this PR adds). Running pylint on the
same file at `upstream/master` reports the identical seven. No new warning comes
from this change, and `format.sh` without `--files` lints only `sky/` and
`examples/`, where this PR scores clean:

```
$ pylint --load-plugins pylint_quotes sky/provision/kubernetes/network.py
Your code has been rated at 10.00/10
```

Not run locally: this path needs a cluster with an ingress controller, which I
do not have. The change is control flow inside SkyPilot rather than Kubernetes
behavior, so the unit tests cover it, but `/smoke-test` on a real Kubernetes
cluster would be worth a run.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI)
- [ ] Backward compatibility: `/quicktest-core` (CI)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->