### PR TITLE
[Dashboard] Build the app tree once, after plugin registration settles

### DIFF
--- a/sky/dashboard/src/components/elements/layout.jsx
+++ b/sky/dashboard/src/components/elements/layout.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { TopBar, SidebarProvider } from './sidebar';
 import { useMobile } from '@/hooks/useMobile';
 import { WelcomeNotification } from './WelcomeNotification';
@@ -10,10 +10,6 @@ import {
 } from '@/hooks/useUpgradeDetection';
 import { installUpgradeInterceptor } from '@/utils/apiInterceptor';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import {
-  EVENT_NAVIGATION_READY,
-  EVENT_PLUGINS_LOADED,
-} from '@/data/connectors/constants';
 
 function DefaultNavbarLayout({ children }) {
   return (
@@ -34,55 +30,18 @@ function DefaultNavbarLayout({ children }) {
   );
 }
 
-// Once plugins have settled in any LayoutContent instance, remember it on the
-// window so a remount (e.g. when a plugin registers an app-level wrapper into
-// PluginWrapperSlot, restructuring the tree) skips the gate immediately
-// instead of flashing bg-gray-50 for another settle cycle.
-const PLUGINS_SETTLED_FLAG = '__skydashboardPluginsSettled';
-
+// This component is only rendered once plugin registration has settled — see
+// the gate in _app.js. That is what keeps the PluginSlot below from first
+// rendering its fallback and then swapping in a navigation plugin's component,
+// which would remount everything under it.
 function LayoutContent({ children, highlighted }) {
   const isMobile = useMobile();
   const { reportUpgrade, clearUpgrade } = useUpgradeDetection();
-  const [pluginsSettled, setPluginsSettled] = useState(
-    () => typeof window !== 'undefined' && window[PLUGINS_SETTLED_FLAG] === true
-  );
 
   // Install the fetch interceptor on mount
   useEffect(() => {
     installUpgradeInterceptor(reportUpgrade, clearUpgrade);
   }, [reportUpgrade, clearUpgrade]);
-
-  // Wait for navigation plugins to register before showing layout.
-  // A navigation plugin (e.g. sidebar) dispatches 'skydashboard:navigation-ready'
-  // to cut the wait short. Otherwise we wait until all plugin scripts have
-  // finished loading ('skydashboard:plugins-loaded') so the sidebar plugin has
-  // a chance to register before falling back to the default top bar.
-  // A safety timeout prevents blocking indefinitely if plugin loading hangs.
-  useEffect(() => {
-    if (pluginsSettled) return undefined;
-    const settle = () => {
-      if (typeof window !== 'undefined') {
-        window[PLUGINS_SETTLED_FLAG] = true;
-      }
-      setPluginsSettled(true);
-    };
-    const timer = setTimeout(settle, 1000);
-    const handler = () => {
-      clearTimeout(timer);
-      settle();
-    };
-    window.addEventListener(EVENT_NAVIGATION_READY, handler, { once: true });
-    window.addEventListener(EVENT_PLUGINS_LOADED, handler, { once: true });
-    return () => {
-      clearTimeout(timer);
-      window.removeEventListener(EVENT_NAVIGATION_READY, handler);
-      window.removeEventListener(EVENT_PLUGINS_LOADED, handler);
-    };
-  }, [pluginsSettled]);
-
-  if (!pluginsSettled) {
-    return <div className="min-h-screen bg-gray-50" />;
-  }
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -73,9 +73,11 @@ export const VERSION_HEADER = 'X-SkyPilot-Version';
 // identifying placeholder that the server parses but doesn't depend on
 // for correctness (only used to format upgrade-hint messages).
 export const CLIENT_VERSION = 'dashboard;';
-// Custom events used to coordinate plugin loading with the layout shell.
-// layout.jsx listens for these to avoid flashing the fallback top bar before
-// a navigation plugin (e.g. sidebar) has had a chance to register.
+// Custom events used to coordinate plugin loading with the app shell.
+// _app.js waits for EVENT_PLUGINS_LOADED before building the tree, so that
+// slots plugins register into are already populated on first render.
+// EVENT_NAVIGATION_READY is dispatched by a navigation plugin once it has
+// registered; it is kept for plugins that want to observe that point.
 export const EVENT_NAVIGATION_READY = 'skydashboard:navigation-ready';
 export const EVENT_PLUGINS_LOADED = 'skydashboard:plugins-loaded';
 

--- a/sky/dashboard/src/pages/_app.js
+++ b/sky/dashboard/src/pages/_app.js
@@ -8,8 +8,8 @@ import { CacheProvider } from '@emotion/react';
 import dynamic from 'next/dynamic';
 import PropTypes from 'prop-types';
 import '@/app/globals.css';
-import { useEffect } from 'react';
-import { BASE_PATH } from '@/data/connectors/constants';
+import { useEffect, useState } from 'react';
+import { BASE_PATH, EVENT_PLUGINS_LOADED } from '@/data/connectors/constants';
 import { TourProvider } from '@/hooks/useTour';
 import { PluginProvider } from '@/plugins/PluginProvider';
 import { VersionProvider } from '@/components/elements/version-display';
@@ -34,7 +34,56 @@ if (typeof window !== 'undefined') {
 const nonce = getNonce();
 const emotionCache = createCache({ key: 'css', nonce: nonce || undefined });
 
+// Plugin bundles are fetched and registered asynchronously after the app
+// mounts, and two of the slots they register into change the *shape* of the
+// tree rather than just its contents: PluginWrapperSlot('app.providers')
+// inserts a provider level around everything below it, and
+// PluginSlot('layout.navigation') swaps its fallback element for the
+// registered one. React cannot reconcile a changed element type in place, so
+// each of those transitions tears down and remounts the entire subtree —
+// including the page and any plugin-mounted React roots inside it. A page
+// that fetches on mount therefore fetches once per transition, and flashes
+// its loading state each time.
+//
+// Holding the tree back until plugin registration has settled builds it
+// exactly once. The timeout is a backstop for a plugin script that never
+// settles; normal loads open the gate on the event.
+const PLUGIN_BOOTSTRAP_TIMEOUT_MS = 3000;
+
+function usePluginsSettled() {
+  // Starts false on both server and client so the first client render matches
+  // the prerendered markup; the effect below opens the gate.
+  const [settled, setSettled] = useState(false);
+
+  useEffect(() => {
+    if (window.__skyDashboardPluginsLoaded === true) {
+      setSettled(true);
+      return undefined;
+    }
+    let timer = null;
+    const open = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      setSettled(true);
+    };
+    timer = setTimeout(open, PLUGIN_BOOTSTRAP_TIMEOUT_MS);
+    window.addEventListener(EVENT_PLUGINS_LOADED, open, { once: true });
+    return () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      window.removeEventListener(EVENT_PLUGINS_LOADED, open);
+    };
+  }, []);
+
+  return settled;
+}
+
 function App({ Component, pageProps }) {
+  const pluginsSettled = usePluginsSettled();
+
   useEffect(() => {
     const link = document.createElement('link');
     link.rel = 'icon';
@@ -44,16 +93,22 @@ function App({ Component, pageProps }) {
 
   return (
     <CacheProvider value={emotionCache}>
+      {/* PluginProvider must render unconditionally — it is what loads the
+          plugin bundles the gate below is waiting on. */}
       <PluginProvider>
-        <PluginWrapperSlot name="app.providers">
-          <VersionProvider>
-            <TourProvider>
-              <Layout highlighted={pageProps.highlighted}>
-                <Component {...pageProps} />
-              </Layout>
-            </TourProvider>
-          </VersionProvider>
-        </PluginWrapperSlot>
+        {pluginsSettled ? (
+          <PluginWrapperSlot name="app.providers">
+            <VersionProvider>
+              <TourProvider>
+                <Layout highlighted={pageProps.highlighted}>
+                  <Component {...pageProps} />
+                </Layout>
+              </TourProvider>
+            </VersionProvider>
+          </PluginWrapperSlot>
+        ) : (
+          <div className="min-h-screen bg-gray-50" />
+        )}
       </PluginProvider>
     </CacheProvider>
   );


### PR DESCRIPTION
## Summary

- A cold dashboard load can mount the whole app tree — `Layout`, the page, and any React roots a plugin route mounted inside it — up to **three times**, because plugin bundles register into slots that change the *shape* of the tree as they arrive.
- Pages that fetch on mount therefore issue their requests once per remount and flash their loading state each time. On a page whose fetch is slow this reads as the page reloading two or three times before it settles.
- Fix: hold the tree in `_app.js` until plugin registration has settled, so every slot is already populated on the first render and the tree is built exactly once.

## The three transitions

Two plugin slots return a *different element type* depending on whether anything is registered, and React cannot reconcile a changed type in place:

| Slot | Empty | Occupied |
|---|---|---|
| `PluginWrapperSlot('app.providers')` (`_app.js`) | `children` | `<Wrapper>{children}</Wrapper>` |
| `PluginSlot('layout.navigation')` (`layout.jsx`) | the `fallback` element | the registered component |

Plus the settle gate in `layout.jsx`, which could open on its 1 s timeout *before* a navigation plugin had registered — mounting `children` under the fallback, only to remount them a moment later.

Measured on a deployment with a navigation plugin and a provider plugin (timestamps from ms after navigation; `MOUNT` is a `ReactDOM.createRoot` call from a plugin route's `mount()`):

```
*** MOUNT @3842   <- layout.jsx settle timeout fired first
4132 register layout.navigation
*** MOUNT @4154
4846 register app.providers
*** MOUNT @4853
```

## Changes

- `_app.js`: new `usePluginsSettled()` gate around `PluginWrapperSlot` → `VersionProvider` → `TourProvider` → `Layout` → `Component`. It opens on `skydashboard:plugins-loaded` (dispatched by `PluginProvider` once every plugin script has resolved), with a 3 s timeout backstop should a script never settle. `PluginProvider` still renders unconditionally, since it is what loads the bundles the gate waits on. The gate starts closed on both server and client so the first client render matches the prerendered markup.
- `layout.jsx`: removed the now-redundant settle gate. Leaving it in would have cost every load an extra second — its `{ once: true }` listeners are attached *after* those events have already fired, so it would always fall through to its own timeout.
- `constants.jsx`: refreshed the stale comment on the two event constants.

## Trade-off

Page content now appears once all plugin bundles have registered rather than as soon as a navigation plugin has. On the deployment measured above that moved first content from ~700 ms to ~1.5 s. The same gray placeholder was already shown for up to 1 s by the old gate, and previously the content that appeared at 700 ms was torn down twice before it was usable.

## Tested

- `npm run build` in `sky/dashboard` — succeeds.
- `npx jest` — 217/217 pass.
- `npx next lint --max-warnings 0` on the touched files — clean.
- `npx prettier --check` on the touched files — clean.
- Manual A/B: built the dashboard with and without this change, served each build through a local proxy in front of an API server with plugins loaded (one registering `layout.navigation`, one registering `app.providers`), with artificial per-bundle latency so the bundles arrive well after the app shell. Hooked `ReactDOM.createRoot` in the page and counted calls while loading a plugin-registered route:
  - before: 3 mounts, 3 identical backend requests from the page (trace above);
  - after: 1 mount, 1 request, with the navigation and provider registrations both landing before the tree is built.
- Verified the rendered page is unchanged after the fix: navigation chrome and page content both render normally, and client-side navigation between pages still mounts each page exactly once.

To reproduce manually: load a page provided by a plugin route directly (not via client-side navigation) with a plugin registering `app.providers` present, and watch the page's requests in the network panel — before this change the page's on-mount request fires two or three times.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->