### PR TITLE
Lift the typing_extensions cap by bumping selenium; drop pydantic<2.12

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,7 +48,12 @@ boto3-stubs[s3,ec2,sts,iam,service-quotas]
 psycopg2-binary==2.9.10
 
 # For helm okta test
-selenium==4.33.0
+# Floor, not an exact pin: selenium 4.33.0 requires `typing_extensions~=4.13.2`,
+# which caps typing_extensions at 4.13.x for the whole dev environment. Any
+# upstream package that adopts `typing_extensions.Sentinel`/`sentinel` (added in
+# 4.15.0) then fails to import -- pydantic-core 2.41.x did, and anyio 4.15.0
+# does. 4.36.0 is the first release that drops the `~=` cap.
+selenium>=4.36.0
 webdriver-manager==4.0.2
 
 # For grpcio/protobuf code generation
@@ -64,11 +69,3 @@ grpcio==1.63.0
 # CVE-2026-0994 (JSON recursion bypass). grpcio 1.63.0 supports
 # protobuf >= 5.x, so this minor bump is compatible.
 protobuf==5.29.6
-
-# Pin to avoid a runtime break between pydantic>=2.12 (which requires
-# pydantic-core 2.41.x) and typing_extensions 4.13.x. In 2.41.x,
-# pydantic-core does `from typing_extensions import Sentinel`, but 4.13.x no
-# longer exports the public `Sentinel` symbol, causing ImportError. Keeping
-# pydantic<2.12 avoids pulling pydantic-core 2.41.x. Revisit once upstream
-# resolves the import or we align versions accordingly.
-pydantic<2.12


### PR DESCRIPTION
## The cap

`selenium==4.33.0` requires **`typing_extensions~=4.13.2`**, which pins typing_extensions to `4.13.*` for the whole dev environment. Any upstream package that adopts `typing_extensions.Sentinel` / `sentinel` (added in 4.15.0) then fails at import time.

This has now bitten twice:

| adopter | symptom | previous handling |
|---|---|---|
| `pydantic-core` 2.41.x | `from typing_extensions import Sentinel` → ImportError | pinned `pydantic<2.12` |
| `anyio` 4.15.0 (2026-09-02) | `from typing_extensions import sentinel` → ImportError | *(this PR)* |

The second one reaches `sky` through fastapi, so **every `import sky` dies**:

```
ImportError: cannot import name 'sentinel' from 'typing_extensions'
  sky -> fastapi -> anyio.abc -> anyio._core._typedattr:10
```

The `pydantic<2.12` pin treated the symptom. The cap is the cause, and it will keep breaking on each new adopter — so this bumps selenium instead and drops the pydantic pin, which is no longer needed once typing_extensions can move.

`selenium` 4.36.0 is the first release that drops the `~=` form (`typing_extensions<5.0,>=4.14.0`).

## Why a floor rather than an exact pin

An exact pin is exactly what created this: `selenium==4.33.0` was added in #6104 as a routine "pin what I tested with", and its transitive `~=` cap silently became an environment-wide constraint. A fresh exact pin would recreate the same trap on the next upstream move, so this uses `>=4.36.0`.

## Verification

Reproduced the documented install order in a clean venv, one step at a time:

```
uv pip install --prerelease allow "azure-cli<2.87.0"
uv pip install -e ".[all]"
uv pip install -r requirements-dev.txt
```

| | before | after |
|---|---|---|
| typing_extensions | **4.13.2** | **4.16.0** |
| selenium | 4.33.0 | 4.48.0 |
| pydantic / pydantic-core | 2.11.10 / 2.33.2 | 2.13.5 / 2.46.5 |
| anyio | 4.15.0 | 4.15.0 |
| `import sky` | **ImportError** | **OK** |

Also confirmed the intermediate state is genuinely the trigger: removing only `pydantic<2.12` (leaving selenium pinned) still leaves typing_extensions at 4.13.2 and `import sky` still fails — the cap has to be lifted.

## selenium upgrade risk

Used in two files:

- `tests/kubernetes/scripts/okta_auto_login.py`
- `tests/load_tests/db_scale_tests/verify_dashboard_browser.py`

only via `webdriver.Chrome`, `Options`, `Service`, `By`, `Keys`, `WebDriverWait` and `expected_conditions` — all stable selenium 4.x APIs, and all import successfully on 4.48.0 in the verification env above. I did not run the Okta or dashboard browser tests themselves (they need a live cluster / Chrome), so that is worth a look during review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->