### PR TITLE
[Docs] Add GB300 NVL72 Ray recovery example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ Machine learning examples:
 
 - [**`resnet_distributed_torch.yaml`**](./resnet_distributed_torch.yaml): Run Distributed PyTorch (DDP) training of ResNet50 on 2 nodes.
 
-- [**`ray_resilient_training/`**](./ray_resilient_training/README.md): Run resilient Ray training with a CPU-only head, two GPU workers, node recovery, and RocksDB-backed GCS state.
+- [**`ray_resilient_training/`**](./ray_resilient_training/README.md): Run resilient Ray training with a CPU-only head, GPU worker recovery, RocksDB-backed GCS state, and optional NVLink domain-aware placement.
 
 - [**`detectron2_app.yaml`**](./detectron2_app.yaml): Run Detectron2 on a V100 GPU.
 

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -123,9 +123,10 @@ the node's clique label through the Kubernetes API, and registers the value as
 the Ray node label `ray.io/gpu-domain`.
 
 > [!NOTE]
-> The helper is one way to pass the node label to Ray. A mutation policy, such
-> as [Kyverno](https://kyverno.io/), can instead copy the clique label onto the
-> scheduled pod and expose it to the container through the Downward API.
+> The helper is one way to pass the node label to Ray. A mutating admission
+> webhook, such as [Kyverno](https://kyverno.io/), can instead copy the clique
+> label onto the scheduled pod and expose it to the container through the
+> Downward API.
 
 Launch the variant from the repository root:
 

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -148,5 +148,5 @@ for details about the embedded RocksDB backend.
 
 ## Acknowledgements
 
-The NVLink domain-aware example was inspired by Anyscale's
+The NVLink domain-aware example was inspired by
 [Maximizing the Power of NVIDIA GB300 NVL72: NVLink Domain-Aware Placement Groups in Ray](https://www.anyscale.com/blog/nvidia-gb300-nvlink-domain-aware-placement-groups-ray).

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -7,8 +7,9 @@ resumes without a full-cluster restart. This minimizes training downtime
 during failures.
 
 > [!NOTE]
-> This example uses **Frontier Trainer** for Dynamic Node Set recovery, which
-> is available on the **[SkyPilot Platform](https://docs.skypilot.ai/en/latest/skypilot-platform.html)**.
+> This example uses **Frontier Trainer** for Dynamic Node Set recovery. The
+> NVL72 variant also uses topology-aware scheduling. Both are available on the
+> **[SkyPilot Platform](https://docs.skypilot.ai/en/latest/skypilot-platform.html)**.
 
 ## Requirements
 

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -145,3 +145,8 @@ make retried work idempotent.
 
 See Ray's [GCS fault-tolerance documentation](https://docs.ray.io/en/latest/ray-core/fault_tolerance/gcs.html#fault-tolerance-gcs-rocksdb)
 for details about the embedded RocksDB backend.
+
+## Acknowledgements
+
+The NVLink domain-aware example was inspired by Anyscale's
+[Maximizing the Power of NVIDIA GB300 NVL72: NVLink Domain-Aware Placement Groups in Ray](https://www.anyscale.com/blog/nvidia-gb300-nvlink-domain-aware-placement-groups-ray).

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -96,6 +96,48 @@ The published Ray GPU image does not include PyTorch, so the worker `setup`
 installs it. For shorter replacement times, build an image containing both Ray
 and PyTorch and use it for `ray-workers`.
 
+## NVLink domain-aware placement
+
+For GB300 NVL72 clusters,
+`ray-nvl72-resilient-training.yaml` extends the same recovery design across two
+NVLink domains. It runs 32 Ray actors on 32 four-GPU workers and creates two
+detached placement groups with 16 bundles each. `STRICT_PACK` on
+`ray.io/gpu-domain` keeps each group in one domain, while `PACK` on
+`ray.io/node-id` gives Ray flexibility within that domain.
+
+An NVL72 domain has 18 four-GPU nodes. Using 16 workers per placement group
+leaves up to two nodes in each domain as standby capacity. When one worker is
+replaced, Ray preserves the placement group's domain assignment and
+reconstructs the lost actor. Healthy actors continue their current rollouts.
+
+Before launching this variant:
+
+- Configure topology-aware scheduling to place the workers as two 16-node
+  slices keyed by the `nvidia.com/gpu.clique` Kubernetes Node label.
+- Confirm that every GPU node has a non-empty `nvidia.com/gpu.clique` label.
+  NVIDIA GPU Feature Discovery normally creates this label.
+- Create the same `ray-gcs-rocksdb` volume used by the basic example.
+
+The worker task gets its Kubernetes Node name through the Downward API, reads
+the node's clique label through the Kubernetes API, and registers the value as
+the Ray node label `ray.io/gpu-domain`.
+
+Launch the variant from the repository root:
+
+```bash
+sky jobs launch \
+  examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
+```
+
+The program reserves all 128 Ray GPU resources but runs a CPU-only synthetic
+rollout. Replace `RolloutWorker.rollout()` in `train_nvl72.py` with the
+application's GPU work. Delete one worker pod during a rollout to exercise
+in-domain replacement; the other actors continue on their existing workers.
+
+Ray marks topology strategy scheduling as alpha. See Ray's
+[topology strategy documentation](https://docs.ray.io/en/latest/ray-core/scheduling/placement-group.html#alpha-topology-strategy-scheduling)
+for the current API and fault-tolerance semantics.
+
 Ray marks the embedded RocksDB backend as alpha. RocksDB stores Ray cluster
 metadata, not model weights or mutable actor state. Real training code should
 checkpoint application state to its own durable volume or object store and

--- a/examples/ray_resilient_training/README.md
+++ b/examples/ray_resilient_training/README.md
@@ -122,6 +122,11 @@ The worker task gets its Kubernetes Node name through the Downward API, reads
 the node's clique label through the Kubernetes API, and registers the value as
 the Ray node label `ray.io/gpu-domain`.
 
+> [!NOTE]
+> The helper is one way to pass the node label to Ray. A mutation policy, such
+> as [Kyverno](https://kyverno.io/), can instead copy the clique label onto the
+> scheduled pod and expose it to the container through the Downward API.
+
 Launch the variant from the repository root:
 
 ```bash

--- a/examples/ray_resilient_training/kubernetes_node_label.py
+++ b/examples/ray_resilient_training/kubernetes_node_label.py
@@ -1,0 +1,50 @@
+"""Read a label from this pod's Kubernetes Node."""
+
+import argparse
+import json
+import os
+import ssl
+import urllib.parse
+import urllib.request
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--node', required=True)
+    parser.add_argument('--label', required=True)
+    args = parser.parse_args()
+
+    service_host = os.environ['KUBERNETES_SERVICE_HOST']
+    service_port = os.environ.get('KUBERNETES_SERVICE_PORT_HTTPS', '443')
+    service_account_root = '/var/run/secrets/kubernetes.io/serviceaccount'
+    with open(f'{service_account_root}/token', encoding='utf-8') as token_file:
+        token = token_file.read().strip()
+
+    node_name = urllib.parse.quote(args.node, safe='')
+    url = f'https://{service_host}:{service_port}/api/v1/nodes/{node_name}'
+    request = urllib.request.Request(
+        url,
+        headers={
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {token}',
+        },
+    )
+    context = ssl.create_default_context(
+        cafile=f'{service_account_root}/ca.crt')
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        urllib.request.HTTPSHandler(context=context),
+    )
+    with opener.open(request, timeout=30) as response:
+        node = json.load(response)
+
+    labels = node.get('metadata', {}).get('labels', {})
+    value = labels.get(args.label)
+    if not value:
+        raise RuntimeError(f'Kubernetes Node {args.node!r} has no non-empty '
+                           f'{args.label!r} label')
+    print(value)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
+++ b/examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
@@ -1,0 +1,134 @@
+# A CPU-only Ray head and two 16-node NVLink domains run as one Job Group.
+# The actors reserve Ray GPU resources but execute CPU-only work so the example
+# can focus on topology placement and worker recovery.
+#
+# Prerequisite:
+#   sky volumes apply examples/ray_resilient_training/gcs-volume.yaml
+#
+# Launch:
+#   sky jobs launch \
+#     examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
+---
+name: ray-nvl72-resilient-training
+execution: parallel
+inter_connection: true
+primary_tasks: [ray-head]
+termination_delay: 20s
+
+---
+name: ray-head
+
+resources:
+  infra: kubernetes
+  cpus: 4+
+  memory: 16+
+  image_id: docker:rayproject/ray:2.58.0-py311
+  job_recovery:
+    strategy: DYNAMIC_NODE_SET
+
+volumes:
+  /ray-gcs: ray-gcs-rocksdb
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        securityContext:
+          fsGroup: 100
+          fsGroupChangePolicy: OnRootMismatch
+
+envs:
+  NUM_CLIQUES: 2
+  WORKERS_PER_CLIQUE: 16
+  GPUS_PER_WORKER: 4
+  TOTAL_STEPS: 1000
+  ROLLOUT_SECONDS: 600
+  HEARTBEAT_SECONDS: 30
+  RECOVERY_TIMEOUT_SECONDS: 1800
+
+workdir: examples/ray_resilient_training
+
+run: |
+  set -euo pipefail
+  ulimit -n 65536
+
+  RAY_HEAD_HOST="ray-head-0.${SKYPILOT_JOBGROUP_NAME}"
+  RAY_GCS_ROOT="/ray-gcs/nvl72-job-${SKYPILOT_MANAGED_JOB_ID}"
+  mkdir -p "${RAY_GCS_ROOT}"
+
+  export RAY_gcs_storage=rocksdb
+  export RAY_gcs_storage_path="${RAY_GCS_ROOT}/rocksdb"
+
+  ray start \
+    --head \
+    --port=6379 \
+    --dashboard-host=0.0.0.0 \
+    --num-cpus=0 \
+    --num-gpus=0 \
+    --disable-usage-stats
+
+  python train_nvl72.py \
+    --address "${RAY_HEAD_HOST}:6379" \
+    --num-cliques "${NUM_CLIQUES}" \
+    --workers-per-clique "${WORKERS_PER_CLIQUE}" \
+    --gpus-per-worker "${GPUS_PER_WORKER}" \
+    --steps "${TOTAL_STEPS}" \
+    --rollout-seconds "${ROLLOUT_SECONDS}" \
+    --heartbeat-seconds "${HEARTBEAT_SECONDS}" \
+    --recovery-timeout "${RECOVERY_TIMEOUT_SECONDS}" \
+    --state-path "${RAY_GCS_ROOT}/driver-state.json"
+
+---
+name: ray-workers
+
+num_nodes: 32
+
+resources:
+  infra: kubernetes
+  cpus: 2+
+  memory: 4+
+  accelerators: GB300:4
+  image_id: docker:rayproject/ray:2.58.0-py311
+  job_recovery:
+    strategy: DYNAMIC_NODE_SET
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+        - name: ray-node
+          env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+
+envs:
+  RAY_gcs_rpc_server_reconnect_timeout_s: 600
+
+workdir: examples/ray_resilient_training
+
+run: |
+  set -euo pipefail
+  ulimit -n 65536
+
+  RAY_HEAD_HOST="ray-head-0.${SKYPILOT_JOBGROUP_NAME}"
+  python wait_for_head.py \
+    --host "${RAY_HEAD_HOST}" \
+    --port 6379 \
+    --timeout 900
+
+  NVIDIA_GPU_CLIQUE="$(python kubernetes_node_label.py \
+    --node "${K8S_NODE_NAME}" \
+    --label nvidia.com/gpu.clique)"
+  export NVIDIA_GPU_CLIQUE
+  echo "Ray worker rank=${SKYPILOT_NODE_RANK} node=${K8S_NODE_NAME} clique=${NVIDIA_GPU_CLIQUE}"
+
+  ray start \
+    --address="${RAY_HEAD_HOST}:6379" \
+    --num-cpus=2 \
+    --num-gpus=4 \
+    --labels="ray.io/accelerator-type=GB300,ray.io/gpu-domain=${NVIDIA_GPU_CLIQUE}" \
+    --disable-usage-stats \
+    --block

--- a/examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
+++ b/examples/ray_resilient_training/ray-nvl72-resilient-training.yaml
@@ -97,8 +97,7 @@ config:
     pod_config:
       spec:
         containers:
-        - name: ray-node
-          env:
+        - env:
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:

--- a/examples/ray_resilient_training/train_nvl72.py
+++ b/examples/ray_resilient_training/train_nvl72.py
@@ -1,0 +1,316 @@
+"""Run a CPU-only RL-shaped workload on topology-aware Ray actors."""
+
+import argparse
+import collections
+import json
+import os
+import socket
+import tempfile
+import time
+from typing import Any, Dict, List
+import uuid
+
+import ray
+from ray.util.placement_group import get_placement_group
+from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+
+@ray.remote(max_restarts=-1, max_task_retries=-1)
+class RolloutWorker:
+    """A recoverable actor that reserves one four-GPU Ray bundle."""
+
+    def __init__(self, rank: int):
+        self.rank = rank
+        self.incarnation = uuid.uuid4().hex[:8]
+        self.host = socket.gethostname()
+        self.pid = os.getpid()
+        self.node_id = str(ray.get_runtime_context().get_node_id())
+        self.clique = os.environ.get('NVIDIA_GPU_CLIQUE', 'unknown')
+        self.sky_rank = os.environ.get('SKYPILOT_NODE_RANK', 'unknown')
+        print(json.dumps(self._event('actor_started')), flush=True)
+
+    def _event(self, event: str, **fields: Any) -> Dict[str, Any]:
+        return {
+            'event': event,
+            'time': time.time(),
+            'rank': self.rank,
+            'incarnation': self.incarnation,
+            'host': self.host,
+            'pid': self.pid,
+            'node_id': self.node_id,
+            'clique': self.clique,
+            'skypilot_node_rank': self.sky_rank,
+            **fields,
+        }
+
+    def identity(self) -> Dict[str, Any]:
+        return self._event('identity')
+
+    def rollout(self, step: int, duration_seconds: int,
+                heartbeat_seconds: int) -> Dict[str, Any]:
+        """Execute an idempotent long-running rollout with progress logs."""
+        call_id = uuid.uuid4().hex[:8]
+        started = time.monotonic()
+        print(
+            json.dumps(
+                self._event('rollout_started', step=step, call_id=call_id)),
+            flush=True,
+        )
+        while True:
+            elapsed = time.monotonic() - started
+            if elapsed >= duration_seconds:
+                break
+            print(
+                json.dumps(
+                    self._event(
+                        'rollout_progress',
+                        step=step,
+                        call_id=call_id,
+                        elapsed_seconds=round(elapsed, 1),
+                    )),
+                flush=True,
+            )
+            time.sleep(min(heartbeat_seconds, duration_seconds - elapsed))
+        result = self._event(
+            'rollout_completed',
+            step=step,
+            call_id=call_id,
+            elapsed_seconds=round(time.monotonic() - started, 1),
+        )
+        print(json.dumps(result), flush=True)
+        return result
+
+
+def load_state(path: str) -> Dict[str, int]:
+    if not os.path.exists(path):
+        return {'last_completed_step': -1}
+    with open(path, encoding='utf-8') as state_file:
+        return json.load(state_file)
+
+
+def save_state(path: str, state: Dict[str, int]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, temporary_path = tempfile.mkstemp(dir=os.path.dirname(path),
+                                          prefix='.driver-state-',
+                                          text=True)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as state_file:
+            json.dump(state, state_file)
+            state_file.flush()
+            os.fsync(state_file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def wait_for_cluster_gpus(total_gpus: int, timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resources = ray.cluster_resources()
+        connected_gpus = int(resources.get('GPU', 0))
+        if connected_gpus >= total_gpus:
+            print(f'Ray cluster has {connected_gpus} GPUs: {resources}',
+                  flush=True)
+            return
+        print(f'Waiting for {total_gpus} GPUs; resources={resources}',
+              flush=True)
+        time.sleep(5)
+    raise TimeoutError(
+        f'Ray did not register {total_gpus} GPUs within {timeout}s')
+
+
+def get_or_create_placement_group(
+    name: str,
+    workers_per_clique: int,
+    gpus_per_worker: int,
+    timeout: int,
+    allow_create: bool,
+):
+    try:
+        group = get_placement_group(name)
+        print(f'Reattached to detached placement group {name}', flush=True)
+    except ValueError as error:
+        if not allow_create:
+            raise RuntimeError(
+                f'Detached placement group {name!r} is missing while '
+                'resuming from a completed step') from error
+        group = placement_group(  # pylint: disable=unexpected-keyword-arg
+            bundles=[{
+                'CPU': 1,
+                'GPU': gpus_per_worker,
+            }] * workers_per_clique,
+            name=name,
+            lifetime='detached',
+            topology_strategy={
+                'ray.io/node-id': 'PACK',
+                'ray.io/gpu-domain': 'STRICT_PACK',
+            },
+        )
+        print(f'Created detached placement group {name}', flush=True)
+    ray.get(group.ready(), timeout=timeout)
+    print(f'Placement group ready: id={group.id.hex()} name={name}', flush=True)
+    return group
+
+
+def get_or_create_placement_groups(
+    name_prefix: str,
+    num_cliques: int,
+    workers_per_clique: int,
+    gpus_per_worker: int,
+    timeout: int,
+    allow_create: bool,
+) -> List[Any]:
+    return [
+        get_or_create_placement_group(
+            name=f'{name_prefix}-clique-{clique_index}',
+            workers_per_clique=workers_per_clique,
+            gpus_per_worker=gpus_per_worker,
+            timeout=timeout,
+            allow_create=allow_create,
+        ) for clique_index in range(num_cliques)
+    ]
+
+
+def get_or_create_workers(
+    groups: List[Any],
+    workers_per_clique: int,
+    gpus_per_worker: int,
+    allow_create: bool,
+) -> List[ray.actor.ActorHandle]:
+    workers = []
+    num_workers = len(groups) * workers_per_clique
+    for rank in range(num_workers):
+        name = f'nvl72-rollout-worker-{rank}'
+        try:
+            worker = ray.get_actor(name)
+            print(f'Reattached to detached actor {name}', flush=True)
+        except ValueError as error:
+            if not allow_create:
+                raise RuntimeError(
+                    f'Detached actor {name!r} is missing while resuming '
+                    'from a completed step') from error
+            clique_index = rank // workers_per_clique
+            bundle_index = rank % workers_per_clique
+            strategy = PlacementGroupSchedulingStrategy(
+                placement_group=groups[clique_index],
+                placement_group_bundle_index=bundle_index,
+                placement_group_capture_child_tasks=True,
+            )
+            worker = RolloutWorker.options(
+                name=name,
+                lifetime='detached',
+                num_cpus=1,
+                num_gpus=gpus_per_worker,
+                scheduling_strategy=strategy,
+            ).remote(rank)
+            print(f'Created detached actor {name}', flush=True)
+        workers.append(worker)
+    return workers
+
+
+def get_with_recovery_timeout(object_refs: List[ray.ObjectRef],
+                              timeout: int) -> List[Dict[str, Any]]:
+    deadline = time.monotonic() + timeout
+    remaining = list(object_refs)
+    results: List[Dict[str, Any]] = []
+    while remaining:
+        time_left = deadline - time.monotonic()
+        if time_left <= 0:
+            raise TimeoutError(
+                f'{len(remaining)} Ray rollout(s) did not recover within '
+                f'{timeout}s')
+        ready, remaining = ray.wait(remaining,
+                                    num_returns=1,
+                                    timeout=min(10, time_left))
+        if ready:
+            results.extend(ray.get(ready))
+        else:
+            alive_nodes = sum(1 for node in ray.nodes() if node['Alive'])
+            print(
+                f'Waiting for {len(remaining)} rollout(s); '
+                f'alive_nodes={alive_nodes}; '
+                f'resources={ray.cluster_resources()}',
+                flush=True,
+            )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--address', required=True)
+    parser.add_argument('--num-cliques', required=True, type=int)
+    parser.add_argument('--workers-per-clique', required=True, type=int)
+    parser.add_argument('--gpus-per-worker', required=True, type=int)
+    parser.add_argument('--steps', required=True, type=int)
+    parser.add_argument('--rollout-seconds', required=True, type=int)
+    parser.add_argument('--heartbeat-seconds', required=True, type=int)
+    parser.add_argument('--recovery-timeout', required=True, type=int)
+    parser.add_argument('--state-path', required=True)
+    args = parser.parse_args()
+
+    managed_job_id = os.environ['SKYPILOT_MANAGED_JOB_ID']
+    namespace = f'ray-nvl72-training-{managed_job_id}'
+    ray.init(address=args.address, namespace=namespace)
+
+    state = load_state(args.state_path)
+    allow_create = int(state['last_completed_step']) == -1
+    num_workers = args.num_cliques * args.workers_per_clique
+    wait_for_cluster_gpus(num_workers * args.gpus_per_worker,
+                          args.recovery_timeout)
+    groups = get_or_create_placement_groups(
+        name_prefix=f'nvl72-trainers-{managed_job_id}',
+        num_cliques=args.num_cliques,
+        workers_per_clique=args.workers_per_clique,
+        gpus_per_worker=args.gpus_per_worker,
+        timeout=args.recovery_timeout,
+        allow_create=allow_create,
+    )
+    workers = get_or_create_workers(
+        groups,
+        args.workers_per_clique,
+        args.gpus_per_worker,
+        allow_create=allow_create,
+    )
+    identities = ray.get([worker.identity.remote() for worker in workers])
+    workers_by_clique = collections.Counter(
+        identity['clique'] for identity in identities)
+    if len(workers_by_clique) != args.num_cliques or any(
+            count != args.workers_per_clique
+            for count in workers_by_clique.values()):
+        raise RuntimeError('Unexpected Ray placement across GPU cliques: '
+                           f'expected {args.num_cliques} clique(s) with '
+                           f'{args.workers_per_clique} worker(s) each, got '
+                           f'{dict(workers_by_clique)}')
+    print(
+        json.dumps({
+            'event': 'initial_placement',
+            'workers': sorted(identities, key=lambda item: item['rank']),
+        }),
+        flush=True,
+    )
+
+    first_step = int(state['last_completed_step']) + 1
+    print(f'Starting at step {first_step}; state={state}', flush=True)
+    for step in range(first_step, args.steps):
+        refs = [
+            worker.rollout.remote(step, args.rollout_seconds,
+                                  args.heartbeat_seconds) for worker in workers
+        ]
+        results = get_with_recovery_timeout(refs, args.recovery_timeout)
+        results.sort(key=lambda result: result['rank'])
+        state = {'last_completed_step': step}
+        save_state(args.state_path, state)
+        print(
+            json.dumps({
+                'event': 'step_completed',
+                'step': step,
+                'workers': results
+            }),
+            flush=True,
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ray_resilient_training/train_nvl72.py
+++ b/examples/ray_resilient_training/train_nvl72.py
@@ -273,7 +273,8 @@ def main() -> None:
         args.gpus_per_worker,
         allow_create=allow_create,
     )
-    identities = ray.get([worker.identity.remote() for worker in workers])
+    identities = ray.get([worker.identity.remote() for worker in workers],
+                         timeout=args.recovery_timeout)
     workers_by_clique = collections.Counter(
         identity['clique'] for identity in identities)
     if len(workers_by_clique) != args.num_cliques or any(


### PR DESCRIPTION
## Summary

- Add an advanced GB300 NVL72 variant to the resilient Ray training example.
- Register each Ray worker's Kubernetes GPU clique as `ray.io/gpu-domain` and use two detached, topology-aware placement groups with 16 four-GPU bundles each.
- Preserve the existing CPU-only Ray head, RocksDB-backed GCS, named actors, and Dynamic Node Set recovery design.
- Document the required Kubernetes topology labels, 16-node slices, standby capacity, and the synthetic workload's scope.

## Test plan

- `bash format.sh --files examples/ray_resilient_training/kubernetes_node_label.py examples/ray_resilient_training/train_nvl72.py` (Python formatting, mypy, and pylint passed; dashboard checks were skipped because npm is unavailable locally.)
- Parsed both Python files with `ast.parse()` and all three YAML documents with PyYAML.
- Ran the same Python files with a cluster-specific YAML overlay on a mock GB300 Kubernetes cluster; the generic YAML in this PR was not launched unchanged.
  - Launched one CPU head and 32 workers advertising four logical GPUs each.
  - Observed two ready 16-bundle placement groups assigned to two distinct `nvidia.com/gpu.clique` values.
  - Injected a synthetic XID 79 on one worker node. The replacement worker landed in the same clique, Ray reconstructed only the lost actor, the other 31 actors completed their original rollouts, and step 0 completed with all 32 results.
  - The mock cluster did not execute CUDA kernels or NVLink communication.
