### PR TITLE
[k8s] Distinguish the context a cluster is submitted to from the one it runs on

### DIFF
--- a/sky/provision/kubernetes/constants.py
+++ b/sky/provision/kubernetes/constants.py
@@ -28,5 +28,12 @@ RAY_NODE_CONTAINER_NAME = 'ray-node'
 # replacement is observed, so it blocks garbage-collection of a deleted pod.
 KUEUE_MANAGED_FINALIZER = 'kueue.x-k8s.io/managed'
 
+# Provider-config key recording the Kubernetes context a cluster's pods
+# actually run on, when that can differ from the context the cluster was
+# submitted to (see get_execution_context_from_config). Recorded alongside
+# `provider.context` rather than replacing it: teardown, status and resource
+# cleanup all read `context` and must keep addressing the submitting cluster.
+PROVIDER_EXECUTION_CONTEXT_KEY = 'execution_context'
+
 # Pod phases that are not holding PVCs
 PVC_NOT_HOLD_POD_PHASES = ['Succeeded', 'Failed']

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2165,7 +2165,7 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
     """Create pods based on the config."""
     provider_config = config.provider_config
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_control_context_from_config(provider_config)
     pod_spec = copy.deepcopy(config.node_config)
     create_pods_start = datetime.datetime.now(datetime.timezone.utc)
 
@@ -2733,7 +2733,7 @@ def terminate_instances(
 ) -> None:
     """See sky/provision/__init__.py"""
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_control_context_from_config(provider_config)
     pods = kubernetes_utils.filter_pods(namespace, context,
                                         ray_tag_filter(cluster_name_on_cloud),
                                         None)
