### PR TITLE
[Server] Add a second plugin install pass for innermost middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,12 @@ required_plugins = [
 ]
 env = [
     "SKYPILOT_DEBUG=1",
-    "SKYPILOT_DISABLE_USAGE_COLLECTION=1"
+    "SKYPILOT_DISABLE_USAGE_COLLECTION=1",
+    # Never load the developer's own ~/.sky/plugins.yaml. A missing path means
+    # "no plugins", which is what CI has, so tests behave the same in both
+    # places; without this, plugin loading happens at conftest import, before
+    # any fixture could intervene.
+    "SKYPILOT_SERVER_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-plugins.yaml"
 ]
 addopts = "-s -n 16 -q --tb=short --dist loadgroup --disable-warnings"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,7 @@ required_plugins = [
 ]
 env = [
     "SKYPILOT_DEBUG=1",
-    "SKYPILOT_DISABLE_USAGE_COLLECTION=1",
-    # Never load the developer's own ~/.sky/plugins.yaml or remote_plugins.yaml.
-    # A missing path means "no plugins", which is what CI has, so tests behave
-    # the same in both places; without this, plugin loading happens at conftest
-    # import, before any fixture could intervene. Tests that need a config set
-    # these themselves.
-    "SKYPILOT_SERVER_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-plugins.yaml",
-    "SKYPILOT_SERVER_REMOTE_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-remote-plugins.yaml"
+    "SKYPILOT_DISABLE_USAGE_COLLECTION=1"
 ]
 addopts = "-s -n 16 -q --tb=short --dist loadgroup --disable-warnings"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,13 @@ required_plugins = [
 env = [
     "SKYPILOT_DEBUG=1",
     "SKYPILOT_DISABLE_USAGE_COLLECTION=1",
-    # Never load the developer's own ~/.sky/plugins.yaml. A missing path means
-    # "no plugins", which is what CI has, so tests behave the same in both
-    # places; without this, plugin loading happens at conftest import, before
-    # any fixture could intervene.
-    "SKYPILOT_SERVER_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-plugins.yaml"
+    # Never load the developer's own ~/.sky/plugins.yaml or remote_plugins.yaml.
+    # A missing path means "no plugins", which is what CI has, so tests behave
+    # the same in both places; without this, plugin loading happens at conftest
+    # import, before any fixture could intervene. Tests that need a config set
+    # these themselves.
+    "SKYPILOT_SERVER_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-plugins.yaml",
+    "SKYPILOT_SERVER_REMOTE_PLUGINS_CONFIG=/nonexistent/skypilot-tests-no-remote-plugins.yaml"
 ]
 addopts = "-s -n 16 -q --tb=short --dist loadgroup --disable-warnings"
 asyncio_default_fixture_loop_scope = "function"

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -364,6 +364,10 @@ class BasePlugin(abc.ABC):
         configured plugin order.
 
         Only for that ordering need. Everything else belongs in `install`.
+
+        Raising here aborts the load, exactly as raising from `install` does:
+        plugins are infrastructure, and a half-installed one is not something
+        to serve requests with. "Second pass" does not mean optional.
         """
         del extension_context  # Unused by the default no-op.
 
@@ -585,8 +589,9 @@ def load_plugins(extension_context: ExtensionContext):
     for class_path, plugin in installed_now:
         try:
             plugin.install_late(extension_context)
-        except Exception:  # pylint: disable=broad-except
-            logger.error(f'Plugin {class_path} failed its late install pass.')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f'Plugin {class_path} failed its late install pass: '
+                         f'{common_utils.format_exception(e)}')
             raise
 
     _plugins_loaded = True

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -346,6 +346,27 @@ class BasePlugin(abc.ABC):
         """Hook called by API server to let the plugin install itself."""
         raise NotImplementedError
 
+    def install_late(self, extension_context: ExtensionContext):
+        """Second install pass, run after every plugin's `install`.
+
+        For middleware that must sit *inside* the middleware other plugins
+        register — anything that reads state an earlier middleware populates,
+        `request.state.auth_user` above all.
+
+        Middleware order is install order: `add_middleware_last` appends to
+        `app.user_middleware`, and the stack is built by wrapping that list in
+        reverse, so an entry appended earlier ends up further out. A plugin
+        registering an authorization middleware in `install` therefore runs
+        outside the authentication middleware of any plugin that happens to be
+        listed after it in the server config, sees no identity, and — since
+        "no identity" conventionally means "local caller, allow" — fails open.
+        Registering it here instead makes it innermost regardless of the
+        configured plugin order.
+
+        Only for that ordering need. Everything else belongs in `install`.
+        """
+        del extension_context  # Unused by the default no-op.
+
     def shutdown(self):
         """Hook called by API server to let the plugin shutdown."""
         pass
@@ -547,6 +568,18 @@ def load_plugins(extension_context: ExtensionContext):
         plugin = plugin_cls(**parameters)
         plugin.install(extension_context)
         _PLUGINS[class_path] = plugin
+
+    # Second pass, after every plugin has installed: see
+    # `BasePlugin.install_late`. A plugin whose middleware must be innermost
+    # (because it reads what another plugin's middleware sets) cannot get
+    # there from `install`, where its position depends on where it happens to
+    # sit in the configured plugin list.
+    for class_path, plugin in _PLUGINS.items():
+        try:
+            plugin.install_late(extension_context)
+        except Exception:  # pylint: disable=broad-except
+            logger.error(f'Plugin {class_path} failed its late install pass.')
+            raise
 
     _plugins_loaded = True
 

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -540,6 +540,7 @@ def load_plugins(extension_context: ExtensionContext):
         _plugins_loaded = True
         return
 
+    installed_now: List[Tuple[str, BasePlugin]] = []
     for plugin_config in config.get('plugins', []):
         class_path = plugin_config['class']
         logger.debug(f'Loading plugins: {class_path}')
@@ -568,13 +569,20 @@ def load_plugins(extension_context: ExtensionContext):
         plugin = plugin_cls(**parameters)
         plugin.install(extension_context)
         _PLUGINS[class_path] = plugin
+        installed_now.append((class_path, plugin))
 
     # Second pass, after every plugin has installed: see
     # `BasePlugin.install_late`. A plugin whose middleware must be innermost
     # (because it reads what another plugin's middleware sets) cannot get
     # there from `install`, where its position depends on where it happens to
     # sit in the configured plugin list.
-    for class_path, plugin in _PLUGINS.items():
+    #
+    # Over what this call installed, not over `_PLUGINS`: that dict is
+    # module-global and never cleared, so in a process that loads plugins more
+    # than once (MAIN, then UVICORN in-process) it still holds instances from
+    # the earlier load — including ones whose `load_contexts` excludes the
+    # context we are in now. Those must not get a late install here.
+    for class_path, plugin in installed_now:
         try:
             plugin.install_late(extension_context)
         except Exception:  # pylint: disable=broad-except

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -390,3 +390,90 @@ def test_load_plugin_viewer_allowlist_default_empty(monkeypatch, tmp_path):
 
     result = plugins.load_plugin_viewer_allowlist()
     assert not result
+
+
+def test_install_late_runs_after_every_install(monkeypatch, tmp_path):
+    """The late pass is what lets a plugin's middleware be innermost.
+
+    Middleware order is install order, so a plugin listed before another
+    cannot get inside that other plugin's middleware from `install`. Assert
+    the guarantee the late pass exists to provide: every `install` completes
+    before any `install_late` starts.
+    """
+    module_name = 'sky_test_late_plugin'
+    calls = []
+
+    class FirstPlugin(plugins.BasePlugin):
+
+        def install(self, extension_context):
+            del extension_context
+            calls.append('first.install')
+
+        def install_late(self, extension_context):
+            del extension_context
+            calls.append('first.install_late')
+
+    class SecondPlugin(plugins.BasePlugin):
+
+        def install(self, extension_context):
+            del extension_context
+            calls.append('second.install')
+
+    FirstPlugin.__module__ = module_name
+    SecondPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.FirstPlugin = FirstPlugin
+    module.SecondPlugin = SecondPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config = {
+        'plugins': [
+            {
+                'class': f'{module_name}.FirstPlugin'
+            },
+            {
+                'class': f'{module_name}.SecondPlugin'
+            },
+        ],
+    }
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(yaml.safe_dump(config))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
+                                 app=FastAPI()))
+
+    # The plugin declaring install_late is listed *first*, so this ordering
+    # only holds because the late pass is a separate pass.
+    assert calls == ['first.install', 'second.install', 'first.install_late']
+
+
+def test_install_late_defaults_to_noop(monkeypatch, tmp_path):
+    """A plugin that does not override install_late still loads."""
+    module_name = 'sky_test_no_late_plugin'
+
+    class PlainPlugin(plugins.BasePlugin):
+
+        def install(self, extension_context):
+            del extension_context
+
+    PlainPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.PlainPlugin = PlainPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(
+        yaml.safe_dump({'plugins': [{
+            'class': f'{module_name}.PlainPlugin'
+        }]}))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
+                                 app=FastAPI()))
+
+    assert len(plugins.get_plugins()) == 1

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -450,6 +450,52 @@ def test_install_late_runs_after_every_install(monkeypatch, tmp_path):
     assert calls == ['first.install', 'second.install', 'first.install_late']
 
 
+def test_install_late_skips_plugins_from_an_earlier_load(monkeypatch, tmp_path):
+    """Only what this call installed gets a late install.
+
+    `_PLUGINS` is module-global and never cleared, and a process can load
+    plugins more than once (MAIN, then UVICORN in-process). Without care the
+    second load's late pass would reach the first load's instances, including
+    ones whose `load_contexts` excludes the context now being loaded.
+    """
+    module_name = 'sky_test_context_late_plugin'
+    late_calls = []
+
+    class MainOnlyPlugin(plugins.BasePlugin):
+        load_contexts = frozenset({plugins.PluginContext.MAIN})
+
+        def install(self, extension_context):
+            del extension_context
+
+        def install_late(self, extension_context):
+            late_calls.append(extension_context.context)
+
+    MainOnlyPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.MainOnlyPlugin = MainOnlyPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(
+        yaml.safe_dump(
+            {'plugins': [{
+                'class': f'{module_name}.MainOnlyPlugin'
+            }]}))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.MAIN))
+    assert late_calls == [plugins.PluginContext.MAIN]
+
+    # Same process, second load in a context this plugin opted out of. It stays
+    # in `_PLUGINS` from the first load, but must not be installed again.
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
+                                 app=FastAPI()))
+    assert late_calls == [plugins.PluginContext.MAIN]
+
+
 def test_install_late_defaults_to_noop(monkeypatch, tmp_path):
     """A plugin that does not override install_late still loads."""
     module_name = 'sky_test_no_late_plugin'


### PR DESCRIPTION
## Summary

Adds `BasePlugin.install_late`, a no-op by default, called in a second pass after every plugin's `install`.

Middleware order is install order: `add_middleware_last` appends to `app.user_middleware`, and Starlette builds the stack by wrapping that list in reverse, so an entry appended *earlier* ends up *further out*. A plugin therefore cannot register a middleware that sits inside another plugin's middleware unless it happens to be listed after that plugin in the server config.

That is a problem for **authorization** middleware, which by definition reads what an **authentication** middleware wrote. A plugin listed before the one that establishes identity sees `request.state.auth_user` unset — and since "no identity" conventionally means "local caller, allow", it fails **open**, silently, in exactly the deployments that bothered to configure authentication. There is no way to express "put me innermost" today; the only lever is the ordering of the plugin list, which is composed by deployment tooling and is not something a plugin can see or control.

A plugin that needs the innermost position now registers its middleware in `install_late` and gets it regardless of the configured order.

This was found the hard way: an enterprise-plugin authorization gate that passed its end-to-end tests under one plugin ordering and silently allowed everything under the ordering the deployment tooling actually produces.

Scope is deliberately narrow — the new hook is documented as being for that ordering need only; everything else still belongs in `install`.

## Test plan

```bash
pytest tests/unit_tests/test_sky/server/test_plugins.py
```

- `test_install_late_runs_after_every_install` — two plugins, the one declaring `install_late` listed **first**, asserting the call order is `first.install → second.install → first.install_late`. This ordering can only hold because the late pass is a separate pass; deleting the second loop turns it red (verified).
- `test_install_late_defaults_to_noop` — a plugin that does not override it still loads.

12 passed locally (the file's 10 existing tests plus these 2).

Note when running locally: if you have a `~/.sky/plugins.yaml`, point `SKYPILOT_SERVER_PLUGINS_CONFIG` at an empty one, or two unrelated tests in this file pick up your real plugins and fail.

## Backward compatibility

Additive only. `install_late` is a no-op on `BasePlugin`, so every existing plugin is unaffected and no plugin is required to implement it. No API version bump: this is a server-internal extension point, not part of the client-facing API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->