### PR TITLE
[Dashboard] Let plugin routes declare the nav link they belong under

### DIFF
--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -272,7 +272,18 @@ export function TopBar() {
         router.pathname.startsWith('/workspace')
       );
     }
-    return router.pathname.startsWith(path);
+    if (router.pathname.startsWith(path)) {
+      return true;
+    }
+    // Plugin routes are served by a catch-all page, so router.pathname is
+    // '/[...path]' for all of them. A plugin route may declare the nav link
+    // it belongs under via `navHref`; match those against the real URL.
+    const currentPath = router.asPath.split(/[?#]/)[0];
+    return pluginRoutes.some(
+      (route) =>
+        route.navHref === path &&
+        (currentPath === route.path || currentPath.startsWith(`${route.path}/`))
+    );
   };
 
   // Modify the getLinkClasses function to handle mobile styles

--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -266,13 +266,12 @@ export function TopBar() {
   // Function to determine if a path is active
   const isActivePath = (path) => {
     // Special case: highlight workspaces for both /workspaces and /workspace paths
-    if (path === '/workspaces') {
-      return (
-        router.pathname.startsWith('/workspaces') ||
-        router.pathname.startsWith('/workspace')
-      );
-    }
-    if (router.pathname.startsWith(path)) {
+    const builtInMatch =
+      path === '/workspaces'
+        ? router.pathname.startsWith('/workspaces') ||
+          router.pathname.startsWith('/workspace')
+        : router.pathname.startsWith(path);
+    if (builtInMatch) {
       return true;
     }
     // Plugin routes are served by a catch-all page, so router.pathname is

--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -353,9 +353,19 @@ function normalizeRoute(route) {
     ? normalizedPath
     : `/${normalizedPath}`;
 
+  // Optional: the built-in nav link this route belongs under (e.g. '/jobs'),
+  // so the sidebar can highlight it while the route is open. Plugin routes
+  // are all served by one catch-all page, so the router's pathname alone
+  // cannot tell the sidebar which section a plugin page is part of.
+  const navHref =
+    typeof route.navHref === 'string' && route.navHref.startsWith('/')
+      ? route.navHref
+      : undefined;
+
   return {
     id: String(route.id),
     path: pathname,
+    navHref,
     title: typeof route.title === 'string' ? route.title : undefined,
     description:
       typeof route.description === 'string' ? route.description : undefined,


### PR DESCRIPTION
Plugin-registered dashboard routes are all served by the catch-all page (`pages/[...path].js`), so `router.pathname` is `/[...path]` for every one of them. The sidebar decides which nav link is active with `router.pathname.startsWith(path)`, which therefore never matches while a plugin page is open: a plugin page that lives conceptually under Jobs (or Clusters, or Infra) shows no highlighted section, while the built-in pages next to it do.

This lets a plugin route say which built-in nav link it belongs under:

```js
api.registerRoute({
  id: 'my-plugin-detail',
  path: '/my-things',
  navHref: '/jobs',   // new, optional
  mount: ...,
});
```

`normalizeRoute` keeps `navHref` when it is a string starting with `/`. `isActivePath` in the sidebar, after the existing `pathname` check, also returns true when a registered plugin route has `navHref === path` and the real URL (`router.asPath`, query and hash stripped) is that route's path or a sub-path of it. Routes without `navHref` behave exactly as before.

Tested so far: `next lint --max-warnings 0` and `prettier --check` clean on both files. A live check with a plugin route registered under `/jobs` is pending and will be posted here.