### PR TITLE
[Catalog] Azure: map the H200, GB200/GB300, MI300X, NCC H100 and NC A10 v4 families

### DIFF
--- a/sky/catalog/data_fetchers/fetch_azure.py
+++ b/sky/catalog/data_fetchers/fetch_azure.py
@@ -69,6 +69,38 @@ FAMILY_NAME_TO_SKYPILOT_GPU_NAME = {
     'StandardNVADSA10v5Family': 'A10',
     'StandardNCadsH100v5Family': 'H100',
     'standardNDSH100v5Family': 'H100',
+    # NC A10 v4: the COMPUTE A10 line (24GB, full GPUs, standard drivers),
+    # distinct from the NV A10 v5 visualization line above.
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nca10v4-series
+    'StandardNCADSA10v4Family': 'A10',
+    # NCC H100 v5: the confidential-computing H100 NVL 94GB (note the double
+    # C). Same accelerator as NC H100 v5, different family.
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nccadsh100v5-series
+    'StandardNCCads2023Family': 'H100',
+    # ND H200 v5: 8x H200 141GB.
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ndh200v5-series
+    'standardNDISRH200V5Family': 'H200',
+    # ND GB200 v6 / ND GB300 v6: Grace-Blackwell NVL72 racks; each VM carries
+    # 4 GPUs (see AZURE_MISSING_GPU_COUNT: the SKU API reports no `GPUs`
+    # capability for these sizes).
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series
+    'standardNDISRGB200V6NDRFamily': 'GB200',
+    'standardNDISRGB300V6Family': 'GB300',
+    # ND MI300X v5: 8x AMD MI300X 192GB.
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ndmi300xv5-series
+    'standardNDISv5MI300XFamily': 'MI300X',
+}
+
+# Instance types whose SKU API entry carries NO `GPUs` capability even though
+# the family is a GPU family (observed 2026-09-02 via `az vm list-skus --all`).
+# Without this table those rows would be emitted without an accelerator and
+# `sky show-gpus` would not know the size exists. Counts are GPUs per VM from
+# the Azure size documentation linked above, not from the API.
+AZURE_MISSING_GPU_COUNT = {
+    'Standard_ND128isr_NDR_GB200_v6': 4,
+    'Standard_ND128isr_GB300_v6': 4,
+    'Standard_ND96is_MI300X_v5': 8,
 }
 
 
@@ -181,6 +213,42 @@ def get_gpu_name(family: str) -> Optional[str]:
     return FAMILY_NAME_TO_SKYPILOT_GPU_NAME.get(family)
 
 
+def parse_capabilities(instance_type: str, family: str, caps: List[dict]):
+    """Extract (gpu_name, gpu_count, vcpus, memory, hyperv_generation).
+
+    The GPU name comes from the FAMILY (FAMILY_NAME_TO_SKYPILOT_GPU_NAME) and
+    the count from the `GPUs` capability. Some GPU sizes carry no `GPUs`
+    capability at all (ND GB200/GB300 v6, ND96is MI300X v5); for those the
+    count comes from AZURE_MISSING_GPU_COUNT. A GPU family with neither source
+    is emitted without an accelerator rather than with a guessed count.
+    """
+    gpu_name = get_gpu_name(family)
+    gpu_count = np.nan
+    vcpus = np.nan
+    memory = np.nan
+    gen_version = None
+    for item in caps:
+        assert isinstance(item, dict), (item, caps)
+        if item['name'] == 'GPUs':
+            if gpu_name is not None:
+                gpu_count = item['value']
+        elif item['name'] == 'vCPUs':
+            vcpus = float(item['value'])
+        elif item['name'] == 'MemoryGB':
+            memory = item['value']
+        elif item['name'] == 'HyperVGenerations':
+            gen_version = item['value']
+    if gpu_name is not None and gpu_count is np.nan:
+        manual = AZURE_MISSING_GPU_COUNT.get(instance_type)
+        if manual is not None:
+            gpu_count = str(manual)
+    if gpu_name is not None and gpu_count is np.nan:
+        # A GPU family the API describes without a GPU count: do not invent
+        # one -- drop the accelerator so the row is a plain VM row.
+        gpu_name = None
+    return gpu_name, gpu_count, vcpus, memory, gen_version
+
+
 def get_all_regions_instance_types_df(region_set: Set[str]):
     if SINGLE_THREADED:
         dfs = [get_pricing_df(region) for region in region_set]
@@ -238,29 +306,9 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
                      how='left')
     df = df.join(spot_df, on=['merge_name', 'Region', 'is_promo'], how='left')
 