@@ -2781,7 +2781,7 @@ def cleanup_cluster_resources(
         provider_config: Provider configuration dictionary
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_control_context_from_config(provider_config)
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
@@ -2850,7 +2850,8 @@ def get_cluster_info(
     del region  # unused
     assert provider_config is not None
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_execution_context_from_config(
+        provider_config)
 
     running_pods = kubernetes_utils.filter_pods(
         namespace, context, ray_tag_filter(cluster_name_on_cloud), ['Running'])
@@ -3161,7 +3162,8 @@ def get_node_health_for_cluster(
         Dict mapping node_name -> NodeHealthInfo for unhealthy nodes.
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_execution_context_from_config(
+        provider_config)
     is_ssh = context.startswith('ssh-') if context else False
     identity = 'SSH Node Pool' if is_ssh else 'Kubernetes cluster'
     label_selector = (f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
@@ -3225,7 +3227,8 @@ def get_missing_node_reason(node_names: List[str],
         A human-readable reason, or None when every node is present and
         healthy (or none could be checked).
     """
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_execution_context_from_config(
+        provider_config)
     unique_names = sorted({name for name in node_names if name})
     if not unique_names:
         return None
@@ -3485,7 +3488,8 @@ def _first_pod_failure_reason(
     name a cause. Best-effort -- per_pod_fn is expected to never raise.
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_execution_context_from_config(
+        provider_config)
     for pod_name in pod_names:
         reason = per_pod_fn(context, namespace, pod_name)
         if reason is not None:
@@ -3539,7 +3543,8 @@ def emit_autostop_event_best_effort(provider_config: Dict[str, Any],
     """
     try:
         namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-        context = kubernetes_utils.get_context_from_config(provider_config)
+        context = kubernetes_utils.get_control_context_from_config(
+            provider_config)
         k8s_client = kubernetes.kubernetes.client
         now = datetime.datetime.now(datetime.timezone.utc)
         # The event references the head pod, whose name is exactly
@@ -3592,7 +3597,8 @@ def get_cluster_autostop_event(
     """
     try:
         namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-        context = kubernetes_utils.get_context_from_config(provider_config)
+        context = kubernetes_utils.get_control_context_from_config(
+            provider_config)
         events = kubernetes.core_api(context).list_namespaced_event(
             namespace,
             field_selector=f'reason={AUTOSTOP_EVENT_REASON}',
@@ -4049,7 +4055,7 @@ def query_instances(
 
     assert provider_config is not None
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
+    context = kubernetes_utils.get_control_context_from_config(provider_config)
     is_ssh = context.startswith('ssh-') if context else False
     identity = 'SSH Node Pool' if is_ssh else 'Kubernetes cluster'
     label_selector = (f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
@@ -4141,7 +4147,7 @@ def get_command_runners(
     instances = cluster_info.instances
     namespace = kubernetes_utils.get_namespace_from_config(
         cluster_info.provider_config)
-    context = kubernetes_utils.get_context_from_config(
+    context = kubernetes_utils.get_execution_context_from_config(
         cluster_info.provider_config)
 
     runners: List[command_runner.CommandRunner] = []

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -4982,6 +4982,14 @@ def set_autodown_annotations(handle: 'backends.CloudVmRayResourceHandle',
 
 
 def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
+    """The context recorded for this cluster at provision time.
+
+    This is the cluster's *control* context. Prefer the explicit
+    get_control_context_from_config / get_execution_context_from_config at
+    new call sites, so that a reader of the code (and of a future
+    multi-cluster placement change) can tell which of the two a call site
+    meant; they are the same string for every cluster today.
+    """
     context = provider_config.get('context')
     assert isinstance(context, str)
     if context == kubernetes.in_cluster_context_name():
@@ -4989,6 +4997,72 @@ def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
         # to use in-cluster auth by setting the context to None.
         context = None
     return context
+
+
+def get_control_context_from_config(
+        provider_config: Dict[str, Any]) -> Optional[str]:
+    """The context holding the objects SkyPilot created for this cluster.
+
+    Identical to get_context_from_config; a distinct name so a call site can
+    say that the submitting cluster is what it means, rather than leaving that
+    to be inferred. See get_execution_context_from_config for why the two can
+    differ.
+    """
+    return get_context_from_config(provider_config)
+
+
+def get_execution_context_from_config(
+        provider_config: Dict[str, Any]) -> Optional[str]:
+    """The context this cluster's pods actually run on.
+
+    SkyPilot has a single notion of "the context" for a cluster: the one
+    written to `provider.context` at provision time and read back through
+    get_context_from_config. That works because the cluster SkyPilot submits
+    to is the cluster the pods run on.
+
+    A multi-cluster admission layer breaks that identity: the pods can be
+    admitted somewhere other than where they were submitted. The submitting
+    cluster keeps the objects SkyPilot created (and the API server it talks
+    to), while the pods run wherever there was room. Two questions then have
+    two answers:
+
+    - the *control* context -- where SkyPilot submitted, and so where
+      everything it writes on the cluster's behalf goes;
+    - the *execution* context -- where the pods run, and so what to exec
+      into, and read logs and events from.
+
+    Unless a provisioner records the placement under
+    `constants.PROVIDER_EXECUTION_CONTEXT_KEY`, this falls back to the
+    control context, which is the right answer whenever a cluster runs where
+    it was submitted -- that is, for every cluster today.
+    """
+    recorded = provider_config.get(
+        kubernetes_constants.PROVIDER_EXECUTION_CONTEXT_KEY)
+    if recorded is None:
+        return get_control_context_from_config(provider_config)
+    if recorded == kubernetes.in_cluster_context_name():
+        # Mirrors get_context_from_config: the in-cluster context name is not
+        # a kubeconfig entry, and passing it on would defeat in-cluster auth.
+        return None
+    return recorded
+
+
+def set_execution_context_in_config(provider_config: Dict[str, Any],
+                                    context: Optional[str]) -> None:
+    """Record the context a cluster's pods run on in its provider config.
+
+    A no-op for a cluster with no context, so that the fallback in
+    get_execution_context_from_config stays in charge rather than a null
+    placement being pinned.
+
+    Note the value is recorded raw, exactly as `provider.context` holds it:
+    the in-cluster context name is mapped to None on read, by the same
+    accessor that maps `provider.context`.
+    """
+    if context is None:
+        return
+    provider_config[
+        kubernetes_constants.PROVIDER_EXECUTION_CONTEXT_KEY] = context
 
 
 def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -5035,6 +5035,13 @@ def get_execution_context_from_config(
     `constants.PROVIDER_EXECUTION_CONTEXT_KEY`, this falls back to the
     control context, which is the right answer whenever a cluster runs where
     it was submitted -- that is, for every cluster today.
+
+    This resolves the context and nothing else. The namespace still comes
+    from get_namespace_from_config, and any object a caller addresses by name
+    is still named as the submitting cluster named it -- the head Deployment
+    get_command_runners targets, for one. Whoever first resolves a real
+    placement owns those too: a context alone is not enough to reach a pod in
+    a cluster that holds different objects.
     """
     recorded = provider_config.get(
         kubernetes_constants.PROVIDER_EXECUTION_CONTEXT_KEY)
@@ -5058,6 +5065,10 @@ def set_execution_context_in_config(provider_config: Dict[str, Any],
     Note the value is recorded raw, exactly as `provider.context` holds it:
     the in-cluster context name is mapped to None on read, by the same
     accessor that maps `provider.context`.
+
+    Mutating the provider config is all this does. Whether a later reader
+    sees the placement depends on the caller persisting that config -- into
+    the cluster record, for a provisioner writing it at launch.
     """
     if context is None:
         return

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -19,7 +19,9 @@ import yaml
 
 from sky import exceptions
 from sky import models
+from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.catalog import kubernetes_catalog
+from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import utils
 
 
@@ -5759,3 +5761,74 @@ def test_unbounded_oom_hint_precedes_plain_oomkilled():
     assert unbounded != bounded
     assert 'no memory limit' in unbounded
     assert bounded.startswith('The container ran out of memory.')
+
+
+# ---------------------------------------------------------------------------
+# Control vs. execution context
+# ---------------------------------------------------------------------------
+# The two are the same string for every cluster today. What these tests pin is
+# the shape that keeps it that way -- the fallback, and the in-cluster
+# handling -- so that the day a provisioner records a real placement, the
+# blast radius is one accessor and everything here still holds.
+
+_EXECUTION_KEY = k8s_constants.PROVIDER_EXECUTION_CONTEXT_KEY
+
+
+def test_control_and_execution_context_agree_by_default():
+    provider_config = {'context': 'ctx-a'}
+    assert utils.get_control_context_from_config(provider_config) == 'ctx-a'
+    assert utils.get_execution_context_from_config(provider_config) == 'ctx-a'
+
+
+def test_execution_context_falls_back_to_control_context():
+    """Every cluster provisioned before the key existed must still resolve."""
+    provider_config = {'context': 'ctx-a'}
+    assert _EXECUTION_KEY not in provider_config
+    assert utils.get_execution_context_from_config(provider_config) == 'ctx-a'
+
+
+def test_recorded_execution_context_wins():
+    """The one behaviour that matters once placements can differ: the
+    execution reader follows the recorded placement, and the control reader
+    keeps addressing the cluster the objects were submitted to."""
+    provider_config = {'context': 'ctx-manager', _EXECUTION_KEY: 'ctx-worker'}
+    assert utils.get_execution_context_from_config(
+        provider_config) == 'ctx-worker'
+    assert utils.get_control_context_from_config(
+        provider_config) == 'ctx-manager'
+
+
+def test_in_cluster_execution_context_resolves_to_none():
+    """A recorded in-cluster context has to be mapped to None just as
+    `provider.context` is -- it is not a kubeconfig entry, and passing it to
+    the client would defeat in-cluster auth."""
+    provider_config = {
+        'context': 'ctx-a',
+        _EXECUTION_KEY: kubernetes_adaptor.in_cluster_context_name(),
+    }
+    assert utils.get_execution_context_from_config(provider_config) is None
+
+
+def test_in_cluster_control_context_resolves_to_none():
+    provider_config = {'context': kubernetes_adaptor.in_cluster_context_name()}
+    assert utils.get_control_context_from_config(provider_config) is None
+    # ... and the fallback inherits that, rather than the raw name.
+    assert utils.get_execution_context_from_config(provider_config) is None
+
+
+def test_set_execution_context_records_alongside_the_control_context():
+    provider_config = {'context': 'ctx-a'}
+    utils.set_execution_context_in_config(provider_config, 'ctx-worker')
+    assert provider_config[_EXECUTION_KEY] == 'ctx-worker'
+    # `provider.context` is untouched: teardown, status and resource cleanup
+    # all read it and must keep pointing at the submitting cluster.
+    assert provider_config['context'] == 'ctx-a'
+
+
+def test_set_execution_context_ignores_none():
+    """Nothing to record for a cluster with no context: leaving the key out
+    keeps the fallback in charge rather than pinning a null placement."""
+    provider_config = {'context': 'ctx-a'}
+    utils.set_execution_context_in_config(provider_config, None)
+    assert _EXECUTION_KEY not in provider_config
+    assert utils.get_execution_context_from_config(provider_config) == 'ctx-a'

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -15,6 +15,7 @@ from sky.adaptors import kubernetes
 from sky.backends import cloud_vm_ray_backend
 from sky.provision import common as provision_common
 from sky.provision.kubernetes import config as config_lib
+from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import instance
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.instance import logger
@@ -4956,3 +4957,44 @@ class TestGetMissingNodeReason:
 
     def test_unexpected_error_is_swallowed(self):
         assert self._reason({'node-1': RuntimeError('boom')}) is None
+
+
+def _cluster_info_with(provider_config):
+    """A ClusterInfo with one head pod, enough to drive get_command_runners."""
+    return provision_common.ClusterInfo(
+        instances={
+            'pod-head': [
+                provision_common.InstanceInfo(instance_id='pod-head',
+                                              internal_ip='10.0.0.1',
+                                              external_ip=None,
+                                              tags={})
+            ]
+        },
+        head_instance_id='pod-head',
+        provider_name='kubernetes',
+        provider_config=provider_config,
+    )
+
+
+def test_command_runners_target_the_execution_context():
+    """`kubectl exec` has to reach the pod that is actually running, so a
+    recorded placement -- not the context the cluster was submitted to --
+    is what the runners address."""
+    runners = instance.get_command_runners(
+        _cluster_info_with({
+            'context': 'ctx-manager',
+            'namespace': 'ns',
+            k8s_constants.PROVIDER_EXECUTION_CONTEXT_KEY: 'ctx-worker',
+        }))
+    assert [r.context for r in runners] == ['ctx-worker']
+
+
+def test_command_runners_fall_back_to_the_submitting_context():
+    """With nothing recorded -- every cluster today -- the runners address
+    the context the cluster was provisioned against, exactly as before."""
+    runners = instance.get_command_runners(
+        _cluster_info_with({
+            'context': 'ctx-a',
+            'namespace': 'ns',
+        }))
+    assert [r.context for r in runners] == ['ctx-a']

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -530,7 +530,7 @@ class TestGetClusterFailureReasonFromEvents:
     @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
     def test_returns_first_evicted(self, mock_events, mock_kutils):
         mock_kutils.get_namespace_from_config.return_value = 'ns'
-        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.get_execution_context_from_config.return_value = 'ctx'
         mock_events.return_value = [
             _make_event(
                 'Evicted', 'Pod ephemeral local storage usage '
@@ -546,7 +546,7 @@ class TestGetClusterFailureReasonFromEvents:
     @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
     def test_none_when_no_failure_event(self, mock_events, mock_kutils):
         mock_kutils.get_namespace_from_config.return_value = 'ns'
-        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.get_execution_context_from_config.return_value = 'ctx'
         mock_events.return_value = [_make_event('Scheduled', 'assigned')]
         assert k8s_instance.get_cluster_failure_reason_from_events(
             {}, ['pod-0', 'pod-1']) is None
@@ -566,7 +566,7 @@ class TestGetClusterFailureReasonFromPods:
     def test_returns_condensed_reason_for_abnormal_pod(self, mock_kutils,
                                                        mock_core_api):
         mock_kutils.get_namespace_from_config.return_value = 'ns'
-        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.get_execution_context_from_config.return_value = 'ctx'
         mock_kutils.pod_terminated_abnormally.return_value = True
         mock_kutils.get_condensed_pod_reason.return_value = (
             'OOMKilled (exit code 137)')
@@ -578,7 +578,7 @@ class TestGetClusterFailureReasonFromPods:
     @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
     def test_none_when_no_pod_abnormal(self, mock_kutils, mock_core_api):
         mock_kutils.get_namespace_from_config.return_value = 'ns'
-        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.get_execution_context_from_config.return_value = 'ctx'
         mock_kutils.pod_terminated_abnormally.return_value = False
         assert k8s_instance.get_cluster_failure_reason_from_pods(
             {}, ['pod-0', 'pod-1']) is None
@@ -587,7 +587,7 @@ class TestGetClusterFailureReasonFromPods:
     @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
     def test_skips_pod_read_errors(self, mock_kutils, mock_core_api):
         mock_kutils.get_namespace_from_config.return_value = 'ns'
-        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.get_execution_context_from_config.return_value = 'ctx'
         # First pod read raises; the second pod is abnormal.
         mock_core_api.return_value.read_namespaced_pod.side_effect = [
             Exception('boom'),


### PR DESCRIPTION
## The problem

SkyPilot has a single notion of "the context" for a Kubernetes cluster: the one written to `provider.context` at provision time, read back through `kubernetes_utils.get_context_from_config`, and used for everything afterwards. That works today because the cluster SkyPilot submits to is the cluster the pods run on.

A multi-cluster admission layer breaks that identity. Pods can be admitted somewhere other than where they were submitted: the submitting cluster keeps the objects SkyPilot created (and is the API server SkyPilot talks to), while the real pods run on whichever cluster had room. Two questions then have two answers, and only the caller knows which one it is asking:

| **Control context** — where SkyPilot submitted | **Execution context** — where the pods run |
|---|---|
| `_create_pods`, `terminate_instances`, `cleanup_cluster_resources`, `query_instances`, the autostop event it writes and reads back | `get_cluster_info`, `get_command_runners`, `get_node_health_for_cluster`, `get_missing_node_reason`, `_first_pod_failure_reason` |

The reason to introduce the distinction *before* anything can diverge is that it cannot be added mechanically afterwards. ~24 call sites funnel through one resolver and they mean different things; wrapping the resolver cannot recover which — one function, one signature, two meanings — so the alternative is inspecting the call stack. Each site has to say what it wants, and that is what this PR makes possible.

## What is here

- **`get_execution_context_from_config`** — reads an optional `provider.execution_context` and falls back to the control context, so a cluster provisioned without the key (every cluster today) resolves exactly as before. Maps the in-cluster context name to `None` just as `get_context_from_config` does, so in-cluster auth is not defeated.
- **`set_execution_context_in_config`** — records the placement, *alongside* `provider.context` rather than replacing it: teardown, status and resource cleanup all read `context` and must keep addressing the submitting cluster. A no-op for a context-less cluster, so the fallback stays in charge rather than a null placement being pinned.
- **`get_control_context_from_config`** — `get_context_from_config` under a name that says which of the two meanings it is, so that a bare `get_context_from_config` reads as a call site that has not said yet. `get_context_from_config` keeps working and gains a docstring pointing at the pair.
- **Every context read in `provision/kubernetes/instance.py` now says which it means** — exec and diagnostic readers take the execution context; writers and status readers take the control context.

**Zero behaviour change.** With nothing recorded under the new key, both accessors return exactly what `get_context_from_config` returned before, for every cluster.

## What a recorded context does not settle

Review raised this and the docstrings now say it in place: a context resolves *where*, not *what*. The namespace still comes from `get_namespace_from_config`, and any object a caller addresses by name — the head Deployment `get_command_runners` targets, for one — is still named as the submitting cluster named it. So a remote HA head command would address a Deployment absent from the execution cluster. That is unreachable today (nothing records a placement, so both accessors return the same context), and it is not a gap to paper over here: what a pod's identity is across clusters is a decision that belongs to whatever makes placements real. Guarding it now would cost an extra API call on every command-runner build for a case that cannot occur.

`set_execution_context_in_config` likewise only mutates the dict it is handed; whether a later reader sees the placement is up to the caller persisting that config.

## Deliberately left alone

`config.py` (namespace and FUSE-daemonset setup), `network.py` (port services and ingresses) and `authentication.py` (SSH secrets) still call the resolver directly. Whether a FUSE device manager or a port service belongs on the submitting cluster or the running one depends on how a real placement mechanism works, and guessing now would bake in an answer that a later change has to unpick. They keep the current behaviour and want the same treatment alongside whatever first resolves a genuine placement.

Nothing sets `provider.execution_context` in this PR, so `set_execution_context_in_config` has no in-tree caller yet — it is the entry point a provisioner uses once placement is known, and `get_execution_context_from_config` is the single function that has to learn how to resolve it.

## Tested

- **New accessor tests** in `tests/unit_tests/kubernetes/test_kubernetes_utils.py` (7): the two accessors agree by default; the fallback covers records without the key; a recorded placement wins on the execution path while the control path still addresses the submitting cluster; the in-cluster name maps to `None` on both paths; recording leaves `provider.context` untouched and is a no-op for a context-less cluster.
- **New behavioural tests** in `tests/unit_tests/kubernetes/test_provision.py` (2): `get_command_runners` targets a recorded execution context, and falls back to the submitting one when nothing is recorded. The first was confirmed to **fail** with the `get_command_runners` migration reverted, so it is not vacuous.
- `tests/unit_tests/kubernetes/` and `tests/unit_tests/test_sky/provision/`: **931 passed**.
- `format.sh --files` clean on every touched file (the single mypy error it reports is pre-existing on master, in a file this PR does not touch); pylint 10.00/10 on the touched modules.
