### PR TITLE
[Dashboard] Show Started and Partition on the managed job detail page

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -301,6 +301,8 @@ export async function getManagedJobs(options = {}) {
         resources_str_full: job.cluster_resources_full || cluster_resources,
         cloud: cloud,
         region: job.region,
+        // Zone; for Slurm this is the partition the job was scheduled to.
+        zone: job.zone && job.zone !== '-' ? job.zone : null,
         infra: infra,
         full_infra: full_infra,
         recoveries: job.recovery_count,
@@ -315,6 +317,7 @@ export async function getManagedJobs(options = {}) {
         submitted_at: job.submitted_at
           ? new Date(job.submitted_at * 1000)
           : null,
+        started_at: job.start_at ? new Date(job.start_at * 1000) : null,
         events: events,
         dag_yaml: job.user_yaml,
         entrypoint: job.entrypoint,

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1457,6 +1457,12 @@ function JobDetailsContent({
         </div>
       </div>
       <div>
+        <div className="text-gray-600 font-medium text-base">Started</div>
+        <div className="text-base mt-1">
+          {jobData.started_at ? formatFullTimestamp(jobData.started_at) : '-'}
+        </div>
+      </div>
+      <div>
         <div className="text-gray-600 font-medium text-base">Duration</div>
         <div className="text-base mt-1">
           {formatDuration(jobData.job_duration)}
@@ -1522,6 +1528,16 @@ function JobDetailsContent({
           )}
         </div>
       </div>
+      {/* Slurm schedules onto a partition (its zone); it is how quota and
+          priority are carved up on a Slurm cluster, so it gets its own row. */}
+      {jobData.cloud &&
+        jobData.cloud.toLowerCase() === 'slurm' &&
+        jobData.zone && (
+          <div>
+            <div className="text-gray-600 font-medium text-base">Partition</div>
+            <div className="text-base mt-1">{jobData.zone}</div>
+          </div>
+        )}
       <div>
         <div className="text-gray-600 font-medium text-base">Resources</div>
         <div className="text-base mt-1">

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1529,15 +1529,40 @@ function JobDetailsContent({
         </div>
       </div>
       {/* Slurm schedules onto a partition (its zone); it is how quota and
-          priority are carved up on a Slurm cluster, so it gets its own row. */}
-      {jobData.cloud &&
-        jobData.cloud.toLowerCase() === 'slurm' &&
-        jobData.zone && (
+          priority are carved up on a Slurm cluster, so it gets its own row.
+          Multi-task jobs list every task's partition, like Requested
+          Resources above. */}
+      {(() => {
+        const slurmTasks = allTasks.filter(
+          (t) => t.cloud && t.cloud.toLowerCase() === 'slurm' && t.zone
+        );
+        if (slurmTasks.length === 0) return null;
+        const partitions = [...new Set(slurmTasks.map((t) => t.zone))];
+        return (
           <div>
             <div className="text-gray-600 font-medium text-base">Partition</div>
-            <div className="text-base mt-1">{jobData.zone}</div>
+            <div className="text-base mt-1">
+              {allTasks.length > 1 ? (
+                <NonCapitalizedTooltip
+                  content={slurmTasks
+                    .map(
+                      (task) =>
+                        `Task ${allTasks.indexOf(task)}${task.task ? ` (${task.task})` : ''}: ${task.zone}`
+                    )
+                    .join('\n')}
+                  className="text-sm text-muted-foreground"
+                >
+                  <span className="cursor-help border-b border-dotted border-gray-400">
+                    {partitions.join(', ')}
+                  </span>
+                </NonCapitalizedTooltip>
+              ) : (
+                partitions[0]
+              )}
+            </div>
           </div>
-        )}
+        );
+      })()}
       <div>
         <div className="text-gray-600 font-medium text-base">Resources</div>
         <div className="text-base mt-1">


### PR DESCRIPTION
The managed job detail page shows Submitted and Duration but not when the job actually started, so the time spent queued is invisible. And for a Slurm job the partition it was scheduled to, which is the unit quota and priority attach to on a Slurm cluster, appears nowhere: `formatted_str()` deliberately drops the zone for Slurm so that `slurm (cluster)` stays unambiguous across clusters.

Both facts are already in the job row (`start_at`, `zone`); this carries them through the connector and renders them:

- **Started**: after Submitted, `formatFullTimestamp(start_at)`, `-` while the job has not started.
- **Partition**: after Infra, only when `cloud` is Slurm and the zone is set. The infra string is unchanged.

Tested: `next lint --max-warnings 0` and `prettier --check` clean on both files.