-    def get_capabilities(row):
-        gpu_name = None
-        gpu_count = np.nan
-        vcpus = np.nan
-        memory = np.nan
-        gen_version = None
-        caps = row['capabilities']
-        for item in caps:
-            assert isinstance(item, dict), (item, caps)
-            if item['name'] == 'GPUs':
-                gpu_name = get_gpu_name(row['family'])
-                if gpu_name is not None:
-                    gpu_count = item['value']
-            elif item['name'] == 'vCPUs':
-                vcpus = float(item['value'])
-            elif item['name'] == 'MemoryGB':
-                memory = item['value']
-            elif item['name'] == 'HyperVGenerations':
-                gen_version = item['value']
-        return gpu_name, gpu_count, vcpus, memory, gen_version
-
     def get_additional_columns(row):
-        gpu_name, gpu_count, vcpus, memory, gen_version = get_capabilities(row)
+        gpu_name, gpu_count, vcpus, memory, gen_version = parse_capabilities(
+            row['InstanceType'], row['family'], row['capabilities'])
         return pd.Series({
             'AcceleratorName': gpu_name,
             'AcceleratorCount': gpu_count,

--- a/tests/unit_tests/test_azure_catalog_fetcher.py
+++ b/tests/unit_tests/test_azure_catalog_fetcher.py
@@ -1,0 +1,85 @@
+"""Tests for the Azure catalog fetcher's GPU family and count mapping."""
+# pylint: disable=protected-access
+import math
+
+import pytest
+
+pytest.importorskip('pandas')
+# pylint: disable=wrong-import-position
+from sky.catalog.data_fetchers import fetch_azure
+
+
+def _caps(**values):
+    return [{'name': name, 'value': value} for name, value in values.items()]
+
+
+@pytest.mark.parametrize(
+    'family, expected',
+    [
+        # Pre-existing mappings must be unchanged.
+        ('StandardNCASv3_T4Family', 'T4'),
+        ('StandardNCadsH100v5Family', 'H100'),
+        ('standardNDSH100v5Family', 'H100'),
+        # Families added 2026-09: each was present in `az vm list-skus --all`
+        # for a real subscription and absent from the catalog.
+        ('StandardNCADSA10v4Family', 'A10'),
+        ('StandardNCCads2023Family', 'H100'),
+        ('standardNDISRH200V5Family', 'H200'),
+        ('standardNDISRGB200V6NDRFamily', 'GB200'),
+        ('standardNDISRGB300V6Family', 'GB300'),
+        ('standardNDISv5MI300XFamily', 'MI300X'),
+        # The SKU API sometimes spells families with spaces.
+        ('standardNDISR GB300V6 Family', 'GB300'),
+        # Non-GPU and FPGA families stay unmapped.
+        ('standardDSv3Family', None),
+        ('standardNPSFamily', None),
+    ],
+)
+def test_get_gpu_name(family, expected):
+    assert fetch_azure.get_gpu_name(family) == expected
+
+
+def test_parse_capabilities_uses_the_api_gpu_count_when_present():
+    gpu_name, gpu_count, vcpus, memory, gen = fetch_azure.parse_capabilities(
+        'Standard_ND96isr_H200_v5', 'standardNDISRH200V5Family',
+        _caps(GPUs='8', vCPUs='96', MemoryGB='1850', HyperVGenerations='V2'))
+    assert (gpu_name, gpu_count, vcpus, memory, gen) == ('H200', '8', 96.0,
+                                                         '1850', 'V2')
+
+
+@pytest.mark.parametrize(
+    'instance_type, family, expected_count',
+    [
+        ('Standard_ND128isr_NDR_GB200_v6', 'standardNDISRGB200V6NDRFamily',
+         '4'),
+        ('Standard_ND128isr_GB300_v6', 'standardNDISRGB300V6Family', '4'),
+        ('Standard_ND96is_MI300X_v5', 'standardNDISv5MI300XFamily', '8'),
+    ],
+)
+def test_parse_capabilities_fills_the_documented_count_when_the_api_has_none(
+        instance_type, family, expected_count):
+    # These sizes carry no `GPUs` capability in the SKU API (observed
+    # 2026-09-02); the documented per-VM count is used instead.
+    gpu_name, gpu_count, _, _, _ = fetch_azure.parse_capabilities(
+        instance_type, family, _caps(vCPUs='128', MemoryGB='864'))
+    assert gpu_name == fetch_azure.get_gpu_name(family)
+    assert gpu_count == expected_count
+
+
+def test_parse_capabilities_never_invents_a_count():
+    # A GPU family with no `GPUs` capability AND no documented count is
+    # emitted as a plain VM row rather than with a guessed accelerator count.
+    gpu_name, gpu_count, _, _, _ = fetch_azure.parse_capabilities(
+        'Standard_ND_Fictional_v9', 'standardNDISRH200V5Family',
+        _caps(vCPUs='96'))
+    assert gpu_name is None
+    assert math.isnan(gpu_count)
+
+
+def test_parse_capabilities_ignores_gpu_capability_on_non_gpu_families():
+    # NP-series (FPGA) rows expose a `GPUs`-like capability shape in some API
+    # versions; a family that is not mapped must never become a GPU row.
+    gpu_name, gpu_count, _, _, _ = fetch_azure.parse_capabilities(
+        'Standard_NP10s', 'standardNPSFamily', _caps(GPUs='1', vCPUs='10'))
+    assert gpu_name is None
+    assert math.isnan(gpu_count)


### PR DESCRIPTION
The Azure fetcher only emits a GPU row when a size's `family` appears in `FAMILY_NAME_TO_SKYPILOT_GPU_NAME`. Six GPU families Azure sells today are not in that table, so `sky show-gpus --infra azure` cannot see them at all:

| family (as returned by `az vm list-skus --all`) | GPU | sizes |
|---|---|---|
| `standardNDISRH200V5Family` | `H200` | `Standard_ND96isr_H200_v5` (8× 141GB) |
| `standardNDISRGB200V6NDRFamily` | `GB200` | `Standard_ND128isr_NDR_GB200_v6` (4 GPUs) |
| `standardNDISRGB300V6Family` | `GB300` | `Standard_ND128isr_GB300_v6` (4 GPUs) |
| `standardNDISv5MI300XFamily` | `MI300X` | `Standard_ND96isr_MI300X_v5`, `Standard_ND96is_MI300X_v5` (8×) |
| `StandardNCCads2023Family` | `H100` | `Standard_NCC40ads_H100_v5` (confidential-computing H100 NVL 94GB) |
| `StandardNCADSA10v4Family` | `A10` | `Standard_NC8/16/32ads_A10_v4` (the compute A10 line; distinct from NV A10 v5) |

Three of those sizes (`ND128isr_NDR_GB200_v6`, `ND128isr_GB300_v6`, `ND96is_MI300X_v5`) carry **no `GPUs` capability** in the SKU API, so mapping the family alone would still drop them. `parse_capabilities` (extracted from the per-row lambda so it is unit-testable) now falls back to `AZURE_MISSING_GPU_COUNT`, a per-size table sourced from Azure's size documentation ([ND GB200 v6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series): 2 Grace + 4 Blackwell per VM; [ND GB300 v6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series): 4 per VM; [ND MI300X v5](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ndmi300xv5-series): 8 per VM). It refuses to invent a count for anything not in that table: a GPU family with neither source is emitted as a plain VM row, never with a guessed accelerator.

### Evidence

Ran the fetcher for eight US regions (`--regions westus3 eastus2 westus eastus westus2 southcentralus centralus northcentralus`) against a live subscription on 2026-09-03, once with this patch and once with the unpatched `master` fetcher, and diffed the two outputs:

| InstanceType | AcceleratorName (before → after) | AcceleratorCount (before → after) | regions |
|---|---|---|---|
| `Standard_NC16ads_A10_v4` | (none) → **A10** | (none) → **1** | westus3 |
| `Standard_NC32ads_A10_v4` | (none) → **A10** | (none) → **2** | westus3 |
| `Standard_NC8ads_A10_v4` | (none) → **A10** | (none) → **1** | westus3 |
| `Standard_NCC40ads_H100_v5` | (none) → **H100** | (none) → **1** | centralus, eastus2 |
| `Standard_ND128isr_GB300_v6` | (none) → **GB300** | (none) → **4** | centralus, eastus2, northcentralus, westus2, westus3 |
| `Standard_ND128isr_NDR_GB200_v6` | (none) → **GB200** | (none) → **4** | centralus, eastus, westus2, westus3 |
| `Standard_ND96is_MI300X_v5` | (none) → **MI300X** | (none) → **8** | westus |
| `Standard_ND96isr_H200_v5` | (none) → **H200** | (none) → **8** | eastus2, northcentralus, westus3 |
| `Standard_ND96isr_MI300X_v5` | (none) → **MI300X** | (none) → **8** | westus |

19 rows changed out of 10277; every change is in `AcceleratorName`/`GpuInfo`/`AcceleratorCount` on the sizes above, no other column and no other row differs.


Incidentally, the same run shows `Standard_ND96isr_H100_v5` at `AcceleratorCount=8` from the API. The hosted catalog CSV currently carries **12** on that row, so the hosted CSV is stale rather than the fetcher wrong; a regeneration will correct it.

`Standard_ND128isr_GB300_v6` has no retail-price rows yet (preview), so its rows carry an empty price — same as the pre-2023 H100 situation, and the reason this PR does not extend the `$0` H100 fill to it.

Tested (run the relevant ones):

- [x] Code formatting: `yapf` 0.32.0, `isort` 5.12.0, `pylint` 2.14.5 with `pylint_quotes` (10.00/10) on the changed files
- [x] New unit tests: `tests/unit_tests/test_azure_catalog_fetcher.py` (18 cases: family mapping incl. spaced spellings, API-count precedence, documented-count fallback, never-invent, non-GPU families untouched)
- [x] Manual: full fetcher run for 8 US regions with and without the patch, diffed (above)
- [ ] All smoke tests: not applicable (catalog fetcher only; no launch path touched)
- [ ] Backward compatibility: not applicable

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->